### PR TITLE
Compile the usage examples instead of ```ignore-ing them

### DIFF
--- a/prebindgen-proc-macro/Cargo.toml
+++ b/prebindgen-proc-macro/Cargo.toml
@@ -16,6 +16,9 @@ rust-version = { workspace = true }
 [lib]
 proc-macro = true
 
+[build-dependencies]
+prebindgen = { workspace = true }
+
 [dependencies]
 proc-macro2 = { workspace = true }
 quote = { workspace = true }

--- a/prebindgen-proc-macro/build.rs
+++ b/prebindgen-proc-macro/build.rs
@@ -1,4 +1,3 @@
 fn main() {
-    // This build script just ensures that OUT_DIR is available for tests
-    println!("cargo:rerun-if-changed=build.rs");
+    prebindgen::init_prebindgen_out_dir();
 }

--- a/prebindgen-proc-macro/src/lib.rs
+++ b/prebindgen-proc-macro/src/lib.rs
@@ -191,7 +191,8 @@ fn get_prebindgen_jsonl_path(group: &str) -> std::path::PathBuf {
 ///
 /// # Usage
 ///
-/// ```rust,ignore
+/// ```rust
+/// # use prebindgen_proc_macro::prebindgen;
 /// // Use with explicit group name
 /// #[prebindgen("group_name")]
 /// #[repr(C)]
