### PR TITLE
S43: a conversion function is a signature

### DIFF
--- a/prebindgen/src/api/core/flat/boundary.ledger
+++ b/prebindgen/src/api/core/flat/boundary.ledger
@@ -104,11 +104,10 @@
 2	api/core/registry/scan.rs
 5	api/core/types_util.rs
 4	api/lang/cbindgen/builder.rs
-1	api/lang/cbindgen/convert.rs
 4	api/lang/cbindgen/emit.rs
 3	api/lang/cbindgen/mod.rs
 2	api/lang/cbindgen/trait_impl.rs
-4	api/lang/jnigen/jni/builder.rs
+3	api/lang/jnigen/jni/builder.rs
 4	api/lang/jnigen/jni/emit/convert.rs
 4	api/lang/jnigen/jni/emit/flat_input.rs
 7	api/lang/jnigen/jni/emit/names.rs
@@ -120,7 +119,7 @@
 2	api/lang/jnigen/jni/wire_access.rs
 1	api/lang/jnigen/util.rs
 
-# total classification sites: 53
+# total classification sites: 51
 
 ## escapes: types
 
@@ -130,9 +129,7 @@
 1	api/core/prebindgen.rs
 2	api/core/registry/scan.rs
 1	api/core/write.rs
-2	api/lang/cbindgen/convert.rs
 1	api/lang/cbindgen/trait_impl.rs
-2	api/lang/jnigen/jni/builder.rs
 1	api/lang/jnigen/jni/trait_impl.rs
 
-# total escapes: items: 10
+# total escapes: items: 6

--- a/prebindgen/src/api/core/types_util.rs
+++ b/prebindgen/src/api/core/types_util.rs
@@ -75,11 +75,6 @@ pub fn result_ok_type(ty: &syn::Type) -> Option<syn::Type> {
     result_parts(ty).map(|(ok, _)| ok)
 }
 
-/// If `ty` is `Result<T, E>`, return `E`.
-pub fn result_err_type(ty: &syn::Type) -> Option<syn::Type> {
-    result_parts(ty).map(|(_, err)| err)
-}
-
 /// First angle-bracketed **type** argument of a path type (`T` of `Option<T>`
 /// / `Vec<T>` / `Result<T, _>`), skipping lifetime/const args. `None` when
 /// there is no type argument.

