### PR TITLE
S39: the C wrapper emitter reads the element

### DIFF
--- a/prebindgen/src/api/core/flat/boundary.ledger
+++ b/prebindgen/src/api/core/flat/boundary.ledger
@@ -33,18 +33,12 @@
 # has a node to take apart.
 #
 #   ## escapes: types   `as_syn()`, `stripped_syntax()`, `to_syn()`,
-#                       `type_from_ident()`   — ZERO, as of #351. It must STAY
-#                       zero: a new row here is a consumer taking a node the
-#                       model can answer for, and the fix is to ask the model
+#                       `type_from_ident()`   — MUST reach zero
 #   ## escapes: items   `f.origin.as_syn()`, `enum_item()`
 #                                             — expected to persist
 #
-# A type escape is a source type the model should have been able to answer for.
-# There are none: every consumer outside `core::flat` now reads `kind`, spells
-# `spell()`, or looks up a `TypeKey`. The classification sites above are what
-# remains, and they are a different population — a wire type this adapter
-# COMPOSED (`matches!(wire, syn::Type::Ptr(_))`, the JNI lifetime splices), which
-# never was the model's to answer for. An
+# A type escape is a source type the model should have been able to answer for;
+# the classification sites above are the subset that visibly does classify. An
 # item escape is a captured item's own node, which an emitter re-stating a whole
 # item legitimately needs until items grow modelled accessors.
 #
@@ -111,7 +105,7 @@
 6	api/core/types_util.rs
 8	api/lang/cbindgen/builder.rs
 1	api/lang/cbindgen/convert.rs
-5	api/lang/cbindgen/emit.rs
+4	api/lang/cbindgen/emit.rs
 5	api/lang/cbindgen/mod.rs
 2	api/lang/cbindgen/trait_impl.rs
 4	api/lang/jnigen/jni/builder.rs
@@ -126,7 +120,7 @@
 2	api/lang/jnigen/jni/wire_access.rs
 1	api/lang/jnigen/util.rs
 
-# total classification sites: 61
+# total classification sites: 60
 
 ## escapes: types
 
@@ -137,10 +131,10 @@
 2	api/core/registry/scan.rs
 1	api/core/write.rs
 2	api/lang/cbindgen/convert.rs
-2	api/lang/cbindgen/trait_impl.rs
+1	api/lang/cbindgen/trait_impl.rs
 2	api/lang/jnigen/jni/builder.rs
 1	api/lang/jnigen/jni/kotlin_emit.rs
 3	api/lang/jnigen/jni/symbols.rs
 1	api/lang/jnigen/jni/trait_impl.rs
 
-# total escapes: items: 15
+# total escapes: items: 14

