### PR TITLE
Compile the emitted Rust for shapes only the unit tests reach (#269)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ members = [
     "examples/perftest-kotlin",
     "examples/covertest-helpers",
     "examples/covertest-kotlin",
+    "examples/emitcheck",
 ]
 resolver = "2"
 package.version = "0.5.0"

--- a/README.md
+++ b/README.md
@@ -220,6 +220,7 @@ See example projects in the [examples directory](https://github.com/milyin/prebi
 - **example-cbindgen**: experimental C proof of concept using `prebindgen-c`'s `CbindgenBuilder` + cbindgen for C headers
 - **perftest-flat** / **perftest-c** / **perftest-kotlin**: A shared flat library and its performance-oriented C and Kotlin/JNI bindings
 - **covertest-kotlin**: A Kotlin/JNI binding that exercises *every* `prebindgen-jni` feature and verifies behavior with `check(...)` asserts (see its [README](https://github.com/milyin/prebindgen/tree/main/examples/covertest-kotlin))
+- **emitcheck**: A binding with no JVM side whose only job is to *compile* the emitted Rust, for the type spellings the adapter unit tests reach and the examples above do not (`Box<Option<T>>`, `Cow<'_, str>`, …). Success is `cargo build`.
 
 ## Documentation
 

--- a/examples/covertest-kotlin/src/generated_bindings.rs
+++ b/examples/covertest-kotlin/src/generated_bindings.rs
@@ -799,7 +799,7 @@ pub(crate) unsafe fn Box_String_to_JString_027f6250<'a>(
     v: Box<String>,
 ) -> ::core::result::Result<jni::objects::JString<'a>, __JniErr> {
     Ok({
-        env.new_string(v.as_str())
+        env.new_string(&*v)
             .map_err(|e| {
                 <__JniErr as ::core::convert::From<
                     String,
@@ -9150,7 +9150,7 @@ pub(crate) unsafe fn String_to_JString_c7f3ca43<'a>(
     v: String,
 ) -> ::core::result::Result<jni::objects::JString<'a>, __JniErr> {
     Ok({
-        env.new_string(v.as_str())
+        env.new_string(&*v)
             .map_err(|e| {
                 <__JniErr as ::core::convert::From<
                     String,

--- a/examples/emitcheck/Cargo.toml
+++ b/examples/emitcheck/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "emitcheck"
+version = { workspace = true }
+edition = { workspace = true }
+build = "build.rs"
+publish = false
+
+[lib]
+name = "emitcheck"
+
+[dependencies]
+# Exactly what generated JNI code calls into. No `prebindgen`, no source crate:
+# the flat surface is `src/myflat.rs`, compiled as part of this crate.
+prebindgen-jni-runtime = { workspace = true }
+jni = "0.21.1"
+# The generated JNI error path logs via `tracing::error!`.
+tracing = "0.1"
+
+[build-dependencies]
+prebindgen = { workspace = true }
+prebindgen-registry = { workspace = true }
+prebindgen-jni = { workspace = true }
+syn = { workspace = true }

--- a/examples/emitcheck/build.rs
+++ b/examples/emitcheck/build.rs
@@ -1,0 +1,102 @@
+//! Emits JNI bindings for `src/myflat.rs` so that **rustc** gets to judge them.
+//!
+//! ## Why this crate exists (#269)
+//!
+//! The adapter unit tests call `write_rust` in ~100 places and then assert on
+//! the result as *text*. An emission can be well-formed, contain every
+//! substring a test looks for, and still not compile — #268 was exactly that,
+//! and 41 of 41 tests stayed green over it. The two Kotlin examples do compile
+//! their generated Rust, but only for the shapes they declare; the shapes only
+//! the unit tests reach were compiled by nothing.
+//!
+//! So this crate compiles emitted Rust and nothing else. There is no JVM side,
+//! no runtime assertion, no Kotlin: "does this emit valid Rust" is a question
+//! it can answer on its own, which is what separates it from `covertest-kotlin`.
+//!
+//! ## How it differs from the other examples
+//!
+//! Every other example crate pairs a `#[prebindgen]`-annotated source crate
+//! with a consumer that reads the captured records. This one has no source
+//! crate: it parses `src/myflat.rs` and hands the items to
+//! `Flat::builder().items(..)` — the same entry point the unit-test fixtures
+//! use, which is the point, since the shape space being covered is theirs.
+//! One file is therefore both the compiled definitions and the model input,
+//! and adding a spelling means editing `src/myflat.rs` alone.
+
+use prebindgen_jni::{matching, package, ptr_class, JniGen};
+use prebindgen_registry::{expand_return, fields, fun};
+
+/// The crate name stamped on every item, and so the qualifier the generated
+/// code calls through (`myflat::z_keyexpr_as_str(..)`). `src/lib.rs` mounts
+/// `src/myflat.rs` under this name to match. Kept identical to the unit-test
+/// fixtures' `myflat_loc()`.
+const SOURCE_CRATE: &str = "myflat";
+
+fn main() {
+    let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").unwrap();
+    let myflat = std::path::Path::new(&manifest_dir)
+        .join("src")
+        .join("myflat.rs");
+    println!("cargo:rerun-if-changed={}", myflat.display());
+
+    let loc = prebindgen::SourceLocation {
+        crate_name: Some(SOURCE_CRATE.to_string()),
+        ..Default::default()
+    };
+    let source = std::fs::read_to_string(&myflat).expect("read src/myflat.rs");
+    let items = syn::parse_file(&source)
+        .expect("src/myflat.rs parses")
+        .items
+        .into_iter()
+        // The model's item kinds. `src/myflat.rs` is a real Rust file, so it
+        // also carries the `use` its own signatures need — which is not
+        // something a flat surface declares.
+        .filter(|item| {
+            matches!(
+                item,
+                syn::Item::Fn(_) | syn::Item::Struct(_) | syn::Item::Enum(_) | syn::Item::Const(_)
+            )
+        })
+        .map(|item| (item, loc.clone()));
+
+    let jni = JniGen::builder()
+        // `items` rather than `source`: there is no captured JSONL, because
+        // there is no `#[prebindgen]` source crate. This is the entry point the
+        // builder documents for "synthetic items in a test".
+        .items(items)
+        .set_package_prefix("io.prebindgen.emitcheck")
+        .package(
+            package!()
+                .class(ptr_class!(ZSample))
+                .class(ptr_class!(ZKeyExpr))
+                // The one output position: everything below is reached through
+                // `ZSample` crossing into this callback.
+                .fun(fun!(z_sample_sub)),
+        )
+        // The child boundary every value-form handle field must still cross
+        // through.
+        .expand(expand_return!(ZKeyExpr).field(fun!(z_keyexpr_as_str)))
+        // `.fields(fields!(..))` derives the boundary FROM the struct, so every
+        // field of `ZSampleStruct` becomes an emitted access — which is the
+        // code under test.
+        .expand(expand_return!(ZSample).fields(fields!(z_sample_to_struct)))
+        // The value form is read through `fields!`, never emitted as a class of
+        // its own — acknowledge it so the build log carries no standing
+        // "skipping undeclared" warning to hide a real one behind.
+        .ignore(matching(|name| name == "ZSampleStruct"));
+
+    let generation = jni.build().unwrap_or_else(|err| {
+        // A resolve failure names its own item; surface it as the build error
+        // rather than letting a stale generated file compile.
+        panic!("emitcheck: resolving the binding failed: {err}");
+    });
+
+    // Committed next to the source (not `OUT_DIR`) for the same two reasons the
+    // other examples do it: `examples/regen-check.sh` can diff it, and a rustc
+    // error lands on a stable reviewable path instead of a build hash.
+    let dest = std::path::Path::new(&manifest_dir)
+        .join("src")
+        .join("generated_bindings.rs");
+    let written = generation.write_rust(&dest).expect("write_rust failed");
+    println!("cargo:warning=emitcheck: wrote {}", written.display());
+}

--- a/examples/emitcheck/src/generated_bindings.rs
+++ b/examples/emitcheck/src/generated_bindings.rs
@@ -1,0 +1,675 @@
+#[allow(dead_code)]
+pub(crate) type __JniErr = ::prebindgen_jni_runtime::JniBindingError<()>;
+/// See module-level docs at [`owned_object_prerequisite_items`].
+#[allow(dead_code)]
+pub(crate) struct OwnedObject<T: ?Sized> {
+    ptr: *const T,
+}
+impl<T: ?Sized> std::ops::Deref for OwnedObject<T> {
+    type Target = T;
+    fn deref(&self) -> &Self::Target {
+        unsafe { &*self.ptr }
+    }
+}
+impl<T: ?Sized> std::ops::DerefMut for OwnedObject<T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        unsafe { &mut *(self.ptr as *mut T) }
+    }
+}
+impl<T: ?Sized> OwnedObject<T> {
+    /// Borrow a `T` whose backing `Box<T>` lives on the
+    /// Java side. Stores only the pointer; the wrapper
+    /// does not own the heap allocation and never frees
+    /// it on drop.
+    ///
+    /// # Safety
+    ///
+    /// `ptr` must be the result of an earlier
+    /// `Box::into_raw(Box::new(v))` and the allocation
+    /// must still be live (Java still owns it). The Java
+    /// side is responsible for sequencing this call
+    /// against any concurrent free or consume (via
+    /// `NativeHandle.withPtr` read-lock vs `consume` /
+    /// `close` write-lock) so the borrow cannot race a
+    /// deallocation on the same pointer.
+    #[allow(dead_code)]
+    pub(crate) unsafe fn from_raw(ptr: *const T) -> Self {
+        Self { ptr }
+    }
+}
+#[allow(non_snake_case, dead_code)]
+pub(crate) fn signal_binding_error(
+    env: &mut jni::JNIEnv,
+    sink: &jni::objects::JObject,
+    mid: &::prebindgen_jni_runtime::CachedIfaceMethod,
+    fqn: &str,
+    descr: &str,
+    je: &str,
+) {
+    if env.exception_check().unwrap_or(false) {
+        return;
+    }
+    let __je: jni::objects::JObject = match env.new_string(je) {
+        Ok(s) => s.into(),
+        Err(e) => {
+            tracing::error!("signal_binding_error: new_string failed: {}", e);
+            return;
+        }
+    };
+    let __args = [
+        jni::sys::jvalue {
+            l: __je.as_raw(),
+        },
+    ];
+    if let Err(e) = mid.call_object(env, fqn, "run", descr, sink, &__args) {
+        tracing::error!("signal_binding_error: error-callback invoke failed: {}", e);
+    }
+}
+#[allow(non_snake_case, dead_code)]
+pub(crate) fn signal_domain_error(
+    env: &mut jni::JNIEnv,
+    sink: &jni::objects::JObject,
+    mid: &::prebindgen_jni_runtime::CachedIfaceMethod,
+    fqn: &str,
+    descr: &str,
+    ze: &[jni::sys::jvalue],
+) {
+    if env.exception_check().unwrap_or(false) {
+        return;
+    }
+    if let Err(e) = mid.call_object(env, fqn, "run", descr, sink, ze) {
+        tracing::error!("signal_domain_error: error-callback invoke failed: {}", e);
+    }
+}
+#[no_mangle]
+#[allow(non_snake_case, unused_variables)]
+pub(crate) unsafe extern "C" fn Java_io_prebindgen_emitcheck_ZKeyExpr_freePtr(
+    _env: jni::JNIEnv,
+    _class: jni::objects::JClass,
+    ptr: jni::sys::jlong,
+) {
+    if ptr != 0 && (ptr & 1) == 0 {
+        drop(Box::from_raw(ptr as *mut myflat::ZKeyExpr));
+    }
+}
+const _: () = {
+    if ::core::mem::align_of::<myflat::ZKeyExpr>() < 2 {
+        panic!("opaque handle types must have alignment >= 2 (bit 0 is the closed tag)");
+    }
+};
+#[no_mangle]
+#[allow(non_snake_case, unused_variables)]
+pub(crate) unsafe extern "C" fn Java_io_prebindgen_emitcheck_ZSample_freePtr(
+    _env: jni::JNIEnv,
+    _class: jni::objects::JClass,
+    ptr: jni::sys::jlong,
+) {
+    if ptr != 0 && (ptr & 1) == 0 {
+        drop(Box::from_raw(ptr as *mut myflat::ZSample));
+    }
+}
+const _: () = {
+    if ::core::mem::align_of::<myflat::ZSample>() < 2 {
+        panic!("opaque handle types must have alignment >= 2 (bit 0 is the closed tag)");
+    }
+};
+#[allow(
+    non_snake_case,
+    unused_mut,
+    unused_variables,
+    unused_braces,
+    unused_parens,
+    dead_code,
+    clippy::useless_conversion,
+    clippy::needless_question_mark,
+    clippy::let_and_return,
+    clippy::nonminimal_bool,
+    clippy::eq_op
+)]
+pub(crate) unsafe fn Box_String_to_JString_027f6250<'a>(
+    env: &mut jni::JNIEnv<'a>,
+    v: Box<String>,
+) -> ::core::result::Result<jni::objects::JString<'a>, __JniErr> {
+    Ok({
+        env.new_string(&*v)
+            .map_err(|e| {
+                <__JniErr as ::core::convert::From<
+                    String,
+                >>::from(format!("encode_str: {}", e))
+            })?
+    })
+}
+#[allow(
+    non_snake_case,
+    unused_mut,
+    unused_variables,
+    unused_braces,
+    unused_parens,
+    dead_code,
+    clippy::useless_conversion,
+    clippy::needless_question_mark,
+    clippy::let_and_return,
+    clippy::nonminimal_bool,
+    clippy::eq_op
+)]
+pub(crate) unsafe fn JObject_to_impl_Fn_ZSample_Send_Sync_static_24e97b15<'env, 'v>(
+    env: &mut jni::JNIEnv<'env>,
+    v: &jni::objects::JObject<'v>,
+) -> ::core::result::Result<impl Fn(myflat::ZSample) + Send + Sync + 'static, __JniErr> {
+    Ok({
+        use std::sync::Arc;
+        let java_vm = Arc::new(
+            env
+                .get_java_vm()
+                .map_err(|e| <__JniErr as ::core::convert::From<
+                    String,
+                >>::from(format!("Unable to retrieve JVM: {}", e)))?,
+        );
+        let callback_global_ref = env
+            .new_global_ref(&v)
+            .map_err(|e| <__JniErr as ::core::convert::From<
+                String,
+            >>::from(format!("Unable to global-ref callback: {}", e)))?;
+        let __invoke_class = env
+            .get_object_class(&v)
+            .map_err(|e| <__JniErr as ::core::convert::From<
+                String,
+            >>::from(
+                format!("Unable to get callback class for {}: {}", "Fn(ZSample)", e),
+            ))?;
+        let __invoke_id = env
+            .get_method_id(
+                &__invoke_class,
+                "run",
+                "(Ljava/lang/String;Ljava/lang/String;[B[BLjava/lang/String;Ljava/lang/String;Ljava/lang/String;)V",
+            )
+            .map_err(|e| <__JniErr as ::core::convert::From<
+                String,
+            >>::from(format!("Unable to resolve run for {}: {}", "Fn(ZSample)", e)))?;
+        Box::new(move |__cb_arg0: myflat::ZSample| {
+            let _ = (|| -> ::core::result::Result<(), __JniErr> {
+                let mut env = java_vm
+                    .attach_current_thread_as_daemon()
+                    .map_err(|e| <__JniErr as ::core::convert::From<
+                        String,
+                    >>::from(format!("Attach thread for {}: {}", "Fn(ZSample)", e)))?;
+                env.push_local_frame(20)
+                    .map_err(|e| <__JniErr as ::core::convert::From<
+                        String,
+                    >>::from(format!("push local frame for {}: {}", "Fn(ZSample)", e)))?;
+                let __frame_res = (|| -> ::core::result::Result<(), __JniErr> {
+                    let __vf0 = myflat::z_sample_to_struct(&__cb_arg0);
+                    let __cb0_obj0: jni::objects::JObject = {
+                        let __o0: &::core::option::Option<_> = &(&__vf0).opt_plain;
+                        match __o0 {
+                            ::core::option::Option::Some(__n0) => {
+                                let __enc0 = match str_to_JString_7b77dc67(
+                                    &mut env,
+                                    myflat::z_keyexpr_as_str(__n0),
+                                ) {
+                                    ::core::result::Result::Ok(__w) => __w,
+                                    ::core::result::Result::Err(__e) => {
+                                        return ::core::result::Result::Err(
+                                            <__JniErr as ::core::convert::From<
+                                                String,
+                                            >>::from(__e.to_string()),
+                                        );
+                                    }
+                                };
+                                __enc0.into()
+                            }
+                            ::core::option::Option::None => jni::objects::JObject::null(),
+                        }
+                    };
+                    let __cb0_obj1: jni::objects::JObject = {
+                        let __o0: &::core::option::Option<_> = &(&__vf0).opt_boxed;
+                        match __o0 {
+                            ::core::option::Option::Some(__n0) => {
+                                let __enc1 = match str_to_JString_7b77dc67(
+                                    &mut env,
+                                    myflat::z_keyexpr_as_str(__n0),
+                                ) {
+                                    ::core::result::Result::Ok(__w) => __w,
+                                    ::core::result::Result::Err(__e) => {
+                                        return ::core::result::Result::Err(
+                                            <__JniErr as ::core::convert::From<
+                                                String,
+                                            >>::from(__e.to_string()),
+                                        );
+                                    }
+                                };
+                                __enc1.into()
+                            }
+                            ::core::option::Option::None => jni::objects::JObject::null(),
+                        }
+                    };
+                    let __cb0_obj2: jni::objects::JObject = {
+                        let __enc2 = match Vec_u8_to_JByteArray_7936d5de(
+                            &mut env,
+                            __vf0.seq_plain.clone(),
+                        ) {
+                            ::core::result::Result::Ok(__w) => __w,
+                            ::core::result::Result::Err(__e) => {
+                                return ::core::result::Result::Err(
+                                    <__JniErr as ::core::convert::From<
+                                        String,
+                                    >>::from(__e.to_string()),
+                                );
+                            }
+                        };
+                        __enc2.into()
+                    };
+                    let __cb0_obj3: jni::objects::JObject = {
+                        let __enc3 = match std_borrow_Cow_u8_to_JByteArray_c6a6bddf(
+                            &mut env,
+                            __vf0.seq_cow.clone(),
+                        ) {
+                            ::core::result::Result::Ok(__w) => __w,
+                            ::core::result::Result::Err(__e) => {
+                                return ::core::result::Result::Err(
+                                    <__JniErr as ::core::convert::From<
+                                        String,
+                                    >>::from(__e.to_string()),
+                                );
+                            }
+                        };
+                        __enc3.into()
+                    };
+                    let __cb0_obj4: jni::objects::JObject = {
+                        let __enc4 = match String_to_JString_c7f3ca43(
+                            &mut env,
+                            __vf0.text_plain.clone(),
+                        ) {
+                            ::core::result::Result::Ok(__w) => __w,
+                            ::core::result::Result::Err(__e) => {
+                                return ::core::result::Result::Err(
+                                    <__JniErr as ::core::convert::From<
+                                        String,
+                                    >>::from(__e.to_string()),
+                                );
+                            }
+                        };
+                        __enc4.into()
+                    };
+                    let __cb0_obj5: jni::objects::JObject = {
+                        let __enc5 = match Box_String_to_JString_027f6250(
+                            &mut env,
+                            __vf0.text_boxed.clone(),
+                        ) {
+                            ::core::result::Result::Ok(__w) => __w,
+                            ::core::result::Result::Err(__e) => {
+                                return ::core::result::Result::Err(
+                                    <__JniErr as ::core::convert::From<
+                                        String,
+                                    >>::from(__e.to_string()),
+                                );
+                            }
+                        };
+                        __enc5.into()
+                    };
+                    let __cb0_obj6: jni::objects::JObject = {
+                        let __enc6 = match std_borrow_Cow_str_to_JString_df3f677f(
+                            &mut env,
+                            __vf0.text_cow.clone(),
+                        ) {
+                            ::core::result::Result::Ok(__w) => __w,
+                            ::core::result::Result::Err(__e) => {
+                                return ::core::result::Result::Err(
+                                    <__JniErr as ::core::convert::From<
+                                        String,
+                                    >>::from(__e.to_string()),
+                                );
+                            }
+                        };
+                        __enc6.into()
+                    };
+                    let __call_res: ::core::result::Result<(), __JniErr> = unsafe {
+                        env.call_method_unchecked(
+                            &callback_global_ref,
+                            __invoke_id,
+                            jni::signature::ReturnType::Primitive(
+                                jni::signature::Primitive::Void,
+                            ),
+                            &[
+                                jni::sys::jvalue {
+                                    l: __cb0_obj0.as_raw(),
+                                },
+                                jni::sys::jvalue {
+                                    l: __cb0_obj1.as_raw(),
+                                },
+                                jni::sys::jvalue {
+                                    l: __cb0_obj2.as_raw(),
+                                },
+                                jni::sys::jvalue {
+                                    l: __cb0_obj3.as_raw(),
+                                },
+                                jni::sys::jvalue {
+                                    l: __cb0_obj4.as_raw(),
+                                },
+                                jni::sys::jvalue {
+                                    l: __cb0_obj5.as_raw(),
+                                },
+                                jni::sys::jvalue {
+                                    l: __cb0_obj6.as_raw(),
+                                },
+                            ],
+                        )
+                    }
+                        .map(|_| ())
+                        .map_err(|e| {
+                            let _ = env.exception_describe();
+                            <__JniErr as ::core::convert::From<
+                                String,
+                            >>::from(e.to_string())
+                        });
+                    __call_res?;
+                    Ok(())
+                })();
+                let _ = unsafe { env.pop_local_frame(&jni::objects::JObject::null()) };
+                __frame_res?;
+                Ok(())
+            })()
+                .map_err(|e| tracing::error!("{} callback error: {e}", "Fn(ZSample)"));
+        })
+    })
+}
+#[allow(
+    non_snake_case,
+    unused_mut,
+    unused_variables,
+    unused_braces,
+    unused_parens,
+    dead_code,
+    clippy::useless_conversion,
+    clippy::needless_question_mark,
+    clippy::let_and_return,
+    clippy::nonminimal_bool,
+    clippy::eq_op
+)]
+pub(crate) unsafe fn String_to_JString_c7f3ca43<'a>(
+    env: &mut jni::JNIEnv<'a>,
+    v: String,
+) -> ::core::result::Result<jni::objects::JString<'a>, __JniErr> {
+    Ok({
+        env.new_string(&*v)
+            .map_err(|e| {
+                <__JniErr as ::core::convert::From<
+                    String,
+                >>::from(format!("encode_str: {}", e))
+            })?
+    })
+}
+#[allow(
+    non_snake_case,
+    unused_mut,
+    unused_variables,
+    unused_braces,
+    unused_parens,
+    dead_code,
+    clippy::useless_conversion,
+    clippy::needless_question_mark,
+    clippy::let_and_return,
+    clippy::nonminimal_bool,
+    clippy::eq_op
+)]
+pub(crate) unsafe fn Vec_u8_to_JByteArray_7936d5de<'a>(
+    env: &mut jni::JNIEnv<'a>,
+    v: Vec<u8>,
+) -> ::core::result::Result<jni::objects::JByteArray<'a>, __JniErr> {
+    Ok({
+        env.byte_array_from_slice(v.as_slice())
+            .map_err(|e| {
+                <__JniErr as ::core::convert::From<
+                    String,
+                >>::from(format!("encode_byte_array: {}", e))
+            })?
+    })
+}
+#[allow(
+    non_snake_case,
+    unused_mut,
+    unused_variables,
+    unused_braces,
+    unused_parens,
+    dead_code,
+    clippy::useless_conversion,
+    clippy::needless_question_mark,
+    clippy::let_and_return,
+    clippy::nonminimal_bool,
+    clippy::eq_op
+)]
+pub(crate) unsafe fn ZKeyExpr_to_jlong_37f9dc18<'a>(
+    env: &mut jni::JNIEnv<'a>,
+    v: myflat::ZKeyExpr,
+) -> ::core::result::Result<jni::sys::jlong, __JniErr> {
+    Ok(std::boxed::Box::into_raw(std::boxed::Box::new(v)) as i64)
+}
+#[allow(
+    non_snake_case,
+    unused_mut,
+    unused_variables,
+    unused_braces,
+    unused_parens,
+    dead_code,
+    clippy::useless_conversion,
+    clippy::needless_question_mark,
+    clippy::let_and_return,
+    clippy::nonminimal_bool,
+    clippy::eq_op
+)]
+pub(crate) unsafe fn ZSample_to_jlong_757bca9c<'a>(
+    env: &mut jni::JNIEnv<'a>,
+    v: myflat::ZSample,
+) -> ::core::result::Result<jni::sys::jlong, __JniErr> {
+    Ok(std::boxed::Box::into_raw(std::boxed::Box::new(v)) as i64)
+}
+#[allow(
+    non_snake_case,
+    unused_mut,
+    unused_variables,
+    unused_braces,
+    unused_parens,
+    dead_code,
+    clippy::useless_conversion,
+    clippy::needless_question_mark,
+    clippy::let_and_return,
+    clippy::nonminimal_bool,
+    clippy::eq_op
+)]
+pub(crate) unsafe fn jlong_to_ZKeyExpr_37f9dc18<'env, 'v>(
+    env: &mut jni::JNIEnv<'env>,
+    v: &jni::sys::jlong,
+) -> ::core::result::Result<OwnedObject<myflat::ZKeyExpr>, __JniErr> {
+    if *v == 0 || (*v & 1) == 1 {
+        return ::core::result::Result::Err(
+            <__JniErr as ::core::convert::From<
+                String,
+            >>::from("Operation on a closed native handle.".to_string()),
+        );
+    }
+    Ok(unsafe { OwnedObject::from_raw(*v as *const myflat::ZKeyExpr) })
+}
+#[allow(
+    non_snake_case,
+    unused_mut,
+    unused_variables,
+    unused_braces,
+    unused_parens,
+    dead_code,
+    clippy::useless_conversion,
+    clippy::needless_question_mark,
+    clippy::let_and_return,
+    clippy::nonminimal_bool,
+    clippy::eq_op
+)]
+pub(crate) unsafe fn jlong_to_ZSample_757bca9c<'env, 'v>(
+    env: &mut jni::JNIEnv<'env>,
+    v: &jni::sys::jlong,
+) -> ::core::result::Result<OwnedObject<myflat::ZSample>, __JniErr> {
+    if *v == 0 || (*v & 1) == 1 {
+        return ::core::result::Result::Err(
+            <__JniErr as ::core::convert::From<
+                String,
+            >>::from("Operation on a closed native handle.".to_string()),
+        );
+    }
+    Ok(unsafe { OwnedObject::from_raw(*v as *const myflat::ZSample) })
+}
+#[allow(
+    non_snake_case,
+    unused_mut,
+    unused_variables,
+    unused_braces,
+    unused_parens,
+    dead_code,
+    clippy::useless_conversion,
+    clippy::needless_question_mark,
+    clippy::let_and_return,
+    clippy::nonminimal_bool,
+    clippy::eq_op
+)]
+pub(crate) unsafe fn std_borrow_Cow_str_to_JString_df3f677f<'a>(
+    env: &mut jni::JNIEnv<'a>,
+    v: ::std::borrow::Cow<'_, str>,
+) -> ::core::result::Result<jni::objects::JString<'a>, __JniErr> {
+    Ok({
+        env.new_string(&*v)
+            .map_err(|e| {
+                <__JniErr as ::core::convert::From<
+                    String,
+                >>::from(format!("encode_str: {}", e))
+            })?
+    })
+}
+#[allow(
+    non_snake_case,
+    unused_mut,
+    unused_variables,
+    unused_braces,
+    unused_parens,
+    dead_code,
+    clippy::useless_conversion,
+    clippy::needless_question_mark,
+    clippy::let_and_return,
+    clippy::nonminimal_bool,
+    clippy::eq_op
+)]
+pub(crate) unsafe fn std_borrow_Cow_u8_to_JByteArray_c6a6bddf<'a>(
+    env: &mut jni::JNIEnv<'a>,
+    v: ::std::borrow::Cow<'_, [u8]>,
+) -> ::core::result::Result<jni::objects::JByteArray<'a>, __JniErr> {
+    Ok({
+        env.byte_array_from_slice(&v)
+            .map_err(|e| {
+                <__JniErr as ::core::convert::From<
+                    String,
+                >>::from(format!("encode_byte_array: {}", e))
+            })?
+    })
+}
+#[allow(
+    non_snake_case,
+    unused_mut,
+    unused_variables,
+    unused_braces,
+    unused_parens,
+    dead_code,
+    clippy::useless_conversion,
+    clippy::needless_question_mark,
+    clippy::let_and_return,
+    clippy::nonminimal_bool,
+    clippy::eq_op
+)]
+pub(crate) unsafe fn str_to_JString_7b77dc67<'a>(
+    env: &mut jni::JNIEnv<'a>,
+    v: &str,
+) -> ::core::result::Result<jni::objects::JString<'a>, __JniErr> {
+    Ok({
+        env.new_string(v)
+            .map_err(|e| {
+                <__JniErr as ::core::convert::From<
+                    String,
+                >>::from(format!("encode_str: {}", e))
+            })?
+    })
+}
+#[allow(
+    non_snake_case,
+    unused_mut,
+    unused_variables,
+    unused_braces,
+    unused_parens,
+    dead_code,
+    clippy::useless_conversion,
+    clippy::needless_question_mark,
+    clippy::let_and_return,
+    clippy::nonminimal_bool,
+    clippy::eq_op
+)]
+pub(crate) unsafe fn u8_to_jint_553cf6ec<'a>(
+    env: &mut jni::JNIEnv<'a>,
+    v: u8,
+) -> ::core::result::Result<jni::sys::jint, __JniErr> {
+    Ok(v as jni::sys::jint)
+}
+#[allow(
+    non_snake_case,
+    unused_mut,
+    unused_variables,
+    unused_braces,
+    unused_parens,
+    dead_code,
+    clippy::useless_conversion,
+    clippy::needless_question_mark,
+    clippy::let_and_return,
+    clippy::nonminimal_bool,
+    clippy::eq_op
+)]
+pub(crate) unsafe fn unit_to_unit_9ecccf8e<'a>(
+    env: &mut jni::JNIEnv<'a>,
+    v: (),
+) -> ::core::result::Result<(), __JniErr> {
+    Ok(v)
+}
+#[no_mangle]
+#[allow(non_snake_case, unused_mut, unused_variables, dead_code)]
+pub unsafe extern "C" fn Java_io_prebindgen_emitcheck_JNINative_zSampleSub<'a>(
+    mut env: jni::JNIEnv<'a>,
+    _class: jni::objects::JClass<'a>,
+    cb: jni::objects::JObject<'a>,
+    __error_sink: jni::objects::JObject<'a>,
+) -> () {
+    #[allow(non_upper_case_globals)]
+    static __SINK_MID: ::prebindgen_jni_runtime::CachedIfaceMethod = ::prebindgen_jni_runtime::CachedIfaceMethod::new();
+    const __SINK_FQN: &str = "io/prebindgen/emitcheck/JniErrorHandler";
+    const __SINK_DESCR: &str = "(Ljava/lang/String;)Ljava/lang/Object;";
+    let cb = match JObject_to_impl_Fn_ZSample_Send_Sync_static_24e97b15(&mut env, &cb) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__e) => {
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e.to_string(),
+            );
+            return ();
+        }
+    };
+    let __out = myflat::z_sample_sub(cb);
+    match unit_to_unit_9ecccf8e(&mut env, __out) {
+        ::core::result::Result::Ok(__w) => __w,
+        ::core::result::Result::Err(__e) => {
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e.to_string(),
+            );
+            ()
+        }
+    }
+}