--- a/prebindgen/src/api/lang/cbindgen/convert.rs
+++ b/prebindgen/src/api/lang/cbindgen/convert.rs
@@ -193,18 +193,20 @@ impl CbindgenBuilder {
         let target = self.src_ty_of(&decl.rust_type.key());
         match spec {
             ConvertSpec::PrebindgenFn(f) => {
-                let item = &registry
+                let item = registry
                     .flat()
                     .function(&f)
-                    .map(|func| func.origin.as_syn())
                     .unwrap_or_else(|| panic!("Cbindgen conversion function {} was not found", f));
-                let (repr, by_ref) = one_param(item);
-                let ret = fn_ret(item);
-                let (ok, fallible) = match result_parts(&ret) {
+                let (repr_reading, by_ref) = one_param(item);
+                let repr = spelled(repr_reading);
+                // The element normalizes an elided return to `Unit`, and
+                // `TypeKind::Fallible` is the `Result` `result_parts` looked for
+                // in a path.
+                let (ok, fallible) = match item.ret.fallible_parts() {
                     Some((ok, _)) => (ok, true),
-                    None => (ret, false),
+                    None => (&item.ret, false),
                 };
-                assert_eq!(TypeKey::from_type(&ok), decl.key);
+                assert_eq!(ok.key(), decl.key);
                 let path = self.conversion_fn_path(registry, f);
                 let expr = if by_ref {
                     syn::parse_quote!(#path(&v))
@@ -237,17 +239,15 @@ impl CbindgenBuilder {
         let target = self.src_ty_of(&decl.rust_type.key());
         match spec {
             ConvertSpec::PrebindgenFn(f) => {
-                let item = &registry
+                let item = registry
                     .flat()
                     .function(&f)
-                    .map(|func| func.origin.as_syn())
                     .unwrap_or_else(|| panic!("Cbindgen conversion function {} was not found", f));
                 let (param, by_ref) = one_param(item);
-                assert_eq!(TypeKey::from_type(&param), decl.key);
-                let ret = fn_ret(item);
-                let (repr, fallible) = match result_parts(&ret) {
-                    Some((ok, _)) => (ok, true),
-                    None => (ret, false),
+                assert_eq!(param.key(), decl.key);
+                let (repr, fallible) = match item.ret.fallible_parts() {
+                    Some((ok, _)) => (spelled(ok), true),
+                    None => (spelled(&item.ret), false),
                 };
                 let path = self.conversion_fn_path(registry, f);
                 let expr = if by_ref {
@@ -331,34 +331,21 @@ impl CbindgenBuilder {
     }
 }
 
-fn one_param(item: &syn::ItemFn) -> (syn::Type, bool) {
-    let params: Vec<_> = item
-        .sig
-        .inputs
-        .iter()
-        .filter_map(|p| {
-            if let syn::FnArg::Typed(p) = p {
-                Some(&*p.ty)
-            } else {
-                None
-            }
-        })
-        .collect();
+/// The single parameter of a conversion fn, peeled of a leading `&`.
+///
+/// Off the ELEMENT: a signature is a parameter list, and the borrow is
+/// `TypeKind::Ref` — where this filtered `syn::FnArg::Typed` and matched
+/// `syn::Type::Reference` to reach the same two facts.
+fn one_param(f: &crate::api::core::flat::Function) -> (&TypeRef, bool) {
     assert_eq!(
-        params.len(),
+        f.params.len(),
         1,
         "conversion functions take exactly one parameter"
     );
-    match params[0] {
-        syn::Type::Reference(r) => ((*r.elem).clone(), true),
-        ty => (ty.clone(), false),
-    }
-}
-
-fn fn_ret(item: &syn::ItemFn) -> syn::Type {
-    match &item.sig.output {
-        syn::ReturnType::Default => syn::parse_quote!(()),
-        syn::ReturnType::Type(_, ty) => (**ty).clone(),
+    let ty = &f.params[0].ty;
+    match ty.kind() {
+        TypeKind::Ref { inner, .. } => (inner, true),
+        _ => (ty, false),
     }
 }
 

--- a/prebindgen/src/api/lang/jnigen/jni/builder.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/builder.rs
@@ -1491,29 +1491,21 @@ impl Declarations {
         let target = decl.rust_type.spell();
         let result = match decl.input.as_ref()? {
             ConvertSpec::PrebindgenFn(f) => {
-                let item_fn = registry
-                    .flat()
-                    .function(&f)
-                    .map(|func| func.origin.as_syn())
-                    .unwrap_or_else(|| {
-                        panic!(
-                            "convert!({}).input({f}): function not found among #[prebindgen] items",
-                            key.as_str()
-                        )
-                    });
-                let (param_ty, by_ref) = convert_single_param(key, f, item_fn, "input");
+                let item_fn = registry.flat().function(&f).unwrap_or_else(|| {
+                    panic!(
+                        "convert!({}).input({f}): function not found among #[prebindgen] items",
+                        key.as_str()
+                    )
+                });
+                let (param_reading, by_ref) = convert_single_param(key, f, item_fn, "input");
+                let param_ty = spelled_ty(param_reading);
                 // Return: `T` (infallible) or `Result<T, E>` (fallible — E
                 // routes to the caller's error handler via the exc slot).
-                let ret = fn_return_type(item_fn);
-                let (ok_ty, exc) = match crate::api::core::types_util::result_ok_type(&ret) {
-                    Some(ok) => (
-                        ok,
-                        Some(
-                            crate::api::core::types_util::result_err_type(&ret)
-                                .expect("result_ok_type implies result_err_type"),
-                        ),
-                    ),
-                    None => (ret, None),
+                // Off `TypeKind::Fallible`, where `result_ok_type` /
+                // `result_err_type` each found the `Result` in a path.
+                let (ok_ty, exc) = match item_fn.ret.fallible_parts() {
+                    Some((ok, err)) => (spelled_ty(ok), Some(spelled_ty(err))),
+                    None => (spelled_ty(&item_fn.ret), None),
                 };
                 assert!(
                     TypeKey::from_type(&ok_ty) == *key,
@@ -1569,33 +1561,22 @@ impl Declarations {
         let target = decl.rust_type.spell();
         let result = match decl.output.as_ref()? {
             ConvertSpec::PrebindgenFn(g) => {
-                let item_fn = registry
-                    .flat()
-                    .function(&g)
-                    .map(|func| func.origin.as_syn())
-                    .unwrap_or_else(|| {
-                        panic!(
+                let item_fn = registry.flat().function(&g).unwrap_or_else(|| {
+                    panic!(
                         "convert!({}).output({g}): function not found among #[prebindgen] items",
                         key.as_str()
                     )
-                    });
-                let (param_ty, by_ref) = convert_single_param_any(g, item_fn);
+                });
+                let (param_reading, by_ref) = convert_single_param_any(g, item_fn);
                 assert!(
-                    TypeKey::from_type(&param_ty) == *key,
+                    param_reading.key() == *key,
                     "convert!({k}).output({g}): the function takes `{got}`, not `{k}`",
                     k = key.as_str(),
-                    got = TypeKey::from_type(&param_ty).as_str()
+                    got = param_reading.key().as_str()
                 );
-                let ret = fn_return_type(item_fn);
-                let (repr, exc) = match crate::api::core::types_util::result_ok_type(&ret) {
-                    Some(ok) => (
-                        ok,
-                        Some(
-                            crate::api::core::types_util::result_err_type(&ret)
-                                .expect("result_ok_type implies result_err_type"),
-                        ),
-                    ),
-                    None => (ret, None),
+                let (repr, exc) = match item_fn.ret.fallible_parts() {
+                    Some((ok, err)) => (spelled_ty(ok), Some(spelled_ty(err))),
+                    None => (spelled_ty(&item_fn.ret), None),
                 };
                 assert!(
                     TypeKey::from_type(&repr) != *key,
@@ -1736,49 +1717,42 @@ impl Declarations {
 
 /// The single typed parameter of a conversion fn, peeled of a leading `&`;
 /// asserts arity 1. Returns `(peeled_type, was_by_ref)`.
-fn convert_single_param_any(f: &syn::Ident, item_fn: &syn::ItemFn) -> (syn::Type, bool) {
-    let params: Vec<&syn::PatType> = item_fn
-        .sig
-        .inputs
-        .iter()
-        .filter_map(|i| match i {
-            syn::FnArg::Typed(pt) => Some(pt),
-            _ => None,
-        })
-        .collect();
+fn convert_single_param_any<'f>(
+    f: &syn::Ident,
+    item_fn: &'f crate::api::core::flat::Function,
+) -> (&'f TypeRef, bool) {
     assert!(
-        params.len() == 1,
+        item_fn.params.len() == 1,
         "convert fn `{f}` must take exactly one parameter, it takes {}",
-        params.len()
+        item_fn.params.len()
     );
-    match &*params[0].ty {
-        syn::Type::Reference(r) => ((*r.elem).clone(), true),
-        other => (other.clone(), false),
+    let ty = &item_fn.params[0].ty;
+    match ty.kind() {
+        flat::TypeKind::Ref { inner, .. } => (inner, true),
+        _ => (ty, false),
     }
 }
 
 /// [`convert_single_param_any`] + the direction-specific error context.
-fn convert_single_param(
+fn convert_single_param<'f>(
     key: &TypeKey,
     f: &syn::Ident,
-    item_fn: &syn::ItemFn,
+    item_fn: &'f crate::api::core::flat::Function,
     dir: &str,
-) -> (syn::Type, bool) {
+) -> (&'f TypeRef, bool) {
     let (ty, by_ref) = convert_single_param_any(f, item_fn);
     assert!(
-        TypeKey::from_type(&ty) != *key,
+        ty.key() != *key,
         "convert!({k}).{dir}({f}): the function must take the converted form, not `{k}` itself",
         k = key.as_str()
     );
     (ty, by_ref)
 }
 
-/// A fn's return type (`()` for none).
-fn fn_return_type(item_fn: &syn::ItemFn) -> syn::Type {
-    match &item_fn.sig.output {
-        syn::ReturnType::Default => syn::parse_quote!(()),
-        syn::ReturnType::Type(_, t) => (**t).clone(),
-    }
+/// A reading spelled back as a `syn::Type` — the source's own tokens, re-parsed.
+fn spelled_ty(t: &TypeRef) -> syn::Type {
+    let toks = t.spell();
+    syn::parse_quote!(#toks)
 }
 
 impl Declarations {


### PR DESCRIPTION
Part of the `syntax → model` transition (umbrella #314).

## The same code, in both adapters

`.convert(...)` (cbindgen) and `convert!(...)` (jnigen) accept a declaration naming a `#[prebindgen]` fn that performs a conversion. Both fetched that fn's whole `syn::ItemFn` — an **item escape** each — to ask two questions of it:

```rust
-fn one_param(item: &syn::ItemFn) -> (syn::Type, bool) {
-    let params: Vec<_> = item.sig.inputs.iter()
-        .filter_map(|p| if let syn::FnArg::Typed(p) = p { Some(&*p.ty) } else { None })
-        .collect();
-    assert_eq!(params.len(), 1, "conversion functions take exactly one parameter");
-    match params[0] {
-        syn::Type::Reference(r) => ((*r.elem).clone(), true),
-        ty => (ty.clone(), false),
-    }
-}
+fn one_param(f: &flat::Function) -> (&TypeRef, bool) {
+    assert_eq!(f.params.len(), 1, "conversion functions take exactly one parameter");
+    let ty = &f.params[0].ty;
+    match ty.kind() {
+        TypeKind::Ref { inner, .. } => (inner, true),
+        _ => (ty, false),
+    }
+}
```

The `syn::FnArg::Typed` filter is gone because a `Param` list has no receiver in it. `fn_ret` / `fn_return_type` are `f.ret`, which the element already normalizes from an elided return to `Unit` — so their `ReturnType::Default => parse_quote!(())` arms go too.

Fifth time this transition has said "a signature is a parameter list and a return, both already classified" — S20 (`overloads`), S28 (`class_members`), S29 (`validate_constant_fn`), S39 (`emit_function_wrapper`), this.

## `fallible_parts` replaces a pair

With the return a reading, both adapters'

```rust
match result_ok_type(&ret) {
    Some(ok) => (ok, Some(result_err_type(&ret).expect("result_ok_type implies result_err_type"))),
```

becomes `match item_fn.ret.fallible_parts() { Some((ok, err)) => … }`. The `expect` was a comment on the model's own invariant, written as a runtime assertion because the two halves were separate functions. `result_err_type` loses its last caller and is deleted.

## Measurement

| | before | after |
|---|---:|---:|
| classification sites | 53 | **51** |
| escapes: types | 0 | **0** |
| escapes: items | 10 | **6** |

```
api/lang/cbindgen/convert.rs     [classification]  1 -> 0   [items]  2 -> 0
api/lang/jnigen/jni/builder.rs   [classification]  4 -> 3   [items]  2 -> 0
```

## The six that remain

They are, for the first time, all of one kind — an emitter re-stating a **whole captured item**, which the ledger header has called legitimate from the start:

* `core/write.rs` — a `Guard`'s `const _` spliced into the generated file verbatim;
* `core/prebindgen.rs` and `jnigen/jni/trait_impl.rs` — `const_path_alias` over a `Constant`'s item, re-emitting the const as an alias;
* `core/registry/scan.rs` (2) — the captured `syn::ItemFn` / `syn::ItemConst` handed to the scan;
* `cbindgen/trait_impl.rs` — `EnumValue::origin`'s **discriminant as written** (`= 0x07` stays `0x07`), which that field's own doc names as its one consumer.

Not "no accessor exists" — these want the item's *tokens*, which is what an `Origin` is for.

## Gate

- `cargo test -p prebindgen --all-features` — 638 lib, 22 doctests
- ledger regenerated, diff above
- clippy `--all-targets --all-features -D warnings` on stable **and** 1.85.0
- `cargo fmt --check` with the CI config
- `examples/regen-check.sh` — every generated artifact byte-identical