### PR TITLE
S42: the JNI symbol checks read, and `enum_item` loses its last caller

### DIFF
--- a/prebindgen/src/api/core/flat/boundary.ledger
+++ b/prebindgen/src/api/core/flat/boundary.ledger
@@ -133,8 +133,6 @@
 2	api/lang/cbindgen/convert.rs
 1	api/lang/cbindgen/trait_impl.rs
 2	api/lang/jnigen/jni/builder.rs
-1	api/lang/jnigen/jni/kotlin_emit.rs
-3	api/lang/jnigen/jni/symbols.rs
 1	api/lang/jnigen/jni/trait_impl.rs
 
-# total escapes: items: 14
+# total escapes: items: 10

--- a/prebindgen/src/api/lang/jnigen/jni/kotlin_emit.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/kotlin_emit.rs
@@ -1038,7 +1038,6 @@ impl Declarations {
                 let Some(func) = registry.flat().function(&ident) else {
                     continue;
                 };
-                let item_fn = func.origin.as_syn();
                 for p in &func.params {
                     if let Some(cb_args) = p.ty.callback_args() {
                         uses.insert(SpecKey::callback(cb_args));
@@ -1046,7 +1045,7 @@ impl Declarations {
                 }
                 if let Some(plan) = registry
                     .unfold_plans()
-                    .get(&item_fn.sig.ident)
+                    .get(&func.name)
                     .filter(|p| p.delivery == Delivery::Callback)
                 {
                     let iterable = is_iterable_fold(&plan.shape);
@@ -1063,7 +1062,7 @@ impl Declarations {
                         _ => {}
                     }
                 }
-                match registry.error_plans().get(&item_fn.sig.ident) {
+                match registry.error_plans().get(&func.name) {
                     Some(ep) => {
                         let d = ep
                             .decon

--- a/prebindgen/src/api/lang/jnigen/jni/symbols.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/symbols.rs
@@ -127,10 +127,15 @@ pub(crate) fn validate_symbols(ext: &Declarations, registry: &Registry<KotlinMet
                 short.to_string(),
                 format!("sealed class `{key}` itself (its variants' supertype)"),
             )]);
-            if let Some(item_enum) = key.ident().and_then(|i| registry.flat().enum_item(&i)) {
-                for v in &item_enum.variants {
-                    let name = ext.sum_variant_class_name(sum_cfg, &v.ident);
-                    let vorigin = format!("variant `{}` of sealed class `{key}`", v.ident);
+            // The ELEMENT's alternatives, not the `syn::ItemEnum`'s variants:
+            // this needs each one's NAME, which an `Alternative` carries.
+            if let Some(alts) = key
+                .ident()
+                .and_then(|i| declared_member_names(registry, &i))
+            {
+                for v in alts {
+                    let name = ext.sum_variant_class_name(sum_cfg, &v);
+                    let vorigin = format!("variant `{v}` of sealed class `{key}`");
                     check_ident(&name, &vorigin, &mut errors);
                     if let Some(prev) = seen.insert(name.clone(), vorigin.clone()) {
                         errors.push(format!(
@@ -269,13 +274,9 @@ fn warn_derived_name_changes(ext: &Declarations, registry: &Registry<KotlinMeta>
         let Some(ident) = key.ident() else {
             continue;
         };
-        if let Some(s) = registry
-            .flat()
-            .struct_type(&ident)
-            .map(|st| st.origin.as_syn())
-        {
+        if let Some(s) = registry.flat().struct_type(&ident) {
             for f in &s.fields {
-                if let Some(fname) = &f.ident {
+                if let Some(fname) = &f.name {
                     let camel = kt_snake_to_camel(&fname.to_string());
                     warn(
                         &camel,
@@ -286,10 +287,10 @@ fn warn_derived_name_changes(ext: &Declarations, registry: &Registry<KotlinMeta>
                 }
             }
         }
-        if let Some(e) = registry.flat().enum_item(&ident) {
-            for v in &e.variants {
+        if let Some(names) = declared_member_names(registry, &ident) {
+            for v in names {
                 let screaming =
-                    crate::api::lang::jnigen::util::camel_to_screaming_snake(&v.ident.to_string());
+                    crate::api::lang::jnigen::util::camel_to_screaming_snake(&v.to_string());
                 warn(
                     &screaming,
                     &mangle_kotlin_ident(&screaming),
@@ -298,6 +299,24 @@ fn warn_derived_name_changes(ext: &Declarations, registry: &Registry<KotlinMeta>
                 );
             }
         }
+    }
+}
+
+/// The member names of a declared `enum` — its values for a fieldless one, its
+/// alternatives for a sum.
+///
+/// `enum_item` answered for both shapes by handing back the whole
+/// `syn::ItemEnum`; the model states them as two elements, and both carry the
+/// names this asks for. `None` when `ident` names neither.
+fn declared_member_names(
+    registry: &impl crate::api::core::registry::Conversions<KotlinMeta>,
+    ident: &syn::Ident,
+) -> Option<Vec<syn::Ident>> {
+    use crate::api::core::flat::Type;
+    match registry.flat().declared_type(ident)? {
+        Type::Enum(e) => Some(e.values.iter().map(|v| v.name.clone()).collect()),
+        Type::Variant(v) => Some(v.alternatives.iter().map(|a| a.name.clone()).collect()),
+        _ => None,
     }
 }
 


### PR DESCRIPTION
Part of the `syntax → model` transition (umbrella #314). Working `escapes: items`, the count the header always expected to persist — and which keeps turning out to be a missing accessor.

## `symbols.rs`

It validates that generated Kotlin identifiers do not collide. Every check wants a **name**, and all three took an item to get one:

| check | was | is |
|---|---|---|
| sealed class's variant names | `enum_item(&i)` → `item_enum.variants[].ident` | `Alternative::name` |
| data class's field names | `st.origin.as_syn()` → `s.fields[].ident` | `Field::name` |
| enum's value names | `enum_item(&ident)` → `e.variants[].ident` | `EnumValue::name` |

The third is why this adds `declared_member_names` rather than three inline matches: `enum_item` answered for **both** enum shapes by handing back the whole `syn::ItemEnum`, and the model splits them into `Enum` (values) and `Variant` (alternatives). This check is the one place that wants them alike, so one helper says so:

```rust
match registry.flat().declared_type(ident)? {
    Type::Enum(e) => Some(e.values.iter().map(|v| v.name.clone()).collect()),
    Type::Variant(v) => Some(v.alternatives.iter().map(|a| a.name.clone()).collect()),
    _ => None,
}
```

## `kotlin_emit`

```rust
-let item_fn = func.origin.as_syn();
```

Two uses, both `item_fn.sig.ident` — which is `func.name`.

## `enum_item` has no caller left

It is one of the five doors the census counts by name. Nothing in production code walks through it any more: `unit_enum` (S25), `payload_enum` (S25), `enum_alternatives` (S24) and now `declared_member_names` each ask the model which shape a declared enum is, and get the element that answers.

It stays **defined** — `Flat`'s public surface, and `registry/tests.rs` exercises it — so this is not a deletion, it is the count going to zero for that door.

## Measurement

| | before | after |
|---|---:|---:|
| classification sites | 53 | 53 |
| escapes: types | 0 | **0** |
| escapes: items | 14 | **10** |

```
api/lang/jnigen/jni/symbols.rs      3 -> 0
api/lang/jnigen/jni/kotlin_emit.rs  1 -> 0
```

Of the ten left, several are the shape the header describes as legitimate: `cbindgen/trait_impl.rs`'s is `EnumValue::origin`'s **discriminant as written** (`= 0x07` stays `0x07`), which the model's own docs name as that field's one consumer. The rest are a `.convert(...)` / `.fun(...)` declaration's referenced `syn::ItemFn`, spliced whole.

## Gate

- `cargo test -p prebindgen --all-features` — 638 lib, 22 doctests
- ledger regenerated, diff above
- clippy `--all-targets --all-features -D warnings` on stable **and** 1.85.0
- `cargo fmt --check` with the CI config
- `examples/regen-check.sh` — every generated artifact byte-identical