### PR TITLE
C4: an overload collides by identity, not by spelling

### DIFF
--- a/prebindgen/src/api/lang/jnigen/jni/overloads.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/overloads.rs
@@ -164,7 +164,14 @@ fn rust_type_erased(
     {
         return erase_kt_type(&[], &kt);
     }
-    ErasedJvmType::raw(peeled.spell().to_string())
+    // The type's IDENTITY, not its spelling. `ErasedJvmType` is a string
+    // compared with `==` — "two parameters collide as overloads iff their
+    // tokens are equal" — so keying it on what the source wrote meant two
+    // spellings of one type (`Box<Payload>` and `Payload`, `crate::Foo` and
+    // `Foo`) erased to different tokens and were judged NOT to collide. The
+    // JVM would then reject the emitted class for a clash this check exists
+    // to catch first. A `TypeKey` is canonical, so equal types compare equal.
+    ErasedJvmType::raw(peeled.key().as_str())
 }
 
 /// Whether `plan` is a multi-variant expansion that can be turned into


### PR DESCRIPTION
Part of the capability umbrella [#361](https://github.com/milyin/prebindgen/pull/361), which named this site up front as the thing threading the capability would find. It did.

## The site

`ErasedJvmType` is a `String` compared with `==`, and its doc states the contract:

> A JVM-erased parameter type token: two parameters collide as overloads **iff their tokens are equal**.

The fallback for a type with no resolved Kotlin surface built that token from a **spelling**:

```rust
-ErasedJvmType::raw(peeled.spell().to_string())
+ErasedJvmType::raw(peeled.key().as_str())
```

So two spellings of one type would erase to different tokens, be judged not to collide, and both be emitted — after which the JVM rejects the class for exactly the clash this check exists to catch first.

The sibling `ErasedJvmType::raw` four lines up already took a `TypeKey`. This one was the odd one out.

## It is latent, not live — and why that matters

`Flat::parse` runs `spelling::normalize_item_types` over every captured item, so **every reading of one type shares a spelling in-tree**. The raw-token comparison therefore agreed with identity in practice, and artifacts here are byte-identical.

The defect is that it was depending on an upstream invariant it did not state and could not see. Normalization exists to make the flat namespace nameable from the generated crate, not to make string comparison of types sound; a change to it would have broken overload detection silently, in the JVM, at a consumer's build.

This is the shape of thing the census could not surface: `spell()` is not a counted door, and a token string fed to `==` looks exactly like a token string fed to `quote!`.

## Why the capability found it

`rust_type_erased` decides whether two overloads clash. It is not emission, so it never receives an `&Emit` — which is what made the `spell()` call there stand out once the emission sites around it had one. The fix needs no capability at all, which is the point.

## Measurement

| | before | after |
|---|---:|---:|
| classification sites | 48 | 48 |
| escapes: types / items | 0 / 0 | 0 / 0 |

No ledger movement. Adapter `spell()` calls: **22 → 21**.

## Gate

- `cargo test -p prebindgen --all-features` — 640 lib, 27 doctests, including the two existing overload-collision tests
- clippy `--all-targets --all-features -D warnings` on stable **and** 1.85.0
- `cargo fmt --check` with the CI config
- `examples/regen-check.sh` — byte-identical, which is the evidence for "latent"
