### PR TITLE
Let a value form carry an Option<sum> field (#220)

### DIFF
--- a/docs/sum-types.md
+++ b/docs/sum-types.md
@@ -201,6 +201,16 @@ The slots then ride the parent's single `call_static_method("fromParts", …)`. 
 for the sum, and both sides enumerate the same slots in the same order because both walk one
 `StructPlan` — the invariant that module already exists to hold.
 
+**`Option<sum>` gates the same way in both output paths, by two different means** (#220). On the
+`fromParts` bridge it is the separate `<field>__present` flag above; on a **value form**'s leaf list
+it is the selector leaf's own **nullability** — the tag boxes, and JVM `null` means "no sum at all",
+which tag `0` cannot say because that is a real alternative. The leaf list needs no present-flag
+concept for it: a sum's leaves are not independent, so the whole segment binds as one tuple whose
+absent arm carries every slot's wire default — the shape a sum under a *conditional* value form
+already crossed by, applied to an optional step inside the segment's own path
+(`prebindgen-jni/src/jni/emit/delivery.rs`, the sum-segment loop). `Vec<sum>` stays refused in a leaf
+list: variable arity has no fixed layout to lay out.
+
 ### 4.4 Input path (Kotlin → Rust)
 
 `FlatFieldNode::Sum` joins `Value` / `Nested`

--- a/examples/covertest-kotlin/build.rs
+++ b/examples/covertest-kotlin/build.rs
@@ -246,6 +246,10 @@ fn main() {
                 // being restated field by field — #213. The form it names is
                 // the CONSUMING one, so the fields are moved, not cloned.
                 .class(ptr_class!(Report))
+                // #220: the same derived-boundary idea with an `Option<sum>`
+                // FIELD — the shape that used to be refused on a value form
+                // while a `data_class` accepted it.
+                .class(ptr_class!(Probe))
                 // `Hold`'s payload is a CONVERTED type, so its leaf crosses
                 // through the `convert!(Duration)` chain; `HoldPolicy` puts
                 // that same payload in the data-class-field position.
@@ -393,6 +397,11 @@ fn main() {
         // its `Stamp` fields, `taken` stays one `Stamp?` leaf, and `outcome`
         // decomposes into a selector plus one group per alternative.
         .expand(expand_return!(Report).fields_self_into(fields!(report_into_struct)))
+        // #220: `ProbeStruct.outcome` is `Option<Lookup>`. Its whole segment
+        // gates together — one tuple bind whose absent arm defaults every slot
+        // — because a sum's leaves are not independent. The selector boxes, so
+        // JVM null is "no sum" and cannot be read as `Lookup.Absent` (tag 0).
+        .expand(expand_return!(Probe).fields(fields!(probe_to_struct)))
         // `Ledger` reaches that same derived boundary through an `Option`, so
         // `Report`'s value form is hoisted CONDITIONALLY — built in the `Some`
         // arm, its leaves (the sum among them) sharing one `match`, null in the
@@ -522,6 +531,11 @@ fn main() {
                 // `Report` in one crossing; the leaf list comes from
                 // `ReportStruct`'s fields, so it cannot drift from it.
                 .fun(fun!(report_each))
+                // #220: the value form whose `outcome` field is `Option<sum>`.
+                // `probe_each` walks the absent case and every alternative, so
+                // one crossing covers the gate and the groups it gates.
+                .fun(fun!(probe_new))
+                .fun(fun!(probe_each))
                 // The same derived boundary reached through an `Option` — a
                 // CONDITIONAL hoist. `ledger_each` delivers both at once, so one
                 // crossing covers the borrowed payload, the owned one, and the

--- a/examples/covertest-kotlin/kotlin/REPORT.md
+++ b/examples/covertest-kotlin/kotlin/REPORT.md
@@ -103,6 +103,9 @@ Base package: `io.prebindgen.covertest`
 - `plain_note_echo` — `fun plainNoteEcho(note: String?, onError: JniErrorHandler<String?>): String?`
 - `priority_or` — `fun priorityOr(p: Priority?, fallback: Priority, onError: JniErrorHandler<Priority>): Priority`
 - `priority_weight` — `fun priorityWeight(p: Priority, onError: JniErrorHandler<Int>): Int`
+- `probe_each` — `fun probeEach(n: Long, total: Double, sink: ProbeCallback, onError: JniErrorHandler<Unit>)`
+- `probe_new` — `fun <R> probeNew(seq: Long, count: Long, total: Double, onError: JniErrorHandler<R>, build: ProbeBuilder<R>): R`
+  - shaped by: return `Probe` decomposed → [seq, outcome__tag, outcome__found_v0, outcome__failed_v0] (Callback delivery)
 - `reading_each` — `fun readingEach(n: Int, sink: ReadingCallback, onError: JniErrorHandler<Unit>)`
 - `reading_maybe` — `fun readingMaybe(which: Int, onError: JniErrorHandler<Reading?>): Reading?`
   - shaped by: return `Reading` decomposed → [tag, exact_v0, range_low, range_high, tagged_v0, tagged_v1, companion_v0] (Callback delivery)
@@ -217,6 +220,7 @@ Base package: `io.prebindgen.covertest`
 - `PayloadHandler`: ptr_class → `io.prebindgen.covertest.PayloadHandler` (wire `jni :: sys :: jlong`)
 - `PayloadVecHandler`: ptr_class → `io.prebindgen.covertest.PayloadVecHandler` (wire `jni :: sys :: jlong`)
 - `Priority`: enum_class → `io.prebindgen.covertest.model.Priority` (wire `jni :: sys :: jint`)
+- `Probe`: ptr_class → `io.prebindgen.covertest.model.Probe` (wire `jni :: sys :: jlong`)
 - `Reading`: sealed_class → `io.prebindgen.covertest.model.Reading` (wire `?`)
 - `RepliesConfig`: data_class → `io.prebindgen.covertest.model.RepliesConfig` (wire `jni :: objects :: JObject`)
 - `Report`: ptr_class → `io.prebindgen.covertest.model.Report` (wire `jni :: sys :: jlong`)

--- a/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest.kt
+++ b/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest.kt
@@ -1093,6 +1093,10 @@ internal object CovNative {
 
     external fun priorityWeight(p: Int, errorSink: Any): Int
 
+    external fun probeEach(n: Long, total: Double, sink: Any, errorSink: Any)
+
+    external fun probeNew(seq: Long, count: Long, total: Double, build: Any, errorSink: Any): Any?
+
     external fun readingEach(n: Int, sink: Any, errorSink: Any)
 
     external fun readingMaybe(which: Int, build: Any, errorSink: Any): Any?

--- a/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest/model.kt
+++ b/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest/model.kt
@@ -864,6 +864,30 @@ public data class Unsigned(val byte: Int, val short: Int, val int: Long, val lon
     }
 }
 
+/** Typed handle for a native Zenoh `Probe`. */
+public class Probe(initialPtr: Long) : NativeHandle(initialPtr) {
+    @Synchronized
+    override fun close() {
+        val p = ptr
+        if (p != 0L && (p and 1L) == 0L) {
+            ptr = p or 1L
+            freePtr(p)
+        }
+    }
+
+    @Synchronized
+    public fun take(): Probe {
+        val p = ptr
+        ptr = p or 1L
+        return Probe(p)
+    }
+
+    public companion object {
+        @JvmStatic
+        external fun freePtr(ptr: Long)
+    }
+}
+
 /** Typed handle for a native Zenoh `Report`. */
 public class Report(initialPtr: Long) : NativeHandle(initialPtr) {
     @Synchronized
@@ -903,6 +927,31 @@ public fun LookupCallback.asRaw(): LookupCallbackRaw =
         failed_v0 ->
         run(
             when (tag) { 0 -> Lookup.Absent; 1 -> Lookup.Found(Summary(found_v0)); 2 -> Lookup.Failed(failed_v0!!); else -> throw IllegalArgumentException("Lookup: invalid tag $tag") }
+        )
+    }
+
+public fun interface ProbeCallback {
+    public fun run(seq: Long, outcome: Lookup?)
+}
+
+public fun interface ProbeCallbackRaw {
+    public fun run(
+        seq: Long,
+        outcome__tag: Int?,
+        outcome__found_v0: Long?,
+        outcome__failed_v0: String?,
+    )
+}
+
+public fun ProbeCallback.asRaw(): ProbeCallbackRaw =
+    ProbeCallbackRaw {
+        seq,
+        outcome__tag,
+        outcome__found_v0,
+        outcome__failed_v0 ->
+        run(
+            seq,
+            when (outcome__tag) { null -> null; 0 -> Lookup.Absent; 1 -> Lookup.Found(Summary(outcome__found_v0!!)); 2 -> Lookup.Failed(outcome__failed_v0!!); else -> throw IllegalArgumentException("Lookup: invalid tag $outcome__tag") }
         )
     }
 
@@ -1039,6 +1088,38 @@ internal val __MarkerBuilder: MarkerBuilder<Marker> =
 MarkerBuilder { tag, ranked_v0 ->
     when (tag) { 0 -> Marker.None_; 1 -> Marker.Ranked(ranked_v0?.let { Priority.fromInt(it) }); else -> throw IllegalArgumentException("Marker: invalid tag $tag") }
 }
+
+public fun interface ProbeBuilder<out R> {
+    public fun run(
+        seq: Long,
+        outcome__tag: Int?,
+        outcome__found_v0: Summary?,
+        outcome__failed_v0: String?,
+    ): R
+}
+
+public fun interface ProbeBuilderRaw<out R> {
+    public fun run(
+        seq: Long,
+        outcome__tag: Int?,
+        outcome__found_v0: Long?,
+        outcome__failed_v0: String?,
+    ): R
+}
+
+public fun <R> ProbeBuilder<R>.asRaw(): ProbeBuilderRaw<R> =
+    ProbeBuilderRaw<R> {
+        seq,
+        outcome__tag,
+        outcome__found_v0,
+        outcome__failed_v0 ->
+        run(
+            seq,
+            outcome__tag,
+            outcome__found_v0?.let { Summary(it) },
+            outcome__failed_v0
+        )
+    }
 
 public fun interface ReadingBuilder<out R> {
     public fun run(
@@ -1565,6 +1646,37 @@ public fun lookupEach(n: Long, total: Double, sink: LookupCallback, onError: Jni
 public fun reportEach(n: Long, sink: ReportCallback, onError: JniErrorHandler<Unit>) {
     val __bcap = JniErrorHandlerCapture.acquire()
     CovNative.reportEach(n, sink.asRaw(), __bcap)
+    if (__bcap.failed) return onError.run(__bcap.ze0)
+}
+
+/**
+ * Build a [`Probe`]. `count < -1` leaves the outcome absent; anything else
+ * takes it from [`lookup_of`], so all four cases (absent, failed, empty,
+ * found-with-a-handle) are reachable from one argument.
+ *
+ * The Rust `Probe` result is delivered decomposed: the builder callback receives (`seq`, `outcome__tag`, `outcome__found_v0`, `outcome__failed_v0`).
+ */
+@Suppress("UNCHECKED_CAST")
+public fun <R> probeNew(
+    seq: Long,
+    count: Long,
+    total: Double,
+    onError: JniErrorHandler<R>,
+    build: ProbeBuilder<R>,
+): R {
+    val __bcap = JniErrorHandlerCapture.acquire()
+    val __ret = CovNative.probeNew(seq, count, total, build.asRaw(), __bcap)
+    if (__bcap.failed) return onError.run(__bcap.ze0)
+    return __ret as R
+}
+
+/**
+ * Deliver [`Probe`]s to a callback, one per `i` starting at `-2`, so the first
+ * is the ABSENT case and the rest walk `Lookup`'s alternatives.
+ */
+public fun probeEach(n: Long, total: Double, sink: ProbeCallback, onError: JniErrorHandler<Unit>) {
+    val __bcap = JniErrorHandlerCapture.acquire()
+    CovNative.probeEach(n, total, sink.asRaw(), __bcap)
     if (__bcap.failed) return onError.run(__bcap.ze0)
 }
 

--- a/examples/covertest-kotlin/kotlin/io/prebindgen/covertest/Test.kt
+++ b/examples/covertest-kotlin/kotlin/io/prebindgen/covertest/Test.kt
@@ -83,6 +83,8 @@ import io.prebindgen.covertest.model.lookupEach
 import io.prebindgen.covertest.model.ledgerEach
 import io.prebindgen.covertest.model.ledgerNew
 import io.prebindgen.covertest.model.reportEach
+import io.prebindgen.covertest.model.probeEach
+import io.prebindgen.covertest.model.probeNew
 import io.prebindgen.covertest.model.lookupOf
 import io.prebindgen.covertest.model.archiveReading
 import io.prebindgen.covertest.model.archiveReadingMaybe
@@ -644,6 +646,61 @@ fun main() {
         check(kept.size == 1)
         kept[0].close()
         check(kept[0].isClosed())
+    }
+
+    // An `Option<sum>` FIELD of a value form (#220) — the shape that used to be
+    // refused here while a `data_class` field of the same type was accepted.
+    //
+    // The gate is the SEGMENT's, not the form's: `seq` beside it is an ordinary
+    // leaf that crosses whether or not the sum is there. And absence rides the
+    // selector's own nullability rather than a present flag beside it, which is
+    // what this pins: `null` and `Lookup.Absent` are different answers, and a
+    // raw `jint` tag could not tell them apart because `Absent` IS tag 0.
+    section("Option<sum> as a value-form field") {
+        val rows = mutableListOf<String>()
+        val kept = mutableListOf<Summary>()
+        probeEach(4L, 5.0, { seq, outcome ->
+            val which = when (outcome) {
+                null -> "none"
+                is Lookup.Failed -> "failed:${outcome.v0}"
+                Lookup.Absent -> "absent"
+                is Lookup.Found -> {
+                    val s = outcome.v0
+                    check(!s.isClosed())
+                    kept.add(s)
+                    "found:${s.count(boom)}"
+                }
+            }
+            rows.add("$seq|$which")
+        }, boom)
+
+        // i = 0 → count -2 → the field itself is absent; the rest walk `Lookup`.
+        // `0|none` vs `1|failed…` is the whole point: the first has no sum at
+        // all, the second has one whose alternative happens to be tag 0's
+        // neighbour. A present flag would have said the same thing; the boxed
+        // selector says it for free.
+        check(
+            rows == listOf(
+                "0|none",
+                "1|failed:negative count",
+                "2|absent",
+                "3|found:1",
+            )
+        ) { "Option<sum> value-form leaves: $rows" }
+
+        check(kept.size == 1)
+        kept[0].close()
+        check(kept[0].isClosed())
+
+        // The same field at a BUILDER position, where the sum stays raw — so the
+        // absent case is readable as a null TAG, ahead of any variant.
+        val absentTag = probeNew(9L, -2L, 0.0, boom) { seq, tag, _, _ -> "$seq:$tag" }
+        check(absentTag == "9:null") { "an absent sum nulls its selector: $absentTag" }
+        // …and the exact collision the boxing exists to prevent: a PRESENT sum
+        // whose alternative is `Lookup.Absent` is tag `0`. A raw `jint` selector
+        // would have made these two calls indistinguishable.
+        val presentTag = probeNew(9L, 0L, 0.0, boom) { seq, tag, _, _ -> "$seq:$tag" }
+        check(presentTag == "9:0") { "a present `Lookup.Absent` is tag 0, not null: $presentTag" }
     }
 
     // The same derived boundary reached through an `Option` — a CONDITIONAL

--- a/examples/covertest-kotlin/src/generated_bindings.rs
+++ b/examples/covertest-kotlin/src/generated_bindings.rs
@@ -211,6 +211,22 @@ const _: () = {
 };
 #[no_mangle]
 #[allow(non_snake_case, unused_variables)]
+pub(crate) unsafe extern "C" fn Java_io_prebindgen_covertest_model_Probe_freePtr(
+    _env: jni::JNIEnv,
+    _class: jni::objects::JClass,
+    ptr: jni::sys::jlong,
+) {
+    if ptr != 0 && (ptr & 1) == 0 {
+        drop(Box::from_raw(ptr as *mut perftest_flat::Probe));
+    }
+}
+const _: () = {
+    if ::core::mem::align_of::<perftest_flat::Probe>() < 2 {
+        panic!("opaque handle types must have alignment >= 2 (bit 0 is the closed tag)");
+    }
+};
+#[no_mangle]
+#[allow(non_snake_case, unused_variables)]
 pub(crate) unsafe extern "C" fn Java_io_prebindgen_covertest_model_Report_freePtr(
     _env: jni::JNIEnv,
     _class: jni::objects::JClass,
@@ -5058,6 +5074,233 @@ pub(crate) unsafe fn JObject_to_impl_Fn_Payload_Send_Sync_static_96d50906<'env, 
     clippy::nonminimal_bool,
     clippy::eq_op
 )]
+pub(crate) unsafe fn JObject_to_impl_Fn_Probe_Send_Sync_static_b0418db6<'env, 'v>(
+    env: &mut jni::JNIEnv<'env>,
+    v: &jni::objects::JObject<'v>,
+) -> ::core::result::Result<
+    impl Fn(perftest_flat::Probe) + Send + Sync + 'static,
+    __JniErr,
+> {
+    Ok({
+        use std::sync::Arc;
+        let java_vm = Arc::new(
+            env
+                .get_java_vm()
+                .map_err(|e| <__JniErr as ::core::convert::From<
+                    String,
+                >>::from(format!("Unable to retrieve JVM: {}", e)))?,
+        );
+        let callback_global_ref = env
+            .new_global_ref(&v)
+            .map_err(|e| <__JniErr as ::core::convert::From<
+                String,
+            >>::from(format!("Unable to global-ref callback: {}", e)))?;
+        let __invoke_class = env
+            .get_object_class(&v)
+            .map_err(|e| <__JniErr as ::core::convert::From<
+                String,
+            >>::from(
+                format!("Unable to get callback class for {}: {}", "Fn(Probe)", e),
+            ))?;
+        let __invoke_id = env
+            .get_method_id(
+                &__invoke_class,
+                "run",
+                "(JLjava/lang/Integer;Ljava/lang/Long;Ljava/lang/String;)V",
+            )
+            .map_err(|e| <__JniErr as ::core::convert::From<
+                String,
+            >>::from(format!("Unable to resolve run for {}: {}", "Fn(Probe)", e)))?;
+        Box::new(move |__cb_arg0: perftest_flat::Probe| {
+            let _ = (|| -> ::core::result::Result<(), __JniErr> {
+                let mut env = java_vm
+                    .attach_current_thread_as_daemon()
+                    .map_err(|e| <__JniErr as ::core::convert::From<
+                        String,
+                    >>::from(format!("Attach thread for {}: {}", "Fn(Probe)", e)))?;
+                env.push_local_frame(16)
+                    .map_err(|e| <__JniErr as ::core::convert::From<
+                        String,
+                    >>::from(format!("push local frame for {}: {}", "Fn(Probe)", e)))?;
+                let __frame_res = (|| -> ::core::result::Result<(), __JniErr> {
+                    let __vf0 = perftest_flat::probe_to_struct(&__cb_arg0);
+                    let (
+                        __cb0_obj1,
+                        __cb0_obj2,
+                        __cb0_obj3,
+                    ): (
+                        jni::objects::JObject,
+                        jni::objects::JObject,
+                        jni::objects::JObject,
+                    ) = {
+                        let __so1: &::core::option::Option<_> = &(&__vf0).outcome;
+                        match __so1 {
+                            ::core::option::Option::Some(__sg1) => {
+                                let __cb0_obj1: jni::objects::JObject;
+                                let __cb0_obj2: jni::objects::JObject;
+                                let __cb0_obj3: jni::objects::JObject;
+                                match __sg1 {
+                                    perftest_flat::Lookup::Absent => {
+                                        __cb0_obj1 = match ::prebindgen_jni_runtime::box_jint(
+                                            &mut env,
+                                            0,
+                                        ) {
+                                            ::core::result::Result::Ok(__o) => __o,
+                                            ::core::result::Result::Err(__e) => {
+                                                return ::core::result::Result::Err(
+                                                    <__JniErr as ::core::convert::From<String>>::from(__e),
+                                                );
+                                            }
+                                        };
+                                        __cb0_obj2 = jni::objects::JObject::null();
+                                        __cb0_obj3 = jni::objects::JObject::null();
+                                    }
+                                    perftest_flat::Lookup::Found(__sv0) => {
+                                        let __enc___cb0_obj2 = match Summary_to_jlong_3cb103b9(
+                                            &mut env,
+                                            __sv0.clone(),
+                                        ) {
+                                            ::core::result::Result::Ok(__w) => __w,
+                                            ::core::result::Result::Err(__e) => {
+                                                return ::core::result::Result::Err(
+                                                    <__JniErr as ::core::convert::From<
+                                                        String,
+                                                    >>::from(__e.to_string()),
+                                                );
+                                            }
+                                        };
+                                        __cb0_obj2 = match ::prebindgen_jni_runtime::box_jlong(
+                                            &mut env,
+                                            __enc___cb0_obj2,
+                                        ) {
+                                            ::core::result::Result::Ok(__o) => __o,
+                                            ::core::result::Result::Err(__e) => {
+                                                return ::core::result::Result::Err(
+                                                    <__JniErr as ::core::convert::From<String>>::from(__e),
+                                                );
+                                            }
+                                        };
+                                        __cb0_obj1 = match ::prebindgen_jni_runtime::box_jint(
+                                            &mut env,
+                                            1,
+                                        ) {
+                                            ::core::result::Result::Ok(__o) => __o,
+                                            ::core::result::Result::Err(__e) => {
+                                                return ::core::result::Result::Err(
+                                                    <__JniErr as ::core::convert::From<String>>::from(__e),
+                                                );
+                                            }
+                                        };
+                                        __cb0_obj3 = jni::objects::JObject::null();
+                                    }
+                                    perftest_flat::Lookup::Failed(__sv0) => {
+                                        let __enc___cb0_obj3 = match String_to_JString_c7f3ca43(
+                                            &mut env,
+                                            __sv0.clone(),
+                                        ) {
+                                            ::core::result::Result::Ok(__w) => __w,
+                                            ::core::result::Result::Err(__e) => {
+                                                return ::core::result::Result::Err(
+                                                    <__JniErr as ::core::convert::From<
+                                                        String,
+                                                    >>::from(__e.to_string()),
+                                                );
+                                            }
+                                        };
+                                        __cb0_obj3 = __enc___cb0_obj3.into();
+                                        __cb0_obj1 = match ::prebindgen_jni_runtime::box_jint(
+                                            &mut env,
+                                            2,
+                                        ) {
+                                            ::core::result::Result::Ok(__o) => __o,
+                                            ::core::result::Result::Err(__e) => {
+                                                return ::core::result::Result::Err(
+                                                    <__JniErr as ::core::convert::From<String>>::from(__e),
+                                                );
+                                            }
+                                        };
+                                        __cb0_obj2 = jni::objects::JObject::null();
+                                    }
+                                }
+                                (__cb0_obj1, __cb0_obj2, __cb0_obj3)
+                            }
+                            ::core::option::Option::None => {
+                                (
+                                    jni::objects::JObject::null(),
+                                    jni::objects::JObject::null(),
+                                    jni::objects::JObject::null(),
+                                )
+                            }
+                        }
+                    };
+                    let __cb0_obj0: jni::sys::jvalue = {
+                        let __enc0 = match i64_to_jlong_fbf9a9bc(
+                            &mut env,
+                            __vf0.seq.clone(),
+                        ) {
+                            ::core::result::Result::Ok(__w) => __w,
+                            ::core::result::Result::Err(__e) => {
+                                return ::core::result::Result::Err(
+                                    <__JniErr as ::core::convert::From<
+                                        String,
+                                    >>::from(__e.to_string()),
+                                );
+                            }
+                        };
+                        jni::sys::jvalue { j: __enc0 }
+                    };
+                    let __call_res: ::core::result::Result<(), __JniErr> = unsafe {
+                        env.call_method_unchecked(
+                            &callback_global_ref,
+                            __invoke_id,
+                            jni::signature::ReturnType::Primitive(
+                                jni::signature::Primitive::Void,
+                            ),
+                            &[
+                                __cb0_obj0,
+                                jni::sys::jvalue {
+                                    l: __cb0_obj1.as_raw(),
+                                },
+                                jni::sys::jvalue {
+                                    l: __cb0_obj2.as_raw(),
+                                },
+                                jni::sys::jvalue {
+                                    l: __cb0_obj3.as_raw(),
+                                },
+                            ],
+                        )
+                    }
+                        .map(|_| ())
+                        .map_err(|e| {
+                            let _ = env.exception_describe();
+                            <__JniErr as ::core::convert::From<
+                                String,
+                            >>::from(e.to_string())
+                        });
+                    __call_res?;
+                    Ok(())
+                })();
+                let _ = unsafe { env.pop_local_frame(&jni::objects::JObject::null()) };
+                __frame_res?;
+                Ok(())
+            })()
+                .map_err(|e| tracing::error!("{} callback error: {e}", "Fn(Probe)"));
+        })
+    })
+}
+#[allow(
+    non_snake_case,
+    unused_mut,
+    unused_variables,
+    unused_braces,
+    unused_parens,
+    dead_code,
+    clippy::useless_conversion,
+    clippy::needless_question_mark,
+    clippy::let_and_return,
+    clippy::nonminimal_bool,
+    clippy::eq_op
+)]
 pub(crate) unsafe fn JObject_to_impl_Fn_Reading_Send_Sync_static_5964f1fc<'env, 'v>(
     env: &mut jni::JNIEnv<'env>,
     v: &jni::objects::JObject<'v>,
@@ -8951,6 +9194,25 @@ pub(crate) unsafe fn Priority_to_jint_447102d2<'a>(
     clippy::nonminimal_bool,
     clippy::eq_op
 )]
+pub(crate) unsafe fn Probe_to_jlong_76f3d10e<'a>(
+    env: &mut jni::JNIEnv<'a>,
+    v: perftest_flat::Probe,
+) -> ::core::result::Result<jni::sys::jlong, __JniErr> {
+    Ok(std::boxed::Box::into_raw(std::boxed::Box::new(v)) as i64)
+}
+#[allow(
+    non_snake_case,
+    unused_mut,
+    unused_variables,
+    unused_braces,
+    unused_parens,
+    dead_code,
+    clippy::useless_conversion,
+    clippy::needless_question_mark,
+    clippy::let_and_return,
+    clippy::nonminimal_bool,
+    clippy::eq_op
+)]
 pub(crate) unsafe fn RepliesConfig_to_JObject_eb8e9079<'a>(
     env: &mut jni::JNIEnv<'a>,
     v: perftest_flat::RepliesConfig,
@@ -10308,6 +10570,32 @@ pub(crate) unsafe fn jlong_to_PayloadVecHandler_b32d2812<'env, 'v>(
         );
     }
     Ok(unsafe { OwnedObject::from_raw(*v as *const perftest_flat::PayloadVecHandler) })
