### PR TITLE
S46: the scan reads, and the item floor is accounted too

### DIFF
--- a/prebindgen/src/api/core/flat/boundary.ledger
+++ b/prebindgen/src/api/core/flat/boundary.ledger
@@ -37,12 +37,23 @@
 #                       row is a consumer taking a node the model can answer
 #                       for, and the fix is to ask the model
 #   ## escapes: items   `f.origin.as_syn()`, `enum_item()`
-#                                             — expected to persist
+#                                             — persists, and is ACCOUNTED:
+#                       an emitter re-stating a whole item verbatim, nothing
+#                       else
 #
 # A type escape is a source type the model should have been able to answer for.
 # There are none: every consumer outside `core::flat` reads `kind`, spells
-# `spell()`, or looks up a `TypeKey`. An item escape is a captured item's own
-# node, which an emitter re-stating a whole item legitimately needs.
+# `spell()`, or looks up a `TypeKey`.
+#
+# An item escape is a captured item's own node, which an emitter re-stating a
+# whole item verbatim legitimately needs — and that is the ONLY reason it is
+# legitimate. Taking an item to read a FACT off it (a name, a type, a signature)
+# is a missing accessor. `ITEM_FLOOR` says per file which of the two it is, and
+# `the_item_floor_is_accounted_for` fails on an unaccounted file or a stale
+# entry, exactly as `FLOOR` does below. Two `registry/scan.rs` sites sat in this
+# count for forty-five stages reading a signature and a const's type: the header
+# called the whole population `expected to persist` and nothing checked which
+# sites had earned it (S46).
 #
 # So the classification sites above are a DIFFERENT POPULATION — one this
 # transition never had to remove, because it was never the model's to answer
@@ -145,9 +156,8 @@
 
 ## escapes: items
 1	api/core/prebindgen.rs
-2	api/core/registry/scan.rs
 1	api/core/write.rs
 1	api/lang/cbindgen/trait_impl.rs
 1	api/lang/jnigen/jni/trait_impl.rs
 
-# total escapes: items: 6
+# total escapes: items: 4

--- a/prebindgen/src/api/core/flat/boundary.rs
+++ b/prebindgen/src/api/core/flat/boundary.rs
@@ -133,12 +133,23 @@ const HEADER: &str = "\
 #                       row is a consumer taking a node the model can answer
 #                       for, and the fix is to ask the model
 #   ## escapes: items   `f.origin.as_syn()`, `enum_item()`
-#                                             — expected to persist
+#                                             — persists, and is ACCOUNTED:
+#                       an emitter re-stating a whole item verbatim, nothing
+#                       else
 #
 # A type escape is a source type the model should have been able to answer for.
 # There are none: every consumer outside `core::flat` reads `kind`, spells
-# `spell()`, or looks up a `TypeKey`. An item escape is a captured item's own
-# node, which an emitter re-stating a whole item legitimately needs.
+# `spell()`, or looks up a `TypeKey`.
+#
+# An item escape is a captured item's own node, which an emitter re-stating a
+# whole item verbatim legitimately needs — and that is the ONLY reason it is
+# legitimate. Taking an item to read a FACT off it (a name, a type, a signature)
+# is a missing accessor. `ITEM_FLOOR` says per file which of the two it is, and
+# `the_item_floor_is_accounted_for` fails on an unaccounted file or a stale
+# entry, exactly as `FLOOR` does below. Two `registry/scan.rs` sites sat in this
+# count for forty-five stages reading a signature and a const's type: the header
+# called the whole population `expected to persist` and nothing checked which
+# sites had earned it (S46).
 #
 # So the classification sites above are a DIFFERENT POPULATION — one this
 # transition never had to remove, because it was never the model's to answer
@@ -734,6 +745,73 @@ const FLOOR: &[(&str, Floor)] = &[
     ("api/lang/jnigen/jni/wire_access.rs", Floor::Wire),
     ("api/lang/jnigen/util.rs", Floor::GeneratedSignature),
 ];
