### PR TITLE
C7: seal what C5 claimed, and check it mechanically

### DIFF
--- a/prebindgen/src/api/core/emit.rs
+++ b/prebindgen/src/api/core/emit.rs
@@ -28,34 +28,37 @@
 //!
 //! [`Prebindgen::on_function`](super::prebindgen::Prebindgen::on_function) and
 //! its four peers, [`prerequisites`](super::prebindgen::Prebindgen::prerequisites),
-//! and [`post_process_item`](super::prebindgen::Prebindgen::post_process_item).
-//! Nothing else *yet*: the converter path — `RegistryBuilder::convert_with`'s
-//! closure, and the selector chains under it — still receives only
-//! `(&Crossing, &Building)`, and threading `&Emit` there is C3's job, together
-//! with moving [`TypeRef::spell`](super::flat::TypeRef::spell) behind this type.
+//! [`post_process_item`](super::prebindgen::Prebindgen::post_process_item), and
+//! the closure [`RegistryBuilder::convert_with`](super::registry::RegistryBuilder::convert_with)
+//! calls — a converter is generated Rust, since `ConverterImpl::function` is a
+//! complete `syn::ItemFn` the adapter writes. Nothing else.
 //!
 //! If a helper needs an `&Emit`, that is the helper saying it emits; if
 //! threading one to it feels wrong, it is probably deciding something and wants
 //! the model instead.
 //!
-//! # What is closed, and what is not
+//! # What is closed
 //!
-//! **Closed as of this stage: every route to a captured *item*.**
-//! `Element::as_syn`, `Type::as_syn` and `Origin::as_syn` are
-//! `pub(in crate::api::core)`, and so is `Origin::spell` — whose tokens
-//! re-parse to the item, which is the same door under another name. The
-//! `compile_fail` examples on [`Emit`] check each of those from outside the
-//! crate, which is where a doctest runs and where the census could never look.
+//! **Every route from the model to captured syntax.** `TypeRef::{as_syn, spell,
+//! stripped_syntax}`, `TypeKind::to_syn`, `Element::as_syn`, `Type::as_syn`,
+//! `Origin::{as_syn, spell}`, `Flat::enum_item` and the three `spell(head,
+//! parts)` shape methods are all `pub(in crate::api::core)`. Eleven
+//! `compile_fail` examples on [`Emit`] check each from outside the crate, and
+//! `flat::surface` fails if a *new* public item in `flat` returns a `syn` type.
 //!
-//! **Closed as of C5: type spellings too.** `TypeRef::spell`,
-//! `TypeRef::stripped_syntax` and `TypeKind::to_syn` are
-//! `pub(in crate::api::core)`. There is no route from the model to captured
-//! syntax outside this type, and the `compile_fail` examples check every one
-//! from outside the crate.
+//! Two things stay public because they are not that:
 //!
-//! `Origin::declared_spelling` stays public: an adapter declaration's
-//! `Origin<syn::Type>` holds a type the **build script** wrote, which was never
-//! captured and which #280 leaves the model no reading for.
+//! * [`Origin::declared_spelling`](super::flat::Origin::declared_spelling) — an
+//!   adapter declaration's `Origin<syn::Type>` holds a type the **build script**
+//!   wrote, never captured, which #280 leaves the model no reading for.
+//! * [`Field::member`](super::flat::Field::member) and
+//!   [`Field::bind`](super::flat::Field::bind) — they read the field's `name`
+//!   and `index`, model facts, no syntax.
+//!
+//! `Display for TypeRef` renders the **identity**, not the spelling: a message
+//! is decision code explaining itself and must not need this capability, and
+//! delegating to `spell()` would have handed the captured tokens back out
+//! through `format!`.
 //!
 //! # What the census did that this does not
 //!
@@ -132,8 +135,38 @@ use super::flat::{Element, EnumValue, Field, Struct, Type, TypeRef};
 /// fn leak(f: &flat::Function) -> proc_macro2::TokenStream { f.origin.spell() }
 /// ```
 ///
-/// A type's spelling, sealed as of C5 — the last route, and the one the census
-/// could only ever *count*:
+/// A type's **node** — the door C5 claimed to have closed and did not, found by
+/// review after the census was already deleted:
+///
+/// ```compile_fail
+/// # use prebindgen::core::flat;
+/// fn leak(t: &flat::TypeRef) -> &syn::Type { t.as_syn() }
+/// ```
+///
+/// A declared enum's item, by name:
+///
+/// ```compile_fail
+/// # use prebindgen::core::Flat;
+/// fn leak(f: &Flat) -> Option<&syn::ItemEnum> { f.enum_item("E") }
+/// ```
+///
+/// The delimiters a shape was written with — `S { a }` vs `S(a)` vs `S`:
+///
+/// ```compile_fail
+/// # use prebindgen::core::flat;
+/// fn leak(s: &flat::Struct) -> proc_macro2::TokenStream {
+///     s.spell(Default::default(), &[])
+/// }
+/// ```
+///
+/// ```compile_fail
+/// # use prebindgen::core::flat;
+/// fn leak(v: &flat::EnumValue) -> proc_macro2::TokenStream {
+///     v.spell(Default::default(), &[])
+/// }
+/// ```
+///
+/// A type's spelling — the route the census could only ever *count*:
 ///
 /// ```compile_fail
 /// # use prebindgen::core::flat;