--- a/examples/emitcheck/src/lib.rs
+++ b/examples/emitcheck/src/lib.rs
@@ -1,0 +1,16 @@
+//! Compiles the JNI bindings `build.rs` emits for [`myflat`], and does nothing
+//! else — see `build.rs` for why (#269).
+//!
+//! There is no test here on purpose. Success *is* `cargo build`: if the
+//! generated file does not type-check against `myflat`'s definitions, this
+//! crate fails to compile, and CI's `cargo build` at the workspace root is
+//! already the gate.
+
+// Generator findings belong to the generator, not to this file.
+#![allow(clippy::all)]
+
+// Mounted under the name the generated code qualifies its calls with
+// (`build.rs`'s `SOURCE_CRATE`).
+pub mod myflat;
+
+include!("generated_bindings.rs");

--- a/examples/emitcheck/src/myflat.rs
+++ b/examples/emitcheck/src/myflat.rs
@@ -1,0 +1,82 @@
+//! The flat surface under test: one field per **Rust spelling** of a shape the
+//! model already reads representation-agnostically.
+//!
+//! This module is ordinary compiled Rust, and `build.rs` parses this very file
+//! to build the flat model — so a shape added here is emitted, compiled, and
+//! called against the same definitions, with nothing restated. Bodies are
+//! `unimplemented!()`: the question is whether the *emitted* code type-checks
+//! against these signatures, not what they compute.
+//!
+//! The generated bindings qualify every call as `myflat::…` (build.rs stamps
+//! that crate name onto each item, exactly as the unit-test fixtures do), which
+//! is why `lib.rs` mounts this file under that name.
+
+// The shapes are chosen for the generator, not for idiomatic Rust — nobody
+// writes a `Box<Option<T>>` field by hand.
+#![allow(clippy::box_collection, clippy::redundant_allocation)]
+
+use std::borrow::Cow;
+
+/// An opaque handle. Every value-form field below reaches one of these, or a
+/// leaf.
+///
+/// The field is not decoration: a handle crosses as a `jlong` whose bit 0 is
+/// the closed tag, so the generated code asserts `align_of::<T>() >= 2` and a
+/// zero-sized handle fails that at compile time.
+pub struct ZKeyExpr(pub u64);
+
+/// The subject whose value form carries the spellings.
+pub struct ZSample(pub u64);
+
+/// The child boundary: a `ZKeyExpr` field must still cross through *this*,
+/// because the field's own type decides how it crosses — not the wrapper the
+/// value form happens to spell it with.
+pub fn z_keyexpr_as_str(k: &ZKeyExpr) -> &str {
+    let _ = k;
+    unimplemented!()
+}
+
+/// The value form, one field per spelling. `prebindgen-flat`'s `acceptance.rs`
+/// pins that each pair below *reads* the same; the emitted access for each one
+/// is what this crate compiles.
+///
+/// The pairs, in the order the model's own acceptance test lists them:
+///
+/// | shape    | plain            | wrapped                |
+/// |----------|------------------|------------------------|
+/// | optional | `Option<T>`      | `Box<Option<T>>` (#268)|
+/// | sequence | `Vec<u8>`        | `Cow<'_, [u8]>`        |
+/// | `Str`    | `String`         | `Box<String>`, `Cow<'_, str>` |
+///
+/// `Box<Option<T>>` is the shape of #268 specifically: match ergonomics does
+/// not deref a `Box`, so an access that destructures the raw place is `E0308`
+/// here and compiles one field up.
+pub struct ZSampleStruct {
+    pub opt_plain: Option<ZKeyExpr>,
+    pub opt_boxed: Box<Option<ZKeyExpr>>,
+    pub seq_plain: Vec<u8>,
+    pub seq_cow: Cow<'static, [u8]>,
+    pub text_plain: String,
+    pub text_boxed: Box<String>,
+    pub text_cow: Cow<'static, str>,
+}
+
+pub fn z_sample_to_struct(s: &ZSample) -> ZSampleStruct {
+    let _ = s;
+    unimplemented!()
+}
+
+// The fourth spelling the model's acceptance test pins — a run of values
+// spelled **bare**, `[T]` — is deliberately absent, and cannot be added. It is
+// unsized, so it is not a struct field, not a return, and not a by-value
+// callback argument: there is no signature carrying it that is itself valid
+// Rust. A spelling that no compilable source can hold has no emitted access to
+// compile, which is why `prebindgen-flat`'s acceptance test is the only place
+// it can be pinned.
+
+/// The one output position: `ZSample` crossing into this callback is what makes
+/// the value form above get reached, and so emitted.
+pub fn z_sample_sub(cb: impl Fn(ZSample) + Send + Sync + 'static) {
+    let _ = cb;
+    unimplemented!()
+}

