### PR TITLE
C5: the type half is sealed

### DIFF
--- a/prebindgen/src/api/core/emit.rs
+++ b/prebindgen/src/api/core/emit.rs
@@ -47,13 +47,15 @@
 //! `compile_fail` examples on [`Emit`] check each of those from outside the
 //! crate, which is where a doctest runs and where the census could never look.
 //!
-//! **Open until C3: type spellings.** [`TypeRef::spell`](super::flat::TypeRef::spell)
-//! is still public and has 71 adapter call sites;
-//! [`Origin::declared_spelling`](super::flat::Origin::declared_spelling) is
-//! public for the two sites that spell a *build-script declaration*, which was
-//! never captured syntax. Until those move, an adapter can still reach a type's
-//! tokens — so this stage closes the item half of the boundary and says so
-//! rather than claiming both.
+//! **Closed as of C5: type spellings too.** `TypeRef::spell`,
+//! `TypeRef::stripped_syntax` and `TypeKind::to_syn` are
+//! `pub(in crate::api::core)`. There is no route from the model to captured
+//! syntax outside this type, and the `compile_fail` examples check every one
+//! from outside the crate.
+//!
+//! `Origin::declared_spelling` stays public: an adapter declaration's
+//! `Origin<syn::Type>` holds a type the **build script** wrote, which was never
+//! captured and which #280 leaves the model no reading for.
 //!
 //! # The residual
 //!
@@ -116,6 +118,26 @@ use super::flat::{Element, EnumValue, Field, Struct, Type, TypeRef};
 /// fn leak(f: &flat::Function) -> proc_macro2::TokenStream { f.origin.spell() }
 /// ```
 ///
+/// A type's spelling, sealed as of C5 — the last route, and the one the census
+/// could only ever *count*:
+///
+/// ```compile_fail
+/// # use prebindgen::core::flat;
+/// fn leak(t: &flat::TypeRef) -> proc_macro2::TokenStream { t.spell() }
+/// ```
+///
+/// …its stripped form, and the kind's reconstruction:
+///
+/// ```compile_fail
+/// # use prebindgen::core::flat;
+/// fn leak(t: &flat::TypeRef) -> syn::Type { t.stripped_syntax() }
+/// ```
+///
+/// ```compile_fail
+/// # use prebindgen::core::flat;
+/// fn leak(k: &flat::TypeKind) -> syn::Type { k.to_syn() }
+/// ```
+///
 /// Minting one is not available either — the field is private and `new` is
 /// `pub(in crate::api::core)`:
 ///
