### PR TITLE
docs: give the same-kind rule a live home (refs #230)

### DIFF
--- a/prebindgen-c/src/builder.rs
+++ b/prebindgen-c/src/builder.rs
@@ -303,6 +303,31 @@ impl CbindgenBuilder {
     /// plain data (a by-value crossing is a bitwise copy with no write-back). The source
     /// type needs `Default` **only** if it has a bare `Box<T>` field (whose gravestone
     /// can't be a NULL pointer); `Option<Box<T>>` fields are nulled in place.
+    ///
+    /// # Why the spelling is load-bearing here
+    ///
+    /// This is the one position that is **exempt** from the rule stated on
+    /// [`prebindgen_registry::Prebindgen`] — *same `kind` ⇒ same
+    /// destination-language type* — and the exemption is structural rather than
+    /// a concession. A mirror is not converted; it is **reinterpreted from the
+    /// source struct's bytes**, so its field types are a *layout* fact. `Box<T>`
+    /// is a pointer and `T` is inline: to C they really are different types, and
+    /// the size/align assert above would reject a mirror that pretended
+    /// otherwise. So this path reads the wrapper the model erases —
+    /// [`kind`](prebindgen_registry::flat::TypeRef::kind) rather than
+    /// [`unwrapped`](prebindgen_registry::flat::TypeRef::unwrapped) — on
+    /// purpose. It is the one place the usual "classify off `kind`, spell off
+    /// the syntax" split inverts, and it inverts because the contract is layout
+    /// rather than surface.
+    ///
+    /// That is also why a wrapper the model erases must **not** be refused here
+    /// (prebindgen#230). `Option<Box<String>>` is how a source crate says "this
+    /// field is a nullable pointer" — a layout statement a zero-copy mirror is
+    /// entitled to read, not the source naming a C type. There is no competing
+    /// spelling to prefer: `Option<String>` is a 24-byte niche-optimised value
+    /// with no C representation at all, and declaring one is a hard error naming
+    /// the field. Rejecting the `Box` would leave a nullable-pointer field
+    /// inexpressible.
     pub fn repr_c_struct(mut self, ty: syn::Type) -> Self {
         let key = TypeKey::from_type(&ty);
         assert!(

--- a/prebindgen-c/src/tests/tagged_unions.rs
+++ b/prebindgen-c/src/tests/tagged_unions.rs
@@ -762,26 +762,18 @@ fn bool_payload_is_normalised_not_materialised() {
 /// **Same `kind` ⇒ same destination-language type.** Three spellings of one
 /// optional handle present one C type.
 ///
-/// The rule the wire question actually obeys, and a correction to how #292
-/// stated it: "same `kind` ⇒ same wire" is false — a generator owns wire
-/// selection and may legitimately vary it per spelling, absorbing the
-/// difference in the destination-language wrapper (the JNI adapter crosses `&[Payload]`
-/// as a `Long` Vec handle and `Vec<Box<Payload>>` as a `JObject`, both surfacing
-/// as `List<Payload>`). What must not vary is **what the destination sees**.
+/// The rule itself is stated on [`prebindgen_registry::Prebindgen`], and the
+/// layout-mirror exemption on [`CbindgenBuilder::repr_c_struct`]; this pins the
+/// **converted** case in C.
 ///
-/// A union payload is the position where that bites in C, because it is
-/// *converted* — rebuilt arm by arm — so nothing about the Rust layout is
-/// forced on the C type. `Option<Box<Handle>>` took an opaque-pointer arm keyed
-/// on the `Box` in the spelling, while `Option<Handle>` fell through to the
-/// converter-destination rule and was **refused outright** (its output side is a
+/// A union payload is where the rule bites here, because it is *converted* —
+/// rebuilt arm by arm — so nothing about the Rust layout is forced on the C
+/// type. `Option<Box<Handle>>` took an opaque-pointer arm keyed on the `Box` in
+/// the spelling, while `Option<Handle>` fell through to the converter-
+/// destination rule and was **refused outright** (its output side is a
 /// structural marker whose `()` cannot agree with the input's pointer). So an
 /// erased wrapper decided whether the shape was expressible at all — the same
 /// defect shape as the JNI adapter's declaration lookup in #292.
-///
-/// The exemption this does *not* touch is [`CbindgenBuilder::repr_c_struct`]: a
-/// zero-copy mirror is reinterpreted from the source struct's bytes, so its C
-/// type is a **layout** fact and `Box<T>` (a pointer) really is a different C
-/// type from `T` (inline). There the spelling is load-bearing by construction.
 #[test]
 fn one_kind_presents_one_c_type_however_it_is_spelled() {
     let loc = SourceLocation::default();

--- a/prebindgen-registry/src/prebindgen.rs
+++ b/prebindgen-registry/src/prebindgen.rs
@@ -160,7 +160,7 @@ pub struct ConverterImpl<M = ()> {
 /// | Rust | `kind` | Kotlin type | wire |
 /// |---|---|---|---|
 /// | `&[Payload]` | `Ref(Slice)` | `List<Payload>` | `Long` — a handle to a Rust-side `Vec` |
-/// | `Vec<Box<Payload>>` | `Vec(Boxed)` | `List<Payload>` | `List<Payload>` — a `JObject` |
+/// | `Vec<Box<Payload>>` | `Vec(Boxed)` | `List<Payload>` | `JObject` — a Java `List<Payload>` |
 ///
 /// Two wires, one surface. Choosing a wire is exactly the generator's job, and
 /// the destination-language wrapper absorbs the difference; a caller cannot

--- a/prebindgen-registry/src/prebindgen.rs
+++ b/prebindgen-registry/src/prebindgen.rs
@@ -142,6 +142,43 @@ pub struct ConverterImpl<M = ()> {
 /// chooses. It is set in each `ConverterImpl::metadata`, propagated by the
 /// resolver into `TypeEntry::metadata`, and read back by the adapter's own
 /// emitter. Adapters that need no extras leave it at the default `()`.
+///
+/// # The rule an adapter must obey
+///
+/// "Classify off [`kind`](crate::flat::TypeRef::kind), spell off the syntax"
+/// tells an adapter where to get each fact. It is silent on the question
+/// adapters actually face — what the **destination language** ends up seeing.
+/// That one has its own answer:
+///
+/// > **Same `kind` ⇒ same destination-language type.** The *wire* is the
+/// > generator's to choose, and may differ per spelling.
+///
+/// The weaker-sounding half is the important one. It is tempting to write "same
+/// `kind` ⇒ same wire", and that is **false** — prebindgen's own adapters
+/// violate it deliberately:
+///
+/// | Rust | `kind` | Kotlin type | wire |
+/// |---|---|---|---|
+/// | `&[Payload]` | `Ref(Slice)` | `List<Payload>` | `Long` — a handle to a Rust-side `Vec` |
+/// | `Vec<Box<Payload>>` | `Vec(Boxed)` | `List<Payload>` | `List<Payload>` — a `JObject` |
+///
+/// Two wires, one surface. Choosing a wire is exactly the generator's job, and
+/// the destination-language wrapper absorbs the difference; a caller cannot
+/// tell. What a caller *can* tell — and what
+/// [`unwrapped`](crate::flat::TypeRef::unwrapped) exists to prevent — is the
+/// **type** changing because the source spelled a `Box`.
+///
+/// The rule scopes to **converted** positions: those where a converter stands
+/// between the Rust value and the destination and is therefore free to bridge.
+/// It cannot apply to a **layout mirror**, where the destination type is
+/// reinterpreted from the source struct's bytes and is a *layout* fact rather
+/// than a surface choice — there `Box<T>` (a pointer) genuinely is a different
+/// destination type from `T` (inline), the spelling is load-bearing by
+/// construction, and no erasure can apply. The C adapter's `repr_c_struct` is
+/// the one such position in-tree, and its own documentation carries that half.
+///
+/// Reusing a mirror's spelling test in a converted position is how the rule
+/// gets broken (prebindgen#230, #292).
 pub trait Prebindgen {
     /// Adapter-specific extras every resolved converter carries. The
     /// resolver copies this from each `ConverterImpl` it accepts into


### PR DESCRIPTION
Groundwork for closing #230, which turned out to be a documentation problem rather than a code one.

## Why

#230 reports that `Option<Box<String>>` and `Option<String>` get different C wires. Its own comment already diagnoses that as miscategorised — the wire is the generator's to choose — and the real defect it exposed (a *converted* tagged-union payload reusing the *mirror's* `Box`-in-the-spelling test) was fixed by PR#295.

But the rule that makes that diagnosis land lived in `docs/language-integration.md`, and #369 deleted that file as a dead program document. Correctly, as a whole — nothing linked to it. The rule went with it, and now survives only as a doc comment on one `prebindgen-c` test. A governing invariant for adapter authors should not live there.

## What moves where

- **`Prebindgen`** (`prebindgen-registry/src/prebindgen.rs`) — the extension point every adapter implements — gets the rule itself:

  > **Same `kind` ⇒ same destination-language type.** The *wire* is the generator's to choose, and may differ per spelling.

  With the table that keeps the weaker half from being "corrected" into the false *same `kind` ⇒ same wire*: `&[Payload]` crosses as a `Long` handle and `Vec<Box<Payload>>` as a `JObject`, both surfacing as `List<Payload>`. Two wires, one surface — deliberately. And its scope: **converted** positions, where a converter stands between the Rust value and the destination.

- **`CbindgenBuilder::repr_c_struct`** gets the exemption, stated as structural rather than as a concession. A mirror is reinterpreted from the source struct's bytes, so its field types are a *layout* fact; `Box<T>` (a pointer) and `T` (inline) really are different C types, and the size/align assert would reject a mirror that pretended otherwise. This is the one place the "classify off `kind`, spell off the syntax" split inverts, and it inverts because the contract is layout rather than surface.

- **The test's doc comment** now points at both rather than restating the rule — one statement, two references, instead of three copies that can drift.

## Measured while writing it

The exemption argument is stronger than #230's comment assumed, and I checked rather than repeated it:

| | size | in a `repr_c_struct` |
|---|---|---|
| `Option<Box<String>>` | 8 | `*mut string_t` |
| `Option<String>` | 24 | **hard error** |

`mirror_field_wire` returns `None` for `Option<String>`, and `generate_mirror` panics naming the field. So this was never "two wires for one type" — only one of the two spellings has a C representation at all, and refusing the `Box` would leave a nullable-pointer field inexpressible.

## Verified

Docs only — no behaviour.

- `cargo test --all --all-features` — 595 passed, 0 failed.
- `examples/regen-check.sh` after `cargo clean --release` — **byte-identical**. These are prebindgen's own API docs, not source-crate item docs, so nothing should reach generated output, and nothing did.
- **rustdoc**: the two crates' error sets are byte-identical before and after (compared on messages, since inserting doc text shifts every line number below it). The workspace doc job is already red on `main` for 46 pre-existing intra-doc links — that is what `fix/intra-doc-links` is about, and none of them are here. One redundant-explicit-link the first draft did add is fixed.
- `cargo fmt --check` with the CI config; clippy `-D warnings` clean on both 1.85.0 and stable.

Based on `main`; touches no file that #383 or #385 touches.