### PR TITLE
jnigen: a `Box` on a Vec element keeps the push-helper path (closes #296)

### DIFF
--- a/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest.kt
+++ b/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest.kt
@@ -949,7 +949,7 @@ internal object CovNative {
 
     external fun boxedDurationEcho(value: Long, errorSink: Any): Long
 
-    external fun boxedElemIdSum(ps: List<Payload>, errorSink: Any): Long
+    external fun boxedElemIdSum(ps: Long, errorSink: Any): Long
 
     external fun boxedLatest(a: Long, build: Any, errorSink: Any): Any?
 

--- a/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest/model.kt
+++ b/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest/model.kt
@@ -1731,12 +1731,27 @@ public fun boxedOptPriorityWeight(p: Priority?, onError: JniErrorHandler<Long>):
 }
 
 /**
- * A wrapped **element** in the Vec-build path: the storage is `Vec<Box<Payload>>`
- * and each push wraps its own literal.
+ * A wrapped **element** in the Vec-build path. The storage is the CANONICAL
+ * `Vec<Payload>` — one helper trio per Kotlin class, shared with every other
+ * spelling of the same element — and the `Box` goes back on where the Vec is
+ * consumed, in one pass (#296).
+ *
+ * Load-bearing: the refusal it replaced was silent and cost-only, so nothing
+ * failed while `Vec<Box<Payload>>` fell back to a per-element `JObject` plus a
+ * field read per field. Its generated Rust is the evidence — take the wrap off
+ * the consumption site with this declared and the crate does not build.
  */
 public fun boxedElemIdSum(ps: List<Payload>, onError: JniErrorHandler<Long>): Long {
     val __bcap = JniErrorHandlerCapture.acquire()
-    val __ret = CovNative.boxedElemIdSum(ps, __bcap)
+    val __vec_ps = CovNative.payloadVecNew(ps.size)
+    val __ret = try {
+        for (__e in ps) {
+            CovNative.payloadVecPush(__vec_ps, __e.id, __e.seq, __e.value, __e.flag, __e.label)
+        }
+        CovNative.boxedElemIdSum(__vec_ps, __bcap)
+    } finally {
+        CovNative.payloadVecFree(__vec_ps)
+    }
     if (__bcap.failed) return onError.run(__bcap.ze0)
     return __ret
 }

--- a/examples/covertest-kotlin/kotlin/io/prebindgen/covertest/Test.kt
+++ b/examples/covertest-kotlin/kotlin/io/prebindgen/covertest/Test.kt
@@ -1480,6 +1480,14 @@ fun main() {
         val many = listOf(payload(1L, 0, 0.0, false, null), payload(2L, 0, 0.0, false, null))
         check(boxedElemIdSum(many, boom) == 3L)           // wrapped element
         check(boxedRunIdSum(many, boom) == 3L)            // wrapped run, by value
+        // Both now take the push-helper path through the ONE `payloadVec` trio
+        // (#296): the wrapped element is keyed on the canonical `Payload`, and
+        // its `Box` goes back on where the Vec is consumed. Weighed against each
+        // other rather than each against a literal — the claim is that a `Box`
+        // the model erases changes neither the surface nor the answer, and
+        // `boxedRunIdSum` is the bare-element control that always took this path.
+        check(boxedElemIdSum(many, boom) == boxedRunIdSum(many, boom))
+        check(boxedElemIdSum(emptyList(), boom) == 0L)    // …and the empty run
 
         // FIELDS (#289). `boxed: Box<Option<Long>>` and `plain: Option<Long>`
         // are one type to the model, so both cross as `Long?` on the decoupled

--- a/examples/covertest-kotlin/src/generated_bindings.rs
+++ b/examples/covertest-kotlin/src/generated_bindings.rs
@@ -13391,27 +13391,19 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_boxedDurationEch
 pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_boxedElemIdSum<'a>(
     mut env: jni::JNIEnv<'a>,
     _class: jni::objects::JClass<'a>,
-    ps: jni::objects::JObject<'a>,
+    ps_handle: jni::sys::jlong,
     __error_sink: jni::objects::JObject<'a>,
 ) -> jni::sys::jlong {
     #[allow(non_upper_case_globals)]
     static __SINK_MID: ::prebindgen_jni_runtime::CachedIfaceMethod = ::prebindgen_jni_runtime::CachedIfaceMethod::new();
     const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
     const __SINK_DESCR: &str = "(Ljava/lang/String;)Ljava/lang/Object;";
-    let ps = match JObject_to_Vec_Box_Payload_ae68babe(&mut env, &ps) {
-        ::core::result::Result::Ok(__v) => __v,
-        ::core::result::Result::Err(__e) => {
-            signal_binding_error(
-                &mut env,
-                &__error_sink,
-                &__SINK_MID,
-                __SINK_FQN,
-                __SINK_DESCR,
-                &__e.to_string(),
-            );
-            return 0 as jni::sys::jlong;
-        }
-    };
+    let ps = unsafe {
+        ::core::mem::take(&mut *(ps_handle as *mut Vec<perftest_flat::Payload>))
+    }
+        .into_iter()
+        .map(|__e| ::std::boxed::Box::new(__e))
+        .collect::<Vec<_>>();
     let __out = perftest_flat::boxed_elem_id_sum(ps);
     match i64_to_jlong_fbf9a9bc(&mut env, __out) {
         ::core::result::Result::Ok(__w) => __w,

--- a/examples/perftest-flat/src/ext.rs
+++ b/examples/perftest-flat/src/ext.rs
@@ -1770,8 +1770,15 @@ pub fn boxed_opt_priority_weight(p: Box<Option<Priority>>) -> i64 {
     }
 }
 
-/// A wrapped **element** in the Vec-build path: the storage is `Vec<Box<Payload>>`
-/// and each push wraps its own literal.
+/// A wrapped **element** in the Vec-build path. The storage is the CANONICAL
+/// `Vec<Payload>` — one helper trio per Kotlin class, shared with every other
+/// spelling of the same element — and the `Box` goes back on where the Vec is
+/// consumed, in one pass (#296).
+///
+/// Load-bearing: the refusal it replaced was silent and cost-only, so nothing
+/// failed while `Vec<Box<Payload>>` fell back to a per-element `JObject` plus a
+/// field read per field. Its generated Rust is the evidence — take the wrap off
+/// the consumption site with this declared and the crate does not build.
 #[prebindgen]
 pub fn boxed_elem_id_sum(ps: Vec<Box<Payload>>) -> i64 {
     ps.iter().map(|p| p.id).sum()

--- a/prebindgen-jni/src/jni/emit/vec_build.rs
+++ b/prebindgen-jni/src/jni/emit/vec_build.rs
@@ -7,7 +7,7 @@
 use prebindgen_registry::flat::{self, TypeRef};
 
 use super::*;
-use crate::jni::trait_impl::build_through_erased_wrappers;
+use crate::jni::trait_impl::{build_through_erased_wrappers, build_through_wrappers};
 
 // `slice_or_vec_elem` lived here: it matched `&[T]` / `Vec<T>` off the SPELLING
 // and returned the element. `vec_build_elem` was its only caller and now reads
@@ -17,12 +17,36 @@ use crate::jni::trait_impl::build_through_erased_wrappers;
 // because mutate-back semantics keep the `input_vec` path — survives as the
 // `mutable: false` guard on that match.
 
-/// `Some((element_type, by_ref))` when `arg_ty` is a slice/`Vec` input whose
-/// element is a **flattenable `data_class`** — i.e. it decomposes into the
-/// conservative leaf set [`build_flat_input_plan`] accepts, so each element can
-/// cross as decoupled raw params and be rebuilt on the Rust side with no
-/// `env.get_field(...)`. `None` for any other shape (opaque handles, enums,
-/// nested-`Option` structs), which keep the `input_vec` path.
+/// What a slice/`Vec` parameter contributes to the Vec-build path: the
+/// **canonical** element, whether the run is borrowed, and the element wrappers
+/// the storage does not carry.
+///
+/// A named return rather than a tuple because the third field is only meaningful
+/// against the first: `elem` is the element with every transparent wrapper taken
+/// off, and `elem_wrappers` is what has to go back on. Reading `(a, b, c)` at
+/// three call sites would not say that.
+pub(crate) struct VecBuildElem {
+    /// The element with its transparent wrappers removed — what the helper trio
+    /// stores, what its name is derived from, and what the flatten plan is built
+    /// for. `Vec<Payload>` and `Vec<Box<Payload>>` answer with the same node,
+    /// which is the whole mechanism: one trio per Kotlin class.
+    pub elem: TypeRef,
+    /// The run is a `&[T]`/`&Vec<T>` borrow rather than an owned value.
+    pub by_ref: bool,
+    /// The wrappers taken off the element, outermost first — empty for the
+    /// ordinary case. Applied per element where the Vec is consumed, since the
+    /// storage holds the canonical type. A list and not a `TypeRef`: it is the
+    /// only part a rebuild uses, and it rides in [`InputKind::VecBuild`], whose
+    /// size every variant pays.
+    pub elem_wrappers: Vec<&'static str>,
+}
+
+/// `Some(..)` when `arg_ty` is a slice/`Vec` input whose element is a
+/// **flattenable `data_class`** — i.e. it decomposes into the conservative leaf
+/// set [`build_flat_input_plan`] accepts, so each element can cross as decoupled
+/// raw params and be rebuilt on the Rust side with no `env.get_field(...)`.
+/// `None` for any other shape (opaque handles, enums, nested-`Option` structs),
+/// which keep the `input_vec` path.
 ///
 /// This is the single detection seam shared by `emit_input_param`, the param
 /// classifier, `render_extern_decl`, and the synthetic-extern emitter so all
@@ -31,7 +55,7 @@ pub(crate) fn vec_build_elem(
     ext: &Declarations,
     registry: &Registry<KotlinMeta>,
     arg: &TypeRef,
-) -> Option<(TypeRef, bool)> {
+) -> Option<VecBuildElem> {
     // The run and its element off the MODEL. `&mut [T]` is still refused —
     // mutate-back semantics keep the `input_vec` path — and that is the one
     // fact the layer accessors do not carry, so the borrow's mutability is read
@@ -81,28 +105,48 @@ pub(crate) fn vec_build_elem(
         build_through_erased_wrappers(run, quote!(__probe))?;
     }
     let elem = run.sequence_elem()?;
-    // A wrapped ELEMENT keeps the general converter path, and the obstruction is
-    // naming rather than typing. The helper trio stores a `Vec<#elem>`, so
-    // `Vec<Payload>` and `Vec<Box<Payload>>` are two different storages needing
-    // two trios — but the trio's base name is derived from the element's
-    // **Kotlin class** (`Payload` → `payloadVec`), which the two share, so both
-    // would emit `payloadVecNew`/`Push`/`Free` and collide.
+    // A wrapped ELEMENT is served here. #294 refused it and called the refusal
+    // definitive; #296 re-read it as reserved and this closes it.
     //
-    // **Reserved, not definitive** (#296). The collision is real; the choice it
-    // seems to force is not. Keying the trio on the CANONICAL element gives one
-    // trio per Kotlin class — storage `Vec<Payload>` — with the element's
-    // wrapper applied where the Vec is consumed
-    // (`.into_iter().map(Box::new).collect()`), so no Rust wrapper reaches a JNI
-    // symbol and nothing collides.
+    // The trio stores a `Vec<#elem>` and its base name comes from the element's
+    // **Kotlin class** (`Payload` → `payloadVec`), so keying it on the SPELLING
+    // would make `Vec<Payload>` and `Vec<Box<Payload>>` two storages wanting one
+    // name. Keying it on the CANONICAL element removes the question: one trio
+    // per Kotlin class, storage `Vec<Payload>`, and the element's wrapper goes
+    // back on where the Vec is CONSUMED — `.into_iter().map(Box::new).collect()`
+    // in `emit_input_param`. No Rust wrapper reaches a JNI symbol, which is the
+    // representation leak this layer exists to prevent, and nothing collides.
     //
-    // The cost of not doing it is not correctness: the general converter serves
-    // the shape (see `input_transparent_bridge`). It is that a `Box` the model
-    // erases silently downgrades the crossing from raw scalar leaves to a
-    // per-element `JObject` plus a field read per field — which is exactly what
-    // this path exists to remove.
-    if !elem.erased_wrappers().is_empty() {
-        return None;
+    // What that buys: a `Box` the model erases no longer downgrades the crossing
+    // from raw scalar leaves to a per-element `JObject` plus a field read per
+    // field. Correctness was never the issue — the general converter serves the
+    // shape (see `input_transparent_bridge`) — the cost was, and it was silent.
+    let elem_wrappers = elem.erased_wrappers();
+    if !elem_wrappers.is_empty() {
+        // **Definitive on the BORROWED path.** By value the local is owned, so
+        // the per-element wrap is one O(n) `Box::new` over a Vec already being
+        // moved. Borrowed, the local is a borrow of the Vec the Kotlin side
+        // owns, and a `Vec<Box<T>>` is not a `Vec<T>` viewed differently — it is
+        // a different allocation. Serving it would mean `mem::take`ing that Vec
+        // and borrowing a fresh one, which turns the single arm whose whole
+        // point is not copying into one that consumes its input.
+        //
+        // So the shapes coincide with the wrapped-run refusal above and the
+        // reasons do not: that one cannot copy without a `T: Clone`, this one
+        // could copy and must not.
+        if by_ref {
+            return None;
+        }
+        // `Cow` still declines, and by its own policy rather than this path's:
+        // `Cow::Owned` is well-typed, and refusing it is what keeps a binding
+        // from silently removing the borrow path. See its `WRAPPER_OPS` row.
+        build_through_wrappers(&elem_wrappers, quote!(__probe))?;
     }
+    // Canonical from here down: the flatten plan, the trio's storage and its
+    // name are all the element's, and the wrapper is the consumption site's
+    // business. `unwrapped` and not `stripped_syntax` because this stays a model
+    // node — it still has to answer `key`, `kind` and its own spelling.
+    let elem = elem.unwrapped();
     // The element must flatten; the probe ident is irrelevant here.
     let plan = build_flat_input_plan(ext, registry, &format_ident!("e"), elem)
         .ok()
@@ -119,7 +163,11 @@ pub(crate) fn vec_build_elem(
     {
         return None;
     }
-    Some((elem.clone(), by_ref))
+    Some(VecBuildElem {
+        elem: elem.clone(),
+        by_ref,
+        elem_wrappers,
+    })
 }
 
 /// Every distinct flattenable element type `T` that a scanned, declared function
@@ -127,6 +175,11 @@ pub(crate) fn vec_build_elem(
 /// externs are emitted for (once per type, shared across all such functions).
 /// Deduped by [`TypeKey`] and sorted for deterministic output (mirrors
 /// [`build_handle_destructor_items`]).
+///
+/// The key is the **canonical** element's, since that is what
+/// [`vec_build_elem`] answers with — so `Vec<Payload>` and `Vec<Box<Payload>>`
+/// land on one entry and get one trio, rather than two storages contending for
+/// the name `payloadVec` (#296).
 pub(crate) fn collect_vec_build_elem_types(
     ext: &Declarations,
     registry: &Registry<KotlinMeta>,
@@ -140,8 +193,8 @@ pub(crate) fn collect_vec_build_elem_types(
             continue;
         }
         for p in &f.params {
-            if let Some((elem, _)) = vec_build_elem(ext, registry, &p.ty) {
-                seen.insert(elem.key().as_str().to_string(), elem);
+            if let Some(v) = vec_build_elem(ext, registry, &p.ty) {
+                seen.insert(v.elem.key().as_str().to_string(), v.elem);
             }
         }
     }

--- a/prebindgen-jni/src/jni/emit/wrapper.rs
+++ b/prebindgen-jni/src/jni/emit/wrapper.rs
@@ -611,15 +611,21 @@ fn emit_input_param(
         // by-value `Vec<T>` moves it out with `mem::take` (leaving an empty
         // Vec the Kotlin `finally` frees). Decode is infallible, like the
         // by-value-handle consume below.
-        InputKind::VecBuild { elem, by_ref } => {
-            // Generated Rust spells the reading's own tokens.
+        InputKind::VecBuild {
+            elem,
+            by_ref,
+            elem_wrappers,
+        } => {
+            // Generated Rust spells the reading's own tokens. This is the
+            // CANONICAL element, which is what the helper trio stores — so the
+            // cast below and `build_vec_build_helper_items` name one type.
             let elem = emit.spell(elem);
             let handle_ident = format_ident!("{}_handle", arg_ident);
             wire_params.push(quote!(#handle_ident: jni::sys::jlong));
             if *by_ref {
-                // `vec_build_elem` refuses a wrapped run on this path, so the
-                // borrow is the parameter's own spelling and there is nothing
-                // to put back.
+                // `vec_build_elem` refuses a wrapped run OR a wrapped element on
+                // this path, so the borrow is the parameter's own spelling and
+                // there is nothing to put back.
                 prelude.push(quote!(
                     let #arg_ident: &[#elem] =
                         unsafe { &*(#handle_ident as *const Vec<#elem>) };
@@ -630,13 +636,28 @@ fn emit_input_param(
                 // ascription is dropped rather than restated: the wrapped
                 // spelling is what the expression now produces, and naming it
                 // here would be the same fact written twice.
-                let taken = build_through_erased_wrappers(
-                    &leaf.reading,
-                    quote!(unsafe {
-                        ::core::mem::take(&mut *(#handle_ident as *mut Vec<#elem>))
-                    }),
-                )
-                .expect("vec_build_elem accepted this run spelling");
+                let taken = quote!(unsafe {
+                    ::core::mem::take(&mut *(#handle_ident as *mut Vec<#elem>))
+                });
+                // The ELEMENT's wrappers, which the storage does not carry
+                // (#296). One O(n) pass over a Vec already being moved, and it
+                // goes INSIDE the run wrap: `Box<Vec<Box<Payload>>>` boxes each
+                // element, collects, then boxes the run. Emitted only when there
+                // are wrappers, so every existing shape keeps its exact tokens.
+                let taken = if elem_wrappers.is_empty() {
+                    taken
+                } else {
+                    let wrapped = build_through_wrappers(elem_wrappers, quote!(__e))
+                        .expect("vec_build_elem accepted this element spelling");
+                    quote!(
+                        #taken
+                            .into_iter()
+                            .map(|__e| #wrapped)
+                            .collect::<Vec<_>>()
+                    )
+                };
+                let taken = build_through_erased_wrappers(&leaf.reading, taken)
+                    .expect("vec_build_elem accepted this run spelling");
                 prelude.push(quote!(let #arg_ident = #taken;));
             }
             (wire_params, prelude, quote!(#arg_ident))

--- a/prebindgen-jni/src/jni/fn_plan.rs
+++ b/prebindgen-jni/src/jni/fn_plan.rs
@@ -116,9 +116,17 @@ pub(crate) enum InputKind {
     Callback { iface: Option<Arc<IfaceSpec>> },
     /// `&[T]` / `Vec<T>` of a flattenable data_class: a single `jlong`
     /// Vec-handle on the wire, built by pushing element leaves.
-    /// The element as a **reading**: the vec-helper plan and the element key
-    /// are both taken from it, and generated Rust spells `elem.spell()`.
-    VecBuild { elem: TypeRef, by_ref: bool },
+    /// The element as a **reading**, and the CANONICAL one: the vec-helper plan
+    /// and the element key are both taken from it, and generated Rust spells
+    /// `elem.spell()`. `elem_wrappers` is what the storage therefore does not
+    /// carry, put back per element on consumption (#296) — empty for the
+    /// ordinary case, and a list rather than a second `TypeRef` because every
+    /// variant of this enum pays its size.
+    VecBuild {
+        elem: TypeRef,
+        by_ref: bool,
+        elem_wrappers: Vec<&'static str>,
+    },
     /// Bare `Option<primitive>` / `Option<enum>`: a decoupled
     /// `(present: jboolean, value: <wire>)` pair.
     OptionScalar(OptionScalarInputPlan),
@@ -653,11 +661,15 @@ fn classify_leaf(
 
     let flat_plan = build_flat_input_plan(ext, registry, ident, reading)
         .map_err(PlanError::UnflattenableDataClass)?;
-    let kind = if let Some((elem, by_ref)) = (!expanded)
+    let kind = if let Some(v) = (!expanded)
         .then(|| vec_build_elem(ext, registry, reading))
         .flatten()
     {
-        InputKind::VecBuild { elem, by_ref }
+        InputKind::VecBuild {
+            elem: v.elem,
+            by_ref: v.by_ref,
+            elem_wrappers: v.elem_wrappers,
+        }
     } else if let Some(sp) = build_option_scalar_input_plan(ext, registry, ident, reading) {
         InputKind::OptionScalar(sp)
     } else if let Some(plan) = flat_plan {

--- a/prebindgen-jni/src/jni/tests/values.rs
+++ b/prebindgen-jni/src/jni/tests/values.rs
@@ -2024,3 +2024,151 @@ fn an_outer_wrapper_around_a_reference_is_seen_before_the_layers_are_read() {
          `Box<&Vec<Foo>>` — an E0308 in the generated crate:\n{kotlin}"
     );
 }
+
+/// A `Box` on the ELEMENT keeps the push-helper fast path, and the two spellings
+/// share **one** helper trio (#296).
+///
+/// The trio stores a `Vec<#elem>` and takes its name from the element's Kotlin
+/// class, so keying it on the spelling would make `Vec<Foo>` and `Vec<Box<Foo>>`
+/// two storages wanting the one name `fooVec`. That collision is what #294 read
+/// as forcing the refusal. Keying on the CANONICAL element dissolves it: one
+/// storage, one name, and the `Box` goes back on per element where the Vec is
+/// consumed.
+///
+/// The cost of the old refusal was never correctness — the general converter
+/// serves the shape — it was that the crossing silently fell back to a
+/// per-element `JObject` plus a field read per field, which is the entire thing
+/// this path exists to remove. So the assertion is about **which path**, and the
+/// bare twin is carried alongside as the control.
+///
+/// `&[Box<Foo>]` is asserted absent rather than left untested: it is a
+/// deliberate refusal (the by-ref arm borrows the Kotlin-owned Vec, and a
+/// `Vec<Box<Foo>>` is a different allocation rather than a different view), and
+/// an unpinned refusal decays into an accident.
+#[test]
+fn a_wrapped_vec_element_keeps_the_push_path_and_shares_one_trio() {
+    let loc = myflat_loc();
+    let items: Vec<(syn::Item, SourceLocation)> = vec![
+        (
+            syn::Item::Struct(syn::parse_quote!(
+                pub struct Foo {
+                    pub id: i64,
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn put_bare(v: Vec<Foo>) {
+                    unimplemented!()
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn put_boxed_elem(v: Vec<Box<Foo>>) {
+                    unimplemented!()
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn put_boxed_elem_slice(v: &[Box<Foo>]) {
+                    unimplemented!()
+                }
+            )),
+            loc.clone(),
+        ),
+    ];
+    let registry =
+        crate::test_util::reg_from_items(declare_referenced(items)).expect("index items");
+    let jni = JniGenBuilder::new()
+        .set_package_prefix("io.test.jni")
+        .package(
+            crate::package!("foo")
+                .class(crate::data_class!(Foo))
+                .fun(prebindgen_registry::fun!(put_bare))
+                .fun(prebindgen_registry::fun!(put_boxed_elem))
+                .fun(prebindgen_registry::fun!(put_boxed_elem_slice)),
+        );
+
+    let dir = unique_test_dir("jnigen_wrapped_vec_elem");
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+
+    let gen = jni.build_with(registry).expect("resolve");
+    let kdir = dir.join("kotlin");
+    let paths = gen.write_kotlin(&kdir).expect("write_kotlin");
+    let kotlin: String = paths
+        .iter()
+        .map(|p| std::fs::read_to_string(p).unwrap())
+        .collect::<Vec<_>>()
+        .join("\n");
+    let kc: String = kotlin.split_whitespace().collect();
+    let rust_path = gen.write_rust(dir.join("gen.rs")).expect("write_rust");
+    let rust = std::fs::read_to_string(&rust_path).expect("read rust");
+    let rc: String = rust.split_whitespace().collect();
+
+    // The control: the bare `Vec<Foo>` twin takes the Vec-build path, so a
+    // finding below is about the wrapper and not about the fixture failing to
+    // reach the specialized path at all.
+    assert!(
+        kc.contains("val__vec_v=JNINative.fooVecNew(v.size)"),
+        "the bare `Vec<Foo>` must take the Vec-build path — otherwise this test \
+         proves nothing about the wrapped one:\n{kotlin}"
+    );
+    // The finding: the wrapped element takes it too. Split on the wrapper so the
+    // shared `fooVecNew` declarations in `JNINative` cannot be read as this
+    // function's body (the trap the sibling test above documents).
+    let boxed_body = kc
+        .split("publicfunputBoxedElem(")
+        .nth(1)
+        .map(|s| s.split("publicfun").next().unwrap_or(s).to_string())
+        .unwrap_or_default();
+    assert!(
+        boxed_body.contains("fooVecNew"),
+        "`Vec<Box<Foo>>` fell back to the general `JObject` converter — a `Box` \
+         the model erases must not cost the push-helper path (#296):\n{kotlin}"
+    );
+
+    // One trio, not two: the declaration is emitted once for the two spellings.
+    // This is the collision claim, measured rather than argued.
+    assert_eq!(
+        kc.matches("externalfunfooVecNew(cap:Int):Long").count(),
+        1,
+        "the two spellings must share ONE helper trio — a per-spelling trio \
+         would emit `fooVecNew` twice and collide:\n{kotlin}"
+    );
+    // …and the storage is the canonical element on the Rust side, which is what
+    // makes one trio serve both.
+    assert!(
+        rc.contains("Vec::<myflat::Foo>::with_capacity"),
+        "the trio must store the CANONICAL element:\n{rust}"
+    );
+    assert!(
+        rc.contains(".map(|__e|::std::boxed::Box::new(__e))"),
+        "the element wrapper must go back on where the Vec is consumed:\n{rust}"
+    );
+    // The bare twin must NOT gain that pass — the wrap is per-spelling, not
+    // something the emitter adds to every Vec-build param.
+    assert_eq!(
+        rc.matches(".map(|__e|::std::boxed::Box::new(__e))").count(),
+        1,
+        "only the wrapped spelling maps its elements:\n{rust}"
+    );
+
+    // The stated refusal: the by-ref arm borrows the Kotlin-owned `Vec<Foo>`,
+    // and there is no `Vec<Box<Foo>>` to borrow without building one.
+    let slice_body = kc
+        .split("publicfunputBoxedElemSlice(")
+        .nth(1)
+        .map(|s| s.split("publicfun").next().unwrap_or(s).to_string())
+        .unwrap_or_default();
+    assert!(
+        !slice_body.contains("fooVecNew"),
+        "`&[Box<Foo>]` must keep the general converter path — serving it would \
+         mean consuming the Vec the arm exists to borrow:\n{kotlin}"
+    );
+}


### PR DESCRIPTION
Closes #296.

`vec_build_elem` declined a wrapped element, so `Vec<Payload>` crossed as one `jlong` handle to a Rust-side Vec filled with raw scalar leaves and no `JObject` at all, while `Vec<Box<Payload>>` fell back to `JList::from_env` plus a `JObject` and a field read per element. That is precisely the cost this path exists to remove, lost for a `Box` the model erases. Correctness was never at stake — the general converter serves the shape — so nothing failed while it happened.

## The collision, answered

#294 called the refusal definitive: the trio's base name comes from the element's **Kotlin class** (`Payload` → `payloadVec`), which two spellings share, so both would emit `payloadVecNew`/`Push`/`Free`. The collision is real; the dichotomy is not.

Key the trio on the **canonical** element. One trio per Kotlin class, storage `Vec<Payload>`, and the element's wrapper goes back on where the Vec is **consumed**:

```rust
let ps = unsafe { ::core::mem::take(&mut *(ps_handle as *mut Vec<perftest_flat::Payload>)) }
    .into_iter()
    .map(|__e| ::std::boxed::Box::new(__e))
    .collect::<Vec<_>>();
```

One O(n) pass over a Vec already being moved, and no Rust wrapper reaches a JNI symbol — which is the representation leak the naming rule protects. It composes with the run-level wrap already there, so `Box<Vec<Box<Payload>>>` boxes each element, collects, then boxes the run.

`collect_vec_build_elem_types` and `vec_build_helpers` needed **no change**: both key on what `vec_build_elem` answers with, and that is now canonical. The change is the seam, not the sites.

## `&[Box<Payload>]` is refused, for its own reason

Acceptance item 4, refusal branch. The by-ref arm hands the callee a borrow *of the Kotlin-owned Vec* — zero copy. A `Vec<Box<T>>` is not a `Vec<T>` viewed differently, it is a different allocation, so serving it would mean `mem::take`ing that Vec and borrowing a fresh one: the single arm whose whole point is not copying would consume its input. The shape coincides with the wrapped-run refusal above it and the reason does not — that one *cannot* copy without a `T: Clone`, this one *could* and must not.

`Cow` still declines, by its existing `WRAPPER_OPS` policy rather than anything this path decides.

## Golden movement

Deliberate, and confined to the fixture. `boxed_elem_id_sum`'s extern takes `ps_handle: jlong` instead of a `JObject`, its Kotlin gains the `payloadVecNew`/`Push`/`Free` loop, and the public surface is untouched at `List<Payload>`. Nothing else moved — anything that had would mean the empty-wrapper branch was leaking.

## Verified

- `cargo test --all --all-features` — 596 passed, 0 failed.
- **The new test bites.** Restore #294's `if !elem.erased_wrappers().is_empty() { return None }` with nothing else changed and `a_wrapped_vec_element_keeps_the_push_path_and_shares_one_trio` fails on exactly its claim: ``` `Vec<Box<Foo>>` fell back to the general `JObject` converter ```. It asserts the bare twin as a control, that `fooVecNew` is declared **once** (the collision claim, measured rather than argued), that the storage is canonical, that only the wrapped spelling maps its elements, and that `&[Box<Foo>]` stays refused so the refusal cannot decay into an accident.
- `examples/regen-check.sh` after `cargo clean --release` — only the three fixture-driven files move; `example_flat_aarch64.{rs,h}` did not drift.
- `examples/covertest-kotlin$ ./gradlew run` — `PASS`, 49 sections. The exercise now weighs `boxedElemIdSum` against `boxedRunIdSum` (the bare-element control that always took this path) rather than each against a literal, so the claim is that the `Box` changes neither the surface nor the answer.
- `cargo fmt --check` with the CI config; `cargo clippy --all-targets --all-features -- -D warnings` clean on **both** 1.85.0 and stable, including `large_enum_variant` on the grown `InputKind`.

## Noticed, not touched

The by-ref arm emits `let a: &[#elem] = …` unconditionally while `vec_build_elem` also accepts a `&Vec<T>` parameter, which would be an `E0308`. No fixture spells `&Vec<T>`, so nothing exercises it. Pre-existing and unrelated; worth its own issue.