--- a/examples/perftest-kotlin/src/generated_bindings.rs
+++ b/examples/perftest-kotlin/src/generated_bindings.rs
@@ -261,7 +261,7 @@ pub(crate) unsafe fn Box_String_to_JString_027f6250<'a>(
     v: Box<String>,
 ) -> ::core::result::Result<jni::objects::JString<'a>, __JniErr> {
     Ok({
-        env.new_string(v.as_str())
+        env.new_string(&*v)
             .map_err(|e| {
                 <__JniErr as ::core::convert::From<
                     String,

--- a/examples/regen-check.sh
+++ b/examples/regen-check.sh
@@ -23,6 +23,7 @@ cd "$repo_root"
 
 # Committed generated outputs, per example crate.
 generated_paths=(
+    examples/emitcheck/src/generated_bindings.rs
     examples/covertest-kotlin/src/generated_bindings.rs
     examples/covertest-kotlin/kotlin/generated
     examples/perftest-kotlin/src/generated_bindings.rs
@@ -35,6 +36,7 @@ generated_paths=(
 
 echo "== regenerating in-repo bindings (cargo build)"
 cargo build --release \
+    -p emitcheck \
     -p covertest-kotlin \
     -p perftest-kotlin \
     -p perftest-c \

--- a/prebindgen-jni/src/jni/trait_impl.rs
+++ b/prebindgen-jni/src/jni/trait_impl.rs
@@ -2566,9 +2566,10 @@ impl Declarations {
             return Some(self.str_ref_output());
         }
         // An owned string in any representation the model erases — `Box<String>`,
-        // `Cow<'_, str>`. It classifies each of them `Str`, and the body was
-        // already representation-agnostic: `v.as_str()` reaches through any of
-        // them by `Deref`. Only the *dispatch* was spelling-keyed, as one
+        // `Cow<'_, str>`. It classifies each of them `Str`, and the body is
+        // representation-agnostic: `&*v` reaches through any of them by `Deref`
+        // to something `new_string` accepts (`&String` through a `Box`, `&str`
+        // through a `Cow`). Only the *dispatch* was spelling-keyed, as one
         // hardcoded `TypeKey == "Box < String >"` arm (#270).
         //
         // Plain `String` keeps its own earlier arm in `primitive_output`, whose
@@ -2580,16 +2581,28 @@ impl Declarations {
         ) {
             let wire: syn::Type = syn::parse_quote!(jni::objects::JString);
             let body: syn::Expr = syn::parse_quote!({
-                env.new_string(v.as_str()).map_err(|e| {
+                env.new_string(&*v).map_err(|e| {
                     <__JniErr as ::core::convert::From<String>>::from(format!("encode_str: {}", e))
                 })?
             });
             let kotlin_name = self.override_kotlin_name(&reading.key(), Some(KtType::string()));
             let niches = default_niches_for_wire(&wire);
+            // A `Cow` accessor may spell its own path any way it likes, but the
+            // generated fn's param type has to resolve with no imports in the
+            // consumer crate — normalize it, exactly as the `Cow<'_, [u8]>` arm
+            // below does. Every other spelling here (`String`, `Box<String>`)
+            // is already prelude-resolvable, so it keeps its own.
+            let function = match reading.kind() {
+                prebindgen_registry::flat::TypeKind::Cow { .. } => {
+                    let norm: syn::Type = syn::parse_quote!(::std::borrow::Cow<'_, str>);
+                    self.build_output_fn(&norm, &wire, &body, None)
+                }
+                _ => self.build_output_fn_of(reading, &wire, &body, None, emit),
+            };
             return Some(ConverterImpl {
                 subs: vec![],
                 pre_stages: vec![],
-                function: self.build_output_fn_of(reading, &wire, &body, None, emit),
+                function,
                 destination: wire,
                 niches,
                 metadata: self.framework_meta(kotlin_name),


### PR DESCRIPTION
Closes #269.

## The gap

The adapter tests call `write_rust` in ~100 places and assert on the result as **text** — ~737 `contains(..)` in the jnigen suite alone. Nothing handed that Rust to rustc, so an emission could be well-formed, contain every substring a test looked for, and still not compile. #268 was exactly that, green across 41 of 41 tests.

## `examples/emitcheck`

One crate, no JVM side — which is what separates it from `covertest-kotlin`, where "emits valid Rust" and "behaves correctly at runtime" are answered together.

```
examples/emitcheck/
  src/myflat.rs             ordinary compiled Rust — the flat surface under test
  build.rs                  parses that same file → JniGenBuilder::items → write_rust
  src/generated_bindings.rs committed; included by lib.rs
```

`build.rs` parses `src/myflat.rs` and hands the items to `JniGenBuilder::items` — the entry point the builder already documents for "synthetic items in a test", and the one the unit-test fixtures use. That is deliberate: the shape space being covered is theirs. One file is therefore both the compiled definitions and the model input, so adding a spelling means editing `src/myflat.rs` alone — nothing is restated.

Success is `cargo build`, which is already CI's gate (`rust.yml` builds the workspace). The generated file is committed like every other example's, so `regen-check.sh` diffs it and a rustc error lands on a stable reviewable path instead of a build hash.

## What it covers

The representation-variety spellings `prebindgen-flat`'s `acceptance.rs` pins on the model side, now extended to the emitters:

| shape | plain | wrapped |
|---|---|---|
| optional | `Option<T>` | `Box<Option<T>>` (#268) |
| sequence | `Vec<u8>` | `Cow<'_, [u8]>` |
| `Str` | `String` | `Box<String>`, `Cow<'_, str>` |

Bare `[T]` cannot join them, and `src/myflat.rs` says so: it is unsized, so it is not a struct field, not a return, and not a by-value callback argument. No compilable signature holds it, so there is no emitted access to compile — which is why the model's acceptance test is the only place it can be pinned.

## It found one on the first run

The `Str` output converter had two defects on the `Cow<'_, str>` path:

1. It spelled the accessor's path **verbatim**, so a consumer crate got a bare `Cow<'static, str>` in a generated signature — `E0425`, since the consumer has no reason to import it. The `Cow<'_, [u8]>` arm right below it already normalized to `::std::borrow::Cow` for exactly this reason.
2. It reached the value with `v.as_str()`. `Cow<'_, str>` derefs to `str`, and `str::as_str` is nightly-only (`str_as_str`, rust#130366) — so this never compiled on stable.

Both fixed here: normalize the path as the byte arm does, and reach through `&*v`, which is the representation-agnostic access the comment there already claimed (`&String` through a `Box`, `&str` through a `Cow`, `&str` from a `String`). That second change is the golden-file drift in the two Kotlin examples — `v.as_str()` → `&*v` at three call sites, same behaviour.

## Acceptance

- ✅ **Generated Rust for a shape only the unit tests reach is compiled by CI** — `cargo build` covers the new member.
- ✅ **`Box<Option<T>>` compiles, and would have failed before #268.** Reverting `bind_as_option`'s coercion site reproduces #268's emission, and `emitcheck` fails with the original `E0308`:
  ```
  error[E0308]: mismatched types
     --> examples/emitcheck/src/generated_bindings.rs:227:29
      |
  226 |   match __o0 {
      |         ---- this expression has type `&Box<Option<ZKeyExpr>>`
  227 |       ::core::option::Option::Some(__n0) => {
      |       ^^^^ expected `Box<Option<ZKeyExpr>>`, found `Option<_>`
  ```
- ✅ **The representation-variety spellings compile as a set** — the table above, minus bare `[T]` for the reason given.
- ✅ **The check names the offending shape.** The error above names `Box<Option<ZKeyExpr>>` against a committed path, not a temp dir.
- ➖ **The `destructure_ledger` should be reconsidered** — already gone, deleted by #369. Nothing to do.

### The gap, demonstrated

Reverting *either* fix in this PR leaves **all 246 jnigen unit tests passing** while `emitcheck` fails to compile. That is the whole point of the issue, on a live example the check found itself.

## Verified

`cargo fmt --check` (CI's exact config), `cargo clippy --all-targets --all-features -- --deny warnings` on **1.85.0 and stable**, `cargo test --all`, and `examples/regen-check.sh` — all clean.