### PR TITLE
C3b: a plan carried a spelling so that decisions could peel it

### DIFF
--- a/prebindgen/src/api/lang/jnigen/jni/builder.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/builder.rs
@@ -112,8 +112,14 @@ impl Declarations {
     /// question asked of the model, and is what a caller holding a reading
     /// should use.
     pub(crate) fn is_kotlin_enum(&self, ty: &syn::Type) -> bool {
-        let key = TypeKey::from_type(ty);
-        self.types.get(&key).is_some_and(|c| c.is_enum_class())
+        self.is_kotlin_enum_key(&TypeKey::from_type(ty))
+    }
+
+    /// [`Self::is_kotlin_enum`] off the **identity** — the whole type's, not a
+    /// probe through its layers. See [`Self::is_kotlin_enum_reading`] for the
+    /// question that does peel, and why the two are not interchangeable.
+    pub(crate) fn is_kotlin_enum_key(&self, key: &TypeKey) -> bool {
+        self.types.get(key).is_some_and(|c| c.is_enum_class())
     }
 
     /// Whether this value's core is a type registered via an `EnumClassDecl`,

--- a/prebindgen/src/api/lang/jnigen/jni/fn_plan.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/fn_plan.rs
@@ -791,11 +791,11 @@ fn build_output(
     // Kotlin error peel rides the entry's `value_rust_type`, so the full
     // `Result<T, E>` type is looked up as written.)
     let ret_decl = if is_convert { target_ty } else { &f.ret };
-    let (surface, canonical) = ReturnSurface::classify(ext, registry, ret_decl);
-    let is_enum = ext.is_kotlin_enum(&canonical);
-    let is_option_enum = crate::api::core::types_util::option_inner_type(&canonical)
-        .map(|inner| ext.is_kotlin_enum(&inner))
-        .unwrap_or(false);
+    let (surface, enums) = ReturnSurface::classify(ext, registry, ret_decl);
+    let EnumSurface {
+        is_enum,
+        is_option_enum,
+    } = enums;
 
     Ok(FnOutputPlan::Value(Box::new(ValueOutputPlan {
         is_convert,
@@ -807,6 +807,15 @@ fn build_output(
     })))
 }
 
+/// Whether a return surfaces as a Kotlin enum class, and whether an optional
+/// one does — the only two things the old `canonical` spelling was consulted
+/// for, now answered at the one place that can see how it was obtained.
+#[derive(Clone, Copy)]
+pub(crate) struct EnumSurface {
+    pub is_enum: bool,
+    pub is_option_enum: bool,
+}
+
 impl ReturnSurface {
     /// Classify a declared return type. Returns the surface plus the
     /// canonical (`value_rust_type`-peeled) type the enum probes run over —
@@ -816,7 +825,7 @@ impl ReturnSurface {
         ext: &Declarations,
         registry: &impl Conversions<KotlinMeta>,
         ret: &crate::api::core::flat::TypeRef,
-    ) -> (Self, syn::Type) {
+    ) -> (Self, EnumSurface) {
         // The RETURN, as the model classified it. Both callers used to spell a
         // reading into a `-> #ty` fragment for this to take apart again, and
         // the `ReturnType::Default` arm was a unit the element already states.
@@ -836,12 +845,37 @@ impl ReturnSurface {
             Some(t) => crate::api::lang::jnigen::util::is_unit(t),
             None => matches!(ret.kind(), crate::api::core::flat::TypeKind::Unit),
         };
-        let canonical: syn::Type = match stored {
-            Some(t) => t.clone(),
-            None => {
-                let toks = ret.spell();
-                syn::parse_quote!(#toks)
-            }
+        // The two enum questions, answered where BOTH branches are in view.
+        // They used to ride out on a `canonical: syn::Type` built by spelling
+        // the reading — and then `option_inner_type` peeled that spelling to
+        // ask about its inner, which is the layer-off-a-spelling mistake #273
+        // is named for: the model erases wrappers the spelling still shows.
+        // A stored `value_rust_type` is an adapter-composed node and keeps its
+        // node-shaped answer; with no metadata the reading answers directly.
+        let enum_probe = |t: &syn::Type| ext.is_kotlin_enum(t);
+        let (is_enum, is_option_enum) = match stored {
+            Some(t) => (
+                enum_probe(t),
+                crate::api::core::types_util::option_inner_type(t)
+                    .map(|inner| enum_probe(&inner))
+                    .unwrap_or(false),
+            ),
+            // `is_kotlin_enum_reading` is NOT the peer here: it probes THROUGH
+            // the layers, so `Option<Level>` answers true for the first
+            // question, where the node version keys on the whole type and
+            // answers false. Both questions want the exact type's identity —
+            // the second asks it of the optional's inner, which is what
+            // `option_inner_type` did to the spelling.
+            None => (
+                ext.is_kotlin_enum_key(&ret.key()),
+                ret.optional_inner()
+                    .map(|inner| ext.is_kotlin_enum_key(&inner.key()))
+                    .unwrap_or(false),
+            ),
+        };
+        let canonical = EnumSurface {
+            is_enum,
+            is_option_enum,
         };
         if is_unit {
             return (Self::Unit, canonical);


### PR DESCRIPTION
Part of the capability umbrella [#361](https://github.com/milyin/prebindgen/pull/361).

## The stage that turned into a bug report

C3 threaded the capability through the converter chain. This stage was meant to extend it into the deeper emission helpers (`emit/*.rs`, `prim_array.rs`, `kotlin_emit.rs`). Threading immediately leaked into places that are not Rust emission at all:

```
param -> jni/kotlin_emit.rs   write_kotlin
param -> jni/trait_impl.rs    validate_resolved
param -> jni/symbols.rs       validate_symbols
param -> jni/fn_plan.rs       validate_bindings
```

Kotlin rendering and **validation** demanding an emission capability is not a threading problem. It is the design reporting something, so I stopped and traced it.

## What it found

`ReturnSurface::classify` built a `canonical: syn::Type` by **spelling the return's reading**, and handed it out in the function plan. Its only two consumers were decisions:

```rust
let is_enum = ext.is_kotlin_enum(&canonical);
let is_option_enum = option_inner_type(&canonical)
    .map(|inner| ext.is_kotlin_enum(&inner))
    .unwrap_or(false);
```

The second **peels a layer off a spelling** to ask about its inner. That is precisely the mistake [#273](https://github.com/milyin/prebindgen/issues/273) is named for — the model erases transparent wrappers that the spelling still shows, so a `Box<Option<Level>>` and an `Option<Level>` answer differently here despite meaning the same thing to Kotlin.

Because it lived in a plan field, everything downstream of a plan inherited a spelling it never wanted. That is why the capability leaked: it was following the spelling, and the spelling had gone somewhere it should not be.

## The fix

Both questions are answered inside `classify`, where both branches are in view:

* a stored `value_rust_type` is an **adapter-composed** node — it keeps its node-shaped answer, and needs no capability;
* with no metadata, the **reading** answers directly.

`classify` returns an `EnumSurface { is_enum, is_option_enum }` instead of a `syn::Type`. The spelling is gone, and with it the reason validation and Kotlin rendering would have needed an emission capability.

## The trap, caught by a test

```
---- values::recursive_data_class_input_flattens_nested_and_optional_fields
```

**`is_kotlin_enum_reading` is not the peer of `is_kotlin_enum`.** It probes *through* the layers (`enum_probe` peels borrow and optional), so `Option<Level>` answers `true`; the node version keys on the whole type and answers `false`. Both questions here want the exact type's identity, so this adds `is_kotlin_enum_key` and says at the site why the peeling one is wrong for them.

Fourth time this transition has met two model readings that look interchangeable and are not — S31 (`borrow_target` vs `TypeKind::Ref`), S38 (`is_exclusive_borrow` vs `mutable`), S40 (`sequence_elem` vs `TypeKind::Vec`), this. Each is stated at its site; the pattern is that the convenience readings *peel* and the identity questions must not.

## Measurement

| | before | after |
|---|---:|---:|
| classification sites | 48 | 48 |
| escapes: types / items | 0 / 0 | 0 / 0 |

Adapter `spell()` calls: **23 → 22**. A small number for the stage, and the point is what it cost to find: the remaining 22 are genuinely inside Rust emission, and the one that was not is gone.

## Gate

- `cargo test -p prebindgen --all-features` — 640 lib, 27 doctests
- clippy `--all-targets --all-features -D warnings` on stable **and** 1.85.0
- `cargo fmt --check` with the CI config
- `examples/regen-check.sh` — every generated artifact byte-identical