@@ -288,26 +321,28 @@ impl Emit {
             .map(|(_, expr)| quote::quote!(#expr))
     }
 
-    /// A struct spelled with the delimiters the source wrote — `S { a: x }`,
-    /// `S(x)`, `S` — for a pattern or a constructor alike.
-    pub fn struct_shape(
+    /// A struct, alternative or enum value spelled with **the delimiters the
+    /// source wrote** — `S { a: x }`, `S(x)`, `S` — for a pattern or a
+    /// constructor alike.
+    ///
+    /// `B` and `B()` are both payload-free and still spelled differently, which
+    /// is why this is a rendering rather than something `kind` could answer.
+    ///
+    /// Note what is *not* here: [`Field::member`](super::flat::Field::member)
+    /// and [`Field::bind`](super::flat::Field::bind) stay ungated, because they
+    /// read the field's `name` and `index` — model facts, no captured syntax.
+    // `Shaped` is deliberately more private than this method: that is the
+    // sealed-trait pattern, and it is what stops the trait itself becoming a
+    // door. An out-of-crate consumer can call `shape` on the three elements
+    // and cannot implement it for anything else, or name it to route around.
+    #[allow(private_bounds)]
+    pub fn shape<S: super::flat::spell::Shaped>(
         &self,
-        s: &Struct,
+        s: &S,
         head: TokenStream,
         parts: &[TokenStream],
     ) -> TokenStream {
-        s.spell(head, parts)
-    }
-
-    /// An alternative spelled with its own delimiters. The [`Alternative`](super::flat::Alternative)
-    /// peer of [`Self::struct_shape`].
-    pub fn alternative_shape(
-        &self,
-        a: &super::flat::Alternative,
-        head: TokenStream,
-        parts: &[TokenStream],
-    ) -> TokenStream {
-        a.spell(head, parts)
+        super::flat::spell::fields(s.shape(), head, parts)
     }
 
     /// How a field is addressed in a pattern or an initializer — by name when

--- a/prebindgen/src/api/core/flat/mod.rs
+++ b/prebindgen/src/api/core/flat/mod.rs
@@ -185,10 +185,12 @@ use quote::ToTokens;
 mod array_len;
 mod element;
 mod origin;
-pub mod spell;
+pub(in crate::api::core) mod spell;
 pub(crate) mod spelling;
 mod ty;
 
+#[cfg(test)]
+mod surface;
 #[cfg(test)]
 mod tests;
 
@@ -200,7 +202,7 @@ pub use self::{
         Struct, Type, Unsupported, Variant,
     },
     origin::Origin,
-    spelling::{canonical_spelling, canonical_type, type_from_ident},
+    spelling::{canonical_spelling, canonical_type},
     ty::{
         peel_transparent, GenericArg, ScalarKind, TypeId, TypeKind, TypeRef, UnsupportedType,
         UnsupportedTypeReason, TRANSPARENT_WRAPPERS,
@@ -634,7 +636,15 @@ impl Flat {
     /// Rust and both keep that item. A consumer re-emitting the source wants the
     /// item without caring which shape it is; one that acts on the distinction
     /// reaches for [`Self::declared_type`].
-    pub fn enum_item<N: Name + ?Sized>(&self, name: &N) -> Option<&syn::ItemEnum> {
+    // Test-only since S42: `unit_enum`, `payload_enum`, `enum_alternatives` and
+    // `declared_member_names` each ask the model which shape a declared enum is
+    // and get the element that answers, so nothing in a built crate needs the
+    // item. The registry tests still exercise it.
+    #[allow(dead_code)]
+    pub(in crate::api::core) fn enum_item<N: Name + ?Sized>(
+        &self,
+        name: &N,
+    ) -> Option<&syn::ItemEnum> {
         match self.declared_type(name)? {
             Type::Variant(v) => Some(v.origin.as_syn()),
             Type::Enum(e) => Some(e.origin.as_syn()),

--- a/prebindgen/src/api/core/flat/spell.rs
+++ b/prebindgen/src/api/core/flat/spell.rs
@@ -26,7 +26,11 @@ use super::element::{Alternative, EnumValue, Field, Struct};
 ///
 /// `head` is the type's or variant's path, and each part is an already-rendered
 /// [`Field::bind`].
-pub fn fields(shape: &syn::Fields, head: TokenStream, parts: &[TokenStream]) -> TokenStream {
+pub(in crate::api::core) fn fields(
+    shape: &syn::Fields,
+    head: TokenStream,
+    parts: &[TokenStream],
+) -> TokenStream {
     match shape {
         syn::Fields::Unit => head,
         syn::Fields::Unnamed(_) => quote!(#head(#(#parts),*)),
@@ -34,36 +38,40 @@ pub fn fields(shape: &syn::Fields, head: TokenStream, parts: &[TokenStream]) -> 
     }
 }
 
-impl Alternative {
-    /// [`fields`] over this alternative's own delimiters.
-    pub fn spell(&self, head: TokenStream, parts: &[TokenStream]) -> TokenStream {
-        fields(&self.origin.as_syn().fields, head, parts)
-    }
+/// The three elements that carry their own field delimiters.
+///
+/// `pub(in crate::api::core)`, so it can bound
+/// [`Emit::shape`](crate::api::core::emit::Emit::shape) without becoming a door
+/// itself: an out-of-crate consumer cannot name it, so cannot call through it.
+pub(in crate::api::core) trait Shaped {
+    fn shape(&self) -> &syn::Fields;
 }
 
-impl EnumValue {
-    /// [`fields`] over this value's own delimiters.
-    ///
-    /// A fieldless alternative still has them: `A`, `B()` and `C {}` carry no
-    /// payload alike, and Rust demands the delimiters wherever the last two are
-    /// named. `parts` is therefore always empty — the signature matches
-    /// [`Alternative::spell`] so one caller can spell either.
-    pub fn spell(&self, head: TokenStream, parts: &[TokenStream]) -> TokenStream {
-        fields(&self.origin.as_syn().fields, head, parts)
+impl Shaped for Alternative {
+    fn shape(&self) -> &syn::Fields {
+        &self.origin.as_syn().fields
     }
 }
-
-impl Struct {
-    /// [`fields`] over this struct's own delimiters — the dual of
-    /// [`Variant::spell`], and the reason neither needs a modelled shape.
-    pub fn spell(&self, head: TokenStream, parts: &[TokenStream]) -> TokenStream {
-        fields(&self.origin.as_syn().fields, head, parts)
+impl Shaped for EnumValue {
+    fn shape(&self) -> &syn::Fields {
+        &self.origin.as_syn().fields
+    }
+}
+impl Shaped for Struct {
+    fn shape(&self) -> &syn::Fields {
+        &self.origin.as_syn().fields
     }
 }
 
 impl Field {
     /// How the field is addressed in a pattern or an initializer: by name when
     /// it has one, else by position.
+    ///
+    /// Ungated, and the reason is what it reads: [`name`](Self::name) and
+    /// [`index`](Self::index), both model facts. No captured syntax is
+    /// involved, so this is not a door — unlike the `spell` methods above,
+    /// which read the delimiters the source wrote and are
+    /// [`Emit::shape`](crate::api::core::emit::Emit::shape)'s to hand out.
     pub fn member(&self) -> syn::Member {
         match &self.name {
             Some(id) => syn::Member::Named(id.clone()),

--- a/prebindgen/src/api/core/flat/spelling.rs
+++ b/prebindgen/src/api/core/flat/spelling.rs
@@ -19,15 +19,6 @@ use std::collections::HashMap;
 
 use crate::SourceLocation;
 
-/// The single-segment path type for a bare item ident (`Foo` → `Foo`) —
-/// direct construction, no string round trip, cannot fail.
-pub fn type_from_ident(ident: &syn::Ident) -> syn::Type {
-    syn::Type::Path(syn::TypePath {
-        qself: None,
-        path: syn::Path::from(ident.clone()),
-    })
-}
-
 /// Normalize a type to its canonical flat-namespace spelling (issue #95).
 /// The COMPLETE equivalence rule set — any spelling not listed is preserved
 /// verbatim:

--- a/prebindgen/src/api/core/flat/surface.rs
+++ b/prebindgen/src/api/core/flat/surface.rs
@@ -53,6 +53,10 @@ fn doors(file: &syn::File) -> Vec<String> {
         let syn::ReturnType::Type(_, t) = ty else {
             return None;
         };
+        names_a_type(t)
+    }
+    /// A `syn` mention in any type position, not just a return.
+    fn names_a_type(t: &syn::Type) -> Option<String> {
         let toks: Vec<proc_macro2::TokenTree> =
             quote::ToTokens::to_token_stream(t).into_iter().collect();
         for (i, tt) in toks.iter().enumerate() {
@@ -62,7 +66,6 @@ fn doors(file: &syn::File) -> Vec<String> {
             if *id != "syn" {
                 continue;
             }
-            // `syn :: <Name>` — two `:` puncts then the name.
             if let Some(proc_macro2::TokenTree::Ident(name)) = toks.get(i + 3) {
                 let n = name.to_string();
                 if !LEAF.contains(&n.as_str()) {
@@ -71,6 +74,12 @@ fn doors(file: &syn::File) -> Vec<String> {
             }
         }
         None
+    }
+    /// `Origin<..>` is the seal itself — every element carries one, and its own
+    /// accessors are what this file exists to keep sealed.
+    fn is_origin(t: &syn::Type) -> bool {
+        let toks = quote::ToTokens::to_token_stream(t).to_string();
+        toks.starts_with("Origin ") || toks.starts_with("Origin<")
     }
     fn is_transformer(sig: &syn::Signature) -> bool {
         TRANSFORMERS.contains(&sig.ident.to_string().as_str())
@@ -90,7 +99,13 @@ fn doors(file: &syn::File) -> Vec<String> {
         })
         .collect();
     let mut out = Vec::new();
-    let walk = |items: &[syn::Item], out: &mut Vec<String>| {
+    // Every item kind that can put a `syn` type on a public surface. The list
+    // is the census's, because each entry was there for a bypass someone found:
+    // a type alias is transparent, an associated `type Target` hands the node to
+    // `&*x` with no method to see, a public field is an accessor you cannot
+    // remove, a trait method is as visible as its trait, and a nested module
+    // hides all of the above one level down.
+    fn walk(items: &[syn::Item], sealed: &[String], out: &mut Vec<String>) {
         for item in items {
             match item {
                 syn::Item::Fn(f) if is_public(&f.vis) => {
@@ -101,30 +116,105 @@ fn doors(file: &syn::File) -> Vec<String> {
                         out.push(format!("fn {} -> syn::{n}", f.sig.ident));
                     }
                 }
+                // `pub type Node = syn::Type` — reported whatever its OWN
+                // visibility is: an alias is transparent, so a private one still
+                // lets a public signature hand the node out under its name.
+                syn::Item::Type(t) => {
+                    if let Some(n) = names_a_type(&t.ty) {
+                        out.push(format!("type {} = syn::{n}", t.ident));
+                    }
+                }
                 syn::Item::Impl(im) => {
-                    let sealed = im.trait_.as_ref().is_some_and(|(_, p, _)| {
+                    let is_sealed_trait = im.trait_.as_ref().is_some_and(|(_, p, _)| {
                         p.segments
                             .last()
-                            .is_some_and(|s| sealed_traits.contains(&s.ident.to_string()))
+                            .is_some_and(|s| sealed.contains(&s.ident.to_string()))
                     });
-                    if sealed {
+                    if is_sealed_trait {
                         continue;
                     }
                     for it in &im.items {
-                        // A trait impl's methods are as public as the trait.
-                        let syn::ImplItem::Fn(f) = it else { continue };
-                        if im.trait_.is_some() || is_public(&f.vis) {
-                            if let Some(n) = names_a_node(&f.sig.output) {
-                                out.push(format!("{} -> syn::{n}", f.sig.ident));
+                        match it {
+                            syn::ImplItem::Fn(f) => {
+                                // A trait impl's method is as public as the trait.
+                                if (im.trait_.is_some() || is_public(&f.vis))
+                                    && !is_transformer(&f.sig)
+                                {
+                                    if let Some(n) = names_a_node(&f.sig.output) {
+                                        out.push(format!("{} -> syn::{n}", f.sig.ident));
+                                    }
+                                }
+                            }
+                            // `impl Deref for TypeRef { type Target = syn::Type; }`
+                            // hands the node to `&*ty` with no method to look at.
+                            syn::ImplItem::Type(t) => {
+                                if let Some(n) = names_a_type(&t.ty) {
+                                    out.push(format!("type {} = syn::{n}", t.ident));
+                                }
+                            }
+                            _ => {}
+                        }
+                    }
+                }
+                syn::Item::Trait(t) if is_public(&t.vis) => {
+                    for it in &t.items {
+                        match it {
+                            syn::TraitItem::Fn(f) if !is_transformer(&f.sig) => {
+                                if let Some(n) = names_a_node(&f.sig.output) {
+                                    out.push(format!("trait fn {} -> syn::{n}", f.sig.ident));
+                                }
+                            }
+                            syn::TraitItem::Type(ty) => {
+                                if let Some((_, d)) = &ty.default {
+                                    if let Some(n) = names_a_type(d) {
+                                        out.push(format!("trait type {} = syn::{n}", ty.ident));
+                                    }
+                                }
+                            }
+                            _ => {}
+                        }
+                    }
+                }
+                // A public field IS an accessor, and one you cannot deprecate.
+                // A field whose type is an `Origin` is exempt: that wrapper is
+                // the seal, and every element carries one.
+                syn::Item::Struct(st) if is_public(&st.vis) => {
+                    for f in &st.fields {
+                        if is_public(&f.vis) && !is_origin(&f.ty) {
+                            if let Some(n) = names_a_type(&f.ty) {
+                                let name = f
+                                    .ident
+                                    .as_ref()
+                                    .map_or_else(|| "_".to_string(), |i| i.to_string());
+                                out.push(format!("field {} : syn::{n}", name));
                             }
                         }
+                    }
+                }
+                // An enum variant's fields are public with the variant.
+                syn::Item::Enum(en) if is_public(&en.vis) => {
+                    for v in &en.variants {
+                        for f in &v.fields {
+                            if !is_origin(&f.ty) {
+                                if let Some(n) = names_a_type(&f.ty) {
+                                    out.push(format!("variant {} : syn::{n}", v.ident));
+                                }
+                            }
+                        }
+                    }
+                }
+                // A nested module hides every one of the above a level down.
+                syn::Item::Mod(m) if is_public(&m.vis) => {
+                    if let Some((_, items)) = &m.content {
+                        walk(items, sealed, out);
                     }
                 }
                 _ => {}
             }
         }
-    };
-    walk(&file.items, &mut out);
+    }
+
+    walk(&file.items, &sealed_traits, &mut out);
     out
 }
 
@@ -160,5 +250,79 @@ fn nothing_public_in_flat_hands_out_syntax() {
          emitter needs it; if it is genuinely a leaf, add it to `LEAF` here and \
          say why.\n",
         found.join("\n")
+    );
+}
+
+/// The guard catches every item kind that can put a `syn` type on a public
+/// surface.
+///
+/// Without this, the guard's coverage is an assumption — and the first version
+/// of it silently missed five of these six, which review caught. Each case is
+/// parsed as if it were a file in `flat`, so adding an item kind to [`doors`]
+/// means adding it here too.
+#[test]
+fn the_guard_sees_every_item_kind() {
+    let cases: &[(&str, &str)] = &[
+        ("free fn", "pub fn leak() -> syn::Type { unimplemented!() }"),
+        (
+            "trait method",
+            "pub trait T { fn leak(&self) -> syn::Type; }",
+        ),
+        ("type alias", "pub type Alias = syn::Type;"),
+        ("public field", "pub struct S { pub node: syn::Type }"),
+        (
+            "associated type",
+            "impl std::ops::Deref for S { type Target = syn::Type;              fn deref(&self) -> &syn::Type { unimplemented!() } }",
+        ),
+        (
+            "nested module",
+            "pub mod inner { pub fn leak() -> syn::Type { unimplemented!() } }",
+        ),
+        (
+            "enum variant field",
+            "pub enum E { V(syn::Type) }",
+        ),
+    ];
+    let mut missed = Vec::new();
+    for (what, src) in cases {
+        let file: syn::File = syn::parse_str(src).expect("case parses");
+        if doors(&file).is_empty() {
+            missed.push(*what);
+        }
+    }
+    assert!(
+        missed.is_empty(),
+        "the surface guard does not see: {missed:?}\n\n         Each of these can hand a `syn` node to a consumer, so each has to be a \
+         door. Add the item kind to `doors` — and note that the reason this test \
+         exists is that the first version of the guard missed five of them.\n"
+    );
+}
+
+/// A **transformer** and a **leaf** are still exempt, and the `_decoy` trick
+/// still fails — the two rules the census learned from real bypasses.
+#[test]
+fn the_exemptions_are_shape_checked() {
+    let exempt: syn::File =
+        syn::parse_str("pub fn canonical_type(ty: &syn::Type) -> syn::Type { unimplemented!() }")
+            .unwrap();
+    assert!(
+        doors(&exempt).is_empty(),
+        "a one-node transformer is exempt"
+    );
+
+    let leaf: syn::File =
+        syn::parse_str("pub fn name(&self) -> syn::Ident { unimplemented!() }").unwrap();
+    assert!(doors(&leaf).is_empty(), "a leaf is not a door");
+
+    // Named like a transformer, shaped like a leak: the model is the source of
+    // the returned node and the `syn` parameter is a decoy.
+    let decoy: syn::File = syn::parse_str(
+        "pub fn canonical_type(model: &TypeRef, _decoy: &syn::Type) -> syn::Type          { unimplemented!() }",
+    )
+    .unwrap();
+    assert_eq!(
+        doors(&decoy).len(),
+        1,
+        "a transformer is exempt by name AND shape — one parameter, itself a node"
     );
 }

--- a/prebindgen/src/api/core/flat/surface.rs
+++ b/prebindgen/src/api/core/flat/surface.rs
@@ -1,0 +1,164 @@
+//! One test: **nothing public in `flat` hands out captured syntax.**
+//!
+//! The census had a 300-line `escape_surface_is_closed` doing this, and C6
+//! deleted it on the argument that visibility makes it unnecessary. That
+//! argument was wrong, and this file exists because a reviewer proved it:
+//! `TypeRef::as_syn` — the single door this whole umbrella is about — was
+//! still `pub` after C5 claimed the type half was sealed, along with the three
+//! `spell(head, parts)` shape methods.
+//!
+//! Visibility enforces the boundary only for the methods someone remembered to
+//! seal. What it cannot do is *notice the one you missed*, and at C5 I checked
+//! the three methods I had changed rather than the property I had claimed.
+//!
+//! So this reads the module's own surface, as the census did, and fails on
+//! anything public returning a `syn` type. It is ~60 lines rather than ~300
+//! because it no longer has to bucket, count or attribute anything: with the
+//! capability in place the answer is simply *none*, and a new door is a test
+//! failure rather than a number to justify.
+
+use std::{fs, path::Path};
+
+/// `syn` types small enough that handing one out is not handing out structure.
+///
+/// The allowlist is the exception side on purpose — a `syn` type nobody
+/// considered is a door until someone argues it is a leaf, and that argument is
+/// a diff on this line. (Inverting it is what the census learned the hard way:
+/// a method returning `&[syn::Attribute]` was invisible because `Attribute` was
+/// not on the opposite list.)
+const LEAF: &[&str] = &["Ident", "Lifetime", "Member", "Index"];
+
+/// A **transformer** takes a node and gives one back, so it hands out nothing a
+/// caller did not already hold. Exempt by name *and* shape — exactly one
+/// parameter, itself a node — because a name alone is defeated by
+/// `fn leak(model: &TypeRef, _decoy: &syn::Type) -> &syn::Type`, which the
+/// census learned before this file existed.
+const TRANSFORMERS: &[&str] = &[
+    "canonical_type",
+    "normalize_type",
+    "normalize_item_types",
+    "extract_fn_trait_args",
+];
+
+fn flat_dir() -> std::path::PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("src/api/core/flat")
+}
+
+/// Public items in `flat` whose return type names a non-leaf `syn` type.
+fn doors(file: &syn::File) -> Vec<String> {
+    fn is_public(v: &syn::Visibility) -> bool {
+        matches!(v, syn::Visibility::Public(_))
+    }
+    fn names_a_node(ty: &syn::ReturnType) -> Option<String> {
+        let syn::ReturnType::Type(_, t) = ty else {
+            return None;
+        };
+        let toks: Vec<proc_macro2::TokenTree> =
+            quote::ToTokens::to_token_stream(t).into_iter().collect();
+        for (i, tt) in toks.iter().enumerate() {
+            let proc_macro2::TokenTree::Ident(id) = tt else {
+                continue;
+            };
+            if *id != "syn" {
+                continue;
+            }
+            // `syn :: <Name>` — two `:` puncts then the name.
+            if let Some(proc_macro2::TokenTree::Ident(name)) = toks.get(i + 3) {
+                let n = name.to_string();
+                if !LEAF.contains(&n.as_str()) {
+                    return Some(n);
+                }
+            }
+        }
+        None
+    }
+    fn is_transformer(sig: &syn::Signature) -> bool {
+        TRANSFORMERS.contains(&sig.ident.to_string().as_str())
+            && sig.inputs.len() == 1
+            && matches!(sig.inputs.first(), Some(syn::FnArg::Typed(pt))
+                if quote::ToTokens::to_token_stream(&pt.ty).to_string().contains("syn"))
+    }
+    // A trait impl's methods are as visible as the trait. `Shaped` is
+    // `pub(in crate::api::core)`, so its impls are not a public surface — the
+    // trait's own declaration is what this checks, not the impl block.
+    let sealed_traits: Vec<String> = file
+        .items
+        .iter()
+        .filter_map(|i| match i {
+            syn::Item::Trait(t) if !is_public(&t.vis) => Some(t.ident.to_string()),
+            _ => None,
+        })
+        .collect();
+    let mut out = Vec::new();
+    let walk = |items: &[syn::Item], out: &mut Vec<String>| {
+        for item in items {
+            match item {
+                syn::Item::Fn(f) if is_public(&f.vis) => {
+                    if is_transformer(&f.sig) {
+                        continue;
+                    }
+                    if let Some(n) = names_a_node(&f.sig.output) {
+                        out.push(format!("fn {} -> syn::{n}", f.sig.ident));
+                    }
+                }
+                syn::Item::Impl(im) => {
+                    let sealed = im.trait_.as_ref().is_some_and(|(_, p, _)| {
+                        p.segments
+                            .last()
+                            .is_some_and(|s| sealed_traits.contains(&s.ident.to_string()))
+                    });
+                    if sealed {
+                        continue;
+                    }
+                    for it in &im.items {
+                        // A trait impl's methods are as public as the trait.
+                        let syn::ImplItem::Fn(f) = it else { continue };
+                        if im.trait_.is_some() || is_public(&f.vis) {
+                            if let Some(n) = names_a_node(&f.sig.output) {
+                                out.push(format!("{} -> syn::{n}", f.sig.ident));
+                            }
+                        }
+                    }
+                }
+                _ => {}
+            }
+        }
+    };
+    walk(&file.items, &mut out);
+    out
+}
+
+#[test]
+fn nothing_public_in_flat_hands_out_syntax() {
+    let mut found: Vec<String> = Vec::new();
+    for entry in fs::read_dir(flat_dir()).expect("flat is a directory") {
+        let path = entry.expect("readable").path();
+        if path.extension().is_none_or(|e| e != "rs") || path.ends_with("tests.rs") {
+            continue;
+        }
+        let name = path.file_name().unwrap().to_string_lossy().to_string();
+        // This file, and `surface.rs` itself, are test-only.
+        if name == "surface.rs" {
+            continue;
+        }
+        let text = fs::read_to_string(&path).expect("utf-8");
+        let file: syn::File = syn::parse_str(&text).expect("flat source parses");
+        for d in doors(&file) {
+            found.push(format!("  {name}: {d}"));
+        }
+    }
+    found.sort();
+    assert!(
+        found.is_empty(),
+        "PUBLIC SYNTAX DOOR IN `flat`\n{}\n\n\
+         Captured syntax leaves the model through `core::emit::Emit` and nothing \
+         else — that is what lets an adapter's *decisions* be checked by the \
+         compiler instead of by a census. A `pub` method here returning a `syn` \
+         node reopens the boundary for every consumer, including out-of-crate \
+         ones no test in this repo compiles.\n\n\
+         Seal it (`pub(in crate::api::core)`) and expose it on `Emit` if an \
+         emitter needs it; if it is genuinely a leaf, add it to `LEAF` here and \
+         say why.\n",
+        found.join("\n")
+    );
+}

--- a/prebindgen/src/api/core/flat/tests/roundtrip.rs
+++ b/prebindgen/src/api/core/flat/tests/roundtrip.rs
@@ -192,7 +192,9 @@ fn empty_delimiters_survive_and_spell() {
 
     let spell = |a: &Alternative| {
         let name = &a.name;
-        a.spell(quote::quote!(E::#name), &[]).to_string()
+        crate::api::core::emit::Emit::for_test()
+            .shape(a, quote::quote!(E::#name), &[])
+            .to_string()
     };
     assert_eq!(spell(&v.alternatives[0]), "E :: A");
     assert_eq!(spell(&v.alternatives[1]), "E :: B ()");
@@ -210,7 +212,9 @@ fn empty_delimiters_survive_and_spell() {
     let e = as_enum(&element);
     let spell = |v: &EnumValue| {
         let name = &v.name;
-        v.spell(quote::quote!(F::#name), &[]).to_string()
+        crate::api::core::emit::Emit::for_test()
+            .shape(v, quote::quote!(F::#name), &[])
+            .to_string()
     };
     assert_eq!(spell(&e.values[0]), "F :: A");
     assert_eq!(spell(&e.values[1]), "F :: B ()");
@@ -231,7 +235,9 @@ fn empty_delimiters_survive_and_spell() {
             .map(|f| f.bind(&quote::format_ident!("__f{}", f.index)))
             .collect();
         let name = &a.name;
-        a.spell(quote::quote!(Reading::#name), &parts).to_string()
+        crate::api::core::emit::Emit::for_test()
+            .shape(a, quote::quote!(Reading::#name), &parts)
+            .to_string()
     };
     assert_eq!(bind(&v.alternatives[0]), "Reading :: Exact (__f0)");
     assert_eq!(
@@ -252,7 +258,9 @@ fn struct_delimiters_survive_and_spell() {
         let name = &s.name;
         (
             s.fields.len(),
-            s.spell(quote::quote!(#name), parts).to_string(),
+            crate::api::core::emit::Emit::for_test()
+                .shape(s, quote::quote!(#name), parts)
+                .to_string(),
         )
     };
 

--- a/prebindgen/src/api/core/flat/ty.rs
+++ b/prebindgen/src/api/core/flat/ty.rs
@@ -106,12 +106,15 @@ impl fmt::Display for TypeRef {
     /// [`Emit`](crate::api::core::emit::Emit) capability to say so. So this is
     /// ungated where [`spell`](Self::spell) is not.
     ///
-    /// **Not a spelling.** It renders the same tokens today, and nothing should
-    /// depend on that: re-parsing a message is not a supported route to a node,
-    /// and the reason it is not is that a message is allowed to get friendlier.
-    /// Generated Rust spells through `Emit`.
+    /// **The identity, not the spelling** — `TypeKey`, which is
+    /// `canonical_type` rendered. Delegating to `spell()` would have handed the
+    /// captured spelling back out through `format!("{ty}")`, so
+    /// `syn::parse_str(&ty.to_string())` reconstructed it exactly and the
+    /// capability was a suggestion. Rendering the canonical form keeps
+    /// diagnostics readable while making the round trip land on a *normalized*
+    /// type rather than the source's own tokens.
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.spell())
+        write!(f, "{}", self.key().as_str())
     }
 }
 
@@ -156,7 +159,12 @@ impl TypeRef {
     }
 
     /// The type as `syn` — **the escape**. See [`Origin::as_syn`].
-    pub fn as_syn(&self) -> &syn::Type {
+    // Test-only as of C7: `Emit` hands out a spelling, never the node, so the
+    // round-trip checks (`syntax_is_recoverable_from_kind`) are the last
+    // callers. That is the correct end state — the check that a kind can
+    // reproduce its own syntax needs both halves.
+    #[allow(dead_code)]
+    pub(in crate::api::core) fn as_syn(&self) -> &syn::Type {
         self.origin.as_syn()
     }
 

--- a/prebindgen/src/api/core/registry/declare.rs
+++ b/prebindgen/src/api/core/registry/declare.rs
@@ -18,7 +18,7 @@ use super::*;
 /// let registry = Registry::builder(flat)?
 ///     .export(&name)
 ///     .decompose(decompositions)
-///     .convert_with(|crossing, built| my_gen.convert(crossing, built))?
+///     .convert_with(|crossing, built, emit| my_gen.convert(crossing, built, emit))?
 ///     .build()?;
 /// ```
 ///

--- a/prebindgen/src/api/core/registry/mod.rs
+++ b/prebindgen/src/api/core/registry/mod.rs
@@ -110,7 +110,7 @@
 //!     .decompose(self.decompositions())
 //!     // `built` already holds everything this crossing composes from: that is
 //!     // what sorted means.
-//!     .convert_with(|crossing, built| self.convert(crossing, built))?
+//!     .convert_with(|crossing, built, emit| self.convert(crossing, built, emit))?
 //!     .build()?;
 //!
 //! self.emit(&registry, out)   // read-only from here

--- a/prebindgen/src/api/lang/cbindgen/selector.rs
+++ b/prebindgen/src/api/lang/cbindgen/selector.rs
@@ -17,7 +17,7 @@ impl CbindgenBuilder {
             .or_else(|| self.in_data_struct(ty, registry))
             .or_else(|| self.in_value_opaque(ty, registry))
             .or_else(|| self.in_enum(ty, registry))
-            .or_else(|| self.in_tagged_union(ty, registry))
+            .or_else(|| self.in_tagged_union(ty, registry, emit))
             .or_else(|| self.in_string(ty))
             .or_else(|| self.in_str(ty))
             .or_else(|| self.in_bool(ty))
@@ -34,7 +34,7 @@ impl CbindgenBuilder {
         emit: &crate::api::core::emit::Emit,
     ) -> Option<ConverterImpl<()>> {
         self.out_custom(ty, registry, emit)
-            .or_else(|| self.out_terminal(ty, registry))
+            .or_else(|| self.out_terminal(ty, registry, emit))
             .or_else(|| self.out_wrappers(ty, registry))
     }
 }

--- a/prebindgen/src/api/lang/cbindgen/trait_impl.rs
+++ b/prebindgen/src/api/lang/cbindgen/trait_impl.rs
@@ -868,7 +868,11 @@ impl CbindgenBuilder {
     /// `<base>_drop(t_t *)` that frees the **active arm** and nulls the freed
     /// slots, so a second drop is a no-op. A union of plain data owns nothing
     /// and gets no drop.
-    fn prereq_tagged_unions(&self, registry: &Registry<()>) -> Vec<syn::Item> {
+    fn prereq_tagged_unions(
+        &self,
+        registry: &Registry<()>,
+        emit: &crate::api::core::emit::Emit,
+    ) -> Vec<syn::Item> {
         let mut items: Vec<syn::Item> = Vec::new();
         for (key, _cfg) in sorted_by_key(&self.tagged_unions) {
             let Some(reading) = registry.reading(key) else {
@@ -903,7 +907,7 @@ impl CbindgenBuilder {
                     .zip(&wires)
                     .map(|(f, w)| f.bind(w))
                     .collect();
-                variant_defs.push(a.spell(quote!(#vident), &defs));
+                variant_defs.push(emit.shape(a, quote!(#vident), &defs));
 
                 // Drop arm: bind every field, free the owning ones.
                 let owning: Vec<(usize, &Field, &syn::Type)> = a
@@ -926,7 +930,7 @@ impl CbindgenBuilder {
                     .zip(&binds)
                     .map(|(f, b)| f.bind(b))
                     .collect();
-                let pattern = a.spell(quote!(#cname::#vident), &parts);
+                let pattern = emit.shape(a, quote!(#cname::#vident), &parts);
                 let frees = owning.iter().map(|(i, f, _)| {
                     let b = &binds[*i];
                     self.payload_free_stmt(&f.ty, b, registry)
@@ -1091,6 +1095,7 @@ impl CbindgenBuilder {
         &self,
         ty: &TypeRef,
         r: &impl Conversions<()>,
+        emit: &crate::api::core::emit::Emit,
     ) -> Option<ConverterImpl<()>> {
         let key = ty.key();
         if !self.tagged_unions.contains_key(&key) {
@@ -1128,7 +1133,7 @@ impl CbindgenBuilder {
                     .zip(&binds)
                     .map(|(f, b)| f.bind(b))
                     .collect();
-                let from = a.spell(quote!(#cname::#vident), &parts);
+                let from = emit.shape(a, quote!(#cname::#vident), &parts);
                 let exprs: Vec<TokenStream> = a
                     .fields
                     .iter()
@@ -1152,7 +1157,7 @@ impl CbindgenBuilder {
                     .zip(&exprs)
                     .map(|(f, e)| f.bind(e))
                     .collect();
-                let to = a.spell(quote!(#src::#vident), &inits);
+                let to = emit.shape(a, quote!(#src::#vident), &inits);
                 quote!(#from => #to,)
             })
             .collect();
@@ -1232,6 +1237,7 @@ impl CbindgenBuilder {
         &self,
         ty: &TypeRef,
         r: &impl Conversions<()>,
+        emit: &crate::api::core::emit::Emit,
     ) -> Option<ConverterImpl<()>> {
         let key = ty.key();
         if !self.tagged_unions.contains_key(&key) {
@@ -1264,7 +1270,7 @@ impl CbindgenBuilder {
                     .zip(&binds)
                     .map(|(f, b)| f.bind(b))
                     .collect();
-                let from = a.spell(quote!(#src::#vident), &parts);
+                let from = emit.shape(a, quote!(#src::#vident), &parts);
                 let exprs: Vec<TokenStream> = a
                     .fields
                     .iter()
@@ -1282,7 +1288,7 @@ impl CbindgenBuilder {
                     .zip(&exprs)
                     .map(|(f, e)| f.bind(e))
                     .collect();
-                let to = a.spell(quote!(#cname::#vident), &inits);
+                let to = emit.shape(a, quote!(#cname::#vident), &inits);
                 quote!(#from => #to,)
             })
             .collect();
@@ -1839,7 +1845,7 @@ impl Prebindgen for CbindgenBuilder {
         items.extend(self.prereq_data_structs(registry));
         items.extend(self.prereq_value_opaque(registry));
         items.extend(self.prereq_enums(registry, emit));
-        items.extend(self.prereq_tagged_unions(registry));
+        items.extend(self.prereq_tagged_unions(registry, emit));
         items.extend(self.prereq_callback_structs(registry));
         items.extend(self.prereq_domain_constants(registry));
         items
@@ -1893,6 +1899,7 @@ impl CbindgenBuilder {
         &self,
         ty: &TypeRef,
         _r: &impl Conversions<()>,
+        emit: &crate::api::core::emit::Emit,
     ) -> Option<ConverterImpl<()>> {
         // Unit return: trivial converter so `()` (and `Result<(), _>`) resolves.
         // Never actually called — void-returning wrappers ignore it, and
@@ -2092,7 +2099,7 @@ impl CbindgenBuilder {
 
         // Tagged-union output: `match` the source enum to the C union,
         // converting each arm's payload.
-        if let Some(c) = self.out_tagged_union(ty, _r) {
+        if let Some(c) = self.out_tagged_union(ty, _r, emit) {
             return Some(c);
         }
 

--- a/prebindgen/src/api/lang/jnigen/jni/emit/callback.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/callback.rs
@@ -128,8 +128,15 @@ pub(crate) fn callback_input(
             let obj_idents: Vec<syn::Ident> = (0..plan.leaves.len())
                 .map(|k| format_ident!("__cbfold{}_obj{}", i, k))
                 .collect();
-            let (leaf_stmts, leaf_args) =
-                encode_plan_leaves(ext, registry, plan, &obj_idents, &quote!(__cb_elem), &fail);
+            let (leaf_stmts, leaf_args) = encode_plan_leaves(
+                ext,
+                registry,
+                plan,
+                &obj_idents,
+                &quote!(__cb_elem),
+                &fail,
+                emit,
+            );
             let elem_frame = std::cmp::max(16, 2 * plan.leaves.len() + 6);
             let elem_frame_lit = syn::LitInt::new(&elem_frame.to_string(), Span::call_site());
             preludes.push(quote! {
@@ -185,8 +192,15 @@ pub(crate) fn callback_input(
             let obj_idents: Vec<syn::Ident> = (0..plan.leaves.len())
                 .map(|k| format_ident!("__cb{}_obj{}", i, k))
                 .collect();
-            let (stmts, arg_exprs) =
-                encode_plan_leaves(ext, registry, plan, &obj_idents, &quote!(#cb_arg), &fail);
+            let (stmts, arg_exprs) = encode_plan_leaves(
+                ext,
+                registry,
+                plan,
+                &obj_idents,
+                &quote!(#cb_arg),
+                &fail,
+                emit,
+            );
             preludes.push(stmts);
             total += arg_exprs.len();
             jvalue_exprs.extend(arg_exprs);

--- a/prebindgen/src/api/lang/jnigen/jni/emit/delivery.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/delivery.rs
@@ -36,6 +36,7 @@ pub(crate) fn emit_unfold_delivery(
     iface: Option<&IfaceSpec>,
     call_expr: &TokenStream,
     on_err: &TokenStream,
+    emit: &crate::api::core::emit::Emit,
 ) -> TokenStream {
     use crate::api::core::unfold::UnfoldShape;
 
@@ -60,7 +61,7 @@ pub(crate) fn emit_unfold_delivery(
     // `__elem`) into `__obj0…__objN` (shared with the callback trampoline),
     // yielding the per-leaf typed jvalue arg expressions.
     let encode_leaves = |value: &TokenStream| -> (TokenStream, Vec<TokenStream>) {
-        encode_plan_leaves(ext, registry, plan, &obj_idents, value, &fail)
+        encode_plan_leaves(ext, registry, plan, &obj_idents, value, &fail, emit)
     };
 
     // Cached-interface call statics for the builder / folder `run`.
@@ -862,6 +863,7 @@ pub(crate) fn encode_plan_leaves(
     obj_idents: &[syn::Ident],
     value: &TokenStream,
     fail: &dyn Fn(TokenStream) -> TokenStream,
+    emit: &crate::api::core::emit::Emit,
 ) -> (TokenStream, Vec<TokenStream>) {
     // Per-fn origin qualification: each accessor call is prefixed with the
     // module of the crate that defines it (multi-source bindings).
@@ -964,6 +966,7 @@ pub(crate) fn encode_plan_leaves(
             &obj_idents[seg.clone()],
             matched,
             fail,
+            emit,
         );
         // The whole segment — its slot declarations and its `match` — is
         // routed like any other leaf under the same form.

--- a/prebindgen/src/api/lang/jnigen/jni/emit/flat_input.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/flat_input.rs
@@ -293,7 +293,7 @@ pub(crate) fn struct_input_body(
     // refuse both; the per-field name check cannot, because an empty struct
     // has no field to refuse. `Struct::spell` is the dual of the
     // `Alternative::spell` the sum decoder uses for exactly this.
-    let ctor = s.spell(quote!(#struct_module::#struct_ident), &field_init);
+    let ctor = emit.shape(s, quote!(#struct_module::#struct_ident), &field_init);
     let body: syn::Expr = syn::parse_quote!({
         #(#field_preludes)*
         #ctor
@@ -370,7 +370,7 @@ pub(crate) fn sum_input_body(
         // a three-arm `syn::Fields` match here would have had to re-derive
         // that, and `Alternative::is_empty()` cannot: `B`, `B()` and `B {}`
         // are all empty by it.
-        let ctor = alt.spell(quote!(#source_module::#enum_ident::#vident), &inits);
+        let ctor = emit.shape(alt, quote!(#source_module::#enum_ident::#vident), &inits);
         arms.push(quote! {
             if env.is_instance_of(__obj, #jvm_class)
                 .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(

--- a/prebindgen/src/api/lang/jnigen/jni/emit/sum_out.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/sum_out.rs
@@ -168,6 +168,7 @@ pub(crate) fn encode_sum_group(
     obj_idents: &[syn::Ident],
     matched: TokenStream,
     fail: &dyn Fn(TokenStream) -> TokenStream,
+    emit: &crate::api::core::emit::Emit,
 ) -> (TokenStream, Vec<TokenStream>) {
     use crate::api::core::unfold::LeafSource;
 
@@ -271,7 +272,7 @@ pub(crate) fn encode_sum_group(
                 .zip(&binds)
                 .map(|(f, b)| f.bind(b))
                 .collect();
-            let pattern = alt.spell(quote!(#source::#vident), &parts);
+            let pattern = emit.shape(alt, quote!(#source::#vident), &parts);
             // The live group: convert each payload through its own output
             // converter, exactly as a struct field of the same type would be.
             let live: TokenStream = group

--- a/prebindgen/src/api/lang/jnigen/jni/emit/wrapper.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/emit/wrapper.rs
@@ -331,8 +331,15 @@ pub(crate) fn emit_jni_function_wrapper_with_callee(
                 return #on_err;
             }
         };
-        let (ze_stmts, ze_args) =
-            encode_plan_leaves(ext, registry, ep, &eze_idents, &quote!(__de), &ze_fail);
+        let (ze_stmts, ze_args) = encode_plan_leaves(
+            ext,
+            registry,
+            ep,
+            &eze_idents,
+            &quote!(__de),
+            &ze_fail,
+            emit,
+        );
         quote! {
             match #raw_call {
                 ::core::result::Result::Ok(__v) => __v,
@@ -399,6 +406,7 @@ pub(crate) fn emit_jni_function_wrapper_with_callee(
             u.iface.as_deref(),
             &call_expr,
             &on_err,
+            emit,
         )
     } else {
         let output_entry = output_entry.expect("normal path has an output entry");

--- a/prebindgen/src/api/lang/jnigen/jni/tests/callbacks.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/callbacks.rs
@@ -636,11 +636,13 @@ fn a_callback_identity_is_the_same_from_the_reading_or_the_syntax() {
     // signature's own `impl Fn` bounds agree on every arg's identity.
     let from_reading = SpecKey::callback(arg_readings);
     let from_syntax = SpecKey::Callback(
-        crate::api::core::registry::extract_fn_trait_args(param.ty.as_syn())
-            .expect("the param is an impl Fn")
-            .iter()
-            .map(crate::api::core::registry::TypeKey::from_type)
-            .collect(),
+        crate::api::core::registry::extract_fn_trait_args(
+            &crate::api::core::emit::Emit::for_test().spell_ty(&param.ty),
+        )
+        .expect("the param is an impl Fn")
+        .iter()
+        .map(crate::api::core::registry::TypeKey::from_type)
+        .collect(),
     );
 
     assert_eq!(

--- a/prebindgen/src/api/lang/jnigen/jni/tests/values.rs
+++ b/prebindgen/src/api/lang/jnigen/jni/tests/values.rs
@@ -1778,11 +1778,11 @@ fn the_enum_probe_sees_through_wrappers_a_spelling_key_misses() {
     // The difference from the spelling-keyed probe, pinned: a transparent
     // wrapper is invisible to the model and decisive for a canonical key.
     assert!(
-        !ext.is_kotlin_enum(field("borrowed").as_syn()),
+        !ext.is_kotlin_enum_key(&field("borrowed").key()),
         "if the spelling key ever started seeing through `Box`, this test would \
          stop distinguishing the two probes"
     );
-    assert!(ext.is_kotlin_enum(field("plain").as_syn()));
+    assert!(ext.is_kotlin_enum_key(&field("plain").key()));
 }
 
 /// A **transparently-wrapped** parameter takes the same specialized lowering as


### PR DESCRIPTION
Addresses the review on [#361](https://github.com/milyin/prebindgen/pull/361). Every point was correct; the central one is bad enough to lead with.

## C5 claimed the type half was sealed. It was not.

`TypeRef::as_syn` — the single most direct door, the one this umbrella is named for — was still `pub` after C5, and C6 deleted the census on top of that claim. The reviewer compiled `fn leak(t: &TypeRef) -> &syn::Type { t.as_syn() }` from an external crate.

**The cause matters more than the fix.** At C5 I did verify from an external crate — but I wrote the check myself and tested the three methods I had just changed. I verified my diff, not my claim. That is exactly the S8 failure this project already recorded (`api/core holds zero type escapes`, true of nothing, unchecked for twenty-five stages), committed by me two stages after writing it up.

## Sealed, each confirmed `E0624` from a real external crate

| | |
|---|---|
| `TypeRef::as_syn` | the door C5 missed |
| `Flat::enum_item` | one of the five original doors |
| `{Struct,Alternative,EnumValue}::spell` | the delimiters the source wrote |
| `flat::spell` (the module) | so `fields` cannot be reached around them |
| `flat::type_from_ident` | **deleted** — a public `syn::Type` factory with no caller since S33, which the plan said to delete and I did not |

`Emit::shape` replaces the three shape methods, bounded by a `pub(in crate::api::core)` `Shaped` trait: an out-of-crate consumer can call `shape` on the three elements, and cannot name the trait to route around it.

## One thing the reviewer did not ask for, and I got wrong first

I initially sealed `Field::member` and `Field::bind` too. They read the field's `name` and `index` — model facts, no captured syntax — and sealing them dragged the capability back into Kotlin data-class rendering, which was the C3b/C5 symptom all over again. Reverted, with the reason written next to them.

## `Display` renders the identity

```rust
-write!(f, "{}", self.spell())
+write!(f, "{}", self.key().as_str())
```

As reported, delegating to `spell()` handed the captured spelling back out through `format!`, so `syn::parse_str(&ty.to_string())` reconstructed it exactly. It renders the canonical form now — readable in a `panic!`, and a round trip lands on a *normalized* type rather than the source's own tokens.

## The actual fix: `flat::surface`

C6 deleted the census's `escape_surface_is_closed` on my argument that visibility makes it unnecessary. **That argument was wrong**, and this PR is the proof: visibility enforces the methods someone remembered to seal, and cannot notice the one they missed.

Restored as a ~110-line test that reads `flat`'s own public surface and fails on anything returning a `syn` type — with the census's two hard-won rules kept, because both were learned from real bypasses:

* an inverted `LEAF` allowlist (a `syn` type nobody considered is a door until someone argues otherwise);
* `TRANSFORMERS` exempt by **name and shape** — exactly one parameter, itself a node — because a name alone is defeated by `fn leak(model: &TypeRef, _decoy: &syn::Type) -> &syn::Type`.

On its first run it found `enum_item`, `type_from_ident` and all three shape methods. Four of those I was not looking for.

## Copilot

Both applied: the `convert_with` rustdoc examples in `registry/{mod,declare}.rs` still showed the two-argument closure, and `emit.rs`'s module doc still said the converter path had not been threaded.

## Verification

The check I should have run at C5 — eleven bypasses, all now `E0624` or `E0599`:

```
4 error[E0624]: method `as_syn` is private
2 error[E0624]: method `spell` is private
1 error[E0624]: method `stripped_syntax` is private
1 error[E0624]: method `to_syn` is private
3 error[E0599]: no method named `spell` found for {Struct,EnumValue,Alternative}
```

## Gate

- `cargo test -p prebindgen --all-features` — 632 lib (one new), 34 doctests (11 `compile_fail`, up from 8)
- clippy `--all-targets --all-features -D warnings` on stable **and** 1.85.0
- `cargo fmt --check` with the CI config
- `examples/regen-check.sh` — every generated artifact byte-identical
