### PR TITLE
registry: a declared function cannot be looked up without its target (#223 cheap win)

### DIFF
--- a/prebindgen-registry/src/declared_target.rs
+++ b/prebindgen-registry/src/declared_target.rs
@@ -1,0 +1,54 @@
+//! The one check every declarator owes: a declared function must be **about**
+//! the type it was declared for.
+//!
+//! Both expansion directions ask it — an input constructor must *produce* the
+//! parameter's target, an output accessor must *take* the deconstructor's
+//! source — and each used to carry its own private copy. Two copies is how the
+//! check went missing from a third declarator (prebindgen#223, the P2 from
+//! [#221](https://github.com/milyin/prebindgen/pull/221)): the policy lived in
+//! prose, so a new declarator started with zero checks and nothing noticed.
+//!
+//! **The comparison is shared here; being *asked* is enforced elsewhere.** A
+//! helper alone would not have prevented that defect — a new declarator could
+//! simply not call it. What prevents it is that the signature lookups
+//! ([`ctor_signature`](crate::expand), `accessor_signature` in
+//! [`crate::unfold`]) take the expected target as a **parameter** and run this
+//! check themselves. There is no way to obtain a declared function's signature
+//! without naming the type it must match, so the obligation is discharged by
+//! the compiler rather than by remembering.
+
+use crate::registry::TypeKey;
+
+/// A declared function that is not about its declared type.
+///
+/// Deliberately vocabulary-free: it names the two keys that disagreed and
+/// leaves the wording to whichever error type absorbs it, because the two
+/// directions say it differently — a constructor *produces*, an accessor
+/// *takes*. Those messages are the binding author's diagnostics and belong with
+/// their own error enum, not here.
+pub(crate) struct TargetMismatch {
+    /// The declared function's ident.
+    pub(crate) func: String,
+    /// The type it is actually about.
+    pub(crate) actual: String,
+    /// The type it was declared for.
+    pub(crate) expected: String,
+}
+
+/// The comparison itself: two [`TypeKey`]s, keyed so that spelling differences
+/// which do not change identity cannot make a correct declaration fail.
+pub(crate) fn check_declared_target(
+    func: &syn::Ident,
+    actual: &TypeKey,
+    expected: &TypeKey,
+) -> Result<(), TargetMismatch> {
+    if actual == expected {
+        Ok(())
+    } else {
+        Err(TargetMismatch {
+            func: func.to_string(),
+            actual: actual.to_string(),
+            expected: expected.to_string(),
+        })
+    }
+}

--- a/prebindgen-registry/src/declared_target.rs
+++ b/prebindgen-registry/src/declared_target.rs
@@ -11,8 +11,8 @@
 //! **The comparison is shared here; being *asked* is enforced elsewhere.** A
 //! helper alone would not have prevented that defect — a new declarator could
 //! simply not call it. What prevents it is that the signature lookups
-//! ([`ctor_signature`](crate::expand), `accessor_signature` in
-//! [`crate::unfold`]) take the expected target as a **parameter** and run this
+//! (`expand::ctor_signature` and `unfold::accessor_signature`) take the
+//! expected target as a **parameter** and run this
 //! check themselves. There is no way to obtain a declared function's signature
 //! without naming the type it must match, so the obligation is discharged by
 //! the compiler rather than by remembering.

--- a/prebindgen-registry/src/expand.rs
+++ b/prebindgen-registry/src/expand.rs
@@ -30,7 +30,10 @@ use prebindgen_flat::types_util::ident;
 use proc_macro2::TokenStream;
 use quote::quote;
 
-use crate::registry::{Registry, TypeKey};
+use crate::{
+    declared_target::check_declared_target,
+    registry::{Registry, TypeKey},
+};
 
 mod error;
 mod plan;
@@ -347,7 +350,19 @@ fn resolve_constructor<M>(
 
 /// Constructor signature: parameter `(name, type)` pairs, the produced
 /// (`Ok`) target type, and whether it is fallible (`-> Result<_, _>`).
-fn ctor_signature<M>(registry: &Registry<M>, func: &syn::Ident) -> Result<CtorSig, ExpandError> {
+///
+/// `expected` is the type the declaration is *for*, and the returned signature
+/// is one already proven to produce it. Taking it as a parameter rather than
+/// leaving the caller to check afterwards is the point: a declarator cannot
+/// reach a constructor's signature without saying what that constructor is
+/// supposed to build, so the check cannot be the thing a new declarator forgets
+/// (#223). The comparison is [`check_declared_target`], shared with the output
+/// side's accessor lookup.
+fn ctor_signature<M>(
+    registry: &Registry<M>,
+    func: &syn::Ident,
+    expected: &TypeKey,
+) -> Result<CtorSig, ExpandError> {
     // Read off the element rather than re-walked from the signature: `params`
     // and `ret` are the same facts, already decided once — including that an
     // elided return and a written `-> ()` are one thing.
@@ -367,20 +382,14 @@ fn ctor_signature<M>(registry: &Registry<M>, func: &syn::Ident) -> Result<CtorSi
         Some((ok, _)) => (ok.key(), true),
         None => (f.ret.key(), false),
     };
-    Ok(CtorSig {
-        params,
-        target,
-        fallible,
-    })
+    check_declared_target(func, &target, expected)?;
+    Ok(CtorSig { params, fallible })
 }
 
 struct CtorSig {
     /// Readings, not spellings: they come off `Function::params`, and a consumer
     /// that needs the spelling takes it at the point it stores one.
     params: Vec<(syn::Ident, prebindgen_flat::flat::TypeRef)>,
-    /// The type the constructor produces, as an **identity**: every use of it
-    /// is `check_target`, which keyed both sides.
-    target: TypeKey,
     fallible: bool,
 }
 
@@ -439,8 +448,7 @@ fn build_plan<M>(
                 variants: fold_variants,
             });
         };