@@ -360,7 +361,7 @@ pub fn prebindgen(args: TokenStream, input: TokenStream) -> TokenStream {
 ///
 /// # Example
 ///
-/// ```rust,ignore
+/// ```rust
 /// use prebindgen_proc_macro::prebindgen_out_dir;
 ///
 /// // Create a public constant for use by binding crates
@@ -397,7 +398,7 @@ pub fn prebindgen_out_dir(_input: TokenStream) -> TokenStream {
 ///
 /// # Example
 ///
-/// ```rust,ignore
+/// ```rust
 /// use prebindgen_proc_macro::features;
 ///
 /// pub const ENABLED_FEATURES: &str = features!();
@@ -425,7 +426,7 @@ pub fn features(_input: TokenStream) -> TokenStream {
 ///
 /// # Example
 ///
-/// ```rust,ignore
+/// ```rust
 /// use prebindgen_proc_macro::manifest_dir;
 ///
 /// // Create a public constant for use by binding crates

--- a/prebindgen/Cargo.toml
+++ b/prebindgen/Cargo.toml
@@ -37,6 +37,12 @@ testing = []
 [dev-dependencies]
 serde_json = { workspace = true }
 tempfile = { workspace = true }
+# Path-only, deliberately: this is a dev-dependency *cycle* (prebindgen-proc-macro
+# depends on prebindgen), which Cargo allows, but a `version` here would make
+# `cargo publish` demand a crates.io release that does not exist yet. Without one,
+# Cargo strips the dev-dep from the published manifest. Needed so the crate-level
+# and `Source` doctests can actually run `#[prebindgen]` instead of being ```ignore.
+prebindgen-proc-macro = { path = "../prebindgen-proc-macro" }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/prebindgen/build.rs
+++ b/prebindgen/build.rs
@@ -1,14 +1,32 @@
 // Exists only so this crate's own doctests can run `#[prebindgen]`.
 //
-// The macro hard-requires `OUT_DIR` (and a `prebindgen` subdirectory to write
-// its JSONL into), and Cargo sets `OUT_DIR` for doctests only when the package
-// has a build script. Without this, the crate-level and `Source` examples had to
-// be ```ignore — never compiled, free to rot.
+// The macro hard-requires `OUT_DIR`, and Cargo sets it for doctests only when
+// the package has a build script. Without this, the crate-level and `Source`
+// examples had to be ```ignore — never compiled, free to rot.
 //
-// It duplicates the three lines of `init_prebindgen_out_dir` rather than calling
-// it, because a crate cannot take itself as a build-dependency.
+// This is *not* `init_prebindgen_out_dir` in miniature. That function also
+// cleans the output directory, writes `crate_name.txt` and `features.txt`, and
+// exports the crate's real feature list — all of which exist so a *downstream*
+// crate can later read this one's captured surface through `Source`. Nothing
+// reads prebindgen's own output, so this supplies only the two things macro
+// expansion itself touches:
+//
+//   - the `prebindgen` subdirectory, which `#[prebindgen]` opens with
+//     `create_new` to write its JSONL into;
+//   - `PREBINDGEN_FEATURES`, which `features!()` reads. Empty is correct here:
+//     the doctests assert nothing about its contents.
+//
+// It cannot delegate to `init_prebindgen_out_dir` in any case, because a crate
+// cannot take itself as a build-dependency.
 fn main() {
-    let out = std::path::PathBuf::from(std::env::var("OUT_DIR").unwrap()).join("prebindgen");
-    std::fs::create_dir_all(&out).unwrap();
+    let out_dir =
+        std::env::var("OUT_DIR").expect("OUT_DIR is not set; this build script requires Cargo");
+    let prebindgen_dir = std::path::PathBuf::from(out_dir).join("prebindgen");
+    std::fs::create_dir_all(&prebindgen_dir).unwrap_or_else(|e| {
+        panic!(
+            "failed to create the prebindgen output directory {}: {e}",
+            prebindgen_dir.display()
+        )
+    });
     println!("cargo:rustc-env=PREBINDGEN_FEATURES=");
 }

--- a/prebindgen/build.rs
+++ b/prebindgen/build.rs
@@ -1,0 +1,14 @@
+// Exists only so this crate's own doctests can run `#[prebindgen]`.
+//
+// The macro hard-requires `OUT_DIR` (and a `prebindgen` subdirectory to write
+// its JSONL into), and Cargo sets `OUT_DIR` for doctests only when the package
+// has a build script. Without this, the crate-level and `Source` examples had to
+// be ```ignore — never compiled, free to rot.
+//
+// It duplicates the three lines of `init_prebindgen_out_dir` rather than calling
+// it, because a crate cannot take itself as a build-dependency.
+fn main() {
+    let out = std::path::PathBuf::from(std::env::var("OUT_DIR").unwrap()).join("prebindgen");
+    std::fs::create_dir_all(&out).unwrap();
+    println!("cargo:rustc-env=PREBINDGEN_FEATURES=");
+}

--- a/prebindgen/src/api/buildrs.rs
+++ b/prebindgen/src/api/buildrs.rs
@@ -22,6 +22,9 @@ use crate::{CRATE_NAME_FILE, FEATURES_FILE};
 ///     prebindgen::init_prebindgen_out_dir();
 /// }
 /// ```
+// The `fn main` above is the subject of the example, not boilerplate rustdoc
+// would supply: this shows a whole `build.rs`, and where the call sits in it.
+#[allow(clippy::needless_doctest_main)]
 pub fn init_prebindgen_out_dir() {
     env::var("OUT_DIR").expect(
         "OUT_DIR environment variable not set. This function should be called from build.rs.",

--- a/prebindgen/src/api/buildrs.rs
+++ b/prebindgen/src/api/buildrs.rs
@@ -16,7 +16,7 @@ use crate::{CRATE_NAME_FILE, FEATURES_FILE};
 ///
 /// # Example
 ///
-/// ```rust,ignore
+/// ```rust,no_run
 /// // build.rs
 /// fn main() {
 ///     prebindgen::init_prebindgen_out_dir();

--- a/prebindgen/src/api/source.rs
+++ b/prebindgen/src/api/source.rs
@@ -42,9 +42,9 @@ thread_local! {
 /// The `PREBINDGEN_OUT_DIR` constant is defined in the source FFI crate using the
 /// `prebindgen_out_dir!()` macro:
 ///
-/// ```ignore
+/// ```rust
 /// // In source_ffi/src/lib.rs
-/// use prebindgen_proc_macro::{prebindgen, prebindgen_out_dir};
+/// use prebindgen_proc_macro::{features, prebindgen, prebindgen_out_dir};
 ///
 /// pub const PREBINDGEN_OUT_DIR: &str = prebindgen_out_dir!();
 /// pub const FEATURES: &str = features!();
@@ -482,7 +482,7 @@ impl Builder {
     /// Filtering is enabled by default; the default constant name is `FEATURES`.
     ///
     /// The features constant should be defined in the source crate as follows:
-    /// ```rust,ignore
+    /// ```rust
     /// const FEATURES: &str = prebindgen_proc_macro::features!();
     /// ```
     #[roxygen]
@@ -521,7 +521,7 @@ impl Builder {
     /// for correct code generation it's necessary to inform the underlying "ffi"
     /// crate about the real target in a way like this:
     ///
-    /// ```ignore
+    /// ```sh
     /// CROSS_TARGET=x86_64-pc-windows-gnu cargo build --target x86_64-pc-windows-gnu
     /// ```
     ///

--- a/prebindgen/src/lib.rs
+++ b/prebindgen/src/lib.rs
@@ -58,7 +58,7 @@
 //! ordinary types returned by value, fallible calls return `Result<T, E>`; the
 //! language adapter does the C-ABI lowering, so there is no `#[repr(C)]` here.
 //!
-//! ```rust,ignore
+//! ```rust
 //! // example-flat/src/lib.rs
 //! use prebindgen_proc_macro::{features, prebindgen, prebindgen_out_dir};
 //!


### PR DESCRIPTION
## Why

`cargo test --all --all-features` reported **22 ignored tests**. None came from `#[ignore]` — there isn't one in the workspace. Every one was a **doctest behind a ```ignore fence**, which rustdoc counts but never compiles.

That put the snippets a crates.io reader copies first — the crate-level walkthrough, `Source`, and all four `prebindgen-proc-macro` macros — outside the compiler's reach. With publishing as goal #1, they were free to rot.

**And they already had.** The `Source` example called `features!()` while importing only `{prebindgen, prebindgen_out_dir}` — anyone copying it got a compile error. The first conversion caught it.

## What the fences were working around

Two things, both avoidable:

1. **`OUT_DIR`.** `#[prebindgen]`, `prebindgen_out_dir!()` and `features!()` all hard-require it, and Cargo sets it for doctests only when the package has a build script.
   - `prebindgen-proc-macro` **already had one**, commented *"just ensures that OUT_DIR is available for tests"* — which it never actually did. It now calls `init_prebindgen_out_dir()`. No new build-script cost.
   - `prebindgen` gains a `build.rs` inlining the same three lines, since a crate cannot take itself as a build-dependency.
2. **The dev-dependency cycle.** `prebindgen` needs `prebindgen-proc-macro` to show the source-crate side. Cargo permits dev-dep cycles. It is declared **path-only**: with a `version`, `cargo publish` fails demanding a crates.io release that doesn't exist yet — verified, see below.

## Converted (9 of 22)

| Location | Was | Now |
|---|---|---|
| `prebindgen/src/lib.rs` crate walkthrough | `rust,ignore` | `rust` |
| `prebindgen/src/api/source.rs` `Source` | `ignore` | `rust` — **fixed the missing import** |
| `prebindgen/src/api/source.rs` `enable_feature_filtering` | `rust,ignore` | `rust` |
| `prebindgen/src/api/source.rs` `enable_target_filtering` | `ignore` | `sh` — a shell command, never Rust |
| `prebindgen/src/api/buildrs.rs` | `rust,ignore` | `no_run` — matches the identical snippet already spelled that way in `lib.rs` |
| `prebindgen-proc-macro/src/lib.rs` ×4 | `rust,ignore` | `rust` |

## Left alone (13) — correct as-is

- **9 builder fragments** — bare chains like `.constant(constant!(MAX_LEN))`, no receiver, no `fn main`.
- **1 deliberately-invalid** — `prebindgen-flat/src/flat/mod.rs`, documenting what the resolver *refuses*. Compiling it is the opposite of the point.
- **3 reaching downstream** — the `prebindgen-c` build.rs example, `include!(concat!(env!("OUT_DIR"), …))` (can never compile), and `prebindgen-registry`'s `JniGen`/`zenoh_flat` flow sketch. Compiling these would invert the layering #371 established onto the base crate, for illustrative snippets. Not worth it.

## Verification

- `cargo test --all --all-features` — **green, 0 failures**; ignored **22 → 13**.
- `cargo publish --dry-run -p prebindgen` — packages cleanly with the path-only dev-dep (fails with a `version`, which is what motivated it).

## One judgment call for review

`prebindgen/build.rs` is **new** — the base crate had none, so downstream consumers now run a trivial build script (create a dir, set one env var). It's commented explaining why it duplicates three lines rather than calling `init_prebindgen_out_dir()`.

If you'd rather keep the flagship crate build-script-free, dropping that file costs 3 of the 9 conversions; the other 6 are independent of it.