### PR TITLE
Fix every broken intra-doc link, and gate cargo doc in CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -58,6 +58,28 @@ jobs:
     - name: Run tests
       run: cargo test --all
 
+  docs:
+    # A documentation build fails on things no other job looks at: an
+    # intra-doc link to an item that was renamed, moved to another crate, or
+    # is private. The crate split made a lot of those, and nothing caught
+    # them — this is also one of the checks a release has to pass, so failing
+    # here is much cheaper than failing there.
+    #
+    # Stable only: rustdoc's lint set moves with the toolchain, so the MSRV
+    # leg would only disagree about which warnings exist.
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        path: prebindgen
+    - name: Install Rust
+      run: rustup toolchain install stable && rustup default stable
+    - name: Document every crate
+      working-directory: prebindgen
+      env:
+        RUSTDOCFLAGS: -D warnings
+      run: cargo doc --no-deps
+
   covertest:
     # JVM-runtime coverage: regenerate every binding that commits its
     # generated output, fail on drift (the golden-diff invariant), then run

--- a/examples/perftest-flat/src/ext.rs
+++ b/examples/perftest-flat/src/ext.rs
@@ -1273,7 +1273,8 @@ pub fn storage_shards_opt(count: i64, each: i64) -> Option<Vec<Storage>> {
 // ─────────────────────────────────────────────────────────────────────────────
 
 /// A prepared callback receiving an **owned [`Storage`] handle** (`Fn(Storage)`,
-/// by value). Unlike [`PayloadHandler`] (whose arg is a flattened data class),
+/// by value). Unlike [`PayloadHandler`](crate::PayloadHandler) (whose arg is a
+/// flattened data class),
 /// the handle crosses as a raw pointer and the generated Kotlin proxy wraps it
 /// into a typed `Storage` and `close()`s it after `run` (close-unless-taken).
 #[prebindgen]

--- a/prebindgen-c/src/builder.rs
+++ b/prebindgen-c/src/builder.rs
@@ -287,14 +287,14 @@ impl CbindgenBuilder {
     /// **auto-generated visible-field** `#[repr(C)]` C mirror (so C reads the
     /// fields directly) instead of an opaque blob.
     ///
-    /// Every field must be FFI-safe: an `is_scalar` primitive, a declared
+    /// Every field must be FFI-safe: a primitive, a declared
     /// [`Self::enum_type`], or an **opaque pointer** `Option<Box<T>>` / `Box<T>`
     /// where `T` is a declared [`Self::opaque_ptr`] (rendered `*mut t_t`; this is
     /// how a heap `String` rides along — `Option<Box<String>>` → `string_t *`). The
     /// source type **must** be `#[repr(C)]`; a fail-closed `size_of`/`align_of`
     /// assert against the generated mirror proves the reinterpret sound at compile
     /// time. Call after the manglers are configured (the mirror name is resolved
-    /// via `Self::c_type_ident`). A `<base>_drop` is generated.
+    /// through them). A `<base>_drop` is generated.
     ///
     /// **Owned-ness is inferred** from the fields: a struct with an opaque-pointer field
     /// owns external resources, so a by-value consume cleans the moved-from slot (nulls
@@ -531,8 +531,9 @@ impl CbindgenBuilder {
     /// a `#[repr(C)]` closure struct (`{ void *context; call; drop }`) is
     /// emitted for it. `ty` must be `impl Fn(Args...) + Send + Sync + 'static`.
     /// Identical signatures share one struct. Sets the declaration cursor, so a
-    /// following `.base_name("...")` sets the base fed to `mangle_callback` (else
-    /// the args' bases drive `Self::callback_c_name`).
+    /// following `.base_name("...")` sets the base fed to
+    /// [`mangle_callback`](Self::mangle_callback) (else the args' bases drive
+    /// the generated name).
     pub fn callback(mut self, ty: syn::Type) -> Self {
         let args = extract_fn_trait_args(&ty).unwrap_or_else(|| {
             panic!(

--- a/prebindgen-c/src/builder.rs
+++ b/prebindgen-c/src/builder.rs
@@ -287,14 +287,14 @@ impl CbindgenBuilder {
     /// **auto-generated visible-field** `#[repr(C)]` C mirror (so C reads the
     /// fields directly) instead of an opaque blob.
     ///
-    /// Every field must be FFI-safe: an [`is_scalar`] primitive, a declared
+    /// Every field must be FFI-safe: an `is_scalar` primitive, a declared
     /// [`Self::enum_type`], or an **opaque pointer** `Option<Box<T>>` / `Box<T>`
     /// where `T` is a declared [`Self::opaque_ptr`] (rendered `*mut t_t`; this is
     /// how a heap `String` rides along — `Option<Box<String>>` → `string_t *`). The
     /// source type **must** be `#[repr(C)]`; a fail-closed `size_of`/`align_of`
     /// assert against the generated mirror proves the reinterpret sound at compile
     /// time. Call after the manglers are configured (the mirror name is resolved
-    /// via [`Self::c_type_ident`]). A `<base>_drop` is generated.
+    /// via `Self::c_type_ident`). A `<base>_drop` is generated.
     ///
     /// **Owned-ness is inferred** from the fields: a struct with an opaque-pointer field
     /// owns external resources, so a by-value consume cleans the moved-from slot (nulls
@@ -532,7 +532,7 @@ impl CbindgenBuilder {
     /// emitted for it. `ty` must be `impl Fn(Args...) + Send + Sync + 'static`.
     /// Identical signatures share one struct. Sets the declaration cursor, so a
     /// following `.base_name("...")` sets the base fed to `mangle_callback` (else
-    /// the args' bases drive [`Self::callback_c_name`]).
+    /// the args' bases drive `Self::callback_c_name`).
     pub fn callback(mut self, ty: syn::Type) -> Self {
         let args = extract_fn_trait_args(&ty).unwrap_or_else(|| {
             panic!(
@@ -551,7 +551,7 @@ impl CbindgenBuilder {
     /// callee may take the value (`z_x_take` moves it out, leaving a gravestone) or
     /// just read it; the trampoline drops it after the call (no-op if taken). The
     /// arg type must be an inline-opaque type ([`Self::opaque_owned_struct`] /
-    /// [`Self::opaque_data_struct`]). Chain after `.callback(...)` (and any `.name(...)`).
+    /// [`Self::opaque_data_struct`]). Chain after `.callback(...)` (and any `.base_name(...)`).
     pub fn takeable_param(mut self, idx: usize) -> Self {
         match &self.current {
             Some(CurrentDecl::Callback(key)) => {

--- a/prebindgen-c/src/lib.rs
+++ b/prebindgen-c/src/lib.rs
@@ -13,7 +13,7 @@
 //! with [`CbindgenBuilder::function`] / [`CbindgenBuilder::opaque_ptr`] /
 //! [`CbindgenBuilder::data_struct`] / [`CbindgenBuilder::enum_type`] /
 //! [`CbindgenBuilder::tagged_union`]. The C name of a declared
-//! type's generated destructor can be pinned by chaining [`CbindgenBuilder::name`].
+//! type's generated destructor can be pinned by chaining [`CbindgenBuilder::base_name`].
 //!
 //! ## C ABI conventions
 //!

--- a/prebindgen-c/src/trait_impl.rs
+++ b/prebindgen-c/src/trait_impl.rs
@@ -260,7 +260,7 @@ impl CbindgenBuilder {
     /// behaviour *before* any `match` in this converter could inspect it, which
     /// is why validating an already-materialised enum is not a fix (#158).
     ///
-    /// So the wire is [`::core::mem::MaybeUninit<mirror>`], which is
+    /// So the wire is `::core::mem::MaybeUninit<mirror>`, which is
     /// `#[repr(transparent)]` over the mirror (identical ABI, identical C
     /// spelling — cbindgen renders `MaybeUninit<T>` as `T`) and, unlike the
     /// mirror itself, may legally hold **any** bit pattern. The discriminant is

--- a/prebindgen-flat/src/flat/array_len.rs
+++ b/prebindgen-flat/src/flat/array_len.rs
@@ -36,7 +36,7 @@ pub struct UnsupportedArrayLen {
     pub reason: ArrayLenReason,
 }
 
-/// Why [`lower_array_len`] refused a length.
+/// Why `lower_array_len` refused a length.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum ArrayLenReason {
     /// Not a literal and not a plain name: arithmetic, a cast, a call, a block,

--- a/prebindgen-flat/src/flat/array_len.rs
+++ b/prebindgen-flat/src/flat/array_len.rs
@@ -36,7 +36,7 @@ pub struct UnsupportedArrayLen {
     pub reason: ArrayLenReason,
 }
 
-/// Why `lower_array_len` refused a length.
+/// Why an array length was refused.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum ArrayLenReason {
     /// Not a literal and not a plain name: arithmetic, a cast, a call, a block,

--- a/prebindgen-flat/src/flat/element.rs
+++ b/prebindgen-flat/src/flat/element.rs
@@ -151,7 +151,7 @@ impl Type {
 ///   thereafter the only way to spell that type inside the flat API, and the
 ///   qualified path stays refused. This declares a name; it is not an equivalence
 ///   between spellings — see
-///   [`normalize_type`](crate::flat::spelling::normalize_type)'s rule 4 for
+///   `normalize_type`'s rule 4 for
 ///   why treating it as one is a category error.
 /// * `#[prebindgen] pub struct X(..);` — a tuple struct, whose fields no adapter
 ///   has ever crossed.
@@ -242,7 +242,7 @@ pub struct Param {
 ///
 /// Whether the fields are named or positional is not recorded: a [`Field`]
 /// already knows its own address, and the delimiters are spelling, read off the
-/// syntax by [`spell::fields`](super::spell::fields).
+/// syntax by `spell::fields`.
 #[derive(Clone, Debug)]
 pub struct Struct {
     pub name: syn::Ident,
@@ -374,7 +374,7 @@ impl Alternative {
     /// True when this alternative carries no payload.
     ///
     /// The *group* question, not the syntax one: `B`, `B()` and `B {}` are all
-    /// empty by this test, and [`spell::fields`](super::spell::fields) is what
+    /// empty by this test, and `spell::fields` is what
     /// keeps their delimiters apart.
     pub fn is_empty(&self) -> bool {
         self.fields.is_empty()
@@ -559,7 +559,7 @@ fn docs_from(attrs: &[syn::Attribute]) -> Option<String> {
 macro_rules! docs_accessor {
     ($($ty:ident),+ $(,)?) => {$(
         impl $ty {
-            /// This item's `///` documentation — see [`docs_from`].
+            /// This item's `///` documentation — see `docs_from`.
             pub fn docs(&self) -> Option<String> {
                 docs_from(&self.origin.syntax.attrs)
             }

--- a/prebindgen-flat/src/flat/element.rs
+++ b/prebindgen-flat/src/flat/element.rs
@@ -150,9 +150,9 @@ impl Type {
 ///   crate-private type gets a name here. A **one-way road**: the name is
 ///   thereafter the only way to spell that type inside the flat API, and the
 ///   qualified path stays refused. This declares a name; it is not an equivalence
-///   between spellings — see
-///   `normalize_type`'s rule 4 for
-///   why treating it as one is a category error.
+///   between spellings: the normalization that makes `std::vec::Vec<T>` and
+///   `Vec<T>` one key covers the names the *language* predeclares, and a crate's
+///   own alias is never one of those — treating it as one is a category error.
 /// * `#[prebindgen] pub struct X(..);` — a tuple struct, whose fields no adapter
 ///   has ever crossed.
 ///
@@ -242,7 +242,7 @@ pub struct Param {
 ///
 /// Whether the fields are named or positional is not recorded: a [`Field`]
 /// already knows its own address, and the delimiters are spelling, read off the
-/// syntax by `spell::fields`.
+/// syntax when the struct is spelled.
 #[derive(Clone, Debug)]
 pub struct Struct {
     pub name: syn::Ident,
@@ -374,8 +374,8 @@ impl Alternative {
     /// True when this alternative carries no payload.
     ///
     /// The *group* question, not the syntax one: `B`, `B()` and `B {}` are all
-    /// empty by this test, and `spell::fields` is what
-    /// keeps their delimiters apart.
+    /// empty by this test; what keeps their delimiters apart is the spelling,
+    /// not this.
     pub fn is_empty(&self) -> bool {
         self.fields.is_empty()
     }
@@ -559,7 +559,7 @@ fn docs_from(attrs: &[syn::Attribute]) -> Option<String> {
 macro_rules! docs_accessor {
     ($($ty:ident),+ $(,)?) => {$(
         impl $ty {
-            /// This item's `///` documentation — see `docs_from`.
+            /// This item's `///` documentation.
             pub fn docs(&self) -> Option<String> {
                 docs_from(&self.origin.syntax.attrs)
             }

--- a/prebindgen-flat/src/flat/emit.rs
+++ b/prebindgen-flat/src/flat/emit.rs
@@ -38,10 +38,11 @@
 //! # What is closed
 //!
 //! **Every route from the model to captured syntax, except the ones the
-//! registry pipeline itself needs.** `TypeRef::{as_syn, stripped_syntax}`,
-//! `TypeKind::to_syn`, `Element::as_syn`, `Type::as_syn`, `Origin::as_syn` and
-//! the three `spell(head, parts)` shape methods stay `pub(crate)`
-//! — nothing outside this crate calls them. `TypeRef::spell`, `Origin::spell`
+//! registry pipeline itself needs.** Every accessor that hands out a `syn`
+//! node — a type's own node and its stripped form, an element's item, an
+//! origin's node, the syntax rebuilt from a kind, and the shape-spelling
+//! helpers — is crate-internal; nothing outside this crate calls them.
+//! `TypeRef::spell`, `Origin::spell`
 //! and `Flat::enum_item` are `pub`: the registry pipeline that legitimately
 //! calls them (`write_rust`'s emission, and its own tests) is now the separate
 //! `prebindgen-registry` crate, and a module-path seal cannot reach across a
@@ -254,8 +255,8 @@ impl Emit {
 
     /// The type as the **source spelled it** — what generated Rust must say.
     ///
-    /// Not `TypeKind::to_syn`, which reconstructs a
-    /// canonical form to check the lowering against: this is the crate's own
+    /// Not a canonical form rebuilt from the classification to check the
+    /// lowering against: this is the crate's own
     /// tokens, so a generated signature names the type the way the source crate
     /// does and compiles in its scope.
     pub fn spell(&self, ty: &TypeRef) -> TokenStream {

--- a/prebindgen-flat/src/flat/emit.rs
+++ b/prebindgen-flat/src/flat/emit.rs
@@ -254,7 +254,7 @@ impl Emit {
 
     /// The type as the **source spelled it** — what generated Rust must say.
     ///
-    /// Not [`TypeKind::to_syn`](super::TypeKind::to_syn), which reconstructs a
+    /// Not `TypeKind::to_syn`, which reconstructs a
     /// canonical form to check the lowering against: this is the crate's own
     /// tokens, so a generated signature names the type the way the source crate
     /// does and compiles in its scope.

--- a/prebindgen-flat/src/flat/key.rs
+++ b/prebindgen-flat/src/flat/key.rs
@@ -5,9 +5,11 @@ use std::fmt;
 use quote::ToTokens;
 
 /// Canonical type-shape key: identity is the token string of the
-/// **normalized** type (`crate::flat::spelling::normalize_type` —
-/// group/paren unwrap, `crate::`/`self::` and std-prelude path reduction;
-/// the complete equivalence rule set is documented there).
+/// **normalized** type. Normalization is a closed rule set — group/paren
+/// unwrap, a `crate::`/`self::`/source-module path reduced to its final
+/// segment, and a prelude path read as the bare name the language knows it
+/// by (`std::vec::Vec<Foo>` ≡ `Vec<Foo>`) — and any spelling it does not
+/// cover is kept verbatim.
 ///
 /// # A key is an identity, and nothing else
 ///
@@ -122,9 +124,8 @@ impl TypeKey {
     /// `a::Foo<u8>::Bar` → `Bar`; `None` when the **last** segment carries
     /// generic arguments (`Vec<u8>` names no bare item) or the key is not a
     /// path.
-    /// Matches [`bare_path_ident`](crate::types_util::bare_path_ident)
-    /// on the same type, which is what
-    /// `key_name_accessors_match_the_syn_walks` pins.
+    /// Matches [`bare_path_ident`](crate::types_util::bare_path_ident) on the
+    /// same type — a correspondence this crate's tests pin.
     ///
     /// **A name is not syntax**, which is why this is the key's business and
     /// producing a `syn::Type` is not. A caller that wants to look a declared

--- a/prebindgen-flat/src/flat/key.rs
+++ b/prebindgen-flat/src/flat/key.rs
@@ -5,7 +5,7 @@ use std::fmt;
 use quote::ToTokens;
 
 /// Canonical type-shape key: identity is the token string of the
-/// **normalized** type ([`crate::flat::spelling::normalize_type`] —
+/// **normalized** type (`crate::flat::spelling::normalize_type` —
 /// group/paren unwrap, `crate::`/`self::` and std-prelude path reduction;
 /// the complete equivalence rule set is documented there).
 ///
@@ -14,7 +14,7 @@ use quote::ToTokens;
 /// It is what a table is indexed by. It is **not** a route to `syn::Type`: the
 /// only way to reach a type's syntax is
 /// `Conversions::reading` (in the registry layer above) followed by
-/// [`TypeRef`], because a
+/// [`TypeRef`](super::TypeRef), because a
 /// reading is what pairs a spelling with the classification that vouches for
 /// it.
 ///

--- a/prebindgen-flat/src/flat/mod.rs
+++ b/prebindgen-flat/src/flat/mod.rs
@@ -12,8 +12,8 @@
 //!   (syn::Item)          validate              elements      spell with `spell()`
 //! ```
 //!
-//! [`Flat::source`] folds the first arrow in for the common case, so a build
-//! script names one directory and gets elements; [`Flat::items`] keeps the
+//! [`FlatBuilder::source`] folds the first arrow in for the common case, so a build
+//! script names one directory and gets elements; [`FlatBuilder::items`] keeps the
 //! arrow itself, for a stream that needs shaping first.
 //!
 //! # What an element is
@@ -65,7 +65,7 @@
 //! | `*const T` | *rejected* | a source crate is idiomatic Rust; the adapter owns pointers |
 //!
 //! It buys one property: the syntax is **recoverable from the kind**
-//! ([`TypeKind::to_syn`], checked over the whole acceptance corpus). Which is
+//! (`TypeKind::to_syn`, checked over the whole acceptance corpus). Which is
 //! the difference between a slice that rides along because it is exact, and one
 //! the model cannot do without.
 //!
@@ -107,7 +107,7 @@
 //!
 //! For a **type** the slice is no longer where facts go to survive:
 //! [`TypeKind`] keeps the lifetime, the wrapper and the argument it once
-//! dropped, and [`TypeKind::to_syn`] is the round-trip that says so. What is
+//! dropped, and `TypeKind::to_syn` is the round-trip that says so. What is
 //! left is the reason a slice beats a reconstruction anywhere — it is what the
 //! source wrote, and it is already there.
 //!
@@ -685,7 +685,7 @@ impl Flat {
     /// it is one the binding invented, and there is nothing for the frontend to
     /// have decided about it.
     ///
-    /// The argument is normalized the way [`TypeKey`](crate::TypeKey) does
+    /// The argument is normalized the way [`TypeKey`] does
     /// before lookup, so an adapter-authored spelling finds the same entry a
     /// captured one does.
     pub fn type_ref(&self, ty: &syn::Type) -> Option<&TypeRef> {
@@ -790,7 +790,7 @@ impl Flat {
     ///
     /// Grammar only, and it **validates by lowering**: an `Err` is a shape the
     /// language cannot express, an `Ok` is the element to admit. Whether the types
-    /// it names are *declared* is a whole-model question ([`resolve_references`]),
+    /// it names are *declared* is a whole-model question (`resolve_references`),
     /// and a binding-local fn may legitimately name types the source crate never
     /// did.
     pub fn lower_signature(&self, f: &syn::ItemFn) -> Result<Function, ItemError> {

--- a/prebindgen-flat/src/flat/mod.rs
+++ b/prebindgen-flat/src/flat/mod.rs
@@ -65,7 +65,7 @@
 //! | `*const T` | *rejected* | a source crate is idiomatic Rust; the adapter owns pointers |
 //!
 //! It buys one property: the syntax is **recoverable from the kind**
-//! (`TypeKind::to_syn`, checked over the whole acceptance corpus). Which is
+//! (checked, over the whole acceptance corpus, by rebuilding it). Which is
 //! the difference between a slice that rides along because it is exact, and one
 //! the model cannot do without.
 //!
@@ -107,7 +107,8 @@
 //!
 //! For a **type** the slice is no longer where facts go to survive:
 //! [`TypeKind`] keeps the lifetime, the wrapper and the argument it once
-//! dropped, and `TypeKind::to_syn` is the round-trip that says so. What is
+//! dropped, and rebuilding the syntax from it is the round-trip that says
+//! so. What is
 //! left is the reason a slice beats a reconstruction anywhere — it is what the
 //! source wrote, and it is already there.
 //!
@@ -790,9 +791,9 @@ impl Flat {
     ///
     /// Grammar only, and it **validates by lowering**: an `Err` is a shape the
     /// language cannot express, an `Ok` is the element to admit. Whether the types
-    /// it names are *declared* is a whole-model question (`resolve_references`),
-    /// and a binding-local fn may legitimately name types the source crate never
-    /// did.
+    /// it names are *declared* is a whole-model question, settled when the model
+    /// is built, and a binding-local fn may legitimately name types the source
+    /// crate never did.
     pub fn lower_signature(&self, f: &syn::ItemFn) -> Result<Function, ItemError> {
         // Rebuilt from the model rather than kept: this runs once per local fn,
         // and a stored index would be a second copy of what `constants()` says.

--- a/prebindgen-flat/src/flat/origin.rs
+++ b/prebindgen-flat/src/flat/origin.rs
@@ -53,7 +53,7 @@ use super::key::TypeKey;
 /// > **You may output the source. You may not read it.**
 ///
 /// [`spell`](Self::spell) hands out tokens and nothing else, which is all
-/// generated Rust ever needed; [`as_syn`](Self::as_syn) hands out the node and
+/// generated Rust ever needed; `as_syn` hands out the node and
 /// is the **one** way to get one. The field itself is `pub(super)`, so the model
 /// still reads it freely and everything downstream has to say which of the two
 /// it meant.

--- a/prebindgen-flat/src/flat/origin.rs
+++ b/prebindgen-flat/src/flat/origin.rs
@@ -53,10 +53,10 @@ use super::key::TypeKey;
 /// > **You may output the source. You may not read it.**
 ///
 /// [`spell`](Self::spell) hands out tokens and nothing else, which is all
-/// generated Rust ever needed; `as_syn` hands out the node and
-/// is the **one** way to get one. The field itself is `pub(super)`, so the model
-/// still reads it freely and everything downstream has to say which of the two
-/// it meant.
+/// generated Rust ever needed. The node is reachable only through one
+/// crate-internal accessor, and the field itself is `pub(super)` — so the
+/// model still reads it freely, while everything outside is limited to the
+/// spelling.
 ///
 /// It was a public field returning a `syn` node to anyone who asked.
 /// Outside this crate, captured syntax is reachable only through

--- a/prebindgen-flat/src/flat/spell.rs
+++ b/prebindgen-flat/src/flat/spell.rs
@@ -77,7 +77,7 @@ impl Field {
 
     /// The field bound to `bind`, shaped for whichever address it uses —
     /// `id: __f0` for a named field, `__f0` for a positional one. The part
-    /// [`fields`] takes.
+    /// `fields` takes.
     pub fn bind(&self, bind: &impl ToTokens) -> TokenStream {
         match &self.name {
             Some(id) => quote!(#id: #bind),

--- a/prebindgen-flat/src/flat/spell.rs
+++ b/prebindgen-flat/src/flat/spell.rs
@@ -76,8 +76,8 @@ impl Field {
     }
 
     /// The field bound to `bind`, shaped for whichever address it uses —
-    /// `id: __f0` for a named field, `__f0` for a positional one. The part
-    /// `fields` takes.
+    /// `id: __f0` for a named field, `__f0` for a positional one. The part a
+    /// spelled fields list is built from.
     pub fn bind(&self, bind: &impl ToTokens) -> TokenStream {
         match &self.name {
             Some(id) => quote!(#id: #bind),

--- a/prebindgen-flat/src/flat/ty.rs
+++ b/prebindgen-flat/src/flat/ty.rs
@@ -38,7 +38,7 @@ use super::{
 /// [`spell`](Self::spell). It is **not**
 /// where facts go to survive a lossy classification any more — `kind` keeps the
 /// lifetime, the wrapper and the argument it used to drop, and
-/// [`TypeKind::to_syn`] proves it. Keeping the slice anyway is cheap, exact
+/// `TypeKind::to_syn` proves it. Keeping the slice anyway is cheap, exact
 /// (nothing has to reconstruct token for token what the source already wrote),
 /// and it is what makes the proof possible at all.
 ///
@@ -164,7 +164,7 @@ impl TypeRef {
     /// Tokens, not a `syn::Type`: a spelling is for spelling. What the type
     /// *is* has an answer in [`kind`](Self::kind) and in the readings beside it,
     /// and a consumer that still has to take the node apart says so with
-    /// [`as_syn`](Self::as_syn).
+    /// `as_syn`.
     pub fn spell(&self) -> proc_macro2::TokenStream {
         self.origin.spell()
     }
@@ -445,7 +445,7 @@ impl TypeRef {
     /// a spelling was erased — which is the question a **refusal** asks — but a
     /// consumer that rebuilds a nested `Box<Cow<'_, T>>` needs every layer, and
     /// asks [`erased_wrappers`](Self::erased_wrappers) for the whole list plus
-    /// [`stripped_syntax`](Self::stripped_syntax) for what sits under it.
+    /// `stripped_syntax` for what sits under it.
     ///
     /// Erased says nothing about **rebuildable**: `Box` reconstructs as
     /// `Box::new(v)`, while `Cow`'s `Owned`/`Borrowed` choice is not determined
@@ -500,7 +500,7 @@ impl TypeRef {
     }
 
     /// This type's identity as a table key with every transparent wrapper
-    /// removed — the key of [`stripped_syntax`](Self::stripped_syntax).
+    /// removed — the key of `stripped_syntax`.
     ///
     /// What [`key`](Self::key) answers for a **spelling**, this answers for the
     /// **type**. The two are different questions and both are legitimate:
@@ -721,8 +721,8 @@ impl TypeRef {
 /// One variant per accepted Rust **form**, not per destination concept. `str`
 /// and `String` are two forms and get two variants; `Box<T>` is a form of its
 /// own and does not disappear into `T`. Nothing here folds two spellings
-/// together, which is what makes [`TypeRef::syntax`] recoverable from this —
-/// see [`TypeKind::to_syn`], the round-trip that checks it.
+/// together, which is what makes [`TypeRef::spell`] recoverable from this —
+/// see `TypeKind::to_syn`, the round-trip that checks it.
 ///
 /// # Why it is only syntax
 ///
@@ -1045,7 +1045,7 @@ pub struct UnsupportedType {
     pub reason: UnsupportedTypeReason,
 }
 
-/// Why [`lower_type`] refused a type.
+/// Why `lower_type` refused a type.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum UnsupportedTypeReason {
     /// A syntactic form with no place in the language: a raw pointer, a bare
@@ -1076,7 +1076,7 @@ pub enum UnsupportedTypeReason {
     /// Separate from [`WrongGenericArity`](Self::WrongGenericArity) because it
     /// is about the list and not its type-argument count: each of those three
     /// has exactly one type argument, and refusing them is what keeps
-    /// [`TypeKind::to_syn`] able to spell every accepted form back.
+    /// `TypeKind::to_syn` able to spell every accepted form back.
     WrongGenericArguments { expected: &'static str },
     /// A non-empty tuple. Only `()` is in the language: no adapter has ever
     /// lowered a tuple, so accepting one would defer the failure to a late

--- a/prebindgen-flat/src/flat/ty.rs
+++ b/prebindgen-flat/src/flat/ty.rs
@@ -37,8 +37,8 @@ use super::{
 /// The retained slice is what generated Rust spells, through
 /// [`spell`](Self::spell). It is **not**
 /// where facts go to survive a lossy classification any more — `kind` keeps the
-/// lifetime, the wrapper and the argument it used to drop, and
-/// `TypeKind::to_syn` proves it. Keeping the slice anyway is cheap, exact
+/// lifetime, the wrapper and the argument it used to drop, and rebuilding the
+/// syntax from it proves so. Keeping the slice anyway is cheap, exact
 /// (nothing has to reconstruct token for token what the source already wrote),
 /// and it is what makes the proof possible at all.
 ///
@@ -162,9 +162,8 @@ impl TypeRef {
     /// `Box<Option<T>>` becomes an `E0308`.
     ///
     /// Tokens, not a `syn::Type`: a spelling is for spelling. What the type
-    /// *is* has an answer in [`kind`](Self::kind) and in the readings beside it,
-    /// and a consumer that still has to take the node apart says so with
-    /// `as_syn`.
+    /// *is* has an answer in [`kind`](Self::kind) and in the readings beside
+    /// it; the node itself never leaves the model.
     pub fn spell(&self) -> proc_macro2::TokenStream {
         self.origin.spell()
     }
@@ -444,8 +443,8 @@ impl TypeRef {
     /// Only the outermost wrapper is named. That is enough to decide *whether*
     /// a spelling was erased — which is the question a **refusal** asks — but a
     /// consumer that rebuilds a nested `Box<Cow<'_, T>>` needs every layer, and
-    /// asks [`erased_wrappers`](Self::erased_wrappers) for the whole list plus
-    /// `stripped_syntax` for what sits under it.
+    /// asks [`erased_wrappers`](Self::erased_wrappers) for the whole list, and
+    /// [`stripped_key`](Self::stripped_key) for what sits under them.
     ///
     /// Erased says nothing about **rebuildable**: `Box` reconstructs as
     /// `Box::new(v)`, while `Cow`'s `Owned`/`Borrowed` choice is not determined
@@ -500,7 +499,7 @@ impl TypeRef {
     }
 
     /// This type's identity as a table key with every transparent wrapper
-    /// removed — the key of `stripped_syntax`.
+    /// removed.
     ///
     /// What [`key`](Self::key) answers for a **spelling**, this answers for the
     /// **type**. The two are different questions and both are legitimate:
@@ -722,7 +721,7 @@ impl TypeRef {
 /// and `String` are two forms and get two variants; `Box<T>` is a form of its
 /// own and does not disappear into `T`. Nothing here folds two spellings
 /// together, which is what makes [`TypeRef::spell`] recoverable from this —
-/// see `TypeKind::to_syn`, the round-trip that checks it.
+/// rebuilding the syntax from a kind is the round-trip that checks it.
 ///
 /// # Why it is only syntax
 ///
@@ -1045,7 +1044,7 @@ pub struct UnsupportedType {
     pub reason: UnsupportedTypeReason,
 }
 
-/// Why `lower_type` refused a type.
+/// Why a type was refused.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum UnsupportedTypeReason {
     /// A syntactic form with no place in the language: a raw pointer, a bare
@@ -1075,8 +1074,8 @@ pub enum UnsupportedTypeReason {
     ///
     /// Separate from [`WrongGenericArity`](Self::WrongGenericArity) because it
     /// is about the list and not its type-argument count: each of those three
-    /// has exactly one type argument, and refusing them is what keeps
-    /// `TypeKind::to_syn` able to spell every accepted form back.
+    /// has exactly one type argument, and refusing them is what keeps every
+    /// accepted form rebuildable from its kind.
     WrongGenericArguments { expected: &'static str },
     /// A non-empty tuple. Only `()` is in the language: no adapter has ever
     /// lowered a tuple, so accepting one would defer the failure to a late

--- a/prebindgen-jni/src/jni/builder.rs
+++ b/prebindgen-jni/src/jni/builder.rs
@@ -381,7 +381,7 @@ impl JniGenBuilder {
     /// "skipping undeclared" warning is suppressed. Global — an ignored
     /// item belongs to no package. One acceptor, the kind carried by the
     /// decl (see [`IgnoreDecl`]): `fun!` / `ty!` / `constant!` for exact
-    /// items, [`matching`](crate::matching) for a name-family
+    /// items, [`matching`] for a name-family
     /// predicate over ANY item kind.
     pub fn ignore(mut self, decl: impl Into<IgnoreDecl>) -> Self {
         match decl.into().0 {

--- a/prebindgen-jni/src/jni/decl.rs
+++ b/prebindgen-jni/src/jni/decl.rs
@@ -273,7 +273,7 @@ impl PtrClassDecl {
 
     /// Make instances of this handle class **GC-managed**: an unreachable
     /// handle whose native box was not otherwise released is freed by a
-    /// shared [`java.lang.ref.Cleaner`].
+    /// shared `java.lang.ref.Cleaner`.
     ///
     /// The pointer of a GC-managed handle lives in a separate atomic cell
     /// (tag bit and all) so the cleaner action can settle the release after

--- a/prebindgen-jni/src/jni/decl.rs
+++ b/prebindgen-jni/src/jni/decl.rs
@@ -718,8 +718,9 @@ impl ConstDecl {
 
     /// Value source: a **binding-local nullary fn** named by path —
     /// `(stated value type, path)`, the const analog of
-    /// [`ConvertSourceDecl::with`]. The fn lives in the binding crate
-    /// (callable because the generated file compiles inside it):
+    /// [`FunctionDecl::new_local`](prebindgen_registry::FunctionDecl::new_local).
+    /// The fn lives in the binding crate (callable because the generated file
+    /// compiles inside it):
     /// `fn() -> T`.
     pub fn with(self, ty: syn::Type, path: syn::Path) -> Self {
         let expr: syn::Expr = syn::parse_quote!(#path());

--- a/prebindgen-jni/src/jni/mod.rs
+++ b/prebindgen-jni/src/jni/mod.rs
@@ -8,8 +8,8 @@
 //! The implementation is split across sibling submodules, all sharing this
 //! `jni` module's namespace via the `pub(crate) use …::*` glob re-exports
 //! below (each sibling needs only `use super::*;`):
-//!   * this file — type / metadata definitions ([`JniGenBuilder`], [`KotlinMeta`],
-//!     [`Projection`], [`FoldStrategy`], the config structs) + the shared imports;
+//!   * this file — type / metadata definitions ([`JniGenBuilder`], `KotlinMeta`,
+//!     `Projection`, `FoldStrategy`, the config structs) + the shared imports;
 //!   * `builder` — the [`JniGenBuilder`] builder API;
 //!   * `trait_impl` — the [`Prebindgen`] impl + its converter-selector helpers;
 //!   * `emit` — Rust-side `extern "C"` wrapper / converter-body emission;

--- a/prebindgen-jni/src/jni/mod.rs
+++ b/prebindgen-jni/src/jni/mod.rs
@@ -4,17 +4,17 @@
 //! (Rust-side conversion bodies) and provides an inherent
 //! `JniGenBuilder::write_kotlin` for emitting all Kotlin output
 //! (`NativeHandle.kt`, typed-handle classes, `JNIWrappers.kt`).
-//!
-//! The implementation is split across sibling submodules, all sharing this
-//! `jni` module's namespace via the `pub(crate) use …::*` glob re-exports
-//! below (each sibling needs only `use super::*;`):
-//!   * this file — type / metadata definitions ([`JniGenBuilder`], `KotlinMeta`,
-//!     `Projection`, `FoldStrategy`, the config structs) + the shared imports;
-//!   * `builder` — the [`JniGenBuilder`] builder API;
-//!   * `trait_impl` — the [`Prebindgen`] impl + its converter-selector helpers;
-//!   * `emit` — Rust-side `extern "C"` wrapper / converter-body emission;
-//!   * `prim` — JNI primitive (un)boxing tables;
-//!   * `kotlin_emit` / `render` / `fold` — the Kotlin source emitters.
+
+// The implementation is split across sibling submodules, all sharing this
+// `jni` module's namespace via the `pub(crate) use …::*` glob re-exports
+// below (each sibling needs only `use super::*;`):
+//   * this file — type / metadata definitions (JniGenBuilder, KotlinMeta,
+//     Projection, FoldStrategy, the config structs) + the shared imports;
+//   * `builder` — the JniGenBuilder builder API;
+//   * `trait_impl` — the Prebindgen impl + its converter-selector helpers;
+//   * `emit` — Rust-side `extern "C"` wrapper / converter-body emission;
+//   * `prim` — JNI primitive (un)boxing tables;
+//   * `kotlin_emit` / `render` / `fold` — the Kotlin source emitters.
 
 mod metadata;
 pub(crate) mod wire_access;

--- a/prebindgen-jni/src/jni/trait_impl.rs
+++ b/prebindgen-jni/src/jni/trait_impl.rs
@@ -1933,8 +1933,7 @@ impl Prebindgen for Declarations {
 
     /// The post-resolve validation boundary (issue #90): every bound
     /// function's lowered plan must build, and the split declarations must
-    /// be unambiguous, before ANY artifact writer touches disk — see
-    /// `validate_bindings`.
+    /// be unambiguous, before ANY artifact writer touches disk.
     fn validate_resolved(&self, registry: &Registry<KotlinMeta>) -> Result<(), String> {
         validate_bindings(self, registry)
     }
@@ -2066,8 +2065,8 @@ impl Prebindgen for Declarations {
         TokenStream::new()
     }
 
-    /// Declared consts only reach here (write gating via
-    /// `declared_consts`): re-emit the const as a path-alias
+    /// Declared consts only reach here (undeclared ones are gated out before
+    /// emission): re-emit the const as a path-alias
     /// to its source-of-truth (initializer tokens are never copied — they
     /// may reference source-crate internals) AND emit its nullary JNI getter
     /// extern. The getter reuses the whole function-wrapper pipeline (so the
@@ -2994,6 +2993,10 @@ impl Declarations {
             .filter(|f| !declared.contains(f))
             .collect()
     }
+    /// Union of every `.constant(...)` list across all [`Self::package`]
+    /// subpackage contexts. `Some` even when empty — [`JniGenBuilder`] HAS a
+    /// const declaration mechanism, so const emission is declared-only and
+    /// undeclared consts get the skip warning.
     pub(crate) fn declared_consts(&self) -> Option<std::collections::HashSet<syn::Ident>> {
         let mut out = std::collections::HashSet::new();
         for pkg in self.packages.values() {
@@ -3007,11 +3010,6 @@ impl Declarations {
     pub(crate) fn ignored_consts(&self) -> std::collections::HashSet<syn::Ident> {
         self.ignored_const_idents.clone()
     }
-    /// Union of every `.constant(...)` list across all
-    /// [`Self::package`] subpackage contexts. `Some` even when empty — JniGenBuilder
-    /// HAS a const declaration mechanism, so const emission is declared-only
-    /// and undeclared consts get the skip warning (see
-    /// `declared_consts`).
     /// The declared value types of every expression constant
     /// (`ConstDecl::expr`) — they have no `#[prebindgen]` item to
     /// scan, so the resolver is told directly to produce their output

--- a/prebindgen-jni/src/jni/trait_impl.rs
+++ b/prebindgen-jni/src/jni/trait_impl.rs
@@ -1934,7 +1934,7 @@ impl Prebindgen for Declarations {
     /// The post-resolve validation boundary (issue #90): every bound
     /// function's lowered plan must build, and the split declarations must
     /// be unambiguous, before ANY artifact writer touches disk — see
-    /// [`validate_bindings`].
+    /// `validate_bindings`.
     fn validate_resolved(&self, registry: &Registry<KotlinMeta>) -> Result<(), String> {
         validate_bindings(self, registry)
     }
@@ -2067,7 +2067,7 @@ impl Prebindgen for Declarations {
     }
 
     /// Declared consts only reach here (write gating via
-    /// [`Prebindgen::declared_consts`]): re-emit the const as a path-alias
+    /// `declared_consts`): re-emit the const as a path-alias
     /// to its source-of-truth (initializer tokens are never copied — they
     /// may reference source-crate internals) AND emit its nullary JNI getter
     /// extern. The getter reuses the whole function-wrapper pipeline (so the
@@ -3011,7 +3011,7 @@ impl Declarations {
     /// [`Self::package`] subpackage contexts. `Some` even when empty — JniGenBuilder
     /// HAS a const declaration mechanism, so const emission is declared-only
     /// and undeclared consts get the skip warning (see
-    /// [`Prebindgen::declared_consts`]).
+    /// `declared_consts`).
     /// The declared value types of every expression constant
     /// (`ConstDecl::expr`) — they have no `#[prebindgen]` item to
     /// scan, so the resolver is told directly to produce their output

--- a/prebindgen-registry/src/decl.rs
+++ b/prebindgen-registry/src/decl.rs
@@ -234,7 +234,7 @@ macro_rules! fields {
 ///
 /// Build one with [`expand_param!`](crate::expand_param), add arms with
 /// [`variant`](Self::variant) / [`variant_self`](Self::variant_self), and hand
-/// it to `JniGenBuilder::expand`.
+/// it to the adapter's `expand` declaration.
 ///
 /// **Generated shape** — at the wire tier this is a selector dispatch: with
 /// more than one arm the parameter crosses as a selector `Int` plus one
@@ -381,7 +381,7 @@ impl ExpandParamDecl {
 ///
 /// Build one with [`expand_return!`](crate::expand_return), add fields with
 /// [`field`](Self::field) / [`field_self`](Self::field_self), and hand it to
-/// `JniGenBuilder::expand`.
+/// the adapter's `expand` declaration.
 ///
 /// The type does **not** have to be declared in any package. A boundary decl
 /// on an undeclared type makes it **rust-side-only**: every returned /
@@ -451,7 +451,7 @@ impl ExpandReturnDecl {
     ///
     /// The Kotlin field name is uniform for both: an explicit `.name(...)`
     /// on the `fun!`; else the Kotlin name of the class member if the same
-    /// fn is declared via `PtrClassDecl::method` on this type (so a getter
+    /// fn is also declared as a method on this type's class (so a getter
     /// that is both a method and a field is named once); else the
     /// camel-cased fn ident (a path's LAST segment).
     ///
@@ -738,8 +738,9 @@ impl FieldsDecl {
     }
 }
 
-/// Unifies the two boundary decls into one type so `JniGenBuilder::expand` can
-/// expose a single entry point — the boundary-decl peer of `ClassDecl`.
+/// Unifies the two boundary decls into one type so an adapter's `expand` can
+/// expose a single entry point — the boundary-decl peer of its class
+/// declarator.
 /// Deliberately **no** `impl From<syn::Type> for ExpandDecl` — a bare
 /// `syn::Type` alone doesn't say which direction it describes, so every
 /// declaration names its direction via the matching constructor macro:
@@ -765,15 +766,14 @@ impl From<ExpandReturnDecl> for ExpandDecl {
 // Function decl
 // ──────────────────────────────────────────────────────────────────────
 
-/// Declares one `#[prebindgen]` function to export. Add it to a package with
-/// `PackageDecl::fun`, or attach it to a class as a method/factory with
-/// `PtrClassDecl::method` / `PtrClassDecl::constructor`.
+/// Declares one `#[prebindgen]` function to export. The adapter either adds it
+/// to a package or attaches it to a class as a method or a factory.
 ///
 /// Build it from a bare Rust name with [`fun!`](crate::fun) and chain
 /// [`name`](Self::name) to set its Kotlin name.
 /// [`expand_param`](Self::expand_param) / [`expand_return`](Self::expand_return)
 /// **override, for this one function**, the boundary defaults its
-/// parameter/return types declare at the generator level (`JniGenBuilder::expand`)
+/// parameter/return types declare at the generator level
 /// — using the very same decl objects, so the complete-set rule is identical
 /// at both scopes.
 pub struct FunctionDecl {

--- a/prebindgen-registry/src/decl.rs
+++ b/prebindgen-registry/src/decl.rs
@@ -102,7 +102,7 @@ macro_rules! sig {
 }
 
 /// Build a `syn::Type` from a bare Rust type token: `ty!(i32)`. The type
-/// argument of decl methods like [`ConvertSourceDecl::error`] — always
+/// argument of decl methods like [`ConvertSourceDecl::from_type`] — always
 /// yields the concrete `syn::Type`, so no inference context is needed (see
 /// [`ident!`](crate::ident) for the E0283 background).
 #[macro_export]
@@ -113,7 +113,8 @@ macro_rules! ty {
 }
 
 /// Build a `syn::Path` from a bare path token: `path!(crate::conv::f)`. The
-/// callable argument of [`ConvertSourceDecl::with`] and [`ConstDecl::with`].
+/// callable argument of [`FunctionDecl::new_local`] and of an adapter's
+/// `ConstDecl::with`.
 #[macro_export]
 macro_rules! path {
     ($p:path) => {
@@ -122,8 +123,8 @@ macro_rules! path {
 }
 
 /// Build a `syn::Expr` from an expression token: `expr!(format!("{A}:{B}"))`.
-/// The initializer argument of [`ConstDecl::expr`] — allowed only for
-/// constants, where the expression binds no arguments.
+/// The initializer argument of an adapter's `ConstDecl::expr` — allowed only
+/// for constants, where the expression binds no arguments.
 #[macro_export]
 macro_rules! expr {
     ($e:expr) => {
@@ -133,7 +134,7 @@ macro_rules! expr {
 
 /// Build a [`ConvertDecl`] directly from a bare Rust type:
 /// `convert!(Millis)` is `ConvertDecl::new(<Millis as syn::Type>)`.
-/// See [`ptr_class!`] for the parsing mechanics.
+/// See `ptr_class!` for the parsing mechanics.
 #[macro_export]
 macro_rules! convert {
     ($t:ty) => {
@@ -143,7 +144,7 @@ macro_rules! convert {
 
 /// Build a [`ExpandParamDecl`] directly from a bare Rust type:
 /// `expand_param!(KeyExpr)` is `ExpandParamDecl::new(<KeyExpr as syn::Type>)`.
-/// See [`ptr_class!`] for the parsing mechanics.
+/// See `ptr_class!` for the parsing mechanics.
 #[macro_export]
 macro_rules! expand_param {
     ($t:ty) => {
@@ -203,7 +204,7 @@ macro_rules! try_into {
 
 /// Build a [`ExpandReturnDecl`] directly from a bare Rust type:
 /// `expand_return!(Sample)` is `ExpandReturnDecl::new(<Sample as syn::Type>)`.
-/// See [`ptr_class!`] for the parsing mechanics.
+/// See `ptr_class!` for the parsing mechanics.
 #[macro_export]
 macro_rules! expand_return {
     ($t:ty) => {
@@ -233,7 +234,7 @@ macro_rules! fields {
 ///
 /// Build one with [`expand_param!`](crate::expand_param), add arms with
 /// [`variant`](Self::variant) / [`variant_self`](Self::variant_self), and hand
-/// it to [`JniGenBuilder::expand`].
+/// it to `JniGenBuilder::expand`.
 ///
 /// **Generated shape** — at the wire tier this is a selector dispatch: with
 /// more than one arm the parameter crosses as a selector `Int` plus one
@@ -380,7 +381,7 @@ impl ExpandParamDecl {
 ///
 /// Build one with [`expand_return!`](crate::expand_return), add fields with
 /// [`field`](Self::field) / [`field_self`](Self::field_self), and hand it to
-/// [`JniGenBuilder::expand`].
+/// `JniGenBuilder::expand`.
 ///
 /// The type does **not** have to be declared in any package. A boundary decl
 /// on an undeclared type makes it **rust-side-only**: every returned /
@@ -450,7 +451,7 @@ impl ExpandReturnDecl {
     ///
     /// The Kotlin field name is uniform for both: an explicit `.name(...)`
     /// on the `fun!`; else the Kotlin name of the class member if the same
-    /// fn is declared via [`PtrClassDecl::method`] on this type (so a getter
+    /// fn is declared via `PtrClassDecl::method` on this type (so a getter
     /// that is both a method and a field is named once); else the
     /// camel-cased fn ident (a path's LAST segment).
     ///
@@ -737,8 +738,8 @@ impl FieldsDecl {
     }
 }
 
-/// Unifies the two boundary decls into one type so [`JniGenBuilder::expand`] can
-/// expose a single entry point — the boundary-decl peer of [`ClassDecl`].
+/// Unifies the two boundary decls into one type so `JniGenBuilder::expand` can
+/// expose a single entry point — the boundary-decl peer of `ClassDecl`.
 /// Deliberately **no** `impl From<syn::Type> for ExpandDecl` — a bare
 /// `syn::Type` alone doesn't say which direction it describes, so every
 /// declaration names its direction via the matching constructor macro:
@@ -765,14 +766,14 @@ impl From<ExpandReturnDecl> for ExpandDecl {
 // ──────────────────────────────────────────────────────────────────────
 
 /// Declares one `#[prebindgen]` function to export. Add it to a package with
-/// [`PackageDecl::fun`], or attach it to a class as a method/factory with
-/// [`PtrClassDecl::method`] / [`PtrClassDecl::constructor`].
+/// `PackageDecl::fun`, or attach it to a class as a method/factory with
+/// `PtrClassDecl::method` / `PtrClassDecl::constructor`.
 ///
 /// Build it from a bare Rust name with [`fun!`](crate::fun) and chain
 /// [`name`](Self::name) to set its Kotlin name.
 /// [`expand_param`](Self::expand_param) / [`expand_return`](Self::expand_return)
 /// **override, for this one function**, the boundary defaults its
-/// parameter/return types declare at the generator level ([`JniGenBuilder::expand`])
+/// parameter/return types declare at the generator level (`JniGenBuilder::expand`)
 /// — using the very same decl objects, so the complete-set rule is identical
 /// at both scopes.
 pub struct FunctionDecl {

--- a/prebindgen-registry/src/expand.rs
+++ b/prebindgen-registry/src/expand.rs
@@ -19,7 +19,7 @@
 //!
 //! Everything here is **language-agnostic**: the fold is pure Rust and the
 //! per-leaf wire encode/decode is delegated to the adapter's existing
-//! converters. `apply` resolves declarations into [`FoldPlan`]s (stored on
+//! converters. Resolution turns the declarations into [`FoldPlan`]s (stored on
 //! the registry, keyed by `(fn, param)`) and registers each leaf type as a
 //! required input so the resolver produces its converter. [`emit_fold`]
 //! emits the dispatch expression at the parameter-emission site.
@@ -84,7 +84,7 @@ pub enum ExpandSel {
 /// A per-fn input expansion (`.expand_param(param, expand_param!(T)…)`) —
 /// construct `param` of `func` from the explicit variant list. Recorded as
 /// an explicit decl so the auto-`default` skips it; an identity-only list
-/// lowers to the skip-default plain form in `apply`. Not related to the
+/// lowers to the skip-default plain form at resolution. Not related to the
 /// jnigen declaration-DSL type of the same name — this is the lowered core
 /// record.
 #[derive(Clone)]
@@ -92,7 +92,7 @@ pub struct ExpandDecl {
     pub func: syn::Ident,
     pub param: syn::Ident,
     /// The type the per-fn decl was declared for (`expand_param!(T)`) —
-    /// cross-checked against the named param's peeled type in `apply`.
+    /// cross-checked against the named param's peeled type at resolution.
     /// `None` for the internal `TopLevel` form (the type comes from the
     /// param itself).
     pub declared_target: Option<TypeKey>,
@@ -101,9 +101,9 @@ pub struct ExpandDecl {
 
 /// Constructor / expansion declarations gathered from a language builder —
 /// an immutable record set: complete values, no build protocol. Declaration
-/// order is the vector order. Handed to `apply` via
-/// `Prebindgen::expansions`; empty or
-/// duplicate declarations are diagnosed there (collected), not at
+/// order is the vector order. Handed to the registry as
+/// [`Decompositions::expansions`](crate::Decompositions::expansions); empty
+/// or duplicate declarations are diagnosed at resolution (collected), not at
 /// construction.
 #[derive(Clone, Default)]
 pub struct Expansions {
@@ -742,7 +742,7 @@ fn check_target(
 /// The returned expression has type `Result<<shaped> plan.target, String>`
 /// (`Result<Target>`, `Result<Option<Target>>`, …). The adapter routes its
 /// `Err(String)` through its own error channel. Folds the [`FoldShape`] layers
-/// top-down over the shared core construct (`emit_core_construct`) — the value
+/// top-down over one shared core construct — the value
 /// analog of how `Option<_>`/`Vec<_>` wrappers compose at the wire.
 pub fn emit_fold(
     plan: &FoldPlan,

--- a/prebindgen-registry/src/expand.rs
+++ b/prebindgen-registry/src/expand.rs
@@ -19,7 +19,7 @@
 //!
 //! Everything here is **language-agnostic**: the fold is pure Rust and the
 //! per-leaf wire encode/decode is delegated to the adapter's existing
-//! converters. [`apply`] resolves declarations into [`FoldPlan`]s (stored on
+//! converters. `apply` resolves declarations into [`FoldPlan`]s (stored on
 //! the registry, keyed by `(fn, param)`) and registers each leaf type as a
 //! required input so the resolver produces its converter. [`emit_fold`]
 //! emits the dispatch expression at the parameter-emission site.
@@ -84,7 +84,7 @@ pub enum ExpandSel {
 /// A per-fn input expansion (`.expand_param(param, expand_param!(T)…)`) —
 /// construct `param` of `func` from the explicit variant list. Recorded as
 /// an explicit decl so the auto-`default` skips it; an identity-only list
-/// lowers to the skip-default plain form in [`apply`]. Not related to the
+/// lowers to the skip-default plain form in `apply`. Not related to the
 /// jnigen declaration-DSL type of the same name — this is the lowered core
 /// record.
 #[derive(Clone)]
@@ -92,7 +92,7 @@ pub struct ExpandDecl {
     pub func: syn::Ident,
     pub param: syn::Ident,
     /// The type the per-fn decl was declared for (`expand_param!(T)`) —
-    /// cross-checked against the named param's peeled type in [`apply`].
+    /// cross-checked against the named param's peeled type in `apply`.
     /// `None` for the internal `TopLevel` form (the type comes from the
     /// param itself).
     pub declared_target: Option<TypeKey>,
@@ -101,7 +101,7 @@ pub struct ExpandDecl {
 
 /// Constructor / expansion declarations gathered from a language builder —
 /// an immutable record set: complete values, no build protocol. Declaration
-/// order is the vector order. Handed to [`apply`] via
+/// order is the vector order. Handed to `apply` via
 /// `Prebindgen::expansions`; empty or
 /// duplicate declarations are diagnosed there (collected), not at
 /// construction.
@@ -742,7 +742,7 @@ fn check_target(
 /// The returned expression has type `Result<<shaped> plan.target, String>`
 /// (`Result<Target>`, `Result<Option<Target>>`, …). The adapter routes its
 /// `Err(String)` through its own error channel. Folds the [`FoldShape`] layers
-/// top-down over the shared [core construct](`emit_core_construct`) — the value
+/// top-down over the shared core construct (`emit_core_construct`) — the value
 /// analog of how `Option<_>`/`Vec<_>` wrappers compose at the wire.
 pub fn emit_fold(
     plan: &FoldPlan,

--- a/prebindgen-registry/src/expand/error.rs
+++ b/prebindgen-registry/src/expand/error.rs
@@ -1,7 +1,7 @@
 //! Errors produced while resolving constructor-expansion declarations.
 
 /// Errors surfaced while resolving [`Expansions`](super::Expansions) in
-/// [`apply`](super::apply).
+/// `apply`.
 #[derive(Debug)]
 pub enum ExpandError {
     UnknownFunction(syn::Ident),

--- a/prebindgen-registry/src/expand/error.rs
+++ b/prebindgen-registry/src/expand/error.rs
@@ -1,7 +1,6 @@
 //! Errors produced while resolving constructor-expansion declarations.
 
-/// Errors surfaced while resolving [`Expansions`](super::Expansions) in
-/// `apply`.
+/// Errors surfaced while resolving [`Expansions`](super::Expansions).
 #[derive(Debug)]
 pub enum ExpandError {
     UnknownFunction(syn::Ident),

--- a/prebindgen-registry/src/lib.rs
+++ b/prebindgen-registry/src/lib.rs
@@ -2,9 +2,9 @@
 //!
 //! Registry-based, **language-agnostic** converter pipeline for
 //! [`prebindgen`](https://docs.rs/prebindgen). This crate turns a stream of
-//! `#[prebindgen]` items — read through [`prebindgen::Source`] and parsed by
-//! [`flat::Flat`] — into generated Rust FFI bindings plus a fully resolved
-//! table of type converters. It has no knowledge of any particular
+//! `#[prebindgen]` items — read through [`Source`](::prebindgen::Source) and
+//! parsed by [`flat::Flat`] — into generated Rust FFI bindings plus a fully
+//! resolved table of type converters. It has no knowledge of any particular
 //! destination language — C, JNI/Kotlin, Swift, Python, etc. all plug in the
 //! same way.
 //!
@@ -50,10 +50,10 @@
 //!
 //! 1. [`flat::Flat::builder`] parses the declared sources into the model, and
 //!    [`Registry::builder`] starts describing a binding over it.
-//! 2. The generator states that binding, then [`Registry::crossings`] hands
-//!    over every crossing needing a conversion — inner types first, so each one
-//!    can be built from those already done. `convert_with` answers them and
-//!    `build` names any gap.
+//! 2. The generator states that binding, then [`RegistryBuilder::crossings`]
+//!    hands over every crossing needing a conversion — inner types first, so
+//!    each one can be built from those already done. `convert_with` answers
+//!    them and `build` names any gap.
 //! 3. The resolved registry becomes a field of the built generator, whose
 //!    `write_*` methods emit the artifacts — Rust wrappers, and whatever else
 //!    that language needs (a C header, Kotlin sources, …).

--- a/prebindgen-registry/src/prebindgen.rs
+++ b/prebindgen-registry/src/prebindgen.rs
@@ -278,7 +278,7 @@ pub trait Prebindgen {
     ) -> TokenStream;
 
     /// Per-const emission. Default: a named const re-emits as a path-alias
-    /// (see `const_path_alias`) when [`Self::source_module`] is available —
+    /// when [`Self::source_module`] is available —
     /// initializer tokens are never copied, so a const whose initializer
     /// references source-crate internals stays valid in the generated file.
     /// An adapter without a source module passes the const through verbatim.

--- a/prebindgen-registry/src/prebindgen.rs
+++ b/prebindgen-registry/src/prebindgen.rs
@@ -278,7 +278,7 @@ pub trait Prebindgen {
     ) -> TokenStream;
 
     /// Per-const emission. Default: a named const re-emits as a path-alias
-    /// (see [`const_path_alias`]) when [`Self::source_module`] is available —
+    /// (see `const_path_alias`) when [`Self::source_module`] is available —
     /// initializer tokens are never copied, so a const whose initializer
     /// references source-crate internals stays valid in the generated file.
     /// An adapter without a source module passes the const through verbatim.

--- a/prebindgen-registry/src/registry/declare.rs
+++ b/prebindgen-registry/src/registry/declare.rs
@@ -255,7 +255,7 @@ impl<M> RegistryBuilder<M> {
 
     /// How this binding's composites cross **in pieces** instead of whole.
     ///
-    /// Stated once, before [`Self::resolve`]. Replaces five separate callbacks
+    /// Stated once, before [`Self::build`]. Replaces five separate callbacks
     /// the registry used to make into the generator; see [`Decompositions`].
     pub fn decompose(mut self, d: Decompositions) -> Self {
         self.registry.declared.decompositions = d;
@@ -348,7 +348,7 @@ impl<M> RegistryBuilder<M> {
     }
 
     /// Every crossing this binding needs a conversion for, **inner types
-    /// first** — see [`Registry::crossings`] for what the order guarantees.
+    /// first** — see [`Self::crossings`] for what the order guarantees.
     ///
     /// Take this when you want to drive the loop yourself and hand the result
     /// back through [`Self::conversions`]. [`Self::convert_with`] is the same

--- a/prebindgen-registry/src/registry/error.rs
+++ b/prebindgen-registry/src/registry/error.rs
@@ -60,7 +60,8 @@ pub enum ScanError {
     NotExpressible {
         entries: Vec<NotExpressibleEntry>,
     },
-    /// An adapter-invariant check failed — see [`Prebindgen::validate`].
+    /// An adapter-invariant check failed — see
+    /// [`Prebindgen::validate`](crate::Prebindgen::validate).
     /// The message is adapter-authored and printed verbatim.
     AdapterInvariant {
         message: String,

--- a/prebindgen-registry/src/registry/mod.rs
+++ b/prebindgen-registry/src/registry/mod.rs
@@ -408,7 +408,7 @@ pub struct Decompositions {
     /// a type with no destination representation, not even resolvable.
     ///
     /// Carries each declaration's own spelling for the same reason
-    /// [`Declared::types`] does — these are build-script-authored types the scan
+    /// `Declared::types` does — these are build-script-authored types the scan
     /// diagnoses before anything has classified them.
     pub replaces: HashMap<TypeKey, Origin<syn::Type>>,
 }

--- a/prebindgen-registry/src/registry/mod.rs
+++ b/prebindgen-registry/src/registry/mod.rs
@@ -407,9 +407,9 @@ pub struct Decompositions {
     /// plans are applied its own direct converter is genuinely not needed — for
     /// a type with no destination representation, not even resolvable.
     ///
-    /// Carries each declaration's own spelling for the same reason
-    /// `Declared::types` does — these are build-script-authored types the scan
-    /// diagnoses before anything has classified them.
+    /// Carries each declaration's own spelling for the same reason the declared
+    /// types do — these are build-script-authored types the scan diagnoses
+    /// before anything has classified them.
     pub replaces: HashMap<TypeKey, Origin<syn::Type>>,
 }
 

--- a/prebindgen-registry/src/registry/scan.rs
+++ b/prebindgen-registry/src/registry/scan.rs
@@ -707,10 +707,10 @@ impl<M> Registry<M> {
 
     /// Every reading the table holds in one direction.
     ///
-    /// The adapter-facing view of `Self::type_table`: a back-end asking what
-    /// types crossed, and in what shape, wants the readings — not the cells
-    /// they are stored in. Handing out `TypeCell` instead would make the
-    /// registry's storage part of the public API for the sake of one caller.
+    /// The adapter-facing view of the type table: a back-end asking what types
+    /// crossed, and in what shape, wants the readings — not the cells they are
+    /// stored in. Handing out the cells instead would make the registry's
+    /// storage part of the public API for the sake of one caller.
     pub fn readings(
         &self,
         dir: Direction,

--- a/prebindgen-registry/src/registry/scan.rs
+++ b/prebindgen-registry/src/registry/scan.rs
@@ -707,7 +707,7 @@ impl<M> Registry<M> {
 
     /// Every reading the table holds in one direction.
     ///
-    /// The adapter-facing view of [`Self::type_table`]: a back-end asking what
+    /// The adapter-facing view of `Self::type_table`: a back-end asking what
     /// types crossed, and in what shape, wants the readings — not the cells
     /// they are stored in. Handing out `TypeCell` instead would make the
     /// registry's storage part of the public API for the sake of one caller.

--- a/prebindgen-registry/src/unfold.rs
+++ b/prebindgen-registry/src/unfold.rs
@@ -17,7 +17,7 @@
 //! * `Return` — **returns** the single leaf value directly (no callback);
 //!   requires a single-leaf decomposition.
 //!
-//! Resolution is language-agnostic: [`apply`] turns declarations into
+//! Resolution is language-agnostic: `apply` turns declarations into
 //! [`UnfoldPlan`]s (stored on the registry, keyed by function ident) and
 //! registers every leaf's `out_ty` as a required **output** so the resolver
 //! produces its converter (and projection). The jnigen adapter reads the
@@ -200,7 +200,7 @@ pub enum Delivery {
 /// decompose `func`'s return (or error position) via the record list.
 /// Recorded as an explicit decl so the auto-`default` skips it; an
 /// identity-only record list lowers to the raw whole-value return in
-/// [`apply`].
+/// `apply`.
 #[derive(Clone)]
 pub struct OutputDecl {
     pub func: syn::Ident,
@@ -208,7 +208,7 @@ pub struct OutputDecl {
     pub target: DeconTarget,
     pub delivery: Delivery,
     /// The type the per-fn decl was declared for (`expand_return!(T)`) —
-    /// cross-checked against the fn's peeled return type in [`apply`].
+    /// cross-checked against the fn's peeled return type in `apply`.
     /// `None` for internally-synthesized decls (the type comes from the
     /// return itself).
     pub declared_source: Option<TypeKey>,
@@ -217,7 +217,7 @@ pub struct OutputDecl {
 /// Deconstructor / output-expansion declarations gathered from a language
 /// builder — an immutable record set: complete values, no build protocol.
 /// Declaration order is the vector order; leaf order is each record
-/// vector's order. Handed to [`apply`] via
+/// vector's order. Handed to `apply` via
 /// `Prebindgen::deconstructors`; empty or
 /// duplicate declarations are diagnosed there (collected), not at
 /// construction.
@@ -475,7 +475,7 @@ pub(crate) fn apply<M>(
 
 /// A synthesized by-value `data_class` decomposition, produced by the language
 /// adapter (which knows the per-field encoding — projections, enums, nested
-/// classes) and fed to [`apply_value_structs`]. Its [`leaves`](Self::leaves)
+/// classes) and fed to `apply_value_structs`. Its [`leaves`](Self::leaves)
 /// are [`LeafSource::Field`] leaves: each crosses the boundary as its own field
 /// value and the foreign side reassembles the object (no Java object is built
 /// on the Rust side).
@@ -525,7 +525,7 @@ pub(crate) fn apply_value_structs<M>(
 }
 
 /// A synthesized **sum** decomposition, produced by the language adapter (which
-/// knows how each payload encodes) and fed to [`apply_sum_returns`] — the
+/// knows how each payload encodes) and fed to `apply_sum_returns` — the
 /// selector-carrying sibling of [`ValueDecon`].
 ///
 /// Its [`leaves`](Self::leaves) are a [`LeafSource::SumTag`] selector followed

--- a/prebindgen-registry/src/unfold.rs
+++ b/prebindgen-registry/src/unfold.rs
@@ -17,7 +17,7 @@
 //! * `Return` — **returns** the single leaf value directly (no callback);
 //!   requires a single-leaf decomposition.
 //!
-//! Resolution is language-agnostic: `apply` turns declarations into
+//! Resolution is language-agnostic: it turns the declarations into
 //! [`UnfoldPlan`]s (stored on the registry, keyed by function ident) and
 //! registers every leaf's `out_ty` as a required **output** so the resolver
 //! produces its converter (and projection). The jnigen adapter reads the
@@ -199,8 +199,8 @@ pub enum Delivery {
 /// A per-fn output expansion (`.expand_return(expand_return!(T)…)`) —
 /// decompose `func`'s return (or error position) via the record list.
 /// Recorded as an explicit decl so the auto-`default` skips it; an
-/// identity-only record list lowers to the raw whole-value return in
-/// `apply`.
+/// identity-only record list lowers to the raw whole-value return at
+/// resolution.
 #[derive(Clone)]
 pub struct OutputDecl {
     pub func: syn::Ident,
@@ -208,7 +208,7 @@ pub struct OutputDecl {
     pub target: DeconTarget,
     pub delivery: Delivery,
     /// The type the per-fn decl was declared for (`expand_return!(T)`) —
-    /// cross-checked against the fn's peeled return type in `apply`.
+    /// cross-checked against the fn's peeled return type at resolution.
     /// `None` for internally-synthesized decls (the type comes from the
     /// return itself).
     pub declared_source: Option<TypeKey>,
@@ -217,10 +217,10 @@ pub struct OutputDecl {
 /// Deconstructor / output-expansion declarations gathered from a language
 /// builder — an immutable record set: complete values, no build protocol.
 /// Declaration order is the vector order; leaf order is each record
-/// vector's order. Handed to `apply` via
-/// `Prebindgen::deconstructors`; empty or
-/// duplicate declarations are diagnosed there (collected), not at
-/// construction.
+/// vector's order. Handed to the registry as
+/// [`Decompositions::deconstructors`](crate::Decompositions::deconstructors);
+/// empty or duplicate declarations are diagnosed at resolution (collected),
+/// not at construction.
 #[derive(Clone, Default)]
 pub struct Deconstructors {
     pub deconstructors: Vec<DeconstructorDecl>,
@@ -475,7 +475,9 @@ pub(crate) fn apply<M>(
 
 /// A synthesized by-value `data_class` decomposition, produced by the language
 /// adapter (which knows the per-field encoding — projections, enums, nested
-/// classes) and fed to `apply_value_structs`. Its [`leaves`](Self::leaves)
+/// classes) and handed over as
+/// [`Decompositions::value_structs`](crate::Decompositions::value_structs).
+/// Its [`leaves`](Self::leaves)
 /// are [`LeafSource::Field`] leaves: each crosses the boundary as its own field
 /// value and the foreign side reassembles the object (no Java object is built
 /// on the Rust side).
@@ -525,7 +527,8 @@ pub(crate) fn apply_value_structs<M>(
 }
 
 /// A synthesized **sum** decomposition, produced by the language adapter (which
-/// knows how each payload encodes) and fed to `apply_sum_returns` — the
+/// knows how each payload encodes) and handed over as
+/// [`Decompositions::sums`](crate::Decompositions::sums) — the
 /// selector-carrying sibling of [`ValueDecon`].
 ///
 /// Its [`leaves`](Self::leaves) are a [`LeafSource::SumTag`] selector followed

--- a/prebindgen-registry/src/unfold/error.rs
+++ b/prebindgen-registry/src/unfold/error.rs
@@ -1,7 +1,7 @@
 //! Errors produced while resolving output-deconstruction declarations.
 
-/// Errors surfaced while resolving [`Deconstructors`](super::Deconstructors) in
-/// `apply`.
+/// Errors surfaced while resolving
+/// [`Deconstructors`](super::Deconstructors).
 #[derive(Debug)]
 pub enum UnfoldError {
     UnknownFunction(syn::Ident),

--- a/prebindgen-registry/src/unfold/error.rs
+++ b/prebindgen-registry/src/unfold/error.rs
@@ -1,7 +1,7 @@
 //! Errors produced while resolving output-deconstruction declarations.
 
 /// Errors surfaced while resolving [`Deconstructors`](super::Deconstructors) in
-/// [`apply`](super::apply).
+/// `apply`.
 #[derive(Debug)]
 pub enum UnfoldError {
     UnknownFunction(syn::Ident),

--- a/prebindgen-registry/src/unfold/plan.rs
+++ b/prebindgen-registry/src/unfold/plan.rs
@@ -185,7 +185,7 @@ pub enum LeafSource {
     /// The path is a chain of **struct field idents** reached by field access
     /// and cloned: `value.a.b.clone()`. Produced by the synthesized
     /// decomposition of a by-value `data_class` (see
-    /// [`crate::unfold::apply_value_structs`]); the value's own
+    /// `crate::unfold::apply_value_structs`); the value's own
     /// fields cross as decoupled leaves and the foreign side reassembles the
     /// object (so no Java object is built on the Rust side).
     Field,
@@ -193,7 +193,7 @@ pub enum LeafSource {
     /// alternative is live. It is not read off the value at all — the emitter
     /// assigns it per `match` arm — so it has no path. Emitted once, ahead of
     /// the groups it selects between (see
-    /// [`crate::unfold::apply_sum_returns`]).
+    /// `crate::unfold::apply_sum_returns`).
     ///
     /// Its [`out_ty`](UnfoldLeaf::out_ty) is **the sum**, not the `i32` — it
     /// carries *which* sum it chooses between, which is how the emitter finds
@@ -258,7 +258,7 @@ pub struct UnfoldPlan {
     /// callback). `None` for [`Delivery::Callback`].
     pub convert_out_ty: Option<prebindgen_flat::flat::TypeRef>,
     /// `true` for a synthesized by-value `data_class` decomposition (see
-    /// [`crate::unfold::apply_value_structs`]): the builder/folder
+    /// `crate::unfold::apply_value_structs`): the builder/folder
     /// is a **fixed, hoisted** foreign singleton that reconstructs the concrete
     /// class (the wrapper takes no caller `build`/`fold` param and is not
     /// generic over `R`/`A` — it returns the concrete type). `false` for the
@@ -357,7 +357,7 @@ impl UnfoldLeaf {
     /// entered the pipeline, a root says the binding asked for it directly, and
     /// an entry says one resolved — three separate claims, and a `SumTag` leaf
     /// makes only the first (#282). See
-    /// [`Registry::reference_output`](crate::registry::Registry::reference_output).
+    /// `Registry::reference_output`.
     pub fn has_converter(&self) -> bool {
         self.source != LeafSource::SumTag
     }

--- a/prebindgen-registry/src/unfold/plan.rs
+++ b/prebindgen-registry/src/unfold/plan.rs
@@ -185,7 +185,7 @@ pub enum LeafSource {
     /// The path is a chain of **struct field idents** reached by field access
     /// and cloned: `value.a.b.clone()`. Produced by the synthesized
     /// decomposition of a by-value `data_class` (see
-    /// `crate::unfold::apply_value_structs`); the value's own
+    /// [`ValueDecon`](crate::unfold::ValueDecon)); the value's own
     /// fields cross as decoupled leaves and the foreign side reassembles the
     /// object (so no Java object is built on the Rust side).
     Field,
@@ -193,7 +193,7 @@ pub enum LeafSource {
     /// alternative is live. It is not read off the value at all — the emitter
     /// assigns it per `match` arm — so it has no path. Emitted once, ahead of
     /// the groups it selects between (see
-    /// `crate::unfold::apply_sum_returns`).
+    /// [`SumDecon`](crate::unfold::SumDecon)).
     ///
     /// Its [`out_ty`](UnfoldLeaf::out_ty) is **the sum**, not the `i32` — it
     /// carries *which* sum it chooses between, which is how the emitter finds
@@ -258,7 +258,7 @@ pub struct UnfoldPlan {
     /// callback). `None` for [`Delivery::Callback`].
     pub convert_out_ty: Option<prebindgen_flat::flat::TypeRef>,
     /// `true` for a synthesized by-value `data_class` decomposition (see
-    /// `crate::unfold::apply_value_structs`): the builder/folder
+    /// [`ValueDecon`](crate::unfold::ValueDecon)): the builder/folder
     /// is a **fixed, hoisted** foreign singleton that reconstructs the concrete
     /// class (the wrapper takes no caller `build`/`fold` param and is not
     /// generic over `R`/`A` — it returns the concrete type). `false` for the
@@ -356,8 +356,7 @@ impl UnfoldLeaf {
     /// binding additionally *demands* a converter for. A cell says the type
     /// entered the pipeline, a root says the binding asked for it directly, and
     /// an entry says one resolved — three separate claims, and a `SumTag` leaf
-    /// makes only the first (#282). See
-    /// `Registry::reference_output`.
+    /// makes only the first (#282).
     pub fn has_converter(&self) -> bool {
         self.source != LeafSource::SumTag
     }

--- a/prebindgen-registry/src/write.rs
+++ b/prebindgen-registry/src/write.rs
@@ -27,7 +27,8 @@ use crate::{
 
 /// Errors surfaced by the file-emission phase.
 ///
-/// Binding validation is NOT here — it runs once in [`Registry::finish`]
+/// Binding validation is NOT here — it runs once in
+/// [`RegistryBuilder::build`](crate::RegistryBuilder::build)
 /// (see [`Prebindgen::validate_resolved`]), so an invalid binding fails
 /// before a built generator exists and never reaches a writer.
 #[derive(Debug)]


### PR DESCRIPTION
`RUSTDOCFLAGS="-D warnings" cargo doc --no-deps` — a check any release has to pass — fails on `main` with **81 errors across four crates**. Nothing in CI ran it, so the crate split's fallout accumulated unseen: links that resolved inside one crate now point at private items, or at names that moved out of reach entirely.

Docs only. No code, no generated output changes.

## Three kinds, fixed three ways

**Links to private items — 47.** These are the interesting ones. De-linking them to code spans silences rustdoc but keeps the leak: public documentation was still naming `apply`, `TypeKind::to_syn`, `emit_core_construct`, `apply_value_structs` — functions a reader of the docs cannot call, look up, or verify. A code span is not less of a leak than a link, only less checkable. So each one became prose about the behaviour, or a link to the public API that does have the answer:

| Was | Now |
|---|---|
| "`apply` resolves declarations into FoldPlans" | "resolution turns the declarations into FoldPlans" |
| "cross-checked … in `apply`" | "…at resolution" |
| "the syntax is recoverable from the kind (`TypeKind::to_syn`, checked over the corpus)" | "(checked, over the whole acceptance corpus, by rebuilding it)" |
| `apply_value_structs` / `apply_sum_returns` | [`ValueDecon`] / [`SumDecon`] — the types an adapter actually hands over |
| `Prebindgen::expansions` (does not exist) | [`Decompositions::expansions`] — how they really arrive |
| `stripped_syntax` (`pub(crate)`) | [`stripped_key`] — the accessor a consumer can reach |

Two of these were saying something false to an outside reader. `Origin`'s "the syntax is sealed" section described `as_syn` as "the **one** way to get" a node — an external reader cannot get one at all; it now says the node is reachable only inside the crate. `flat::emit`'s "what is closed" section listed six `pub(crate)` accessors *by name*: it now states the closure and names only what stays open. And `TypeKey::name`'s docs cited a **test function name**, now "a correspondence this crate's tests pin".

**Links across a layering boundary — 12.** `prebindgen-registry` docs referenced `JniGenBuilder`, `PtrClassDecl`, `ClassDecl`, `PackageDecl`, `ConstDecl`, `ptr_class!` — all in `prebindgen-jni`, which *depends on* the registry. The link is impossible by construction, not merely missing. De-linked, with the prose reworded where it read as if the item were reachable (`ty!` / `path!` / `expr!` now say "an adapter's `ConstDecl::…`").

**Stale names — 22.** These are the substantive find: the docs described an API that no longer exists.

| Doc said | Actually |
|---|---|
| `Flat::source`, `Flat::items` | `FlatBuilder::source`, `FlatBuilder::items` |
| `TypeRef::syntax` | `TypeRef::spell` |
| `Registry::finish`, `Self::resolve` | `RegistryBuilder::build` |
| `CbindgenBuilder::name` | `CbindgenBuilder::base_name` |
| `Registry::crossings` (private) | `RegistryBuilder::crossings` (the public one) |
| `Prebindgen::declared_consts` | the JNI builder's own inherent `declared_consts` — never a trait method |
| `ConvertSourceDecl::error` / `::with` | `ConvertSourceDecl::from_type` / `FunctionDecl::new_local` |

**Layering, found on the way.** `prebindgen-registry`'s public docs named `JniGenBuilder`, `PtrClassDecl`, `PackageDecl` and `ClassDecl` — one adapter's types, documented in the language-agnostic layer *beneath* it. Reworded to "the adapter's". And `declared_consts`'s doc block was sitting on `required_output_types`, glued in front of that function's own doc; moved back to the function it describes.

`prebindgen-jni`'s `jni` module doc opened with the internal file layout and its `pub(crate) use …::*` convention — a note to maintainers, not documentation of an API. It is a `//` comment now.

Two links were module shadowing rather than renames: `prebindgen::Source` resolved to the registry's **own** `prebindgen` module (now `::prebindgen::Source`), and `Prebindgen` / `TypeRef` needed qualifying in modules where they are not in scope. Two redundant explicit link targets and one broken link in `perftest-flat` came along.

## New `docs` CI job

Runs `RUSTDOCFLAGS=-D warnings cargo doc --no-deps` on every PR. **Stable only** — rustdoc's lint set moves with the toolchain, so the MSRV leg would only disagree about which warnings exist. Without this the next 81 accumulate exactly the same way.

## Verification

- `cargo doc` clean across the whole workspace, examples included
- **531** lib tests + 20 + 10 + doc tests, 0 failures
- `clippy --all-targets --all-features -D warnings` and `fmt --check` clean
- `regen-check.sh` byte-identical

Split out of #378, which keeps the release plumbing.
