### PR TITLE
jnigen: a `Vec<data class>` field crosses; drop its dead guard (closes #217)

### DIFF
--- a/prebindgen-jni/src/jni/struct_plan.rs
+++ b/prebindgen-jni/src/jni/struct_plan.rs
@@ -311,17 +311,24 @@ pub(crate) fn classify_field(
             };
         }
         // Nested plain data-class (optionally under `Option`).
+        //
+        // A `Vec<data class>` does NOT arrive here and needs no guard of its
+        // own (#217). `type_kind` answers `DataStruct` only for a key that is a
+        // single identifier, which a `Vec<_>` key never is — so this branch
+        // cannot be entered with a sequence in hand, and the field falls
+        // through to the simple-leaf arm below. That is the right answer rather
+        // than a missed one: the field stays ONE slot whose own converter is
+        // the element's fixed folder, so the bridge keeps its fixed slot count
+        // and the elements still cross as raw leaves. #217 expected this to
+        // need array codegen — a count slot plus a per-element sub-plan in all
+        // three producers — and it does not, because the sequence never has to
+        // enter the fixed layout at all.
+        //
+        // The `Vec<sum>` refusal above is a different question and stays: a sum
+        // has no converter of its own, so there is no single slot to fall
+        // through to.
         let inner_ty = bare_ref;
         if let TypeKind::DataStruct { st, cfg } = ext.type_kind(registry, &inner_ty.key()) {
-            // `Vec` off the kind — the layer the model names, not a last path
-            // segment that spells it.
-            if matches!(reading.kind(), prebindgen_registry::flat::TypeKind::Vec(_)) {
-                panic!(
-                    "fromParts bridge: `Vec<{}>` data-class field (`{owner}`) is not supported \
-                     (variable arity)",
-                    inner_ty,
-                );
-            }
             let child_fqn = cfg
                 .and_then(|c| c.name_spec.as_ref())
                 .map(|s| ext.fqn_of(s));

--- a/prebindgen-jni/src/jni/tests/value_form.rs
+++ b/prebindgen-jni/src/jni/tests/value_form.rs
@@ -554,6 +554,142 @@ fn a_sum_field_behind_option_or_vec_is_rejected_by_name() {
     }
 }
 
+/// `Vec<data class>` crosses in BOTH positions — as a return and as a value-form
+/// **field** — with its elements folded from raw leaves either way (#217).
+///
+/// #217 reported the field position as a hard panic ("variable arity"), on the
+/// reasoning that the `fromParts` bridge is fixed-layout: `encode_plan`,
+/// `flatten_struct_factory` and `build_data_class` enumerate identical slots in
+/// identical order, and a runtime length breaks that agreement. That was true,
+/// and the resolution was not the array codegen the issue anticipated — it is
+/// that the field never needs to enter the fixed layout at all. It stays **one**
+/// slot whose own converter is the element's leaf-vec fold, so the slot count is
+/// still fixed and the elements still cross as raw leaves.
+///
+/// So the guard the issue names is now unreachable: it sits inside
+/// `classify_field`'s `TypeKind::DataStruct` branch, and `type_kind` answers
+/// `DataStruct` only for a key that is a single identifier — which a `Vec<_>`
+/// key never is. The `Vec<sum>` guard beside it is a different question and
+/// stays live (see
+/// [`a_sum_field_behind_option_or_vec_is_rejected_by_name`]).
+///
+/// **The raw-leaf fold is asserted separately, and that is the point.** #217's
+/// standing warning is that silently degrading the field to a whole-object
+/// crossing would reintroduce the per-value JVM object the bridge exists to
+/// avoid. Such a degradation would still surface as `List<Rec>` and still build
+/// through `fromParts` — it would pass every other assertion here. Only the
+/// folder assertion would catch it.
+#[test]
+fn a_vec_of_data_classes_crosses_as_a_return_and_as_a_field() {
+    let loc = myflat_loc();
+    // `field` = the value form's field type. `None` builds only the control
+    // (the `Vec<Rec>` return), so the two claims do not share a failure mode.
+    let build = |field: Option<syn::Type>| {
+        let mut items = vec![
+            (
+                syn::Item::Struct(syn::parse_quote!(
+                    pub struct Rec {
+                        pub id: i64,
+                    }
+                )),
+                loc.clone(),
+            ),
+            // The CONTROL: the same `Vec<Rec>`, in the position that works.
+            (
+                syn::Item::Fn(syn::parse_quote!(
+                    pub fn stack_records(n: i64) -> Vec<Rec> {
+                        unimplemented!()
+                    }
+                )),
+                loc.clone(),
+            ),
+        ];
+        let has_field = field.is_some();
+        if let Some(field) = field {
+            items.push((
+                syn::Item::Struct(syn::parse_quote!(
+                    pub struct StackStruct {
+                        pub records: #field,
+                    }
+                )),
+                loc.clone(),
+            ));
+            // Returning the struct by value is what BUILDS the flattened
+            // bridge (`wire_fixed_returns` → `build_struct_plan`). Declaring
+            // the data class alone only renders it, with a whole-object
+            // `fromParts`, and never asks `classify_field` anything.
+            items.push((
+                syn::Item::Fn(syn::parse_quote!(
+                    pub fn stack_struct_of(n: i64) -> StackStruct {
+                        unimplemented!()
+                    }
+                )),
+                loc.clone(),
+            ));
+        }
+        let registry =
+            crate::test_util::reg_from_items(declare_referenced(items)).expect("index items");
+        let mut jni = JniGenBuilder::new()
+            .set_package_prefix("io.test.jni")
+            .package(
+                crate::package!()
+                    .class(crate::data_class!(Rec))
+                    .fun(prebindgen_registry::fun!(stack_records)),
+            );
+        if has_field {
+            jni = jni.package(
+                crate::package!()
+                    .class(crate::data_class!(StackStruct))
+                    .fun(prebindgen_registry::fun!(stack_struct_of)),
+            );
+        }
+        let dir = unique_test_dir("jnigen_vec_dataclass_field");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let gen = jni.build_with(registry).expect("resolve");
+        let kdir = dir.join("kotlin");
+        let paths = gen.write_kotlin(&kdir).expect("write_kotlin");
+        gen.write_rust(dir.join("g.rs")).expect("write_rust");
+        paths
+            .iter()
+            .map(|p| std::fs::read_to_string(p).unwrap())
+            .collect::<Vec<_>>()
+            .join("\n")
+    };
+
+    // 1. The control. Without this the refusal below says nothing about
+    //    POSITION — it would be satisfied by `Vec<Rec>` failing everywhere.
+    let kotlin = build(None);
+    let kc: String = kotlin.split_whitespace().collect();
+    assert!(
+        kc.contains("stackRecords") && kc.contains("List<Rec>"),
+        "`Vec<Rec>` must cross as `List<Rec>` in the RETURN position — that is \
+         the half of the asymmetry that works:\n{kotlin}"
+    );
+
+    // 2. The same element type as a FIELD of a value form. This is the
+    //    position #217 reported as a hard panic; it crosses.
+    let kotlin = build(Some(syn::parse_quote!(Vec<Rec>)));
+    let kc: String = kotlin.split_whitespace().collect();
+    assert!(
+        kc.contains("publicdataclassStackStruct(valrecords:List<Rec>)"),
+        "the `Vec<Rec>` FIELD must surface as `List<Rec>`:\n{kotlin}"
+    );
+    assert!(
+        kc.contains("StackStructBuilder{records->StackStruct.fromParts(records)}"),
+        "the field is delivered as one builder slot:\n{kotlin}"
+    );
+    // The property the guard existed to protect: elements are rebuilt Kotlin-side
+    // from RAW leaves, so no per-element JVM object crosses the boundary. A
+    // whole-object degradation would satisfy the two assertions above and fail
+    // this one, which is why it is asserted separately.
+    assert!(
+        kc.contains("RecFolderRaw{acc,id->acc.add(Rec.fromParts(id));acc}"),
+        "each element must be folded from its raw leaves, not crossed as an \
+         object — that is what the fixed bridge exists to avoid:\n{kotlin}"
+    );
+}
+
 /// A field's optional-ness is read off `kind`; **how Rust spells it is the
 /// source's business**, and the emitter must accept any of the spellings.
 ///


