### PR TITLE
Take a leaf's niche sentinel from its own type, not its ancestor (#142)

### DIFF
--- a/examples/covertest-kotlin/build.rs
+++ b/examples/covertest-kotlin/build.rs
@@ -246,6 +246,12 @@ fn main() {
                 // being restated field by field — #213. The form it names is
                 // the CONSUMING one, so the fields are moved, not cloned.
                 .class(ptr_class!(Report))
+                // #142: two bounded-`convert!` leaves — one with a niche of its
+                // own, one without — reached through a CONDITIONAL hoist, so both
+                // are nullable. Only the niche-carrying one keeps a sentinel in
+                // its wrap; the other's absence is the ancestor's `?.`.
+                .class(ptr_class!(Span))
+                .class(ptr_class!(SpanHolder))
                 // `Hold`'s payload is a CONVERTED type, so its leaf crosses
                 // through the `convert!(Duration)` chain; `HoldPolicy` puts
                 // that same payload in the data-class-field position.
@@ -393,6 +399,12 @@ fn main() {
         // its `Stamp` fields, `taken` stays one `Stamp?` leaf, and `outcome`
         // decomposes into a selector plus one group per alternative.
         .expand(expand_return!(Report).fields_self_into(fields!(report_into_struct)))
+        // #142: `Span`'s value form is two bounded leaves; `SpanHolder` reaches
+        // it through an `Option`, so both become nullable. `delay` keeps its own
+        // niche sentinel, `required` takes none — a sentinel is the leaf's own
+        // `None`, never an ancestor's.
+        .expand(expand_return!(Span).fields(fields!(span_to_struct)))
+        .expand(expand_return!(SpanHolder).field(fun!(span_holder_span)))
         // `Ledger` reaches that same derived boundary through an `Option`, so
         // `Report`'s value form is hoisted CONDITIONALLY — built in the `Some`
         // arm, its leaves (the sum among them) sharing one `match`, null in the
@@ -527,6 +539,8 @@ fn main() {
                 // crossing covers the borrowed payload, the owned one, and the
                 // sum each report carries.
                 .fun(fun!(ledger_each))
+                // #142: the holder whose span is optional.
+                .fun(fun!(span_holder_new))
                 // A transparent wrapper (`Box<Option<String>>`) in and out. The
                 // model erases the `Box`, so this must cross exactly as a
                 // `String?` — and because this crate compiles its generated

--- a/examples/covertest-kotlin/kotlin/REPORT.md
+++ b/examples/covertest-kotlin/kotlin/REPORT.md
@@ -111,6 +111,8 @@ Base package: `io.prebindgen.covertest`
 - `reading_series` — `fun readingSeries(n: Int, onError: JniErrorHandler<List<Reading>>): List<Reading>`
   - shaped by: return `Reading` decomposed → [tag, exact_v0, range_low, range_high, tagged_v0, tagged_v1, companion_v0] (Callback delivery)
 - `report_each` — `fun reportEach(n: Long, sink: ReportCallback, onError: JniErrorHandler<Unit>)`
+- `span_holder_new` — `fun <R> spanHolderNew(seq: Long, requiredMs: ULong, delayMs: Long, onError: JniErrorHandler<R>, build: SpanHolderBuilder<R>): R`
+  - shaped by: return `SpanHolder` decomposed → [spanHolderSpan__required, spanHolderSpan__delay] (Callback delivery)
 - `stamp_new` — `fun stampNew(secs: Long, nanos: Long, onError: JniErrorHandler<Stamp>): Stamp`
   - shaped by: return `Stamp` decomposed → [secs, nanos] (Callback delivery)
 - `stamp_series` — `fun stampSeries(count: Long, onError: JniErrorHandler<List<Stamp>>): List<Stamp>`
@@ -220,6 +222,8 @@ Base package: `io.prebindgen.covertest`
 - `Reading`: sealed_class → `io.prebindgen.covertest.model.Reading` (wire `?`)
 - `RepliesConfig`: data_class → `io.prebindgen.covertest.model.RepliesConfig` (wire `jni :: objects :: JObject`)
 - `Report`: ptr_class → `io.prebindgen.covertest.model.Report` (wire `jni :: sys :: jlong`)
+- `Span`: ptr_class → `io.prebindgen.covertest.model.Span` (wire `jni :: sys :: jlong`)
+- `SpanHolder`: ptr_class → `io.prebindgen.covertest.model.SpanHolder` (wire `jni :: sys :: jlong`)
 - `Stamp`: data_class → `io.prebindgen.covertest.model.Stamp` (wire `jni :: objects :: JObject`)
 - `Storage`: ptr_class → `io.prebindgen.covertest.Storage` (wire `jni :: sys :: jlong`)
 - `StorageError`: ptr_class → `io.prebindgen.covertest.errors.StorageError` (wire `jni :: sys :: jlong`)

--- a/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest.kt
+++ b/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest.kt
@@ -1103,6 +1103,14 @@ internal object CovNative {
 
     external fun reportEach(n: Long, sink: Any, errorSink: Any)
 
+    external fun spanHolderNew(
+        seq: Long,
+        requiredMs: Long,
+        delayMs: Long,
+        build: Any,
+        errorSink: Any,
+    ): Any?
+
     external fun stampNanos(sSecs: Long, sNanos: Long, errorSink: Any): Long
 
     external fun stampNew(secs: Long, nanos: Long, build: Any, errorSink: Any): Any?

--- a/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest/model.kt
+++ b/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest/model.kt
@@ -888,6 +888,54 @@ public class Report(initialPtr: Long) : NativeHandle(initialPtr) {
     }
 }
 
+/** Typed handle for a native Zenoh `Span`. */
+public class Span(initialPtr: Long) : NativeHandle(initialPtr) {
+    @Synchronized
+    override fun close() {
+        val p = ptr
+        if (p != 0L && (p and 1L) == 0L) {
+            ptr = p or 1L
+            freePtr(p)
+        }
+    }
+
+    @Synchronized
+    public fun take(): Span {
+        val p = ptr
+        ptr = p or 1L
+        return Span(p)
+    }
+
+    public companion object {
+        @JvmStatic
+        external fun freePtr(ptr: Long)
+    }
+}
+
+/** Typed handle for a native Zenoh `SpanHolder`. */
+public class SpanHolder(initialPtr: Long) : NativeHandle(initialPtr) {
+    @Synchronized
+    override fun close() {
+        val p = ptr
+        if (p != 0L && (p and 1L) == 0L) {
+            ptr = p or 1L
+            freePtr(p)
+        }
+    }
+
+    @Synchronized
+    public fun take(): SpanHolder {
+        val p = ptr
+        ptr = p or 1L
+        return SpanHolder(p)
+    }
+
+    public companion object {
+        @JvmStatic
+        external fun freePtr(ptr: Long)
+    }
+}
+
 public fun interface LookupCallback {
     public fun run(lookup: Lookup)
 }
@@ -1056,6 +1104,24 @@ internal val __ReadingBuilder: ReadingBuilder<Reading> =
 ReadingBuilder { tag, exact_v0, range_low, range_high, tagged_v0, tagged_v1, companion_v0 ->
     when (tag) { 0 -> Reading.Missing; 1 -> Reading.Exact(exact_v0); 2 -> Reading.Range(range_low, range_high); 3 -> Reading.Tagged(tagged_v0!!, Priority.fromInt(tagged_v1)); 4 -> Reading.Companion(companion_v0); else -> throw IllegalArgumentException("Reading: invalid tag $tag") }
 }
+
+public fun interface SpanHolderBuilder<out R> {
+    public fun run(spanHolderSpan__required: ULong?, spanHolderSpan__delay: ULong?): R
+}
+
+public fun interface SpanHolderBuilderRaw<out R> {
+    public fun run(spanHolderSpan__required: Long?, spanHolderSpan__delay: Long?): R
+}
+
+public fun <R> SpanHolderBuilder<R>.asRaw(): SpanHolderBuilderRaw<R> =
+    SpanHolderBuilderRaw<R> {
+        spanHolderSpan__required,
+        spanHolderSpan__delay ->
+        run(
+            spanHolderSpan__required?.toULong(),
+            spanHolderSpan__delay?.let { if (it == -1L) null else it.toULong() }
+        )
+    }
 
 public fun interface StampBuilder<out R> {
     public fun run(secs: Long, nanos: Long): R
@@ -1577,6 +1643,26 @@ public fun ledgerEach(n: Long, sink: LedgerCallback, onError: JniErrorHandler<Un
     val __bcap = JniErrorHandlerCapture.acquire()
     CovNative.ledgerEach(n, sink.asRaw(), __bcap)
     if (__bcap.failed) return onError.run(__bcap.ze0)
+}
+
+/**
+ * `None` when `seq` is negative, so the absent case is reachable from the
+ * same argument that drives the present ones.
+ *
+ * The Rust `SpanHolder` result is delivered decomposed: the builder callback receives (`spanHolderSpan__required`, `spanHolderSpan__delay`).
+ */
+@Suppress("UNCHECKED_CAST")
+public fun <R> spanHolderNew(
+    seq: Long,
+    requiredMs: ULong,
+    delayMs: Long,
+    onError: JniErrorHandler<R>,
+    build: SpanHolderBuilder<R>,
+): R {
+    val __bcap = JniErrorHandlerCapture.acquire()
+    val __ret = CovNative.spanHolderNew(seq, requiredMs.toLong(), delayMs, build.asRaw(), __bcap)
+    if (__bcap.failed) return onError.run(__bcap.ze0)
+    return __ret as R
 }
 
 /**

--- a/examples/covertest-kotlin/kotlin/io/prebindgen/covertest/Test.kt
+++ b/examples/covertest-kotlin/kotlin/io/prebindgen/covertest/Test.kt
@@ -62,6 +62,7 @@ import io.prebindgen.covertest.model.celsiusDouble
 import io.prebindgen.covertest.model.boxedDurationEcho
 import io.prebindgen.covertest.model.durationOptional
 import io.prebindgen.covertest.model.durationBoundaryEcho
+import io.prebindgen.covertest.model.spanHolderNew
 import io.prebindgen.covertest.model.durationEmit
 import io.prebindgen.covertest.model.durationOutOfRange
 import io.prebindgen.covertest.model.holdEcho
@@ -290,6 +291,27 @@ fun main() {
             durationBoundaryEcho(DurationBoundary(86_400_000uL, 1uL), boom) ==
                 DurationBoundary(86_400_000uL, 1uL),
         )
+
+        // The same two leaves under an OPTIONAL ancestor (#142) — the
+        // combination `DurationBoundary` cannot reach, since its fields are
+        // never absent as a pair. A conditional value form makes both nullable,
+        // which crosses the two facts that decide the wrap: does the leaf carry
+        // a niche of its own (`delay` yes, `required` no), and can an ancestor
+        // be absent (both). Only the first grants a sentinel.
+        //
+        // `0uL` is the value that makes this observable: it is legal in the
+        // declared range AND is what a zero-defaulted slot would carry, so a
+        // wrap that confused the two absences would report it as `null`.
+        check(spanHolderNew(0L, 0uL, 0L, boom) { req, del -> "$req/$del" } == "0/0")
+        // …and the niche-carrying leaf still reads its own `None`, while its
+        // sibling — which has no niche — is unaffected.
+        check(spanHolderNew(0L, 5uL, -1L, boom) { req, del -> "$req/$del" } == "5/null")
+        // Ancestor absent: BOTH leaves are null, through the `?.` alone. The
+        // `required` leaf has no sentinel to be confused by; before #142's fix
+        // its wrap tested `-1L`, a value its own encoder can never produce.
+        check(spanHolderNew(-1L, 9uL, 3L, boom) { req, del -> "$req/$del" } == "null/null")
+        check(spanHolderNew(0L, 86_400_000uL, 12_345L, boom) { req, del -> "$req/$del" }
+            == "86400000/12345")
 
         // A whole-value CALLBACK argument is a third encoder path, independent
         // of the data-class and sum emitters above: the trampoline encodes the

--- a/examples/covertest-kotlin/src/generated_bindings.rs
+++ b/examples/covertest-kotlin/src/generated_bindings.rs
@@ -227,6 +227,38 @@ const _: () = {
 };
 #[no_mangle]
 #[allow(non_snake_case, unused_variables)]
+pub(crate) unsafe extern "C" fn Java_io_prebindgen_covertest_model_SpanHolder_freePtr(
+    _env: jni::JNIEnv,
+    _class: jni::objects::JClass,
+    ptr: jni::sys::jlong,
+) {
+    if ptr != 0 && (ptr & 1) == 0 {
+        drop(Box::from_raw(ptr as *mut perftest_flat::SpanHolder));
+    }
+}
+const _: () = {
+    if ::core::mem::align_of::<perftest_flat::SpanHolder>() < 2 {
+        panic!("opaque handle types must have alignment >= 2 (bit 0 is the closed tag)");
+    }
+};
+#[no_mangle]
+#[allow(non_snake_case, unused_variables)]
+pub(crate) unsafe extern "C" fn Java_io_prebindgen_covertest_model_Span_freePtr(
+    _env: jni::JNIEnv,
+    _class: jni::objects::JClass,
+    ptr: jni::sys::jlong,
+) {
+    if ptr != 0 && (ptr & 1) == 0 {
+        drop(Box::from_raw(ptr as *mut perftest_flat::Span));
+    }
+}
+const _: () = {
+    if ::core::mem::align_of::<perftest_flat::Span>() < 2 {
+        panic!("opaque handle types must have alignment >= 2 (bit 0 is the closed tag)");
+    }
+};
+#[no_mangle]
+#[allow(non_snake_case, unused_variables)]
 pub(crate) unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_payloadVecFree(
     _env: jni::JNIEnv,
     _class: jni::objects::JClass,
@@ -9051,6 +9083,44 @@ pub(crate) unsafe fn Result_Summary_String_to_Summary_dfdf7f9e<'a>(
     clippy::nonminimal_bool,
     clippy::eq_op
 )]
+pub(crate) unsafe fn SpanHolder_to_jlong_7ffe9314<'a>(
+    env: &mut jni::JNIEnv<'a>,
+    v: perftest_flat::SpanHolder,
+) -> ::core::result::Result<jni::sys::jlong, __JniErr> {
+    Ok(std::boxed::Box::into_raw(std::boxed::Box::new(v)) as i64)
+}
+#[allow(
+    non_snake_case,
+    unused_mut,
+    unused_variables,
+    unused_braces,
+    unused_parens,
+    dead_code,
+    clippy::useless_conversion,
+    clippy::needless_question_mark,
+    clippy::let_and_return,
+    clippy::nonminimal_bool,
+    clippy::eq_op
+)]
+pub(crate) unsafe fn Span_to_jlong_6d59d587<'a>(
+    env: &mut jni::JNIEnv<'a>,
+    v: perftest_flat::Span,
+) -> ::core::result::Result<jni::sys::jlong, __JniErr> {
+    Ok(std::boxed::Box::into_raw(std::boxed::Box::new(v)) as i64)
+}
+#[allow(
+    non_snake_case,
+    unused_mut,
+    unused_variables,
+    unused_braces,
+    unused_parens,
+    dead_code,
+    clippy::useless_conversion,
+    clippy::needless_question_mark,
+    clippy::let_and_return,
+    clippy::nonminimal_bool,
+    clippy::eq_op
+)]
 pub(crate) unsafe fn Stamp_to_JObject_f6b1e942<'a>(
     env: &mut jni::JNIEnv<'a>,
     v: perftest_flat::Stamp,
@@ -10334,6 +10404,58 @@ pub(crate) unsafe fn jlong_to_Report_eaed4ba1<'env, 'v>(
         );
     }
     Ok(unsafe { OwnedObject::from_raw(*v as *const perftest_flat::Report) })
+}
+#[allow(
+    non_snake_case,
+    unused_mut,
+    unused_variables,
+    unused_braces,
+    unused_parens,
+    dead_code,
+    clippy::useless_conversion,
+    clippy::needless_question_mark,
+    clippy::let_and_return,
+    clippy::nonminimal_bool,
+    clippy::eq_op
+)]
+pub(crate) unsafe fn jlong_to_SpanHolder_7ffe9314<'env, 'v>(
+    env: &mut jni::JNIEnv<'env>,
+    v: &jni::sys::jlong,
+) -> ::core::result::Result<OwnedObject<perftest_flat::SpanHolder>, __JniErr> {
+    if *v == 0 || (*v & 1) == 1 {
+        return ::core::result::Result::Err(
+            <__JniErr as ::core::convert::From<
+                String,
+            >>::from("Operation on a closed native handle.".to_string()),
+        );
+    }
+    Ok(unsafe { OwnedObject::from_raw(*v as *const perftest_flat::SpanHolder) })
+}
+#[allow(
+    non_snake_case,
+    unused_mut,
+    unused_variables,
+    unused_braces,
+    unused_parens,
+    dead_code,
+    clippy::useless_conversion,
+    clippy::needless_question_mark,
+    clippy::let_and_return,
+    clippy::nonminimal_bool,
+    clippy::eq_op
+)]
+pub(crate) unsafe fn jlong_to_Span_6d59d587<'env, 'v>(
+    env: &mut jni::JNIEnv<'env>,
+    v: &jni::sys::jlong,
+) -> ::core::result::Result<OwnedObject<perftest_flat::Span>, __JniErr> {
+    if *v == 0 || (*v & 1) == 1 {
+        return ::core::result::Result::Err(
+            <__JniErr as ::core::convert::From<
+                String,
+            >>::from("Operation on a closed native handle.".to_string()),
+        );
+    }
+    Ok(unsafe { OwnedObject::from_raw(*v as *const perftest_flat::Span) })
 }
 #[allow(
     non_snake_case,
@@ -17869,6 +17991,195 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_reportEach<'a>(
                 &__e.to_string(),
             );
             ()
+        }
+    }
+}
+#[no_mangle]
+#[allow(non_snake_case, unused_mut, unused_variables, dead_code)]
+pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_spanHolderNew<'a>(
+    mut env: jni::JNIEnv<'a>,
+    _class: jni::objects::JClass<'a>,
+    seq: jni::sys::jlong,
+    required_ms: jni::sys::jlong,
+    delay_ms: jni::sys::jlong,
+    __builder: jni::objects::JObject<'a>,
+    __error_sink: jni::objects::JObject<'a>,
+) -> jni::objects::JObject<'a> {
+    #[allow(non_upper_case_globals)]
+    static __SINK_MID: ::prebindgen_jni_runtime::CachedIfaceMethod = ::prebindgen_jni_runtime::CachedIfaceMethod::new();
+    const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
+    const __SINK_DESCR: &str = "(Ljava/lang/String;)Ljava/lang/Object;";
+    let seq = match jlong_to_i64_fbf9a9bc(&mut env, &seq) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__e) => {
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e.to_string(),
+            );
+            return jni::objects::JObject::null().into();
+        }
+    };
+    let required_ms = match jlong_to_u64_4384a5d6(&mut env, &required_ms) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__e) => {
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e.to_string(),
+            );
+            return jni::objects::JObject::null().into();
+        }
+    };
+    let delay_ms = match jlong_to_i64_fbf9a9bc(&mut env, &delay_ms) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__e) => {
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e.to_string(),
+            );
+            return jni::objects::JObject::null().into();
+        }
+    };
+    #[allow(non_upper_case_globals)]
+    static __CB_MID: ::prebindgen_jni_runtime::CachedIfaceMethod = ::prebindgen_jni_runtime::CachedIfaceMethod::new();
+    const __CB_FQN: &str = "io/prebindgen/covertest/model/SpanHolderBuilderRaw";
+    const __CB_DESCR: &str = "(Ljava/lang/Long;Ljava/lang/Long;)Ljava/lang/Object;";
+    let __out = perftest_flat::span_holder_new(seq, required_ms, delay_ms);
+    let __vf0 = perftest_flat::span_holder_span(&__out)
+        .map(|__hb0| perftest_flat::span_to_struct(__hb0));
+    let (__obj0, __obj1): (jni::objects::JObject, jni::objects::JObject) = match __vf0 {
+        ::core::option::Option::Some(__u0) => {
+            let __obj0: jni::objects::JObject = {
+                let __enc0 = {
+                    let __cs0_0 = match Duration_to_u64_e3980876(
+                        &mut env,
+                        __u0.required.clone(),
+                    ) {
+                        ::core::result::Result::Ok(__w) => __w,
+                        ::core::result::Result::Err(__e) => {
+                            signal_binding_error(
+                                &mut env,
+                                &__error_sink,
+                                &__SINK_MID,
+                                __SINK_FQN,
+                                __SINK_DESCR,
+                                &__e.to_string(),
+                            );
+                            return jni::objects::JObject::null().into();
+                        }
+                    };
+                    match u64_to_jlong_4384a5d6(&mut env, __cs0_0) {
+                        ::core::result::Result::Ok(__w) => __w,
+                        ::core::result::Result::Err(__e) => {
+                            signal_binding_error(
+                                &mut env,
+                                &__error_sink,
+                                &__SINK_MID,
+                                __SINK_FQN,
+                                __SINK_DESCR,
+                                &__e.to_string(),
+                            );
+                            return jni::objects::JObject::null().into();
+                        }
+                    }
+                };
+                match ::prebindgen_jni_runtime::box_jlong(&mut env, __enc0) {
+                    ::core::result::Result::Ok(__o) => __o,
+                    ::core::result::Result::Err(__e) => {
+                        signal_binding_error(
+                            &mut env,
+                            &__error_sink,
+                            &__SINK_MID,
+                            __SINK_FQN,
+                            __SINK_DESCR,
+                            &__e,
+                        );
+                        return jni::objects::JObject::null().into();
+                    }
+                }
+            };
+            let __obj1: jni::objects::JObject = {
+                let __enc1 = match Option_Duration_to_jlong_1cfa4d44(
+                    &mut env,
+                    __u0.delay.clone(),
+                ) {
+                    ::core::result::Result::Ok(__w) => __w,
+                    ::core::result::Result::Err(__e) => {
+                        signal_binding_error(
+                            &mut env,
+                            &__error_sink,
+                            &__SINK_MID,
+                            __SINK_FQN,
+                            __SINK_DESCR,
+                            &__e.to_string(),
+                        );
+                        return jni::objects::JObject::null().into();
+                    }
+                };
+                match ::prebindgen_jni_runtime::box_jlong(&mut env, __enc1) {
+                    ::core::result::Result::Ok(__o) => __o,
+                    ::core::result::Result::Err(__e) => {
+                        signal_binding_error(
+                            &mut env,
+                            &__error_sink,
+                            &__SINK_MID,
+                            __SINK_FQN,
+                            __SINK_DESCR,
+                            &__e,
+                        );
+                        return jni::objects::JObject::null().into();
+                    }
+                }
+            };
+            (__obj0, __obj1)
+        }
+        ::core::option::Option::None => {
+            (jni::objects::JObject::null(), jni::objects::JObject::null())
+        }
+    };
+    match __CB_MID
+        .call_object(
+            &mut env,
+            __CB_FQN,
+            "run",
+            __CB_DESCR,
+            &__builder,
+            &[
+                jni::sys::jvalue {
+                    l: __obj0.as_raw(),
+                },
+                jni::sys::jvalue {
+                    l: __obj1.as_raw(),
+                },
+            ],
+        )
+    {
+        ::core::result::Result::Ok(__o) => __o,
+        ::core::result::Result::Err(__e) => {
+            let _ = env.exception_describe();
+            let __e2 = <__JniErr as ::core::convert::From<
+                String,
+            >>::from(__e.to_string());
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e2.to_string(),
+            );
+            jni::objects::JObject::null().into()
         }
     }
 }

--- a/examples/perftest-flat/src/ext.rs
+++ b/examples/perftest-flat/src/ext.rs
@@ -66,6 +66,17 @@ mod handles {
         pub(super) label: String,
     }
 
+    /// Two bounded-`convert!` leaves, one with a niche of its own and one
+    /// without, behind an `Option` — see [`super::Span`] (#142).
+    pub struct Span {
+        pub(super) required: super::Duration,
+        pub(super) delay: Option<super::Duration>,
+    }
+
+    pub struct SpanHolder {
+        pub(super) span: Option<Span>,
+    }
+
     pub struct EscapeProbe {
         pub(super) value: i64,
     }
@@ -772,6 +783,57 @@ pub struct DurationBoundary {
 #[prebindgen]
 pub fn duration_boundary_echo(value: &DurationBoundary) -> DurationBoundary {
     value.clone()
+}
+
+/// The same two converted leaves under an **optional ancestor** (#142) — the
+/// combination `DurationBoundary` alone cannot reach, because its own fields
+/// are never absent as a pair.
+///
+/// A conditional value form (`Option<&Span>`) makes every leaf below it
+/// nullable, which crosses the two facts that decide a wrap: whether the leaf
+/// carries a niche of its OWN (`delay` does, `required` does not) and whether an
+/// ancestor can be absent (both, here). Only the first grants a sentinel — the
+/// ancestor's absence is carried by `?.`, and testing `required` against `-1`
+/// would ask about a value its own encoder can never produce.
+#[prebindgen]
+pub type Span = handles::Span;
+
+/// [`Span`]'s value form: one bounded leaf with a niche, one without.
+#[prebindgen]
+pub struct SpanStruct {
+    pub required: Duration,
+    pub delay: Option<Duration>,
+}
+
+/// The accessor `expand_return!(Span).fields(fields!(..))` names.
+#[prebindgen]
+pub fn span_to_struct(s: &Span) -> SpanStruct {
+    SpanStruct {
+        required: s.required,
+        delay: s.delay,
+    }
+}
+
+/// The holder whose span is reached **optionally** — the conditional hoist.
+#[prebindgen]
+pub type SpanHolder = handles::SpanHolder;
+
+/// `None` when `seq` is negative, so the absent case is reachable from the
+/// same argument that drives the present ones.
+#[prebindgen]
+pub fn span_holder_new(seq: i64, required_ms: u64, delay_ms: i64) -> SpanHolder {
+    SpanHolder {
+        span: (seq >= 0).then(|| Span {
+            required: Duration::from_millis(required_ms),
+            delay: (delay_ms >= 0).then(|| Duration::from_millis(delay_ms as u64)),
+        }),
+    }
+}
+
+/// The borrowed optional accessor that makes `Span`'s leaves nullable.
+#[prebindgen]
+pub fn span_holder_span(h: &SpanHolder) -> Option<&Span> {
+    h.span.as_ref()
 }
 
 /// Deliver a converted value through the generated typed/raw callback twin —

--- a/prebindgen-jni/src/jni/fold.rs
+++ b/prebindgen-jni/src/jni/fold.rs
@@ -592,6 +592,40 @@ pub(crate) fn projection_leaf_sentinel(proj: &crate::jni::Projection) -> Option<
     kotlin_null_sentinel(&leaf_wire).map(|s| s.to_string())
 }
 
+/// The sentinel a **wrap** should test, given the projection and whether an
+/// ancestor makes the leaf nullable — the one rule both derivations of that
+/// wrap read (`unfold_leaf_kt` in `render.rs`, `leaf_iface_param` in
+/// `iface.rs`), so it cannot drift between them again (#142).
+///
+/// A sentinel is the leaf's **own** `None` representation, so it belongs to the
+/// leaf's own type and to nothing above it. Two independent facts meet here and
+/// only the first one answers:
+///
+/// * the leaf's type carries a niche — `Option<Duration>` over a bounded
+///   `convert!`, whose strategy is `Optional(Niche, _)`. Its `None` IS the
+///   sentinel, and the test stays whatever the ancestor does.
+/// * an **ancestor** can be absent (a conditional value form, an
+///   `Option<sum>`/`Option<nested>` field). That widens the wire — the Rust
+///   side boxes any nullable leaf, see
+///   [`leaf_is_prim`](crate::jni::emit::leaf_is_prim) — and `?.` alone carries
+///   it. It grants no sentinel.
+///
+/// [`projection_leaf_sentinel`] answers off `niche_sentinels`, which
+/// `attach_domain_sentinels` puts on the **bare** type's converter as well as
+/// the `Option` one. Asking it without the `Base` check therefore handed a
+/// sentinel to a leaf that has no niche encoding at all, splicing
+/// `?.let { if (it == -1L) … }` into a wrap whose own encoder can never emit
+/// `-1`. Harmless at runtime — the value is outside the declared range — and
+/// wrong on its face.
+pub(crate) fn wrap_sentinel(proj: &crate::jni::Projection, nullable: bool) -> Option<String> {
+    // `Base` means the leaf has no `Option` of its own: whatever absence it can
+    // express is the ancestor's, and `?.` already expresses that.
+    if nullable && matches!(proj.strategy, crate::jni::FoldStrategy::Base) {
+        return None;
+    }
+    projection_leaf_sentinel(proj)
+}
+
 /// Kotlin literal for the null-sentinel of a primitive wire — used by
 /// [`fold_projection_wrap`] when a `Niche` layer covers a primitive wire and
 /// can't carry JVM null. Mirrors `jni_field_access`'s primitive descriptors.

--- a/prebindgen-jni/src/jni/iface.rs
+++ b/prebindgen-jni/src/jni/iface.rs
@@ -800,8 +800,14 @@ fn leaf_iface_param(
                 // mapping its sentinel to null would both invent an absence the
                 // type does not have and contradict the non-nullable typed view
                 // this same param declares.
+                //
+                // `wrap_sentinel` adds the other half of that rule: an absence
+                // the leaf gets from an ANCESTOR is carried by the `?.` above,
+                // not by a sentinel of its own (#142). It is the same call
+                // `unfold_leaf_kt` makes, so the two derivations of this wrap
+                // cannot disagree.
                 let niche_sentinel = if builder_kt.is_nullable() {
-                    projection_leaf_sentinel(proj?)
+                    wrap_sentinel(proj?, nullable)
                 } else {
                     None
                 };

--- a/prebindgen-jni/src/jni/render.rs
+++ b/prebindgen-jni/src/jni/render.rs
@@ -2032,7 +2032,10 @@ pub(crate) fn unfold_leaf_kt(
             .kotlin_fqn(&p.leaf_key)
             .unwrap_or_else(|| p.leaf_key.to_string());
         let short = leaf_fqn.rsplit('.').next().unwrap_or(&leaf_fqn).to_string();
-        let sentinel = projection_leaf_sentinel(p);
+        // The sentinel is the leaf's OWN `None`, so an absence it inherits from
+        // an ancestor grants it none — `wrap_sentinel` is that rule, shared with
+        // `leaf_iface_param`, which derives the same wrap (#142).
+        let sentinel = wrap_sentinel(p, nullable);
         let mut wrap = fold_projection_wrap(&p.strategy, pk, &p.kind, &short, sentinel.as_deref());
         // A `nullable` leaf (an `Option` nesting step on its path) makes the
         // wire nullable even when the strategy itself is `Direct` — guard the

--- a/prebindgen-jni/src/jni/tests/values.rs
+++ b/prebindgen-jni/src/jni/tests/values.rs
@@ -171,6 +171,176 @@ fn flattened_field_composes_bounded_conversion_stages() {
     );
 }
 
+/// The four ways a **bounded** `convert!` leaf can meet optionality, in one
+/// fixture — the matrix #142 is about.
+///
+/// Two independent facts decide the wrap: whether the leaf carries a niche of
+/// its own (`Option<Duration>` ⇒ the sentinel IS its `None`), and whether an
+/// **ancestor** can be absent (a conditional value form here, which makes every
+/// leaf below it nullable). They compose, and the sentinel belongs to the first
+/// fact alone:
+///
+/// | ancestor optional | leaf's own type | wire | wrap |
+/// |---|---|---|---|
+/// | no  | `Duration`         | `Long`  | `x.toULong()` |
+/// | no  | `Option<Duration>` | `Long`  | `if (x == -1L) null else x.toULong()` |
+/// | yes | `Duration`         | `Long?` | `x?.toULong()` — **no sentinel** |
+/// | yes | `Option<Duration>` | `Long?` | `x?.let { if (it == -1L) null else it.toULong() }` |
+///
+/// Row 3 is the one that was wrong: `projection_leaf_sentinel` answers off the
+/// declared domain, which `attach_domain_sentinels` puts on the **bare** type's
+/// converter too, so a leaf with no niche encoding at all got a sentinel test
+/// spliced into its wrap. `-1` is outside the declared range so nothing
+/// mis-decoded in practice, but the emitted expression tested for a value its
+/// own encoder can never produce.
+///
+/// Row 4 is the one #142 predicted would be wrong and is not: the two absences
+/// are independent and both collapse to the `ULong?` the typed view declares.
+/// The Rust side boxes any nullable leaf (`leaf_is_prim`), so the nullable wire
+/// is real, and the inner `None` still rides the sentinel inside it.
+#[test]
+fn a_bounded_leaf_takes_its_sentinel_from_its_own_type_not_its_ancestor() {
+    let loc = myflat_loc();
+    let items = vec![
+        (
+            syn::Item::Struct(syn::parse_quote!(
+                pub struct SpanStruct {
+                    pub required: Duration,
+                    pub delay: Option<Duration>,
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn duration_from_millis(v: u64) -> Duration {
+                    unimplemented!()
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn duration_to_millis(v: &Duration) -> u64 {
+                    unimplemented!()
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn span_to_struct(s: &Span) -> SpanStruct {
+                    unimplemented!()
+                }
+            )),
+            loc.clone(),
+        ),
+        // The CONDITIONAL hoist: `Span`'s value form is reached through an
+        // `Option`, so every leaf below it is nullable — rows 3 and 4.
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn holder_span(h: &Holder) -> Option<&Span> {
+                    unimplemented!()
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn holder_each(cb: impl Fn(Holder) + Send + Sync + 'static) {
+                    unimplemented!()
+                }
+            )),
+            loc.clone(),
+        ),
+        // …and the same two leaves NOT under an optional ancestor — rows 1 and 2.
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn span_each(cb: impl Fn(Span) + Send + Sync + 'static) {
+                    unimplemented!()
+                }
+            )),
+            loc,
+        ),
+    ];
+    let registry =
+        crate::test_util::reg_from_items(declare_referenced(items)).expect("index items");
+    let jni = JniGenBuilder::new()
+        .set_package_prefix("io.test.jni")
+        .convert(
+            prebindgen_registry::convert!(Duration)
+                .input(prebindgen_registry::fun!(duration_from_millis))
+                .output(prebindgen_registry::fun!(duration_to_millis))
+                .valid_range(0u64..=1_000_000u64),
+        )
+        .package(
+            crate::package!()
+                .class(crate::ptr_class!(Span))
+                .class(crate::ptr_class!(Holder))
+                .fun(prebindgen_registry::fun!(span_each))
+                .fun(prebindgen_registry::fun!(holder_each)),
+        )
+        .expand(
+            prebindgen_registry::expand_return!(Span)
+                .fields(prebindgen_registry::fields!(span_to_struct)),
+        )
+        .expand(
+            prebindgen_registry::expand_return!(Holder)
+                .field(prebindgen_registry::fun!(holder_span)),
+        );
+    let dir = unique_test_dir("jnigen_niche_matrix");
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    let generation = jni.build_with(registry).expect("resolve");
+    let kotlin = generation
+        .write_kotlin(&dir.join("kotlin"))
+        .unwrap()
+        .iter()
+        .map(|path| std::fs::read_to_string(path).unwrap())
+        .collect::<Vec<_>>()
+        .join("\n");
+    let kc: String = kotlin.split_whitespace().collect();
+
+    // Rows 1 and 2 — no optional ancestor. Both wires stay primitive `Long`,
+    // and only the leaf that HAS a niche tests for it.
+    assert!(
+        kc.contains("funrun(required:Long,delay:Long)"),
+        "with no optional ancestor both leaves keep the primitive wire:\n{kotlin}"
+    );
+    assert!(
+        kc.contains("required.toULong()"),
+        "row 1: a bare bounded leaf just converts:\n{kotlin}"
+    );
+    assert!(
+        kc.contains("if(delay==-1L)nullelsedelay.toULong()"),
+        "row 2: the leaf's own niche is tested, unguarded:\n{kotlin}"
+    );
+
+    // Rows 3 and 4 — under the conditional hoist. Both wires widen, because the
+    // Rust side boxes any nullable leaf.
+    assert!(
+        kc.contains("funrun(holderSpan__required:Long?,holderSpan__delay:Long?)"),
+        "under an optional ancestor both leaves box:\n{kotlin}"
+    );
+    // Row 3: the ancestor's `?` is the WHOLE of this leaf's absence. A sentinel
+    // test here would ask about a value the encoder cannot emit.
+    assert!(
+        kc.contains("holderSpan__required?.toULong()"),
+        "row 3: a bare bounded leaf under an optional ancestor takes no \
+         sentinel:\n{kotlin}"
+    );
+    assert!(
+        !kc.contains("holderSpan__required?.let{if(it==-1L)"),
+        "row 3: …and specifically not the doubly-optional shape:\n{kotlin}"
+    );
+    // Row 4: both absences are live and independent — the ancestor's null and
+    // the leaf's own `None` — and both collapse to the declared `ULong?`.
+    assert!(
+        kc.contains("holderSpan__delay?.let{if(it==-1L)nullelseit.toULong()}"),
+        "row 4: an ancestor's `?` does not erase the leaf's own niche:\n{kotlin}"
+    );
+}
+
 #[test]
 fn duration_requires_an_explicit_conversion() {
     let alias: syn::Item =


### PR DESCRIPTION
Closes #142 — but **not** with the guard it asks for. Both halves of its premise turned out wrong, and in a way that inverts the fix.

## What #142 says

Assert that a niche projection is never reached with `leaf.nullable == true` in `leaf_iface_param`'s `Unsigned64` arm, because that would emit a nullable wire *and* a sentinel test. Stated as unreachable and harmless today.

## What the matrix shows

I pinned all four combinations first (`a_bounded_leaf_takes_its_sentinel_from_its_own_type_not_its_ancestor`, in `tests/values.rs`) before changing anything:

| ancestor optional | leaf's own type | wire | wrap | |
|---|---|---|---|---|
| no | `Duration` | `Long` | `x.toULong()` | ok |
| no | `Option<Duration>` | `Long` | `if (x == -1L) null else x.toULong()` | ok |
| yes | `Duration` | `Long?` | `x?.let { if (it == -1L) null else it.toULong() }` | **WRONG** |
| yes | `Option<Duration>` | `Long?` | `x?.let { if (it == -1L) null else it.toULong() }` | ok |

**It is reachable.** `leaf.nullable` is set by five sites in `flatten` — a conditional value-form hoist, `Option<nested>`, a field under an optional ancestor, adapter-built leaves under an optional field — plus `iface.rs:1257`, a plan-less whole callback arg. Nothing stops a bounded `convert!` leaf sitting under any of them; no declared type does, which is the only reason it hadn't surfaced.

**Row 4 — the case #142 names — is correct.** The two absences are independent (the ancestor's JVM null, the leaf's own sentinel) and both collapse to the `ULong?` the typed view already declares. `leaf_is_prim` boxes *any* nullable leaf, so the nullable wire is real and the inner `None` still rides the sentinel inside it.

**Row 3 — which #142 doesn't mention — is the defect.** A bare `Duration` under an optional ancestor got a sentinel test its own encoder can never satisfy (`-1` is outside the declared range).

## The actual bug: one wrap, two rules

| | `unfold_leaf_kt` (`render.rs:2040`) | `leaf_iface_param` (`iface.rs:803`) |
|---|---|---|
| gate | `matches!(p.strategy, FoldStrategy::Base)` | `builder_kt.is_nullable()` |
| `nullable && Base` | drops the sentinel ✓ | keeps it ✗ |

`builder_kt.is_nullable()` is `nullable \|\| strategy-already-nullable` — it conflates the **ancestor's** optionality with the **projection's**. `projection_leaf_sentinel` answers off `niche_sentinels`, which `attach_domain_sentinels` attaches to the *bare* type's converter as well as the `Option` one, so the weaker gate hands a sentinel to a leaf that has no niche encoding at all.

`fold::wrap_sentinel(proj, nullable)` is now that rule, called from both sites so they can't drift again. The raw widening at `iface.rs:794` stays — it matches what `leaf_is_prim` makes the Rust side emit.

**No `debug_assert`.** An assertion that is false for legal declarations is worse than the mis-derivation it guards.

## Coverage

`covertest` gains `Span`/`SpanHolder`: the two converted leaves — one with a niche, one without — reached through a conditional hoist, so both are nullable. Committed output now shows the fix directly:

```kotlin
spanHolderSpan__required?.toULong(),                              // no sentinel
spanHolderSpan__delay?.let { if (it == -1L) null else it.toULong() }
```

The JVM harness pins `0uL` — legal in the declared range *and* what a zero-defaulted slot carries — so a wrap that confused the two absences would report it as `null`. **49 sections pass** under `./gradlew run`.

## Verified

`cargo test --all`; clippy `-D warnings` + `cargo fmt --check` (CI's exact config) on **1.85.0 and stable**; `regen-check.sh` clean; `regen-check.sh --with-zenoh-flat-jni` byte-identical.

Generated output is **additive only — 405 insertions, zero deletions, no existing declaration's wrap moved**. That is the evidence that nothing declared today was hitting row 3, and that the fix reached exactly as far as intended.