### PR TITLE
jnigen: a `&Vec<T>` parameter gets the Vec borrow, not a slice of it (closes #384)

### DIFF
--- a/examples/covertest-kotlin/build.rs
+++ b/examples/covertest-kotlin/build.rs
@@ -549,6 +549,12 @@ fn main() {
                 .fun(fun!(boxed_opt_priority_weight))
                 .fun(fun!(boxed_elem_id_sum))
                 .fun(fun!(boxed_run_id_sum))
+                // The two spellings of a borrowed run (#384). One type to the
+                // model, so both take the Vec-build path — and the compiled
+                // binding is what proves the emitter serves both, since the
+                // failure was an `E0308` rather than a wrong answer.
+                .fun(fun!(slice_id_sum))
+                .fun(fun!(ref_vec_id_sum))
                 // The same wrapper over a DECOMPOSED return (#292). `Summary`
                 // has an output expansion, so this return takes no converter to
                 // name the spelling for it — the extern binds the value and

--- a/examples/covertest-kotlin/kotlin/REPORT.md
+++ b/examples/covertest-kotlin/kotlin/REPORT.md
@@ -110,7 +110,9 @@ Base package: `io.prebindgen.covertest`
   - shaped by: return `Reading` decomposed → [tag, exact_v0, range_low, range_high, tagged_v0, tagged_v1, companion_v0] (Callback delivery)
 - `reading_series` — `fun readingSeries(n: Int, onError: JniErrorHandler<List<Reading>>): List<Reading>`
   - shaped by: return `Reading` decomposed → [tag, exact_v0, range_low, range_high, tagged_v0, tagged_v1, companion_v0] (Callback delivery)
+- `ref_vec_id_sum` — `fun refVecIdSum(ps: List<Payload>, onError: JniErrorHandler<Long>): Long`
 - `report_each` — `fun reportEach(n: Long, sink: ReportCallback, onError: JniErrorHandler<Unit>)`
+- `slice_id_sum` — `fun sliceIdSum(ps: List<Payload>, onError: JniErrorHandler<Long>): Long`
 - `stamp_new` — `fun stampNew(secs: Long, nanos: Long, onError: JniErrorHandler<Stamp>): Stamp`
   - shaped by: return `Stamp` decomposed → [secs, nanos] (Callback delivery)
 - `stamp_series` — `fun stampSeries(count: Long, onError: JniErrorHandler<List<Stamp>>): List<Stamp>`

--- a/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest.kt
+++ b/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest.kt
@@ -1101,7 +1101,11 @@ internal object CovNative {
 
     external fun readingSeries(n: Int, acc: Any?, fold: Any, errorSink: Any): Any?
 
+    external fun refVecIdSum(ps: Long, errorSink: Any): Long
+
     external fun reportEach(n: Long, sink: Any, errorSink: Any)
+
+    external fun sliceIdSum(ps: Long, errorSink: Any): Long
 
     external fun stampNanos(sSecs: Long, sNanos: Long, errorSink: Any): Long
 

--- a/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest/model.kt
+++ b/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest/model.kt
@@ -1763,7 +1763,8 @@ public fun boxedRunIdSum(ps: List<Payload>, onError: JniErrorHandler<Long>): Lon
 }
 
 /**
- * The **borrowed** run, spelled as a slice — the control for the pair below.
+ * The **borrowed** run spelled as a slice — the control half of the pair with
+ * [`ref_vec_id_sum`].
  *
  * Declared as a sum rather than reusing [`crate::storage_put_slice`] so the two
  * spellings can be weighed against each other directly: same argument, same

--- a/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest/model.kt
+++ b/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest/model.kt
@@ -1763,6 +1763,58 @@ public fun boxedRunIdSum(ps: List<Payload>, onError: JniErrorHandler<Long>): Lon
 }
 
 /**
+ * The **borrowed** run, spelled as a slice — the control for the pair below.
+ *
+ * Declared as a sum rather than reusing [`crate::storage_put_slice`] so the two
+ * spellings can be weighed against each other directly: same argument, same
+ * answer, or the claim is only that each compiles.
+ */
+public fun sliceIdSum(ps: List<Payload>, onError: JniErrorHandler<Long>): Long {
+    val __bcap = JniErrorHandlerCapture.acquire()
+    val __vec_ps = CovNative.payloadVecNew(ps.size)
+    val __ret = try {
+        for (__e in ps) {
+            CovNative.payloadVecPush(__vec_ps, __e.id, __e.seq, __e.value, __e.flag, __e.label)
+        }
+        CovNative.sliceIdSum(__vec_ps, __bcap)
+    } finally {
+        CovNative.payloadVecFree(__vec_ps)
+    }
+    if (__bcap.failed) return onError.run(__bcap.ze0)
+    return __ret
+}
+
+/**
+ * The same borrowed run spelled `&Vec<T>`, which is **one type** to the model:
+ * `sequence_elem` answers for `&[T]` and `&Vec<T>` alike, so both reach the
+ * Vec-build path and the emitter has to serve both.
+ *
+ * It did not. The by-ref lowering hands the callee a borrow of the transient
+ * Rust-side `Vec`, and ascribing that borrow `&[T]` coerced it at the `let` —
+ * so this spelling got a `&[Payload]` and the generated crate did not build
+ * (`E0308`; the deref coercion runs `&Vec<T>` → `&[T]`, not back). #384.
+ *
+ * Load-bearing, and the only kind of fixture that can be: a lib test emits
+ * tokens and never compiles them, while this crate's binding is `include!`d
+ * and built. Put the ascription back and `cargo build -p covertest-kotlin`
+ * fails here.
+ */
+public fun refVecIdSum(ps: List<Payload>, onError: JniErrorHandler<Long>): Long {
+    val __bcap = JniErrorHandlerCapture.acquire()
+    val __vec_ps = CovNative.payloadVecNew(ps.size)
+    val __ret = try {
+        for (__e in ps) {
+            CovNative.payloadVecPush(__vec_ps, __e.id, __e.seq, __e.value, __e.flag, __e.label)
+        }
+        CovNative.refVecIdSum(__vec_ps, __bcap)
+    } finally {
+        CovNative.payloadVecFree(__vec_ps)
+    }
+    if (__bcap.failed) return onError.run(__bcap.ze0)
+    return __ret
+}
+
+/**
  * A transparent wrapper over a **decomposed** return — the shape `boxed_note_echo`
  * does not reach.
  *

--- a/examples/covertest-kotlin/kotlin/io/prebindgen/covertest/Test.kt
+++ b/examples/covertest-kotlin/kotlin/io/prebindgen/covertest/Test.kt
@@ -52,6 +52,8 @@ import io.prebindgen.covertest.model.boxedOptPayloadId
 import io.prebindgen.covertest.model.boxedOptPriorityWeight
 import io.prebindgen.covertest.model.boxedPayloadId
 import io.prebindgen.covertest.model.boxedRunIdSum
+import io.prebindgen.covertest.model.refVecIdSum
+import io.prebindgen.covertest.model.sliceIdSum
 import io.prebindgen.covertest.model.holderTagOr
 import io.prebindgen.covertest.model.wrappedFieldsSum
 import io.prebindgen.covertest.model.boxedNoteEcho
@@ -1480,6 +1482,15 @@ fun main() {
         val many = listOf(payload(1L, 0, 0.0, false, null), payload(2L, 0, 0.0, false, null))
         check(boxedElemIdSum(many, boom) == 3L)           // wrapped element
         check(boxedRunIdSum(many, boom) == 3L)            // wrapped run, by value
+
+        // The two spellings of a BORROWED run (#384). `&[Payload]` and
+        // `&Vec<Payload>` are one type to the model, so both take the Vec-build
+        // path and must come out identical — the `&Vec` one used to be handed a
+        // `&[Payload]`, which is an E0308 in the generated crate rather than a
+        // wrong answer. Weighed against each other, not against a literal.
+        check(refVecIdSum(many, boom) == sliceIdSum(many, boom))
+        check(sliceIdSum(many, boom) == 3L)
+        check(refVecIdSum(emptyList(), boom) == 0L)       // …and the empty run
 
         // FIELDS (#289). `boxed: Box<Option<Long>>` and `plain: Option<Long>`
         // are one type to the model, so both cross as `Long?` on the decoupled

--- a/examples/covertest-kotlin/src/generated_bindings.rs
+++ b/examples/covertest-kotlin/src/generated_bindings.rs
@@ -17814,6 +17814,35 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_readingSeries<'a
 }
 #[no_mangle]
 #[allow(non_snake_case, unused_mut, unused_variables, dead_code)]
+pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_refVecIdSum<'a>(
+    mut env: jni::JNIEnv<'a>,
+    _class: jni::objects::JClass<'a>,
+    ps_handle: jni::sys::jlong,
+    __error_sink: jni::objects::JObject<'a>,
+) -> jni::sys::jlong {
+    #[allow(non_upper_case_globals)]
+    static __SINK_MID: ::prebindgen_jni_runtime::CachedIfaceMethod = ::prebindgen_jni_runtime::CachedIfaceMethod::new();
+    const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
+    const __SINK_DESCR: &str = "(Ljava/lang/String;)Ljava/lang/Object;";
+    let ps = unsafe { &*(ps_handle as *const Vec<perftest_flat::Payload>) };
+    let __out = perftest_flat::ref_vec_id_sum(ps);
+    match i64_to_jlong_fbf9a9bc(&mut env, __out) {
+        ::core::result::Result::Ok(__w) => __w,
+        ::core::result::Result::Err(__e) => {
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e.to_string(),
+            );
+            0 as jni::sys::jlong
+        }
+    }
+}
+#[no_mangle]
+#[allow(non_snake_case, unused_mut, unused_variables, dead_code)]
 pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_reportEach<'a>(
     mut env: jni::JNIEnv<'a>,
     _class: jni::objects::JClass<'a>,
@@ -17869,6 +17898,35 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_reportEach<'a>(
                 &__e.to_string(),
             );
             ()
+        }
+    }
+}
+#[no_mangle]
+#[allow(non_snake_case, unused_mut, unused_variables, dead_code)]
+pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_sliceIdSum<'a>(
+    mut env: jni::JNIEnv<'a>,
+    _class: jni::objects::JClass<'a>,
+    ps_handle: jni::sys::jlong,
+    __error_sink: jni::objects::JObject<'a>,
+) -> jni::sys::jlong {
+    #[allow(non_upper_case_globals)]
+    static __SINK_MID: ::prebindgen_jni_runtime::CachedIfaceMethod = ::prebindgen_jni_runtime::CachedIfaceMethod::new();
+    const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
+    const __SINK_DESCR: &str = "(Ljava/lang/String;)Ljava/lang/Object;";
+    let ps = unsafe { &*(ps_handle as *const Vec<perftest_flat::Payload>) };
+    let __out = perftest_flat::slice_id_sum(ps);
+    match i64_to_jlong_fbf9a9bc(&mut env, __out) {
+        ::core::result::Result::Ok(__w) => __w,
+        ::core::result::Result::Err(__e) => {
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e.to_string(),
+            );
+            0 as jni::sys::jlong
         }
     }
 }
@@ -19788,9 +19846,7 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_storagePutSlice<
             return ();
         }
     };
-    let payloads: &[perftest_flat::Payload] = unsafe {
-        &*(payloads_handle as *const Vec<perftest_flat::Payload>)
-    };
+    let payloads = unsafe { &*(payloads_handle as *const Vec<perftest_flat::Payload>) };
     let __out = perftest_flat::storage_put_slice(&mut s, payloads);
     match unit_to_unit_9ecccf8e(&mut env, __out) {
         ::core::result::Result::Ok(__w) => __w,

--- a/examples/perftest-flat/src/ext.rs
+++ b/examples/perftest-flat/src/ext.rs
@@ -1790,6 +1790,39 @@ pub fn boxed_run_id_sum(ps: Box<Vec<Payload>>) -> i64 {
     ps.iter().map(|p| p.id).sum()
 }
 
+/// The **borrowed** run spelled as a slice — the control half of the pair with
+/// [`ref_vec_id_sum`].
+///
+/// Declared as a sum rather than reusing [`crate::storage_put_slice`] so the two
+/// spellings can be weighed against each other directly: same argument, same
+/// answer, or the claim is only that each compiles.
+#[prebindgen]
+pub fn slice_id_sum(ps: &[Payload]) -> i64 {
+    ps.iter().map(|p| p.id).sum()
+}
+
+/// The same borrowed run spelled `&Vec<T>`, which is **one type** to the model:
+/// `sequence_elem` answers for `&[T]` and `&Vec<T>` alike, so both reach the
+/// Vec-build path and the emitter has to serve both.
+///
+/// It did not. The by-ref lowering hands the callee a borrow of the transient
+/// Rust-side `Vec`, and ascribing that borrow `&[T]` coerced it at the `let` —
+/// so this spelling got a `&[Payload]` and the generated crate did not build
+/// (`E0308`; the deref coercion runs `&Vec<T>` → `&[T]`, not back). #384.
+///
+/// Load-bearing, and the only kind of fixture that can be: a lib test emits
+/// tokens and never compiles them, while this crate's binding is `include!`d
+/// and built. Put the ascription back and `cargo build -p covertest-kotlin`
+/// fails here.
+#[prebindgen]
+// A `&Vec` parameter IS the point here — clippy is right that it should be
+// `&[_]`, and that is what makes it a fixture: the two spellings are one type
+// to the model, so the binding must serve both.
+#[allow(clippy::ptr_arg)]
+pub fn ref_vec_id_sum(ps: &Vec<Payload>) -> i64 {
+    ps.iter().map(|p| p.id).sum()
+}
+
 /// Deliver a [`Ledger`] to a callback, so both conditional decompositions cross
 /// in ONE call — including the sum (`Report::outcome`) each one carries, whose
 /// `match` belongs inside the arm that binds the report.

--- a/examples/perftest-kotlin/src/generated_bindings.rs
+++ b/examples/perftest-kotlin/src/generated_bindings.rs
@@ -5694,9 +5694,7 @@ pub unsafe extern "C" fn Java_io_prebindgen_perftest_JNINative_storagePutSlice<'
             return ();
         }
     };
-    let payloads: &[perftest_flat::Payload] = unsafe {
-        &*(payloads_handle as *const Vec<perftest_flat::Payload>)
-    };
+    let payloads = unsafe { &*(payloads_handle as *const Vec<perftest_flat::Payload>) };
     let __out = perftest_flat::storage_put_slice(&mut s, payloads);
     match unit_to_unit_9ecccf8e(&mut env, __out) {
         ::core::result::Result::Ok(__w) => __w,

--- a/prebindgen-jni/src/jni/emit/wrapper.rs
+++ b/prebindgen-jni/src/jni/emit/wrapper.rs
@@ -607,10 +607,10 @@ fn emit_input_param(
         // single `jlong` handle to a Rust-side `Vec<T>` that the Kotlin
         // wrapper builds by pushing each element's decoupled leaves in a loop
         // (see `build_vec_build_helper_items` + `ParamMode::VecBuild`) — no
-        // per-element `env.get_field(...)`. `&[T]` borrows the boxed Vec;
-        // by-value `Vec<T>` moves it out with `mem::take` (leaving an empty
-        // Vec the Kotlin `finally` frees). Decode is infallible, like the
-        // by-value-handle consume below.
+        // per-element `env.get_field(...)`. A borrowed run — `&[T]` or
+        // `&Vec<T>` — borrows the boxed Vec; by-value `Vec<T>` moves it out
+        // with `mem::take` (leaving an empty Vec the Kotlin `finally` frees).
+        // Decode is infallible, like the by-value-handle consume below.
         InputKind::VecBuild { elem, by_ref } => {
             // Generated Rust spells the reading's own tokens.
             let elem = emit.spell(elem);
@@ -620,9 +620,25 @@ fn emit_input_param(
                 // `vec_build_elem` refuses a wrapped run on this path, so the
                 // borrow is the parameter's own spelling and there is nothing
                 // to put back.
+                //
+                // **No ascription**, for the reason the by-value branch below
+                // gives: the expression already produces the local's type, and
+                // naming it here writes the same fact twice — but here it also
+                // got it WRONG. `&*(.. as *const Vec<T>)` is a `&Vec<T>`, and
+                // ascribing `&[T]` coerced it at the `let`, where only one of
+                // the two spellings the model accepts can come out. A
+                // `&Vec<T>` parameter — which `sequence_elem` answers for
+                // exactly as it does for `&[T]` — was then handed a `&[T]`:
+                // `E0308` in the generated crate, since the deref coercion runs
+                // `&Vec<T>` → `&[T]` and not back (#384).
+                //
+                // Unascribed, the coercion moves to the call site and serves
+                // both: exact for `&Vec<T>`, deref for `&[T]`. `&mut Vec<T>`
+                // stays refused, and by `sequence_elem` returning `None` for a
+                // `Ref` kind rather than by the `mutable: false` guard — that
+                // guard is what refuses `&mut [T]`.
                 prelude.push(quote!(
-                    let #arg_ident: &[#elem] =
-                        unsafe { &*(#handle_ident as *const Vec<#elem>) };
+                    let #arg_ident = unsafe { &*(#handle_ident as *const Vec<#elem>) };
                 ));
             } else {
                 // By value the local is owned, so the run's wrappers go back on

--- a/prebindgen-jni/src/jni/tests/values.rs
+++ b/prebindgen-jni/src/jni/tests/values.rs
@@ -2024,3 +2024,106 @@ fn an_outer_wrapper_around_a_reference_is_seen_before_the_layers_are_read() {
          `Box<&Vec<Foo>>` — an E0308 in the generated crate:\n{kotlin}"
     );
 }
+
+/// The two spellings of a **borrowed run** get the same local, and it is the
+/// borrow of the `Vec` rather than a slice of it (#384).
+///
+/// `sequence_elem` answers for `&[T]` and `&Vec<T>` alike — they are one type to
+/// the model — so both reach the Vec-build path. The emitter was not symmetric
+/// with that: it ascribed `&[#elem]` to the local, which coerced
+/// `&*(.. as *const Vec<T>)` at the `let` and could therefore produce only one
+/// of the two. A `&Vec<T>` parameter was then handed a `&[T]`, which does not
+/// coerce back — `E0308` in the generated crate.
+///
+/// Unascribed, the coercion moves to the call site and serves both. What this
+/// test can pin is the **shape**; that it compiles is `covertest-kotlin`'s
+/// `ref_vec_id_sum`/`slice_id_sum` pair, since a lib test emits tokens and never
+/// builds them.
+#[test]
+fn both_spellings_of_a_borrowed_run_get_the_vec_borrow() {
+    let loc = myflat_loc();
+    let items: Vec<(syn::Item, SourceLocation)> = vec![
+        (
+            syn::Item::Struct(syn::parse_quote!(
+                pub struct Foo {
+                    pub id: i64,
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn put_slice(v: &[Foo]) {
+                    unimplemented!()
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn put_ref_vec(v: &Vec<Foo>) {
+                    unimplemented!()
+                }
+            )),
+            loc.clone(),
+        ),
+    ];
+    let registry =
+        crate::test_util::reg_from_items(declare_referenced(items)).expect("index items");
+    let jni = JniGenBuilder::new()
+        .set_package_prefix("io.test.jni")
+        .package(
+            crate::package!("foo")
+                .class(crate::data_class!(Foo))
+                .fun(prebindgen_registry::fun!(put_slice))
+                .fun(prebindgen_registry::fun!(put_ref_vec)),
+        );
+
+    let dir = unique_test_dir("jnigen_borrowed_run_spellings");
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+
+    let gen = jni.build_with(registry).expect("resolve");
+    let kdir = dir.join("kotlin");
+    let paths = gen.write_kotlin(&kdir).expect("write_kotlin");
+    let kotlin: String = paths
+        .iter()
+        .map(|p| std::fs::read_to_string(p).unwrap())
+        .collect::<Vec<_>>()
+        .join("\n");
+    let kc: String = kotlin.split_whitespace().collect();
+    let rust_path = gen.write_rust(dir.join("gen.rs")).expect("write_rust");
+    let rust = std::fs::read_to_string(&rust_path).expect("read rust");
+    let rc: String = rust.split_whitespace().collect();
+
+    // Both spellings reach the Vec-build path — the premise. `&Vec<Foo>` did
+    // too before the fix, which is exactly why it broke rather than falling
+    // back to the general converter.
+    for f in ["publicfunputSlice(", "publicfunputRefVec("] {
+        let body = kc
+            .split(f)
+            .nth(1)
+            .map(|s| s.split("publicfun").next().unwrap_or(s).to_string())
+            .unwrap_or_default();
+        assert!(
+            body.contains("fooVecNew"),
+            "`{f}` must take the Vec-build path — both spellings are one type to \
+             the model:\n{kotlin}"
+        );
+    }
+
+    // The finding: ONE local, and it is the `Vec` borrow. Counted rather than
+    // merely found, so a per-spelling form cannot pass.
+    assert_eq!(
+        rc.matches("letv=unsafe{&*(v_handleas*constVec<myflat::Foo>)};")
+            .count(),
+        2,
+        "both borrowed runs must get the same unascribed `&Vec<Foo>` local:\n{rust}"
+    );
+    // …and no slice ascription survives, which is the thing that broke.
+    assert!(
+        !rc.contains("letv:&[myflat::Foo]="),
+        "ascribing `&[Foo]` coerces at the `let`, so a `&Vec<Foo>` parameter \
+         gets a `&[Foo]` and the generated crate does not build (E0308):\n{rust}"
+    );
+}


### PR DESCRIPTION
Closes #384.

`vec_build_elem` reads the run off the **model**, and `sequence_elem` answers for `&[T]` and `&Vec<T>` alike — they are one type there. The emitter was not symmetric with it. The by-ref branch ascribed one spelling:

```rust
let #arg_ident: &[#elem] = unsafe { &*(#handle_ident as *const Vec<#elem>) };
```

`&*(.. as *const Vec<T>)` already **is** a `&Vec<T>`. The ascription forced the coercion at the `let`, where only one of the two spellings the model accepts can come out — so a `&Vec<T>` parameter was handed a `&[T]`, and the deref coercion runs `&Vec<T>` → `&[T]` and not back. `E0308` **in the generated crate**: a build failure, not a wrong answer.

## The fix

Drop the ascription. The local stays `&Vec<T>` and the coercion moves to the call site, which serves both — exact for `&Vec<T>`, deref for `&[T]`. One spelling instead of two.

This is not a new idea in this file; the sibling by-value branch four lines down already argues it:

> The ascription is dropped rather than restated: the wrapped spelling is what the expression now produces, and naming it here would be the same fact written twice.

The by-ref branch is the one that did not follow its own rule — and where writing the fact twice also got it wrong. The alternative (branch on `borrow_target().kind()`, `Slice` vs `Vec`, emit a form per arm) is strictly more code for the same result.

`&mut Vec<T>` stays refused, and the comment now attributes it correctly: it falls out of `sequence_elem` returning `None` for a `Ref` kind, not out of the `mutable: false` guard — that guard is what refuses `&mut [T]`.

## The fixture is the load-bearing part

`slice_id_sum(ps: &[Payload])` and `ref_vec_id_sum(ps: &Vec<Payload>)` — a matched pair, so the Kotlin exercise can weigh them against each other rather than each against a literal. `ref_vec_id_sum` carries a deliberate `#[allow(clippy::ptr_arg)]`: clippy is right that `&Vec` should be `&[_]`, and that is exactly what makes it a fixture, the same way the `boxed_*` family carries `#[allow(clippy::boxed_local)]`.

**A lib test cannot catch this.** It emits tokens and never compiles them. Only covertest's `include!`d binding can, which is why the fixture is declared there and why it is the real acceptance:

```
error[E0308]: mismatched types
  --> examples/covertest-kotlin/src/generated_bindings.rs:17830:47
   |    ----------------------------- ^^ expected `&Vec<Payload>`, found `&[Payload]`
error: could not compile `covertest-kotlin` (lib) due to 1 previous error
```

That is with the ascription restored and nothing else changed — measured, then restored.

## Verified

- `cargo test --all --all-features` — 596 passed, 0 failed.
- **The fixture bites**: the E0308 above.
- `examples/regen-check.sh` after `cargo clean --release` — the pre-existing movement is exactly two lines, both `storage_put_slice` losing their ascription (`covertest-kotlin` and `perftest-kotlin`), plus the new fixtures' own output. `example_flat_aarch64.{rs,h}` did not drift.
- `examples/covertest-kotlin$ ./gradlew run` — `PASS`, 49 sections, with the new pair agreeing at runtime.
- `cargo fmt --check` with the CI config; clippy `-D warnings` clean on **both** 1.85.0 and stable.

## Note

Based on `main`, not stacked on #383 — this repo squash-merges, which orphans stacked branches. The two touch adjacent lines in the same arm, so whichever lands second wants a trivial rebase.