+}
+#[allow(
+    non_snake_case,
+    unused_mut,
+    unused_variables,
+    unused_braces,
+    unused_parens,
+    dead_code,
+    clippy::useless_conversion,
+    clippy::needless_question_mark,
+    clippy::let_and_return,
+    clippy::nonminimal_bool,
+    clippy::eq_op
+)]
+pub(crate) unsafe fn jlong_to_Probe_76f3d10e<'env, 'v>(
+    env: &mut jni::JNIEnv<'env>,
+    v: &jni::sys::jlong,
+) -> ::core::result::Result<OwnedObject<perftest_flat::Probe>, __JniErr> {
+    if *v == 0 || (*v & 1) == 1 {
+        return ::core::result::Result::Err(
+            <__JniErr as ::core::convert::From<
+                String,
+            >>::from("Operation on a closed native handle.".to_string()),
+        );
+    }
+    Ok(unsafe { OwnedObject::from_raw(*v as *const perftest_flat::Probe) })
 }
 #[allow(
     non_snake_case,
@@ -17055,6 +17343,328 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_priorityWeight<'
                 &__e.to_string(),
             );
             0 as jni::sys::jint
+        }
+    }
+}
+#[no_mangle]
+#[allow(non_snake_case, unused_mut, unused_variables, dead_code)]
+pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_probeEach<'a>(
+    mut env: jni::JNIEnv<'a>,
+    _class: jni::objects::JClass<'a>,
+    n: jni::sys::jlong,
+    total: jni::sys::jdouble,
+    sink: jni::objects::JObject<'a>,
+    __error_sink: jni::objects::JObject<'a>,
+) -> () {
+    #[allow(non_upper_case_globals)]
+    static __SINK_MID: ::prebindgen_jni_runtime::CachedIfaceMethod = ::prebindgen_jni_runtime::CachedIfaceMethod::new();
+    const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
+    const __SINK_DESCR: &str = "(Ljava/lang/String;)Ljava/lang/Object;";
+    let n = match jlong_to_i64_fbf9a9bc(&mut env, &n) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__e) => {
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e.to_string(),
+            );
+            return ();
+        }
+    };
+    let total = match jdouble_to_f64_9e4a8f70(&mut env, &total) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__e) => {
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e.to_string(),
+            );
+            return ();
+        }
+    };
+    let sink = match JObject_to_impl_Fn_Probe_Send_Sync_static_b0418db6(
+        &mut env,
+        &sink,
+    ) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__e) => {
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e.to_string(),
+            );
+            return ();
+        }
+    };
+    let __out = perftest_flat::probe_each(n, total, sink);
+    match unit_to_unit_9ecccf8e(&mut env, __out) {
+        ::core::result::Result::Ok(__w) => __w,
+        ::core::result::Result::Err(__e) => {
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e.to_string(),
+            );
+            ()
+        }
+    }
+}
+#[no_mangle]
+#[allow(non_snake_case, unused_mut, unused_variables, dead_code)]
+pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_probeNew<'a>(
+    mut env: jni::JNIEnv<'a>,
+    _class: jni::objects::JClass<'a>,
+    seq: jni::sys::jlong,
+    count: jni::sys::jlong,
+    total: jni::sys::jdouble,
+    __builder: jni::objects::JObject<'a>,
+    __error_sink: jni::objects::JObject<'a>,
+) -> jni::objects::JObject<'a> {
+    #[allow(non_upper_case_globals)]
+    static __SINK_MID: ::prebindgen_jni_runtime::CachedIfaceMethod = ::prebindgen_jni_runtime::CachedIfaceMethod::new();
+    const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
+    const __SINK_DESCR: &str = "(Ljava/lang/String;)Ljava/lang/Object;";
+    let seq = match jlong_to_i64_fbf9a9bc(&mut env, &seq) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__e) => {
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e.to_string(),
+            );
+            return jni::objects::JObject::null().into();
+        }
+    };
+    let count = match jlong_to_i64_fbf9a9bc(&mut env, &count) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__e) => {
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e.to_string(),
+            );
+            return jni::objects::JObject::null().into();
+        }
+    };
+    let total = match jdouble_to_f64_9e4a8f70(&mut env, &total) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__e) => {
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e.to_string(),
+            );
+            return jni::objects::JObject::null().into();
+        }
+    };
+    #[allow(non_upper_case_globals)]
+    static __CB_MID: ::prebindgen_jni_runtime::CachedIfaceMethod = ::prebindgen_jni_runtime::CachedIfaceMethod::new();
+    const __CB_FQN: &str = "io/prebindgen/covertest/model/ProbeBuilderRaw";
+    const __CB_DESCR: &str = "(JLjava/lang/Integer;Ljava/lang/Long;Ljava/lang/String;)Ljava/lang/Object;";
+    let __out = perftest_flat::probe_new(seq, count, total);
+    let __vf0 = perftest_flat::probe_to_struct(&__out);
+    let (
+        __obj1,
+        __obj2,
+        __obj3,
+    ): (jni::objects::JObject, jni::objects::JObject, jni::objects::JObject) = {
+        let __so1: &::core::option::Option<_> = &(&__vf0).outcome;
+        match __so1 {
+            ::core::option::Option::Some(__sg1) => {
+                let __obj1: jni::objects::JObject;
+                let __obj2: jni::objects::JObject;
+                let __obj3: jni::objects::JObject;
+                match __sg1 {
+                    perftest_flat::Lookup::Absent => {
+                        __obj1 = match ::prebindgen_jni_runtime::box_jint(&mut env, 0) {
+                            ::core::result::Result::Ok(__o) => __o,
+                            ::core::result::Result::Err(__e) => {
+                                signal_binding_error(
+                                    &mut env,
+                                    &__error_sink,
+                                    &__SINK_MID,
+                                    __SINK_FQN,
+                                    __SINK_DESCR,
+                                    &__e,
+                                );
+                                return jni::objects::JObject::null().into();
+                            }
+                        };
+                        __obj2 = jni::objects::JObject::null();
+                        __obj3 = jni::objects::JObject::null();
+                    }
+                    perftest_flat::Lookup::Found(__sv0) => {
+                        let __enc___obj2 = match Summary_to_jlong_3cb103b9(
+                            &mut env,
+                            __sv0.clone(),
+                        ) {
+                            ::core::result::Result::Ok(__w) => __w,
+                            ::core::result::Result::Err(__e) => {
+                                signal_binding_error(
+                                    &mut env,
+                                    &__error_sink,
+                                    &__SINK_MID,
+                                    __SINK_FQN,
+                                    __SINK_DESCR,
+                                    &__e.to_string(),
+                                );
+                                return jni::objects::JObject::null().into();
+                            }
+                        };
+                        __obj2 = match ::prebindgen_jni_runtime::box_jlong(
+                            &mut env,
+                            __enc___obj2,
+                        ) {
+                            ::core::result::Result::Ok(__o) => __o,
+                            ::core::result::Result::Err(__e) => {
+                                signal_binding_error(
+                                    &mut env,
+                                    &__error_sink,
+                                    &__SINK_MID,
+                                    __SINK_FQN,
+                                    __SINK_DESCR,
+                                    &__e,
+                                );
+                                return jni::objects::JObject::null().into();
+                            }
+                        };
+                        __obj1 = match ::prebindgen_jni_runtime::box_jint(&mut env, 1) {
+                            ::core::result::Result::Ok(__o) => __o,
+                            ::core::result::Result::Err(__e) => {
+                                signal_binding_error(
+                                    &mut env,
+                                    &__error_sink,
+                                    &__SINK_MID,
+                                    __SINK_FQN,
+                                    __SINK_DESCR,
+                                    &__e,
+                                );
+                                return jni::objects::JObject::null().into();
+                            }
+                        };
+                        __obj3 = jni::objects::JObject::null();
+                    }
+                    perftest_flat::Lookup::Failed(__sv0) => {
+                        let __enc___obj3 = match String_to_JString_c7f3ca43(
+                            &mut env,
+                            __sv0.clone(),
+                        ) {
+                            ::core::result::Result::Ok(__w) => __w,
+                            ::core::result::Result::Err(__e) => {
+                                signal_binding_error(
+                                    &mut env,
+                                    &__error_sink,
+                                    &__SINK_MID,
+                                    __SINK_FQN,
+                                    __SINK_DESCR,
+                                    &__e.to_string(),
+                                );
+                                return jni::objects::JObject::null().into();
+                            }
+                        };
+                        __obj3 = __enc___obj3.into();
+                        __obj1 = match ::prebindgen_jni_runtime::box_jint(&mut env, 2) {
+                            ::core::result::Result::Ok(__o) => __o,
+                            ::core::result::Result::Err(__e) => {
+                                signal_binding_error(
+                                    &mut env,
+                                    &__error_sink,
+                                    &__SINK_MID,
+                                    __SINK_FQN,
+                                    __SINK_DESCR,
+                                    &__e,
+                                );
+                                return jni::objects::JObject::null().into();
+                            }
+                        };
+                        __obj2 = jni::objects::JObject::null();
+                    }
+                }
+                (__obj1, __obj2, __obj3)
+            }
+            ::core::option::Option::None => {
+                (
+                    jni::objects::JObject::null(),
+                    jni::objects::JObject::null(),
+                    jni::objects::JObject::null(),
+                )
+            }
+        }
+    };
+    let __obj0: jni::sys::jvalue = {
+        let __enc0 = match i64_to_jlong_fbf9a9bc(&mut env, __vf0.seq.clone()) {
+            ::core::result::Result::Ok(__w) => __w,
+            ::core::result::Result::Err(__e) => {
+                signal_binding_error(
+                    &mut env,
+                    &__error_sink,
+                    &__SINK_MID,
+                    __SINK_FQN,
+                    __SINK_DESCR,
+                    &__e.to_string(),
+                );
+                return jni::objects::JObject::null().into();
+            }
+        };
+        jni::sys::jvalue { j: __enc0 }
+    };
+    match __CB_MID
+        .call_object(
+            &mut env,
+            __CB_FQN,
+            "run",
+            __CB_DESCR,
+            &__builder,
+            &[
+                __obj0,
+                jni::sys::jvalue {
+                    l: __obj1.as_raw(),
+                },
+                jni::sys::jvalue {
+                    l: __obj2.as_raw(),
+                },
+                jni::sys::jvalue {
+                    l: __obj3.as_raw(),
+                },
+            ],
+        )
+    {
+        ::core::result::Result::Ok(__o) => __o,
+        ::core::result::Result::Err(__e) => {
+            let _ = env.exception_describe();
+            let __e2 = <__JniErr as ::core::convert::From<
+                String,
+            >>::from(__e.to_string());
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e2.to_string(),
+            );
+            jni::objects::JObject::null().into()
         }
     }
 }

