### PR TITLE
S41: the source path recurses on readings

### DIFF
--- a/prebindgen/src/api/core/flat/boundary.ledger
+++ b/prebindgen/src/api/core/flat/boundary.ledger
@@ -103,7 +103,7 @@
 
 2	api/core/registry/scan.rs
 5	api/core/types_util.rs
-8	api/lang/cbindgen/builder.rs
+4	api/lang/cbindgen/builder.rs
 1	api/lang/cbindgen/convert.rs
 4	api/lang/cbindgen/emit.rs
 3	api/lang/cbindgen/mod.rs
@@ -120,7 +120,7 @@
 2	api/lang/jnigen/jni/wire_access.rs
 1	api/lang/jnigen/util.rs
 
-# total classification sites: 57
+# total classification sites: 53
 
 ## escapes: types
 

--- a/prebindgen/src/api/lang/cbindgen/builder.rs
+++ b/prebindgen/src/api/lang/cbindgen/builder.rs
@@ -695,24 +695,32 @@ impl CbindgenBuilder {
     /// `&ZSample` becomes `&zenoh_flat::ZSample` and `&[Payload]` becomes
     /// `&[perftest_flat::Payload]` (needed so a callback's `Fn(&[E])` closure type
     /// names the qualified element).
-    /// [`Self::src_ty_deep`] off a reading — the source's own tokens, requalified.
+    /// [`Self::src_ty`], recursing into a borrow's and a slice's element — off
+    /// the classification. `&ZSample` becomes `&zenoh_flat::ZSample` and
+    /// `&[Payload]` becomes `&[perftest_flat::Payload]`, so a callback's
+    /// `Fn(&[E])` closure type names the qualified element.
+    ///
+    /// The two recursing forms are `TypeKind::Ref` and `TypeKind::Slice`, which
+    /// is what the `syn::Type::Reference` / `syn::Type::Slice` match this
+    /// replaces was reading — and the borrow's lifetime and mutability are on
+    /// the kind, so the rebuilt spelling says what the source said.
     pub(super) fn src_ty_deep_of(&self, ty: &TypeRef) -> syn::Type {
-        self.src_ty_deep(&super::spelled(ty))
-    }
-
-    pub(super) fn src_ty_deep(&self, ty: &syn::Type) -> syn::Type {
-        match ty {
-            syn::Type::Reference(r) => {
-                let mut out = r.clone();
-                out.elem = Box::new(self.src_ty_deep(&r.elem));
-                syn::Type::Reference(out)
+        match ty.kind() {
+            TypeKind::Ref {
+                lifetime,
+                mutable,
+                inner,
+            } => {
+                let inner = self.src_ty_deep_of(inner);
+                let lt = lifetime.as_ref().map(|l| quote!(#l)).unwrap_or_default();
+                let m = if *mutable { quote!(mut) } else { quote!() };
+                syn::parse_quote!(& #lt #m #inner)
             }
-            syn::Type::Slice(s) => {
-                let mut out = s.clone();
-                out.elem = Box::new(self.src_ty_deep(&s.elem));
-                syn::Type::Slice(out)
+            TypeKind::Slice(elem) => {
+                let elem = self.src_ty_deep_of(elem);
+                syn::parse_quote!([#elem])
             }
-            _ => self.src_ty(ty),
+            _ => self.src_ty_of(&ty.key()),
         }
     }
 

--- a/prebindgen/src/api/lang/cbindgen/emit.rs
+++ b/prebindgen/src/api/lang/cbindgen/emit.rs
@@ -1071,7 +1071,7 @@ impl CbindgenBuilder {
 
             // `&[E]` slice (scalar `E`): two wire params (`*const E`, `usize`),
             // decoded zero-copy. NULL pointer ⇒ empty slice (not an error).
-            if let Some(elem) = scalar_slice_elem(arg_ty) {
+            if let Some(elem) = r_scalar_slice_elem(arg_reading).map(spelled) {
                 let len_id = format_ident!("{}_len", ident);
                 params.push(quote!(#ident: *const #elem));
                 params.push(quote!(#len_id: usize));
@@ -1092,7 +1092,7 @@ impl CbindgenBuilder {
             // by a generated `const _`), so the whole block transmutes in one shot —
             // the slice analogue of the single-`&E` `__cbg_in_*` converter. NULL ⇒
             // empty slice.
-            if let Some(elem) = self.value_opaque_slice_elem(arg_ty) {
+            if let Some(elem) = self.r_value_opaque_slice_elem(arg_reading).map(spelled) {
                 // The C wire element is the inline-opaque counterpart (e.g. the
                 // generated `payload_t` mirror), layout-identical to the Rust value.
                 let elem_wire = self

--- a/prebindgen/src/api/lang/cbindgen/trait_impl.rs
+++ b/prebindgen/src/api/lang/cbindgen/trait_impl.rs
@@ -1356,7 +1356,7 @@ impl CbindgenBuilder {
             };
         }
         if let Some(inner) = r_boxed_inner(fty) {
-            let src_inner = self.src_ty(&spelled(inner));
+            let src_inner = self.src_ty_of(&inner.key());
             let boxed = quote!(::std::boxed::Box::from_raw(#b as *mut #src_inner));
             return if fty.optional_inner().is_some() {
                 quote!(if #b.is_null() {


### PR DESCRIPTION
Part of the `syntax → model` transition (umbrella #314).

## `src_ty_deep`

`src_ty` qualifies a bare source type against `source_module`; `src_ty_deep` is the same thing recursing into a borrow's and a slice's element, so a callback's `Fn(&[E])` closure type names the qualified element. It did that by matching nodes and rebuilding each with its element replaced:

```rust
-match ty {
-    syn::Type::Reference(r) => {
-        let mut out = r.clone();
-        out.elem = Box::new(self.src_ty_deep(&r.elem));
-        syn::Type::Reference(out)
-    }
-    syn::Type::Slice(s) => { … }
-    _ => self.src_ty(ty),
-}
+match ty.kind() {
+    TypeKind::Ref { lifetime, mutable, inner } => {
+        let inner = self.src_ty_deep_of(inner);
+        let lt = lifetime.as_ref().map(|l| quote!(#l)).unwrap_or_default();
+        let m = if *mutable { quote!(mut) } else { quote!() };
+        syn::parse_quote!(& #lt #m #inner)
+    }
+    TypeKind::Slice(elem) => { … }
+    _ => self.src_ty_of(&ty.key()),
+}
```

Four of `cbindgen/builder.rs`'s eight classification sites. The borrow's **lifetime and mutability are on the kind**, so the rebuilt spelling says what the source said — which is what `r.clone()` with a replaced `elem` was preserving. The node version is deleted; it had no other caller.

## The slice arms, and the one that stays

`emit_inputs`' two `&[E]` arms take the parameter's reading now (S39 put it in scope), so `scalar_slice_elem` and `value_opaque_slice_elem` lose their last non-declaration callers.

Both stay **defined**, for `callback_slice_elem_wire` — whose one caller walks a `.callback(...)` declaration's argument list. That is a type the build script wrote, which the model may never have interned, so there is no reading to ask. Same category as `validate_constant_expr` (S29) and `arm_erased_sig`'s `SelfIdentity` arm (S32): the node paths that remain are the ones pointed at declarations, not at captured source.

## Measurement

| | before | after |
|---|---:|---:|
| classification sites | 57 | **53** |
| escapes: types | 0 | **0** |
| escapes: items | 14 | 14 |

```
api/lang/cbindgen/builder.rs  8 -> 4
```

`builder.rs`'s remaining four are `src_ty`'s own path-qualification match (still reached by `src_ty_of` and by the declaration paths) and `value_opaque_slice_elem`'s `&[E]` shape check.

## Gate

- `cargo test -p prebindgen --all-features` — 638 lib, 22 doctests
- ledger regenerated, diff above
- clippy `--all-targets --all-features -D warnings` on stable **and** 1.85.0
- `cargo fmt --check` with the CI config
- `examples/regen-check.sh` — every generated artifact byte-identical