### PR TITLE
Close a handle by where it sits, not by how the field is spelled (#218)

### DIFF
--- a/docs/sum-types.md
+++ b/docs/sum-types.md
@@ -314,7 +314,12 @@ the alternatives is emitted **once**, in the sum, and every position that holds 
   (close-unless-taken: a no-op if the receiver `take()`-ed the payload) — as a plan-less
   `impl Fn(Handle)` argument is;
 - a sum held in a **data-class field** is closed by the container's own `close()` cascade — as a
-  handle-typed field is.
+  handle-typed field is;
+- an **element of a fold** (`fold(acc) { acc, element -> … }` over a sequence of such values) is a
+  callback argument like any other, so it is closed after each `run` — which means a folder that
+  accumulates its elements (`{ acc, e -> acc + e }`, the most natural body there is) accumulates
+  closed handles unless it `take()`s each one. This is the same rule, but it is **not** a sum-only
+  rule: it applies to any element type that reaches a handle, a nested `data_class` included.
 
 The three positions agree, which is the point, and the agreement is now with the *bare handle* in
 each of them rather than only with each other. Before #218 a sum payload took `WrapKind::Handle` and
@@ -326,9 +331,14 @@ derivation, that difference could never have been a deliberate contract.
 The same rule reaches a handle held through a **nested data class**, which had the identical gap and
 no issue of its own.
 
-Two of the three are exercised on the JVM in `examples/covertest-kotlin` ("sum return with a handle
-payload", "sum with a handle payload delivered to a callback"); the latter asserts the payload is
-usable inside `run`, closed once `run` returns, and kept alive across the boundary by `take()`.
+Every row is exercised on the JVM in `examples/covertest-kotlin`: "sum return with a handle
+payload", "sum with a handle payload delivered to a callback" (which asserts the payload is usable
+inside `run`, closed once `run` returns, and kept alive across the boundary by `take()`), "a
+data-class field reaching a handle through a sum cascades", and "…through a nested data class
+cascades". The last one earns its place by *compiling*: its container's cascade is a one-line
+`holder.close()` that frees something only because the inner class was independently rendered
+`AutoCloseable`, and an emission test — which never compiles the inner class — cannot tell the
+difference.
 
 **A borrowed sum return (`&E`, `Option<&E>`) crosses like an owned one.** `unfold::returns_type`
 peels the leading `&` and `wire_fixed_returns` records `by_ref`, so the encoder matches *through*

--- a/docs/sum-types.md
+++ b/docs/sum-types.md
@@ -185,9 +185,9 @@ public data class RecoveryConfig(val mode: RecoveryMode?, val retentionPeriod: L
 ### 4.3 Output path (Rust → Kotlin)
 
 `PlanFieldKind::Sum { tag_slot, variants }` joins the shared bridge plan
-(`prebindgen/src/api/lang/jnigen/jni/struct_plan.rs`). The Rust encoder emits **one `match`**
+(`prebindgen-jni/src/jni/struct_plan.rs`). The Rust encoder emits **one `match`**
 binding the tag and every slot, inert slots filled by the existing
-`primitive_default_for_descriptor` (`prebindgen/src/api/lang/jnigen/jni/emit/struct_out.rs:51`):
+`primitive_default_for_descriptor` (`prebindgen-jni/src/jni/emit/struct_out.rs`):
 
 ```rust
 let (mode__present, mode__tag, mode_periodic_queries_period) = match &v.mode {
@@ -204,7 +204,7 @@ for the sum, and both sides enumerate the same slots in the same order because b
 ### 4.4 Input path (Kotlin → Rust)
 
 `FlatFieldNode::Sum` joins `Value` / `Nested`
-(`prebindgen/src/api/lang/jnigen/jni/emit/flat_input.rs:349`), and `FlatInputPlan.root` generalizes
+(`prebindgen-jni/src/jni/emit/flat_input.rs`), and `FlatInputPlan.root` generalizes
 from `FlatStructNode` to a struct-or-sum root so a **sum-typed parameter** flattens too. Extern
 signature:
 
@@ -303,21 +303,32 @@ re-asserted inside its own live arm. Primitive slots keep their `0`/`false` defa
 handle payload rides its raw `jlong`, so an inert handle group is the `0L` sentinel that is simply
 never wrapped.
 
-**Who closes a handle payload: the receiver, in both positions.** A sum payload is a plan **leaf**,
-so it takes `WrapKind::Handle` — the generated code wraps the pointer into its typed handle class
-and stops there. It does *not* take the `WrapKind::HandleOwned` contract that a plan-less
-`impl Fn(Handle)` argument gets, where the proxy also `close()`s the handle in a `finally`
-(close-unless-taken). So:
+**Who closes a handle payload: whoever would close a bare handle in the same position.** A sum that
+reaches an owned handle is itself `AutoCloseable` — the generated `sealed interface` declares it and
+each variant class overrides `close()`, closing its own payload or doing nothing. So the `when` over
+the alternatives is emitted **once**, in the sum, and every position that holds one just calls
+`close()`:
 
-- a **returned** sum hands over a handle the caller owns and must `close()`;
-- a sum delivered to a **callback** does the same — the handle is live for the duration of `run` and
-  stays live after it returns, and closing it is the receiver's job.
+- a **returned** sum hands over a value the caller owns and must `close()` — as a returned handle does;
+- a sum delivered to a **callback** is closed by the `asRaw` proxy in a `finally` after `run`
+  (close-unless-taken: a no-op if the receiver `take()`-ed the payload) — as a plan-less
+  `impl Fn(Handle)` argument is;
+- a sum held in a **data-class field** is closed by the container's own `close()` cascade — as a
+  handle-typed field is.
 
-The two positions agree, which is the point: the reassembly comes from one derivation, so the
-ownership contract cannot differ between them. Both are exercised on the JVM in
-`examples/covertest-kotlin` ("sum return with a handle payload", "sum with a handle payload
-delivered to a callback"), the latter asserting the handle is usable inside `run` and still
-closeable afterwards.
+The three positions agree, which is the point, and the agreement is now with the *bare handle* in
+each of them rather than only with each other. Before #218 a sum payload took `WrapKind::Handle` and
+stopped there, so in the callback and data-class positions the handle was the receiver's to close
+while the same handle passed directly was not — ownership moved when a field or argument changed
+spelling, with nothing in the generated Kotlin saying so. Since the reassembly comes from one
+derivation, that difference could never have been a deliberate contract.
+
+The same rule reaches a handle held through a **nested data class**, which had the identical gap and
+no issue of its own.
+
+Two of the three are exercised on the JVM in `examples/covertest-kotlin` ("sum return with a handle
+payload", "sum with a handle payload delivered to a callback"); the latter asserts the payload is
+usable inside `run`, closed once `run` returns, and kept alive across the boundary by `take()`.
 
 **A borrowed sum return (`&E`, `Option<&E>`) crosses like an owned one.** `unfold::returns_type`
 peels the leading `&` and `wire_fixed_returns` records `by_ref`, so the encoder matches *through*

--- a/examples/covertest-kotlin/build.rs
+++ b/examples/covertest-kotlin/build.rs
@@ -239,8 +239,15 @@ fn main() {
                 .class(sealed_class!(Reading).variant(variant!(Labeled).name("Tagged")))
                 // `Lookup` is the sum in RETURN position whose groups own
                 // resources: one alternative carries an opaque handle, one
-                // carries nothing at all.
+                // carries nothing at all. Because it reaches an owned handle it
+                // is emitted `AutoCloseable`, and each variant class overrides
+                // `close()` — that is what lets a container cascade into it
+                // with the same one-liner a handle field gets (#218).
                 .class(sealed_class!(Lookup))
+                // …and `Verdict` is that container: the sum in DATA-CLASS FIELD
+                // position, the third place a handle is reached through.
+                // `Holder` above is the plain-handle field it must match.
+                .class(data_class!(Verdict))
                 // `Report`'s output boundary is DERIVED from its value form
                 // (`.fields_self_into(fields!(report_into_struct))` below) instead of
                 // being restated field by field — #213. The form it names is
@@ -517,6 +524,9 @@ fn main() {
                 // handle-carrying sum arriving through a CALLBACK, and a sum
                 // returned BORROWED (`&E` / `Option<&E>`).
                 .fun(fun!(lookup_each))
+                // #218: the same handle reached through a data-class FIELD, so
+                // the JVM harness can assert the container's cascade closes it.
+                .fun(fun!(verdict_new))
                 // #213: the output boundary DERIVED from the type's value form
                 // rather than restated. `report_each` delivers the decomposed
                 // `Report` in one crossing; the leaf list comes from

--- a/examples/covertest-kotlin/build.rs
+++ b/examples/covertest-kotlin/build.rs
@@ -212,6 +212,12 @@ fn main() {
         // inside the presence gate or `null` becomes a binding error instead of
         // `None` (PR#294 review).
         .package(package!().class(data_class!(Holder)))
+        // #218's last row: a data class that only REACHES a handle, through
+        // another data class. `Dossier`'s cascade is a one-liner that assumes
+        // `Holder` above was independently made `AutoCloseable` — the JVM
+        // harness is what ties the two decisions together, since an emission
+        // test never compiles the inner class.
+        .package(package!().class(data_class!(Dossier)))
         // A data class whose FIELDS carry transparent wrappers (#289 + #292):
         // `boxed: Box<Option<i64>>` must cross exactly as `plain: Option<i64>`
         // does — the decoupled `(present, value)` pair — with the `Box` put back
@@ -527,6 +533,9 @@ fn main() {
                 // #218: the same handle reached through a data-class FIELD, so
                 // the JVM harness can assert the container's cascade closes it.
                 .fun(fun!(verdict_new))
+                // …and reached one level deeper still, through a nested data
+                // class rather than a sum.
+                .fun(fun!(dossier_new))
                 // #213: the output boundary DERIVED from the type's value form
                 // rather than restated. `report_each` delivers the decomposed
                 // `Report` in one crossing; the leaf list comes from

--- a/examples/covertest-kotlin/kotlin/REPORT.md
+++ b/examples/covertest-kotlin/kotlin/REPORT.md
@@ -74,6 +74,7 @@ Base package: `io.prebindgen.covertest`
 - `boxed_run_id_sum` — `fun boxedRunIdSum(ps: List<Payload>, onError: JniErrorHandler<Long>): Long`
 - `cache_config_weight` — `fun cacheConfigWeight(cache: CacheConfig?, onError: JniErrorHandler<Int>): Int`
 - `celsius_double` — `fun celsiusDouble(c: Int, onError: JniErrorHandler<Int>): Int`
+- `dossier_new` — `fun dossierNew(note: Long, tag: Long, count: Long, total: Double, onError: JniErrorHandler<Dossier>): Dossier`
 - `duration_boundary_echo` — `fun durationBoundaryEcho(value: DurationBoundary, onError: JniErrorHandler<DurationBoundary>): DurationBoundary`
   - shaped by: return `DurationBoundary` decomposed → [required, delay] (Callback delivery)
 - `duration_emit` — `fun durationEmit(value: ULong, f: DurationCallback, onError: JniErrorHandler<Unit>)`
@@ -197,6 +198,7 @@ Base package: `io.prebindgen.covertest`
 - `Arrays`: data_class → `io.prebindgen.covertest.model.Arrays` (wire `jni :: objects :: JObject`)
 - `BlobValue`: data_class → `io.prebindgen.covertest.model.BlobValue` (wire `jni :: objects :: JObject`, input `JObject` opt-in)
 - `CacheConfig`: data_class → `io.prebindgen.covertest.model.CacheConfig` (wire `jni :: objects :: JObject`)
+- `Dossier`: data_class → `io.prebindgen.covertest.Dossier` (wire `jni :: objects :: JObject`)
 - `DurationBoundary`: data_class → `io.prebindgen.covertest.model.DurationBoundary` (wire `jni :: objects :: JObject`, input `JObject` opt-in)
 - `EscapeProbe`: ptr_class → `io.prebindgen.covertest.esc_pkg.Esc_Probe` (wire `jni :: sys :: jlong`)
 - `Hold`: sealed_class → `io.prebindgen.covertest.model.Hold` (wire `?`)

--- a/examples/covertest-kotlin/kotlin/REPORT.md
+++ b/examples/covertest-kotlin/kotlin/REPORT.md
@@ -124,6 +124,7 @@ Base package: `io.prebindgen.covertest`
   - shaped by: return `Unsigned` decomposed → [byte, short, int, long, maybeLong] (Callback delivery)
 - `unsigned_series` — `fun unsignedSeries(onError: JniErrorHandler<List<ULong>>): List<ULong>`
   - shaped by: return `u64` decomposed → [] (Callback delivery)
+- `verdict_new` — `fun verdictNew(id: Long, count: Long, total: Double, onError: JniErrorHandler<Verdict>): Verdict`
 - `wrapped_fields_sum` — `fun wrappedFieldsSum(w: WrappedFields, onError: JniErrorHandler<Long>): Long`
 
 ## package `io.prebindgen.covertest.storage`
@@ -227,6 +228,7 @@ Base package: `io.prebindgen.covertest`
 - `Summary`: ptr_class → `io.prebindgen.covertest.analytics.Summary` (wire `jni :: sys :: jlong`)
 - `Tagged`: data_class → `io.prebindgen.covertest.model.Tagged` (wire `jni :: objects :: JObject`)
 - `Unsigned`: data_class → `io.prebindgen.covertest.model.Unsigned` (wire `jni :: objects :: JObject`)
+- `Verdict`: data_class → `io.prebindgen.covertest.model.Verdict` (wire `jni :: objects :: JObject`)
 - `WrappedFields`: data_class → `io.prebindgen.covertest.WrappedFields` (wire `jni :: objects :: JObject`)
 
 ## conversions

--- a/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest.kt
+++ b/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest.kt
@@ -160,6 +160,29 @@ internal inline fun <R> withSortedHandleLocks(
 }
 
 /**
+ * The **fourth** position, and the last row of the same table: a `data_class`
+ * field whose type is another `data_class` that carries the handle. Nothing
+ * here is a handle and nothing here is a sum — `Dossier` only *reaches* one,
+ * two levels down, and must still close it (#218).
+ *
+ * The cascade this emits is one line, `holder.close()`, which is correct only
+ * because [`Holder`] was independently rendered `AutoCloseable` by its own
+ * pass. An emission test cannot tell: it never compiles the inner class. This
+ * one is exercised from the JVM harness, where a `Dossier` that closed
+ * nothing, or an inner class without a `close()` to call, does not build.
+ */
+public data class Dossier(val note: Long, val holder: Holder) : AutoCloseable {
+    override fun close() {
+        holder.close()
+    }
+
+    public companion object {
+        @JvmStatic
+        public fun fromParts(note: Long, holder_tag: Long, holder_summary: Long): Dossier = Dossier(note, Holder.fromParts(holder_tag, holder_summary))
+    }
+}
+
+/**
  * An `Option<data class>` whose data class has a **required handle** field.
  *
  * The shape that proves an optional node's field decodes stay **inside** its
@@ -516,27 +539,30 @@ public fun LedgerCallback.asRaw(): LedgerCallbackRaw =
         ledgerArchived__outcome__failed_v0,
         ledgerArchived__label ->
         val __own0 = when (ledgerFiled__outcome__tag) { null -> null; 0 -> Lookup.Absent; 1 -> Lookup.Found(Summary(ledgerFiled__outcome__found_v0!!)); 2 -> Lookup.Failed(ledgerFiled__outcome__failed_v0!!); else -> throw IllegalArgumentException("Lookup: invalid tag $ledgerFiled__outcome__tag") }
-        val __own1 = when (ledgerArchived__outcome__tag) { null -> null; 0 -> Lookup.Absent; 1 -> Lookup.Found(Summary(ledgerArchived__outcome__found_v0!!)); 2 -> Lookup.Failed(ledgerArchived__outcome__failed_v0!!); else -> throw IllegalArgumentException("Lookup: invalid tag $ledgerArchived__outcome__tag") }
         try {
-            run(
-                ledgerFiled__summary__count,
-                ledgerFiled__summary__total,
-                ledgerFiled__taken,
-                ledgerFiled__origin__secs,
-                ledgerFiled__origin__nanos,
-                __own0,
-                ledgerFiled__label,
-                ledgerArchived__summary__count,
-                ledgerArchived__summary__total,
-                ledgerArchived__taken,
-                ledgerArchived__origin__secs,
-                ledgerArchived__origin__nanos,
-                __own1,
-                ledgerArchived__label,
-            )
+            val __own1 = when (ledgerArchived__outcome__tag) { null -> null; 0 -> Lookup.Absent; 1 -> Lookup.Found(Summary(ledgerArchived__outcome__found_v0!!)); 2 -> Lookup.Failed(ledgerArchived__outcome__failed_v0!!); else -> throw IllegalArgumentException("Lookup: invalid tag $ledgerArchived__outcome__tag") }
+            try {
+                run(
+                    ledgerFiled__summary__count,
+                    ledgerFiled__summary__total,
+                    ledgerFiled__taken,
+                    ledgerFiled__origin__secs,
+                    ledgerFiled__origin__nanos,
+                    __own0,
+                    ledgerFiled__label,
+                    ledgerArchived__summary__count,
+                    ledgerArchived__summary__total,
+                    ledgerArchived__taken,
+                    ledgerArchived__origin__secs,
+                    ledgerArchived__origin__nanos,
+                    __own1,
+                    ledgerArchived__label,
+                )
+            } finally {
+                __own1?.close()
+            }
         } finally {
             __own0?.close()
-            __own1?.close()
         }
     }
 
@@ -997,6 +1023,14 @@ internal object CovNative {
     external fun celsiusDouble(c: Int, errorSink: Any): Int
 
     external fun coverTagRuntime(errorSink: Any): String
+
+    external fun dossierNew(
+        note: Long,
+        tag: Long,
+        count: Long,
+        total: Double,
+        errorSink: Any,
+    ): Dossier
 
     external fun durationBoundaryEcho(value: DurationBoundary, build: Any, errorSink: Any): Any?
 

--- a/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest.kt
+++ b/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest.kt
@@ -14,6 +14,7 @@ import io.prebindgen.covertest.model.Observation
 import io.prebindgen.covertest.model.Priority
 import io.prebindgen.covertest.model.Stamp
 import io.prebindgen.covertest.model.Tagged
+import io.prebindgen.covertest.model.Verdict
 import java.lang.ref.Cleaner
 import java.lang.ref.Cleaner.Cleanable
 import java.util.concurrent.atomic.AtomicLong
@@ -514,22 +515,29 @@ public fun LedgerCallback.asRaw(): LedgerCallbackRaw =
         ledgerArchived__outcome__found_v0,
         ledgerArchived__outcome__failed_v0,
         ledgerArchived__label ->
-        run(
-            ledgerFiled__summary__count,
-            ledgerFiled__summary__total,
-            ledgerFiled__taken,
-            ledgerFiled__origin__secs,
-            ledgerFiled__origin__nanos,
-            when (ledgerFiled__outcome__tag) { null -> null; 0 -> Lookup.Absent; 1 -> Lookup.Found(Summary(ledgerFiled__outcome__found_v0!!)); 2 -> Lookup.Failed(ledgerFiled__outcome__failed_v0!!); else -> throw IllegalArgumentException("Lookup: invalid tag $ledgerFiled__outcome__tag") },
-            ledgerFiled__label,
-            ledgerArchived__summary__count,
-            ledgerArchived__summary__total,
-            ledgerArchived__taken,
-            ledgerArchived__origin__secs,
-            ledgerArchived__origin__nanos,
-            when (ledgerArchived__outcome__tag) { null -> null; 0 -> Lookup.Absent; 1 -> Lookup.Found(Summary(ledgerArchived__outcome__found_v0!!)); 2 -> Lookup.Failed(ledgerArchived__outcome__failed_v0!!); else -> throw IllegalArgumentException("Lookup: invalid tag $ledgerArchived__outcome__tag") },
-            ledgerArchived__label
-        )
+        val __own0 = when (ledgerFiled__outcome__tag) { null -> null; 0 -> Lookup.Absent; 1 -> Lookup.Found(Summary(ledgerFiled__outcome__found_v0!!)); 2 -> Lookup.Failed(ledgerFiled__outcome__failed_v0!!); else -> throw IllegalArgumentException("Lookup: invalid tag $ledgerFiled__outcome__tag") }
+        val __own1 = when (ledgerArchived__outcome__tag) { null -> null; 0 -> Lookup.Absent; 1 -> Lookup.Found(Summary(ledgerArchived__outcome__found_v0!!)); 2 -> Lookup.Failed(ledgerArchived__outcome__failed_v0!!); else -> throw IllegalArgumentException("Lookup: invalid tag $ledgerArchived__outcome__tag") }
+        try {
+            run(
+                ledgerFiled__summary__count,
+                ledgerFiled__summary__total,
+                ledgerFiled__taken,
+                ledgerFiled__origin__secs,
+                ledgerFiled__origin__nanos,
+                __own0,
+                ledgerFiled__label,
+                ledgerArchived__summary__count,
+                ledgerArchived__summary__total,
+                ledgerArchived__taken,
+                ledgerArchived__origin__secs,
+                ledgerArchived__origin__nanos,
+                __own1,
+                ledgerArchived__label,
+            )
+        } finally {
+            __own0?.close()
+            __own1?.close()
+        }
     }
 
 public fun interface StorageCallback {
@@ -1336,6 +1344,8 @@ internal object CovNative {
     ): Any?
 
     external fun unsignedSeries(acc: Any?, fold: Any, errorSink: Any): Any?
+
+    external fun verdictNew(id: Long, count: Long, total: Double, errorSink: Any): Verdict
 
     external fun wrappedFieldsSum(
         wId: Long,

--- a/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest/model.kt
+++ b/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest/model.kt
@@ -2,6 +2,7 @@
 package io.prebindgen.covertest.model
 
 import io.prebindgen.covertest.CovNative
+import io.prebindgen.covertest.Dossier
 import io.prebindgen.covertest.DurationCallback
 import io.prebindgen.covertest.Holder
 import io.prebindgen.covertest.JniErrorHandler
@@ -1603,6 +1604,20 @@ public fun verdictNew(
 ): Verdict {
     val __bcap = JniErrorHandlerCapture.acquire()
     val __ret = CovNative.verdictNew(id, count, total, __bcap)
+    if (__bcap.failed) return onError.run(__bcap.ze0)
+    return __ret
+}
+
+/** Build a [`Dossier`] over a fresh [`Summary`] — the two-level container. */
+public fun dossierNew(
+    note: Long,
+    tag: Long,
+    count: Long,
+    total: Double,
+    onError: JniErrorHandler<Dossier>,
+): Dossier {
+    val __bcap = JniErrorHandlerCapture.acquire()
+    val __ret = CovNative.dossierNew(note, tag, count, total, __bcap)
     if (__bcap.failed) return onError.run(__bcap.ze0)
     return __ret
 }

--- a/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest/model.kt
+++ b/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest/model.kt
@@ -80,19 +80,31 @@ public sealed interface Hold {
  * is never wrapped.
  *
  * JVM-side surface for the native Rust `Lookup` sum: exactly one alternative is live.
+ *
+ * The live alternative may carry a native handle, so this value is `AutoCloseable`: closing it closes whatever the live alternative holds, and is a no-op for the alternatives that hold nothing native.
  */
-public sealed interface Lookup {
+public sealed interface Lookup : AutoCloseable {
     /** Nothing matched — only the tag is live. */
-    public data object Absent : Lookup
+    public data object Absent : Lookup {
+        override fun close() {
+        }
+    }
 
     /** What matched, as a handle the caller owns (and must close). */
-    public data class Found(public val v0: Summary) : Lookup
+    public data class Found(public val v0: Summary) : Lookup {
+        override fun close() {
+            v0.close()
+        }
+    }
 
     /**
      * Why the lookup could not run — a `String` beside the handle group, so an
      * inert object slot is exercised alongside an inert primitive one.
      */
-    public data class Failed(public val v0: String) : Lookup
+    public data class Failed(public val v0: String) : Lookup {
+        override fun close() {
+        }
+    }
 
     public companion object {
         @JvmStatic
@@ -864,6 +876,30 @@ public data class Unsigned(val byte: Int, val short: Int, val int: Long, val lon
     }
 }
 
+/**
+ * The **third** position a handle can be reached through: a `data_class` field
+ * whose type is a handle-carrying sum. `Holder` covers the plain-handle field
+ * beside it, and the point of this one is that the two behave alike — the
+ * container is `AutoCloseable` and its `close()` cascades either way, because
+ * the field's type is an implementation detail and must not decide who frees
+ * the handle (#218).
+ */
+public data class Verdict(val id: Long, val outcome: Lookup) : AutoCloseable {
+    override fun close() {
+        outcome.close()
+    }
+
+    public companion object {
+        @JvmStatic
+        public fun fromParts(
+            id: Long,
+            outcome__tag: Int,
+            outcome_found_v0: Long,
+            outcome_failed_v0: String?,
+        ): Verdict = Verdict(id, when (outcome__tag) { 0 -> Lookup.Absent; 1 -> Lookup.Found(Summary(outcome_found_v0)); 2 -> Lookup.Failed(outcome_failed_v0!!); else -> throw IllegalArgumentException("Lookup: invalid tag $outcome__tag") })
+    }
+}
+
 /** Typed handle for a native Zenoh `Report`. */
 public class Report(initialPtr: Long) : NativeHandle(initialPtr) {
     @Synchronized
@@ -901,9 +937,12 @@ public fun LookupCallback.asRaw(): LookupCallbackRaw =
         tag,
         found_v0,
         failed_v0 ->
-        run(
-            when (tag) { 0 -> Lookup.Absent; 1 -> Lookup.Found(Summary(found_v0)); 2 -> Lookup.Failed(failed_v0!!); else -> throw IllegalArgumentException("Lookup: invalid tag $tag") }
-        )
+        val __own0 = when (tag) { 0 -> Lookup.Absent; 1 -> Lookup.Found(Summary(found_v0)); 2 -> Lookup.Failed(failed_v0!!); else -> throw IllegalArgumentException("Lookup: invalid tag $tag") }
+        try {
+            run(__own0)
+        } finally {
+            __own0.close()
+        }
     }
 
 public fun interface ReadingCallback {
@@ -973,15 +1012,12 @@ public fun ReportCallback.asRaw(): ReportCallbackRaw =
         outcome__found_v0,
         outcome__failed_v0,
         label ->
-        run(
-            summary__count,
-            summary__total,
-            taken,
-            origin__secs,
-            origin__nanos,
-            when (outcome__tag) { 0 -> Lookup.Absent; 1 -> Lookup.Found(Summary(outcome__found_v0)); 2 -> Lookup.Failed(outcome__failed_v0!!); else -> throw IllegalArgumentException("Lookup: invalid tag $outcome__tag") },
-            label
-        )
+        val __own0 = when (outcome__tag) { 0 -> Lookup.Absent; 1 -> Lookup.Found(Summary(outcome__found_v0)); 2 -> Lookup.Failed(outcome__failed_v0!!); else -> throw IllegalArgumentException("Lookup: invalid tag $outcome__tag") }
+        try {
+            run(summary__count, summary__total, taken, origin__secs, origin__nanos, __own0, label)
+        } finally {
+            __own0.close()
+        }
     }
 
 public fun interface ArraysBuilder<out R> {
@@ -1547,14 +1583,28 @@ public fun lookupOf(count: Long, total: Double, onError: JniErrorHandler<Lookup>
  * delivered in `count` order starting at `-1`, so `n >= 3` covers all three:
  * `Failed` (`i = 0`), `Absent` (`i = 1`), then `Found` with an increasing
  * count. A live group hands a native resource to the callback while the inert
- * groups' slots stay defaulted. A sum payload is a plan LEAF, so the handle is wrapped
- * but not closed by the proxy: it is the callback body's to close, exactly as
- * for a returned sum.
+ * groups' slots stay defaulted. The proxy closes the reassembled value after
+ * `run` returns — close-unless-taken, exactly as for a handle passed directly
+ * to a callback (#218), so a body that means to outlive the call must `take()`
+ * the payload.
  */
 public fun lookupEach(n: Long, total: Double, sink: LookupCallback, onError: JniErrorHandler<Unit>) {
     val __bcap = JniErrorHandlerCapture.acquire()
     CovNative.lookupEach(n, total, sink.asRaw(), __bcap)
     if (__bcap.failed) return onError.run(__bcap.ze0)
+}
+
+/** Build a [`Verdict`] whose outcome comes from [`lookup_of`]. */
+public fun verdictNew(
+    id: Long,
+    count: Long,
+    total: Double,
+    onError: JniErrorHandler<Verdict>,
+): Verdict {
+    val __bcap = JniErrorHandlerCapture.acquire()
+    val __ret = CovNative.verdictNew(id, count, total, __bcap)
+    if (__bcap.failed) return onError.run(__bcap.ze0)
+    return __ret
 }
 
 /**

--- a/examples/covertest-kotlin/kotlin/io/prebindgen/covertest/Test.kt
+++ b/examples/covertest-kotlin/kotlin/io/prebindgen/covertest/Test.kt
@@ -84,6 +84,7 @@ import io.prebindgen.covertest.model.ledgerEach
 import io.prebindgen.covertest.model.ledgerNew
 import io.prebindgen.covertest.model.reportEach
 import io.prebindgen.covertest.model.lookupOf
+import io.prebindgen.covertest.model.verdictNew
 import io.prebindgen.covertest.model.archiveReading
 import io.prebindgen.covertest.model.archiveReadingMaybe
 import io.prebindgen.covertest.model.archiveSetReading
@@ -559,14 +560,14 @@ fun main() {
     }
 
     // The same handle-carrying sum arriving through a CALLBACK rather than as a
-    // return. A sum payload is a plan LEAF, so the generated proxy WRAPS the
-    // pointer but does not `close()` it — unlike a plan-less `impl Fn(Handle)`
-    // arg, which closes in a `finally`. So the handle is live for as long as the
-    // receiver keeps it and is the caller's to close, exactly as for a returned
-    // sum. That contract is what this pins (#161).
+    // return. The proxy binds the reassembled value to a local and `close()`s it
+    // in a `finally` after `run` — the SAME close-unless-taken contract a
+    // plan-less `impl Fn(Handle)` arg has always had, so the payload's lifetime
+    // does not depend on whether it arrived bare or inside a sum (#218,
+    // originally pinned the other way by #161).
     section("sum with a handle payload delivered to a callback") {
         val seen = mutableListOf<String>()
-        val kept = mutableListOf<Summary>()
+        val escaped = mutableListOf<Summary>()
         lookupEach(3L, 2.5, { lookup ->
             when (lookup) {
                 is Lookup.Failed -> seen.add("failed:${lookup.v0}")
@@ -578,20 +579,56 @@ fun main() {
                     check(!s.isClosed())
                     check(s.total(boom) == 2.5)
                     seen.add("found:${s.count(boom)}")
-                    kept.add(s)
+                    escaped.add(s)
                 }
             }
         }, boom)
         check(seen == listOf("failed:negative count", "absent", "found:1"))
 
-        // Still live AFTER the call returns — the proxy did not close it — and
-        // closeable by the receiver that kept it.
+        // Closed once `run` returned: a body that merely kept the reference gets
+        // a closed handle, which is exactly what the bare-handle arg does.
+        check(escaped.size == 1)
+        check(escaped[0].isClosed())
+
+        // `take()` is how a body means to outlive the call — it moves the
+        // pointer out, so the proxy's `close()` finds nothing to free.
+        val kept = mutableListOf<Summary>()
+        lookupEach(3L, 4.0, { lookup ->
+            if (lookup is Lookup.Found) kept.add(lookup.v0.take())
+        }, boom)
         check(kept.size == 1)
         val s = kept[0]
         check(!s.isClosed())
         check(s.count(boom) == 1L)
         s.close()
         check(s.isClosed())
+    }
+
+    // The THIRD position the same handle can be reached through: a data-class
+    // FIELD whose type is the sum. `Holder` (a plain handle field) and `Verdict`
+    // (a sum field) must behave alike — that is the whole of #218. The container
+    // is `AutoCloseable` either way and its `close()` cascades either way; the
+    // walk into the alternatives lives in `Lookup`, not in `Verdict`.
+    section("a data-class field reaching a handle through a sum cascades") {
+        val v = verdictNew(7L, 3L, 1.5, boom)
+        check(v.id == 7L)
+        val found = v.outcome
+        check(found is Lookup.Found)
+        val summary = (found as Lookup.Found).v0
+        check(!summary.isClosed())
+        check(summary.count(boom) == 3L)
+
+        // Closing the CONTAINER closes the handle the sum holds — no
+        // `(v.outcome as Lookup.Found).v0.close()` at the call site.
+        v.close()
+        check(summary.isClosed())
+
+        // …and an alternative owning nothing native closes to a no-op, so the
+        // cascade is safe for every value of the field, not just the live-handle
+        // one.
+        val absent = verdictNew(8L, 0L, 0.0, boom)
+        check(absent.outcome === Lookup.Absent)
+        absent.close()
     }
 
     // An output boundary DERIVED from the type's value form
@@ -693,8 +730,9 @@ fun main() {
                 "an absent report must reconstruct its sum as null, not as a variant"
             }
             check((aOutcome == null) == (aLabel == null))
-            (fOutcome as? Lookup.Found)?.v0?.close()
-            (aOutcome as? Lookup.Found)?.v0?.close()
+            // No `(fOutcome as? Lookup.Found)?.v0?.close()` here any more: an
+            // OPTIONAL sum arg is closed by the proxy too, under the `?.` its
+            // nullability earns (#218).
             seen.add("${fLabel ?: "-"}|${aLabel ?: "-"}")
         }, boom)
         check(seen == listOf("-|-", "l1|-", "-|l2", "l1|l2")) {

--- a/examples/covertest-kotlin/kotlin/io/prebindgen/covertest/Test.kt
+++ b/examples/covertest-kotlin/kotlin/io/prebindgen/covertest/Test.kt
@@ -85,6 +85,7 @@ import io.prebindgen.covertest.model.ledgerNew
 import io.prebindgen.covertest.model.reportEach
 import io.prebindgen.covertest.model.lookupOf
 import io.prebindgen.covertest.model.verdictNew
+import io.prebindgen.covertest.model.dossierNew
 import io.prebindgen.covertest.model.archiveReading
 import io.prebindgen.covertest.model.archiveReadingMaybe
 import io.prebindgen.covertest.model.archiveSetReading
@@ -629,6 +630,26 @@ fun main() {
         val absent = verdictNew(8L, 0L, 0.0, boom)
         check(absent.outcome === Lookup.Absent)
         absent.close()
+    }
+
+    // The FOURTH position, and the row an emission test cannot cover: the field
+    // is a plain data class that itself carries the handle. `Dossier`'s cascade
+    // is the one-liner `holder.close()`, which only frees anything because
+    // `Holder` was independently rendered `AutoCloseable` by its own pass —
+    // two decisions, in two places, that nothing but a compiled run ties
+    // together. This section IS that tie: it would not compile if `Holder` had
+    // no `close()`, and the last check fails if `Dossier` had none.
+    section("a data-class field reaching a handle through a nested data class cascades") {
+        val d = dossierNew(5L, 3L, 4L, 2.0, boom)
+        check(d.note == 5L)
+        check(d.holder.tag == 3L)
+        val summary = d.holder.summary
+        check(!summary.isClosed())
+        check(summary.count(boom) == 4L)
+
+        // Two levels down, closed by one `close()` at the top.
+        d.close()
+        check(summary.isClosed())
     }
 
     // An output boundary DERIVED from the type's value form

--- a/examples/covertest-kotlin/src/generated_bindings.rs
+++ b/examples/covertest-kotlin/src/generated_bindings.rs
@@ -3607,6 +3607,44 @@ pub(crate) unsafe fn JObject_to_Vec_Vec_u8_43404875<'env, 'v>(
     clippy::nonminimal_bool,
     clippy::eq_op
 )]
+pub(crate) unsafe fn JObject_to_Verdict_a94c1ffd<'env, 'v>(
+    env: &mut jni::JNIEnv<'env>,
+    v: &jni::objects::JObject<'v>,
+) -> ::core::result::Result<perftest_flat::Verdict, __JniErr> {
+    Ok({
+        let __id_raw: jni::sys::jlong = env
+            .get_field(v, "id", "J")
+            .and_then(|val| val.j())
+            .map_err(|e| <__JniErr as ::core::convert::From<
+                String,
+            >>::from(format!("Verdict.id: {}", e)))? as _;
+        let id = jlong_to_i64_fbf9a9bc(env, &__id_raw)?;
+        let __outcome_raw: jni::objects::JObject = env
+            .get_field(v, "outcome", "Lio/prebindgen/covertest/model/Lookup;")
+            .and_then(|val| val.l())
+            .map_err(|e| <__JniErr as ::core::convert::From<
+                String,
+            >>::from(format!("Verdict.outcome: {}", e)))?;
+        let outcome = JObject_to_Lookup_94ada15e(env, &__outcome_raw)?;
+        perftest_flat::Verdict {
+            id,
+            outcome,
+        }
+    })
+}
+#[allow(
+    non_snake_case,
+    unused_mut,
+    unused_variables,
+    unused_braces,
+    unused_parens,
+    dead_code,
+    clippy::useless_conversion,
+    clippy::needless_question_mark,
+    clippy::let_and_return,
+    clippy::nonminimal_bool,
+    clippy::eq_op
+)]
 pub(crate) unsafe fn JObject_to_WrappedFields_f14f08c1<'env, 'v>(
     env: &mut jni::JNIEnv<'env>,
     v: &jni::objects::JObject<'v>,
@@ -9544,6 +9582,73 @@ pub(crate) unsafe fn Vec_u8_to_JByteArray_7936d5de<'a>(
                     String,
                 >>::from(format!("encode_byte_array: {}", e))
             })?
+    })
+}
+#[allow(
+    non_snake_case,
+    unused_mut,
+    unused_variables,
+    unused_braces,
+    unused_parens,
+    dead_code,
+    clippy::useless_conversion,
+    clippy::needless_question_mark,
+    clippy::let_and_return,
+    clippy::nonminimal_bool,
+    clippy::eq_op
+)]
+pub(crate) unsafe fn Verdict_to_JObject_a94c1ffd<'a>(
+    env: &mut jni::JNIEnv<'a>,
+    v: perftest_flat::Verdict,
+) -> ::core::result::Result<jni::objects::JObject<'a>, __JniErr> {
+    Ok({
+        let ___id: jni::sys::jlong = i64_to_jlong_fbf9a9bc(env, v.id.clone())?;
+        let ___outcome__tag: jni::sys::jint;
+        let ___outcome_g0: jni::sys::jlong;
+        let ___outcome_g1: jni::objects::JObject;
+        match &v.outcome {
+            perftest_flat::Lookup::Absent => {
+                ___outcome__tag = 0;
+                ___outcome_g0 = 0i64;
+                ___outcome_g1 = jni::objects::JObject::null();
+            }
+            perftest_flat::Lookup::Found(__s0_0) => {
+                let ___outcome_found_v0: jni::sys::jlong = Summary_to_jlong_3cb103b9(
+                    env,
+                    __s0_0.clone(),
+                )?;
+                ___outcome__tag = 1;
+                ___outcome_g0 = ___outcome_found_v0;
+                ___outcome_g1 = jni::objects::JObject::null();
+            }
+            perftest_flat::Lookup::Failed(__s0_0) => {
+                let ___outcome_failed_v0: jni::objects::JObject = String_to_JString_c7f3ca43(
+                        env,
+                        __s0_0.clone(),
+                    )?
+                    .into();
+                ___outcome__tag = 2;
+                ___outcome_g1 = ___outcome_failed_v0;
+                ___outcome_g0 = 0i64;
+            }
+        }
+        let __obj = env
+            .call_static_method(
+                "io/prebindgen/covertest/model/Verdict",
+                "fromParts",
+                "(JIJLjava/lang/String;)Lio/prebindgen/covertest/model/Verdict;",
+                &[
+                    jni::objects::JValue::from(___id),
+                    jni::objects::JValue::from(___outcome__tag),
+                    jni::objects::JValue::from(___outcome_g0),
+                    jni::objects::JValue::Object(&___outcome_g1),
+                ],
+            )
+            .and_then(|__v| __v.l())
+            .map_err(|e| <__JniErr as ::core::convert::From<
+                String,
+            >>::from(format!("encode struct via fromParts: {}", e)))?;
+        __obj
     })
 }
 #[allow(
@@ -23012,6 +23117,78 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_unsignedSeries<'
         };
     }
     __acc
+}
+#[no_mangle]
+#[allow(non_snake_case, unused_mut, unused_variables, dead_code)]
+pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_verdictNew<'a>(
+    mut env: jni::JNIEnv<'a>,
+    _class: jni::objects::JClass<'a>,
+    id: jni::sys::jlong,
+    count: jni::sys::jlong,
+    total: jni::sys::jdouble,
+    __error_sink: jni::objects::JObject<'a>,
+) -> jni::objects::JObject<'a> {
+    #[allow(non_upper_case_globals)]
+    static __SINK_MID: ::prebindgen_jni_runtime::CachedIfaceMethod = ::prebindgen_jni_runtime::CachedIfaceMethod::new();
+    const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
+    const __SINK_DESCR: &str = "(Ljava/lang/String;)Ljava/lang/Object;";
+    let id = match jlong_to_i64_fbf9a9bc(&mut env, &id) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__e) => {
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e.to_string(),
+            );
+            return jni::objects::JObject::null().into();
+        }
+    };
+    let count = match jlong_to_i64_fbf9a9bc(&mut env, &count) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__e) => {
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e.to_string(),
+            );
+            return jni::objects::JObject::null().into();
+        }
+    };
+    let total = match jdouble_to_f64_9e4a8f70(&mut env, &total) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__e) => {
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e.to_string(),
+            );
+            return jni::objects::JObject::null().into();
+        }
+    };
+    let __out = perftest_flat::verdict_new(id, count, total);
+    match Verdict_to_JObject_a94c1ffd(&mut env, __out) {
+        ::core::result::Result::Ok(__w) => __w,
+        ::core::result::Result::Err(__e) => {
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e.to_string(),
+            );
+            jni::objects::JObject::null().into()
+        }
+    }
 }
 #[no_mangle]
 #[allow(non_snake_case, unused_mut, unused_variables, dead_code)]

--- a/examples/covertest-kotlin/src/generated_bindings.rs
+++ b/examples/covertest-kotlin/src/generated_bindings.rs
@@ -884,6 +884,51 @@ pub(crate) unsafe fn Celsius_to_i32_88c8e884<'a>(
     clippy::nonminimal_bool,
     clippy::eq_op
 )]
+pub(crate) unsafe fn Dossier_to_JObject_eabbdbfa<'a>(
+    env: &mut jni::JNIEnv<'a>,
+    v: perftest_flat::Dossier,
+) -> ::core::result::Result<jni::objects::JObject<'a>, __JniErr> {
+    Ok({
+        let ___note: jni::sys::jlong = i64_to_jlong_fbf9a9bc(env, v.note.clone())?;
+        let ___holder_tag: jni::sys::jlong = i64_to_jlong_fbf9a9bc(
+            env,
+            v.holder.tag.clone(),
+        )?;
+        let ___holder_summary: jni::sys::jlong = Summary_to_jlong_3cb103b9(
+            env,
+            v.holder.summary.clone(),
+        )?;
+        let __obj = env
+            .call_static_method(
+                "io/prebindgen/covertest/Dossier",
+                "fromParts",
+                "(JJJ)Lio/prebindgen/covertest/Dossier;",
+                &[
+                    jni::objects::JValue::from(___note),
+                    jni::objects::JValue::from(___holder_tag),
+                    jni::objects::JValue::from(___holder_summary),
+                ],
+            )
+            .and_then(|__v| __v.l())
+            .map_err(|e| <__JniErr as ::core::convert::From<
+                String,
+            >>::from(format!("encode struct via fromParts: {}", e)))?;
+        __obj
+    })
+}
+#[allow(
+    non_snake_case,
+    unused_mut,
+    unused_variables,
+    unused_braces,
+    unused_parens,
+    dead_code,
+    clippy::useless_conversion,
+    clippy::needless_question_mark,
+    clippy::let_and_return,
+    clippy::nonminimal_bool,
+    clippy::eq_op
+)]
 pub(crate) unsafe fn DurationBoundary_to_JObject_9c5bf9bc<'a>(
     env: &mut jni::JNIEnv<'a>,
     v: perftest_flat::DurationBoundary,
@@ -1853,6 +1898,44 @@ pub(crate) unsafe fn JObject_to_CacheConfig_db89a97c<'env, 'v>(
         perftest_flat::CacheConfig {
             replies,
             ttl,
+        }
+    })
+}
+#[allow(
+    non_snake_case,
+    unused_mut,
+    unused_variables,
+    unused_braces,
+    unused_parens,
+    dead_code,
+    clippy::useless_conversion,
+    clippy::needless_question_mark,
+    clippy::let_and_return,
+    clippy::nonminimal_bool,
+    clippy::eq_op
+)]
+pub(crate) unsafe fn JObject_to_Dossier_eabbdbfa<'env, 'v>(
+    env: &mut jni::JNIEnv<'env>,
+    v: &jni::objects::JObject<'v>,
+) -> ::core::result::Result<perftest_flat::Dossier, __JniErr> {
+    Ok({
+        let __note_raw: jni::sys::jlong = env
+            .get_field(v, "note", "J")
+            .and_then(|val| val.j())
+            .map_err(|e| <__JniErr as ::core::convert::From<
+                String,
+            >>::from(format!("Dossier.note: {}", e)))? as _;
+        let note = jlong_to_i64_fbf9a9bc(env, &__note_raw)?;
+        let __holder_raw: jni::objects::JObject = env
+            .get_field(v, "holder", "Lio/prebindgen/covertest/Holder;")
+            .and_then(|val| val.l())
+            .map_err(|e| <__JniErr as ::core::convert::From<
+                String,
+            >>::from(format!("Dossier.holder: {}", e)))?;
+        let holder = JObject_to_Holder_c36a9705(env, &__holder_raw)?;
+        perftest_flat::Dossier {
+            note,
+            holder,
         }
     })
 }
@@ -14171,6 +14254,93 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_coverTagRuntime<
     const __SINK_DESCR: &str = "(Ljava/lang/String;)Ljava/lang/Object;";
     let __out = perftest_flat::cover_tag_runtime();
     match String_to_JString_c7f3ca43(&mut env, __out) {
+        ::core::result::Result::Ok(__w) => __w,
+        ::core::result::Result::Err(__e) => {
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e.to_string(),
+            );
+            jni::objects::JObject::null().into()
+        }
+    }
+}
+#[no_mangle]
+#[allow(non_snake_case, unused_mut, unused_variables, dead_code)]
+pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_dossierNew<'a>(
+    mut env: jni::JNIEnv<'a>,
+    _class: jni::objects::JClass<'a>,
+    note: jni::sys::jlong,
+    tag: jni::sys::jlong,
+    count: jni::sys::jlong,
+    total: jni::sys::jdouble,
+    __error_sink: jni::objects::JObject<'a>,
+) -> jni::objects::JObject<'a> {
+    #[allow(non_upper_case_globals)]
+    static __SINK_MID: ::prebindgen_jni_runtime::CachedIfaceMethod = ::prebindgen_jni_runtime::CachedIfaceMethod::new();
+    const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
+    const __SINK_DESCR: &str = "(Ljava/lang/String;)Ljava/lang/Object;";
+    let note = match jlong_to_i64_fbf9a9bc(&mut env, &note) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__e) => {
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e.to_string(),
+            );
+            return jni::objects::JObject::null().into();
+        }
+    };
+    let tag = match jlong_to_i64_fbf9a9bc(&mut env, &tag) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__e) => {
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e.to_string(),
+            );
+            return jni::objects::JObject::null().into();
+        }
+    };
+    let count = match jlong_to_i64_fbf9a9bc(&mut env, &count) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__e) => {
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e.to_string(),
+            );
+            return jni::objects::JObject::null().into();
+        }
+    };
+    let total = match jdouble_to_f64_9e4a8f70(&mut env, &total) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__e) => {
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e.to_string(),
+            );
+            return jni::objects::JObject::null().into();
+        }
+    };
+    let __out = perftest_flat::dossier_new(note, tag, count, total);
+    match Dossier_to_JObject_eabbdbfa(&mut env, __out) {
         ::core::result::Result::Ok(__w) => __w,
         ::core::result::Result::Err(__e) => {
             signal_binding_error(

--- a/examples/perftest-flat/src/ext.rs
+++ b/examples/perftest-flat/src/ext.rs
@@ -333,13 +333,37 @@ pub fn lookup_of(count: i64, total: f64) -> Lookup {
 /// delivered in `count` order starting at `-1`, so `n >= 3` covers all three:
 /// `Failed` (`i = 0`), `Absent` (`i = 1`), then `Found` with an increasing
 /// count. A live group hands a native resource to the callback while the inert
-/// groups' slots stay defaulted. A sum payload is a plan LEAF, so the handle is wrapped
-/// but not closed by the proxy: it is the callback body's to close, exactly as
-/// for a returned sum.
+/// groups' slots stay defaulted. The proxy closes the reassembled value after
+/// `run` returns — close-unless-taken, exactly as for a handle passed directly
+/// to a callback (#218), so a body that means to outlive the call must `take()`
+/// the payload.
 #[prebindgen]
 pub fn lookup_each(n: i64, total: f64, sink: impl Fn(Lookup) + Send + Sync + 'static) {
     for i in 0..n {
         sink(lookup_of(i - 1, total));
+    }
+}
+
+/// The **third** position a handle can be reached through: a `data_class` field
+/// whose type is a handle-carrying sum. `Holder` covers the plain-handle field
+/// beside it, and the point of this one is that the two behave alike — the
+/// container is `AutoCloseable` and its `close()` cascades either way, because
+/// the field's type is an implementation detail and must not decide who frees
+/// the handle (#218).
+#[prebindgen]
+pub struct Verdict {
+    pub id: i64,
+    /// One alternative carries a `Summary` handle; closing the `Verdict`
+    /// closes it, through `Lookup`'s own `close()`.
+    pub outcome: Lookup,
+}
+
+/// Build a [`Verdict`] whose outcome comes from [`lookup_of`].
+#[prebindgen]
+pub fn verdict_new(id: i64, count: i64, total: f64) -> Verdict {
+    Verdict {
+        id,
+        outcome: lookup_of(count, total),
     }
 }
 

--- a/examples/perftest-flat/src/ext.rs
+++ b/examples/perftest-flat/src/ext.rs
@@ -367,6 +367,35 @@ pub fn verdict_new(id: i64, count: i64, total: f64) -> Verdict {
     }
 }
 
+/// The **fourth** position, and the last row of the same table: a `data_class`
+/// field whose type is another `data_class` that carries the handle. Nothing
+/// here is a handle and nothing here is a sum — `Dossier` only *reaches* one,
+/// two levels down, and must still close it (#218).
+///
+/// The cascade this emits is one line, `holder.close()`, which is correct only
+/// because [`Holder`] was independently rendered `AutoCloseable` by its own
+/// pass. An emission test cannot tell: it never compiles the inner class. This
+/// one is exercised from the JVM harness, where a `Dossier` that closed
+/// nothing, or an inner class without a `close()` to call, does not build.
+#[prebindgen]
+pub struct Dossier {
+    pub note: i64,
+    /// A plain data class whose own field is the `Summary` handle.
+    pub holder: Holder,
+}
+
+/// Build a [`Dossier`] over a fresh [`Summary`] — the two-level container.
+#[prebindgen]
+pub fn dossier_new(note: i64, tag: i64, count: i64, total: f64) -> Dossier {
+    Dossier {
+        note,
+        holder: Holder {
+            tag,
+            summary: Summary { count, total },
+        },
+    }
+}
+
 /// Which alternative an [`Observation`]'s `reading` holds, by declaration
 /// order — the sum crossing back **in** as part of a data-class parameter.
 #[prebindgen]

--- a/prebindgen-jni/src/jni/iface.rs
+++ b/prebindgen-jni/src/jni/iface.rs
@@ -152,6 +152,13 @@ pub(crate) struct TypedGroup {
     pub imports: Vec<String>,
     /// Number of consecutive `params` (raw leaves) this group consumes.
     pub leaf_count: usize,
+    /// The reassembled value reaches an owned native handle, so the `asRaw`
+    /// proxy binds it to a local and `close()`s it after `run` — the same
+    /// close-unless-taken contract [`WrapKind::HandleOwned`] gives a plan-less
+    /// handle arg. Without it a handle reached through a sum or a nested data
+    /// class was nobody's to close, while the same handle passed directly was
+    /// the proxy's, so the owner changed with the argument's spelling (#218).
+    pub owned: bool,
 }
 
 /// Substitute a [`TypedGroup::reassemble`] expression's `$k` placeholders with
@@ -456,6 +463,13 @@ impl IfaceSpec {
             expr: String,
             owned: bool,
             nullable: bool,
+            /// A whole value rebuilt from its leaves (`Class.fromParts(…)`, a
+            /// `when` over a tag) rather than one wrapped leaf. Rendered as one
+            /// piece of raw text, so once anything binds a local — see
+            /// `any_owned` below — these bind too: width-breaking a `when`
+            /// inside a nested call splits its arms into something valid and
+            /// unreadable, and a `val` keeps each on its own line.
+            reassembled: bool,
         }
         let run_args: Vec<RunArg> = if self.typed_groups.is_empty() {
             self.params
@@ -464,6 +478,7 @@ impl IfaceSpec {
                     expr: p.wrap.wrap_expr(&p.name, p.raw.is_nullable()),
                     owned: p.wrap.is_owned_handle(),
                     nullable: p.raw.is_nullable(),
+                    reassembled: false,
                 })
                 .collect()
         } else {
@@ -477,8 +492,13 @@ impl IfaceSpec {
                 match &g.reassemble {
                     Some(expr) => args.push(RunArg {
                         expr: fill_placeholders(expr, &names),
-                        owned: false,
-                        nullable: false,
+                        owned: g.owned,
+                        // The reassembled value is closed through its own
+                        // generated `close()`, which is declared on a
+                        // non-nullable receiver; a group whose typed view is
+                        // nullable needs the `?.` guard.
+                        nullable: g.typed.is_nullable(),
+                        reassembled: true,
                     }),
                     None => {
                         let p = &self.params[at];
@@ -486,6 +506,7 @@ impl IfaceSpec {
                             expr: p.wrap.wrap_expr(&p.name, p.raw.is_nullable()),
                             owned: p.wrap.is_owned_handle(),
                             nullable: p.raw.is_nullable(),
+                            reassembled: false,
                         });
                     }
                 }
@@ -522,16 +543,11 @@ impl IfaceSpec {
             // locals, and `close()` every owned local in a `finally` so the
             // per-invocation handle's `Box` is freed even if `run` threw — a
             // no-op when the consumer `take()`-ed it (its `ptr` is then 0).
-            let lambda_params = self
-                .params
-                .iter()
-                .map(|p| p.name.clone())
-                .collect::<Vec<_>>()
-                .join(", ");
             let mut lines: Vec<String> = Vec::new();
             let mut call_args: Vec<String> = Vec::with_capacity(run_args.len());
             let mut closes: Vec<String> = Vec::new();
             let mut owned_idx = 0usize;
+            let mut val_idx = 0usize;
             for a in &run_args {
                 if a.owned {
                     let local = format!("__own{owned_idx}");
@@ -540,14 +556,36 @@ impl IfaceSpec {
                     call_args.push(local.clone());
                     let dot = if a.nullable { "?." } else { "." };
                     closes.push(format!("{local}{dot}close()"));
+                } else if a.reassembled {
+                    // Not ours to close, but still one piece of raw text that
+                    // must not be broken up inside the nested `run(…)`.
+                    let local = format!("__val{val_idx}");
+                    val_idx += 1;
+                    lines.push(format!("val {local} = {}", a.expr));
+                    call_args.push(local);
                 } else {
                     call_args.push(a.expr.clone());
                 }
             }
             KtCode::new().blk(lambda_open, |mut c| {
-                c = c.line(format!("{lambda_params} ->"));
+                // Lambda parameters one per line, exactly as the common path
+                // above lays them out — the `finally` is the only difference
+                // between the two shapes, and the parameter list should not
+                // move just because a handle appeared among the arguments.
+                for (idx, name) in self.params.iter().map(|p| p.name.as_str()).enumerate() {
+                    let suffix = if idx + 1 == self.params.len() {
+                        " ->"
+                    } else {
+                        ","
+                    };
+                    c = c.line(format!("{name}{suffix}"));
+                }
                 for l in &lines {
-                    c = c.wline(l.clone());
+                    // `line`, not `wline`: the bound value is a reassembly
+                    // expression rendered as one piece of raw text (a `when`
+                    // over the tag), and width-breaking it splits the arms
+                    // mid-expression into something valid but unreadable.
+                    c = c.line(l.clone());
                 }
                 let mut fin = KtCode::new();
                 for cl in &closes {
@@ -1125,6 +1163,11 @@ pub(crate) fn callback_iface_spec(
         reassemble: Option<String>,
         imports: Vec<String>,
         leaf_count: usize,
+        /// The reassembled value reaches an owned native handle, so the proxy
+        /// closes it after `run` — the close-unless-taken contract a plan-less
+        /// handle arg already had (#218). Always `false` for a passthrough
+        /// group, whose own [`IfaceParam::wrap`] answers instead.
+        owned: bool,
     }
     /// One flattened `run` parameter before naming/dedup. A **plan** leaf keeps
     /// the leaf itself, so it classifies through the shared
@@ -1182,6 +1225,8 @@ pub(crate) fn callback_iface_spec(
                     reassemble: Some(reassemble),
                     imports,
                     leaf_count: plan.leaves.len(),
+                    owned: crate::jni::struct_plan::type_close_strategy(ext, registry, core, 0)
+                        .is_some(),
                 });
             } else {
                 // Accessor-plan arg: each leaf is its own passthrough group, so
@@ -1232,6 +1277,13 @@ pub(crate) fn callback_iface_spec(
                             reassemble: Some(reassemble),
                             imports,
                             leaf_count: seg - k,
+                            owned: crate::jni::struct_plan::type_close_strategy(
+                                ext,
+                                registry,
+                                &leaf.out_ty,
+                                0,
+                            )
+                            .is_some(),
                         });
                     } else {
                         groups.push(GroupDesc {
@@ -1240,6 +1292,7 @@ pub(crate) fn callback_iface_spec(
                             reassemble: None,
                             imports: Vec::new(),
                             leaf_count: 1,
+                            owned: false,
                         });
                     }
                     k = seg;
@@ -1265,6 +1318,7 @@ pub(crate) fn callback_iface_spec(
                 reassemble: None,
                 imports: Vec::new(),
                 leaf_count: 1,
+                owned: false,
             });
         }
     }
@@ -1303,6 +1357,7 @@ pub(crate) fn callback_iface_spec(
                 reassemble: g.reassemble.clone(),
                 imports: g.imports.clone(),
                 leaf_count: g.leaf_count,
+                owned: g.owned,
             });
             at += g.leaf_count;
         }
@@ -1465,6 +1520,9 @@ pub(crate) fn fixed_folder_typed_groups(
             reassemble: None,
             imports: Vec::new(),
             leaf_count: 1,
+            // The accumulator is the consumer's own value, of the consumer's
+            // own type variable — never ours to close.
+            owned: false,
         },
         TypedGroup {
             name: "element".to_string(),
@@ -1472,6 +1530,12 @@ pub(crate) fn fixed_folder_typed_groups(
             reassemble: Some(reassemble),
             imports,
             leaf_count: spec.leaves.len(),
+            // Same rule as every other reassembled value. A fold over a
+            // BORROWED run never trips it: a borrowed handle projection carries
+            // `owned: false`, so the element reaches nothing to release and the
+            // per-iteration close that would double-free is not emitted.
+            owned: crate::jni::struct_plan::type_close_strategy(ext, registry, &spec.source, 0)
+                .is_some(),
         },
     ])
 }

--- a/prebindgen-jni/src/jni/iface.rs
+++ b/prebindgen-jni/src/jni/iface.rs
@@ -152,13 +152,62 @@ pub(crate) struct TypedGroup {
     pub imports: Vec<String>,
     /// Number of consecutive `params` (raw leaves) this group consumes.
     pub leaf_count: usize,
-    /// The reassembled value reaches an owned native handle, so the `asRaw`
-    /// proxy binds it to a local and `close()`s it after `run` — the same
-    /// close-unless-taken contract [`WrapKind::HandleOwned`] gives a plan-less
-    /// handle arg. Without it a handle reached through a sum or a nested data
-    /// class was nobody's to close, while the same handle passed directly was
-    /// the proxy's, so the owner changed with the argument's spelling (#218).
-    pub owned: bool,
+    /// How the `asRaw` proxy closes this value after `run`, or `None` when it
+    /// reaches nothing owned — [`type_close_strategy`](crate::jni::struct_plan::type_close_strategy)'s
+    /// answer, carried rather than collapsed to a bool, so the proxy renders it
+    /// through the same [`render_handle_close`] the sealed classes use instead
+    /// of hand-rolling `x.close()` and assuming the answer is `Base`.
+    ///
+    /// Closing at all is the same close-unless-taken contract
+    /// [`WrapKind::HandleOwned`] gives a plan-less handle arg. Without it a
+    /// handle reached through a sum or a nested data class was nobody's to
+    /// close, while the same handle passed directly was the proxy's, so the
+    /// owner changed with the argument's spelling (#218).
+    pub close: Option<FoldStrategy>,
+}
+
+/// One `val` the `asRaw` proxy binds before calling `run`, and how it is
+/// released afterwards. `close: None` is a value bound only to keep a raw
+/// reassembly expression off the argument list.
+struct Bind {
+    line: String,
+    close: Option<String>,
+}
+
+/// Render the bindings and the `run(…)` call, nesting a `try`/`finally` per
+/// closeable one so everything bound after it happens **inside** its `try`.
+///
+/// Reverse order comes out of the nesting for free: the innermost `finally`
+/// runs first, which is the order the locals were taken in, reversed.
+fn nest_binds(mut code: KtCode, binds: &[Bind], call_args: &str) -> KtCode {
+    let Some((first, rest)) = binds.split_first() else {
+        return code.wline(format!("run({call_args})"));
+    };
+    // `line`, not `wline`: the bound value is a reassembly expression rendered
+    // as one piece of raw text (a `when` over the tag), and width-breaking it
+    // splits the arms mid-expression into something valid but unreadable.
+    code = code.line(first.line.clone());
+    match &first.close {
+        Some(close) => code.try_finally(
+            "",
+            nest_binds(KtCode::new(), rest, call_args),
+            KtCode::new().line(close.clone()),
+        ),
+        None => nest_binds(code, rest, call_args),
+    }
+}
+
+/// A close strategy for a receiver whose Kotlin type is nullable for a reason
+/// the *type* does not name: a sum under a conditional value form reconstructs
+/// to `null` where the form was absent, so its selector — not its type — is
+/// what makes the local `T?`. `Optional` already renders as `?.`, so a strategy
+/// that carries one needs nothing added.
+fn nullable_close(strategy: FoldStrategy, nullable: bool) -> FoldStrategy {
+    match strategy {
+        FoldStrategy::Optional(..) => strategy,
+        inner if nullable => FoldStrategy::Optional(NullableKind::Boxed, Box::new(inner)),
+        inner => inner,
+    }
 }
 
 /// Substitute a [`TypedGroup::reassemble`] expression's `$k` placeholders with
@@ -461,7 +510,11 @@ impl IfaceSpec {
         // `close()`-d after `run` (close-unless-taken), so track it per arg.
         struct RunArg {
             expr: String,
-            owned: bool,
+            /// How to close it after `run`, or `None` when it is not ours.
+            close: Option<FoldStrategy>,
+            /// Whether the Kotlin receiver is nullable — which for a
+            /// reassembled sum is a fact about its SELECTOR, not about its
+            /// type, so `close` cannot be asked for it. See [`nullable_close`].
             nullable: bool,
             /// A whole value rebuilt from its leaves (`Class.fromParts(…)`, a
             /// `when` over a tag) rather than one wrapped leaf. Rendered as one
@@ -476,7 +529,9 @@ impl IfaceSpec {
                 .iter()
                 .map(|p| RunArg {
                     expr: p.wrap.wrap_expr(&p.name, p.raw.is_nullable()),
-                    owned: p.wrap.is_owned_handle(),
+                    // A wrapped handle leaf closes as itself; its nullability
+                    // rides `nullable` below, exactly as for a group.
+                    close: p.wrap.is_owned_handle().then_some(FoldStrategy::Base),
                     nullable: p.raw.is_nullable(),
                     reassembled: false,
                 })
@@ -492,7 +547,7 @@ impl IfaceSpec {
                 match &g.reassemble {
                     Some(expr) => args.push(RunArg {
                         expr: fill_placeholders(expr, &names),
-                        owned: g.owned,
+                        close: g.close.clone(),
                         // The reassembled value is closed through its own
                         // generated `close()`, which is declared on a
                         // non-nullable receiver; a group whose typed view is
@@ -504,7 +559,7 @@ impl IfaceSpec {
                         let p = &self.params[at];
                         args.push(RunArg {
                             expr: p.wrap.wrap_expr(&p.name, p.raw.is_nullable()),
-                            owned: p.wrap.is_owned_handle(),
+                            close: p.wrap.is_owned_handle().then_some(FoldStrategy::Base),
                             nullable: p.raw.is_nullable(),
                             reassembled: false,
                         });
@@ -514,7 +569,7 @@ impl IfaceSpec {
             }
             args
         };
-        let any_owned = run_args.iter().any(|a| a.owned);
+        let any_owned = run_args.iter().any(|a| a.close.is_some());
         let lambda_open = format!("{}{gen_args} {{", self.raw_name());
         let body = if self.params.is_empty() {
             KtCode::new().blk(lambda_open, |c| c.line("run()"))
@@ -543,26 +598,37 @@ impl IfaceSpec {
             // locals, and `close()` every owned local in a `finally` so the
             // per-invocation handle's `Box` is freed even if `run` threw — a
             // no-op when the consumer `take()`-ed it (its `ptr` is then 0).
-            let mut lines: Vec<String> = Vec::new();
+            //
+            // Each owned local opens its OWN try/finally and everything after
+            // it is bound INSIDE that try: with one flat `try` around `run`
+            // only, a later reassembly that throws (a `when` over an invalid
+            // tag) would strand every handle already taken by an earlier one.
+            let mut binds: Vec<Bind> = Vec::new();
             let mut call_args: Vec<String> = Vec::with_capacity(run_args.len());
-            let mut closes: Vec<String> = Vec::new();
             let mut owned_idx = 0usize;
             let mut val_idx = 0usize;
             for a in &run_args {
-                if a.owned {
+                if let Some(strategy) = &a.close {
                     let local = format!("__own{owned_idx}");
                     owned_idx += 1;
-                    lines.push(format!("val {local} = {}", a.expr));
                     call_args.push(local.clone());
-                    let dot = if a.nullable { "?." } else { "." };
-                    closes.push(format!("{local}{dot}close()"));
+                    binds.push(Bind {
+                        line: format!("val {local} = {}", a.expr),
+                        close: Some(render_handle_close(
+                            &nullable_close(strategy.clone(), a.nullable),
+                            &local,
+                        )),
+                    });
                 } else if a.reassembled {
                     // Not ours to close, but still one piece of raw text that
                     // must not be broken up inside the nested `run(…)`.
                     let local = format!("__val{val_idx}");
                     val_idx += 1;
-                    lines.push(format!("val {local} = {}", a.expr));
-                    call_args.push(local);
+                    call_args.push(local.clone());
+                    binds.push(Bind {
+                        line: format!("val {local} = {}", a.expr),
+                        close: None,
+                    });
                 } else {
                     call_args.push(a.expr.clone());
                 }
@@ -580,22 +646,7 @@ impl IfaceSpec {
                     };
                     c = c.line(format!("{name}{suffix}"));
                 }
-                for l in &lines {
-                    // `line`, not `wline`: the bound value is a reassembly
-                    // expression rendered as one piece of raw text (a `when`
-                    // over the tag), and width-breaking it splits the arms
-                    // mid-expression into something valid but unreadable.
-                    c = c.line(l.clone());
-                }
-                let mut fin = KtCode::new();
-                for cl in &closes {
-                    fin = fin.line(cl.clone());
-                }
-                c.try_finally(
-                    "",
-                    KtCode::new().wline(format!("run({})", call_args.join(", "))),
-                    fin,
-                )
+                nest_binds(c, &binds, &call_args.join(", "))
             })
         };
         let mut f = KtFun::new("asRaw").vis(KtVis::Public).receiver(recv);
@@ -1163,11 +1214,11 @@ pub(crate) fn callback_iface_spec(
         reassemble: Option<String>,
         imports: Vec<String>,
         leaf_count: usize,
-        /// The reassembled value reaches an owned native handle, so the proxy
-        /// closes it after `run` — the close-unless-taken contract a plan-less
-        /// handle arg already had (#218). Always `false` for a passthrough
-        /// group, whose own [`IfaceParam::wrap`] answers instead.
-        owned: bool,
+        /// How the proxy closes the reassembled value after `run`, or `None`
+        /// when it reaches nothing owned — the close-unless-taken contract a
+        /// plan-less handle arg already had (#218). Always `None` for a
+        /// passthrough group, whose own [`IfaceParam::wrap`] answers instead.
+        close: Option<FoldStrategy>,
     }
     /// One flattened `run` parameter before naming/dedup. A **plan** leaf keeps
     /// the leaf itself, so it classifies through the shared
@@ -1225,8 +1276,7 @@ pub(crate) fn callback_iface_spec(
                     reassemble: Some(reassemble),
                     imports,
                     leaf_count: plan.leaves.len(),
-                    owned: crate::jni::struct_plan::type_close_strategy(ext, registry, core, 0)
-                        .is_some(),
+                    close: crate::jni::struct_plan::type_close_strategy(ext, registry, core, 0),
                 });
             } else {
                 // Accessor-plan arg: each leaf is its own passthrough group, so
@@ -1277,13 +1327,12 @@ pub(crate) fn callback_iface_spec(
                             reassemble: Some(reassemble),
                             imports,
                             leaf_count: seg - k,
-                            owned: crate::jni::struct_plan::type_close_strategy(
+                            close: crate::jni::struct_plan::type_close_strategy(
                                 ext,
                                 registry,
                                 &leaf.out_ty,
                                 0,
-                            )
-                            .is_some(),
+                            ),
                         });
                     } else {
                         groups.push(GroupDesc {
@@ -1292,7 +1341,7 @@ pub(crate) fn callback_iface_spec(
                             reassemble: None,
                             imports: Vec::new(),
                             leaf_count: 1,
-                            owned: false,
+                            close: None,
                         });
                     }
                     k = seg;
@@ -1318,7 +1367,7 @@ pub(crate) fn callback_iface_spec(
                 reassemble: None,
                 imports: Vec::new(),
                 leaf_count: 1,
-                owned: false,
+                close: None,
             });
         }
     }
@@ -1357,7 +1406,7 @@ pub(crate) fn callback_iface_spec(
                 reassemble: g.reassemble.clone(),
                 imports: g.imports.clone(),
                 leaf_count: g.leaf_count,
-                owned: g.owned,
+                close: g.close.clone(),
             });
             at += g.leaf_count;
         }
@@ -1522,7 +1571,7 @@ pub(crate) fn fixed_folder_typed_groups(
             leaf_count: 1,
             // The accumulator is the consumer's own value, of the consumer's
             // own type variable — never ours to close.
-            owned: false,
+            close: None,
         },
         TypedGroup {
             name: "element".to_string(),
@@ -1530,12 +1579,18 @@ pub(crate) fn fixed_folder_typed_groups(
             reassemble: Some(reassemble),
             imports,
             leaf_count: spec.leaves.len(),
-            // Same rule as every other reassembled value. A fold over a
-            // BORROWED run never trips it: a borrowed handle projection carries
-            // `owned: false`, so the element reaches nothing to release and the
-            // per-iteration close that would double-free is not emitted.
-            owned: crate::jni::struct_plan::type_close_strategy(ext, registry, &spec.source, 0)
-                .is_some(),
+            // Same rule as every other reassembled value — and BREAKING for a
+            // fold whose element reaches a handle: the element is now closed
+            // after each `run`, so a body that accumulates its elements
+            // (`{ acc, e -> acc + e }`) accumulates closed handles unless it
+            // `take()`s each one. Note this is not a sum-only rule; a nested
+            // `data_class` element lands here too.
+            //
+            // A fold over a BORROWED run never trips it: a borrowed handle
+            // projection carries `owned: false`, so the element reaches nothing
+            // to release and the per-iteration close that would double-free is
+            // not emitted.
+            close: crate::jni::struct_plan::type_close_strategy(ext, registry, &spec.source, 0),
         },
     ])
 }

--- a/prebindgen-jni/src/jni/kotlin_emit.rs
+++ b/prebindgen-jni/src/jni/kotlin_emit.rs
@@ -601,9 +601,38 @@ impl Declarations {
             .map(|d| format!("{d}\n\n{framework_line}"))
             .unwrap_or(framework_line);
 
+        // A sum whose payload reaches an owned native handle is `AutoCloseable`
+        // (#218): whoever holds the value closes it, exactly as they would a
+        // bare handle in that position, and the `when` over the alternatives is
+        // emitted ONCE — here, in the variant classes — instead of at every
+        // container and callback proxy that touches one. Before this, a handle
+        // reached through a sum was nobody's to close while the same handle in
+        // a plain field was the container's, so the free moved when the field's
+        // type changed.
+        // A variant closes what its own payload owns; the interface is
+        // closeable if any alternative is.
+        let payload_close = |field: &prebindgen_registry::flat::Field| {
+            crate::jni::struct_plan::type_close_strategy(self, registry, &field.ty, 0)
+        };
+        let any_closeable = sum
+            .alternatives
+            .iter()
+            .any(|alt| alt.fields.iter().any(|f| payload_close(f).is_some()));
+
         let mut class = KtClass::sealed_interface(class_name)
             .vis(KtVis::Public)
-            .kdoc(kdoc);
+            .kdoc(if any_closeable {
+                format!(
+                    "{kdoc}\n\nThe live alternative may carry a native handle, so this value is \
+                     `AutoCloseable`: closing it closes whatever the live alternative holds, and \
+                     is a no-op for the alternatives that hold nothing native."
+                )
+            } else {
+                kdoc
+            });
+        if any_closeable {
+            class = class.implements(KtType::cls("AutoCloseable"));
+        }
 
         // Nested variant classes, in declaration (tag) order.
         for alt in &sum.alternatives {
@@ -613,9 +642,13 @@ impl Declarations {
             // alternative is a `data object` with none at all.
             let mut vprops: Vec<(String, KtType)> = Vec::new();
             let mut vparams: Vec<KtCtorParam> = Vec::new();
+            let mut vcloses: Vec<String> = Vec::new();
             for field in &alt.fields {
                 let prop = sum_field_prop_name(&field.member());
                 let ty = self.sum_payload_kt_type(registry, &sum.name, &alt.name, &prop, field);
+                if let Some(strategy) = payload_close(field) {
+                    vcloses.push(render_handle_close(&strategy, &prop));
+                }
                 vprops.push((prop.clone(), ty.clone()));
                 vparams.push(KtCtorParam::new(&prop, ty).val().vis(KtVis::Public));
             }
@@ -647,6 +680,17 @@ impl Declarations {
                 .flatten()
             {
                 vclass = vclass.member(m);
+            }
+            // `close()` on EVERY alternative once the interface is closeable —
+            // Kotlin requires the override, and an alternative holding nothing
+            // native gets the empty body that says so. A `data object` takes an
+            // overridden method as readily as a `data class` does.
+            if any_closeable {
+                let mut body = KtCode::new();
+                for line in &vcloses {
+                    body = body.line(line.clone());
+                }
+                vclass = vclass.member(KtFun::new("close").modifier("override").body(body));
             }
             class = class.member(vclass);
         }

--- a/prebindgen-jni/src/jni/struct_plan.rs
+++ b/prebindgen-jni/src/jni/struct_plan.rs
@@ -469,10 +469,25 @@ impl PlanFieldKind {
         }
     }
 
-    /// The close strategy when this field owns a native handle, so the class
-    /// implements `AutoCloseable` and `close()` walks it. Only an **owned**
-    /// `Handle` projection qualifies: a `ULong` owns nothing, and a borrowed
-    /// handle is not this object's to release.
+    /// The close strategy when this field **reaches** an owned native handle,
+    /// so the class implements `AutoCloseable` and `close()` walks it.
+    ///
+    /// Only an **owned** `Handle` projection is a handle: a `ULong` owns
+    /// nothing, and a borrowed handle is not this object's to release. But
+    /// reaching one is not the same as *being* one — a handle held inside a sum
+    /// payload or a nested data class is just as much this object's to release,
+    /// and used to fall through to `None` (#218). That made ownership depend on
+    /// how the field happened to be spelled: swapping a handle field for an
+    /// enum carrying that handle silently moved the free onto the consumer,
+    /// with nothing in the generated Kotlin saying so.
+    ///
+    /// The wrapped cases fold as `Base`/`Optional` over the field itself rather
+    /// than over the handle inside it, because the field's own generated type
+    /// is `AutoCloseable` too — a sum's `close()` is the `when` over its
+    /// alternatives ([`write_sealed_interface`](super::JniGen::write_sealed_interface)),
+    /// a nested data class's is this same cascade one level down. So every
+    /// container emits the same plain `field.close()`, and the walk into the
+    /// wrapper lives once, in the wrapped type, instead of at each use site.
     pub(crate) fn destructible(&self) -> Option<FoldStrategy> {
         match self {
             PlanFieldKind::Projection { proj, .. }
@@ -480,9 +495,116 @@ impl PlanFieldKind {
             {
                 Some(proj.strategy.clone())
             }
+            PlanFieldKind::Sum {
+                optional, variants, ..
+            } if variants.iter().any(SumPlanVariant::destructible) => {
+                Some(whole_value_close(*optional))
+            }
+            PlanFieldKind::Nested { optional, plan, .. } if plan.destructible() => {
+                Some(whole_value_close(*optional))
+            }
             _ => None,
         }
     }
+}
+
+impl StructPlan {
+    /// Whether closing this struct has anything to do — any field reaching an
+    /// owned handle. The recursion is [`PlanFieldKind::destructible`]'s, and is
+    /// bounded by the same depth guards that bound plan construction.
+    pub(crate) fn destructible(&self) -> bool {
+        self.fields.iter().any(|f| f.kind.destructible().is_some())
+    }
+}
+
+impl SumPlanVariant {
+    /// Whether this alternative's payload reaches an owned handle — so its
+    /// generated variant class needs a `close()` body rather than a no-op one.
+    pub(crate) fn destructible(&self) -> bool {
+        self.fields.iter().any(|f| f.kind.destructible().is_some())
+    }
+}
+
+/// The fold of a wrapper that closes itself: the value is closed as a whole,
+/// `?.`-guarded when it is optional. Shared by the two forms of the
+/// reaches-a-handle question below so they cannot answer differently.
+fn whole_value_close(optional: bool) -> FoldStrategy {
+    if optional {
+        FoldStrategy::Optional(NullableKind::Boxed, Box::new(FoldStrategy::Base))
+    } else {
+        FoldStrategy::Base
+    }
+}
+
+/// How to close a value of this type, or `None` when it **reaches** no owned
+/// native handle and so has nothing to release —
+/// [`PlanFieldKind::destructible`]'s question asked of a type rather than of an
+/// already-classified plan field.
+///
+/// Two callers hold a [`TypeRef`](prebindgen_registry::flat::TypeRef) and no
+/// plan: the sealed-interface emitter, deciding whether a sum is
+/// `AutoCloseable` and what each variant class's `close()` body does; and the
+/// callback interface builder, deciding whether a reassembled whole value is
+/// the proxy's to close after `run`. The two forms answer alike by
+/// construction — this walks the model's own alternatives and fields, which is
+/// the same tree [`classify_field`] walks to build the plan.
+///
+/// Deliberately **total**: unlike `classify_field` it refuses nothing and
+/// panics on nothing, because "is there anything to close" has a defensible
+/// answer for every type, and a shape the bridge would reject is not this
+/// predicate's to diagnose — the plan builders report those, with the path.
+///
+/// `depth` bounds the same recursion `build_struct_plan` and `sum_plan_kind`
+/// bound; a cycle answers `None` rather than hanging.
+pub(crate) fn type_close_strategy(
+    ext: &Declarations,
+    registry: &impl Conversions<KotlinMeta>,
+    ty: &prebindgen_registry::flat::TypeRef,
+    depth: usize,
+) -> Option<FoldStrategy> {
+    if depth > 16 {
+        return None;
+    }
+    // An owned `Handle` projection is the one thing that actually owns
+    // something: a `ULong` owns nothing, and a borrowed handle is not ours to
+    // release. Asked of the whole reading, so the `Option`/`Vec` folds the
+    // projection carries come back in its own strategy.
+    if let Some(proj) = registry
+        .output_entry(ty)
+        .and_then(|e| e.metadata.projection.as_ref())
+    {
+        return (matches!(proj.kind, ProjectionKind::Handle) && proj.owned)
+            .then(|| proj.strategy.clone());
+    }
+    // Peel the layers the model names, exactly as `classify_field` does: what
+    // a `Box<Option<T>>` reaches is what `T` reaches.
+    let bare = ty.optional_inner().unwrap_or(ty);
+    let core = bare.sequence_elem().unwrap_or(bare);
+    let reaches = match ext.type_kind(registry, &core.key()) {
+        TypeKind::Sum => core
+            .key()
+            .ident()
+            .and_then(|ident| registry.flat().declared_type(&ident))
+            .is_some_and(|ty| match ty {
+                prebindgen_registry::flat::Type::Variant(sum) => {
+                    sum.alternatives.iter().any(|alt| {
+                        alt.fields
+                            .iter()
+                            .any(|f| type_close_strategy(ext, registry, &f.ty, depth + 1).is_some())
+                    })
+                }
+                _ => false,
+            }),
+        TypeKind::DataStruct { st, .. } => st
+            .fields
+            .iter()
+            .any(|f| type_close_strategy(ext, registry, &f.ty, depth + 1).is_some()),
+        TypeKind::Handle | TypeKind::Enum | TypeKind::Other => false,
+    };
+    // A `Vec` of such values has no close cascade to fold over: the bridge
+    // already rejects `Vec<sum>` and `Vec<data class>` fields, so the shape
+    // cannot reach a container that would need one.
+    reaches.then(|| whole_value_close(ty.optional_inner().is_some()))
 }
 
 /// Build the [`PlanFieldKind::Sum`] for a `sealed_class`-declared enum: one

--- a/prebindgen-jni/src/jni/struct_plan.rs
+++ b/prebindgen-jni/src/jni/struct_plan.rs
@@ -484,8 +484,8 @@ impl PlanFieldKind {
     /// The wrapped cases fold as `Base`/`Optional` over the field itself rather
     /// than over the handle inside it, because the field's own generated type
     /// is `AutoCloseable` too — a sum's `close()` is the `when` over its
-    /// alternatives ([`write_sealed_interface`](super::JniGen::write_sealed_interface)),
-    /// a nested data class's is this same cascade one level down. So every
+    /// alternatives (`Declarations::build_sealed_class`), a nested data
+    /// class's is this same cascade one level down. So every
     /// container emits the same plain `field.close()`, and the walk into the
     /// wrapper lives once, in the wrapped type, instead of at each use site.
     pub(crate) fn destructible(&self) -> Option<FoldStrategy> {
@@ -495,13 +495,16 @@ impl PlanFieldKind {
             {
                 Some(proj.strategy.clone())
             }
+            // `sequence: false` is `classify_field`'s guarantee, not an
+            // assumption: it rejects `Vec<sum>` and `Vec<data class>` outright,
+            // so a classified field of either kind is never a sequence.
             PlanFieldKind::Sum {
                 optional, variants, ..
             } if variants.iter().any(SumPlanVariant::destructible) => {
-                Some(whole_value_close(*optional))
+                Some(whole_value_close(*optional, false))
             }
             PlanFieldKind::Nested { optional, plan, .. } if plan.destructible() => {
-                Some(whole_value_close(*optional))
+                Some(whole_value_close(*optional, false))
             }
             _ => None,
         }
@@ -526,14 +529,23 @@ impl SumPlanVariant {
 }
 
 /// The fold of a wrapper that closes itself: the value is closed as a whole,
-/// `?.`-guarded when it is optional. Shared by the two forms of the
-/// reaches-a-handle question below so they cannot answer differently.
-fn whole_value_close(optional: bool) -> FoldStrategy {
-    if optional {
-        FoldStrategy::Optional(NullableKind::Boxed, Box::new(FoldStrategy::Base))
-    } else {
-        FoldStrategy::Base
+/// `?.`-guarded when it is optional and `forEach`-ed when it is a sequence.
+/// Shared by the two forms of the reaches-a-handle question below so they
+/// cannot answer differently.
+///
+/// [`NullableKind::Boxed`] is not a guess here. The receiver is always a
+/// generated Kotlin *reference* — a sum or a data class — whose absent form is
+/// a JVM null; a niche encoding is a wire fact of a handle projection, and
+/// those come back carrying their own strategy without passing through this.
+fn whole_value_close(optional: bool, sequence: bool) -> FoldStrategy {
+    let mut fold = FoldStrategy::Base;
+    if sequence {
+        fold = FoldStrategy::Iterable(Box::new(fold));
     }
+    if optional {
+        fold = FoldStrategy::Optional(NullableKind::Boxed, Box::new(fold));
+    }
+    fold
 }
 
 /// How to close a value of this type, or `None` when it **reaches** no owned
@@ -545,26 +557,44 @@ fn whole_value_close(optional: bool) -> FoldStrategy {
 /// plan: the sealed-interface emitter, deciding whether a sum is
 /// `AutoCloseable` and what each variant class's `close()` body does; and the
 /// callback interface builder, deciding whether a reassembled whole value is
-/// the proxy's to close after `run`. The two forms answer alike by
-/// construction — this walks the model's own alternatives and fields, which is
-/// the same tree [`classify_field`] walks to build the plan.
+/// the proxy's to close after `run`.
 ///
-/// Deliberately **total**: unlike `classify_field` it refuses nothing and
-/// panics on nothing, because "is there anything to close" has a defensible
-/// answer for every type, and a shape the bridge would reject is not this
-/// predicate's to diagnose — the plan builders report those, with the path.
+/// The two forms must **agree wherever both answer**, and that is a tested
+/// invariant, not a structural one: `a_types_close_answer_matches_its_plans`
+/// asserts `type_close_strategy(ty).is_some() == plan(ty).destructible()` over
+/// every field of every declared shape in a set covering all the ways one can
+/// reach a handle. It is worth pinning because the walks are not identical.
+/// Two places they differ:
+///
+/// * **Order.** [`classify_field`] classifies a `Sum` *before* it consults
+///   `output_entry` (deliberately — see its comment); this asks `output_entry`
+///   first. Safe only while sums carry no converter of their own, which is a
+///   precondition rather than a construction.
+/// * **Totality.** A field [`classify_field`] refuses collapses the whole
+///   struct's plan to `None`, while this refuses nothing. So on a subtree the
+///   bridge rejects, the two answer differently *by design* — the plan
+///   builders are what diagnose those, with the path, and "is there anything
+///   to close" still has a defensible answer for every type.
+///
+/// A disagreement costs a Kotlin compile error in one direction and a silent
+/// leak — #218 again, at this seam — in the other.
 ///
 /// `depth` bounds the same recursion `build_struct_plan` and `sum_plan_kind`
-/// bound; a cycle answers `None` rather than hanging.
+/// bound, and asserts on the same bound rather than answering: a cycle deep
+/// enough to trip this is a declaration the plan builders already refuse
+/// loudly, and returning `None` for it would report "nothing to close" — the
+/// leak direction — for a shape nobody can compile anyway.
 pub(crate) fn type_close_strategy(
     ext: &Declarations,
     registry: &impl Conversions<KotlinMeta>,
     ty: &prebindgen_registry::flat::TypeRef,
     depth: usize,
 ) -> Option<FoldStrategy> {
-    if depth > 16 {
-        return None;
-    }
+    assert!(
+        depth <= 16,
+        "close-strategy walk: recursion too deep at type `{}` (cyclic data_class?)",
+        ty.spell()
+    );
     // An owned `Handle` projection is the one thing that actually owns
     // something: a `ULong` owns nothing, and a borrowed handle is not ours to
     // release. Asked of the whole reading, so the `Option`/`Vec` folds the
@@ -601,10 +631,17 @@ pub(crate) fn type_close_strategy(
             .any(|f| type_close_strategy(ext, registry, &f.ty, depth + 1).is_some()),
         TypeKind::Handle | TypeKind::Enum | TypeKind::Other => false,
     };
-    // A `Vec` of such values has no close cascade to fold over: the bridge
-    // already rejects `Vec<sum>` and `Vec<data class>` fields, so the shape
-    // cannot reach a container that would need one.
-    reaches.then(|| whole_value_close(ty.optional_inner().is_some()))
+    // Put back exactly the layers peeled above. `reaches` was answered about
+    // the ELEMENT, so a `Vec<sum-that-reaches-a-handle>` must close each
+    // element — `close()` on the `List` itself would not compile. The field
+    // bridge rejects that shape, but this predicate exists precisely for the
+    // callers that hold no plan and so meet no rejection.
+    reaches.then(|| {
+        whole_value_close(
+            ty.optional_inner().is_some(),
+            bare.sequence_elem().is_some(),
+        )
+    })
 }
 
 /// Build the [`PlanFieldKind::Sum`] for a `sealed_class`-declared enum: one

--- a/prebindgen-jni/src/jni/tests/sealed.rs
+++ b/prebindgen-jni/src/jni/tests/sealed.rs
@@ -2078,3 +2078,161 @@ fn empty_sum_alternatives_keep_their_own_pattern_delimiters() {
         "neither empty alternative may be matched bare:\n{rust}"
     );
 }
+
+/// The invariant the whole #218 fix rests on: the **two forms** of "does this
+/// reach an owned handle" must agree.
+///
+/// [`PlanFieldKind::destructible`] answers for a classified plan field;
+/// [`type_close_strategy`] answers for a bare type, because two callers (the
+/// sealed emitter, the callback proxy) hold no plan. They are two independent
+/// walks over the same tree, and the doc-comment's "same tree" is a claim, not
+/// a construction — `classify_field` classifies a `Sum` *before* consulting
+/// `output_entry` while `type_close_strategy` asks `output_entry` first, and
+/// only one of them refuses anything.
+///
+/// A disagreement is a Kotlin compile error in one direction (`field.close()`
+/// on a type that is not `AutoCloseable`) and a silent leak in the other — #218
+/// reappearing at the seam its own fix introduced. So this asserts equality
+/// over every field of every declared type in a set covering all the shapes
+/// that can reach a handle: direct, through a sum, through a nested data class,
+/// optional, sequence, borrowed, and none of the above.
+#[test]
+fn a_types_close_answer_matches_its_plans() {
+    use crate::jni::struct_plan::{classify_field, type_close_strategy};
+
+    let loc = myflat_loc();
+    let items: Vec<(syn::Item, SourceLocation)> = vec![
+        (
+            syn::Item::Struct(syn::parse_quote!(
+                pub struct Probe {
+                    value: i64,
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Enum(syn::parse_quote!(
+                pub enum Lookup {
+                    Absent,
+                    Found(Probe),
+                    Failed(String),
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Enum(syn::parse_quote!(
+                pub enum Tally {
+                    None,
+                    Count(i64),
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Struct(syn::parse_quote!(
+                pub struct Inner {
+                    pub probe: Probe,
+                }
+            )),
+            loc.clone(),
+        ),
+        // Every field position at once: a handle direct and optional, a sum
+        // that reaches one and a sum that does not, a nested data class that
+        // reaches one, and plain scalars that reach nothing.
+        (
+            syn::Item::Struct(syn::parse_quote!(
+                pub struct Everything {
+                    pub id: i64,
+                    pub probe: Probe,
+                    pub maybe_probe: Option<Probe>,
+                    pub outcome: Lookup,
+                    pub tally: Tally,
+                    pub inner: Inner,
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn everything_new(id: i64) -> Everything {
+                    unimplemented!()
+                }
+            )),
+            loc,
+        ),
+    ];
+    let registry =
+        crate::test_util::reg_from_items(declare_referenced(items)).expect("index items");
+    let jni = JniGenBuilder::new()
+        .set_package_prefix("io.test.jni")
+        .package(
+            crate::package!()
+                .class(crate::ptr_class!(Probe))
+                .class(crate::sealed_class!(Lookup))
+                .class(crate::sealed_class!(Tally))
+                .class(crate::data_class!(Inner))
+                .class(crate::data_class!(Everything))
+                .fun(prebindgen_registry::fun!(everything_new)),
+        );
+    let gen = jni.build_with(registry).expect("resolve");
+    let (ext, registry) = (&gen.decls, &gen.registry);
+
+    // Every field of every declared type — struct fields and sum payloads
+    // alike, since a payload goes through the same `classify_field`.
+    let mut checked = 0usize;
+    for ty in registry.flat().types() {
+        let (owner, fields): (&syn::Ident, Vec<&prebindgen_registry::flat::Field>) = match ty {
+            prebindgen_registry::flat::Type::Struct(st) => (&st.name, st.fields.iter().collect()),
+            prebindgen_registry::flat::Type::Variant(sum) => (
+                &sum.name,
+                sum.alternatives
+                    .iter()
+                    .flat_map(|a| a.fields.iter())
+                    .collect(),
+            ),
+            _ => continue,
+        };
+        for field in fields {
+            let path = format!("{owner}.{}", field.member().to_token_stream());
+            // A field `classify_field` refuses has no plan answer to compare
+            // against — the documented, deliberate asymmetry.
+            let Some(kind) = classify_field(ext, registry, &field.ty, &path, 0) else {
+                continue;
+            };
+            assert_eq!(
+                kind.destructible().is_some(),
+                type_close_strategy(ext, registry, &field.ty, 0).is_some(),
+                "the two forms disagree about `{path}`: a plan field and its \
+                 bare type must reach the same handles",
+            );
+            checked += 1;
+        }
+    }
+    // The loop asserting nothing would pass vacuously.
+    assert!(
+        checked >= 10,
+        "expected every declared field to be compared, saw {checked}"
+    );
+    // …and the fixture must actually contain both answers, or agreement is
+    // trivial.
+    let everything = match registry
+        .flat()
+        .declared_type("Everything")
+        .expect("Everything is declared")
+    {
+        prebindgen_registry::flat::Type::Struct(st) => st,
+        _ => panic!("Everything is a struct"),
+    };
+    let closes: Vec<String> = everything
+        .fields
+        .iter()
+        .filter(|f| type_close_strategy(ext, registry, &f.ty, 0).is_some())
+        .map(|f| f.name.as_ref().unwrap().to_string())
+        .collect();
+    assert_eq!(
+        closes,
+        vec!["probe", "maybe_probe", "outcome", "inner"],
+        "the fixture must cover reaching a handle four ways AND not reaching one"
+    );
+}

--- a/prebindgen-jni/src/jni/tests/sealed.rs
+++ b/prebindgen-jni/src/jni/tests/sealed.rs
@@ -1250,13 +1250,14 @@ fn sum_return_group_can_own_a_handle() {
 /// Two consequences of this position, both asserted below so they cannot
 /// change silently:
 ///
-/// * The container is **not** `AutoCloseable` — `destructible()` matches only
-///   a `Projection` field, never a `Sum` one. That follows the documented
-///   ownership rule for sum payloads ("who closes a handle payload: the
-///   receiver"), but it does differ from a plain handle field, which *does*
-///   make its class closeable and cascades. The handle stays reachable and
-///   closeable through the variant (`(h.outcome as Lookup.Found).v0.close()`);
-///   what is absent is the cascade.
+/// * The container **is** `AutoCloseable` and cascades, exactly as it does for
+///   a plain handle field (#218). It did not, until the field's type stopped
+///   deciding who frees the handle: `destructible()` matched only a
+///   `Projection`, so the same handle was the container's to close when the
+///   field was spelled `Probe` and nobody's when it was spelled `Lookup`. What
+///   makes the two spellings agree is that `Lookup` is itself `AutoCloseable`
+///   — the `when` over the alternatives lives in the sum, so the container
+///   emits the same one-line cascade either way.
 /// * A sum field takes its parent off the fixed-builder path onto the
 ///   whole-value `fromParts` bridge (`synth_value_struct_leaves` declines
 ///   `TypeKind::Sum`), so the value costs a JVM object — a slower shape, not a
@@ -1339,14 +1340,205 @@ fn a_data_class_field_may_be_a_sum_carrying_a_handle() {
         kotlin.contains("public data class Holder(val id: Long, val outcome: Lookup)"),
         "the field surfaces as the typed sum:\n{kotlin}"
     );
+    // The cascade, exactly as a plain handle field gets — the container closes
+    // what its field reaches (#218). The `when` is NOT here: `Lookup` closes
+    // itself, so the container's body is the same one line it would emit for a
+    // handle-typed field.
+    let kc: String = kotlin.split_whitespace().collect();
     assert!(
-        !kotlin.contains("Holder(val id: Long, val outcome: Lookup) : AutoCloseable"),
-        "a sum-carried handle is the RECEIVER's to close — the container does \
-         not cascade, unlike a plain handle field:\n{kotlin}"
+        kotlin.contains(
+            "public data class Holder(val id: Long, val outcome: Lookup) : AutoCloseable"
+        ),
+        "a sum-carried handle is the container's to close, like a plain handle \
+         field:\n{kotlin}"
+    );
+    assert!(
+        kc.contains("overridefunclose(){outcome.close()}"),
+        "the container closes the field as a whole; the walk into the \
+         alternatives lives in `Lookup`:\n{kotlin}"
+    );
+    // And that walk: the sum is itself `AutoCloseable`, its handle-carrying
+    // alternative closes the payload, the others are no-ops.
+    assert!(
+        kc.contains("publicsealedinterfaceLookup:AutoCloseable"),
+        "the sum owns the cascade its containers delegate to:\n{kotlin}"
+    );
+    assert!(
+        kc.contains("dataclassFound(publicvalv0:Probe):Lookup{overridefunclose(){v0.close()}}"),
+        "the live alternative closes its payload:\n{kotlin}"
+    );
+    assert!(
+        kc.contains("dataobjectAbsent:Lookup{overridefunclose(){}}"),
+        "an alternative holding nothing native overrides with an empty body — \
+         Kotlin requires the member, and the emptiness is the statement:\n{kotlin}"
     );
     assert!(
         rust.contains("Lookup::Found") && rust.contains("Lookup::Absent"),
         "Rust matches the field's sum, filling every group's slots:\n{rust}"
+    );
+}
+
+/// The **third** spelling of the same handle: reached through a nested data
+/// class rather than through a sum or directly. Unfiled alongside #218 but the
+/// same `_ => None`, and the same argument settles it — swapping a field's type
+/// for a struct that holds the handle must not move the free onto the consumer.
+///
+/// Nothing here is special-cased: `Inner` is `AutoCloseable` because its own
+/// field is a handle, and `Outer` cascades into it with the same one-liner it
+/// would emit for a handle field. The recursion is one level of
+/// [`PlanFieldKind::destructible`], not a second mechanism.
+#[test]
+fn a_data_class_field_may_be_a_nested_data_class_carrying_a_handle() {
+    let loc = myflat_loc();
+    let items: Vec<(syn::Item, SourceLocation)> = vec![
+        (
+            syn::Item::Struct(syn::parse_quote!(
+                pub struct Probe {
+                    value: i64,
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Struct(syn::parse_quote!(
+                pub struct Inner {
+                    pub probe: Probe,
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Struct(syn::parse_quote!(
+                pub struct Outer {
+                    pub id: i64,
+                    pub inner: Inner,
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn outer_new(id: i64) -> Outer {
+                    unimplemented!()
+                }
+            )),
+            loc,
+        ),
+    ];
+    let registry =
+        crate::test_util::reg_from_items(declare_referenced(items)).expect("index items");
+    let jni = JniGenBuilder::new()
+        .set_package_prefix("io.test.jni")
+        .package(
+            crate::package!()
+                .class(crate::ptr_class!(Probe))
+                .class(crate::data_class!(Inner))
+                .class(crate::data_class!(Outer))
+                .fun(prebindgen_registry::fun!(outer_new)),
+        );
+    let dir = unique_test_dir("jnigen_nested_handle_field");
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    let gen = jni.build_with(registry).expect("resolve");
+    let kotlin = gen
+        .write_kotlin(&dir.join("kotlin"))
+        .expect("write_kotlin")
+        .iter()
+        .map(|p| std::fs::read_to_string(p).unwrap())
+        .collect::<Vec<_>>()
+        .join("\n");
+    let kc: String = kotlin.split_whitespace().collect();
+
+    assert!(
+        kc.contains(
+            "dataclassInner(valprobe:Probe):AutoCloseable{overridefunclose(){probe.close()}"
+        ),
+        "the direct handle field cascades, as it always did:\n{kotlin}"
+    );
+    assert!(
+        kc.contains("dataclassOuter(valid:Long,valinner:Inner):AutoCloseable"),
+        "…and so does the container that only REACHES the handle:\n{kotlin}"
+    );
+    assert!(
+        kc.contains("overridefunclose(){inner.close()}"),
+        "the outer closes the field as a whole — the walk is the inner \
+         class's:\n{kotlin}"
+    );
+}
+
+/// The predicate must not over-fire: a sum whose alternatives own nothing
+/// native stays a plain `sealed interface`, with no `AutoCloseable` and no
+/// `close()` on its variant classes. Otherwise every sum in every binding would
+/// grow a lifecycle it has no use for.
+#[test]
+fn a_sum_owning_nothing_native_is_not_closeable() {
+    let loc = myflat_loc();
+    let items: Vec<(syn::Item, SourceLocation)> = vec![
+        (
+            syn::Item::Enum(syn::parse_quote!(
+                pub enum Reading {
+                    Missing,
+                    Exact(i64),
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Struct(syn::parse_quote!(
+                pub struct Gauge {
+                    pub id: i64,
+                    pub reading: Reading,
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn gauge_new(id: i64) -> Gauge {
+                    unimplemented!()
+                }
+            )),
+            loc,
+        ),
+    ];
+    let registry =
+        crate::test_util::reg_from_items(declare_referenced(items)).expect("index items");
+    let jni = JniGenBuilder::new()
+        .set_package_prefix("io.test.jni")
+        .package(
+            crate::package!()
+                .class(crate::sealed_class!(Reading))
+                .class(crate::data_class!(Gauge))
+                .fun(prebindgen_registry::fun!(gauge_new)),
+        );
+    let dir = unique_test_dir("jnigen_sum_no_handle");
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    let gen = jni.build_with(registry).expect("resolve");
+    let kotlin = gen
+        .write_kotlin(&dir.join("kotlin"))
+        .expect("write_kotlin")
+        .iter()
+        .map(|p| std::fs::read_to_string(p).unwrap())
+        .collect::<Vec<_>>()
+        .join("\n");
+    let kc: String = kotlin.split_whitespace().collect();
+
+    assert!(
+        kc.contains("publicsealedinterfaceReading{"),
+        "an `i64` payload owns nothing, so the sum takes no lifecycle:\n{kotlin}"
+    );
+    assert!(
+        !kc.contains("interfaceReading:AutoCloseable"),
+        "…and does not implement `AutoCloseable`:\n{kotlin}"
+    );
+    assert!(
+        !kc.contains("Exact(publicvalv0:Long):Reading{overridefunclose"),
+        "…so its variant classes carry no `close()` either:\n{kotlin}"
+    );
+    assert!(
+        !kc.contains("Gauge(valid:Long,valreading:Reading):AutoCloseable"),
+        "and the container holding it stays non-closeable:\n{kotlin}"
     );
 }
 
@@ -1429,16 +1621,33 @@ fn two_sum_callback_args_keep_their_own_selectors() {
         "each sum contributes its own selector:\n{kotlin}"
     );
     // Each `when` reads ITS OWN selector — in the dispatch and in the message.
+    // Compared whitespace-insensitively: `Lookup` carries a handle, so its
+    // reassembly is bound to a local and the call moves inside a `try` (below).
+    let kc: String = kotlin.split_whitespace().collect();
     assert!(
-        kotlin.contains("when (tag) { 0 -> Reading.Missing;")
+        kc.contains("when(tag){0->Reading.Missing;")
             && kotlin.contains(r#"IllegalArgumentException("Reading: invalid tag $tag")"#),
         "{kotlin}"
     );
     assert!(
-        kotlin.contains("when (tag2) { 0 -> Lookup.Absent;")
+        kc.contains("when(tag2){0->Lookup.Absent;")
             && kotlin.contains(r#"IllegalArgumentException("Lookup: invalid tag $tag2")"#),
         "the second sum's reassembly must follow its renamed selector, template \
          included:\n{kotlin}"
+    );
+    // …and exactly the sum that reaches a handle is the proxy's to close after
+    // `run` (#218). `Reading`'s payload is an `i64`, so it stays inline in the
+    // call and nothing closes it; `Lookup.Found` carries a `Probe`, so it binds
+    // to a local closed in a `finally` — the close-unless-taken contract a
+    // handle passed DIRECTLY to a callback has always had.
+    assert!(
+        kc.contains("val__own0=when(tag2)") && kc.contains("finally{__own0.close()}"),
+        "a handle reached through a sum arg is closed after `run`, exactly as a \
+         handle arg is:\n{kotlin}"
+    );
+    assert!(
+        !kc.contains("__own1"),
+        "a sum whose payload owns nothing native is not bound and not closed:\n{kotlin}"
     );
 }
 


### PR DESCRIPTION
Closes #218.

## The asymmetry

A native handle buried in another value had three different owners, decided only by its Rust spelling:

| the handle sits in… | data-class field | callback argument |
|---|---|---|
| the field/arg directly | container's `close()` | proxy, after `run()` |
| an enum payload (`sealed_class`) | **nobody** | **receiver, by hand** |
| a nested data class | **nobody** | **nobody** |

So swapping a field's type from a handle to an enum carrying that handle silently moved the free onto the consumer, with nothing in the generated Kotlin saying so. `PlanFieldKind::destructible()` matched only a `Projection`; everything else fell through to `_ => None`.

#218 offers "document it" or "cascade" and leans toward documenting. The decision here is **cascade**, on the grounds that the field's type is an implementation detail: replacing a struct with an enum must not change who frees the handle. That argument also settles the **nested-data-class** row, which is the same match arm and had no issue of its own.

## The shape of the fix

Not "teach each use site to walk into wrappers". Instead the generated *type* becomes closeable, so every position keeps calling plain `close()`:

```kotlin
public sealed interface Lookup : AutoCloseable {
    public data object Absent : Lookup { override fun close() {} }
    public data class Found(public val v0: Summary) : Lookup { override fun close() { v0.close() } }
    public data class Failed(public val v0: String) : Lookup { override fun close() {} }
}
```

The `when` over the alternatives is emitted **once**, in the sum. A data-class field then cascades with the same one-liner a handle field gets — no `when` at the container:

```kotlin
public data class Verdict(val id: Long, val outcome: Lookup) : AutoCloseable {
    override fun close() { outcome.close() }
}
```

…and the callback proxy needed only to be told the reassembled arg is owned; the close-unless-taken `finally` already existed for bare handle args.

One rule, asked two ways over the same tree: `PlanFieldKind::destructible` recurses through `Sum`/`Nested` for an already-classified field; `type_close_strategy` answers for a bare type where the caller holds no plan (the sealed emitter, the callback builder). Both refuse a **borrowed** handle — not the holder's to release — so a fold over a borrowed run emits no per-iteration close that would double-free.

## ⚠️ Breaking

**A sum-carried handle delivered to a callback is now closed when `run` returns.** A body meaning to outlive the call must `take()` it — exactly the contract a plain `impl Fn(Handle)` arg has always had. `docs/sum-types.md` §4.5 is rewritten accordingly: the rule is no longer "the receiver closes, in both positions" but "closed exactly as a bare handle in the same position", across all three.

Downstream impact today: **none**. `zenoh-flat-jni`'s only two sums (`RecoveryMode`, `InstrumentationTimestamp`) carry `ULong`/`ByteArray`/`Timestamp` (a `data_class!`) — no handles. Confirmed by `regen-check.sh --with-zenoh-flat-jni`: its generated output is byte-identical. It will apply to `ReplyResult`, which is what prompted the issue.

## Coverage

- `sealed.rs::a_data_class_field_may_be_a_sum_carrying_a_handle` — its negative assertion (and doc-comment rationale) flipped to the cascade.
- **New** `a_data_class_field_may_be_a_nested_data_class_carrying_a_handle` — the previously unfiled row. Verified as a real guard: reverting the `Nested` arm fails it.
- **New** `a_sum_owning_nothing_native_is_not_closeable` — the predicate must not over-fire; a sum of `i64` payloads stays a plain `sealed interface`.
- `two_sum_callback_args_keep_their_own_selectors` — now also pins that exactly the handle-carrying sum binds a local and closes, and the other does not.
- `examples/covertest-kotlin` gains `Verdict` (sum in data-class-field position, beside `Holder`'s plain handle field). Its JVM harness asserts the cascade, the post-`run` close, and `take()` keeping the payload alive — **50 sections pass under `./gradlew run`**, which is what proves close-unless-taken at runtime rather than just in the emission.

## Also

The owned path would otherwise have wrecked the emitted formatting — a reassembly is one piece of raw text, and `wline` width-broke it mid-`when` into something valid but unreadable. It now binds to a `val`, and lambda params stay one-per-line as in the common path, so the golden diff reads as the behaviour change alone.

## Verified

`cargo test --all`; `cargo clippy --all-targets --all-features -- -D warnings` and `cargo fmt --check` (CI's exact config) on **1.85.0 and stable**; `examples/regen-check.sh` clean; `examples/regen-check.sh --with-zenoh-flat-jni` byte-identical; `covertest-kotlin$ ./gradlew run` PASS.