### PR TITLE
C3: the converter path carries the capability

### DIFF
--- a/prebindgen/src/api/core/flat/boundary.ledger
+++ b/prebindgen/src/api/core/flat/boundary.ledger
@@ -136,7 +136,7 @@
 # gaps are listed here rather than implied away.
 
 2	api/core/registry/scan.rs
-5	api/core/types_util.rs
+4	api/core/types_util.rs
 4	api/lang/cbindgen/builder.rs
 4	api/lang/cbindgen/emit.rs
 3	api/lang/cbindgen/mod.rs
@@ -153,7 +153,7 @@
 2	api/lang/jnigen/jni/wire_access.rs
 1	api/lang/jnigen/util.rs
 
-# total classification sites: 49
+# total classification sites: 48
 
 ## escapes: types
 

--- a/prebindgen/src/api/core/registry/declare.rs
+++ b/prebindgen/src/api/core/registry/declare.rs
@@ -373,11 +373,17 @@ impl<M> RegistryBuilder<M> {
         F: FnMut(
             &Crossing,
             &Building<'_, M>,
+            &crate::api::core::emit::Emit,
         ) -> Option<crate::api::core::prebindgen::ConverterImpl<M>>,
     {
+        // A converter IS generated Rust — `ConverterImpl::function` is a
+        // complete `syn::ItemFn` the adapter writes — so this closure is an
+        // emission callback and is handed the capability, exactly as the
+        // `on_*` ones are. See `core::emit`.
+        let emit = crate::api::core::emit::Emit::new();
         let order = self.derive()?.to_vec();
         for crossing in &order {
-            let conv = f(crossing, &self.view());
+            let conv = f(crossing, &self.view(), &emit);
             if let Some(c) = conv {
                 self.built
                     .insert(crossing.clone(), TypeEntry::from_converter(c));

--- a/prebindgen/src/api/core/registry/tests.rs
+++ b/prebindgen/src/api/core/registry/tests.rs
@@ -44,7 +44,9 @@ impl DeclareAndResolve<()> for RegistryBuilder<()> {
             .validate_with(&ext)?
             // The reading, not a spelling re-derived from the key: this is the
             // route a real generator takes, so the stub takes it too (#291).
-            .convert_with(|crossing, built| ext.converter(built.reading(&crossing.1)?.as_syn()))?
+            .convert_with(|crossing, built, emit| {
+                ext.converter(&emit.spell_ty(&built.reading(&crossing.1)?))
+            })?
             .build()?;
         ext.validate_resolved(&registry)
             .map_err(|message| ScanError::AdapterInvariant { message })?;

--- a/prebindgen/src/api/core/types_util.rs
+++ b/prebindgen/src/api/core/types_util.rs
@@ -75,22 +75,11 @@ pub fn result_ok_type(ty: &syn::Type) -> Option<syn::Type> {
     result_parts(ty).map(|(ok, _)| ok)
 }
 
-/// First angle-bracketed **type** argument of a path type (`T` of `Option<T>`
-/// / `Vec<T>` / `Result<T, _>`), skipping lifetime/const args. `None` when
-/// there is no type argument.
-#[cfg(feature = "unstable-cbindgen")]
-pub fn first_type_arg(ty: &syn::Type) -> Option<syn::Type> {
-    let syn::Type::Path(tp) = ty else { return None };
-    let seg = tp.path.segments.last()?;
-    let syn::PathArguments::AngleBracketed(ab) = &seg.arguments else {
-        return None;
-    };
-    ab.args.iter().find_map(|a| match a {
-        syn::GenericArgument::Type(t) => Some(t.clone()),
-        _ => None,
-    })
-}
-
+// `first_type_arg` lived here — the last generic-argument peel done off a
+// path's angle brackets. `TypeKind` names the argument of every wrapper the
+// language accepts (`Optional`, `Vec`, `Fallible`, `Named { args }`), so a
+// reading answers without one.
+//
 // `is_option_ref` lived here — `option_inner_type(ty)` then a `Type::Reference`
 // match — and decided how a handle parameter locks. Both halves read the
 // spelling, so an optional borrow behind an erased wrapper answered `false`.

--- a/prebindgen/src/api/lang/cbindgen/builder.rs
+++ b/prebindgen/src/api/lang/cbindgen/builder.rs
@@ -685,10 +685,7 @@ impl CbindgenBuilder {
         if let Some(wire) = self.value_opaque_ty_of(&key) {
             return Some((self.src_ty_of(&key), wire.clone()));
         }
-        super::r_is_scalar(elem).then(|| {
-            let s = super::spelled(elem);
-            (s.clone(), s)
-        })
+        super::scalar_ty(elem).map(|s| (s.clone(), s))
     }
 
     /// Like [`Self::src_ty`], but recurses into reference and slice element types so

--- a/prebindgen/src/api/lang/cbindgen/convert.rs
+++ b/prebindgen/src/api/lang/cbindgen/convert.rs
@@ -53,11 +53,12 @@ impl CbindgenBuilder {
         &self,
         ty: &TypeRef,
         registry: &impl Conversions<()>,
+        emit: &crate::api::core::emit::Emit,
     ) -> Option<ConverterImpl<()>> {
         let key = ty.key();
         let decl = self.convert_decls.iter().find(|d| d.key == key)?;
         let spec = decl.input.as_ref()?;
-        let (repr, conversion, fallible) = self.input_conversion(decl, spec, registry);
+        let (repr, conversion, fallible) = self.input_conversion(decl, spec, registry, emit);
         assert!(
             is_scalar(&repr),
             "Cbindgen custom representations must be C scalar types"
@@ -120,11 +121,12 @@ impl CbindgenBuilder {
         &self,
         ty: &TypeRef,
         registry: &impl Conversions<()>,
+        emit: &crate::api::core::emit::Emit,
     ) -> Option<ConverterImpl<()>> {
         let key = ty.key();
         let decl = self.convert_decls.iter().find(|d| d.key == key)?;
         let spec = decl.output.as_ref()?;
-        let (repr, conversion, fallible) = self.output_conversion(decl, spec, registry);
+        let (repr, conversion, fallible) = self.output_conversion(decl, spec, registry, emit);
         assert!(
             is_scalar(&repr),
             "Cbindgen custom representations must be C scalar types"
@@ -189,6 +191,7 @@ impl CbindgenBuilder {
         decl: &ConvertDecl,
         spec: &ConvertSpec,
         registry: &impl Conversions<()>,
+        emit: &crate::api::core::emit::Emit,
     ) -> (syn::Type, syn::Expr, bool) {
         let target = self.src_ty_of(&decl.rust_type.key());
         match spec {
@@ -198,7 +201,7 @@ impl CbindgenBuilder {
                     .function(&f)
                     .unwrap_or_else(|| panic!("Cbindgen conversion function {} was not found", f));
                 let (repr_reading, by_ref) = one_param(item);
-                let repr = spelled(repr_reading);
+                let repr = emit.spell_ty(repr_reading);
                 // The element normalizes an elided return to `Unit`, and
                 // `TypeKind::Fallible` is the `Result` `result_parts` looked for
                 // in a path.
@@ -235,6 +238,7 @@ impl CbindgenBuilder {
         decl: &ConvertDecl,
         spec: &ConvertSpec,
         registry: &impl Conversions<()>,
+        emit: &crate::api::core::emit::Emit,
     ) -> (syn::Type, syn::Expr, bool) {
         let target = self.src_ty_of(&decl.rust_type.key());
         match spec {
@@ -246,8 +250,8 @@ impl CbindgenBuilder {
                 let (param, by_ref) = one_param(item);
                 assert_eq!(param.key(), decl.key);
                 let (repr, fallible) = match item.ret.fallible_parts() {
-                    Some((ok, _)) => (spelled(ok), true),
-                    None => (spelled(&item.ret), false),
+                    Some((ok, _)) => (emit.spell_ty(ok), true),
+                    None => (emit.spell_ty(&item.ret), false),
                 };
                 let path = self.conversion_fn_path(registry, f);
                 let expr = if by_ref {

--- a/prebindgen/src/api/lang/cbindgen/emit.rs
+++ b/prebindgen/src/api/lang/cbindgen/emit.rs
@@ -251,7 +251,7 @@ impl CbindgenBuilder {
         if r_is_bool(fty) {
             return Some(bool_wire());
         }
-        r_is_scalar(fty).then(|| spelled(fty))
+        scalar_ty(fty)
     }
 
     /// True when a payload wire hands owned memory to C — a `char *` block or
@@ -401,8 +401,8 @@ impl CbindgenBuilder {
     /// separately by [`Self::restricted_validity_field`] — this function keeps
     /// answering what the layout is.
     pub(super) fn mirror_field_wire(&self, fty: &TypeRef) -> Option<syn::Type> {
-        if r_is_scalar(fty) {
-            return Some(spelled(fty));
+        if let Some(t) = scalar_ty(fty) {
+            return Some(t);
         }
         if self.enums.contains_key(&fty.key()) {
             let c = self.c_type_ident(&fty.key());
@@ -486,6 +486,7 @@ impl CbindgenBuilder {
         &self,
         f: &crate::api::core::flat::Function,
         registry: &Registry<()>,
+        emit: &crate::api::core::emit::Emit,
     ) -> TokenStream {
         let orig = &f.name;
         let call_path = self.src_fn(orig);
@@ -624,7 +625,8 @@ impl CbindgenBuilder {
             },
             None => ErrRoute::Panic,
         };
-        let (in_params, decodes, call_args) = self.emit_inputs(orig, f, registry, &input_route);
+        let (in_params, decodes, call_args) =
+            self.emit_inputs(orig, f, registry, &input_route, emit);
         let call = quote!(#call_path(#(#call_args),*));
 
         let e_param = err_bits
@@ -1056,6 +1058,7 @@ impl CbindgenBuilder {
         f: &crate::api::core::flat::Function,
         registry: &Registry<()>,
         route: &ErrRoute,
+        emit: &crate::api::core::emit::Emit,
     ) -> (Vec<TokenStream>, Vec<TokenStream>, Vec<TokenStream>) {
         let mut params = Vec::new();
         // The alias preflight runs BEFORE every decode, which is the whole
@@ -1067,7 +1070,7 @@ impl CbindgenBuilder {
         for param in &f.params {
             let ident = &param.name;
             let arg_reading = &param.ty;
-            let arg_ty = &spelled(arg_reading);
+            let arg_ty = &emit.spell_ty(arg_reading);
 
             // `&[E]` slice (scalar `E`): two wire params (`*const E`, `usize`),
             // decoded zero-copy. NULL pointer ⇒ empty slice (not an error).

--- a/prebindgen/src/api/lang/cbindgen/mod.rs
+++ b/prebindgen/src/api/lang/cbindgen/mod.rs
@@ -108,7 +108,7 @@ use quote::{format_ident, quote, ToTokens};
 // remain — a build-script declaration, and a converter's own generated
 // signature.
 pub(crate) use crate::api::core::types_util::{
-    first_type_arg, is_result_type as is_result, path_tail_ident as type_path_tail, result_parts,
+    is_result_type as is_result, path_tail_ident as type_path_tail, result_parts,
 };
 use crate::api::{
     core::{
@@ -570,12 +570,6 @@ fn spelled(t: &TypeRef) -> syn::Type {
     syn::parse_quote!(#toks)
 }
 
-/// [`spelled`] under its historical name, for the identity converters whose
-/// `destination` IS the Rust type they pass through.
-fn spelled_ty(t: &TypeRef) -> syn::Type {
-    spelled(t)
-}
-
 /// `String`, off the classification.
 fn r_is_string(t: &TypeRef) -> bool {
     matches!(t.kind(), TypeKind::String)
@@ -589,6 +583,21 @@ fn r_is_str(t: &TypeRef) -> bool {
 /// `bool`, off the classification — the one scalar with a restricted domain.
 fn r_is_bool(t: &TypeRef) -> bool {
     matches!(t.kind(), TypeKind::Scalar(ScalarKind::Bool))
+}
+
+/// A scalar's Rust type, built from its **kind**.
+///
+/// A scalar's spelling is its name — `ScalarKind::as_str` is the closed set the
+/// source can have written — so this needs no captured syntax and no `Emit`.
+/// Three wire policies asked `spelled()` for exactly this behind an
+/// `r_is_scalar` guard, which was a source spelling standing in for an
+/// identity that could answer.
+fn scalar_ty(t: &TypeRef) -> Option<syn::Type> {
+    let TypeKind::Scalar(k) = t.kind() else {
+        return None;
+    };
+    let id = syn::Ident::new(k.as_str(), proc_macro2::Span::call_site());
+    Some(syn::parse_quote!(#id))
 }
 
 /// An FFI-safe scalar primitive, off the classification. `ScalarKind` IS the
@@ -617,24 +626,6 @@ fn r_boxed_inner(t: &TypeRef) -> Option<&TypeRef> {
 
 fn is_string(ty: &syn::Type) -> bool {
     type_path_tail(ty).map(|i| i == "String").unwrap_or(false)
-}
-
-/// If `ty` is `MaybeUninit<T>` (any path form: `MaybeUninit` / `std::mem::…` /
-/// `core::mem::…`), return `T` — the inner of an uninitialized out-param slot.
-fn maybe_uninit_inner(ty: &syn::Type) -> Option<syn::Type> {
-    if type_path_tail(ty)
-        .map(|i| i == "MaybeUninit")
-        .unwrap_or(false)
-    {
-        return first_type_arg(ty);
-    }
-    None
-}
-
-/// Whether `ty` is `bool` — the one scalar whose domain is restricted (`0`/`1`),
-/// so C-supplied bytes may not be held in it without being normalised first.
-fn is_bool(ty: &syn::Type) -> bool {
-    type_path_tail(ty).map(|i| i == "bool").unwrap_or(false)
 }
 
 /// The C wire for a `bool` in any position C can write: `MaybeUninit<bool>`.

--- a/prebindgen/src/api/lang/cbindgen/selector.rs
+++ b/prebindgen/src/api/lang/cbindgen/selector.rs
@@ -10,8 +10,9 @@ impl CbindgenBuilder {
         &self,
         ty: &TypeRef,
         registry: &impl Conversions<()>,
+        emit: &crate::api::core::emit::Emit,
     ) -> Option<ConverterImpl<()>> {
-        self.in_custom(ty, registry)
+        self.in_custom(ty, registry, emit)
             .or_else(|| self.in_opaque_handle(ty))
             .or_else(|| self.in_data_struct(ty, registry))
             .or_else(|| self.in_value_opaque(ty, registry))
@@ -30,8 +31,9 @@ impl CbindgenBuilder {
         &self,
         ty: &TypeRef,
         registry: &impl Conversions<()>,
+        emit: &crate::api::core::emit::Emit,
     ) -> Option<ConverterImpl<()>> {
-        self.out_custom(ty, registry)
+        self.out_custom(ty, registry, emit)
             .or_else(|| self.out_terminal(ty, registry))
             .or_else(|| self.out_wrappers(ty, registry))
     }

--- a/prebindgen/src/api/lang/cbindgen/trait_impl.rs
+++ b/prebindgen/src/api/lang/cbindgen/trait_impl.rs
@@ -423,7 +423,8 @@ impl CbindgenBuilder {
             return None;
         }
         let name = Self::in_name_of(&ty.key());
-        let spelled = ty.spell();
+        // A scalar's spelling is its name, so this needs no captured syntax.
+        let spelled = scalar_ty(ty)?;
         let function: syn::ItemFn = syn::parse_quote!(
             #[allow(non_snake_case, unused_variables, dead_code)]
             pub(crate) fn #name(v: #spelled) -> #spelled {
@@ -432,7 +433,7 @@ impl CbindgenBuilder {
         );
         Some(ConverterImpl {
             subs: vec![],
-            destination: spelled_ty(ty),
+            destination: spelled.clone(),
             function,
             pre_stages: vec![],
             niches: Niches::empty(),
@@ -1000,7 +1001,7 @@ impl CbindgenBuilder {
                         Some(n) => format!(".{n}"),
                         None => String::new(),
                     },
-                    field.ty.spell(),
+                    field.ty,
                     reason,
                 )
             })
@@ -1060,8 +1061,7 @@ impl CbindgenBuilder {
             });
             return quote!(#(#frees)*);
         }
-        let inner = spelled(r_boxed_inner(fty).unwrap_or(fty));
-        let src_inner = self.src_ty(&inner);
+        let src_inner = self.src_ty_of(&r_boxed_inner(fty).unwrap_or(fty).key());
         quote!(
             if !(*#binding).is_null() {
                 drop(::std::boxed::Box::from_raw(*#binding as *mut #src_inner));
@@ -1602,7 +1602,7 @@ impl CbindgenBuilder {
         let registry = self
             .declare_into(registry)?
             .validate_with(&self)?
-            .convert_with(|crossing, built| self.convert_crossing(crossing, built))?
+            .convert_with(|crossing, built, emit| self.convert_crossing(crossing, built, emit))?
             .build()?;
         self.validate_resolved(&registry)
             .map_err(|message| crate::core::ScanError::AdapterInvariant { message })?;
@@ -1617,6 +1617,7 @@ impl CbindgenBuilder {
         &self,
         crossing: &Crossing,
         built: &Building<'_, ()>,
+        emit: &crate::api::core::emit::Emit,
     ) -> Option<ConverterImpl<()>> {
         let (dir, key) = crossing;
         // The reading the scan already took for this crossing, fetched by the
@@ -1626,13 +1627,13 @@ impl CbindgenBuilder {
         // The selectors take the reading now, so nothing here spells it.
         let ty = built.reading(key)?;
         match dir {
-            Direction::Input => self.select_input_type(&ty, built).or_else(|| {
+            Direction::Input => self.select_input_type(&ty, built, emit).or_else(|| {
                 // The callback's arguments off the model's own `Callback` kind,
                 // where `extract_fn_trait_args` re-read the parameter's bounds.
                 let args = ty.callback_args()?;
                 self.dispatch_fn_input(args, built)
             }),
-            Direction::Output => self.select_output_type(&ty, built),
+            Direction::Output => self.select_output_type(&ty, built, emit),
         }
     }
 
@@ -1850,9 +1851,9 @@ impl Prebindgen for CbindgenBuilder {
         &self,
         f: &crate::api::core::flat::Function,
         registry: &Registry<()>,
-        _emit: &crate::api::core::emit::Emit,
+        emit: &crate::api::core::emit::Emit,
     ) -> TokenStream {
-        self.emit_function_wrapper(f, registry)
+        self.emit_function_wrapper(f, registry, emit)
     }
 
     fn on_struct(
@@ -1937,7 +1938,7 @@ impl CbindgenBuilder {
         // FFI-safe scalar (`bool`, integers, floats): identity pass-through.
         if r_is_scalar(ty) {
             let name = Self::out_name_of(&ty.key());
-            let spelled = ty.spell();
+            let spelled = scalar_ty(ty)?;
             let function: syn::ItemFn = syn::parse_quote!(
                 #[allow(non_snake_case, unused_variables, dead_code)]
                 pub(crate) fn #name(v: #spelled) -> #spelled {
@@ -1946,7 +1947,7 @@ impl CbindgenBuilder {
             );
             return Some(ConverterImpl {
                 subs: vec![],
-                destination: spelled_ty(ty),
+                destination: spelled.clone(),
                 function,
                 pre_stages: vec![],
                 niches: Niches::empty(),
@@ -2233,7 +2234,10 @@ impl CbindgenBuilder {
         else {
             return None;
         };
-        let elem = spelled(rf_inner);
+        // The borrow's target, as a reading — every use below is its identity
+        // or its source path, both of which the model answers.
+        let elem = rf_inner;
+
         // `&[E]` slice: marker only — the two-param (`*const E_wire`, `usize`)
         // lowering is done structurally in `emit_inputs`. A scalar `E` crosses as
         // itself (`*const E`); a declared inline-opaque by-value `E` (e.g. a
@@ -2241,7 +2245,7 @@ impl CbindgenBuilder {
         // `&[E]` zero-copy. `subs` marks `E`'s input required so its mirror /
         // prerequisites are emitted.
         if !*rf_mut {
-            if let Some(e) = r_shared_slice_elem(ty).map(spelled) {
+            if let Some(e) = r_shared_slice_elem(ty) {
                 // #170, the slice instance. The two-param lowering builds the
                 // `&[E]` zero-copy from C's own block, so there is nowhere to
                 // normalise the bytes: `&[bool]` would materialise every
@@ -2249,7 +2253,7 @@ impl CbindgenBuilder {
                 // not a fix here — the callee wants `&[bool]`, and rebuilding
                 // the block would silently drop the zero-copy contract this
                 // path exists for. Rejected until a raw-wire lowering exists.
-                if is_bool(&e) {
+                if r_is_bool(e) {
                     panic!(
                         "Cbindgen: `&[bool]` cannot cross IN from C. A `bool` slice is \
                          reinterpreted zero-copy from the caller's block, so a byte outside \
@@ -2258,32 +2262,30 @@ impl CbindgenBuilder {
                          `opaque_ptr` handle."
                     );
                 }
-                if is_scalar(&e) {
-                    let name =
-                        format_ident!("__cbg_inmark_slice_{}", sanitize(&TypeKey::from_type(&e)));
+                if let Some(e_ty) = scalar_ty(e) {
+                    let name = format_ident!("__cbg_inmark_slice_{}", sanitize(&e.key()));
                     let function: syn::ItemFn = syn::parse_quote!(
                         #[allow(non_snake_case, dead_code, unused)]
                         pub(crate) fn #name() {}
                     );
                     return Some(ConverterImpl {
-                        subs: vec![TypeKey::from_type(&e)],
-                        destination: syn::parse_quote!(*const #e),
+                        subs: vec![e.key()],
+                        destination: syn::parse_quote!(*const #e_ty),
                         function,
                         pre_stages: vec![],
                         niches: Niches::empty(),
                         metadata: (),
                     });
                 }
-                if let Some(counterpart) = self.value_opaque_ty(&e) {
+                if let Some(counterpart) = self.value_opaque_ty_of(&e.key()) {
                     let counterpart = counterpart.clone();
-                    let name =
-                        format_ident!("__cbg_inmark_slice_{}", sanitize(&TypeKey::from_type(&e)));
+                    let name = format_ident!("__cbg_inmark_slice_{}", sanitize(&e.key()));
                     let function: syn::ItemFn = syn::parse_quote!(
                         #[allow(non_snake_case, dead_code, unused)]
                         pub(crate) fn #name() {}
                     );
                     return Some(ConverterImpl {
-                        subs: vec![TypeKey::from_type(&e)],
+                        subs: vec![e.key()],
                         destination: syn::parse_quote!(*const #counterpart),
                         function,
                         pre_stages: vec![],
@@ -2315,7 +2317,7 @@ impl CbindgenBuilder {
                 }
             );
             return Some(ConverterImpl {
-                subs: vec![TypeKey::from_type(&elem)],
+                subs: vec![elem.key()],
                 destination: syn::parse_quote!(*const ::core::ffi::c_char),
                 function,
                 pre_stages: vec![],
@@ -2329,11 +2331,13 @@ impl CbindgenBuilder {
         if *rf_mut {
             // `&mut MaybeUninit<X>` (X value-opaque): out-param into uninitialized
             // memory. Rust writes via the `MaybeUninit` (no drop of the garbage slot).
-            if let Some(inner) = maybe_uninit_inner(&elem) {
-                let op = self.value_opaque_ty(&inner)?.clone();
+            // `TypeKind::Uninit` is the form `maybe_uninit_inner` matched by
+            // reading a path's tail ident.
+            if let crate::api::core::flat::TypeKind::Uninit(inner) = elem.kind() {
+                let op = self.value_opaque_ty_of(&inner.key())?.clone();
                 let name = Self::in_name_of(&ty.key());
-                let src = self.src_ty(&inner);
-                let short = type_short(&TypeKey::from_type(&inner));
+                let src = self.src_ty_of(&inner.key());
+                let short = type_short(&inner.key());
                 let null_ptr_msg = format!("null {short} pointer");
                 let function: syn::ItemFn = syn::parse_quote!(
                     #[allow(non_snake_case, unused_variables, dead_code)]
@@ -2349,7 +2353,7 @@ impl CbindgenBuilder {
                     }
                 );
                 return Some(ConverterImpl {
-                    subs: vec![TypeKey::from_type(&inner)],
+                    subs: vec![inner.key()],
                     destination: syn::parse_quote!(*mut #op),
                     function,
                     pre_stages: vec![],
@@ -2360,15 +2364,15 @@ impl CbindgenBuilder {
             // `&mut` opaque handle, or `&mut` value-opaque: both reinterpret the C
             // pointer as a mutable Rust reference. The wire is the handle's C struct
             // or the value-opaque mirror.
-            let wire_ty: syn::Type = if self.opaque.contains_key(&TypeKey::from_type(&elem)) {
-                let c_struct = self.c_type_ident(&TypeKey::from_type(&elem));
+            let wire_ty: syn::Type = if self.opaque.contains_key(&elem.key()) {
+                let c_struct = self.c_type_ident(&elem.key());
                 syn::parse_quote!(#c_struct)
             } else {
-                self.value_opaque_ty(&elem)?.clone()
+                self.value_opaque_ty_of(&elem.key())?.clone()
             };
             let name = Self::in_name_of(&ty.key());
-            let src = self.src_ty(&elem);
-            let short = type_short(&TypeKey::from_type(&elem));
+            let src = self.src_ty_of(&elem.key());
+            let short = type_short(&elem.key());
             let null_ptr_msg = format!("null {short} pointer");
             let function: syn::ItemFn = syn::parse_quote!(
                 #[allow(non_snake_case, unused_variables, dead_code)]
@@ -2384,7 +2388,7 @@ impl CbindgenBuilder {
                 }
             );
             return Some(ConverterImpl {
-                subs: vec![TypeKey::from_type(&elem)],
+                subs: vec![elem.key()],
                 destination: syn::parse_quote!(*mut #wire_ty),
                 function,
                 pre_stages: vec![],
@@ -2393,16 +2397,16 @@ impl CbindgenBuilder {
             });
         }
         // `&T` (shared borrow) of an opaque handle or value-opaque type.
-        let key1 = TypeKey::from_type(&elem);
+        let key1 = elem.key();
         let wire_ty: syn::Type = if self.opaque.contains_key(&key1) {
-            let c_struct = self.c_type_ident(&TypeKey::from_type(&elem));
+            let c_struct = self.c_type_ident(&elem.key());
             syn::parse_quote!(#c_struct)
         } else {
-            self.value_opaque_ty(&elem)?.clone()
+            self.value_opaque_ty_of(&elem.key())?.clone()
         };
         let name = Self::in_name_of(&ty.key());
-        let src = self.src_ty(&elem);
-        let short = type_short(&TypeKey::from_type(&elem));
+        let src = self.src_ty_of(&elem.key());
+        let short = type_short(&elem.key());
         let null_ptr_msg = format!("null {short} pointer");
         let function: syn::ItemFn = syn::parse_quote!(
             #[allow(non_snake_case, unused_variables, dead_code)]
@@ -2416,7 +2420,7 @@ impl CbindgenBuilder {
             }
         );
         Some(ConverterImpl {
-            subs: vec![TypeKey::from_type(&elem)],
+            subs: vec![elem.key()],
             destination: syn::parse_quote!(*const #wire_ty),
             function,
             pre_stages: vec![],

--- a/prebindgen/src/api/lang/jnigen/jni/builder.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/builder.rs
@@ -1082,7 +1082,7 @@ impl Declarations {
                         decl.func,
                         st.name,
                         dotted,
-                        probe.spell(),
+                        probe,
                     );
                     assert!(
                         field.ty.optional_inner().is_none(),
@@ -1095,7 +1095,7 @@ impl Declarations {
                         decl.func,
                         st.name,
                         dotted,
-                        probe.spell(),
+                        probe,
                         dotted,
                     );
                     // The name is the reading's, not a path taken apart to
@@ -1484,6 +1484,7 @@ impl Declarations {
         &self,
         key: &TypeKey,
         registry: &impl Conversions<KotlinMeta>,
+        emit: &crate::api::core::emit::Emit,
     ) -> Option<(syn::Type, Option<syn::Type>, syn::Expr)> {
         let decl = self.convert_decls.iter().find(|d| &d.key == key)?;
         // The `convert!` declaration's own spelling — the key is how the decl
@@ -1498,14 +1499,14 @@ impl Declarations {
                     )
                 });
                 let (param_reading, by_ref) = convert_single_param(key, f, item_fn, "input");
-                let param_ty = spelled_ty(param_reading);
+                let param_ty = emit.spell_ty(param_reading);
                 // Return: `T` (infallible) or `Result<T, E>` (fallible — E
                 // routes to the caller's error handler via the exc slot).
                 // Off `TypeKind::Fallible`, where `result_ok_type` /
                 // `result_err_type` each found the `Result` in a path.
                 let (ok_ty, exc) = match item_fn.ret.fallible_parts() {
-                    Some((ok, err)) => (spelled_ty(ok), Some(spelled_ty(err))),
-                    None => (spelled_ty(&item_fn.ret), None),
+                    Some((ok, err)) => (emit.spell_ty(ok), Some(emit.spell_ty(err))),
+                    None => (emit.spell_ty(&item_fn.ret), None),
                 };
                 assert!(
                     TypeKey::from_type(&ok_ty) == *key,
@@ -1554,6 +1555,7 @@ impl Declarations {
         &self,
         key: &TypeKey,
         registry: &impl Conversions<KotlinMeta>,
+        emit: &crate::api::core::emit::Emit,
     ) -> Option<(syn::Type, Option<syn::Type>, syn::Expr)> {
         let decl = self.convert_decls.iter().find(|d| &d.key == key)?;
         // The `convert!` declaration's own spelling — the key is how the decl
@@ -1575,8 +1577,8 @@ impl Declarations {
                     got = param_reading.key().as_str()
                 );
                 let (repr, exc) = match item_fn.ret.fallible_parts() {
-                    Some((ok, err)) => (spelled_ty(ok), Some(spelled_ty(err))),
-                    None => (spelled_ty(&item_fn.ret), None),
+                    Some((ok, err)) => (emit.spell_ty(ok), Some(emit.spell_ty(err))),
+                    None => (emit.spell_ty(&item_fn.ret), None),
                 };
                 assert!(
                     TypeKey::from_type(&repr) != *key,
@@ -1749,12 +1751,6 @@ fn convert_single_param<'f>(
     (ty, by_ref)
 }
 
-/// A reading spelled back as a `syn::Type` — the source's own tokens, re-parsed.
-fn spelled_ty(t: &TypeRef) -> syn::Type {
-    let toks = t.spell();
-    syn::parse_quote!(#toks)
-}
-
 impl Declarations {
     /// Build a `KotlinMeta` carrying just the value-context Kotlin name.
     /// Used by every built-in converter (primitives, structs, `Option<_>`,
@@ -1859,16 +1855,60 @@ impl Declarations {
     ///   [`Self::build_output_fn`]) prepended to the inner chain. Defer
     ///   (`None`) if the inner converter isn't resolved yet.
     ///
+    /// The type a `convert!` declaration's conversion chains through, by
+    /// **identity**.
+    ///
+    /// The declare-time probe: `declare_into` crosses this type and records an
+    /// edge to it, and both are identity uses. It used to call
+    /// `convert_{input,output}_body` and throw the body away — which now would
+    /// mean handing the capability to declaration code, for a spelling it
+    /// discards.
+    ///
+    /// The representation, per direction, is what those bodies return: the
+    /// input fn's **parameter** (what the wire hands in), the output fn's
+    /// **return** (what the wire gets back), and for a `Trait` spec the `repr`
+    /// the declaration states outright.
+    ///
+    /// A `TypeKey` is a normalized type, so re-parsing one is exactly what
+    /// `cross` canonicalizes to anyway.
+    pub(crate) fn convert_target(
+        &self,
+        key: &TypeKey,
+        registry: &impl Conversions<KotlinMeta>,
+        dir: Direction,
+    ) -> Option<syn::Type> {
+        let decl = self.convert_decls.iter().find(|d| &d.key == key)?;
+        let spec = match dir {
+            Direction::Input => decl.input.as_ref()?,
+            Direction::Output => decl.output.as_ref()?,
+        };
+        match spec {
+            ConvertSpec::Trait { repr, .. } => Some(repr.clone()),
+            ConvertSpec::PrebindgenFn(f) => {
+                let item_fn = registry.flat().function(f)?;
+                let reading = match dir {
+                    Direction::Input => convert_single_param_any(f, item_fn).0,
+                    Direction::Output => item_fn
+                        .ret
+                        .fallible_parts()
+                        .map_or(&item_fn.ret, |(ok, _)| ok),
+                };
+                syn::parse_str(reading.key().as_str()).ok()
+            }
+        }
+    }
+
     pub(crate) fn lookup_input(
         &self,
         outer: &crate::api::core::flat::TypeRef,
         registry: &impl Conversions<KotlinMeta>,
+        emit: &crate::api::core::emit::Emit,
     ) -> Option<ConverterImpl<KotlinMeta>> {
         // A `convert!`-declared conversion is the only thing that answers here.
         // There was a wildcard-pattern table beside it; nothing ever wrote to
         // the input half, so every lookup through it returned `None`.
         let key = outer.key();
-        let (ty, exc_ty, body) = self.convert_input_body(&key, registry)?;
+        let (ty, exc_ty, body) = self.convert_input_body(&key, registry, emit)?;
         // The closure's middle slot carries the `Result`'s raw Rust error
         // type (or `None` for the framework `__JniErr`); it feeds the
         // converter signature `Result<_, E>` directly — no registration.
@@ -1880,7 +1920,7 @@ impl Declarations {
         // (terminal) without forcing `()` either way. A non-wire `ty` that
         // isn't yet resolved defers.
         let outer_node: syn::Type = {
-            let spelled = outer.spell();
+            let spelled = emit.spell(outer);
             syn::parse_quote!(#spelled)
         };
         let is_self = TypeKey::from_type(&ty) == outer.key();
@@ -1975,9 +2015,10 @@ impl Declarations {
         &self,
         outer: &crate::api::core::flat::TypeRef,
         registry: &impl Conversions<KotlinMeta>,
+        emit: &crate::api::core::emit::Emit,
     ) -> Option<ConverterImpl<KotlinMeta>> {
         let key = outer.key();
-        let (ty, exc_ty, body) = self.convert_output_body(&key, registry)?;
+        let (ty, exc_ty, body) = self.convert_output_body(&key, registry, emit)?;
         self.build_output_converter(outer, None, ty, exc_ty, body, registry)
     }
 

--- a/prebindgen/src/api/lang/jnigen/jni/selector.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/selector.rs
@@ -44,6 +44,7 @@ impl Declarations {
         &self,
         ty: &crate::api::core::flat::TypeRef,
         registry: &impl Conversions<KotlinMeta>,
+        emit: &crate::api::core::emit::Emit,
     ) -> Option<ConverterImpl<KotlinMeta>> {
         // What the converter YIELDS: this crossing's own reading, so a
         // `Box<Option<T>>` crossing produces a `Box<Option<T>>` — the shape it
@@ -52,7 +53,7 @@ impl Declarations {
         let produced = crate::api::lang::jnigen::jni::trait_impl::Produced::Reading(ty);
 
         // 1. Terminal categories (incl. the terminal user-wrapper lookup).
-        if let Some(c) = self.input_terminal(ty, registry) {
+        if let Some(c) = self.input_terminal(ty, registry, emit) {
             return Some(c);
         }
         // 3. Built-in wrapper shapes, read one layer at a time rather than as a
@@ -70,6 +71,7 @@ impl Declarations {
                     &produced,
                     target,
                     registry,
+                    emit,
                 ) {
                     c.subs = vec![target.key()];
                     return Some(c);
@@ -88,7 +90,7 @@ impl Declarations {
                 return None;
             }
             if let Some(mut c) =
-                self.input_wrapper_shape(WrapperShape::Optional, &produced, inner, registry)
+                self.input_wrapper_shape(WrapperShape::Optional, &produced, inner, registry, emit)
             {
                 c.subs = vec![inner.key()];
                 return Some(c);
@@ -97,7 +99,7 @@ impl Declarations {
         }
         if let Some(elem) = ty.sequence_elem().filter(|_| !is_unsized_spelling(ty)) {
             if let Some(mut c) =
-                self.input_wrapper_shape(WrapperShape::Sequence, &produced, elem, registry)
+                self.input_wrapper_shape(WrapperShape::Sequence, &produced, elem, registry, emit)
             {
                 c.subs = vec![elem.key()];
                 return Some(c);
@@ -130,7 +132,7 @@ impl Declarations {
             // sub, exactly as the old syntactic slice check did.
             if !*mutable && decoded_vec_satisfies(inner) {
                 if let Some(elem) = inner.sequence_elem() {
-                    let elem_ty = elem.spell();
+                    let elem_ty = emit.spell(elem);
                     // The one place `produced` is NOT the crossing's spelling:
                     // there is no owned `[T]` to decode into, so the converter
                     // yields an owned `Vec<T>` and the call site borrows it.
@@ -146,9 +148,13 @@ impl Declarations {
                     let produced = crate::api::lang::jnigen::jni::trait_impl::Produced::Composed(
                         syn::parse_quote!(Vec<#elem_ty>),
                     );
-                    if let Some(mut c) =
-                        self.input_wrapper_shape(WrapperShape::Sequence, &produced, elem, registry)
-                    {
+                    if let Some(mut c) = self.input_wrapper_shape(
+                        WrapperShape::Sequence,
+                        &produced,
+                        elem,
+                        registry,
+                        emit,
+                    ) {
                         c.subs = vec![elem.key()];
                         return Some(c);
                     }
@@ -161,6 +167,7 @@ impl Declarations {
                 &produced,
                 inner,
                 registry,
+                emit,
             ) {
                 c.subs = vec![inner.key()];
                 return Some(c);
@@ -178,6 +185,7 @@ impl Declarations {
         &self,
         ty: &crate::api::core::flat::TypeRef,
         registry: &impl Conversions<KotlinMeta>,
+        emit: &crate::api::core::emit::Emit,
     ) -> Option<ConverterImpl<KotlinMeta>> {
         // What the converter YIELDS. This direction used to be handed only the
         // spelling — `convert_crossing` fetched the reading and threw it away —
@@ -187,7 +195,7 @@ impl Declarations {
         let produced = crate::api::lang::jnigen::jni::trait_impl::Produced::Reading(ty);
 
         // 1. Terminal categories (incl. the terminal user-wrapper lookup).
-        if let Some(c) = self.output_terminal(ty, registry) {
+        if let Some(c) = self.output_terminal(ty, registry, emit) {
             return Some(c);
         }
         // 2. `Result<T, E>`: succeeds as `T`, routes `E` to the error sink.
@@ -205,7 +213,7 @@ impl Declarations {
         //    output handler).
         if let Some(inner) = ty.optional_inner() {
             if let Some(mut c) =
-                self.output_wrapper_shape(WrapperShape::Optional, &produced, inner, registry)
+                self.output_wrapper_shape(WrapperShape::Optional, &produced, inner, registry, emit)
             {
                 c.subs = vec![inner.key()];
                 return Some(c);
@@ -214,7 +222,7 @@ impl Declarations {
         }
         if let Some(elem) = ty.sequence_elem().filter(|_| !is_unsized_spelling(ty)) {
             if let Some(mut c) =
-                self.output_wrapper_shape(WrapperShape::Sequence, &produced, elem, registry)
+                self.output_wrapper_shape(WrapperShape::Sequence, &produced, elem, registry, emit)
             {
                 c.subs = vec![elem.key()];
                 return Some(c);
@@ -231,7 +239,7 @@ impl Declarations {
             // directly is a question about the SPELLING.
             if !*mutable && decoded_vec_satisfies(inner) {
                 if let Some(elem) = inner.sequence_elem() {
-                    return self.output_slice(elem, registry);
+                    return self.output_slice(elem, registry, emit);
                 }
             }
             let mutable = ty.is_exclusive_borrow();
@@ -240,6 +248,7 @@ impl Declarations {
                 &produced,
                 inner,
                 registry,
+                emit,
             ) {
                 c.subs = vec![inner.key()];
                 return Some(c);

--- a/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
@@ -303,9 +303,10 @@ impl Declarations {
     pub fn opaque_handle_input(
         &self,
         reading: &crate::api::core::flat::TypeRef,
+        emit: &crate::api::core::emit::Emit,
     ) -> ConverterImpl<KotlinMeta> {
         let wire: syn::Type = syn::parse_quote!(jni::sys::jlong);
-        let ty = reading.spell();
+        let ty = emit.spell(reading);
         let name = input_name(&ty, &wire);
         let gen_allow = generated_converter_attr();
         let function: syn::ItemFn = syn::parse_quote!(
@@ -503,6 +504,7 @@ impl Declarations {
     pub fn opaque_handle_output(
         &self,
         reading: &crate::api::core::flat::TypeRef,
+        _emit: &crate::api::core::emit::Emit,
     ) -> ConverterImpl<KotlinMeta> {
         let wire: syn::Type = syn::parse_quote!(jni::sys::jlong);
         let body: syn::Expr =
@@ -628,6 +630,7 @@ pub(crate) fn build_signal_domain_error_item() -> syn::Item {
 pub(crate) fn build_handle_destructor_items(
     ext: &Declarations,
     registry: &Registry<KotlinMeta>,
+    emit: &crate::api::core::emit::Emit,
 ) -> Vec<syn::Item> {
     let mut named: Vec<(String, syn::Item)> = Vec::new();
     for (key, cfg) in &ext.types {
@@ -644,7 +647,7 @@ pub(crate) fn build_handle_destructor_items(
         if registry.input_entry(&reading).is_none() && registry.output_entry(&reading).is_none() {
             continue;
         }
-        let ty = reading.spell();
+        let ty = emit.spell(&reading);
         let class_fqn = cfg
             .name_spec
             .as_ref()
@@ -833,9 +836,9 @@ impl Produced<'_> {
     }
 
     /// The tokens generated Rust spells for this type.
-    fn spell(&self) -> TokenStream {
+    fn spell(&self, emit: &crate::api::core::emit::Emit) -> TokenStream {
         match self {
-            Produced::Reading(r) => r.spell(),
+            Produced::Reading(r) => emit.spell(r),
             Produced::Composed(t) => t.to_token_stream(),
         }
     }
@@ -1074,12 +1077,13 @@ impl Declarations {
         produced: &Produced<'_>,
         t1: &crate::api::core::flat::TypeRef,
         registry: &impl Conversions<KotlinMeta>,
+        emit: &crate::api::core::emit::Emit,
     ) -> Option<ConverterImpl<KotlinMeta>> {
         // `t1`'s spelling, for the parts that ask spelling questions — the
         // canonical form a produced spelling is compared against, and the
         // type ascriptions the generated body writes. Everything else takes
         // the READING itself (#284).
-        let t1_ty = t1.spell();
+        let t1_ty = emit.spell(t1);
         let WrapperShape::OptionRef { .. } = shape else {
             return None;
         };
@@ -1097,7 +1101,7 @@ impl Declarations {
         let inner_wire = inner.destination.clone();
         let inner_conv = inner.function.sig.ident.clone();
         let outer_ty = produced.key();
-        let outer_spelled = produced.spell();
+        let outer_spelled = produced.spell(emit);
         let name = input_name(&outer_spelled, &inner_wire);
         let gen_allow = generated_converter_attr();
         let function: syn::ItemFn = syn::parse_quote!(
@@ -1143,12 +1147,13 @@ impl Declarations {
         produced: &Produced<'_>,
         t1: &crate::api::core::flat::TypeRef,
         registry: &impl Conversions<KotlinMeta>,
+        emit: &crate::api::core::emit::Emit,
     ) -> Option<ConverterImpl<KotlinMeta>> {
         // `t1`'s spelling, for the parts that ask spelling questions — the
         // canonical form a produced spelling is compared against, and the
         // type ascriptions the generated body writes. Everything else takes
         // the READING itself (#284).
-        let t1_ty = t1.spell();
+        let t1_ty = emit.spell(t1);
         if shape != WrapperShape::Sequence {
             return None;
         }
@@ -1215,18 +1220,19 @@ impl Declarations {
         produced: &Produced<'_>,
         t1: &crate::api::core::flat::TypeRef,
         registry: &impl Conversions<KotlinMeta>,
+        emit: &crate::api::core::emit::Emit,
     ) -> Option<ConverterImpl<KotlinMeta>> {
         // `t1`'s spelling, for the parts that ask spelling questions — the
         // canonical form a produced spelling is compared against, and the
         // type ascriptions the generated body writes. Everything else takes
         // the READING itself (#284).
-        let t1_ty = t1.spell();
+        let t1_ty = emit.spell(t1);
         if shape == WrapperShape::Optional {
             let inner = registry.input_entry(t1)?;
             if inner.metadata.is_direct_handle() {
                 let inner_wire = inner.destination.clone();
                 let outer_ty = produced.key();
-                let outer_spelled = produced.spell();
+                let outer_spelled = produced.spell(emit);
                 let build = build_from_canonical(produced, quote::quote!(__v))?;
                 let name = input_name(&outer_spelled, &inner_wire);
                 let gen_allow = generated_converter_attr();
@@ -1407,7 +1413,7 @@ impl JniGenBuilder {
         let registry = decls
             .declare_into(registry)?
             .validate_with(&decls)?
-            .convert_with(|crossing, built| decls.convert_crossing(crossing, built))?
+            .convert_with(|crossing, built, emit| decls.convert_crossing(crossing, built, emit))?
             .build()?;
         // Post-resolve invariants, run once here so the writers are pure reads
         // and a `JniGen` is valid by construction.
@@ -1427,6 +1433,7 @@ impl Declarations {
         &self,
         crossing: &Crossing,
         built: &Building<'_, KotlinMeta>,
+        emit: &crate::api::core::emit::Emit,
     ) -> Option<ConverterImpl<KotlinMeta>> {
         let (dir, key) = crossing;
         // The reading the scan already took for this crossing, fetched by the
@@ -1436,7 +1443,7 @@ impl Declarations {
         // there is no spelling to rebuild (#284).
         let reading = built.reading(key)?;
         match dir {
-            Direction::Input => self.select_input_type(&reading, built).or_else(|| {
+            Direction::Input => self.select_input_type(&reading, built, emit).or_else(|| {
                 // `impl Fn(args)` that nothing else claimed. Callback args cross
                 // in the OPPOSITE direction, which is why their required-ness
                 // rides `immediate_edges` rather than this converter's `subs`.
@@ -1449,7 +1456,7 @@ impl Declarations {
                 };
                 self.dispatch_fn_input(args, built)
             }),
-            Direction::Output => self.select_output_type(&reading, built),
+            Direction::Output => self.select_output_type(&reading, built, emit),
         }
     }
 
@@ -1495,7 +1502,7 @@ impl Declarations {
         // fn's return type needs the output twin.
         let mut convert_edges: Vec<(Crossing, Crossing)> = Vec::new();
         for decl in &self.convert_decls {
-            if let Some((ty, _, _)) = self.convert_input_body(&decl.key, &registry) {
+            if let Some(ty) = self.convert_target(&decl.key, &registry, Direction::Input) {
                 registry = registry.cross(Direction::Input, &ty);
                 // The target's conversion chains through this one, and nothing
                 // about the target type says so.
@@ -1504,7 +1511,7 @@ impl Declarations {
                     (Direction::Input, TypeKey::from_type(&ty)),
                 ));
             }
-            if let Some((ty, _, _)) = self.convert_output_body(&decl.key, &registry) {
+            if let Some(ty) = self.convert_target(&decl.key, &registry, Direction::Output) {
                 registry = registry.cross(Direction::Output, &ty);
                 convert_edges.push((
                     (Direction::Output, decl.key.clone()),
@@ -1882,10 +1889,10 @@ impl Prebindgen for Declarations {
                             // peeled sum, since that is what carries the
                             // declaration. Identical for a bare `E`; they
                             // diverge once it is wrapped.
-                            err_ty.spell(),
-                            core.spell(),
-                            err_ty.spell(),
-                            err_ty.spell(),
+                            err_ty,
+                            core,
+                            err_ty,
+                            err_ty,
                         ));
                     }
                 }
@@ -1972,7 +1979,7 @@ impl Prebindgen for Declarations {
         // Handle destructors — one `extern "C" freePtr<suffix>` per
         // non-suppressed opaque handle (the Rust half of the typed-handle
         // `free()` pair the Kotlin emitter generates).
-        items.extend(build_handle_destructor_items(self, registry));
+        items.extend(build_handle_destructor_items(self, registry, _emit));
         // Slice/Vec input helpers — a `…VecNew/Push/Free` trio per flattenable
         // element type a scanned `&[T]`/`Vec<T>` param takes. Kotlin builds the
         // Rust-side `Vec` by pushing each element's decoupled leaves, then passes
@@ -2099,6 +2106,7 @@ impl Declarations {
         &self,
         reading: &crate::api::core::flat::TypeRef,
         registry: &impl Conversions<KotlinMeta>,
+        emit: &crate::api::core::emit::Emit,
     ) -> Option<ConverterImpl<KotlinMeta>> {
         // Classify off `kind`, spell with `spell()`: the arms below that ask what
         // a type IS use `reading`, and everything that has to name it in
@@ -2110,7 +2118,7 @@ impl Declarations {
         let key = reading.key();
         if let Some(cfg) = self.types.get(&key) {
             if cfg.is_opaque() {
-                return Some(self.opaque_handle_input(reading));
+                return Some(self.opaque_handle_input(reading, emit));
             }
         }
         // Fixed-size array of JNI primitives — dual of the output branch.
@@ -2161,7 +2169,7 @@ impl Declarations {
                 }
             }
         }
-        if let Some(conv) = self.lookup_input(reading, registry) {
+        if let Some(conv) = self.lookup_input(reading, registry, emit) {
             return Some(conv);
         }
         // `str` is unsized, so converters can't return it directly.
@@ -2475,14 +2483,15 @@ impl Declarations {
         produced: &Produced<'_>,
         t1: &crate::api::core::flat::TypeRef,
         registry: &impl Conversions<KotlinMeta>,
+        emit: &crate::api::core::emit::Emit,
     ) -> Option<ConverterImpl<KotlinMeta>> {
         // Disjoint shapes (see [`WrapperShape`]), tried in priority order. The
         // borrow/option-ref/vec shapes are mutually exclusive; the two
         // `Optional` sub-cases share a method.
         self.input_borrow(shape, produced, t1, registry)
-            .or_else(|| self.input_option_ref(shape, produced, t1, registry))
-            .or_else(|| self.input_vec(shape, produced, t1, registry))
-            .or_else(|| self.input_option(shape, produced, t1, registry))
+            .or_else(|| self.input_option_ref(shape, produced, t1, registry, emit))
+            .or_else(|| self.input_vec(shape, produced, t1, registry, emit))
+            .or_else(|| self.input_option(shape, produced, t1, registry, emit))
     }
 
     // ── Output converters ────────────────────────────────────────────
@@ -2494,6 +2503,7 @@ impl Declarations {
         &self,
         reading: &crate::api::core::flat::TypeRef,
         registry: &impl Conversions<KotlinMeta>,
+        emit: &crate::api::core::emit::Emit,
     ) -> Option<ConverterImpl<KotlinMeta>> {
         // Classify off `kind`, spell with `spell()` — see `input_terminal`.
         // Everything below reads the reading: the identity for a lookup, the
@@ -2502,7 +2512,7 @@ impl Declarations {
         let key = reading.key();
         if let Some(cfg) = self.types.get(&key) {
             if cfg.is_opaque() {
-                return Some(self.opaque_handle_output(reading));
+                return Some(self.opaque_handle_output(reading, emit));
             }
         }
         // Fixed-size array of JNI primitives: `[u8; N]` -> `ByteArray`,
@@ -2548,7 +2558,7 @@ impl Declarations {
                 }
             }
         }
-        if let Some(conv) = self.lookup_output(reading, registry) {
+        if let Some(conv) = self.lookup_output(reading, registry, emit) {
             return Some(conv);
         }
         // `str` is unsized, so it has no by-value output converter — but it is
@@ -2664,12 +2674,13 @@ impl Declarations {
         produced: &Produced<'_>,
         t1: &crate::api::core::flat::TypeRef,
         registry: &impl Conversions<KotlinMeta>,
+        emit: &crate::api::core::emit::Emit,
     ) -> Option<ConverterImpl<KotlinMeta>> {
         // `t1`'s spelling, for the parts that ask spelling questions — the
         // canonical form a produced spelling is compared against, and the
         // type ascriptions the generated body writes. Everything else takes
         // the READING itself (#284).
-        let t1_ty = t1.spell();
+        let t1_ty = emit.spell(t1);
         // Borrowed opaque-handle output (`&T` / `&'static T` where `T` is a
         // declared opaque handle). Canonical zenoh-flat's `z_*` accessors
         // return *borrowed* handles for the C tier's zero-copy borrows, but
@@ -2844,12 +2855,13 @@ impl Declarations {
         &self,
         elem: &crate::api::core::flat::TypeRef,
         registry: &impl Conversions<KotlinMeta>,
+        emit: &crate::api::core::emit::Emit,
     ) -> Option<ConverterImpl<KotlinMeta>> {
         let inner = registry.output_entry(elem)?;
         let elem_key = elem.key();
         // The element as the source spelled it — the slice type this converter
         // yields is re-emitted, never re-derived.
-        let elem = elem.spell();
+        let elem = emit.spell(elem);
         // A `&[opaque-handle]` callback arg is delivered by the Kotlin-side leaf
         // fold (typed-handle wrap), bypassing this whole-`ArrayList` converter; a
         // handle's `jlong` wire isn't JObject-shaped, so it returns `None` here.


### PR DESCRIPTION
Part of the capability umbrella [#361](https://github.com/milyin/prebindgen/pull/361).

## What moved

`RegistryBuilder::convert_with`'s closure receives an `&Emit`, and core mints one for it:

```rust
 F: FnMut(&Crossing, &Building<'_, M>, &Emit) -> Option<ConverterImpl<M>>,
```

A converter **is** generated Rust — `ConverterImpl::function` is a complete `syn::ItemFn` the adapter writes — so that closure is an emission callback exactly like the `on_*` ones. The token threads from there through `convert_crossing` → `select_{input,output}_type` → the arms, in both adapters.

## What did *not* need it

**18 of ~30 converter arms build generated Rust without touching source syntax at all.** `in_enum`, `in_data_struct`, `in_tagged_union`, `in_wrappers`, `out_wrappers`, `result_peel`, `input_borrow`, both transparent bridges, and the rest — because #314 already moved them onto `key()` and adapter-composed wires.

Their signatures say so: they don't take the parameter. Leaving `_emit` on them would have been precisely the noise that makes a capability meaningless — the point is that a signature tells you which side of the boundary a function is on.

## Four things that were spelling to get an identity

Threading surfaced these the way the census never could:

* **Three wire policies** asked `spelled()` behind an `r_is_scalar` guard. A scalar's spelling *is* its name, so `scalar_ty` builds it from `ScalarKind` — no captured syntax, no capability. `in_scalar` / `out_scalar`'s identity pass-throughs are the same fix.
* **The `&[E]` and `&mut MaybeUninit<X>` arms** spelled an element only to take its key, its source path, and a `MaybeUninit` peel. All three come off the reading now, with `TypeKind::Uninit` replacing `maybe_uninit_inner`.
* **`declare_into` called `convert_{input,output}_body` and threw the body away**, wanting only the target's identity. That is *declaration* code — it would have needed the emission capability for a spelling it discards. Split out as `convert_target`, which reads the representation off the convert fn's own element per direction (input → parameter, output → return, `Trait` → the declared `repr`).

## The launderings are gone

**Both `spelled_ty` helpers are now callerless and deleted.** Those were the `spell()` → `parse_quote!` round-trip that recovers a `syn::Type` while naming no counted door — the hole that made `escapes: types = 0` a statement about names rather than capability, and the reason this umbrella exists. `maybe_uninit_inner`, `is_bool` and `first_type_arg` go with them.

Six more diagnostics that C2's classifier missed (their `format!` was more than twelve lines up) now use `Display`.

## Measurement

| | before | after |
|---|---:|---:|
| classification sites | 49 | **48** |
| escapes: types | 0 | 0 |
| escapes: items | 0 | 0 |

And the number the census never tracked — **adapter `spell()` calls: 47 → 23**.

The 23 that remain are in the deeper emission helpers (`emit/*.rs`, `prim_array.rs`, `kotlin_emit.rs`), reached from `on_function` rather than the converter chain. C3b threads those; the selector chain itself is done, which is what this stage claimed.

## Gate

- `cargo test -p prebindgen --all-features` — 640 lib, 27 doctests
- ledger regenerated, diff above
- clippy `--all-targets --all-features -D warnings` on stable **and** 1.85.0
- `cargo fmt --check` with the CI config
- `examples/regen-check.sh` — every generated artifact byte-identical