--- a/examples/perftest-flat/src/ext.rs
+++ b/examples/perftest-flat/src/ext.rs
@@ -66,6 +66,15 @@ mod handles {
         pub(super) label: String,
     }
 
+    /// The `Option<sum>` value-form field (#220), kept apart from [`Report`]
+    /// on purpose: `Report` is embedded twice in [`Ledger`], so a field there
+    /// would add three positional slots to `report_each` and six to
+    /// `ledger_each` and bury the shape under signature churn.
+    pub struct Probe {
+        pub(super) seq: i64,
+        pub(super) outcome: Option<Lookup>,
+    }
+
     pub struct EscapeProbe {
         pub(super) value: i64,
     }
@@ -1541,6 +1550,62 @@ pub fn report_each(n: i64, sink: impl Fn(Report) + Send + Sync + 'static) {
             i % 2 == 0,
             format!("r{i}"),
         ));
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Probe — a value form with an `Option<sum>` FIELD (#220).
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// The handle whose boundary is derived from [`ProbeStruct`].
+#[prebindgen]
+pub type Probe = handles::Probe;
+
+/// [`Probe`]'s value form. `outcome` is the shape this exists for: a sum behind
+/// an `Option`, which used to be refused here while the very same field was
+/// accepted on a `data_class`.
+///
+/// Absence rides the **selector's own nullability**, not a present flag beside
+/// it — `Lookup::Absent` is tag `0`, so a raw `jint` has no spelling left for
+/// "no sum at all" and the tag boxes. That is the same rule a sum under a
+/// conditional value form already crosses by, which is why this needed no new
+/// leaf kind.
+#[prebindgen]
+pub struct ProbeStruct {
+    /// A plain leaf beside the gated segment: gating is the segment's, not the
+    /// whole form's.
+    pub seq: i64,
+    /// Absent, or one of `Lookup`'s alternatives — including the one carrying
+    /// an opaque handle.
+    pub outcome: Option<Lookup>,
+}
+
+/// Build a [`Probe`]. `count < -1` leaves the outcome absent; anything else
+/// takes it from [`lookup_of`], so all four cases (absent, failed, empty,
+/// found-with-a-handle) are reachable from one argument.
+#[prebindgen]
+pub fn probe_new(seq: i64, count: i64, total: f64) -> Probe {
+    Probe {
+        seq,
+        outcome: (count >= -1).then(|| lookup_of(count, total)),
+    }
+}
+
+/// The value form accessor `expand_return!(Probe).fields(fields!(..))` names.
+#[prebindgen]
+pub fn probe_to_struct(p: &Probe) -> ProbeStruct {
+    ProbeStruct {
+        seq: p.seq,
+        outcome: p.outcome.clone(),
+    }
+}
+
+/// Deliver [`Probe`]s to a callback, one per `i` starting at `-2`, so the first
+/// is the ABSENT case and the rest walk `Lookup`'s alternatives.
+#[prebindgen]
+pub fn probe_each(n: i64, total: f64, sink: impl Fn(Probe) + Send + Sync + 'static) {
+    for i in 0..n {
+        sink(probe_new(i, i - 2, total));
     }
 }
 

--- a/prebindgen-jni/src/jni/builder.rs
+++ b/prebindgen-jni/src/jni/builder.rs
@@ -1081,10 +1081,13 @@ impl Declarations {
                 TypeKind::Sum => {
                     // A sum's leaves are a selector plus one group per
                     // alternative, laid out side by side at a FIXED position.
-                    // A `Vec` of them has variable arity; an `Option` of one
-                    // needs a present flag the unfold leaf list has no notion of
-                    // (the `fromParts` bridge's `PlanFieldKind::Sum` does — a
-                    // data-class field can be `Option<sum>`).
+                    // A `Vec` of them has variable arity, so there is no fixed
+                    // layout to lay out — that one stays refused.
+                    //
+                    // `Option<sum>` does NOT: absence is the selector leaf's own
+                    // nullability, the same mechanism a sum under a conditional
+                    // value form already crosses by (#220). The refusal that
+                    // stood here predated it.
                     assert!(
                         bare.sequence_elem().is_none(),
                         "expand_return!({}).fields(fields!({})): field `{}.{}` is a \
@@ -1095,20 +1098,6 @@ impl Declarations {
                         st.name,
                         dotted,
                         probe,
-                    );
-                    assert!(
-                        field.ty.optional_inner().is_none(),
-                        "expand_return!({}).fields(fields!({})): field `{}.{}` is an \
-                         `Option<{}>` — an optional sum would need a present flag beside its \
-                         tag, which an output leaf list cannot carry. Give the field a \
-                         payload-less alternative instead of wrapping the sum in `Option`, \
-                         or override it with .field(\"{}\", ...)",
-                        key.as_str(),
-                        decl.func(),
-                        st.name,
-                        dotted,
-                        probe,
-                        dotted,
                     );
                     // The name is the reading's, not a path taken apart to
                     // re-derive one.

--- a/prebindgen-jni/src/jni/emit/delivery.rs
+++ b/prebindgen-jni/src/jni/emit/delivery.rs
@@ -949,8 +949,9 @@ pub(crate) fn encode_plan_leaves(
         let leaf = &plan.leaves[seg.start];
         let (base, base_is_ref, path, _) = rebase(leaf);
         // The value to `match` on. The selector's own path reaches the sum
-        // (empty when the sum IS the value); no step on it is optional, since
-        // an optional sum is refused where the leaves are built.
+        // (empty when the sum IS the value), and a step on it MAY be optional:
+        // the refusal that used to guarantee otherwise is gone (#220), which is
+        // what the gate below exists for.
         //
         // A plain field chain is borrowed DIRECTLY (`&base.a.b`) rather than
         // through the base (`&(&base).a.b`). The two are the same value, but
@@ -976,7 +977,30 @@ pub(crate) fn encode_plan_leaves(
                 // statement of it.
                 let opt_e = fold_steps(&qualify, &path[lead..=k], projected, false);
                 let bind = format_ident!("__sg{}", seg.start);
-                let inner = fold_steps(&qualify, &path[k + 1..], quote!(#bind), true);
+                // The tail is empty for every shape that reaches here: a sum
+                // leaf's path stops AT the sum. Stated because two things below
+                // would otherwise be quietly wrong for a non-empty one — a
+                // second optional step would compose `match &Option<..>` against
+                // bare variant patterns, which is the E0308 the deleted
+                // `builder.rs` assert used to pre-empt by name.
+                debug_assert!(
+                    path[k + 1..].is_empty(),
+                    "sum segment: a step after the gated one ({} left) — the tail \
+                     is assumed empty here",
+                    path.len() - k - 1,
+                );
+                // What the `match` binds, asked of the step rather than assumed:
+                // the FIELD branch scrutinizes `&Option<_>` (that is what
+                // `bind_as_option` is for), so ergonomics binds `&Sum` — a
+                // borrow. Only an owned-yielding CALL binds an owned value. The
+                // literal `true` disagreed with `reach_leaf`, which passes
+                // `false` for its analogous recursion.
+                let inner = fold_steps(
+                    &qualify,
+                    &path[k + 1..],
+                    quote!(#bind),
+                    path[k].yields_owned(),
+                );
                 (inner, Some((k, opt_e, bind)))
             }
         };

--- a/prebindgen-jni/src/jni/emit/delivery.rs
+++ b/prebindgen-jni/src/jni/emit/delivery.rs
@@ -958,8 +958,28 @@ pub(crate) fn encode_plan_leaves(
         // rejects once a sibling leaf has moved another field out of it — and
         // borrowing this field while sibling fields move is exactly what a
         // consuming value form does.
-        let (matched, lead) = project_leading_fields(&base, base_is_ref, &path);
-        let matched = fold_steps(&qualify, &path[lead..], matched, false);
+        let (projected, lead) = project_leading_fields(&base, base_is_ref, &path);
+        // An `Option<sum>` field gates the WHOLE segment, not each slot (#220).
+        // A sum's leaves are not independent — only one group is live per value
+        // — so absence cannot be the per-leaf `null` `reach_leaf` gives an
+        // ordinary optional field. It is one tuple bind whose `None` arm carries
+        // every slot's default, which is the shape a conditional value form's
+        // hoist already emits below; this applies it to an optional step inside
+        // the segment's own path.
+        let opt_at = (lead..path.len()).find(|&i| path[i].is_optional());
+        let (matched, gate) = match opt_at {
+            None => (fold_steps(&qualify, &path[lead..], projected, false), None),
+            Some(k) => {
+                // Through the optional step INCLUSIVE, then the rest off the
+                // binding — the same split `reach_leaf` makes, so the borrow in
+                // front of it stays the ordinary rule rather than a second
+                // statement of it.
+                let opt_e = fold_steps(&qualify, &path[lead..=k], projected, false);
+                let bind = format_ident!("__sg{}", seg.start);
+                let inner = fold_steps(&qualify, &path[k + 1..], quote!(#bind), true);
+                (inner, Some((k, opt_e, bind)))
+            }
+        };
         let (group_stmts, group_args) = encode_sum_group(
             ext,
             registry,
@@ -969,6 +989,42 @@ pub(crate) fn encode_plan_leaves(
             fail,
             emit,
         );
+        let group_stmts = match gate {
+            None => group_stmts,
+            Some((k, opt_e, bind)) => {
+                let ids: Vec<&syn::Ident> = obj_idents[seg.clone()].iter().collect();
+                let slots: Vec<Slot> = plan.leaves[seg.clone()]
+                    .iter()
+                    .map(|l| leaf_slot(registry, l))
+                    .collect();
+                let tys = slots.iter().map(|s| &s.ty);
+                let defaults = slots.iter().map(|s| &s.default);
+                // A FIELD step composes to a borrow, so it goes through a
+                // coercion site and the destructure stops caring which
+                // representation the source spelled the optional as (#268). A
+                // CALL yields its own owned value, whose payload downstream may
+                // move, so it keeps the direct match — the same division
+                // `reach_leaf` makes.
+                let (prelude, scrutinee) = if path[k].is_field() {
+                    let opt_bind = format_ident!("__so{}", seg.start);
+                    (bind_as_option(&opt_e, &opt_bind), quote!(#opt_bind))
+                } else {
+                    (TokenStream::new(), opt_e)
+                };
+                quote! {
+                    let (#(#ids,)*): (#(#tys,)*) = {
+                        #prelude
+                        match #scrutinee {
+                            ::core::option::Option::Some(#bind) => {
+                                #group_stmts
+                                (#(#ids,)*)
+                            }
+                            ::core::option::Option::None => (#(#defaults,)*),
+                        }
+                    };
+                }
+            }
+        };
         // The whole segment — its slot declarations and its `match` — is
         // routed like any other leaf under the same form.
         match hoisted.conditional(&leaf.path) {

--- a/prebindgen-jni/src/jni/emit/delivery.rs
+++ b/prebindgen-jni/src/jni/emit/delivery.rs
@@ -977,17 +977,29 @@ pub(crate) fn encode_plan_leaves(
                 // statement of it.
                 let opt_e = fold_steps(&qualify, &path[lead..=k], projected, false);
                 let bind = format_ident!("__sg{}", seg.start);
-                // The tail is empty for every shape that reaches here: a sum
-                // leaf's path stops AT the sum. Stated because two things below
-                // would otherwise be quietly wrong for a non-empty one — a
-                // second optional step would compose `match &Option<..>` against
-                // bare variant patterns, which is the E0308 the deleted
-                // `builder.rs` assert used to pre-empt by name.
-                debug_assert!(
-                    path[k + 1..].is_empty(),
-                    "sum segment: a step after the gated one ({} left) — the tail \
-                     is assumed empty here",
-                    path.len() - k - 1,
+                // ONE optional step is what the gate below handles. A second
+                // one in the tail would compose `match &Option<..>` against bare
+                // variant patterns — the E0308 in the consumer's crate that the
+                // deleted `builder.rs` assert used to pre-empt by name, so the
+                // named diagnostic keeps a home here.
+                //
+                // `assert!`, not `debug_assert!`: a build script inherits the
+                // consumer's profile, so a debug-only check is absent from
+                // exactly the release build where a mis-emission costs the most
+                // to diagnose. Same rule, same phrasing, as the single-return
+                // optional-step assert in `reach_leaf` above.
+                //
+                // The condition is what actually breaks, not the stronger fact
+                // that happens to hold: every sum leaf's path stops AT the sum,
+                // so the tail is empty today, but a NON-optional tail composes
+                // correctly through `fold_steps` — refusing it would refuse a
+                // shape that works.
+                assert!(
+                    !path[k + 1..].iter().any(PathStep::is_optional),
+                    "jnigen unfold: leaf `{}` reaches its sum through TWO optional \
+                     steps — the segment gate has one `None` arm, so the second \
+                     would be matched as if it were the sum itself",
+                    leaf.name,
                 );
                 // What the `match` binds, asked of the step rather than assumed:
                 // the FIELD branch scrutinizes `&Option<_>` (that is what

--- a/prebindgen-jni/src/jni/tests/value_form.rs
+++ b/prebindgen-jni/src/jni/tests/value_form.rs
@@ -470,12 +470,14 @@ fn a_sum_field_crosses_as_its_selector_and_groups() {
     );
 }
 
-/// A sum's slots sit at a FIXED position in the leaf list, so the two shapes
-/// that would move or repeat them are refused by name rather than mis-emitted:
-/// `Vec<sum>` has variable arity, and `Option<sum>` would need a present flag
-/// beside the tag that an output leaf list cannot carry.
+/// A sum's slots sit at a FIXED position in the leaf list, so the shape that
+/// would repeat them is refused by name rather than mis-emitted: `Vec<sum>` has
+/// variable arity and no fixed layout to lay out.
+///
+/// `Option<sum>` used to be refused beside it; it no longer is (#220) — see
+/// [`an_optional_sum_field_gates_its_whole_segment`].
 #[test]
-fn a_sum_field_behind_option_or_vec_is_rejected_by_name() {
+fn a_vec_sum_field_is_rejected_by_name() {
     let loc = myflat_loc();
     let build = |field_ty: syn::Type| {
         let items = vec![
@@ -535,23 +537,227 @@ fn a_sum_field_behind_option_or_vec_is_rejected_by_name() {
             .map(|g| g.write_rust(dir.join("g.rs")));
     };
 
-    for (ty, want) in [
-        (syn::parse_quote!(Vec<ZOutcome>), "variable arity"),
-        (syn::parse_quote!(Option<ZOutcome>), "present flag"),
-    ] {
-        let err = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| build(ty)))
-            .expect_err("a sum behind Option/Vec must be rejected");
-        let msg = err
-            .downcast_ref::<String>()
-            .cloned()
-            .or_else(|| err.downcast_ref::<&str>().map(|s| s.to_string()))
-            .unwrap_or_default();
-        assert!(msg.contains(want), "expected `{want}` in: {msg}");
-        assert!(
-            msg.contains("ZReplyStruct.result"),
-            "the message names the offending field: {msg}"
+    let err = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        build(syn::parse_quote!(Vec<ZOutcome>))
+    }))
+    .expect_err("a Vec of sums must be rejected");
+    let msg = err
+        .downcast_ref::<String>()
+        .cloned()
+        .or_else(|| err.downcast_ref::<&str>().map(|s| s.to_string()))
+        .unwrap_or_default();
+    assert!(
+        msg.contains("variable arity"),
+        "expected the reason in: {msg}"
+    );
+    assert!(
+        msg.contains("ZReplyStruct.result"),
+        "the message names the offending field: {msg}"
+    );
+}
+
+/// `Option<sum>` as a value-form field (#220): the whole segment gates together.
+///
+/// A sum's leaves are not independent — only one group is live per value — so
+/// absence cannot be a per-leaf `null` the way it is for an ordinary optional
+/// field. The segment binds as ONE tuple whose `None` arm carries every slot's
+/// wire default, which is the shape a conditional value form's hoist already
+/// emits, applied to an optional step inside the segment's own path.
+///
+/// The selector is the one slot that must NOT stay a raw `jint`: zero is a real
+/// variant, so an absent sum needs a representation the tag's own domain does
+/// not provide. It boxes, and JVM null means "no value here" — the same rule
+/// that already holds for a sum under a conditional form, and the reason this
+/// needs no present flag beside the tag.
+#[test]
+fn an_optional_sum_field_gates_its_whole_segment() {
+    let loc = myflat_loc();
+    let build = |field_ty: syn::Type| {
+        let items = vec![
+            (
+                syn::Item::Enum(syn::parse_quote!(
+                    pub enum ZOutcome {
+                        Empty,
+                        Failed(String),
+                    }
+                )),
+                loc.clone(),
+            ),
+            (
+                syn::Item::Struct(syn::parse_quote!(
+                    pub struct ZReplyStruct {
+                        pub seq: i64,
+                        pub result: #field_ty,
+                    }
+                )),
+                loc.clone(),
+            ),
+            (
+                syn::Item::Fn(syn::parse_quote!(
+                    pub fn z_reply_to_struct(r: &ZReply) -> ZReplyStruct {
+                        unimplemented!()
+                    }
+                )),
+                loc.clone(),
+            ),
+            (
+                syn::Item::Fn(syn::parse_quote!(
+                    pub fn z_reply_sub(cb: impl Fn(ZReply) + Send + Sync + 'static) {
+                        unimplemented!()
+                    }
+                )),
+                loc.clone(),
+            ),
+        ];
+        let registry =
+            crate::test_util::reg_from_items(declare_referenced(items)).expect("index items");
+        let jni = JniGenBuilder::new()
+            .set_package_prefix("io.test.jni")
+            .package(
+                crate::package!()
+                    .class(crate::ptr_class!(ZReply))
+                    .class(crate::sealed_class!(ZOutcome))
+                    .fun(prebindgen_registry::fun!(z_reply_sub)),
+            )
+            .expand(
+                prebindgen_registry::expand_return!(ZReply)
+                    .fields(prebindgen_registry::fields!(z_reply_to_struct)),
+            );
+        let dir = unique_test_dir("jnigen_vf_opt_sum");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let gen = jni.build_with(registry).expect("resolve");
+        let rust = std::fs::read_to_string(gen.write_rust(dir.join("g.rs")).expect("write_rust"))
+            .expect("read rust");
+        let kotlin = gen
+            .write_kotlin(&dir.join("kotlin"))
+            .expect("write_kotlin")
+            .iter()
+            .map(|p| std::fs::read_to_string(p).unwrap())
+            .collect::<Vec<_>>()
+            .join("\n");
+        (rust, kotlin)
+    };
+
+    let (rust, kotlin) = build(syn::parse_quote!(Option<ZOutcome>));
+    let rc: String = rust.split_whitespace().collect();
+
+    // The segment is one tuple bind over the field's `Option`, reached through a
+    // coercion site so the destructure does not care how the source spelled it.
+    assert!(
+        rc.contains(":&::core::option::Option<_>=&(&__vf0).result;"),
+        "the optional step is a coercion site over the field:\n{rust}"
+    );
+    assert!(
+        rc.contains("::core::option::Option::None=>{(jni::objects::JObject::null(),jni::objects::JObject::null(),)}"),
+        "the absent arm yields the whole segment's defaults as one tuple:\n{rust}"
+    );
+    // The selector boxes: `0` is `ZOutcome::Empty`, so a raw `jint` has no
+    // spelling left for "absent".
+    assert!(
+        rc.contains("jni::objects::JObject::null()"),
+        "an absent segment defaults its slots, the tag's to JVM null:\n{rust}"
+    );
+    // The live groups still convert exactly as an ungated sum's do.
+    assert!(
+        rust.contains("ZOutcome::Failed") && rust.contains("ZOutcome::Empty"),
+        "every alternative still gets its arm:\n{rust}"
+    );
+    // Kotlin reads absence off the selector, ahead of the real tags.
+    assert!(
+        kotlin.contains("null -> null"),
+        "the reassembly answers `null` for an absent sum, before tag 0:\n{kotlin}"
+    );
+
+    // The plain sibling leaf is unaffected — gating is the segment's, not the
+    // whole form's.
+    assert!(
+        rust.contains("seq"),
+        "a non-sum field beside it still crosses normally:\n{rust}"
+    );
+}
+
+/// The dual: a BARE sum field takes no gate at all, so the optional path is not
+/// entered when there is nothing to gate — the selector stays a raw `jint` and
+/// the segment stays a plain `match` with no tuple bind.
+#[test]
+fn a_bare_sum_field_takes_no_gate() {
+    let loc = myflat_loc();
+    let items = vec![
+        (
+            syn::Item::Enum(syn::parse_quote!(
+                pub enum ZOutcome {
+                    Empty,
+                    Failed(String),
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Struct(syn::parse_quote!(
+                pub struct ZReplyStruct {
+                    pub result: ZOutcome,
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn z_reply_to_struct(r: &ZReply) -> ZReplyStruct {
+                    unimplemented!()
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn z_reply_sub(cb: impl Fn(ZReply) + Send + Sync + 'static) {
+                    unimplemented!()
+                }
+            )),
+            loc.clone(),
+        ),
+    ];
+    let registry =
+        crate::test_util::reg_from_items(declare_referenced(items)).expect("index items");
+    let jni = JniGenBuilder::new()
+        .set_package_prefix("io.test.jni")
+        .package(
+            crate::package!()
+                .class(crate::ptr_class!(ZReply))
+                .class(crate::sealed_class!(ZOutcome))
+                .fun(prebindgen_registry::fun!(z_reply_sub)),
+        )
+        .expand(
+            prebindgen_registry::expand_return!(ZReply)
+                .fields(prebindgen_registry::fields!(z_reply_to_struct)),
         );
-    }
+    let dir = unique_test_dir("jnigen_vf_bare_sum");
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    let gen = jni.build_with(registry).expect("resolve");
+    let rust = std::fs::read_to_string(gen.write_rust(dir.join("g.rs")).expect("write_rust"))
+        .expect("read rust");
+    let kotlin = gen
+        .write_kotlin(&dir.join("kotlin"))
+        .expect("write_kotlin")
+        .iter()
+        .map(|p| std::fs::read_to_string(p).unwrap())
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    assert!(
+        !rust.contains("::core::option::Option::None => ("),
+        "nothing to gate, so no tuple bind:\n{rust}"
+    );
+    assert!(
+        !kotlin.contains("null -> null"),
+        "the selector carries no absent case:\n{kotlin}"
+    );
+    assert!(
+        rust.contains("ZOutcome::Failed"),
+        "the segment still emits its arms:\n{rust}"
+    );
 }
 
 /// A field's optional-ness is read off `kind`; **how Rust spells it is the

--- a/prebindgen-jni/src/jni/tests/value_form.rs
+++ b/prebindgen-jni/src/jni/tests/value_form.rs
@@ -746,8 +746,15 @@ fn a_bare_sum_field_takes_no_gate() {
         .collect::<Vec<_>>()
         .join("\n");
 
+    // Whitespace-stripped, as the sibling test asserts: `prettyplease` breaks a
+    // tuple-valued arm after the `{`, so `None => (` on one line never appears
+    // in EITHER emission — the assertion would hold whether or not the gate was
+    // emitted, and pin nothing.
     assert!(
-        !rust.contains("::core::option::Option::None => ("),
+        !rust
+            .split_whitespace()
+            .collect::<String>()
+            .contains("::core::option::Option::None=>{("),
         "nothing to gate, so no tuple bind:\n{rust}"
     );
     assert!(


### PR DESCRIPTION
Closes #220.

## The asymmetry

`Option<sum>` was refused as a **value-form** field while the same field on a **data class** worked — the `fromParts` bridge emits a `<field>__present` flag beside its `<field>__tag` (`PlanFieldKind::Sum { optional }`). Same shape, one position over, different answer.

Rejecting was right when #213 landed: without gating, the emitter composes `match &(&__vf).result` on an `Option<Sum>` against bare variant patterns — `E0308` in the consumer crate. A named error beat emitting that.

## The issue's premise is out of date

#220 proposes teaching core a present-flag notion on the output side, dual to `FlatLeaf::is_present_flag`. **Core does not need one.** The *conditional value form* work already built absence into the leaf model, and it covers this case unchanged — `prebindgen-registry/src/unfold.rs::flatten` today already:

- marks the field's last path step optional — `PathStep::field(last, opt && decomposed)`, and `decomposed` is true for a sum (`FieldDecon::Leaves`);
- ORs the field's own `opt` into every synthesized leaf's `nullable`.

And everything downstream of that flag is already correct: the tag boxes so JVM `null` cannot alias tag `0` (`leaf_is_prim`), `leaf_slot` knows each slot's wire default, `iface.rs` types the selector `Int?` and the group nullable, and `kotlin_emit.rs` puts `null -> null` ahead of the real tags. All of it JVM-tested today through `ledgerEach`.

**So this PR changes no core, no `iface.rs`, no `kotlin_emit.rs`.**

## The one function

`delivery.rs`'s sum-segment loop folded the selector's path with `fold_steps`, which has no optional handling — and said so:

> `// no step on it is optional, since an optional sum is refused where the leaves are built.`

A sum segment can't take the per-leaf treatment `reach_leaf` gives an ordinary optional field: its leaves aren't independent, only one group is live. So the **whole segment** gates as one tuple bind whose absent arm carries every slot's default — the shape a conditional hoist already emits, applied to an optional step inside the segment's own path:

```rust
let (__cb0_obj1, __cb0_obj2, __cb0_obj3): (JObject, JObject, JObject) = {
    let __so1: &::core::option::Option<_> = &(&__vf0).outcome;   // coerced, #268
    match __so1 {
        Some(__sg1) => { /* today's encode_sum_group, unchanged */ (…) }
        None => (JObject::null(), JObject::null(), JObject::null()),
    }
};
```

`encode_sum_group` is reused untouched. The optional step follows `reach_leaf`'s own division: a **field** step goes through `bind_as_option` so the destructure doesn't care how the source spelled the optional (#268); a **call** step keeps its direct match, since an owned position can't be coerced that way.

`Vec<sum>` stays refused — variable arity genuinely has no fixed layout.

## Coverage

- `a_sum_field_behind_option_or_vec_is_rejected_by_name` → `a_vec_sum_field_is_rejected_by_name`; the `Option` row and its rationale are gone.
- **New** `an_optional_sum_field_gates_its_whole_segment` — the coercion site, the tuple-bound absent arm, the tag defaulting to JVM null rather than a raw `jint`, and Kotlin's `null -> null`.
- **New** `a_bare_sum_field_takes_no_gate` — the dual, so the optional path isn't entered when there's nothing to gate.
- `examples/covertest-kotlin` gains `Probe`, whose value form has an `Option<Lookup>` field. The JVM harness pins the distinction the boxing exists for:

  ```kotlin
  probeNew(9, -2, …) { seq, tag, _, _ -> "$seq:$tag" }  // "9:null"  — no sum at all
  probeNew(9,  0, …) { seq, tag, _, _ -> "$seq:$tag" }  // "9:0"     — a PRESENT Lookup.Absent
  ```

  A raw `jint` selector could not tell those apart, which is the whole reason no present flag is needed. **50 sections pass** under `./gradlew run`.

  Deliberately kept off `ReportStruct`: `Report` is embedded twice in `Ledger`, so a field there would add 3 positional slots to `reportEach` and 6 to `ledgerEach` and bury the change under signature churn.

## Verified

`cargo test --all`; clippy `-D warnings` and `cargo fmt --check` (CI's exact config) on **1.85.0 and stable**; `examples/regen-check.sh` clean. Generated output is **additive only** — 866 insertions, no deletions, no existing declaration touched — and `regen-check.sh --with-zenoh-flat-jni` is byte-identical, since zenoh-flat's `ReplyStruct.result` is a bare `ReplyResult`.

`docs/sum-types.md` §4.3 now records that both output paths gate `Option<sum>`, by two different means — a present flag on the `fromParts` bridge, the selector's own nullability in a leaf list.