+
+/// Why each file still takes a captured item's own node.
+///
+/// The header has called this population "expected to persist" from the start,
+/// and that was right about the shape and silent about which sites qualify —
+/// which is how two `registry/scan.rs` sites sat here for forty-five stages
+/// reading a *fact off* an item rather than re-stating one (S46).
+///
+/// So it is accounted the same way [`FLOOR`] accounts the other census, and
+/// [`the_item_floor_is_accounted_for`] enforces it. There is exactly one
+/// legitimate reason, which is why this is a list and not an enum: an emitter
+/// re-states a **whole captured item verbatim**, tokens and all. Anything that
+/// takes an item to read one field off it is a missing accessor, and belongs in
+/// the model instead.
+const ITEM_FLOOR: &[(&str, &str)] = &[
+    (
+        "api/core/prebindgen.rs",
+        "`const_path_alias` re-emits a captured `const` as an alias — attrs,          vis, ident and type spliced verbatim",
+    ),
+    (
+        "api/core/write.rs",
+        "a `Guard`'s `const _` is spliced into the generated file as written",
+    ),
+    (
+        "api/lang/cbindgen/trait_impl.rs",
+        "the C mirror re-states an `EnumValue`'s discriminant AS WRITTEN          (`= 0x07` stays `0x07`) — the one consumer `EnumValue::origin` exists          for, and its own doc says so",
+    ),
+    (
+        "api/lang/jnigen/jni/trait_impl.rs",
+        "`const_path_alias` again, on the JNI side",
+    ),
+];
+
+/// Every file that still takes an item node is accounted for in [`ITEM_FLOOR`],
+/// and every entry there still takes one.
+///
+/// Same two directions as [`the_classification_floor_is_accounted_for`], for
+/// the same reason: a stale entry would let a new item escape land in that file
+/// and inherit an account written for something else.
+#[test]
+fn the_item_floor_is_accounted_for() {
+    let found = scan_tree(&src_root());
+    let accounted: std::collections::BTreeSet<&str> =
+        ITEM_FLOOR.iter().map(|(path, _)| *path).collect();
+
+    let unaccounted: Vec<&String> = found
+        .iter()
+        .filter(|(path, c)| c.escape_item > 0 && !accounted.contains(path.as_str()))
+        .map(|(path, _)| path)
+        .collect();
+    let stale: Vec<&&str> = accounted
+        .iter()
+        .filter(|p| found.get(**p).is_none_or(|c| c.escape_item == 0))
+        .collect();
+
+    assert!(
+        unaccounted.is_empty() && stale.is_empty(),
+        "ITEM FLOOR DRIFT\n\
+         \x20 unaccounted (takes an item node, no `ITEM_FLOOR` entry): {unaccounted:?}\n\
+         \x20 stale (`ITEM_FLOOR` entry, no longer takes one): {stale:?}\n\n\
+         An item escape is legitimate for ONE reason: an emitter re-stating a \
+         whole captured item verbatim, tokens and all. Taking an item to read a \
+         FACT off it — a name, a type, a signature — is a missing accessor, and \
+         the model is where it belongs. If this is the verbatim case, say so in \
+         `ITEM_FLOOR` in this commit.\n"
+    );
+}
 
 /// Every file that still classifies is accounted for in [`FLOOR`], and every
 /// entry there still classifies.

