### PR TITLE
C2: a diagnostic is not an emission

### DIFF
--- a/prebindgen/src/api/core/flat/ty.rs
+++ b/prebindgen/src/api/core/flat/ty.rs
@@ -98,6 +98,23 @@ pub struct TypeRef {
     pub(super) origin: Origin<syn::Type>,
 }
 
+impl fmt::Display for TypeRef {
+    /// The type as the source wrote it, **for a message**.
+    ///
+    /// Diagnostics are not emission: a panic naming an unsupported type is
+    /// decision code reporting why it decided, and it must not need the
+    /// [`Emit`](crate::api::core::emit::Emit) capability to say so. So this is
+    /// ungated where [`spell`](Self::spell) is not.
+    ///
+    /// **Not a spelling.** It renders the same tokens today, and nothing should
+    /// depend on that: re-parsing a message is not a supported route to a node,
+    /// and the reason it is not is that a message is allowed to get friendlier.
+    /// Generated Rust spells through `Emit`.
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.spell())
+    }
+}
+
 impl TypeRef {
     /// What the type means. **Classify off this**, never off the spelling.
     ///

--- a/prebindgen/src/api/lang/cbindgen/trait_impl.rs
+++ b/prebindgen/src/api/lang/cbindgen/trait_impl.rs
@@ -589,7 +589,7 @@ impl CbindgenBuilder {
                         "Cbindgen: field `{}` of data struct `{}` has unsupported type `{}`",
                         fname,
                         type_short(&reading.key()),
-                        fty.spell()
+                        fty
                     )
                 });
                 field_defs.push(quote!(pub #fname: #wire));
@@ -682,7 +682,7 @@ impl CbindgenBuilder {
                                  opaque pointer `Option<Box<T>>`/`Box<T>` with `T` an `opaque_ptr`)",
                                 fname,
                                 type_short(&reading.key()),
-                                fty.spell()
+                                fty
                             )
                         });
                         quote!(pub #fname: #wire)
@@ -1054,8 +1054,7 @@ impl CbindgenBuilder {
                     panic!(
                         "Cbindgen: data-struct field `{}` of type `{}` is owning but has no \
                          release form (expected a `String` or a declared `tagged_union`)",
-                        fname,
-                        fty.spell(),
+                        fname, fty,
                     )
                 }
             });

--- a/prebindgen/src/api/lang/jnigen/jni/builder.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/builder.rs
@@ -909,7 +909,7 @@ impl Declarations {
                 "expand_return!({}).fields(fields!({func})): `{func}` returns `{}`, which is \
                  not a struct — a value form returns a struct whose fields become the leaves",
                 key.as_str(),
-                ret.spell(),
+                ret,
             )
         };
         let st = st.clone();

--- a/prebindgen/src/api/lang/jnigen/jni/emit/callback.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/callback.rs
@@ -419,7 +419,7 @@ pub(crate) fn reject_vec_of_handle(
                 "JniGen: `Vec<{}>` is unsupported — its elements would be closeable native \
                  handles (jlong) the JVM must free individually. Expose a per-element \
                  accessor instead of returning a `Vec` of handles.",
-                elem.spell(),
+                elem,
             );
         }
     }

--- a/prebindgen/src/api/lang/jnigen/jni/emit/wrapper.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/wrapper.rs
@@ -416,7 +416,7 @@ pub(crate) fn emit_jni_function_wrapper_with_callee(
                      Reserved rather than refused for good: rebuilding through every \
                      transparent wrapper is #292 item 3 — until then, spell the return \
                      without it.",
-                    delivered.spell(),
+                    delivered,
                     delivered.erased_wrappers().join("<"),
                 )
             });