### PR DESCRIPTION
Closes #217.

#217 reported a `Vec<data class>` **struct field** as a hard panic, and anticipated the fix as array codegen: a count slot plus a per-element sub-plan that all three fixed-bridge producers (`encode_plan`, `flatten_struct_factory`, `build_data_class`) loop over. Checked against `main` — **the shape crosses today**, and the resolution is not the one the issue expected.

## What actually happens

```kotlin
public data class StackStruct(val records: List<Rec>)
internal val __StackStructBuilder = StackStructBuilder { records -> StackStruct.fromParts(records) }
RecFolderRaw { acc, id -> acc.add(Rec.fromParts(id)); acc }
```

The field never enters the fixed layout. It stays **one** slot whose own converter is the element's fixed folder — so the bridge keeps its fixed slot count *and* elements still cross as raw leaves (`id: Long`), never as per-element JVM objects. That is exactly the property #217 says must not be lost:

> silently degrading a `Vec` field to a whole-object crossing would reintroduce the per-value JVM object the bridge exists to avoid

Preserved, by a route the issue didn't consider: the sequence doesn't need array codegen because it doesn't need to be flattened at all.

## The guard is dead code

Two independent grounds:

- **By construction** — it sits inside `classify_field`'s `TypeKind::DataStruct` branch, and `type_kind` (`classify.rs:75`) answers `DataStruct` only when `bare.ident()` is `Some`, i.e. the key is a single identifier. A `Vec<_>` key never is, so the branch cannot be entered with a sequence in hand.
- **By experiment** — deleting it leaves the entire suite green (596 passed, 0 failed).

Removed, together with a comment that would mislead the next reader into believing the shape is refused. The reasoning now sits where the guard was, so the absence is documented rather than merely empty.

**The `Vec<sum>` guard beside it is untouched.** Different question, still live, still tested (`tests/sealed.rs:809,873`, `tests/value_form.rs:539`): a sum has no converter of its own, so there is no single slot for it to fall through to.

## The test

Pins the capability in **both** positions — `Vec<Rec>` as a return and as a value-form field — and asserts the raw-leaf folder **separately**. That separation is the point: a whole-object degradation would still surface as `List<Rec>` and still build through `fromParts`, so it would pass every other assertion in the test. Only the folder assertion would catch it.

The fixture also documents a trap worth knowing: declaring the data class alone is **not** enough to build the flattened bridge — it renders the class with a whole-object `fromParts` and never asks `classify_field` anything. A declared fn must *return* the struct.

## Verified

- `cargo test --all --all-features` — 596 passed, 0 failed.
- `examples/regen-check.sh` after `cargo clean --release` — **byte-identical**; removing unreachable code moves no output, which is itself part of the deadness claim.
- `cargo fmt --check` with the CI config; clippy `-D warnings` clean on both 1.85.0 and stable.