--- a/prebindgen/src/api/core/registry/scan.rs
+++ b/prebindgen/src/api/core/registry/scan.rs
@@ -106,12 +106,8 @@ impl<M> Registry<M> {
 
         // Scan declared functions.
         for ident in &declared.functions {
-            if let Some(item_fn) = self
-                .flat
-                .function(&ident)
-                .map(|f| f.origin.as_syn().clone())
-            {
-                self.scan_fn_signature(&item_fn)?;
+            if let Some(func) = self.flat.function(&ident).cloned() {
+                self.scan_fn_signature(&func)?;
             } else {
                 missing.push(("function", ident.to_string()));
             }
@@ -130,12 +126,10 @@ impl<M> Registry<M> {
         // Scan declared consts: a const is a nullary source of its type, so
         // the type is required in the output direction only.
         for ident in declared.consts.iter().flatten() {
-            if let Some(item_const) = self
-                .flat
-                .constant(&ident)
-                .map(|c| c.origin.as_syn().clone())
-            {
-                self.intern(Direction::Output, &item_const.ty, true)?;
+            // The const's own TYPE, which the element carries. This cloned the
+            // whole `syn::ItemConst` to reach `.ty`.
+            if let Some(ty) = self.flat.constant(&ident).map(|c| c.ty.clone()) {
+                self.intern_reading(Direction::Output, &ty, true);
             } else {
                 missing.push(("constant", ident.to_string()));
             }
@@ -199,30 +193,32 @@ impl<M> Registry<M> {
         Ok(())
     }
 
-    pub(super) fn scan_fn_signature(&mut self, f: &syn::ItemFn) -> Result<(), ScanError> {
+    pub(super) fn scan_fn_signature(
+        &mut self,
+        f: &crate::api::core::flat::Function,
+    ) -> Result<(), ScanError> {
         // Mechanical: register every fn-signature type as the user wrote it.
         // No semantic transformations (no &T→T strip, no ZResult<T>→T strip,
         // no skip for () / ZResult<()>). The adapter handles structural
         // wrappers; propagation through `subs` then marks transitive deps
         // (e.g. &Foo's `&_` converter returns subs=[Foo], so Foo becomes
         // required).
+        //
+        // The ELEMENT. A signature is a parameter list and a return, both
+        // already classified — so the readings here are the ones `flat`
+        // produced, not ones re-derived by interning a spelling. Two arms this
+        // used to carry are gone with the node: `FnArg::Receiver`, which the
+        // comment below says can never arrive, and `ReturnType::Default`, which
+        // the element normalizes to `TypeKind::Unit`.
+        //
         // No receiver or non-ident pattern can reach here: a captured item was
         // refused by the frontend and `from_flat` failed before indexing it, and
         // a binding-local fn was checked against the same grammar
         // (`Flat::lower_signature`) when `resolve` synthesized it.
-        for input in &f.sig.inputs {
-            match input {
-                syn::FnArg::Receiver(_) => continue,
-                syn::FnArg::Typed(pt) => {
-                    self.intern_recursive(Direction::Input, &pt.ty, true)?;
-                }
-            }
+        for p in &f.params {
+            self.intern_recursive_reading(Direction::Input, &p.ty, true);
         }
-        let ret_ty: syn::Type = match &f.sig.output {
-            syn::ReturnType::Default => syn::parse_quote!(()),
-            syn::ReturnType::Type(_, ty) => (**ty).clone(),
-        };
-        self.intern_recursive(Direction::Output, &ret_ty, true)?;
+        self.intern_recursive_reading(Direction::Output, &f.ret, true);
         Ok(())
     }
 
@@ -406,23 +402,6 @@ impl<M> Registry<M> {
             })?;
         self.ensure_entry(dir, &reading, root);
         Ok(reading)
-    }
-
-    /// [`intern`](Self::intern), then register every nested position — the
-    /// recursive door, for a spelling whose children must become crossings too
-    /// (a parameter, a return, a declared field).
-    ///
-    /// Only the top type is classified: the walk below it takes each child's
-    /// reading off the parent's, so nothing under here is re-derived.
-    pub(super) fn intern_recursive(
-        &mut self,
-        dir: Direction,
-        ty: &syn::Type,
-        root: bool,
-    ) -> Result<(), ScanError> {
-        let reading = self.intern(dir, ty, root)?;
-        self.register_type_recursive(dir, &reading, root);
-        Ok(())
     }
 
     /// [`Self::intern`] for a caller that **already holds the reading**.


### PR DESCRIPTION
Part of the `syntax → model` transition (umbrella #314). **This closes it.**

## Two sites the account was hiding

`escapes: items` has been described as "expected to persist" since the ledger was written. That was right about the shape and silent about *which sites qualify* — so two `registry/scan.rs` sites sat in it for forty-five stages without anyone looking:

```rust
-pub(super) fn scan_fn_signature(&mut self, f: &syn::ItemFn) -> Result<(), ScanError> {
-    for input in &f.sig.inputs {
-        match input {
-            syn::FnArg::Receiver(_) => continue,
-            syn::FnArg::Typed(pt) => self.intern_recursive(Direction::Input, &pt.ty, true)?,
-        }
-    }
-    let ret_ty: syn::Type = match &f.sig.output {
-        syn::ReturnType::Default => syn::parse_quote!(()),
-        syn::ReturnType::Type(_, ty) => (**ty).clone(),
-    };
-    self.intern_recursive(Direction::Output, &ret_ty, true)?;
+pub(super) fn scan_fn_signature(&mut self, f: &flat::Function) -> Result<(), ScanError> {
+    for p in &f.params {
+        self.intern_recursive_reading(Direction::Input, &p.ty, true);
+    }
+    self.intern_recursive_reading(Direction::Output, &f.ret, true);
```

Sixth instance of "a signature is a parameter list and a return" (S20, S28, S29, S39, S43). Two arms leave with the node: `FnArg::Receiver`, which the function's own comment says can never arrive, and `ReturnType::Default`, which the element normalizes to `TypeKind::Unit`.

The const scan cloned a whole `syn::ItemConst` to reach `.ty` — which is `Constant::ty`.

### `intern_recursive` is deleted

Both sites now intern the readings `flat` produced instead of re-interning a spelling, so the node door into the type table has no caller. `intern` itself stays: its remaining callers are build-script declarations, which have no reading to hand it.

## The item floor, accounted

Same treatment S45 gave the classification census — and `ITEM_FLOOR` is a list of reasons rather than an enum because there is exactly **one** legitimate reason to take an item node:

> an emitter re-stating a **whole captured item verbatim**, tokens and all. Taking an item to read a *fact* off it — a name, a type, a signature — is a missing accessor, and the model is where it belongs.

The four that qualify, each with its reason in the table: `const_path_alias` re-emitting a captured `const` as an alias (×2, both adapters), a `Guard`'s `const _` spliced as written, and the C mirror re-stating an `EnumValue`'s discriminant **as written** (`= 0x07` stays `0x07`) — the one consumer `EnumValue::origin` exists for, per its own doc.

`the_item_floor_is_accounted_for` fails both ways, verified by breaking each:

```
unaccounted (takes an item node, no `ITEM_FLOOR` entry): ["api/core/write.rs"]
stale (`ITEM_FLOOR` entry, no longer takes one): ["api/core/registry/scan.rs"]
```

## Measurement

| | before | after |
|---|---:|---:|
| classification sites | 49 | 49 |
| escapes: types | 0 | **0** |
| escapes: items | 6 | **4** |

```
api/core/registry/scan.rs  [items]  2 -> 0
```

## Where #314 stands

| count | at its floor | floor enforced |
|---|---|---|
| `escapes: types` = 0 | ✅ S38 | ✅ ledger ratchet |
| `classification sites` = 49 | ✅ | ✅ `FLOOR`, S45 |
| `escapes: items` = 4 | ✅ S46 | ✅ `ITEM_FLOOR`, S46 |

Every count is at its floor, and **every floor is enforced rather than asserted** — which is the distinction this transition kept learning the hard way: S8 claimed `api/core` was clean and it held seven escapes for twenty-five stages; S38's header edit was reverted by the next regeneration; and this stage's own two sites hid inside a population described as legitimate without saying which members were.

## Gate

- `cargo test -p prebindgen --all-features` — 640 lib (one new), 22 doctests
- ledger regenerated from `HEADER`, diff above
- clippy `--all-targets --all-features -D warnings` on stable **and** 1.85.0
- `cargo fmt --check` with the CI config
- `examples/regen-check.sh` — every generated artifact byte-identical