-        let sig = ctor_signature(registry, func)?;
-        check_target(func, &sig.target, &target.key())?;
+        let sig = ctor_signature(registry, func, &target.key())?;
         if sig.params.len() == 1 {
             let (_pn, pty) = &sig.params[0];
             leaves.push(FoldLeaf {
@@ -553,8 +561,7 @@ fn build_core<M>(
 ) -> Result<(Option<usize>, Vec<FoldVariant>), ExpandError> {
     if let [Variant::Ctor(func)] = variants {
         // Single constructor — no selector; args passed directly (not Option-wrapped).
-        let sig = ctor_signature(registry, func)?;
-        check_target(func, &sig.target, &target.key())?;
+        let sig = ctor_signature(registry, func, &target.key())?;
         let np = sig.params.len();
         let mut args = Vec::new();
         for (pname, pty) in &sig.params {
@@ -588,8 +595,7 @@ fn build_core<M>(
         for (vi, v) in variants.iter().enumerate() {
             match v {
                 Variant::Ctor(func) => {
-                    let sig = ctor_signature(registry, func)?;
-                    check_target(func, &sig.target, &target.key())?;
+                    let sig = ctor_signature(registry, func, &target.key())?;
                     let np = sig.params.len();
                     let mut args = Vec::new();
                     for (pi, (_pname, pty)) in sig.params.iter().enumerate() {
@@ -715,19 +721,15 @@ fn build_arg<M>(
     }
 }
 
-fn check_target(
-    func: &syn::Ident,
-    produces: &TypeKey,
-    expected: &TypeKey,
-) -> Result<(), ExpandError> {
-    if produces == expected {
-        Ok(())
-    } else {
-        Err(ExpandError::TargetMismatch {
-            ctor: func.to_string(),
-            produces: produces.to_string(),
-            expected: expected.to_string(),
-        })
+/// The shared mismatch, in this direction's vocabulary: an input constructor is
+/// declared to **produce** the parameter's target.
+impl From<crate::declared_target::TargetMismatch> for ExpandError {
+    fn from(m: crate::declared_target::TargetMismatch) -> Self {
+        ExpandError::TargetMismatch {
+            ctor: m.func,
+            produces: m.actual,
+            expected: m.expected,
+        }
     }
 }
 

--- a/prebindgen-registry/src/expand.rs
+++ b/prebindgen-registry/src/expand.rs
@@ -348,8 +348,9 @@ fn resolve_constructor<M>(
     }
 }
 
-/// Constructor signature: parameter `(name, type)` pairs, the produced
-/// (`Ok`) target type, and whether it is fallible (`-> Result<_, _>`).
+/// Constructor signature: parameter `(name, type)` pairs and whether it is
+/// fallible (`-> Result<_, _>`). The produced (`Ok`) target type is *checked*
+/// here rather than returned — see below.
 ///
 /// `expected` is the type the declaration is *for*, and the returned signature
 /// is one already proven to produce it. Taking it as a parameter rather than

--- a/prebindgen-registry/src/lib.rs
+++ b/prebindgen-registry/src/lib.rs
@@ -96,6 +96,7 @@
 //! `prebindgen-jni` crate, which hands the result to its `JniGenBuilder`.
 
 pub mod decl;
+pub(crate) mod declared_target;
 mod destination;
 pub mod diagnostics;
 pub mod domain;

--- a/prebindgen-registry/src/unfold.rs
+++ b/prebindgen-registry/src/unfold.rs
@@ -27,7 +27,10 @@
 
 use std::collections::HashSet;
 
-use crate::registry::{Registry, TypeKey};
+use crate::{
+    declared_target::check_declared_target,
+    registry::{Registry, TypeKey},
+};
 
 mod error;
 mod plan;
@@ -1413,8 +1416,7 @@ fn flatten<M>(
                 // The value form is called once; every field hangs off that one
                 // call, so the whole record shares a single `Call` step and the
                 // emitter can hoist it.
-                let (takes, _ret) = accessor_signature(registry, func)?;
-                check_takes(func, &takes, &source.key())?;
+                accessor_signature(registry, func, &source.key())?;
                 // The declarator states whether the value is given away; the
                 // signature has to agree, or the emitted call would not compile
                 // in the consumer's crate. Checked rather than inferred so that
@@ -1600,8 +1602,7 @@ fn flatten<M>(
                     DeconRecord::LocalAcc { path, .. } => (DeconRecord::local_ident(path), true),
                     DeconRecord::Identity | DeconRecord::Fields { .. } => unreachable!(),
                 };
-                let (takes, ret) = accessor_signature(registry, &func)?;
-                check_takes(&func, &takes, &source.key())?;
+                let ret = accessor_signature(registry, &func, &source.key())?;
                 // Default unwrap: if the return type has its own deconstructor,
                 // splice it (recurse); otherwise the return is one leaf. Peel an
                 // `Option` (value may be absent) + leading `&` to reach the child.
@@ -1733,12 +1734,21 @@ pub fn dedup_names(names: &mut [String]) {
     }
 }
 
-/// An accessor `f(&T) -> R`: returns the (peeled) `T` it takes and its return
-/// type `R` as written (a reference where possible).
+/// An accessor `f(&T) -> R`: returns its return type `R` as written (a
+/// reference where possible).
+///
+/// `expected` is the type the deconstructor decomposes, and what comes back is
+/// an accessor already proven to take it. Taking it as a parameter rather than
+/// leaving the caller to check afterwards is the point: a declarator cannot
+/// reach an accessor's signature without saying what that accessor is supposed
+/// to be about, so the check cannot be the thing a new declarator forgets
+/// (#223). The comparison is [`check_declared_target`], shared with the input
+/// side's constructor lookup.
 fn accessor_signature<M>(
     registry: &Registry<M>,
     func: &syn::Ident,
-) -> Result<(TypeKey, prebindgen_flat::flat::TypeRef), UnfoldError> {
+    expected: &TypeKey,
+) -> Result<prebindgen_flat::flat::TypeRef, UnfoldError> {
     let f = registry
         .flat()
         .function(&func)
@@ -1751,13 +1761,14 @@ fn accessor_signature<M>(
         .params
         .first()
         .ok_or_else(|| UnfoldError::UnknownAccessor(func.clone()))?;
-    // The receiver's identity: `accessor_signature`'s one caller compares it,
-    // and `check_takes` keyed both sides to do so.
+    // The receiver's identity, keyed so the comparison below cannot fail on a
+    // spelling difference that does not change which type this is about.
     let takes = match first.ty.borrow_target() {
         Some(inner) => inner.key(),
         None => first.ty.key(),
     };
-    Ok((takes, f.ret.clone()))
+    check_declared_target(func, &takes, expected)?;
+    Ok(f.ret.clone())
 }
 
 /// Whether the value sitting at `path_prefix` is the plan's **to give away**:
@@ -1794,15 +1805,15 @@ fn accessor_consumes<M>(registry: &Registry<M>, func: &syn::Ident) -> bool {
         .is_some_and(|p| p.ty.borrow_target().is_none())
 }
 
-fn check_takes(func: &syn::Ident, takes: &TypeKey, expected: &TypeKey) -> Result<(), UnfoldError> {
-    if takes == expected {
-        Ok(())
-    } else {
-        Err(UnfoldError::AccessorTargetMismatch {
-            accessor: func.to_string(),
-            takes: takes.to_string(),
-            expected: expected.to_string(),
-        })
+/// The shared mismatch, in this direction's vocabulary: an output accessor is
+/// declared to **take** the type the deconstructor decomposes.
+impl From<crate::declared_target::TargetMismatch> for UnfoldError {
+    fn from(m: crate::declared_target::TargetMismatch) -> Self {
+        UnfoldError::AccessorTargetMismatch {
+            accessor: m.func,
+            takes: m.actual,
+            expected: m.expected,
+        }
     }
 }
 


### PR DESCRIPTION
The "independent cheap win" from #223 — *a shared "declared type matches its target" helper, so a new declarator cannot ship without the check*.

## Why a shared helper is not enough

The check existed twice: `check_target` (`expand.rs`) and `check_takes` (`unfold.rs`) — two private functions, two error types, one comparison. #221's P2 was a **new declarator that had neither**, which is the failure mode #223 describes as *"the policy lives in prose, not in a type"*.

A shared helper alone would not have prevented that. A new declarator could simply not call it.

## What makes it unavoidable

There is a chokepoint. Measured before designing anything: **all five callers** of the two signature lookups already ran the check on the very next line — `expand.rs:442,556,591` and `unfold.rs:1416,1603`, no exceptions. So no caller needs an unchecked variant, and the check moves **into** the lookup:

```rust
fn ctor_signature<M>(registry, func, expected: &TypeKey) -> Result<CtorSig, ExpandError>
fn accessor_signature<M>(registry, func, expected: &TypeKey) -> Result<TypeRef, UnfoldError>
```

You cannot reach a declared function's signature without saying what it is supposed to be about. Skipping the check is `E0061`, not a silent omission.

The comparison itself is one function in a new `declared_target` module, deliberately vocabulary-free: the two directions say it differently — a constructor *produces*, an accessor *takes* — so each error enum absorbs a neutral mismatch through `From` and keeps its existing message **verbatim**. Those messages are the binding author's diagnostics and must not regress.

## What folding it in revealed

Both lookups were returning a value that existed *only* so the caller could check it. With the check internal, `CtorSig::target` is dead and `accessor_signature`'s `takes` half is unused at both call sites. Both removed — so the target identity no longer leaves the lookup at all, and there is not even a way to observe a mismatch and ignore it. That was not planned; the compiler pointed it out.

One deviation from the plan: **no `TargetRole` field**. The plan called for the neutral value to carry the direction, but each `From` impl knows its own, so nothing would ever have read it. Dropped rather than shipped unused.

## Verified

- `cargo test --all --all-features` — 595 passed, 0 failed.
- **Both directions bite, on the one comparison.** Disabling it in `declared_target.rs` fails `expand::tests::constructor_target_mismatch_errors` *and* `unfold::tests::accessor_target_mismatch_errors` — the two existing tests, now sharing one enforcement point.
- **The obligation is compiler-enforced.** Dropping the `expected` argument at a call site: `error[E0061]: this function takes 3 arguments but 2 arguments were supplied`.
- `examples/regen-check.sh` after `cargo clean --release` — **byte-identical**. This refactors a check that already passes for every declared binding, so nothing should move, and nothing did.
- `cargo fmt --check` with the CI config; clippy `-D warnings` clean on both 1.85.0 and stable.

## Scope

This is the cheap win only. #223 stays open for item 3 (`UnfoldPlan` keeping its tree), which is the real fix and still tied to #220. A re-scoping comment covering what else in #223 has been overtaken since it was written follows on the issue.