@@ -132,6 +154,17 @@ impl Emit {
     /// Mint one. `pub(in crate::api::core)` is the whole enforcement mechanism:
     /// the hand-out sites are exactly the callers of this.
     pub(in crate::api::core) fn new() -> Self {
+        Self { _seal: () }
+    }
+
+    /// A capability for a test that drives an emission helper directly.
+    ///
+    /// `#[cfg(test)]`, so it does not exist in a built crate — production code
+    /// still cannot mint one, and the `compile_fail` examples above still prove
+    /// the out-of-crate seal, since a doctest compiles against the built crate
+    /// where this is absent.
+    #[cfg(test)]
+    pub(crate) fn for_test() -> Self {
         Self { _seal: () }
     }
 

--- a/prebindgen/src/api/core/flat/element.rs
+++ b/prebindgen/src/api/core/flat/element.rs
@@ -192,6 +192,38 @@ pub struct Function {
     pub origin: Origin<syn::ItemFn>,
 }
 
+impl Function {
+    /// A synthesized **nullary getter**: `pub fn <ident>() -> <ret>`.
+    ///
+    /// The model's own constructor for the one element an adapter legitimately
+    /// needs to invent — a declared `const`'s accessor, whose type flows through
+    /// the ordinary output-converter machinery and so has to arrive as a
+    /// `Function` like any other.
+    ///
+    /// It lives here because building one means **spelling** `ret`, and #280
+    /// says a `TypeRef` is the model's to mint. An adapter that built this
+    /// itself needed a spelling for a model element — which dragged the
+    /// emission capability into validation and Kotlin rendering, both of which
+    /// only wanted the resulting `Function`.
+    ///
+    /// The body is `unimplemented!()` and is never emitted: only the signature
+    /// is read.
+    pub fn synthetic_getter(ident: syn::Ident, ret: TypeRef) -> Self {
+        let ret_syntax = ret.spell();
+        let item: syn::ItemFn = syn::parse_quote! {
+            pub fn #ident() -> #ret_syntax {
+                unimplemented!()
+            }
+        };
+        Self {
+            name: ident,
+            params: Vec::new(),
+            origin: ret.origin_with(item),
+            ret,
+        }
+    }
+}
+
 /// One parameter of a [`Function`].
 #[derive(Clone, Debug)]
 pub struct Param {

--- a/prebindgen/src/api/core/flat/ty.rs
+++ b/prebindgen/src/api/core/flat/ty.rs
@@ -151,7 +151,7 @@ impl TypeRef {
     /// *is* has an answer in [`kind`](Self::kind) and in the readings beside it,
     /// and a consumer that still has to take the node apart says so with
     /// [`as_syn`](Self::as_syn).
-    pub fn spell(&self) -> proc_macro2::TokenStream {
+    pub(in crate::api::core) fn spell(&self) -> proc_macro2::TokenStream {
         self.origin.spell()
     }
 
@@ -522,7 +522,7 @@ impl TypeRef {
     /// tabulates: this strips what stands over *this* node's classification, and
     /// a wrapper under a borrow or inside an `Option` belongs to that inner
     /// node's own spelling.
-    pub fn stripped_syntax(&self) -> syn::Type {
+    pub(in crate::api::core) fn stripped_syntax(&self) -> syn::Type {
         self.unwrapped().origin.as_syn().clone()
     }
 
@@ -832,7 +832,12 @@ impl TypeKind {
     /// * a `Group` or `Paren` around a type, which the lowering sees through;
     /// * a [`Callback`](TypeKind::Callback)'s bound *order* — `Send + Sync` and
     ///   `Sync + Send` are one accepted form, and nothing reads the order.
-    pub fn to_syn(&self) -> syn::Type {
+    // Its whole job is the round-trip check (`syntax_is_recoverable_from_kind`),
+    // and with the spelling sealed nothing in a built crate calls it — which is
+    // the correct end state, not dead code: a kind that cannot reproduce its
+    // own syntax has lost something, and this is what says so.
+    #[allow(dead_code)]
+    pub(in crate::api::core) fn to_syn(&self) -> syn::Type {
         let opt_lifetime =
             |l: &Option<syn::Lifetime>| l.as_ref().map(|l| quote::quote!(#l)).unwrap_or_default();
         match self {

--- a/prebindgen/src/api/lang/cbindgen/emit.rs
+++ b/prebindgen/src/api/lang/cbindgen/emit.rs
@@ -511,7 +511,7 @@ impl CbindgenBuilder {
             Some((ok, e)) => (ok, Some(e)),
             None => (&f.ret, None),
         };
-        let err_ty: Option<syn::Type> = err_reading.map(spelled);
+        let err_ty: Option<syn::Type> = err_reading.map(|t| spelled(t, emit));
         let has_fallible_output = Self::output_is_fallible(value_ty, registry);
 
         // Error wiring: the error type must be declared via `.error()`.
@@ -1074,7 +1074,7 @@ impl CbindgenBuilder {
 
             // `&[E]` slice (scalar `E`): two wire params (`*const E`, `usize`),
             // decoded zero-copy. NULL pointer ⇒ empty slice (not an error).
-            if let Some(elem) = r_scalar_slice_elem(arg_reading).map(spelled) {
+            if let Some(elem) = r_scalar_slice_elem(arg_reading).map(|t| spelled(t, emit)) {
                 let len_id = format_ident!("{}_len", ident);
                 params.push(quote!(#ident: *const #elem));
                 params.push(quote!(#len_id: usize));
@@ -1095,7 +1095,10 @@ impl CbindgenBuilder {
             // by a generated `const _`), so the whole block transmutes in one shot —
             // the slice analogue of the single-`&E` `__cbg_in_*` converter. NULL ⇒
             // empty slice.
-            if let Some(elem) = self.r_value_opaque_slice_elem(arg_reading).map(spelled) {
+            if let Some(elem) = self
+                .r_value_opaque_slice_elem(arg_reading)
+                .map(|t| spelled(t, emit))
+            {
                 // The C wire element is the inline-opaque counterpart (e.g. the
                 // generated `payload_t` mirror), layout-identical to the Rust value.
                 let elem_wire = self

--- a/prebindgen/src/api/lang/cbindgen/mod.rs
+++ b/prebindgen/src/api/lang/cbindgen/mod.rs
@@ -565,8 +565,8 @@ pub fn snake_case(s: &str) -> String {
 /// exists to check the lowering rather than to generate with. Every wire this
 /// back-end builds from a field's own type goes through here, so what C sees
 /// is what the source wrote.
-fn spelled(t: &TypeRef) -> syn::Type {
-    let toks = t.spell();
+fn spelled(t: &TypeRef, emit: &crate::api::core::emit::Emit) -> syn::Type {
+    let toks = emit.spell(t);
     syn::parse_quote!(#toks)
 }
 

--- a/prebindgen/src/api/lang/jnigen/jni/builder.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/builder.rs
@@ -1950,7 +1950,7 @@ impl Declarations {
                 Some(ConverterImpl {
                     subs: vec![],
                     pre_stages: vec![],
-                    function: self.build_input_fn_of(outer, &ty, &body, exc),
+                    function: self.build_input_fn_of(outer, &ty, &body, exc, emit),
                     destination: ty,
                     niches,
                     metadata: KotlinMeta {
@@ -2025,7 +2025,7 @@ impl Declarations {
     ) -> Option<ConverterImpl<KotlinMeta>> {
         let key = outer.key();
         let (ty, exc_ty, body) = self.convert_output_body(&key, registry, emit)?;
-        self.build_output_converter(outer, None, ty, exc_ty, body, registry)
+        self.build_output_converter(outer, None, ty, exc_ty, body, registry, emit)
     }
 
     /// The `Result<T, E>` output peel: the value succeeds as `T`, and `E` routes
@@ -2041,6 +2041,7 @@ impl Declarations {
         ok: &syn::Type,
         err: &syn::Type,
         registry: &impl Conversions<KotlinMeta>,
+        emit: &crate::api::core::emit::Emit,
     ) -> Option<ConverterImpl<KotlinMeta>> {
         self.build_output_converter(
             outer,
@@ -2049,6 +2050,7 @@ impl Declarations {
             Some(err.clone()),
             syn::parse_quote!(v),
             registry,
+            emit,
         )
     }
 
@@ -2057,6 +2059,7 @@ impl Declarations {
     /// `arg0` is the peeled inner type for a shape peel, `None` for a
     /// `convert!`-declared conversion — which is what the old `rank == 0`
     /// tested.
+    #[allow(clippy::too_many_arguments)]
     fn build_output_converter(
         &self,
         outer: &crate::api::core::flat::TypeRef,
@@ -2065,6 +2068,7 @@ impl Declarations {
         exc_ty: Option<syn::Type>,
         body: syn::Expr,
         registry: &impl Conversions<KotlinMeta>,
+        emit: &crate::api::core::emit::Emit,
     ) -> Option<ConverterImpl<KotlinMeta>> {
         let key = outer.key();
         // The middle slot carries the `Result`'s raw Rust error type (or `None`
@@ -2109,7 +2113,7 @@ impl Declarations {
                 Some(ConverterImpl {
                     subs: vec![],
                     pre_stages: vec![],
-                    function: self.build_output_fn_of(outer, &ty, &body, exc),
+                    function: self.build_output_fn_of(outer, &ty, &body, exc, emit),
                     destination: ty,
                     niches,
                     metadata: KotlinMeta {
@@ -2126,7 +2130,7 @@ impl Declarations {
             Some(inner) => {
                 // Composed: `ty` is the continue rust type; chain its converter.
                 let stage = Stage {
-                    function: self.build_output_fn_of(outer, &ty, &body, exc),
+                    function: self.build_output_fn_of(outer, &ty, &body, exc, emit),
                     metadata: KotlinMeta::default(),
                 };
                 let mut pre_stages = vec![stage];

--- a/prebindgen/src/api/lang/jnigen/jni/emit/callback.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/callback.rs
@@ -23,6 +23,7 @@ pub(crate) fn callback_input(
     ext: &Declarations,
     args: &[crate::api::core::flat::TypeRef],
     registry: &impl Conversions<KotlinMeta>,
+    emit: &crate::api::core::emit::Emit,
 ) -> Option<(syn::Type, syn::Expr)> {
     // Human-readable tag for attach/log messages.
     let name = format!(
@@ -49,7 +50,7 @@ pub(crate) fn callback_input(
     let arg_pat_ty: Vec<TokenStream> = args
         .iter()
         .map(|t| {
-            let t = t.spell();
+            let t = emit.spell(t);
             quote!(#t)
         })
         .collect();
@@ -428,9 +429,12 @@ pub(crate) fn reject_vec_of_handle(
 /// Reconstruct the `impl Fn(args...) + Send + Sync + 'static` syn::Type
 /// from a flat slice of arg types. Used by the rank-1/2/3 callback impls
 /// to feed `input_wrapper` the original outer type.
-pub(crate) fn build_fn_type(args: &[crate::api::core::flat::TypeRef]) -> syn::Type {
+pub(crate) fn build_fn_type(
+    args: &[crate::api::core::flat::TypeRef],
+    emit: &crate::api::core::emit::Emit,
+) -> syn::Type {
     // The args as the source spelled them — the callback's Rust type is
     // re-emitted, never re-derived.
-    let arg_iter = args.iter().map(|a| a.spell());
+    let arg_iter = args.iter().map(|a| emit.spell(a));
     syn::parse_quote!(impl Fn( #(#arg_iter),* ) + Send + Sync + 'static)
 }

--- a/prebindgen/src/api/lang/jnigen/jni/emit/convert.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/convert.rs
@@ -244,9 +244,10 @@ pub(crate) fn composed_inner_output(
 pub(crate) fn option_input(
     t1: &crate::api::core::flat::TypeRef,
     registry: &impl Conversions<KotlinMeta>,
+    emit: &crate::api::core::emit::Emit,
 ) -> Option<(syn::Type, syn::Expr, Niches)> {
     let inner_entry = registry.input_entry(t1)?;
-    let t1_spelled = t1.spell();
+    let t1_spelled = emit.spell(t1);
     let inner_wire = inner_entry.destination.clone();
     let inner_decode = composed_inner_input(inner_entry, quote!(v));
 

--- a/prebindgen/src/api/lang/jnigen/jni/emit/flat_input.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/flat_input.rs
@@ -21,6 +21,7 @@ pub(crate) fn struct_input_body(
     ext: &Declarations,
     s: &flat::Struct,
     registry: &impl Conversions<KotlinMeta>,
+    emit: &crate::api::core::emit::Emit,
 ) -> Option<(syn::Type, syn::Expr)> {
     let struct_name = s.name.to_string();
     let struct_module = struct_module_path(ext, registry, &s.name);
@@ -75,7 +76,7 @@ pub(crate) fn struct_input_body(
                     // converter would yield `OwnedObject<T>`, which can't
                     // populate an owned field. `Option<_>` handle fields keep
                     // the niche-aware converter (jlong 0 ⇒ `None`).
-                    let field_ty = field.ty.spell();
+                    let field_ty = emit.spell(&field.ty);
                     let decode = if field_optional {
                         quote! { let #fname_ident = #field_conv; }
                     } else {
@@ -325,6 +326,7 @@ pub(crate) fn sum_input_body(
     ext: &Declarations,
     v: &flat::Variant,
     registry: &impl Conversions<KotlinMeta>,
+    emit: &crate::api::core::emit::Emit,
 ) -> Option<(syn::Type, syn::Expr)> {
     let key = TypeKey::from_ident(&v.name);
     let cfg = ext.types.get(&key)?;
@@ -358,6 +360,7 @@ pub(crate) fn sum_input_body(
                 &field.ty,
                 &bind,
                 &err_prefix,
+                emit,
             )?;
             preludes.push(pre);
             inits.push(field.bind(&value));
@@ -410,6 +413,7 @@ pub(crate) fn sum_input_body(
 /// binding the result to `bind`. Mirrors the per-field decode
 /// [`struct_input_body`] performs, for the positions that are properties of a
 /// generated class rather than fields of a data class.
+#[allow(clippy::too_many_arguments)]
 fn read_kotlin_property(
     ext: &Declarations,
     registry: &impl Conversions<KotlinMeta>,
@@ -418,13 +422,14 @@ fn read_kotlin_property(
     reading: &TypeRef,
     bind: &syn::Ident,
     err_prefix: &str,
+    emit: &crate::api::core::emit::Emit,
 ) -> Option<(TokenStream, TokenStream)> {
     // The payload's own reading straight to its entry, and the layer questions
     // below asked of it once — `option_inner_type` compared the last path
     // segment, so a payload spelled `Box<Option<T>>` answered "not optional"
     // four separate times here (#289).
     let entry = registry.input_entry(reading)?;
-    let ty = reading.spell();
+    let ty = emit.spell(reading);
     let optional = reading.optional_inner().is_some();
     let inner = reading.optional_inner().unwrap_or(reading);
     let wire = entry.destination.clone();
@@ -1751,8 +1756,9 @@ pub(crate) fn render_flat_input_decode(
     plan: &FlatInputPlan,
     arg_ident: &syn::Ident,
     on_err: &TokenStream,
+    emit: &crate::api::core::emit::Emit,
 ) -> (TokenStream, TokenStream) {
-    let reconstruct = render_flat_struct_node(plan, &plan.root, Some(&plan.target), on_err);
+    let reconstruct = render_flat_struct_node(plan, &plan.root, Some(&plan.target), on_err, emit);
     let root_binding = &plan.root.binding;
     let prelude = quote! {
         #reconstruct
@@ -1824,13 +1830,14 @@ fn render_flat_struct_node(
     node: &FlatStructNode,
     target: Option<&RebuildTarget>,
     on_err: &TokenStream,
+    emit: &crate::api::core::emit::Emit,
 ) -> TokenStream {
     let mut decodes = TokenStream::new();
     let mut inits = Vec::new();
     for field in &node.fields {
         match field {
             FlatFieldNode::Nested { field, node: child } => {
-                decodes.extend(render_flat_struct_node(plan, child, None, on_err));
+                decodes.extend(render_flat_struct_node(plan, child, None, on_err, emit));
                 let child_binding = &child.binding;
                 inits.push(quote!(#field: #child_binding));
             }
@@ -1849,7 +1856,7 @@ fn render_flat_struct_node(
                 let tmp = format_ident!("{}_{}", node.binding, field);
                 // The slot's ascription, spelled from the reading the node
                 // carries — see the comment below on why the type is written.
-                let rust_ty = rust_ty.spell();
+                let rust_ty = emit.spell(rust_ty);
                 let tag = &plan.leaves[*tag_leaf].native_ident;
                 let arms = variants.iter().enumerate().map(|(t, v)| {
                     let vident = &v.rust_ident;
@@ -1932,13 +1939,13 @@ fn render_flat_struct_node(
                 let leaf = &plan.leaves[*value_leaf];
                 let wire = &leaf.native_ident;
                 let tmp = format_ident!("{}_{}", node.binding, field);
-                let rust_ty = rust_ty.spell();
+                let rust_ty = emit.spell(rust_ty);
                 let wrap = |e: TokenStream| {
                     build_through_wrappers(wrappers, e)
                         .expect("a field spelling the plan accepted is buildable")
                 };
                 if let Some(target) = direct_handle {
-                    let target_ty = target.spell();
+                    let target_ty = emit.spell(target);
                     if *optional_handle {
                         let gated = wrap(quote! {
                             if #wire == 0 {

--- a/prebindgen/src/api/lang/jnigen/jni/emit/vec_build.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/vec_build.rs
@@ -231,12 +231,13 @@ fn vec_helper_symbol(ext: &Declarations, base: &str, suffix: &str) -> String {
 pub(crate) fn build_vec_build_helper_items(
     ext: &Declarations,
     registry: &Registry<KotlinMeta>,
+    emit: &crate::api::core::emit::Emit,
 ) -> Vec<syn::Item> {
     let mut named: Vec<(String, syn::Item)> = Vec::new();
     for elem_reading in collect_vec_build_elem_types(ext, registry) {
         // Generated Rust spells `spell()`; the reading is what the plan
         // and the key are taken from.
-        let elem = elem_reading.spell();
+        let elem = emit.spell(&elem_reading);
         let Some(h) = vec_build_helpers(ext, registry, &elem_reading) else {
             continue;
         };

--- a/prebindgen/src/api/lang/jnigen/jni/emit/wrapper.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/wrapper.rs
@@ -13,8 +13,9 @@ pub(crate) fn emit_jni_function_wrapper(
     ext: &Declarations,
     f: &crate::api::core::flat::Function,
     registry: &Registry<KotlinMeta>,
+    emit: &crate::api::core::emit::Emit,
 ) -> TokenStream {
-    emit_jni_function_wrapper_with_callee(ext, f, registry, None)
+    emit_jni_function_wrapper_with_callee(ext, f, registry, None, emit)
 }
 
 /// The synthetic nullary getter signature a declared const is emitted
@@ -28,7 +29,7 @@ pub(crate) fn const_getter_fn(
 ) -> crate::api::core::flat::Function {
     let ident = format_ident!("const_get_{}", c.name.to_string().to_lowercase());
     // No lookup: a constant element carries its own `TypeRef`.
-    synthetic_getter(ident, c.ty.clone())
+    crate::api::core::flat::Function::synthetic_getter(ident, c.ty.clone())
 }
 
 /// A const whose (peeled) type is a declared opaque handle is rejected: a
@@ -142,39 +143,8 @@ pub(crate) fn const_expr_getter_fn(
             quote::ToTokens::to_token_stream(ty),
         )
     });
-    synthetic_getter(ident, ret)
+    crate::api::core::flat::Function::synthetic_getter(ident, ret)
 }
-/// A nullary getter as the MODEL would hold it — the one function no source
-/// wrote.
-///
-/// A declared constant crosses as a getter extern, and that getter goes through
-/// exactly the same emitter a real function does. So it needs a
-/// [`flat::Function`](crate::api::core::flat::Function), not a `syn::ItemFn`:
-/// the emitter classifies off `kind` now, and a synthesized item would have no
-/// reading to classify from.
-///
-/// `ret` is supplied by the caller because the two callers get it from
-/// different places — a declared const carries its own `TypeRef`, an
-/// expression constant names a type in the build script — and only the second
-/// has to look one up.
-pub(crate) fn synthetic_getter(
-    ident: syn::Ident,
-    ret: crate::api::core::flat::TypeRef,
-) -> crate::api::core::flat::Function {
-    let ret_syntax = ret.spell();
-    let item: syn::ItemFn = syn::parse_quote! {
-        pub fn #ident() -> #ret_syntax {
-            unimplemented!()
-        }
-    };
-    crate::api::core::flat::Function {
-        name: ident,
-        params: Vec::new(),
-        origin: ret.origin_with(item),
-        ret,
-    }
-}
-
 /// Validates an expression constant's declared value type (checked on both
 /// write paths): not a `Result` (a domain-fallible value is not a constant),
 /// not (peeled to) a declared opaque handle.
@@ -215,6 +185,7 @@ pub(crate) fn emit_jni_function_wrapper_with_callee(
     f: &crate::api::core::flat::Function,
     registry: &Registry<KotlinMeta>,
     callee: Option<syn::Expr>,
+    emit: &crate::api::core::emit::Emit,
 ) -> TokenStream {
     let original_ident = &f.name;
 
@@ -272,7 +243,8 @@ pub(crate) fn emit_jni_function_wrapper_with_callee(
     let on_err = sentinel_for_wire(&wire_ty);
 
     for param in &plan.params {
-        let (wp, pre, call_arg) = emit_input_param(ext, registry, original_ident, param, &on_err);
+        let (wp, pre, call_arg) =
+            emit_input_param(ext, registry, original_ident, param, &on_err, emit);
         wire_params.extend(wp);
         prelude.extend(pre);
         call_args.push(call_arg);
@@ -546,6 +518,7 @@ fn emit_input_param(
     original_ident: &syn::Ident,
     param: &PlanParam,
     on_err: &TokenStream,
+    emit: &crate::api::core::emit::Emit,
 ) -> (Vec<TokenStream>, Vec<TokenStream>, TokenStream) {
     // Constructor-expansion: this parameter's wire form is the fold plan's
     // flattened leaves. Decode each leaf with its own converter, run the
@@ -556,7 +529,7 @@ fn emit_input_param(
                 .expansion_plans()
                 .get(&(original_ident.clone(), param.ident.clone()))
                 .expect("ParamForm::Expanded ⇒ expansion plan present");
-            return emit_expanded_param(ext, registry, fold, leaves, &param.ident, on_err);
+            return emit_expanded_param(ext, registry, fold, leaves, &param.ident, on_err, emit);
         }
         ParamForm::Single(leaf) => &**leaf,
     };
@@ -578,7 +551,7 @@ fn emit_input_param(
                 let pty = &leaf.native_wire_ty;
                 wire_params.push(quote!(#pid: #pty));
             }
-            let (decode, call_arg) = render_flat_input_decode(plan, arg_ident, on_err);
+            let (decode, call_arg) = render_flat_input_decode(plan, arg_ident, on_err, emit);
             prelude.push(decode);
             (wire_params, prelude, call_arg)
         }
@@ -633,7 +606,7 @@ fn emit_input_param(
         // by-value-handle consume below.
         InputKind::VecBuild { elem, by_ref } => {
             // Generated Rust spells the reading's own tokens.
-            let elem = elem.spell();
+            let elem = emit.spell(elem);
             let handle_ident = format_ident!("{}_handle", arg_ident);
             wire_params.push(quote!(#handle_ident: jni::sys::jlong));
             if *by_ref {
@@ -685,7 +658,7 @@ fn emit_input_param(
                 arg_ident.clone()
             };
             wire_params.push(quote!(#wire_ident: jni::sys::jlong));
-            let arg_ty = arg_ty.spell();
+            let arg_ty = emit.spell(arg_ty);
             prelude.push(quote!(
                 if #wire_ident == 0 || (#wire_ident & 1) == 1 {
                     signal_binding_error(&mut env, &__error_sink, &__SINK_MID, __SINK_FQN, __SINK_DESCR, "Operation on a closed native handle.");
@@ -867,6 +840,7 @@ pub(crate) fn emit_expanded_param(
     leaves: &[PlanLeaf],
     orig_param: &syn::Ident,
     on_err: &TokenStream,
+    emit: &crate::api::core::emit::Emit,
 ) -> (Vec<TokenStream>, Vec<TokenStream>, TokenStream) {
     let mut wire_params: Vec<TokenStream> = Vec::new();
     let mut prelude: Vec<TokenStream> = Vec::new();
@@ -876,7 +850,7 @@ pub(crate) fn emit_expanded_param(
     for (leaf, classified) in plan.leaves.iter().zip(leaves) {
         let leaf_ty = &leaf.ty;
         // The ascription generated Rust writes for this leaf's local.
-        let leaf_ty_tokens = leaf_ty.spell();
+        let leaf_ty_tokens = emit.spell(leaf_ty);
         let lookup_entry = || {
             // The leaf's own reading goes straight to the entry: spelling it and
             // looking the same reading back up is the round trip #286 removed.
@@ -903,7 +877,7 @@ pub(crate) fn emit_expanded_param(
                 let wire = &flat_leaf.native_wire_ty;
                 wire_params.push(quote!(#ident: #wire));
             }
-            let (decode, _) = render_flat_input_decode(flat, &local, on_err);
+            let (decode, _) = render_flat_input_decode(flat, &local, on_err, emit);
             prelude.push(decode);
             leaf_locals.push(local);
             continue;

--- a/prebindgen/src/api/lang/jnigen/jni/kotlin_emit.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/kotlin_emit.rs
@@ -755,8 +755,9 @@ impl Declarations {
     ) -> KtType {
         // The field's own reading: the nullability question below is answered
         // from `kind`, so a wrapped spelling answers as the bare one does and
-        // nothing is looked up (#275).
-        let field_ty = field.ty.spell();
+        // nothing is looked up (#275). It is named only in the three panics
+        // below, which is a diagnostic and needs no emission capability.
+        let field_ty = &field.ty;
         let where_ = || format!("sealed_class!({}) payload `{variant}.{prop}`", sum_name);
         let out = registry.output_entry(&field.ty).unwrap_or_else(|| {
             panic!(
@@ -764,7 +765,7 @@ impl Declarations {
                  cannot be derived — register converters for the payload type before \
                  declaring the sealed class",
                 where_(),
-                field_ty.to_token_stream(),
+                field_ty,
             )
         });
 
@@ -783,7 +784,7 @@ impl Declarations {
             panic!(
                 "{}: `{}` has no Kotlin type mapping on its output converter",
                 where_(),
-                field_ty.to_token_stream(),
+                field_ty,
             )
         });
         // The input side must agree on WHICH TYPE the property is — Kotlin
@@ -816,7 +817,7 @@ impl Declarations {
                      type (`{}` in, `{}` out) — a sealed class's properties are read by both \
                      directions, so they must map to one type",
                     where_(),
-                    field_ty.to_token_stream(),
+                    field_ty,
                     in_ty,
                     ty,
                 );

--- a/prebindgen/src/api/lang/jnigen/jni/prim_array.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/prim_array.rs
@@ -130,17 +130,21 @@ pub(crate) fn output_body(spec: &PrimArray) -> syn::Expr {
 ///
 /// The length check is the `try_into`: a JVM array of the wrong size becomes a
 /// binding error naming the type, never a panic or a partially-filled array.
-pub(crate) fn input_body(ty: &crate::api::core::flat::TypeRef, spec: &PrimArray) -> syn::Expr {
+pub(crate) fn input_body(
+    ty: &crate::api::core::flat::TypeRef,
+    spec: &PrimArray,
+    emit: &crate::api::core::emit::Emit,
+) -> syn::Expr {
     let key = ty.key();
     // The element spelled from the model's own `Array`, so the local's type
     // ascription cannot disagree with what `prim_array_of` matched.
     let elem_ty = match ty.kind() {
-        crate::api::core::flat::TypeKind::Array { elem, .. } => elem.spell(),
+        crate::api::core::flat::TypeKind::Array { elem, .. } => emit.spell(elem),
         _ => unreachable!("prim_array_of matched a non-array"),
     };
     // The ascription the decoded array is checked against — spelled from the
     // reading, as generated Rust always spells.
-    let ty = ty.spell();
+    let ty = emit.spell(ty);
     let len_err = format!("fixed-size array decode: `{key}` expects a different length");
     if spec.is_u8 {
         return syn::parse_quote!({

--- a/prebindgen/src/api/lang/jnigen/jni/selector.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/selector.rs
@@ -176,7 +176,7 @@ impl Declarations {
         // 4. Last resort: the spelling differs from something convertible only
         //    by the wrappers the model erased. Nothing that resolves above
         //    reaches here, so this adds routes rather than changing them.
-        self.input_transparent_bridge(ty, registry)
+        self.input_transparent_bridge(ty, registry, emit)
     }
 
     /// Select the output converter for `ty`: terminals, user wrappers, then
@@ -202,8 +202,8 @@ impl Declarations {
         //    Read off the model, which calls this shape `TypeKind::Fallible`.
         //    `result_parts` covers a `Result` the adapter composed itself, which
         //    the frontend never read.
-        if let Some((ok, err)) = fallible_parts(ty) {
-            if let Some(c) = self.result_peel(ty, &ok, &err, registry) {
+        if let Some((ok, err)) = fallible_parts(ty, emit) {
+            if let Some(c) = self.result_peel(ty, &ok, &err, registry, emit) {
                 return Some(c);
             }
         }
@@ -258,7 +258,7 @@ impl Declarations {
         //    by the wrappers the model erased. Dual of the input side's step 4,
         //    and reached the same way — after every layer arm, so nothing that
         //    resolves today changes route (#309).
-        self.output_transparent_bridge(ty, registry)
+        self.output_transparent_bridge(ty, registry, emit)
     }
 }
 
@@ -274,8 +274,11 @@ impl Declarations {
 /// minting to the model, so every reading reaching here was classified, and
 /// `kind` is what says whether it is a `Result`. The fallback was measured
 /// never to fire in-tree; it is now unreachable by construction.
-fn fallible_parts(ty: &crate::api::core::flat::TypeRef) -> Option<(syn::Type, syn::Type)> {
+fn fallible_parts(
+    ty: &crate::api::core::flat::TypeRef,
+    emit: &crate::api::core::emit::Emit,
+) -> Option<(syn::Type, syn::Type)> {
     let (ok, err) = ty.fallible_parts()?;
-    let (ok, err) = (ok.spell(), err.spell());
+    let (ok, err) = (emit.spell(ok), emit.spell(err));
     Some((syn::parse_quote!(#ok), syn::parse_quote!(#err)))
 }

--- a/prebindgen/src/api/lang/jnigen/jni/tests/niches.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/niches.rs
@@ -18,8 +18,12 @@ fn option_carves_single_niche() {
     );
 
     let inner_ty: syn::Type = syn::parse_quote!(TestType);
-    let (wire, _body, niches) = option_input(&reg.reading_of(&inner_ty).expect("interned"), &reg)
-        .expect("Option<TestType> resolves");
+    let (wire, _body, niches) = option_input(
+        &reg.reading_of(&inner_ty).expect("interned"),
+        &reg,
+        &crate::api::core::emit::Emit::for_test(),
+    )
+    .expect("Option<TestType> resolves");
 
     assert_eq!(
         wire.to_token_stream().to_string(),
@@ -58,8 +62,12 @@ fn option_cascades_through_multi_niche() {
 
     // Layer 1: Option<TestType>.
     let layer1_ty: syn::Type = syn::parse_quote!(TestType);
-    let (w1, _, n1) = option_input(&reg.reading_of(&layer1_ty).expect("interned"), &reg)
-        .expect("layer 1 resolves");
+    let (w1, _, n1) = option_input(
+        &reg.reading_of(&layer1_ty).expect("interned"),
+        &reg,
+        &crate::api::core::emit::Emit::for_test(),
+    )
+    .expect("layer 1 resolves");
     assert_eq!(w1.to_token_stream().to_string(), "jni :: sys :: jint");
     assert_eq!(n1.len(), 1, "first carve leaves one niche");
 
@@ -75,8 +83,12 @@ fn option_cascades_through_multi_niche() {
 
     // Layer 2: Option<Option<TestType>>.
     let layer2_ty: syn::Type = syn::parse_quote!(Option<TestType>);
-    let (w2, _, n2) = option_input(&reg.reading_of(&layer2_ty).expect("interned"), &reg)
-        .expect("layer 2 resolves");
+    let (w2, _, n2) = option_input(
+        &reg.reading_of(&layer2_ty).expect("interned"),
+        &reg,
+        &crate::api::core::emit::Emit::for_test(),
+    )
+    .expect("layer 2 resolves");
     assert_eq!(
         w2.to_token_stream().to_string(),
         "jni :: sys :: jint",
@@ -95,8 +107,12 @@ fn option_cascades_through_multi_niche() {
     // Layer 3: Option<Option<Option<TestType>>>. No niches left,
     // inner wire is jint (a JNI primitive) → boxed-Long fallback.
     let layer3_ty: syn::Type = syn::parse_quote!(Option<Option<TestType>>);
-    let (w3, _, n3) = option_input(&reg.reading_of(&layer3_ty).expect("interned"), &reg)
-        .expect("layer 3 resolves via box fallback");
+    let (w3, _, n3) = option_input(
+        &reg.reading_of(&layer3_ty).expect("interned"),
+        &reg,
+        &crate::api::core::emit::Emit::for_test(),
+    )
+    .expect("layer 3 resolves via box fallback");
     assert_eq!(
         w3.to_token_stream().to_string(),
         "jni :: objects :: JObject",
@@ -184,8 +200,12 @@ fn option_over_jobject_uses_default_null_niche() {
     );
 
     let ty: syn::Type = syn::parse_quote!(MyStruct);
-    let (wire, _, rest) = option_input(&reg.reading_of(&ty).expect("interned"), &reg)
-        .expect("Option<MyStruct> resolves");
+    let (wire, _, rest) = option_input(
+        &reg.reading_of(&ty).expect("interned"),
+        &reg,
+        &crate::api::core::emit::Emit::for_test(),
+    )
+    .expect("Option<MyStruct> resolves");
     assert_eq!(
         wire.to_token_stream().to_string(),
         "jni :: objects :: JObject"
@@ -210,7 +230,12 @@ fn option_fails_when_no_niche_and_non_primitive_wire() {
         ),
     );
     let ty: syn::Type = syn::parse_quote!(MyStruct);
-    assert!(option_input(&reg.reading_of(&ty).expect("interned"), &reg).is_none());
+    assert!(option_input(
+        &reg.reading_of(&ty).expect("interned"),
+        &reg,
+        &crate::api::core::emit::Emit::for_test()
+    )
+    .is_none());
 }
 
 /// Boxed fallback widens to `JObject` and exposes no further
@@ -230,8 +255,12 @@ fn option_box_fallback_exposes_no_niches() {
         ),
     );
     let ty: syn::Type = syn::parse_quote!(i64);
-    let (wire, _, rest) = option_input(&reg.reading_of(&ty).expect("interned"), &reg)
-        .expect("Option<i64> via box fallback");
+    let (wire, _, rest) = option_input(
+        &reg.reading_of(&ty).expect("interned"),
+        &reg,
+        &crate::api::core::emit::Emit::for_test(),
+    )
+    .expect("Option<i64> via box fallback");
     assert_eq!(
         wire.to_token_stream().to_string(),
         "jni :: objects :: JObject"

--- a/prebindgen/src/api/lang/jnigen/jni/tests/value_form.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/value_form.rs
@@ -238,7 +238,7 @@ fn deriving_matches_the_equivalent_hand_written_list() {
             .callback_arg_plans
             .values()
             .flat_map(|p| p.leaves.iter())
-            .map(|l| (l.name.clone(), l.out_ty.spell().to_string()))
+            .map(|l| (l.name.clone(), l.out_ty.to_string()))
             .collect()
     };
 

--- a/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/trait_impl.rs
@@ -91,15 +91,16 @@ impl Declarations {
         wire: &syn::Type,
         body: &syn::Expr,
         exc: Option<&syn::Type>,
+        emit: &crate::api::core::emit::Emit,
     ) -> syn::ItemFn {
-        let spelled = rust.spell();
+        let spelled = emit.spell(rust);
         let rust_with_lifetime = match rust.kind() {
             crate::api::core::flat::TypeKind::Ref {
                 lifetime: None,
                 mutable,
                 inner,
             } => {
-                let inner = inner.spell();
+                let inner = emit.spell(inner);
                 let m = if *mutable { quote!(mut) } else { quote!() };
                 quote!(&'env #m #inner)
             }
@@ -163,8 +164,9 @@ impl Declarations {
         wire: &syn::Type,
         body: &syn::Expr,
         exc: Option<&syn::Type>,
+        emit: &crate::api::core::emit::Emit,
     ) -> syn::ItemFn {
-        self.build_output_fn_parts(&rust.spell(), wire, body, exc)
+        self.build_output_fn_parts(&emit.spell(rust), wire, body, exc)
     }
 
     pub(crate) fn build_output_fn_parts(
@@ -504,14 +506,14 @@ impl Declarations {
     pub fn opaque_handle_output(
         &self,
         reading: &crate::api::core::flat::TypeRef,
-        _emit: &crate::api::core::emit::Emit,
+        emit: &crate::api::core::emit::Emit,
     ) -> ConverterImpl<KotlinMeta> {
         let wire: syn::Type = syn::parse_quote!(jni::sys::jlong);
         let body: syn::Expr =
             syn::parse_quote!(std::boxed::Box::into_raw(std::boxed::Box::new(v)) as i64);
         ConverterImpl {
             subs: vec![],
-            function: self.build_output_fn_of(reading, &wire, &body, None),
+            function: self.build_output_fn_of(reading, &wire, &body, None, emit),
             destination: wire,
             pre_stages: vec![],
             niches: Niches::one(syn::parse_quote!(0i64), syn::parse_quote!(*v == 0)),
@@ -874,9 +876,10 @@ impl Declarations {
         wire: &syn::Type,
         body: &syn::Expr,
         exc: Option<&syn::Type>,
+        emit: &crate::api::core::emit::Emit,
     ) -> syn::ItemFn {
         match produced {
-            Produced::Reading(r) => self.build_input_fn_of(r, wire, body, exc),
+            Produced::Reading(r) => self.build_input_fn_of(r, wire, body, exc, emit),
             Produced::Composed(t) => self.build_input_fn_composed(t, wire, body, exc),
         }
     }
@@ -888,9 +891,10 @@ impl Declarations {
         wire: &syn::Type,
         body: &syn::Expr,
         exc: Option<&syn::Type>,
+        emit: &crate::api::core::emit::Emit,
     ) -> syn::ItemFn {
         match produced {
-            Produced::Reading(r) => self.build_output_fn_of(r, wire, body, exc),
+            Produced::Reading(r) => self.build_output_fn_of(r, wire, body, exc, emit),
             Produced::Composed(t) => self.build_output_fn(t, wire, body, exc),
         }
     }
@@ -1198,7 +1202,7 @@ impl Declarations {
         Some(ConverterImpl {
             subs: vec![],
             pre_stages: vec![],
-            function: self.build_input_fn_produced(produced, &wire, &body, None),
+            function: self.build_input_fn_produced(produced, &wire, &body, None, emit),
             destination: wire,
             niches: Niches::empty(),
             metadata: KotlinMeta {
@@ -1288,7 +1292,7 @@ impl Declarations {
         if shape == WrapperShape::Optional {
             let outer_ty = produced.key();
             let build = build_from_canonical(produced, quote::quote!(__v))?;
-            let (wire, inner_body, niches) = option_input(t1, registry)?;
+            let (wire, inner_body, niches) = option_input(t1, registry, emit)?;
             // `option_input` yields the canonical `Option<T>`; the converter
             // yields the spelling.
             let body: syn::Expr = syn::parse_quote!({
@@ -1317,7 +1321,7 @@ impl Declarations {
             return Some(ConverterImpl {
                 subs: vec![],
                 pre_stages: vec![],
-                function: self.build_input_fn_produced(produced, &wire, &body, None),
+                function: self.build_input_fn_produced(produced, &wire, &body, None, emit),
                 destination: wire,
                 niches,
                 metadata: KotlinMeta {
@@ -1454,7 +1458,7 @@ impl Declarations {
                 else {
                     return None;
                 };
-                self.dispatch_fn_input(args, built)
+                self.dispatch_fn_input(args, built, emit)
             }),
             Direction::Output => self.select_output_type(&reading, built, emit),
         }
@@ -1709,9 +1713,10 @@ impl Declarations {
         &self,
         args: &[crate::api::core::flat::TypeRef],
         registry: &impl Conversions<KotlinMeta>,
+        emit: &crate::api::core::emit::Emit,
     ) -> Option<ConverterImpl<KotlinMeta>> {
-        let outer_ty = build_fn_type(args);
-        let (wire, body) = callback_input(self, args, registry)?;
+        let outer_ty = build_fn_type(args, emit);
+        let (wire, body) = callback_input(self, args, registry, emit)?;
         let niches = default_niches_for_wire(&wire);
         // `impl Fn(...)` crosses the extern tier as the erased lambda object
         // (`Any`) — same as the unfold builder / error-sink params. The typed
@@ -1954,7 +1959,7 @@ impl Prebindgen for Declarations {
     fn prerequisites(
         &self,
         registry: &Registry<KotlinMeta>,
-        _emit: &crate::api::core::emit::Emit,
+        emit: &crate::api::core::emit::Emit,
     ) -> Vec<syn::Item> {
         // `__JniErr` is the **framework** error type alias — always the
         // `JniBindingError` String-wrapper. Built-in converter bodies compose
@@ -1979,13 +1984,13 @@ impl Prebindgen for Declarations {
         // Handle destructors — one `extern "C" freePtr<suffix>` per
         // non-suppressed opaque handle (the Rust half of the typed-handle
         // `free()` pair the Kotlin emitter generates).
-        items.extend(build_handle_destructor_items(self, registry, _emit));
+        items.extend(build_handle_destructor_items(self, registry, emit));
         // Slice/Vec input helpers — a `…VecNew/Push/Free` trio per flattenable
         // element type a scanned `&[T]`/`Vec<T>` param takes. Kotlin builds the
         // Rust-side `Vec` by pushing each element's decoupled leaves, then passes
         // the handle (see `ParamMode::VecBuild`), avoiding per-element
         // `env.get_field(...)` upcalls on the Rust side.
-        items.extend(build_vec_build_helper_items(self, registry));
+        items.extend(build_vec_build_helper_items(self, registry, emit));
         // Expression constants — one nullary JNI getter extern per
         // `PackageDecl::constant_expr`, its value the binding-defined
         // expression evaluated with a glob import of every source module (so
@@ -2008,7 +2013,7 @@ impl Prebindgen for Declarations {
                 #expr
             });
             let wrapper =
-                emit_jni_function_wrapper_with_callee(self, &getter, registry, Some(callee));
+                emit_jni_function_wrapper_with_callee(self, &getter, registry, Some(callee), emit);
             items.push(syn::parse2::<syn::Item>(wrapper).expect(
                 "constant_expr: generated getter wrapper is a single item by construction",
             ));
@@ -2031,9 +2036,9 @@ impl Prebindgen for Declarations {
         &self,
         f: &crate::api::core::flat::Function,
         registry: &Registry<KotlinMeta>,
-        _emit: &crate::api::core::emit::Emit,
+        emit: &crate::api::core::emit::Emit,
     ) -> TokenStream {
-        emit_jni_function_wrapper(self, f, registry)
+        emit_jni_function_wrapper(self, f, registry, emit)
     }
 
     fn on_struct(
@@ -2084,7 +2089,8 @@ impl Prebindgen for Declarations {
         let const_ident = &c.name;
         let source_module = self.fn_module(registry, const_ident);
         let callee: syn::Expr = syn::parse_quote!(#source_module::#const_ident);
-        let wrapper = emit_jni_function_wrapper_with_callee(self, &getter, registry, Some(callee));
+        let wrapper =
+            emit_jni_function_wrapper_with_callee(self, &getter, registry, Some(callee), emit);
         let alias = emit.const_alias(c, &source_module);
         quote! {
             #alias
@@ -2125,14 +2131,14 @@ impl Declarations {
         // The `try_into` IS the length check: a JVM array of the wrong size
         // becomes a binding error naming the type, never a panic.
         if let Some(spec) = crate::api::lang::jnigen::jni::prim_array::prim_array_of(reading) {
-            let body = crate::api::lang::jnigen::jni::prim_array::input_body(reading, &spec);
+            let body = crate::api::lang::jnigen::jni::prim_array::input_body(reading, &spec, emit);
             let wire = spec.wire.clone();
             let kotlin_name = self.override_kotlin_name(&reading.key(), Some(spec.kotlin.clone()));
             let niches = default_niches_for_wire(&wire);
             return Some(ConverterImpl {
                 subs: vec![],
                 pre_stages: vec![],
-                function: self.build_input_fn_of(reading, &wire, &body, None),
+                function: self.build_input_fn_of(reading, &wire, &body, None, emit),
                 destination: wire,
                 niches,
                 metadata: self.framework_meta(kotlin_name),
@@ -2160,7 +2166,7 @@ impl Declarations {
                         return Some(ConverterImpl {
                             subs: vec![],
                             pre_stages: vec![],
-                            function: self.build_input_fn_of(reading, &wire, &body, None),
+                            function: self.build_input_fn_of(reading, &wire, &body, None, emit),
                             destination: wire,
                             niches,
                             metadata: self.framework_meta(kotlin_name),
@@ -2231,7 +2237,7 @@ impl Declarations {
             return Some(ConverterImpl {
                 subs: vec![],
                 pre_stages: vec![],
-                function: self.build_input_fn_of(reading, &wire, &body, None),
+                function: self.build_input_fn_of(reading, &wire, &body, None, emit),
                 destination: wire,
                 niches,
                 metadata: self.framework_meta(kotlin_name),
@@ -2248,7 +2254,7 @@ impl Declarations {
             return Some(ConverterImpl {
                 subs: vec![],
                 pre_stages: vec![],
-                function: self.build_input_fn_of(reading, &wire, &body, None),
+                function: self.build_input_fn_of(reading, &wire, &body, None, emit),
                 destination: wire,
                 niches,
                 metadata,
@@ -2265,7 +2271,7 @@ impl Declarations {
                 if let Some(crate::api::core::flat::Type::Variant(v)) =
                     registry.flat().declared_type(&name)
                 {
-                    let (wire, body) = sum_input_body(self, v, registry)?;
+                    let (wire, body) = sum_input_body(self, v, registry, emit)?;
                     // The wire's own null niche, exactly as a data class gets
                     // — that is what lets `Option<sum>` fold with JVM null as
                     // `None` instead of needing a boxed wrapper.
@@ -2278,7 +2284,7 @@ impl Declarations {
                     return Some(ConverterImpl {
                         subs: vec![],
                         pre_stages: vec![],
-                        function: self.build_input_fn_of(reading, &wire, &body, None),
+                        function: self.build_input_fn_of(reading, &wire, &body, None, emit),
                         destination: wire,
                         niches,
                         metadata: self.framework_meta(kotlin_name),
@@ -2286,7 +2292,7 @@ impl Declarations {
                 }
             }
             if let Some(s) = registry.flat().struct_type(&name) {
-                let (wire, body) = struct_input_body(self, s, registry)?;
+                let (wire, body) = struct_input_body(self, s, registry, emit)?;
                 let niches = default_niches_for_wire(&wire);
                 // Auto-generated struct: the value-context Kotlin name is
                 // whatever the user pinned via `data_class`. If
@@ -2300,7 +2306,7 @@ impl Declarations {
                 return Some(ConverterImpl {
                     subs: vec![],
                     pre_stages: vec![],
-                    function: self.build_input_fn_of(reading, &wire, &body, None),
+                    function: self.build_input_fn_of(reading, &wire, &body, None, emit),
                     destination: wire,
                     niches,
                     metadata: self.framework_meta(kotlin_name),
@@ -2340,6 +2346,7 @@ impl Declarations {
         &self,
         reading: &crate::api::core::flat::TypeRef,
         registry: &impl Conversions<KotlinMeta>,
+        emit: &crate::api::core::emit::Emit,
     ) -> Option<ConverterImpl<KotlinMeta>> {
         if reading.erased_wrappers().is_empty() {
             return None;
@@ -2381,7 +2388,7 @@ impl Declarations {
         Some(ConverterImpl {
             subs: vec![stripped],
             pre_stages: vec![],
-            function: self.build_output_fn_of(reading, &wire, &body, None),
+            function: self.build_output_fn_of(reading, &wire, &body, None, emit),
             destination: wire,
             niches: entry.niches.clone(),
             // The surface is the inner type's — a wrapper is invisible to the
@@ -2414,6 +2421,7 @@ impl Declarations {
         &self,
         reading: &crate::api::core::flat::TypeRef,
         registry: &impl Conversions<KotlinMeta>,
+        emit: &crate::api::core::emit::Emit,
     ) -> Option<ConverterImpl<KotlinMeta>> {
         if reading.erased_wrappers().is_empty() {
             return None;
@@ -2459,7 +2467,7 @@ impl Declarations {
         Some(ConverterImpl {
             subs: vec![stripped],
             pre_stages: vec![],
-            function: self.build_input_fn_of(reading, &wire, &body, None),
+            function: self.build_input_fn_of(reading, &wire, &body, None, emit),
             destination: wire,
             niches: entry.niches.clone(),
             // The surface is the inner type's: a wrapper is invisible to the
@@ -2526,7 +2534,7 @@ impl Declarations {
             return Some(ConverterImpl {
                 subs: vec![],
                 pre_stages: vec![],
-                function: self.build_output_fn_of(reading, &wire, &body, None),
+                function: self.build_output_fn_of(reading, &wire, &body, None, emit),
                 destination: wire,
                 niches,
                 metadata: self.framework_meta(kotlin_name),
@@ -2549,7 +2557,7 @@ impl Declarations {
                         return Some(ConverterImpl {
                             subs: vec![],
                             pre_stages: vec![],
-                            function: self.build_output_fn_of(reading, &wire, &body, None),
+                            function: self.build_output_fn_of(reading, &wire, &body, None, emit),
                             destination: wire,
                             niches,
                             metadata: self.framework_meta(kotlin_name),
@@ -2592,7 +2600,7 @@ impl Declarations {
             return Some(ConverterImpl {
                 subs: vec![],
                 pre_stages: vec![],
-                function: self.build_output_fn_of(reading, &wire, &body, None),
+                function: self.build_output_fn_of(reading, &wire, &body, None, emit),
                 destination: wire,
                 niches,
                 metadata: self.framework_meta(kotlin_name),
@@ -2619,7 +2627,7 @@ impl Declarations {
             let body: syn::Expr = syn::parse_quote!(v);
             return Some(ConverterImpl {
                 subs: vec![],
-                function: self.build_output_fn_of(reading, &wire, &body, None),
+                function: self.build_output_fn_of(reading, &wire, &body, None, emit),
                 destination: wire,
                 pre_stages: vec![],
                 niches: Niches::empty(),
@@ -2637,7 +2645,7 @@ impl Declarations {
             return Some(ConverterImpl {
                 subs: vec![],
                 pre_stages: vec![],
-                function: self.build_output_fn_of(reading, &wire, &body, None),
+                function: self.build_output_fn_of(reading, &wire, &body, None, emit),
                 destination: wire,
                 niches,
                 metadata,
@@ -2655,7 +2663,7 @@ impl Declarations {
                 return Some(ConverterImpl {
                     subs: vec![],
                     pre_stages: vec![],
-                    function: self.build_output_fn_of(reading, &wire, &body, None),
+                    function: self.build_output_fn_of(reading, &wire, &body, None, emit),
                     destination: wire,
                     niches,
                     metadata: self.framework_meta(kotlin_name),
@@ -2698,7 +2706,7 @@ impl Declarations {
                 ) as i64);
                 return Some(ConverterImpl {
                     subs: vec![],
-                    function: self.build_output_fn_produced(produced, &wire, &body, None),
+                    function: self.build_output_fn_produced(produced, &wire, &body, None, emit),
                     destination: wire,
                     pre_stages: vec![],
                     niches: Niches::one(syn::parse_quote!(0i64), syn::parse_quote!(*v == 0)),
@@ -2760,7 +2768,7 @@ impl Declarations {
             return Some(ConverterImpl {
                 subs: vec![],
                 pre_stages: vec![],
-                function: self.build_output_fn_produced(produced, &wire, &body, None),
+                function: self.build_output_fn_produced(produced, &wire, &body, None, emit),
                 destination: wire,
                 niches,
                 metadata: KotlinMeta {
@@ -2831,7 +2839,7 @@ impl Declarations {
             return Some(ConverterImpl {
                 subs: vec![],
                 pre_stages: vec![],
-                function: self.build_output_fn_produced(produced, &wire, &body, None),
+                function: self.build_output_fn_produced(produced, &wire, &body, None, emit),
                 destination: wire,
                 niches,
                 metadata: KotlinMeta {


### PR DESCRIPTION
Part of the capability umbrella [#361](https://github.com/milyin/prebindgen/pull/361). **The boundary is now enforced by the compiler in both halves.**

## The seal

`TypeRef::spell`, `TypeRef::stripped_syntax` and `TypeKind::to_syn` are `pub(in crate::api::core)`. Verified from a genuine external crate, not just doctests:

```
error[E0624]: method `spell` is private
error[E0624]: method `stripped_syntax` is private
error[E0624]: method `to_syn` is private
```

Together with C1's item seal, **there is no route from the model to captured syntax outside `Emit`** — in this crate or anyone else's. Eight `compile_fail` doctests pin it; a doctest builds against the published API exactly as a consumer does, which is the population the census could never see.

## What threading the last 19 found

* **`kotlin_emit`'s sealed-class builder** spelled a field type for three `panic!`s. A diagnostic, so `Display`. Its absence is why Kotlin rendering no longer demands an emission capability.
* **`synthetic_getter` minted a `flat::Function` inside the adapter.** Building one means spelling `ret`, so it dragged the capability into `validate_bindings`, `validate_resolved` and `write_kotlin` — none of which emit Rust; they only wanted the resulting `Function`. #280 says a model element is the model's to mint, so it moved to `Function::synthetic_getter`, where the spelling is internal. The leak then stopped cleanly at `on_function` and `prerequisites`, which already hold a token.

That second one is the argument for this whole umbrella, again: the capability did not merely fail to reach validation — it **pointed at the reason it was being asked to**, which was an adapter constructing a model element. A census counts; this explains.

## Two notes on the seal's edges

* `Emit::for_test` is `#[cfg(test)]`. Production code still cannot mint one, and the `compile_fail` doctests still prove the out-of-crate seal, because a doctest compiles against the *built* crate where it does not exist.
* `TypeKind::to_syn` is now `#[allow(dead_code)]`. With the spelling sealed, nothing in a built crate calls it — and that is the correct end state rather than rot: its job is the round-trip check that a kind can reproduce its own syntax, which is a test.
* `Origin::declared_spelling` stays public. An adapter declaration's `Origin<syn::Type>` holds a type the **build script** wrote, never captured, which #280 leaves the model no reading for.

## Measurement

| | before | after |
|---|---:|---:|
| classification sites | 48 | 48 |
| escapes: types / items | 0 / 0 | 0 / 0 |

**Adapter `spell()` calls: 19 → 0.** That number — the one the census never tracked — went 69 → 47 → 23 → 22 → 21 → 19 → 0 across C2…C5.

The ledger's three counts are now all measuring something the compiler independently guarantees, which is what makes C6 (deleting it) safe.

## Gate

- `cargo test -p prebindgen --all-features` — 640 lib, 30 doctests (8 `compile_fail`)
- clippy `--all-targets --all-features -D warnings` on stable **and** 1.85.0
- `cargo fmt --check` with the CI config
- `examples/regen-check.sh` — every generated artifact byte-identical
