### PR TITLE
S44: the return surface reads, and a borrow annotation had no borrows

### DIFF
--- a/prebindgen/src/api/core/flat/boundary.ledger
+++ b/prebindgen/src/api/core/flat/boundary.ledger
@@ -110,7 +110,7 @@
 3	api/lang/jnigen/jni/builder.rs
 4	api/lang/jnigen/jni/emit/convert.rs
 4	api/lang/jnigen/jni/emit/flat_input.rs
-7	api/lang/jnigen/jni/emit/names.rs
+5	api/lang/jnigen/jni/emit/names.rs
 6	api/lang/jnigen/jni/emit/wrapper.rs
 1	api/lang/jnigen/jni/fold.rs
 1	api/lang/jnigen/jni/prim.rs
@@ -119,7 +119,7 @@
 2	api/lang/jnigen/jni/wire_access.rs
 1	api/lang/jnigen/util.rs
 
-# total classification sites: 51
+# total classification sites: 49
 
 ## escapes: types
 

--- a/prebindgen/src/api/lang/jnigen/jni/emit/names.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/names.rs
@@ -189,22 +189,6 @@ impl syn::visit_mut::VisitMut for QualifyLengthPaths<'_> {
     }
 }
 
-/// If `ty` is a `&T` borrow with no explicit lifetime, splice in `'<life>`.
-/// Otherwise return `ty` unchanged.
-pub(crate) fn annotate_borrow_with_lifetime(ty: &syn::Type, life: &str) -> syn::Type {
-    if let syn::Type::Reference(r) = ty {
-        if r.lifetime.is_none() {
-            let mut new = r.clone();
-            new.lifetime = Some(syn::Lifetime::new(
-                &format!("'{}", life),
-                proc_macro2::Span::call_site(),
-            ));
-            return syn::Type::Reference(new);
-        }
-    }
-    ty.clone()
-}
-
 /// If `ty` is `JObject` / `JString` / `JByteArray` (no explicit angle args),
 /// splice in `<'<life>>`. Otherwise return `ty` unchanged.
 pub(crate) fn annotate_jobject_with_lifetime(ty: &syn::Type, life: &str) -> syn::Type {

--- a/prebindgen/src/api/lang/jnigen/jni/fn_plan.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/fn_plan.rs
@@ -790,14 +790,8 @@ fn build_output(
     // for a convert, else the signature's own output. (Not `target_ty`: the
     // Kotlin error peel rides the entry's `value_rust_type`, so the full
     // `Result<T, E>` type is looked up as written.)
-    let ret_decl: syn::ReturnType = if is_convert {
-        let t = target_ty.spell();
-        syn::parse_quote!(-> #t)
-    } else {
-        let ret = f.ret.spell();
-        syn::parse_quote!(-> #ret)
-    };
-    let (surface, canonical) = ReturnSurface::classify(ext, registry, &ret_decl);
+    let ret_decl = if is_convert { target_ty } else { &f.ret };
+    let (surface, canonical) = ReturnSurface::classify(ext, registry, ret_decl);
     let is_enum = ext.is_kotlin_enum(&canonical);
     let is_option_enum = crate::api::core::types_util::option_inner_type(&canonical)
         .map(|inner| ext.is_kotlin_enum(&inner))
@@ -821,28 +815,35 @@ impl ReturnSurface {
     pub fn classify(
         ext: &Declarations,
         registry: &impl Conversions<KotlinMeta>,
-        output: &syn::ReturnType,
+        ret: &crate::api::core::flat::TypeRef,
     ) -> (Self, syn::Type) {
-        let ty = match output {
-            syn::ReturnType::Default => return (Self::Unit, syn::parse_quote!(())),
-            syn::ReturnType::Type(_, t) => &**t,
-        };
-        let outer_meta = registry
-            .reading_of(ty)
-            .and_then(|tr| registry.output_entry(&tr))
-            .map(|e| e.metadata.clone());
+        // The RETURN, as the model classified it. Both callers used to spell a
+        // reading into a `-> #ty` fragment for this to take apart again, and
+        // the `ReturnType::Default` arm was a unit the element already states.
+        let outer_meta = registry.output_entry(ret).map(|e| e.metadata.clone());
         // Unit returns (incl. `ZResult<()>`, whose inner identity rides
         // `value_rust_type`) declare no Kotlin return type. The peeled type is
         // the one the converter's metadata stored — a canonical `syn::Type`,
         // so nothing is rebuilt here. Falling back to the declared return is
         // not a miss: `value_rust_type` is `None` exactly for plain values and
         // arity-0 converters, which have no inner identity to peel to.
-        let canonical: syn::Type = outer_meta
-            .as_ref()
-            .and_then(|m| m.value_rust_type.as_ref())
-            .cloned()
-            .unwrap_or_else(|| ty.clone());
-        if crate::api::lang::jnigen::util::is_unit(&canonical) {
+        //
+        // `value_rust_type` is a canonical `syn::Type` the ADAPTER composed,
+        // which is why `is_unit` still asks it of a node; with no metadata the
+        // question is the reading's own kind.
+        let stored = outer_meta.as_ref().and_then(|m| m.value_rust_type.as_ref());
+        let is_unit = match stored {
+            Some(t) => crate::api::lang::jnigen::util::is_unit(t),
+            None => matches!(ret.kind(), crate::api::core::flat::TypeKind::Unit),
+        };
+        let canonical: syn::Type = match stored {
+            Some(t) => t.clone(),
+            None => {
+                let toks = ret.spell();
+                syn::parse_quote!(#toks)
+            }
+        };
+        if is_unit {
             return (Self::Unit, canonical);
         }
         // Projection return (opaque handle or `ULong`): read the folded

--- a/prebindgen/src/api/lang/jnigen/jni/render.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/render.rs
@@ -2023,12 +2023,7 @@ pub(crate) fn unfold_leaf_kt(
     let builder_kt = if ext.is_kotlin_enum_reading(out_ty) {
         kt::KtType::int()
     } else {
-        // `classify_return` still takes a signature fragment, so the reading is
-        // spelled here — the source's own tokens, as generated Rust always
-        // spells.
-        let spelled = out_ty.spell();
-        let rt: syn::ReturnType = syn::parse_quote!(-> #spelled);
-        classify_return(ext, &rt, registry)?.0?
+        classify_return(ext, out_ty, registry)?.0?
     };
     let (mut wire_kt, wrap) = if is_value_projection {
         let p = proj.as_ref().unwrap();
@@ -2135,7 +2130,7 @@ pub(crate) fn kotlin_for_wire(wire: &syn::Type) -> Option<kt::KtType> {
 ///   plain non-projection returns.
 pub(crate) fn classify_return(
     ext: &Declarations,
-    output: &syn::ReturnType,
+    output: &crate::api::core::flat::TypeRef,
     registry: &impl Conversions<KotlinMeta>,
 ) -> Option<(
     Option<kt::KtType>,

--- a/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
@@ -44,10 +44,20 @@ fn generated_converter_attr() -> syn::Attribute {
 // ──────────────────────────────────────────────────────────────────────
 
 impl Declarations {
-    /// Build the standard JNI input-converter `fn`. Body assumes in-scope
-    /// `env: &mut JNIEnv` and `v: &<wire>` (or `v: <wire>` for raw-pointer
-    /// wires); produces a value of `rust`. Returned function has its name
-    /// already set per the JNI plugin's naming convention.
+    /// Build the standard JNI input-converter `fn` for a Rust type this
+    /// **adapter composed**. Body assumes in-scope `env: &mut JNIEnv` and
+    /// `v: &<wire>` (or `v: <wire>` for raw-pointer wires); produces a value of
+    /// `rust`. Returned function has its name already set per the JNI plugin's
+    /// naming convention.
+    ///
+    /// There are three composed types: `impl Fn(..)` for a callback, `String`
+    /// for the `str` terminal (which yields an owned value the call site
+    /// borrows), and `Vec<T>` for the `&[T]` parameter, likewise. None is a
+    /// borrow, which is why this spells its input verbatim — there is no `&_`
+    /// to splice `'env` into. [`Self::build_input_fn_of`] is the door that
+    /// annotates, and it does so off `TypeKind::Ref`, where
+    /// `annotate_borrow_with_lifetime` matched a `syn::Type::Reference` and
+    /// rebuilt it.
     ///
     /// `exc` ties the body convention to the `Result`'s Rust error type:
     /// * `None` → signature `Result<rust, __JniErr>` and the body is
@@ -55,7 +65,7 @@ impl Declarations {
     /// * `Some(E)` → signature `Result<rust, E>` and the body is emitted
     ///   as-is — `<body>` already evaluates to that `Result`, so no `Ok`
     ///   wrap. `E` is the raw error type peeled from a `Result<T, E>`.
-    pub(crate) fn build_input_fn(
+    pub(crate) fn build_input_fn_composed(
         &self,
         rust: &syn::Type,
         wire: &syn::Type,
@@ -63,8 +73,7 @@ impl Declarations {
         exc: Option<&syn::Type>,
     ) -> syn::ItemFn {
         let spelled = rust.to_token_stream();
-        let rust_with_lifetime = annotate_borrow_with_lifetime(rust, "env").to_token_stream();
-        self.build_input_fn_parts(&spelled, &rust_with_lifetime, wire, body, exc)
+        self.build_input_fn_parts(&spelled, &spelled, wire, body, exc)
     }
 
     /// [`Self::build_input_fn`] for a caller holding the **reading** of the Rust
@@ -865,7 +874,7 @@ impl Declarations {
     ) -> syn::ItemFn {
         match produced {
             Produced::Reading(r) => self.build_input_fn_of(r, wire, body, exc),
-            Produced::Composed(t) => self.build_input_fn(t, wire, body, exc),
+            Produced::Composed(t) => self.build_input_fn_composed(t, wire, body, exc),
         }
     }
 
@@ -1704,7 +1713,7 @@ impl Declarations {
         Some(ConverterImpl {
             subs: vec![],
             pre_stages: vec![],
-            function: self.build_input_fn(&outer_ty, &wire, &body, None),
+            function: self.build_input_fn_composed(&outer_ty, &wire, &body, None),
             destination: wire,
             niches,
             metadata: self.framework_meta(Some(kt::KtType::any())),
@@ -2171,7 +2180,7 @@ impl Declarations {
             return Some(ConverterImpl {
                 subs: vec![],
                 pre_stages: vec![],
-                function: self.build_input_fn(&rust_ty, &wire, &body, None),
+                function: self.build_input_fn_composed(&rust_ty, &wire, &body, None),
                 destination: wire,
                 niches,
                 metadata: self.framework_meta(kotlin_name),


### PR DESCRIPTION
Part of the `syntax → model` transition (umbrella #314).

## `ReturnSurface::classify`

It took a `syn::ReturnType`, matched `ReturnType::Default` for a unit, and looked the reading **back up** from the node inside it:

```rust
-let ty = match output {
-    syn::ReturnType::Default => return (Self::Unit, syn::parse_quote!(())),
-    syn::ReturnType::Type(_, t) => &**t,
-};
-let outer_meta = registry.reading_of(ty).and_then(|tr| registry.output_entry(&tr))…
+let outer_meta = registry.output_entry(ret).map(|e| e.metadata.clone());
```

Both callers built that node by spelling a reading they already held (`syn::parse_quote!(-> #spelled)`), so the fragment existed only to be taken apart again. `classify_return` follows it.

`is_unit` stays, for the metadata case and only that. The split is now explicit:

```rust
let is_unit = match stored {
    Some(t) => util::is_unit(t),                       // value_rust_type: adapter-composed node
    None    => matches!(ret.kind(), TypeKind::Unit),   // the reading's own kind
};
```

## A borrow annotation with no borrows

`annotate_borrow_with_lifetime` splices `'env` into a `&_` that has no lifetime. After S34 split the converter builders, it was reached from exactly one place: `build_input_fn`'s **node** front door — whose three callers compose `impl Fn(..) + Send + Sync + 'static`, `String`, and `Vec<T>`.

**None of them is a borrow.** It never fired.

Deleted. The door is renamed `build_input_fn_composed`, so the constraint lives in the name — an assertion would have been a counted classification site, which is the wrong trade for stating an invariant. `build_input_fn_of` is the door that annotates, and it does so off `TypeKind::Ref { lifetime, mutable, inner }`.

**Byte-identical artifacts is the evidence for "never fired"** — the annotation affects the emitted signature, so any composed type that had been a borrow would show as a diff.

## Measurement

| | before | after |
|---|---:|---:|
| classification sites | 51 | **49** |
| escapes: types | 0 | **0** |
| escapes: items | 6 | 6 |

```
api/lang/jnigen/jni/emit/names.rs  7 -> 5
```

## The jnigen classification count is now irreducible

Every remaining site in that adapter is one of two things, and neither was ever the model's to answer:

* a **wire** — `entry.destination`, a `jlong` / `JObject` / `*mut` this adapter composed. `emit/convert.rs` (4), `emit/wrapper.rs` (6), `emit/flat_input.rs` (4), `wire_access.rs` (2), `prim.rs`, `render.rs`, `fold.rs`, `emit/names.rs`'s `annotate_jobject_with_lifetime` + `wire_short`, `trait_impl.rs`;
* a **build-script declaration's own `syn::Type`** — `builder.rs`'s `check_local_field_ty` (a `LocalField::Local` signature) and `emit/wrapper.rs`'s `validate_constant_expr` peel, both already labelled in place as the #280 category.

The two `syn::Expr` sites in `emit/names.rs` are the array-length whitelist S29 narrowed to the model's own two accepted forms.

## Gate

- `cargo test -p prebindgen --all-features` — 638 lib, 22 doctests
- ledger regenerated, diff above
- clippy `--all-targets --all-features -D warnings` on stable **and** 1.85.0 (`doc_lazy_continuation` on the merged doc block, fixed)
- `cargo fmt --check` with the CI config
- `examples/regen-check.sh` — every generated artifact byte-identical