### PR TITLE
S37: the declare-phase read is an identity too

### DIFF
--- a/prebindgen/src/api/core/flat/boundary.ledger
+++ b/prebindgen/src/api/core/flat/boundary.ledger
@@ -124,9 +124,8 @@
 
 ## escapes: types
 1	api/lang/cbindgen/trait_impl.rs
-1	api/lang/jnigen/jni/trait_impl.rs
 
-# total escapes: types: 2
+# total escapes: types: 1
 
 ## escapes: items
 1	api/core/prebindgen.rs

--- a/prebindgen/src/api/lang/jnigen/jni/mod.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/mod.rs
@@ -54,7 +54,7 @@ pub(crate) use crate::api::{
         niches::{NicheSlot, Niches},
         prebindgen::{ConverterImpl, Prebindgen, Stage},
         registry::{Direction, Registry, TypeKey},
-        types_util::{bare_path_ident, option_inner_type, vec_inner_type},
+        types_util::{option_inner_type, vec_inner_type},
     },
     gen::kotlin::WriteKotlinError,
     lang::jnigen::{

--- a/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
@@ -1576,12 +1576,13 @@ impl Declarations {
             let Some(sum_cfg) = self.types[key].sum() else {
                 continue;
             };
-            // The `sealed_class!` declaration's own spelling. This runs during
+            // The `sealed_class!` declaration's own IDENTITY. This runs during
             // the declare phase, where a `reading()` would legitimately answer
             // `None` for a type nothing has interned yet — the declaration is
-            // the only thing that can say (#291).
-            let source = self.types[key].rust_type.as_syn().clone();
-            let Some(ident) = bare_path_ident(&source) else {
+            // the only thing that can say (#291), and `Origin::key` is what it
+            // says it with. This took the declaration's node and ran
+            // `bare_path_ident` over it to reach the same ident.
+            let Some(ident) = self.types[key].rust_type.key().ident() else {
                 continue;
             };
             let Some(crate::api::core::flat::Type::Variant(sum)) =


### PR DESCRIPTION
Part of the `syntax → model` transition (umbrella #314).

## The declaration is an identity, not a node

```rust
-// The `sealed_class!` declaration's own spelling. This runs during
-// the declare phase, where a `reading()` would legitimately answer
-// `None` for a type nothing has interned yet — the declaration is
-// the only thing that can say (#291).
-let source = self.types[key].rust_type.as_syn().clone();
-let Some(ident) = bare_path_ident(&source) else { continue };
+let Some(ident) = self.types[key].rust_type.key().ident() else { continue };
```

The comment was right about the hard part and wrong about the conclusion. A `reading()` lookup genuinely cannot answer here — this runs in the **declare** phase, before anything is interned, so `#291`'s point stands. But "only the declaration can say" does not make the declaration a *node*: it is an identity, and `Origin::key()` has been what says so since S2. The node was taken only so `bare_path_ident` could walk it back to the ident the sum is looked up by.

`bare_path_ident` loses its last caller on the jnigen side.

## Measurement

| | before | after |
|---|---:|---:|
| classification sites | 65 | 65 |
| escapes: types | 2 | **1** |
| escapes: items | 15 | 15 |

```
api/lang/jnigen/jni/trait_impl.rs  1 -> 0
```

**`jnigen` is now zero.** So is `api/core` (S33), and so is `cbindgen` except for one file.

## The last one, measured

`cbindgen/trait_impl.rs`'s `convert_crossing`:

```rust
let ty = built.reading(key)?.as_syn().clone();
match dir {
    Direction::Input  => self.select_input_type(&ty, built).or_else(…),
    Direction::Output => self.select_output_type(&ty, built),
}
```

This escape is the **gate** on cbindgen's whole selector chain — thirteen arms (`in_opaque_handle`, `in_data_struct`, `in_value_opaque`, `in_enum`, `in_string`, `in_str`, `in_bool`, `in_scalar`, `in_tagged_union`, `in_wrappers`, `out_terminal`, `out_tagged_union`, `out_wrappers`) that each take a `&syn::Type` and key, spell, or classify it. Handing them a node rebuilt from the reading's tokens would drop the count to zero while ungating all thirteen — the ratchet the ledger exists to prevent, so it is deliberately not done here.

I measured the real move: flipping the thirteen signatures to `&TypeRef` produces **75 compiler errors**, essentially all of one of three shapes this transition has already solved elsewhere —

* `TypeKey::from_type(ty)` → `ty.key()`
* `is_option(ty)` + `first_type_arg(ty)` → `ty.optional_inner()`, and `reading_of(&inner).and_then(entry)` → `entry(inner)`
* `is_string` / `is_scalar` / `is_bool` / `is_vec` → the `r_*` peers S25 added, and `src_ty(ty)` / `Self::in_name(ty)` → `src_ty_of(&key)` / `in_name_of(&key)`, both added by S25 and S30 for exactly this.

It is the cbindgen twin of S34, and it is the stage after this one — the one that takes `escapes: types` to **zero** and meets the ledger's own exit condition.

## Gate

- `cargo test -p prebindgen --all-features` — 638 lib, 22 doctests
- ledger regenerated, diff above
- clippy `--all-targets --all-features -D warnings` on stable **and** 1.85.0
- `cargo fmt --check` with the CI config
- `examples/regen-check.sh` — every generated artifact byte-identical