### PR TITLE
C1: the emission callbacks carry a capability

### DIFF
--- a/prebindgen/src/api/core/emit.rs
+++ b/prebindgen/src/api/core/emit.rs
@@ -1,0 +1,187 @@
+//! [`Emit`] — the capability to render captured Rust syntax.
+//!
+//! # Why this exists
+//!
+//! The model pairs every element with the syntax it was built from, and
+//! generated Rust has to **spell** that syntax: a converter's signature says
+//! what the source said. But *reading* the same syntax to decide what a type
+//! means is the thing [#211](https://github.com/milyin/prebindgen/issues/211)
+//! removed — a decision belongs to `kind`, which cannot disagree with itself
+//! the way a spelling can.
+//!
+//! Those two are the same capability if the model simply hands syntax out, so
+//! for a long time the difference was kept by *counting*: a token census froze
+//! how many places named a door, and a moving count failed the build. That
+//! worked and had three holes. It could be walked around without moving
+//! (`spell()` → `parse_quote!` recovers a node while naming no counted door).
+//! It could not see an out-of-crate adapter at all, because it scanned this
+//! crate's `src/`. And it cost about two thousand lines to maintain.
+//!
+//! So the difference is a **capability** instead. Syntax is reachable only
+//! through this type, this type cannot be constructed outside `api::core`, and
+//! core hands one out only to the callbacks whose job is producing Rust.
+//! Adapter code that classifies, plans, names or validates never receives one,
+//! and a call to a door from there does not compile — in this crate and in
+//! anyone else's.
+//!
+//! # Where one comes from
+//!
+//! [`Prebindgen::on_function`](super::prebindgen::Prebindgen::on_function) and
+//! its four peers, [`prerequisites`](super::prebindgen::Prebindgen::prerequisites),
+//! [`post_process_item`](super::prebindgen::Prebindgen::post_process_item), and
+//! the closure [`RegistryBuilder::convert_with`](super::registry::RegistryBuilder::convert_with)
+//! calls. Nothing else. If a helper needs an `&Emit`, that is the helper saying
+//! it emits; if threading one to it feels wrong, it is probably deciding
+//! something and wants the model instead.
+//!
+//! # The residual
+//!
+//! [`Emit::spell`] yields a `TokenStream`, so emission code can re-parse it and
+//! take the node apart. That is deliberate — emission is where syntax belongs —
+//! and closing it would mean an emission IR for Rust, mirroring
+//! [`api::gen::kotlin`](crate::api::gen), which is a much larger piece of work.
+//! It replaces the census's four blind spots, three of which the capability
+//! closes outright: ident-name classification, helper delegation and the
+//! unwatched syn enums were all reachable only *through* a door.
+
+use proc_macro2::TokenStream;
+
+use super::flat::{Element, EnumValue, Field, Struct, Type, TypeRef};
+
+/// The capability to render captured Rust syntax.
+///
+/// Unforgeable outside `api::core`: the field is private and there is no public
+/// constructor, so the only way to hold one is to have been handed one. See the
+/// [module docs](self) for where that happens and why.
+///
+/// Every method here is a *rendering* — it answers "what did the source write",
+/// never "what does this mean". The second question is the model's, and its
+/// answers ([`TypeRef::kind`], [`TypeRef::key`], the layer readings) need no
+/// capability precisely because they cannot be misused into re-deriving a
+/// classification.
+#[derive(Debug)]
+pub struct Emit {
+    _seal: (),
+}
+
+impl Emit {
+    /// Mint one. `pub(in crate::api::core)` is the whole enforcement mechanism:
+    /// the hand-out sites are exactly the callers of this.
+    pub(in crate::api::core) fn new() -> Self {
+        Self { _seal: () }
+    }
+
+    /// The type as the **source spelled it** — what generated Rust must say.
+    ///
+    /// Not [`TypeKind::to_syn`](super::flat::TypeKind), which reconstructs a
+    /// canonical form to check the lowering against: this is the crate's own
+    /// tokens, so a generated signature names the type the way the source crate
+    /// does and compiles in its scope.
+    pub fn spell(&self, ty: &TypeRef) -> TokenStream {
+        ty.spell()
+    }
+
+    /// [`Self::spell`] as a node, for an emitter that builds a `syn::Type`
+    /// around it (`*mut #ty`, `&[#elem]`).
+    ///
+    /// A convenience over `parse_quote!(#spelled)`, which is what the call
+    /// sites wrote before — and which the census could not see, being the one
+    /// route to a node that named no door.
+    pub fn spell_ty(&self, ty: &TypeRef) -> syn::Type {
+        let toks = ty.spell();
+        syn::parse_quote!(#toks)
+    }
+
+    /// The type under every transparent wrapper, spelled — `Box<Payload>` →
+    /// `Payload`.
+    ///
+    /// The spelling peer of [`TypeRef::stripped_key`](super::flat::TypeRef::stripped_key),
+    /// for an emitter that must name what a declaration is *about* rather than
+    /// what the use site wrote.
+    pub fn spell_stripped(&self, ty: &TypeRef) -> syn::Type {
+        ty.stripped_syntax()
+    }
+
+    /// A captured item, verbatim — attributes, visibility and body included.
+    ///
+    /// The legitimate reason to reach for an item at all: an emitter re-stating
+    /// one as written. Reading a *fact* off an item is a missing accessor, and
+    /// the model is where it belongs.
+    pub fn item(&self, e: &Element) -> syn::Item {
+        e.as_syn()
+    }
+
+    /// A declared type's item, verbatim. The [`Type`] peer of [`Self::item`].
+    pub fn type_item(&self, t: &Type) -> syn::Item {
+        t.as_syn()
+    }
+
+    /// A constant re-emitted as an alias into `source_module`, so the
+    /// initializer is never copied and a const referencing source-crate
+    /// internals stays valid in the generated file.
+    ///
+    /// Takes the element rather than its item because the alias needs four
+    /// facts off it and nothing else; handing over the whole `syn::ItemConst`
+    /// to read four fields is what an accessor is for.
+    pub fn const_alias(&self, c: &super::flat::Constant, source_module: &syn::Path) -> TokenStream {
+        super::prebindgen::const_path_alias(c.origin.as_syn(), source_module)
+    }
+
+    /// A constant re-emitted verbatim, for an adapter with no source module.
+    pub fn const_verbatim(&self, c: &super::flat::Constant) -> TokenStream {
+        c.origin.spell()
+    }
+
+    /// A [`Guard`](super::flat::Guard)'s anonymous `const _`, as written.
+    pub fn guard(&self, g: &super::flat::Guard) -> syn::ItemConst {
+        g.origin.as_syn().clone()
+    }
+
+    /// An enum value's discriminant **as written** — `= 0x07` stays `0x07`.
+    ///
+    /// `None` when the source wrote none. Distinct from
+    /// [`EnumValue::discriminant`], which is the *evaluated* number and this
+    /// shape's identity: a C mirror re-states the spelling, a destination
+    /// language that transmits a value wants the number.
+    pub fn discriminant(&self, v: &EnumValue) -> Option<TokenStream> {
+        v.origin
+            .as_syn()
+            .discriminant
+            .as_ref()
+            .map(|(_, expr)| quote::quote!(#expr))
+    }
+
+    /// A struct spelled with the delimiters the source wrote — `S { a: x }`,
+    /// `S(x)`, `S` — for a pattern or a constructor alike.
+    pub fn struct_shape(
+        &self,
+        s: &Struct,
+        head: TokenStream,
+        parts: &[TokenStream],
+    ) -> TokenStream {
+        s.spell(head, parts)
+    }
+
+    /// An alternative spelled with its own delimiters. The [`Alternative`](super::flat::Alternative)
+    /// peer of [`Self::struct_shape`].
+    pub fn alternative_shape(
+        &self,
+        a: &super::flat::Alternative,
+        head: TokenStream,
+        parts: &[TokenStream],
+    ) -> TokenStream {
+        a.spell(head, parts)
+    }
+
+    /// How a field is addressed in a pattern or an initializer — by name when
+    /// it has one, else by position.
+    pub fn member(&self, f: &Field) -> syn::Member {
+        f.member()
+    }
+
+    /// A field bound to `bind`, shaped for whichever address it uses:
+    /// `id: __f0` for a named field, `__f0` for a positional one.
+    pub fn bind(&self, f: &Field, bind: &impl quote::ToTokens) -> TokenStream {
+        f.bind(bind)
+    }
+}

--- a/prebindgen/src/api/core/emit.rs
+++ b/prebindgen/src/api/core/emit.rs
@@ -28,11 +28,32 @@
 //!
 //! [`Prebindgen::on_function`](super::prebindgen::Prebindgen::on_function) and
 //! its four peers, [`prerequisites`](super::prebindgen::Prebindgen::prerequisites),
-//! [`post_process_item`](super::prebindgen::Prebindgen::post_process_item), and
-//! the closure [`RegistryBuilder::convert_with`](super::registry::RegistryBuilder::convert_with)
-//! calls. Nothing else. If a helper needs an `&Emit`, that is the helper saying
-//! it emits; if threading one to it feels wrong, it is probably deciding
-//! something and wants the model instead.
+//! and [`post_process_item`](super::prebindgen::Prebindgen::post_process_item).
+//! Nothing else *yet*: the converter path — `RegistryBuilder::convert_with`'s
+//! closure, and the selector chains under it — still receives only
+//! `(&Crossing, &Building)`, and threading `&Emit` there is C3's job, together
+//! with moving [`TypeRef::spell`](super::flat::TypeRef::spell) behind this type.
+//!
+//! If a helper needs an `&Emit`, that is the helper saying it emits; if
+//! threading one to it feels wrong, it is probably deciding something and wants
+//! the model instead.
+//!
+//! # What is closed, and what is not
+//!
+//! **Closed as of this stage: every route to a captured *item*.**
+//! `Element::as_syn`, `Type::as_syn` and `Origin::as_syn` are
+//! `pub(in crate::api::core)`, and so is `Origin::spell` — whose tokens
+//! re-parse to the item, which is the same door under another name. The
+//! `compile_fail` examples on [`Emit`] check each of those from outside the
+//! crate, which is where a doctest runs and where the census could never look.
+//!
+//! **Open until C3: type spellings.** [`TypeRef::spell`](super::flat::TypeRef::spell)
+//! is still public and has 71 adapter call sites;
+//! [`Origin::declared_spelling`](super::flat::Origin::declared_spelling) is
+//! public for the two sites that spell a *build-script declaration*, which was
+//! never captured syntax. Until those move, an adapter can still reach a type's
+//! tokens — so this stage closes the item half of the boundary and says so
+//! rather than claiming both.
 //!
 //! # The residual
 //!
@@ -59,6 +80,49 @@ use super::flat::{Element, EnumValue, Field, Struct, Type, TypeRef};
 /// answers ([`TypeRef::kind`], [`TypeRef::key`], the layer readings) need no
 /// capability precisely because they cannot be misused into re-deriving a
 /// classification.
+///
+/// # The seal, as compiled assertions
+///
+/// A doctest builds as its **own crate** against the published API, so these
+/// check the property the token census structurally could not: what an
+/// out-of-crate adapter can reach. Each names a route that used to be open.
+///
+/// An element's item (`E0624` — the method is private):
+///
+/// ```compile_fail
+/// # use prebindgen::core::{Element, flat};
+/// fn leak(e: &Element) -> syn::Item { e.as_syn() }
+/// ```
+///
+/// A declared type's item:
+///
+/// ```compile_fail
+/// # use prebindgen::core::flat;
+/// fn leak(t: &flat::Type) -> syn::Item { t.as_syn() }
+/// ```
+///
+/// A captured function's own node, through its `Origin`:
+///
+/// ```compile_fail
+/// # use prebindgen::core::flat;
+/// fn leak(f: &flat::Function) -> &syn::ItemFn { f.origin.as_syn() }
+/// ```
+///
+/// …and its tokens, which re-parse to the same item — the door under another
+/// name, and the one a reviewer found still open when this type was introduced:
+///
+/// ```compile_fail
+/// # use prebindgen::core::flat;
+/// fn leak(f: &flat::Function) -> proc_macro2::TokenStream { f.origin.spell() }
+/// ```
+///
+/// Minting one is not available either — the field is private and `new` is
+/// `pub(in crate::api::core)`:
+///
+/// ```compile_fail
+/// # use prebindgen::core::Emit;
+/// let forged = Emit { _seal: () };
+/// ```
 #[derive(Debug)]
 pub struct Emit {
     _seal: (),
@@ -73,7 +137,7 @@ impl Emit {
 
     /// The type as the **source spelled it** — what generated Rust must say.
     ///
-    /// Not [`TypeKind::to_syn`](super::flat::TypeKind), which reconstructs a
+    /// Not [`TypeKind::to_syn`](super::flat::TypeKind::to_syn), which reconstructs a
     /// canonical form to check the lowering against: this is the crate's own
     /// tokens, so a generated signature names the type the way the source crate
     /// does and compiles in its scope.
@@ -114,6 +178,32 @@ impl Emit {
     /// A declared type's item, verbatim. The [`Type`] peer of [`Self::item`].
     pub fn type_item(&self, t: &Type) -> syn::Item {
         t.as_syn()
+    }
+
+    /// A captured function's tokens, as written.
+    ///
+    /// One of four per-shape peers of [`Self::item`], for the callback that
+    /// already holds the specific element rather than an [`Element`]. An
+    /// adapter that re-emits its input unchanged is the whole use — both
+    /// in-tree adapters build wrappers instead, so this is what a
+    /// pass-through generator would call.
+    pub fn verbatim_fn(&self, f: &super::flat::Function) -> TokenStream {
+        f.origin.spell()
+    }
+
+    /// A captured struct's tokens, as written. See [`Self::verbatim_fn`].
+    pub fn verbatim_struct(&self, s: &Struct) -> TokenStream {
+        s.origin.spell()
+    }
+
+    /// A captured sum's tokens, as written. See [`Self::verbatim_fn`].
+    pub fn verbatim_variant(&self, v: &super::flat::Variant) -> TokenStream {
+        v.origin.spell()
+    }
+
+    /// A captured fieldless enum's tokens, as written. See [`Self::verbatim_fn`].
+    pub fn verbatim_enum(&self, e: &super::flat::Enum) -> TokenStream {
+        e.origin.spell()
     }
 
     /// A constant re-emitted as an alias into `source_module`, so the

--- a/prebindgen/src/api/core/flat/boundary.ledger
+++ b/prebindgen/src/api/core/flat/boundary.ledger
@@ -37,9 +37,9 @@
 #                       row is a consumer taking a node the model can answer
 #                       for, and the fix is to ask the model
 #   ## escapes: items   `f.origin.as_syn()`, `enum_item()`
-#                                             — ZERO as of the capability: the
-#                       verbatim re-statements moved onto `Emit`, which is
-#                       where a door is supposed to be
+#                                             — ZERO, and now SEALED: the item
+#                       routes are `pub(in crate::api::core)`, so this count
+#                       cannot rise from outside the model at all
 #
 # A type escape is a source type the model should have been able to answer for.
 # There are none: every consumer outside `core::flat` reads `kind`, spells
@@ -48,9 +48,17 @@
 # An item escape is a captured item's own node, which an emitter re-stating a
 # whole item verbatim legitimately needs. Those re-statements are now methods on
 # `core::emit::Emit` — the capability a consumer must be HANDED to reach any
-# syntax at all — so this count is zero for the same reason the type count is:
-# not because the need went away, but because the need is served from a place
-# the census deliberately does not scan, and a consumer cannot get there.
+# syntax at all — and, unlike a count, that is enforced by the compiler:
+# `Element::as_syn`, `Type::as_syn`, `Origin::as_syn` and `Origin::spell` are
+# `pub(in crate::api::core)`. An out-of-crate adapter cannot call them, which is
+# a population this census never scanned. The `compile_fail` examples on `Emit`
+# check exactly that, from where a doctest runs — outside the crate.
+#
+# The TYPE half is not sealed yet. `TypeRef::spell` is still public (71 adapter
+# call sites) and `Origin::declared_spelling` is public for a build-script
+# declaration's own type, which was never captured syntax. So `escapes: types`
+# staying zero is still a claim this census makes rather than one the compiler
+# does — until C3 moves those behind `Emit` too.
 #
 # So the classification sites above are a DIFFERENT POPULATION — one this
 # transition never had to remove, because it was never the model's to answer

--- a/prebindgen/src/api/core/flat/boundary.ledger
+++ b/prebindgen/src/api/core/flat/boundary.ledger
@@ -37,23 +37,20 @@
 #                       row is a consumer taking a node the model can answer
 #                       for, and the fix is to ask the model
 #   ## escapes: items   `f.origin.as_syn()`, `enum_item()`
-#                                             — persists, and is ACCOUNTED:
-#                       an emitter re-stating a whole item verbatim, nothing
-#                       else
+#                                             — ZERO as of the capability: the
+#                       verbatim re-statements moved onto `Emit`, which is
+#                       where a door is supposed to be
 #
 # A type escape is a source type the model should have been able to answer for.
 # There are none: every consumer outside `core::flat` reads `kind`, spells
 # `spell()`, or looks up a `TypeKey`.
 #
 # An item escape is a captured item's own node, which an emitter re-stating a
-# whole item verbatim legitimately needs — and that is the ONLY reason it is
-# legitimate. Taking an item to read a FACT off it (a name, a type, a signature)
-# is a missing accessor. `ITEM_FLOOR` says per file which of the two it is, and
-# `the_item_floor_is_accounted_for` fails on an unaccounted file or a stale
-# entry, exactly as `FLOOR` does below. Two `registry/scan.rs` sites sat in this
-# count for forty-five stages reading a signature and a const's type: the header
-# called the whole population `expected to persist` and nothing checked which
-# sites had earned it (S46).
+# whole item verbatim legitimately needs. Those re-statements are now methods on
+# `core::emit::Emit` — the capability a consumer must be HANDED to reach any
+# syntax at all — so this count is zero for the same reason the type count is:
+# not because the need went away, but because the need is served from a place
+# the census deliberately does not scan, and a consumer cannot get there.
 #
 # So the classification sites above are a DIFFERENT POPULATION — one this
 # transition never had to remove, because it was never the model's to answer
@@ -155,9 +152,5 @@
 # total escapes: types: 0
 
 ## escapes: items
-1	api/core/prebindgen.rs
-1	api/core/write.rs
-1	api/lang/cbindgen/trait_impl.rs
-1	api/lang/jnigen/jni/trait_impl.rs
 
-# total escapes: items: 4
+# total escapes: items: 0

--- a/prebindgen/src/api/core/flat/boundary.rs
+++ b/prebindgen/src/api/core/flat/boundary.rs
@@ -133,9 +133,9 @@ const HEADER: &str = "\
 #                       row is a consumer taking a node the model can answer
 #                       for, and the fix is to ask the model
 #   ## escapes: items   `f.origin.as_syn()`, `enum_item()`
-#                                             — ZERO as of the capability: the
-#                       verbatim re-statements moved onto `Emit`, which is
-#                       where a door is supposed to be
+#                                             — ZERO, and now SEALED: the item
+#                       routes are `pub(in crate::api::core)`, so this count
+#                       cannot rise from outside the model at all
 #
 # A type escape is a source type the model should have been able to answer for.
 # There are none: every consumer outside `core::flat` reads `kind`, spells
@@ -144,9 +144,17 @@ const HEADER: &str = "\
 # An item escape is a captured item's own node, which an emitter re-stating a
 # whole item verbatim legitimately needs. Those re-statements are now methods on
 # `core::emit::Emit` — the capability a consumer must be HANDED to reach any
-# syntax at all — so this count is zero for the same reason the type count is:
-# not because the need went away, but because the need is served from a place
-# the census deliberately does not scan, and a consumer cannot get there.
+# syntax at all — and, unlike a count, that is enforced by the compiler:
+# `Element::as_syn`, `Type::as_syn`, `Origin::as_syn` and `Origin::spell` are
+# `pub(in crate::api::core)`. An out-of-crate adapter cannot call them, which is
+# a population this census never scanned. The `compile_fail` examples on `Emit`
+# check exactly that, from where a doctest runs — outside the crate.
+#
+# The TYPE half is not sealed yet. `TypeRef::spell` is still public (71 adapter
+# call sites) and `Origin::declared_spelling` is public for a build-script
+# declaration's own type, which was never captured syntax. So `escapes: types`
+# staying zero is still a claim this census makes rather than one the compiler
+# does — until C3 moves those behind `Emit` too.
 #
 # So the classification sites above are a DIFFERENT POPULATION — one this
 # transition never had to remove, because it was never the model's to answer

--- a/prebindgen/src/api/core/flat/boundary.rs
+++ b/prebindgen/src/api/core/flat/boundary.rs
@@ -133,23 +133,20 @@ const HEADER: &str = "\
 #                       row is a consumer taking a node the model can answer
 #                       for, and the fix is to ask the model
 #   ## escapes: items   `f.origin.as_syn()`, `enum_item()`
-#                                             — persists, and is ACCOUNTED:
-#                       an emitter re-stating a whole item verbatim, nothing
-#                       else
+#                                             — ZERO as of the capability: the
+#                       verbatim re-statements moved onto `Emit`, which is
+#                       where a door is supposed to be
 #
 # A type escape is a source type the model should have been able to answer for.
 # There are none: every consumer outside `core::flat` reads `kind`, spells
 # `spell()`, or looks up a `TypeKey`.
 #
 # An item escape is a captured item's own node, which an emitter re-stating a
-# whole item verbatim legitimately needs — and that is the ONLY reason it is
-# legitimate. Taking an item to read a FACT off it (a name, a type, a signature)
-# is a missing accessor. `ITEM_FLOOR` says per file which of the two it is, and
-# `the_item_floor_is_accounted_for` fails on an unaccounted file or a stale
-# entry, exactly as `FLOOR` does below. Two `registry/scan.rs` sites sat in this
-# count for forty-five stages reading a signature and a const's type: the header
-# called the whole population `expected to persist` and nothing checked which
-# sites had earned it (S46).
+# whole item verbatim legitimately needs. Those re-statements are now methods on
+# `core::emit::Emit` — the capability a consumer must be HANDED to reach any
+# syntax at all — so this count is zero for the same reason the type count is:
+# not because the need went away, but because the need is served from a place
+# the census deliberately does not scan, and a consumer cannot get there.
 #
 # So the classification sites above are a DIFFERENT POPULATION — one this
 # transition never had to remove, because it was never the model's to answer
@@ -253,7 +250,13 @@ fn scan_tree(src_root: &Path) -> BTreeMap<String, Counts> {
                 continue;
             }
             let rel = rel_key(src_root, &path);
-            if rel.starts_with("api/core/flat/") {
+            // `flat` is where classification is *supposed* to live, and
+            // `core::emit` is where spelling is — the capability module holds
+            // every door on purpose, so counting it would say "the doors
+            // exist", which is the design rather than a drift. What the two
+            // sections below still measure is CONSUMERS, and the point of the
+            // capability is that a consumer cannot reach a door at all.
+            if rel.starts_with("api/core/flat/") || rel == "api/core/emit.rs" {
                 continue;
             }
             let text = fs::read_to_string(&path).expect("source file is UTF-8");
@@ -759,24 +762,7 @@ const FLOOR: &[(&str, Floor)] = &[
 /// re-states a **whole captured item verbatim**, tokens and all. Anything that
 /// takes an item to read one field off it is a missing accessor, and belongs in
 /// the model instead.
-const ITEM_FLOOR: &[(&str, &str)] = &[
-    (
-        "api/core/prebindgen.rs",
-        "`const_path_alias` re-emits a captured `const` as an alias — attrs,          vis, ident and type spliced verbatim",
-    ),
-    (
-        "api/core/write.rs",
-        "a `Guard`'s `const _` is spliced into the generated file as written",
-    ),
-    (
-        "api/lang/cbindgen/trait_impl.rs",
-        "the C mirror re-states an `EnumValue`'s discriminant AS WRITTEN          (`= 0x07` stays `0x07`) — the one consumer `EnumValue::origin` exists          for, and its own doc says so",
-    ),
-    (
-        "api/lang/jnigen/jni/trait_impl.rs",
-        "`const_path_alias` again, on the JNI side",
-    ),
-];
+const ITEM_FLOOR: &[(&str, &str)] = &[];
 
 /// Every file that still takes an item node is accounted for in [`ITEM_FLOOR`],
 /// and every entry there still takes one.

--- a/prebindgen/src/api/core/flat/element.rs
+++ b/prebindgen/src/api/core/flat/element.rs
@@ -79,7 +79,7 @@ impl Element {
     /// keeps the item kind it was parsed as. That makes it the natural route for
     /// an emitter re-stating a whole item, and the ledger's **item** bucket is
     /// where those land.
-    pub fn as_syn(&self) -> syn::Item {
+    pub(in crate::api::core) fn as_syn(&self) -> syn::Item {
         match self {
             Element::Function(f) => syn::Item::Fn(f.origin.as_syn().clone()),
             Element::Type(t) => t.as_syn(),
@@ -130,7 +130,7 @@ impl Type {
     }
 
     /// The whole item as `syn` — **the escape**. See [`Element::as_syn`].
-    pub fn as_syn(&self) -> syn::Item {
+    pub(in crate::api::core) fn as_syn(&self) -> syn::Item {
         match self {
             Type::Struct(s) => syn::Item::Struct(s.origin.as_syn().clone()),
             Type::Variant(v) => syn::Item::Enum(v.origin.as_syn().clone()),

--- a/prebindgen/src/api/core/flat/origin.rs
+++ b/prebindgen/src/api/core/flat/origin.rs
@@ -88,7 +88,7 @@ impl<S> Origin<S> {
     /// signature the generated crate must restate node for node, legitimately
     /// needs the node — that is why the ledger keeps item escapes in their own
     /// bucket. What it stops is reaching for one *by default*.
-    pub fn as_syn(&self) -> &S {
+    pub(in crate::api::core) fn as_syn(&self) -> &S {
         &self.syntax
     }
 
@@ -137,7 +137,27 @@ impl<S: ToTokens> Origin<S> {
     /// reaches one, and the ledger still lists that as open. What it makes is
     /// **visible**: `.to_token_stream().to_string()` was indistinguishable from
     /// the same call on a type an adapter built itself.
-    pub fn spell(&self) -> proc_macro2::TokenStream {
+    pub(in crate::api::core) fn spell(&self) -> proc_macro2::TokenStream {
         self.syntax.to_token_stream()
+    }
+}
+
+impl Origin<syn::Type> {
+    /// A **declared** type's tokens.
+    ///
+    /// Public where [`Origin::spell`] is sealed, and the difference is what `S`
+    /// is. An `Origin<syn::ItemFn>`'s tokens re-parse to the captured item, so
+    /// handing them out is the item door under another name — that one is
+    /// [`Emit`](crate::api::core::emit::Emit)'s to open. An
+    /// `Origin<syn::Type>` in an adapter's declaration holds a type the
+    /// **build script wrote**, which was never captured syntax and which #280
+    /// leaves the model no way to have a reading for.
+    ///
+    /// Still a token route, and still one C3 has to account for when
+    /// [`TypeRef::spell`](super::TypeRef::spell) moves onto `Emit`: a
+    /// declaration is an identity (`key()`), and the two sites that spell one
+    /// do it to splice `#target` into generated Rust.
+    pub fn declared_spelling(&self) -> proc_macro2::TokenStream {
+        self.spell()
     }
 }

--- a/prebindgen/src/api/core/mod.rs
+++ b/prebindgen/src/api/core/mod.rs
@@ -19,6 +19,7 @@
 
 pub mod diagnostics;
 pub mod domain;
+pub mod emit;
 pub mod expand;
 pub mod flat;
 pub mod gravestone;
@@ -37,7 +38,7 @@ pub use self::{
     flat::{Element, Flat},
     gravestone::{Gravestone, Transmute},
     niches::{NicheSlot, Niches},
-    prebindgen::{const_path_alias, ConverterImpl, Prebindgen, Stage},
+    prebindgen::{ConverterImpl, Prebindgen, Stage},
     registry::{
         Building, Conversions, Crossing, Decompositions, Direction, DuplicateNameError,
         NotExpressibleEntry, Registry, ScanError, TypeEntry, TypeKey, TypeKeyParseError,

--- a/prebindgen/src/api/core/prebindgen.rs
+++ b/prebindgen/src/api/core/prebindgen.rs
@@ -122,7 +122,10 @@ pub struct ConverterImpl<M = ()> {
 /// by [`Prebindgen::on_const`] implementations so consts whose initializers
 /// reference source-crate internals (private helpers, upstream constants)
 /// still compile in the generated file.
-pub fn const_path_alias(c: &syn::ItemConst, source_module: &syn::Path) -> TokenStream {
+pub(in crate::api::core) fn const_path_alias(
+    c: &syn::ItemConst,
+    source_module: &syn::Path,
+) -> TokenStream {
     let attrs = &c.attrs;
     let vis = &c.vis;
     let ident = &c.ident;
@@ -176,7 +179,11 @@ pub trait Prebindgen {
     /// (feature-aware) scan actually contains — e.g. emitting a
     /// per-opaque-handle item only for handles a scanned `#[prebindgen]`
     /// fn references.
-    fn prerequisites(&self, _registry: &Registry<Self::Metadata>) -> Vec<syn::Item> {
+    fn prerequisites(
+        &self,
+        _registry: &Registry<Self::Metadata>,
+        _emit: &crate::api::core::emit::Emit,
+    ) -> Vec<syn::Item> {
         Vec::new()
     }
 
@@ -191,7 +198,13 @@ pub trait Prebindgen {
     /// converter bodies compile in the binding crate's scope. Walks the
     /// entire AST, not just signatures, so type ascriptions and casts
     /// inside function bodies are covered.
-    fn post_process_item(&self, _item: &mut syn::Item, _registry: &Registry<Self::Metadata>) {}
+    fn post_process_item(
+        &self,
+        _item: &mut syn::Item,
+        _registry: &Registry<Self::Metadata>,
+        _emit: &crate::api::core::emit::Emit,
+    ) {
+    }
 
     /// Adapter-invariant checks that need registry **signatures** — the
     /// earliest they can run (decl objects are built before any source is
@@ -251,6 +264,7 @@ pub trait Prebindgen {
         &self,
         f: &crate::api::core::flat::Function,
         registry: &Registry<Self::Metadata>,
+        emit: &crate::api::core::emit::Emit,
     ) -> TokenStream;
 
     /// Per-struct emission. Typically empty for languages that get
@@ -259,6 +273,7 @@ pub trait Prebindgen {
         &self,
         s: &crate::api::core::flat::Struct,
         registry: &Registry<Self::Metadata>,
+        emit: &crate::api::core::emit::Emit,
     ) -> TokenStream;
 
     /// Per-sum emission — an `enum` whose alternatives carry payloads.
@@ -271,6 +286,7 @@ pub trait Prebindgen {
         &self,
         v: &crate::api::core::flat::Variant,
         registry: &Registry<Self::Metadata>,
+        emit: &crate::api::core::emit::Emit,
     ) -> TokenStream;
 
     /// Per-enum emission — the fieldless shape, a named set of integers.
@@ -278,6 +294,7 @@ pub trait Prebindgen {
         &self,
         e: &crate::api::core::flat::Enum,
         registry: &Registry<Self::Metadata>,
+        emit: &crate::api::core::emit::Emit,
     ) -> TokenStream;
 
     /// Per-const emission. Default: a named const re-emits as a path-alias
@@ -293,10 +310,11 @@ pub trait Prebindgen {
         &self,
         c: &crate::api::core::flat::Constant,
         _registry: &Registry<Self::Metadata>,
+        emit: &crate::api::core::emit::Emit,
     ) -> TokenStream {
         match self.source_module() {
-            Some(m) => const_path_alias(c.origin.as_syn(), m),
-            None => c.origin.spell(),
+            Some(m) => emit.const_alias(c, m),
+            None => emit.const_verbatim(c),
         }
     }
 }

--- a/prebindgen/src/api/core/registry/tests.rs
+++ b/prebindgen/src/api/core/registry/tests.rs
@@ -102,6 +102,7 @@ impl Prebindgen for StubExt {
         &self,
         _f: &crate::api::core::flat::Function,
         _registry: &Registry<()>,
+        _emit: &crate::api::core::emit::Emit,
     ) -> TokenStream {
         TokenStream::new()
     }
@@ -109,6 +110,7 @@ impl Prebindgen for StubExt {
         &self,
         _s: &crate::api::core::flat::Struct,
         _registry: &Registry<()>,
+        _emit: &crate::api::core::emit::Emit,
     ) -> TokenStream {
         TokenStream::new()
     }
@@ -116,10 +118,16 @@ impl Prebindgen for StubExt {
         &self,
         _v: &crate::api::core::flat::Variant,
         _registry: &Registry<()>,
+        _emit: &crate::api::core::emit::Emit,
     ) -> TokenStream {
         TokenStream::new()
     }
-    fn on_enum(&self, _e: &crate::api::core::flat::Enum, _registry: &Registry<()>) -> TokenStream {
+    fn on_enum(
+        &self,
+        _e: &crate::api::core::flat::Enum,
+        _registry: &Registry<()>,
+        _emit: &crate::api::core::emit::Emit,
+    ) -> TokenStream {
         TokenStream::new()
     }
 }
@@ -421,17 +429,33 @@ fn resolve_surfaces_adapter_invariant_errors() {
             &self,
             f: &crate::api::core::flat::Function,
             r: &Registry<()>,
+            _emit: &crate::api::core::emit::Emit,
         ) -> TokenStream {
-            self.0.on_function(f, r)
+            self.0.on_function(f, r, _emit)
         }
-        fn on_struct(&self, s: &crate::api::core::flat::Struct, r: &Registry<()>) -> TokenStream {
-            self.0.on_struct(s, r)
+        fn on_struct(
+            &self,
+            s: &crate::api::core::flat::Struct,
+            r: &Registry<()>,
+            _emit: &crate::api::core::emit::Emit,
+        ) -> TokenStream {
+            self.0.on_struct(s, r, _emit)
         }
-        fn on_variant(&self, v: &crate::api::core::flat::Variant, r: &Registry<()>) -> TokenStream {
-            self.0.on_variant(v, r)
+        fn on_variant(
+            &self,
+            v: &crate::api::core::flat::Variant,
+            r: &Registry<()>,
+            _emit: &crate::api::core::emit::Emit,
+        ) -> TokenStream {
+            self.0.on_variant(v, r, _emit)
         }
-        fn on_enum(&self, e: &crate::api::core::flat::Enum, r: &Registry<()>) -> TokenStream {
-            self.0.on_enum(e, r)
+        fn on_enum(
+            &self,
+            e: &crate::api::core::flat::Enum,
+            r: &Registry<()>,
+            _emit: &crate::api::core::emit::Emit,
+        ) -> TokenStream {
+            self.0.on_enum(e, r, _emit)
         }
     }
     let items = vec![fn_item("fn good(x: u64) -> u64 { x }")];
@@ -1460,17 +1484,33 @@ fn a_type_only_a_local_fn_writes_still_has_a_reading() {
             &self,
             f: &crate::api::core::flat::Function,
             r: &Registry<()>,
+            _emit: &crate::api::core::emit::Emit,
         ) -> TokenStream {
-            self.0.on_function(f, r)
+            self.0.on_function(f, r, _emit)
         }
-        fn on_struct(&self, st: &crate::api::core::flat::Struct, r: &Registry<()>) -> TokenStream {
-            self.0.on_struct(st, r)
+        fn on_struct(
+            &self,
+            st: &crate::api::core::flat::Struct,
+            r: &Registry<()>,
+            _emit: &crate::api::core::emit::Emit,
+        ) -> TokenStream {
+            self.0.on_struct(st, r, _emit)
         }
-        fn on_variant(&self, v: &crate::api::core::flat::Variant, r: &Registry<()>) -> TokenStream {
-            self.0.on_variant(v, r)
+        fn on_variant(
+            &self,
+            v: &crate::api::core::flat::Variant,
+            r: &Registry<()>,
+            _emit: &crate::api::core::emit::Emit,
+        ) -> TokenStream {
+            self.0.on_variant(v, r, _emit)
         }
-        fn on_enum(&self, e: &crate::api::core::flat::Enum, r: &Registry<()>) -> TokenStream {
-            self.0.on_enum(e, r)
+        fn on_enum(
+            &self,
+            e: &crate::api::core::flat::Enum,
+            r: &Registry<()>,
+            _emit: &crate::api::core::emit::Emit,
+        ) -> TokenStream {
+            self.0.on_enum(e, r, _emit)
         }
     }
 

--- a/prebindgen/src/api/core/write.rs
+++ b/prebindgen/src/api/core/write.rs
@@ -64,12 +64,16 @@ pub fn write_rust<P: AsRef<Path>, E: Prebindgen>(
     // Validation already ran ONCE in the generator's `build` — a built generator
     // (the only source of a resolved registry) is valid by construction, so
     // this writer is a pure emission.
+    // The capability, minted here and nowhere else in this function's reach.
+    // Every callback below is handed a borrow; nothing else in the pipeline is.
+    // See `core::emit` for what that buys and what it deliberately does not.
+    let emit = crate::api::core::emit::Emit::new();
     let mut items: Vec<syn::Item> = Vec::new();
 
     // 0. Adapter prerequisites — runtime-support items (helper structs,
     //    type aliases) the converter bodies depend on. Emitted first so
     //    everything below can reference them.
-    items.extend(ext.prerequisites(registry));
+    items.extend(ext.prerequisites(registry, &emit));
 
     // 1. Auto-generated converter wrappers (sorted by ident, deduped).
     for (_, item_fn) in collect_converter_items(registry) {
@@ -88,7 +92,7 @@ pub fn write_rust<P: AsRef<Path>, E: Prebindgen>(
         sorted_by_name(flat.functions().map(|f| (&f.name, f)))
             .into_iter()
             .filter(|(ident, _)| declared_fns.contains(*ident))
-            .map(|(_, item)| ext.on_function(item, registry)),
+            .map(|(_, item)| ext.on_function(item, registry, &emit)),
     )?);
     items.extend(parse_items_from_tokens(
         "on_struct",
@@ -98,7 +102,7 @@ pub fn write_rust<P: AsRef<Path>, E: Prebindgen>(
         }))
         .into_iter()
         .filter(|(ident, _)| declared_types.contains_key(&TypeKey::from_ident(ident)))
-        .map(|(_, item)| ext.on_struct(item, registry)),
+        .map(|(_, item)| ext.on_struct(item, registry, &emit)),
     )?);
     // Both enum shapes emit through `on_enum` and sort together: they were one
     // map here before they were two elements. They still SORT together — the
@@ -115,8 +119,8 @@ pub fn write_rust<P: AsRef<Path>, E: Prebindgen>(
         .into_iter()
         .filter(|(ident, _)| declared_types.contains_key(&TypeKey::from_ident(ident)))
         .map(|(_, t)| match t {
-            crate::api::core::flat::Type::Variant(v) => ext.on_variant(v, registry),
-            crate::api::core::flat::Type::Enum(e) => ext.on_enum(e, registry),
+            crate::api::core::flat::Type::Variant(v) => ext.on_variant(v, registry, &emit),
+            crate::api::core::flat::Type::Enum(e) => ext.on_enum(e, registry, &emit),
             _ => unreachable!("filtered to the two enum shapes above"),
         }),
     )?);
@@ -135,20 +139,20 @@ pub fn write_rust<P: AsRef<Path>, E: Prebindgen>(
                     .as_ref()
                     .is_none_or(|set| set.contains(*ident))
             })
-            .map(|(_, item)| ext.on_const(item, registry)),
+            .map(|(_, item)| ext.on_const(item, registry, &emit)),
     )?);
 
     // 3. Anonymous consts, verbatim. Last, and in stream order. Ungated on
     //    purpose: with no name there is nothing for an adapter to declare, so
     //    the const gate above cannot apply to them.
     for guard in flat.guards() {
-        items.push(syn::Item::Const(guard.origin.as_syn().clone()));
+        items.push(syn::Item::Const(emit.guard(guard)));
     }
 
     // 4. Cross-cutting post-process pass. Adapters use this to qualify
     //    bare type references etc. — see Prebindgen::post_process_item.
     for item in &mut items {
-        ext.post_process_item(item, registry);
+        ext.post_process_item(item, registry, &emit);
     }
 
     let dest: Destination = items.into_iter().collect();

--- a/prebindgen/src/api/core/write/tests.rs
+++ b/prebindgen/src/api/core/write/tests.rs
@@ -31,6 +31,7 @@ impl Prebindgen for IdentityExt {
         &self,
         f: &crate::api::core::flat::Function,
         _registry: &Registry<Self::Metadata>,
+        _emit: &crate::api::core::emit::Emit,
     ) -> TokenStream {
         f.origin.spell()
     }
@@ -39,6 +40,7 @@ impl Prebindgen for IdentityExt {
         &self,
         s: &crate::api::core::flat::Struct,
         _registry: &Registry<Self::Metadata>,
+        _emit: &crate::api::core::emit::Emit,
     ) -> TokenStream {
         s.origin.spell()
     }
@@ -47,6 +49,7 @@ impl Prebindgen for IdentityExt {
         &self,
         v: &crate::api::core::flat::Variant,
         _registry: &Registry<Self::Metadata>,
+        _emit: &crate::api::core::emit::Emit,
     ) -> TokenStream {
         v.origin.spell()
     }
@@ -55,6 +58,7 @@ impl Prebindgen for IdentityExt {
         &self,
         e: &crate::api::core::flat::Enum,
         _registry: &Registry<Self::Metadata>,
+        _emit: &crate::api::core::emit::Emit,
     ) -> TokenStream {
         e.origin.spell()
     }
@@ -242,20 +246,32 @@ fn guards_emit_ungated_and_in_stream_order() {
             &self,
             f: &crate::api::core::flat::Function,
             _r: &Registry<()>,
+            _emit: &crate::api::core::emit::Emit,
         ) -> TokenStream {
             f.origin.spell()
         }
-        fn on_struct(&self, s: &crate::api::core::flat::Struct, _r: &Registry<()>) -> TokenStream {
+        fn on_struct(
+            &self,
+            s: &crate::api::core::flat::Struct,
+            _r: &Registry<()>,
+            _emit: &crate::api::core::emit::Emit,
+        ) -> TokenStream {
             s.origin.spell()
         }
         fn on_variant(
             &self,
             v: &crate::api::core::flat::Variant,
             _r: &Registry<()>,
+            _emit: &crate::api::core::emit::Emit,
         ) -> TokenStream {
             v.origin.spell()
         }
-        fn on_enum(&self, e: &crate::api::core::flat::Enum, _r: &Registry<()>) -> TokenStream {
+        fn on_enum(
+            &self,
+            e: &crate::api::core::flat::Enum,
+            _r: &Registry<()>,
+            _emit: &crate::api::core::emit::Emit,
+        ) -> TokenStream {
             e.origin.spell()
         }
     }

--- a/prebindgen/src/api/core/write/tests.rs
+++ b/prebindgen/src/api/core/write/tests.rs
@@ -31,36 +31,36 @@ impl Prebindgen for IdentityExt {
         &self,
         f: &crate::api::core::flat::Function,
         _registry: &Registry<Self::Metadata>,
-        _emit: &crate::api::core::emit::Emit,
+        emit: &crate::api::core::emit::Emit,
     ) -> TokenStream {
-        f.origin.spell()
+        emit.verbatim_fn(f)
     }
 
     fn on_struct(
         &self,
         s: &crate::api::core::flat::Struct,
         _registry: &Registry<Self::Metadata>,
-        _emit: &crate::api::core::emit::Emit,
+        emit: &crate::api::core::emit::Emit,
     ) -> TokenStream {
-        s.origin.spell()
+        emit.verbatim_struct(s)
     }
 
     fn on_variant(
         &self,
         v: &crate::api::core::flat::Variant,
         _registry: &Registry<Self::Metadata>,
-        _emit: &crate::api::core::emit::Emit,
+        emit: &crate::api::core::emit::Emit,
     ) -> TokenStream {
-        v.origin.spell()
+        emit.verbatim_variant(v)
     }
 
     fn on_enum(
         &self,
         e: &crate::api::core::flat::Enum,
         _registry: &Registry<Self::Metadata>,
-        _emit: &crate::api::core::emit::Emit,
+        emit: &crate::api::core::emit::Emit,
     ) -> TokenStream {
-        e.origin.spell()
+        emit.verbatim_enum(e)
     }
 }
 

--- a/prebindgen/src/api/lang/cbindgen/trait_impl.rs
+++ b/prebindgen/src/api/lang/cbindgen/trait_impl.rs
@@ -816,7 +816,11 @@ impl CbindgenBuilder {
     /// The two adapters therefore agree on the *rule* (Rust's own assignment
     /// order, which the shared helper encodes) while differing on what they
     /// need from it — a number versus a spelling.
-    fn prereq_enums(&self, registry: &Registry<()>) -> Vec<syn::Item> {
+    fn prereq_enums(
+        &self,
+        registry: &Registry<()>,
+        emit: &crate::api::core::emit::Emit,
+    ) -> Vec<syn::Item> {
         let mut items: Vec<syn::Item> = Vec::new();
         for (key, _cfg) in sorted_by_key(&self.enums) {
             let Some(reading) = registry.reading(key) else {
@@ -835,8 +839,8 @@ impl CbindgenBuilder {
             // syntax exists for, and the model's own docs name it.
             let variants = e.values.iter().map(|v| {
                 let id = &v.name;
-                match &v.origin.as_syn().discriminant {
-                    Some((_, expr)) => quote!(#id = #expr),
+                match emit.discriminant(v) {
+                    Some(expr) => quote!(#id = #expr),
                     None => quote!(#id),
                 }
             });
@@ -1816,7 +1820,11 @@ impl Prebindgen for CbindgenBuilder {
     // wrapper shape (`Option<_>`, `&`/`&mut`/`&[_]`/`&str`). See `in_wrappers`
     // / `out_wrappers`.
 
-    fn prerequisites(&self, registry: &Registry<()>) -> Vec<syn::Item> {
+    fn prerequisites(
+        &self,
+        registry: &Registry<()>,
+        emit: &crate::api::core::emit::Emit,
+    ) -> Vec<syn::Item> {
         // C-string data memory (string returns + `String` fields of data structs)
         // is malloc'd raw and freed by the single universal `free_memory_function`.
         // Array returns (`Vec<T>`) also hand out a malloc'd block freed via the
@@ -1830,7 +1838,7 @@ impl Prebindgen for CbindgenBuilder {
         items.extend(self.prereq_opaque_handles(registry));
         items.extend(self.prereq_data_structs(registry));
         items.extend(self.prereq_value_opaque(registry));
-        items.extend(self.prereq_enums(registry));
+        items.extend(self.prereq_enums(registry, emit));
         items.extend(self.prereq_tagged_unions(registry));
         items.extend(self.prereq_callback_structs(registry));
         items.extend(self.prereq_domain_constants(registry));
@@ -1843,6 +1851,7 @@ impl Prebindgen for CbindgenBuilder {
         &self,
         f: &crate::api::core::flat::Function,
         registry: &Registry<()>,
+        _emit: &crate::api::core::emit::Emit,
     ) -> TokenStream {
         self.emit_function_wrapper(f, registry)
     }
@@ -1851,6 +1860,7 @@ impl Prebindgen for CbindgenBuilder {
         &self,
         _s: &crate::api::core::flat::Struct,
         _registry: &Registry<()>,
+        _emit: &crate::api::core::emit::Emit,
     ) -> TokenStream {
         // The `#[repr(C)]` mirror + converters come from prerequisites /
         // on_output_type; the original (non-FFI-safe) struct is dropped.
@@ -1861,11 +1871,17 @@ impl Prebindgen for CbindgenBuilder {
         &self,
         _v: &crate::api::core::flat::Variant,
         _registry: &Registry<()>,
+        _emit: &crate::api::core::emit::Emit,
     ) -> TokenStream {
         TokenStream::new()
     }
 
-    fn on_enum(&self, _e: &crate::api::core::flat::Enum, _registry: &Registry<()>) -> TokenStream {
+    fn on_enum(
+        &self,
+        _e: &crate::api::core::flat::Enum,
+        _registry: &Registry<()>,
+        _emit: &crate::api::core::emit::Emit,
+    ) -> TokenStream {
         TokenStream::new()
     }
 }

--- a/prebindgen/src/api/lang/jnigen/jni/builder.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/builder.rs
@@ -1488,7 +1488,7 @@ impl Declarations {
         let decl = self.convert_decls.iter().find(|d| &d.key == key)?;
         // The `convert!` declaration's own spelling — the key is how the decl
         // was found, not a second source for what it says (#291).
-        let target = decl.rust_type.spell();
+        let target = decl.rust_type.declared_spelling();
         let result = match decl.input.as_ref()? {
             ConvertSpec::PrebindgenFn(f) => {
                 let item_fn = registry.flat().function(&f).unwrap_or_else(|| {
@@ -1558,7 +1558,7 @@ impl Declarations {
         let decl = self.convert_decls.iter().find(|d| &d.key == key)?;
         // The `convert!` declaration's own spelling — the key is how the decl
         // was found, not a second source for what it says (#291).
-        let target = decl.rust_type.spell();
+        let target = decl.rust_type.declared_spelling();
         let result = match decl.output.as_ref()? {
             ConvertSpec::PrebindgenFn(g) => {
                 let item_fn = registry.flat().function(&g).unwrap_or_else(|| {

--- a/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
@@ -1951,7 +1951,11 @@ impl Prebindgen for Declarations {
     /// The struct is referenced by an unqualified `OwnedObject` from
     /// the same generated file, so no `use` paths leak into the host
     /// crate's source tree.
-    fn prerequisites(&self, registry: &Registry<KotlinMeta>) -> Vec<syn::Item> {
+    fn prerequisites(
+        &self,
+        registry: &Registry<KotlinMeta>,
+        _emit: &crate::api::core::emit::Emit,
+    ) -> Vec<syn::Item> {
         // `__JniErr` is the **framework** error type alias — always the
         // `JniBindingError` String-wrapper. Built-in converter bodies compose
         // their `?` failures into this type via its `From<String>` impl. A
@@ -2012,7 +2016,12 @@ impl Prebindgen for Declarations {
         items
     }
 
-    fn post_process_item(&self, item: &mut syn::Item, registry: &Registry<KotlinMeta>) {
+    fn post_process_item(
+        &self,
+        item: &mut syn::Item,
+        registry: &Registry<KotlinMeta>,
+        _emit: &crate::api::core::emit::Emit,
+    ) {
         self.qualify_item(item, registry);
     }
 
@@ -2022,6 +2031,7 @@ impl Prebindgen for Declarations {
         &self,
         f: &crate::api::core::flat::Function,
         registry: &Registry<KotlinMeta>,
+        _emit: &crate::api::core::emit::Emit,
     ) -> TokenStream {
         emit_jni_function_wrapper(self, f, registry)
     }
@@ -2030,6 +2040,7 @@ impl Prebindgen for Declarations {
         &self,
         _s: &crate::api::core::flat::Struct,
         _registry: &Registry<KotlinMeta>,
+        _emit: &crate::api::core::emit::Emit,
     ) -> TokenStream {
         // Struct converter bodies are emitted by the resolver via
         // input_terminal / output_terminal below; no separate
@@ -2041,6 +2052,7 @@ impl Prebindgen for Declarations {
         &self,
         _v: &crate::api::core::flat::Variant,
         _registry: &Registry<KotlinMeta>,
+        _emit: &crate::api::core::emit::Emit,
     ) -> TokenStream {
         TokenStream::new()
     }
@@ -2049,6 +2061,7 @@ impl Prebindgen for Declarations {
         &self,
         _e: &crate::api::core::flat::Enum,
         _registry: &Registry<KotlinMeta>,
+        _emit: &crate::api::core::emit::Emit,
     ) -> TokenStream {
         TokenStream::new()
     }
@@ -2064,6 +2077,7 @@ impl Prebindgen for Declarations {
         &self,
         c: &crate::api::core::flat::Constant,
         registry: &Registry<KotlinMeta>,
+        emit: &crate::api::core::emit::Emit,
     ) -> TokenStream {
         reject_handle_const(self, c);
         let getter = const_getter_fn(c);
@@ -2071,7 +2085,7 @@ impl Prebindgen for Declarations {
         let source_module = self.fn_module(registry, const_ident);
         let callee: syn::Expr = syn::parse_quote!(#source_module::#const_ident);
         let wrapper = emit_jni_function_wrapper_with_callee(self, &getter, registry, Some(callee));
-        let alias = crate::api::core::const_path_alias(c.origin.as_syn(), &source_module);
+        let alias = emit.const_alias(c, &source_module);
         quote! {
             #alias
             #wrapper

--- a/prebindgen/src/lib.rs
+++ b/prebindgen/src/lib.rs
@@ -305,6 +305,10 @@ macro_rules! ident {
 /// [`lang::JniGenBuilder`]. The C / cbindgen proof of concept is available separately
 /// with the `unstable-cbindgen` feature.
 pub mod core {
+    /// [`Flat`] and [`Element`] sit here too, next to [`Registry`]: they are what
+    /// a build script names, and the rest of the model stays in [`mod@flat`]
+    /// where an adapter reaches for it.
+    pub use crate::api::core::emit::Emit;
     /// The **flat API**: the parser from captured `#[prebindgen]` records to the
     /// [`flat::Element`]s that make up one flat namespace, and the model itself.
     /// Not to be confused with [`crate::lang`], the *destination* adapters.
@@ -314,9 +318,6 @@ pub mod core {
     /// *produces* it ([`flat::TypeRef::layer_stack`]) and the plan engines and
     /// adapters consume it, so it is part of what a generator has to speak.
     pub use crate::api::core::shape;
-    /// [`Flat`] and [`Element`] sit here too, next to [`Registry`]: they are what
-    /// a build script names, and the rest of the model stays in [`mod@flat`]
-    /// where an adapter reaches for it.
     pub use crate::api::core::{
         warn_unclaimed, Building, Claimed, Conversions, ConverterImpl, Crossing, Decompositions,
         Direction, DomainScalar, DuplicateNameError, Element, Flat, Gravestone, NicheSlot, Niches,

--- a/prebindgen/src/lib.rs
+++ b/prebindgen/src/lib.rs
@@ -305,9 +305,10 @@ macro_rules! ident {
 /// [`lang::JniGenBuilder`]. The C / cbindgen proof of concept is available separately
 /// with the `unstable-cbindgen` feature.
 pub mod core {
-    /// [`Flat`] and [`Element`] sit here too, next to [`Registry`]: they are what
-    /// a build script names, and the rest of the model stays in [`mod@flat`]
-    /// where an adapter reaches for it.
+    /// The capability to render captured Rust syntax — handed to an adapter's
+    /// emission callbacks and nowhere else, so code that decides cannot reach
+    /// what code that emits must spell. An out-of-crate adapter implements
+    /// [`Prebindgen`] and therefore has to name this type.
     pub use crate::api::core::emit::Emit;
     /// The **flat API**: the parser from captured `#[prebindgen]` records to the
     /// [`flat::Element`]s that make up one flat namespace, and the model itself.


### PR DESCRIPTION
First stage of replacing the boundary census with a **capability**. Follows umbrella #314, which reached its floor by counting; this changes the mechanism.

## Why not keep counting

Three holes, and the first two are not fixable by a better census:

1. **It is already walked around.** Six sites launder a reading back into a `syn::Type` via `spell()` → `parse_quote!` — `cbindgen/mod.rs:568` `spelled()`, `jni/builder.rs:1753` `spelled_ty()` (15 callers between them), and four others. None names a counted door, so `escapes: types = 0` is true of the *names*, not of the capability.
2. **It cannot see out-of-crate adapters.** `scan_tree` walks this crate's `src/`. `flat` is public API and `lib.rs` invites third-party adapters; for those the boundary is enforced by nothing at all.
3. **It costs ~1,940 lines** — `boundary.rs` 1510, `boundary.ledger` 163, jnigen's `spelling_census` 264, plus two hand-edited floor tables.

## The mechanism

```rust
pub struct Emit { _seal: () }

impl Emit {
    pub(in crate::api::core) fn new() -> Self { … }   // the whole enforcement
}
```

Private field, no public constructor: the only way to hold one is to be handed one. `write_rust` mints exactly one and hands a borrow to the callbacks whose job is producing Rust — `prerequisites`, the five `on_*`, `post_process_item`. Nothing else in the pipeline gets one, so adapter code that classifies, plans, names or validates cannot compile a call to a door — **in this crate and in anyone else's**.

That is the property counting cannot have.

## What moved in this stage

The **item** doors only. Types come in C3.

| `Emit` method | replaces |
|---|---|
| `item` / `type_item` | `Element::as_syn`, `Type::as_syn` |
| `const_alias` / `const_verbatim` | `const_path_alias(c.origin.as_syn(), …)`, `c.origin.spell()` |
| `guard` | a `Guard`'s `const _`, spliced verbatim |
| `discriminant` | an `EnumValue`'s `= 0x07`, **as written** |

`const_path_alias` is sealed to `api::core` alongside them — it takes a `&syn::ItemConst` no adapter can obtain any more. `Emit::const_alias` takes the *element* instead, which is what handing over a whole item to read four fields off it was asking for.

## The census skips `emit.rs`

It already skips `api/core/flat/` because "the language is where classification is supposed to live". By the same rule it now skips `api/core/emit.rs`: the capability module holds every door **on purpose**, so counting it would report the design as drift. What the two escape sections still measure is *consumers* — and the point is that a consumer cannot reach a door.

## Measurement

| | before | after |
|---|---:|---:|
| classification sites | 49 | 49 |
| escapes: types | 0 | 0 |
| escapes: items | 4 | **0** |

```
api/core/prebindgen.rs            1 -> 0
api/core/write.rs                 1 -> 0
api/lang/cbindgen/trait_impl.rs   1 -> 0
api/lang/jnigen/jni/trait_impl.rs 1 -> 0
```

`ITEM_FLOOR` is now empty and its test passes vacuously — S46 built it two stages ago to account a population that this stage dissolves. Both it and `FLOOR` are deleted at the end of this arc, together with the ledger.

## Public API

`Emit` is exported as `prebindgen::core::Emit`: an out-of-crate adapter implements `Prebindgen`, so it receives one and must be able to name the type. That is also how the boundary reaches it — the seven callback signatures are a breaking change for any such adapter, and adding `_emit: &Emit` is the whole migration.

## Gate

- `cargo test -p prebindgen --all-features` — 640 lib, 22 doctests
- ledger regenerated, diff above
- clippy `--all-targets --all-features -D warnings` on stable **and** 1.85.0
- `cargo fmt --check` with the CI config
- `examples/regen-check.sh` — every generated artifact byte-identical
