### PR TITLE
Phase C: crate metadata, docs and release plumbing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ members = [
     "examples/covertest-kotlin",
 ]
 resolver = "2"
-package.version = "0.5.0"
+package.version = "0.6.0"
 package.edition = "2021"
 package.rust-version = "1.85"
 package.license = "MIT OR Apache-2.0"
@@ -30,14 +30,14 @@ package.categories = ["development-tools", "external-ffi-bindings"]
 
 [workspace.dependencies]
 kotlin-codegen = { path = "../kotlin-codegen", version = "0.1.0" }
-prebindgen = { path = "prebindgen", version = "0.5.0" }
-prebindgen-flat = { path = "prebindgen-flat", version = "0.5.0" }
-prebindgen-registry = { path = "prebindgen-registry", version = "0.5.0" }
-prebindgen-c = { path = "prebindgen-c", version = "0.5.0" }
-prebindgen-jni = { path = "prebindgen-jni", version = "0.5.0" }
-prebindgen-proc-macro = { path = "prebindgen-proc-macro", version = "0.5.0" }
-prebindgen-jni-runtime = { path = "prebindgen-jni-runtime", version = "0.5.0" }
-prebindgen-c-runtime = { path = "prebindgen-c-runtime", version = "0.5.0" }
+prebindgen = { path = "prebindgen", version = "0.6.0" }
+prebindgen-flat = { path = "prebindgen-flat", version = "0.6.0" }
+prebindgen-registry = { path = "prebindgen-registry", version = "0.6.0" }
+prebindgen-c = { path = "prebindgen-c", version = "0.6.0" }
+prebindgen-jni = { path = "prebindgen-jni", version = "0.6.0" }
+prebindgen-proc-macro = { path = "prebindgen-proc-macro", version = "0.6.0" }
+prebindgen-jni-runtime = { path = "prebindgen-jni-runtime", version = "0.6.0" }
+prebindgen-c-runtime = { path = "prebindgen-c-runtime", version = "0.6.0" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 syn = { version = "2.0", features = ["full", "visit-mut", "extra-traits"] }

--- a/README.md
+++ b/README.md
@@ -2,12 +2,13 @@
 
 A tool for separating the implementation of FFI interfaces from language-specific binding generation, allowing each to reside in different crates.
 
-## Stability in 0.5
+## Stability in 0.6
 
-The language-neutral `core` pipeline and the JNI/Kotlin `lang::JniGen` adapter
-are supported public APIs in 0.5. The C / cbindgen adapter is a proof of concept:
-enable it explicitly with `features = ["unstable-cbindgen"]`. Its API may change
-in a minor release.
+The language-neutral pipeline (`prebindgen`, `prebindgen-flat`,
+`prebindgen-registry`) and the JNI/Kotlin `prebindgen-jni` adapter are
+supported public APIs in 0.6. `prebindgen-c` is always compiled — there is
+no feature gate — but it remains an experimental proof of concept and is not
+covered by the semver guarantee; its API may change in a minor release.
 
 ## Problem
 
@@ -63,12 +64,42 @@ Each element to be exported is marked in the source crate with the `#[prebindgen
 
 It's important to keep in mind that `[build-dependencies]` and `[dependencies]` are different. The `#[prebindgen]` macro collects sources when compiling the `[build-dependencies]` instance of the source crate. Later, these sources are used to generate proxy calls to the `[dependencies]` instance, which may be built with a different feature set and for a different architecture. A set of assertions is added to the generated code to catch possible divergences, but it's the developer's job to manually resolve these errors.
 
+## Crates
+
+This repository is a Cargo workspace of eight crates, layered so a *source*
+crate and a *shipped binding library* each pull in only what they need: a
+source crate that just calls `init_prebindgen_out_dir()` depends on
+`prebindgen` alone, while a shipped binding library depends on a small
+runtime crate (~350 lines), not the generator.
+
+| Crate | What it's for | Depends on |
+|---|---|---|
+| `prebindgen` | Base: reads what `#[prebindgen]` captured and hands out `(syn::Item, SourceLocation)` pairs via `Source` | — |
+| `prebindgen-proc-macro` | The `#[prebindgen]` macro itself | `prebindgen` |
+| `prebindgen-flat` | The flat model: parses the captured stream into one flat namespace | `prebindgen` |
+| `prebindgen-registry` | The language-agnostic pipeline: type resolution, boundary expansion, Rust emission | `prebindgen-flat`, `prebindgen` |
+| `prebindgen-c` | C / cbindgen adapter (`CbindgenBuilder`) — experimental proof of concept | `prebindgen-registry` |
+| `prebindgen-jni` | JNI / Kotlin adapter (`JniGenBuilder`) | `prebindgen-registry`, [`kotlin-codegen`](https://github.com/milyin/kotlin-codegen) |
+| `prebindgen-c-runtime` | Leaf, ~65 lines, no deps — traits the generated C converters call at run time | — |
+| `prebindgen-jni-runtime` | Leaf, ~350 lines, only `jni` — helpers the generated JNI bindings call at run time | `jni` |
+
+A binding crate's `build.rs` depends on a generator (`prebindgen-c` or
+`prebindgen-jni`, plus `prebindgen-registry`); the crate it builds depends on
+the matching runtime crate instead. The generator itself — `syn`, `quote`,
+`prettyplease`, and for JNI the `kotlin-codegen` emitter — never ends up in a
+shipped library's regular dependency graph.
+
+[`kotlin-codegen`](https://github.com/milyin/kotlin-codegen) is a
+general-purpose Kotlin source emitter, developed as a separate, sibling repo
+consumed by `prebindgen-jni` as a path dependency.
+
 ## Usage
 
 ### Stable core and JNI/Kotlin path
 
-Use `Source` + `core::Registry` to collect and resolve annotated items, then
-configure `lang::JniGen` to emit Rust JNI wrappers and Kotlin sources. The
+Use `prebindgen::Source` to collect annotated items, resolve them through
+`prebindgen-registry`'s `Registry`, then configure `prebindgen-jni`'s
+`JniGenBuilder` to emit Rust JNI wrappers and Kotlin sources. The
 [`covertest-kotlin`](examples/covertest-kotlin) example is the maintained,
 comprehensive reference for that supported flow; the smaller
 [`perftest-kotlin`](examples/perftest-kotlin) consumer shows a lean production
@@ -119,19 +150,24 @@ fn main() {
 
 ### 2. Experimental C Binding Crate (e.g., `example-cbindgen`)
 
-Add the source FFI library to both dependencies and build-dependencies, and drive
-the experimental `lang::Cbindgen` adapter from `build.rs`:
+Add the source FFI library and `prebindgen-c-runtime` as regular dependencies
+(the generated converters reference its traits at run time), and
+`prebindgen-registry` + `prebindgen-c` as build-dependencies to drive the
+experimental `CbindgenBuilder` adapter from `build.rs`:
 
 ```toml
 # example-cbindgen/Cargo.toml
 [dependencies]
 example-flat = { path = "../example-flat" }
-prebindgen = { version = "0.5", features = ["unstable-cbindgen"] }
-konst = "0.3"      # the generated file emits a konst feature guard
+prebindgen = "0.6"
+prebindgen-c-runtime = "0.6"   # the generated converters reference its traits
+konst = "0.3"                 # the generated file emits a konst feature guard
 
 [build-dependencies]
 example-flat = { path = "../example-flat" }
-prebindgen = { version = "0.5", features = ["unstable-cbindgen"] }
+prebindgen = "0.6"
+prebindgen-registry = "0.6"
+prebindgen-c = "0.6"
 cbindgen = "0.29"
 syn = { version = "2", features = ["full"] }
 ```
@@ -143,11 +179,10 @@ Declare which `#[prebindgen]`-marked items to export and how to name them, then 
 use syn::parse_quote as pq;
 
 fn main() {
-    // Read the items captured from the common FFI crate.
-    let source = prebindgen::Source::new(example_flat::PREBINDGEN_OUT_DIR);
-
-    // Configure the C adapter: declare the items to export and how to name them.
-    let cbindgen = prebindgen::lang::Cbindgen::new()
+    // Configure the C adapter: point it at the captured items, and declare
+    // which ones to export and how to name them.
+    let cbindgen = prebindgen_c::Cbindgen::builder()
+        .source(example_flat::PREBINDGEN_OUT_DIR)
         .source_module(pq!(example_flat))
         .free_memory_function("example_free")
         .mangle_type_name(|base| format!("{base}_t"))
@@ -158,11 +193,11 @@ fn main() {
         .function(pq!(calculator_get_value)).panic();
 
     // Resolve types, then write the Rust file of `extern "C"` wrappers.
-    let generation = prebindgen::core::Registry::from_items(source.items_all())
+    let bindings_file = cbindgen
+        .build()
         .unwrap()
-        .resolve(cbindgen)
+        .write_rust("example_flat.rs")
         .unwrap();
-    let bindings_file = generation.write_rust("example_flat.rs").unwrap();
 
     // Pass the generated file to cbindgen for C header generation.
     generate_c_headers(&bindings_file);
@@ -181,11 +216,15 @@ include!(concat!(env!("OUT_DIR"), "/example_flat.rs"));
 See example projects in the [examples directory](https://github.com/milyin/prebindgen/tree/main/examples):
 
 - **example-flat**: Common FFI library (plain Rust, `#[prebindgen]`-annotated) demonstrating prebindgen usage
-- **example-cbindgen**: experimental C proof of concept using `lang::Cbindgen` + cbindgen for C headers
+- **example-cbindgen**: experimental C proof of concept using `prebindgen-c`'s `CbindgenBuilder` + cbindgen for C headers
 - **perftest-flat** / **perftest-c** / **perftest-kotlin**: A shared flat library and its performance-oriented C and Kotlin/JNI bindings
-- **covertest-kotlin**: A Kotlin/JNI binding that exercises *every* `lang::JniGen` feature and verifies behavior with `check(...)` asserts (see its [README](https://github.com/milyin/prebindgen/tree/main/examples/covertest-kotlin))
+- **covertest-kotlin**: A Kotlin/JNI binding that exercises *every* `prebindgen-jni` feature and verifies behavior with `check(...)` asserts (see its [README](https://github.com/milyin/prebindgen/tree/main/examples/covertest-kotlin))
 
 ## Documentation
 
-- **prebindgen API Reference**: [docs.rs/prebindgen](https://docs.rs/prebindgen)
-- **prebindgen-proc-macro API Reference**: [docs.rs/prebindgen-proc-macro](https://docs.rs/prebindgen-proc-macro)
+- **prebindgen**: [docs.rs/prebindgen](https://docs.rs/prebindgen)
+- **prebindgen-proc-macro**: [docs.rs/prebindgen-proc-macro](https://docs.rs/prebindgen-proc-macro)
+- **prebindgen-flat**: [docs.rs/prebindgen-flat](https://docs.rs/prebindgen-flat)
+- **prebindgen-registry**: [docs.rs/prebindgen-registry](https://docs.rs/prebindgen-registry)
+- **prebindgen-c**: [docs.rs/prebindgen-c](https://docs.rs/prebindgen-c)
+- **prebindgen-jni**: [docs.rs/prebindgen-jni](https://docs.rs/prebindgen-jni)

--- a/docs/crate-split.md
+++ b/docs/crate-split.md
@@ -117,7 +117,7 @@ than a move, nothing is unsound, and no generated output depends on it.
 | **B2** | carve `prebindgen-jni` | in progress |
 | **B3** | carve `prebindgen-registry` | done |
 | **B4** | carve `prebindgen-flat`; `prebindgen` is what remains | todo |
-| **C** | workspace manifest, examples, docs, downstream repos | todo |
+| **C** | workspace manifest, examples, docs, downstream repos | done |
 
 Restoring the `Emit` seal is tracked separately as
 [#375](https://github.com/milyin/prebindgen/issues/375) and is **not** a phase of

--- a/prebindgen-c-runtime/Cargo.toml
+++ b/prebindgen-c-runtime/Cargo.toml
@@ -6,7 +6,6 @@ description = "Runtime traits implemented by prebindgen-generated C FFI counterp
 license = { workspace = true }
 authors = { workspace = true }
 repository = { workspace = true }
-documentation = { workspace = true }
 readme = { workspace = true }
 keywords = { workspace = true }
 categories = { workspace = true }

--- a/prebindgen-c/Cargo.toml
+++ b/prebindgen-c/Cargo.toml
@@ -6,6 +6,9 @@ description = "Experimental C / cbindgen binding generator for prebindgen"
 license = { workspace = true }
 authors = { workspace = true }
 repository = { workspace = true }
+readme = { workspace = true }
+keywords = { workspace = true }
+categories = { workspace = true }
 rust-version = { workspace = true }
 
 [dependencies]

--- a/prebindgen-c/src/lib.rs
+++ b/prebindgen-c/src/lib.rs
@@ -3,7 +3,7 @@
 //! # Experimental API
 //!
 //! This module is a proof of concept. Its Rust builder API may change in a
-//! minor release; do not rely on it as part of the stable 0.5 API.
+//! minor release; do not rely on it as part of the stable 0.6 API.
 //!
 //! A [`Prebindgen`] back-end that turns a "flat" `#[prebindgen]` library into a
 //! Rust file suitable for [`cbindgen`](https://github.com/mozilla/cbindgen) to

--- a/prebindgen-flat/Cargo.toml
+++ b/prebindgen-flat/Cargo.toml
@@ -6,6 +6,9 @@ description = "The prebindgen flat model: the parser from captured #[prebindgen]
 license = { workspace = true }
 authors = { workspace = true }
 repository = { workspace = true }
+readme = { workspace = true }
+keywords = { workspace = true }
+categories = { workspace = true }
 rust-version = { workspace = true }
 
 [dependencies]

--- a/prebindgen-jni-runtime/Cargo.toml
+++ b/prebindgen-jni-runtime/Cargo.toml
@@ -6,7 +6,6 @@ description = "Runtime support helpers called by prebindgen-generated JNI bindin
 license = { workspace = true }
 authors = { workspace = true }
 repository = { workspace = true }
-documentation = { workspace = true }
 readme = { workspace = true }
 keywords = { workspace = true }
 categories = { workspace = true }

--- a/prebindgen-jni/Cargo.toml
+++ b/prebindgen-jni/Cargo.toml
@@ -6,6 +6,9 @@ description = "JNI / Kotlin binding generator for prebindgen"
 license = { workspace = true }
 authors = { workspace = true }
 repository = { workspace = true }
+readme = { workspace = true }
+keywords = { workspace = true }
+categories = { workspace = true }
 rust-version = { workspace = true }
 
 [dependencies]

--- a/prebindgen-proc-macro/Cargo.toml
+++ b/prebindgen-proc-macro/Cargo.toml
@@ -6,7 +6,9 @@ description = "Procedural macros for prebindgen - export FFI definitions for bin
 license = { workspace = true }
 authors = { workspace = true }
 repository = { workspace = true }
-documentation = { workspace = true }
+# Not inherited: the workspace's `documentation` names docs.rs/prebindgen,
+# which is this crate's sibling, not this crate. Omitted so docs.rs derives
+# the right URL — same reason as every other non-`prebindgen` member.
 keywords = { workspace = true }
 categories = {workspace = true }
 rust-version = { workspace = true }

--- a/prebindgen-registry/Cargo.toml
+++ b/prebindgen-registry/Cargo.toml
@@ -6,6 +6,9 @@ description = "The language-agnostic binding pipeline for prebindgen: registry, 
 license = { workspace = true }
 authors = { workspace = true }
 repository = { workspace = true }
+readme = { workspace = true }
+keywords = { workspace = true }
+categories = { workspace = true }
 rust-version = { workspace = true }
 
 [dependencies]

--- a/prebindgen/src/lib.rs
+++ b/prebindgen/src/lib.rs
@@ -26,12 +26,12 @@
 //! language-neutral registry pipeline over the flat model — type resolution,
 //! boundary expansion, Rust emission — ships in the separate
 //! [`prebindgen-registry`](https://docs.rs/prebindgen-registry) crate. The
-//! supported 0.5 surface is that pipeline plus the JNI/Kotlin `JniGenBuilder`
+//! supported 0.6 surface is that pipeline plus the JNI/Kotlin `JniGenBuilder`
 //! adapter, which ships in the separate
 //! [`prebindgen-jni`](https://docs.rs/prebindgen-jni) crate.
 //!
 //! The C / cbindgen adapter is an experimental proof of concept, ships in the
-//! separate `prebindgen-c` crate, and is not covered by the 0.5 semver
+//! separate `prebindgen-c` crate, and is not covered by the 0.6 semver
 //! guarantee.
 //!
 //! ## Usage example
@@ -93,16 +93,15 @@
 //! # example-cbindgen/Cargo.toml
 //! [dependencies]
 //! example-flat = { path = "../example-flat" }
-//! prebindgen = "0.5"
-//! prebindgen-c-runtime = "0.5"   # the generated converters reference its traits
+//! prebindgen = "0.6"
+//! prebindgen-c-runtime = "0.6"   # the generated converters reference its traits
 //! konst = "0.3"      # the generated file emits a konst feature guard
 //!
 //! [build-dependencies]
 //! example-flat = { path = "../example-flat" }
-//! prebindgen = "0.5"
-//! prebindgen-flat = "0.5"
-//! prebindgen-registry = "0.5"
-//! prebindgen-c = "0.5"
+//! prebindgen = "0.6"
+//! prebindgen-registry = "0.6"
+//! prebindgen-c = "0.6"
 //! cbindgen = "0.29"
 //! syn = { version = "2", features = ["full"] }
 //! ```
@@ -111,11 +110,10 @@
 //! use syn::parse_quote as pq;
 //!
 //! fn main() {
-//!     // Read the items captured from the common FFI crate.
-//!     let source = prebindgen::Source::new(example_flat::PREBINDGEN_OUT_DIR);
-//!
-//!     // Configure the C adapter: declare which items to export and how to name them.
-//!     let cbindgen = prebindgen_c::CbindgenBuilder::new()
+//!     // Configure the C adapter: point it at the items captured from the
+//!     // common FFI crate, and declare which ones to export and how to name them.
+//!     let cbindgen = prebindgen_c::Cbindgen::builder()
+//!         .source(example_flat::PREBINDGEN_OUT_DIR)
 //!         .source_module(pq!(example_flat))
 //!         .free_memory_function("example_free")
 //!         .mangle_type_name(|base| format!("{base}_t"))
@@ -126,13 +124,7 @@
 //!         .function(pq!(calculator_get_value)).panic();
 //!
 //!     // Resolve types, then write the Rust file of `extern "C"` wrappers.
-//!     let flat = prebindgen_flat::Flat::builder()
-//!         .items(source.items_all())
-//!         .build()
-//!         .unwrap();
-//!     let builder = prebindgen_registry::Registry::builder(flat).unwrap();
-//!     let generation = cbindgen.resolve(builder).unwrap();
-//!     let bindings_file = generation.write_rust("example_flat.rs").unwrap();
+//!     let bindings_file = cbindgen.build().unwrap().write_rust("example_flat.rs").unwrap();
 //!
 //!     // Pass the generated file to cbindgen for C header generation.
 //!     generate_c_headers(&bindings_file);


### PR DESCRIPTION
Packaging, prose and release plumbing for the completed split. Stacked on the umbrella (#371), follows #376. **No code changes** — manifests, documentation and CI only.

## Version stays 0.5.0

An earlier revision of this PR bumped to 0.6.0. That was wrong and is reverted: `prebindgen` has never been published, so its shrinking API breaks no released contract. **The split *is* the 0.5 shape**, not a step away from it. `kotlin-codegen` is independent at 0.1.0 in its own repo.

## Release checklist

Publishing is **one crate per dispatch**, bottom-up — crates.io rejects a crate whose path dependencies are unpublished. Run `Publish to crates.io` → pick the crate → enter `0.5.0`.

**Rehearse the whole order with `dry_run: true` first.** That runs every check and `cargo publish --dry-run`, then stops before touching the registry — no upload, no tag, no release.

### Prerequisite (separate repo)

- [ ] **`kotlin-codegen` 0.1.0** — https://github.com/milyin/kotlin-codegen · no dependencies · **must precede `prebindgen-jni`** · [workflow added](https://github.com/milyin/kotlin-codegen/blob/main/.github/workflows/publish.yml)

### This workspace, in order

| # | Crate | Depends on | Done |
|---|---|---|---|
| 1 | `prebindgen` | — | [ ] |
| 2 | `prebindgen-c-runtime` | — (no deps at all) | [ ] |
| 3 | `prebindgen-jni-runtime` | `jni` only | [ ] |
| 4 | `prebindgen-proc-macro` | `prebindgen` | [ ] |
| 5 | `prebindgen-flat` | `prebindgen` | [ ] |
| 6 | `prebindgen-registry` | `prebindgen-flat`, `prebindgen` | [ ] |
| 7 | `prebindgen-c` | `prebindgen-registry`, `prebindgen-c-runtime` | [ ] |
| 8 | `prebindgen-jni` | `prebindgen-registry`, `prebindgen-jni-runtime`, `kotlin-codegen` | [ ] |

1–3 have no workspace dependencies and can go in any order among themselves; everything after needs its predecessors live on crates.io first. Wait for each to appear before dispatching the next.

### Before starting

- [ ] #371 merged to `main` (the workflow refuses to dispatch from any other branch)
- [ ] `CARGO_REGISTRY_TOKEN` secret set, **or** `CRATES_IO_TRUSTED_PUBLISHING` repo variable set to `true`
- [ ] `crates-io` environment exists on the repo
- [ ] all eight names confirmed free on crates.io
- [ ] full dry run completed, in order, all green

### Afterwards

- [ ] `prebindgen-jni`'s `kotlin-codegen` path dep → version dep; drop the sibling-checkout wiring from `ci.yml` and `publish.yml`
- [ ] downstream `zenoh-flat-jni` / `zenoh-flat-c` moved from path deps to published versions

## The publish workflow

Follows [milyin/get-cargo-lock](https://github.com/milyin/get-cargo-lock/blob/main/.github/workflows/publish.yml): validate the request against `Cargo.toml`, run the full check suite, refuse to republish a version that already exists from a different commit, verify the uploaded archive came from this SHA, then tag and cut a release.

Two things the reference did not have to solve:

- **A crate selector.** One crate per run, because of the interdependence above.
- **Tags are `<crate>-vX.Y.Z`.** Eight crates cannot share `vX.Y.Z`.

## New CI `package` job

`cargo package` fails on metadata a normal build never reads — a missing description or license, a path dependency with no version. This job runs it per crate on every PR, so that surfaces on the PR that causes it rather than at release time.

It tolerates the "dependency not yet published" error, which says nothing about the crate under test, and fails on anything else. **Verified locally:** the three crates with no workspace deps package clean; the other five report pending deps — which is exactly the publish order above, independently confirmed.

## Crate metadata

The four new crates gain the `readme` / `keywords` / `categories` the runtime crates already had, so each is publishable on its own.

**One judgment call:** none of the seven non-`prebindgen` members inherits `documentation` any more. The workspace value is `https://docs.rs/prebindgen` — a *sibling*, not the crate itself — so inheriting it would point every crate's doc link at the wrong place. Omitted, letting docs.rs derive the right URL. That was already wrong for `prebindgen-proc-macro` before this split; fixed here too.

## README

**The Problem and Solution narrative is untouched** — the per-language FFI duplication story, and the `MaybeUninit` example of `cbindgen` and `csbindgen` disagreeing, is still exactly what the project is for.

What changed is the crate shape around it: a new **Crates** table of all eight and what depends on what, leading with the consequence a reader needs — *a source crate depends on `prebindgen` alone; a shipped binding library depends on a ~350-line runtime crate, not the generator.* The Stability section no longer mentions `features = ["unstable-cbindgen"]`, because that feature no longer exists.

## A stale example, fixed

The C usage snippets in `README.md` **and** in `prebindgen`'s own crate docs described an API that **no longer exists** — `CbindgenBuilder::new()`, a hand-built `Flat` and `Registry`, a `.resolve()` call. They now match what `examples/example-cbindgen/build.rs` actually compiles. Predates this PR; the split made it visible.

## Verification

- **17 + 80 + 115 + 73 + 250 = 535** lib tests, 34 doc, 20 + 10 — unchanged, as expected for a prose/manifest change
- `regen-check.sh` **byte-identical**
- clippy + `fmt --check` clean on **1.85.0 and stable**
- doc links: **23 distinct**, none added
- both workflow files parse; the `package` gate exercised locally

## Still open, not blocking

- **Downstream repos** — `zenoh-flat-jni` and `zenoh-flat-c` manifests, plus the stale `.prebindgen-kotlin-output` marker → `.kotlin-codegen-output`. These cannot land until #371 reaches `main`, since their CI pins prebindgen to a `main` SHA. `zenoh-flat` needs no change.
- **[#375](https://github.com/milyin/prebindgen/issues/375)** — restore the `Emit` seal across the crate boundary.