--- a/prebindgen/src/api/lang/cbindgen/emit.rs
+++ b/prebindgen/src/api/lang/cbindgen/emit.rs
@@ -484,25 +484,21 @@ impl CbindgenBuilder {
     /// Assemble the `#[no_mangle] extern "C"` wrapper for one declared fn.
     pub(super) fn emit_function_wrapper(
         &self,
-        f: &syn::ItemFn,
+        f: &crate::api::core::flat::Function,
         registry: &Registry<()>,
     ) -> TokenStream {
-        let orig = &f.sig.ident;
+        let orig = &f.name;
         let call_path = self.src_fn(orig);
         let sym = self.fn_symbol(orig);
 
-        let return_ty: syn::Type = match &f.sig.output {
-            syn::ReturnType::Default => syn::parse_quote!(()),
-            syn::ReturnType::Type(_, ty) => (**ty).clone(),
-        };
+        // The ELEMENT: a signature is a parameter list and a return, both
+        // already classified. An elided return is `TypeKind::Unit`, which is
+        // the `ReturnType::Default` arm this used to write.
+        let return_ty: syn::Type = spelled(&f.ret);
 
-        let has_fallible_input = f.sig.inputs.iter().any(|input| {
-            let syn::FnArg::Typed(pt) = input else {
-                return false;
-            };
+        let has_fallible_input = f.params.iter().any(|p| {
             registry
-                .reading_of(&pt.ty)
-                .and_then(|tr| registry.input_entry(&tr))
+                .input_entry(&p.ty)
                 .map(|e| returns_result(&e.function.sig.output))
                 .unwrap_or(false)
         });
@@ -959,33 +955,35 @@ impl CbindgenBuilder {
     /// handle pointer, and comparing the syntactic parameter type instead would
     /// miss `f(x: ZThing, y: Option<ZThing>)` called with the same handle
     /// twice.
-    fn alias_slot(&self, ty: &syn::Type) -> Option<(TypeKey, AliasAccess)> {
-        let inner = if is_option(ty) {
-            first_type_arg(ty)?
-        } else {
-            ty.clone()
-        };
+    /// [`Self::alias_slot`] off the classification: the optional peel, the
+    /// borrow and its mutability, and the `MaybeUninit` under a `&mut` are all
+    /// what `TypeKind` states — where this walked `Option`'s type argument, a
+    /// `syn::Type::Reference` and its `mutability` field.
+    fn alias_slot_of(&self, ty: &TypeRef) -> Option<(TypeKey, AliasAccess)> {
+        let inner = ty.optional_inner().unwrap_or(ty);
         let declared =
             |key: &TypeKey| self.opaque.contains_key(key) || self.value_opaque.contains_key(key);
-        if let syn::Type::Reference(r) = &inner {
+        if let TypeKind::Ref { mutable, inner, .. } = inner.kind() {
             // `&mut MaybeUninit<T>` borrows T's slot exclusively just as
             // `&mut T` does; the wire is the same pointer.
-            let elem = (*r.elem).clone();
-            let elem = maybe_uninit_inner(&elem).unwrap_or(elem);
-            let key = TypeKey::from_type(&elem);
+            let elem = match inner.kind() {
+                TypeKind::Uninit(t) => t,
+                _ => inner,
+            };
+            let key = elem.key();
             if !declared(&key) {
                 return None;
             }
             return Some((
                 key,
-                if r.mutability.is_some() {
+                if *mutable {
                     AliasAccess::Exclusive
                 } else {
                     AliasAccess::Shared
                 },
             ));
         }
-        let key = TypeKey::from_type(&inner);
+        let key = inner.key();
         declared(&key).then_some((key, AliasAccess::Consume))
     }
 
@@ -1012,17 +1010,15 @@ impl CbindgenBuilder {
     ///
     /// Shared/shared is *not* rejected: two `&T` to one resource is legal Rust
     /// and legal C.
-    pub(super) fn alias_preflight(&self, f: &syn::ItemFn, route: &ErrRoute) -> Option<TokenStream> {
+    pub(super) fn alias_preflight(
+        &self,
+        f: &crate::api::core::flat::Function,
+        route: &ErrRoute,
+    ) -> Option<TokenStream> {
         let mut slots: Vec<(syn::Ident, TypeKey, AliasAccess)> = Vec::new();
-        for input in &f.sig.inputs {
-            let syn::FnArg::Typed(pt) = input else {
-                continue;
-            };
-            let syn::Pat::Ident(pat_id) = &*pt.pat else {
-                continue;
-            };
-            if let Some((key, access)) = self.alias_slot(&pt.ty) {
-                slots.push((pat_id.ident.clone(), key, access));
+        for p in &f.params {
+            if let Some((key, access)) = self.alias_slot_of(&p.ty) {
+                slots.push((p.name.clone(), key, access));
             }
         }
 
@@ -1066,7 +1062,7 @@ impl CbindgenBuilder {
     pub(super) fn emit_inputs(
         &self,
         orig: &syn::Ident,
-        f: &syn::ItemFn,
+        f: &crate::api::core::flat::Function,
         registry: &Registry<()>,
         route: &ErrRoute,
     ) -> (Vec<TokenStream>, Vec<TokenStream>, Vec<TokenStream>) {
@@ -1077,15 +1073,10 @@ impl CbindgenBuilder {
         let mut decodes: Vec<TokenStream> = self.alias_preflight(f, route).into_iter().collect();
         let mut call_args = Vec::new();
 
-        for input in &f.sig.inputs {
-            let syn::FnArg::Typed(pt) = input else {
-                continue;
-            };
-            let syn::Pat::Ident(pat_id) = &*pt.pat else {
-                continue;
-            };
-            let ident = &pat_id.ident;
-            let arg_ty = &*pt.ty;
+        for param in &f.params {
+            let ident = &param.name;
+            let arg_reading = &param.ty;
+            let arg_ty = &spelled(arg_reading);
 
             // `&[E]` slice (scalar `E`): two wire params (`*const E`, `usize`),
             // decoded zero-copy. NULL pointer ⇒ empty slice (not an error).

--- a/prebindgen/src/api/lang/cbindgen/trait_impl.rs
+++ b/prebindgen/src/api/lang/cbindgen/trait_impl.rs
@@ -1844,7 +1844,7 @@ impl Prebindgen for CbindgenBuilder {
         f: &crate::api::core::flat::Function,
         registry: &Registry<()>,
     ) -> TokenStream {
-        self.emit_function_wrapper(f.origin.as_syn(), registry)
+        self.emit_function_wrapper(f, registry)
     }
 
     fn on_struct(


### PR DESCRIPTION
Part of the `syntax → model` transition (umbrella #314). First stage past the `escapes: types` goal, working the two counts that remain.

## What moved

`emit_function_wrapper` took the whole `syn::ItemFn` — the **item escape** at its one call site — and then took it apart:

```rust
-let orig = &f.sig.ident;
-let return_ty: syn::Type = match &f.sig.output {
-    syn::ReturnType::Default => syn::parse_quote!(()),
-    syn::ReturnType::Type(_, ty) => (**ty).clone(),
-};
-let has_fallible_input = f.sig.inputs.iter().any(|input| {
-    let syn::FnArg::Typed(pt) = input else { return false };
-    registry.reading_of(&pt.ty).and_then(|tr| registry.input_entry(&tr))…
+let orig = &f.name;
+let return_ty: syn::Type = spelled(&f.ret);
+let has_fallible_input = f.params.iter().any(|p| registry.input_entry(&p.ty)…);
```

A signature is a parameter list and a return, both already classified — the same move S20, S28 and S29 made elsewhere. `emit_inputs` and `alias_preflight` walked the same `sig.inputs` twice more, including `syn::Pat::Ident` to recover each parameter's name, which a `Param` carries.

The `ReturnType::Default → ()` arm goes with them: `Function::ret` is `TypeKind::Unit` for an elided return, by its own doc.

## `alias_slot`

The alias preflight asks what resource each argument names. That is three `TypeKind` facts:

```rust
-let inner = if is_option(ty) { first_type_arg(ty)? } else { ty.clone() };
-if let syn::Type::Reference(r) = &inner {
-    let elem = (*r.elem).clone();
-    let elem = maybe_uninit_inner(&elem).unwrap_or(elem);
-    …if r.mutability.is_some() { Exclusive } else { Shared }
+let inner = ty.optional_inner().unwrap_or(ty);
+if let TypeKind::Ref { mutable, inner, .. } = inner.kind() {
+    let elem = match inner.kind() { TypeKind::Uninit(t) => t, _ => inner };
+    …if *mutable { Exclusive } else { Shared }
```

`mutable` off the `Ref` itself, not `is_exclusive_borrow` — S38's lesson, applied rather than rediscovered: `&mut MaybeUninit<T>` is exactly the case that reading excludes, and it is exactly the case this arm exists to cover. The node peer is deleted; nothing else called it.

## Measurement

| | before | after |
|---|---:|---:|
| classification sites | 61 | **60** |
| escapes: types | 0 | **0** |
| escapes: items | 15 | **14** |

```
api/lang/cbindgen/emit.rs        [classification]  5 -> 4
api/lang/cbindgen/trait_impl.rs  [items]           2 -> 1
```

Modest, and the shape is the point: with the element in hand, the readings now flow into `lower_shape` / `encode_value`, which is what the next stage moves. Those still take `&syn::Type` (`is_unit`, `is_vec` + `first_type_arg`, `is_option`) and are the last reducible classification population in cbindgen — the rest of its count is the C wire (`matches!(wire, syn::Type::Ptr(_))`) and build-script declarations.

## Gate

- `cargo test -p prebindgen --all-features` — 638 lib, 22 doctests
- ledger regenerated, diff above
- clippy `--all-targets --all-features -D warnings` on stable **and** 1.85.0
- `cargo fmt --check` with the CI config
- `examples/regen-check.sh` — every generated artifact byte-identical