--- a/prebindgen/src/api/lang/jnigen/jni/render.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/render.rs
@@ -2263,7 +2263,7 @@ fn shape_notes(
         .collect();
     plans.sort_by_key(|(p, _)| p.to_string());
     for (param, plan) in plans {
-        let target = plan.target.spell().to_string();
+        let target = plan.target.to_string();
         let arms: Vec<String> = plan
             .variants
             .iter()
@@ -2300,7 +2300,7 @@ fn shape_notes(
     }
 
     if let Some(plan) = registry.unfold_plans().get(fn_ident) {
-        let source = plan.source.spell().to_string();
+        let source = plan.source.to_string();
         let leaves: Vec<&str> = plan.leaves.iter().map(|l| l.name.as_str()).collect();
         match plan.delivery {
             crate::api::core::unfold::Delivery::Callback if !leaves.is_empty() => {
@@ -2320,7 +2320,7 @@ fn shape_notes(
     }
 
     if let Some(plan) = registry.error_plans().get(fn_ident) {
-        let source = plan.source.spell().to_string();
+        let source = plan.source.to_string();
         let leaves: Vec<&str> = plan.leaves.iter().map(|l| l.name.as_str()).collect();
         notes.push(format!(
             "On a domain error `onError` receives the decomposed Rust `{source}` error \

--- a/prebindgen/src/api/lang/jnigen/jni/report.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/report.rs
@@ -218,7 +218,7 @@ impl super::JniGen {
                 .collect();
             shaped.push(format!(
                 "param `{param}` expanded from `{}` — variants [{}]",
-                plan.target.spell(),
+                plan.target,
                 variants.join(", ")
             ));
         }
@@ -226,7 +226,7 @@ impl super::JniGen {
             let leaves: Vec<&str> = plan.leaves.iter().map(|l| l.name.as_str()).collect();
             shaped.push(format!(
                 "return `{}` decomposed → [{}] ({:?} delivery)",
-                plan.source.spell(),
+                plan.source,
                 leaves.join(", "),
                 plan.delivery
             ));
@@ -235,7 +235,7 @@ impl super::JniGen {
             let leaves: Vec<&str> = plan.leaves.iter().map(|l| l.name.as_str()).collect();
             shaped.push(format!(
                 "domain error `{}` decomposed → onError [{}] (binding failures → onBindingError)",
-                plan.source.spell(),
+                plan.source,
                 leaves.join(", ")
             ));
         }

--- a/prebindgen/src/api/lang/jnigen/jni/struct_plan.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/struct_plan.rs
@@ -253,7 +253,7 @@ pub(crate) fn classify_field(
             panic!(
                 "fromParts bridge: `Vec<{}>` sealed-class field (`{owner}`) is not supported \
                  (variable arity)",
-                core.spell(),
+                core,
             );
         }
         return sum_plan_kind(
@@ -317,7 +317,7 @@ pub(crate) fn classify_field(
                 panic!(
                     "fromParts bridge: `Vec<{}>` data-class field (`{owner}`) is not supported \
                      (variable arity)",
-                    inner_ty.spell(),
+                    inner_ty,
                 );
             }
             let child_fqn = cfg

--- a/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
@@ -1763,11 +1763,8 @@ impl Prebindgen for Declarations {
                         let has_receiver =
                             func.params.iter().any(|p| &peel_receiver_key(&p.ty) == key);
                         if !has_receiver {
-                            let took: Vec<String> = func
-                                .params
-                                .iter()
-                                .map(|p| p.ty.spell().to_string())
-                                .collect();
+                            let took: Vec<String> =
+                                func.params.iter().map(|p| p.ty.to_string()).collect();
                             return Err(format!(
                                 "class `{}` method `{}`: no parameter of type `{}` — an \
                                  instance method's receiver must appear in the signature \
@@ -1798,7 +1795,7 @@ impl Prebindgen for Declarations {
                                 m.rust_ident,
                                 key.as_str(),
                                 key.as_str(),
-                                func.ret.spell()
+                                func.ret
                             ));
                         }
                     }
@@ -1839,8 +1836,7 @@ impl Prebindgen for Declarations {
                              factory can still hand back a handle. Return `{}` directly and \
                              report failure through the error channel, or model the failure \
                              as one of the sum's own variants",
-                            ok.spell(),
-                            ok.spell(),
+                            ok, ok,
                         ));
                     }
                 }
@@ -1919,10 +1915,7 @@ impl Prebindgen for Declarations {
                              those into the foreign list needs the element folder a `Vec<{}>` \
                              RETURN provides; declare the callback over one value \
                              (`impl Fn({})`) or return `Vec<{}>` instead",
-                            elem.spell(),
-                            elem.spell(),
-                            elem.spell(),
-                            elem.spell(),
+                            elem, elem, elem, elem,
                         ));
                     }
                 }


### PR DESCRIPTION
Part of the capability umbrella [#361](https://github.com/milyin/prebindgen/pull/361).

## What moved

22 sites called `spell()` to put a type into a message:

```rust
-panic!("Cbindgen: field `{}` of `{}` has unsupported type `{}`", fname, short, fty.spell())
+panic!("Cbindgen: field `{}` of `{}` has unsupported type `{}`", fname, short, fty)
```

None of them emits anything. A `panic!` naming an unsupported type is **decision code explaining why it decided**, and it must not need the emission capability to say so — otherwise every validator would have to be handed an `&Emit` and the boundary would say nothing.

So `TypeRef` gets a `Display`, ungated where `spell` is not, with its limits in the doc:

> **Not a spelling.** It renders the same tokens today, and nothing should depend on that: re-parsing a message is not a supported route to a node, and the reason it is not is that a message is allowed to get friendlier. Generated Rust spells through `Emit`.

The 22 split as 18 inside `format!`/`panic!`/`expect!` and 4 that were already `spell().to_string()` — three Kotlin doc-comment notes in `render.rs` and the "took: …" parameter list in `class_members` validation.

## Why this is its own stage

It **isolates the population C3 has to thread**. Before: 69 `spell()` calls in the adapters, of mixed intent. After: 47, all emission. C3's job is now a countable, homogeneous set rather than a set that has to be triaged while it is being threaded — and triaging it *while* threading is how you end up handing an `&Emit` to a validator because it was easier than reading the call site.

## Measurement

| | before | after |
|---|---:|---:|
| classification sites | 49 | 49 |
| escapes: types | 0 | 0 |
| escapes: items | 0 | 0 |

No ledger movement — `spell()` is not a counted door, which is the point of the umbrella. The number that moved is the one the census never tracked: **adapter `spell()` calls, 69 → 47**.

## Gate

- `cargo test -p prebindgen --all-features` — 640 lib, 27 doctests
- clippy `--all-targets --all-features -D warnings` on stable **and** 1.85.0
- `cargo fmt --check` with the CI config
- `examples/regen-check.sh` — every generated artifact byte-identical
