### PR TITLE
Assert the C bindings' behaviour, not just that they build (#387)

### DIFF
--- a/examples/example-cbindgen/c/smoke.c
+++ b/examples/example-cbindgen/c/smoke.c
@@ -1,6 +1,10 @@
 /*
- * C smoke test over the prebindgen-generated `example_flat` C ABI, focused on
- * the **tagged union** (`Shape`, declared `.tagged_union()`).
+ * C smoke test over the prebindgen-generated `example_flat` C ABI: does the
+ * data actually arrive intact, in both directions, for every kind of thing the
+ * C adapter emits? Its longest section is the **tagged union** (`Shape`,
+ * declared `.tagged_union()`); the rest of the declared surface — the opaque
+ * handle, the `char **e` error channel, the owned `char *` / array returns, the
+ * closure struct, and the by-value structs and enums — follows it.
  *
  * A data-carrying Rust enum crosses by value as a `#[repr(C)]` enum with payload
  * variants, which cbindgen renders as a tag + `union`:
@@ -25,7 +29,18 @@
  *     arm): a byte outside `{0,1}` is normalised, not materialised;
  *   - and one level below THAT, on a `bool` field of a `data_struct` payload
  *     (`caption_t`'s `emphatic`) — which is what makes the invariant
- *     transitive rather than true only of the tag and the direct payloads.
+ *     transitive rather than true only of the tag and the direct payloads;
+ *   - the `calculator_t *` opaque handle: mutated through its `&mut` route,
+ *     read back through the borrow accessors, cloned into an independent one;
+ *   - the `Result` error channel in both arms — a rejected `&str` parse, a
+ *     domain error, and an `operation_t` discriminant no variant has (the same
+ *     validate-before-materialise rule as the union tag, one type down);
+ *   - the owned returns — a `char *` and a malloc'd `double[]` + length —
+ *     which C releases through the single universal `example_free`;
+ *   - the closure struct: `call` invoked once per item in order, `drop` invoked
+ *     exactly once, releasing the context C handed in;
+ *   - by-value data structs and fieldless enums crossing both ways, including
+ *     `caption_t`, whose owned `char *` field is the caller's to release.
  *
  * Exits non-zero on the first failed check.
  *
@@ -35,6 +50,7 @@
  * a failure, not a silent PASS.
  */
 #include <math.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -345,6 +361,207 @@ static void test_alias_preflight(void) {
     calculator_drop(merged);
 }
 
+/* The opaque handle end to end: state written through the `&mut` route survives
+ * into the borrow accessors, and a clone is a separate object — mutating it
+ * leaves the original where it was. */
+static void test_handle_lifecycle(void) {
+    char *e = NULL;
+    double out = -1.0;
+    calculator_t *c = calculator_new();
+
+    CHECK(calculator_get_value(c) == 0.0);
+    CHECK(calculator_get_count(c) == 0);
+
+    CHECK(calculator_apply(c, Add, 2.0, &out, &e));
+    CHECK(e == NULL);
+    CHECK(out == 2.0);
+    CHECK(calculator_apply(c, Mul, 3.0, &out, &e));
+    CHECK(out == 6.0);
+
+    /* The mutation stuck on the Rust side of the handle, not on a copy. */
+    CHECK(calculator_get_value(c) == 6.0);
+    CHECK(calculator_get_count(c) == 2);
+    CHECK(calculator_is(c, 6.0));
+    CHECK(!calculator_is(c, 2.0));
+
+    /* The clone carries the state over and then diverges. */
+    calculator_t *clone = calculator_new_clone(c);
+    CHECK(calculator_get_value(clone) == 6.0);
+    CHECK(calculator_get_count(clone) == 2);
+    CHECK(calculator_apply(clone, Sub, 1.0, &out, &e));
+    CHECK(out == 5.0);
+    CHECK(calculator_get_value(clone) == 5.0);
+    CHECK(calculator_get_value(c) == 6.0);
+
+    calculator_drop(clone);
+    calculator_drop(c);
+}
+
+/* The `char **e` channel on a `Result`-returning function. Three sources of
+ * error reach it — a rejected input string, a domain error, and a discriminant
+ * `operation_t` has no variant for — and on the success path neither the error
+ * nor the out-param is touched by the other's convention. */
+static void test_error_channel(void) {
+    char *e = NULL;
+    double out = -1.0;
+
+    /* Ok arm: the handle comes back, `e` stays NULL. */
+    calculator_t *parsed = calculator_new_from_str("42.5", &e);
+    CHECK(parsed != NULL);
+    CHECK(e == NULL);
+    CHECK(calculator_get_value(parsed) == 42.5);
+    CHECK(calculator_get_count(parsed) == 1);
+
+    /* Err arm: NULL handle, message through `e`, and it is ours to free. */
+    calculator_t *bad = calculator_new_from_str("not a number", &e);
+    CHECK(bad == NULL);
+    CHECK(e != NULL);
+    CHECK(strstr(e, "parse error") != NULL);
+    example_free(e);
+    e = NULL;
+
+    /* A domain error leaves the out-param and the handle alone. */
+    CHECK(!calculator_apply(parsed, Div, 0.0, &out, &e));
+    CHECK(e != NULL);
+    CHECK(strstr(e, "division by zero") != NULL);
+    CHECK(out == -1.0);
+    CHECK(calculator_get_value(parsed) == 42.5);
+    CHECK(calculator_get_count(parsed) == 1);
+    example_free(e);
+    e = NULL;
+
+    /* A C caller can pass an `int` no `operation_t` enumerator names. Like the
+     * union tag, it is validated before a Rust `Operation` exists, and reported
+     * through the same channel rather than materialised. */
+    enum operation_t op;
+    int raw = 77;
+    memcpy(&op, &raw, sizeof raw);
+    CHECK(!calculator_apply(parsed, op, 1.0, &out, &e));
+    CHECK(e != NULL);
+    CHECK(strstr(e, "invalid discriminant 77") != NULL);
+    CHECK(out == -1.0);
+    CHECK(calculator_get_value(parsed) == 42.5);
+    example_free(e);
+
+    calculator_drop(parsed);
+}
+
+/* The two owned returns. Both are plain malloc'd blocks released by the single
+ * `example_free` the binding declares — the handles keep their typed `*_drop`,
+ * these do not. An empty `Vec` is the null/zero pair, not a block. */
+static void test_owned_returns(void) {
+    char *e = NULL;
+    double out = 0.0;
+    calculator_t *c = calculator_new();
+
+    /* A `String` return crosses as a NUL-terminated `char *`. */
+    char *empty_repr = calculator_to_string(c);
+    CHECK(strcmp(empty_repr, "Calculator(0)") == 0);
+    example_free(empty_repr);
+
+    /* No history yet: the array is (NULL, 0), with nothing to free. */
+    size_t len = 99;
+    double *none = calculator_get_history(c, &len);
+    CHECK(none == NULL);
+    CHECK(len == 0);
+
+    CHECK(calculator_apply(c, Add, 2.0, &out, &e));
+    CHECK(calculator_apply(c, Mul, 3.0, &out, &e));
+    CHECK(e == NULL);
+
+    char *repr = calculator_to_string(c);
+    CHECK(strcmp(repr, "Calculator(6)") == 0);
+    example_free(repr);
+
+    /* `Vec<f64>` crosses as a pointer + a length out-param, in order. */
+    double *history = calculator_get_history(c, &len);
+    CHECK(len == 2);
+    CHECK(history != NULL);
+    CHECK(history[0] == 2.0);
+    CHECK(history[1] == 6.0);
+    example_free(history);
+
+    calculator_drop(c);
+}
+
+/* The closure struct C fills in and Rust calls back through. `context` is C's
+ * allocation: the generated wrapper owns the closure for the duration and
+ * promises to call `drop` exactly once when it releases it. Both halves are
+ * checked — the count here, and the block itself by LeakSanitizer, which is
+ * what makes a missing `drop` a failure rather than a silent PASS. */
+#define CB_CTX_MAGIC 0xC0FFEEu
+
+static double g_seen[8];
+static size_t g_seen_n;
+static int g_drops;
+
+static void cb_call(double v, void *ctx) {
+    CHECK(ctx != NULL && *(uint32_t *)ctx == CB_CTX_MAGIC);
+    if (g_seen_n < sizeof g_seen / sizeof g_seen[0]) {
+        g_seen[g_seen_n] = v;
+    }
+    g_seen_n++;
+}
+
+static void cb_drop(void *ctx) {
+    CHECK(ctx != NULL && *(uint32_t *)ctx == CB_CTX_MAGIC);
+    free(ctx);
+    g_drops++;
+}
+
+static void test_callback(void) {
+    char *e = NULL;
+    double out = 0.0;
+    calculator_t *c = calculator_new();
+    CHECK(calculator_apply(c, Add, 2.0, &out, &e));
+    CHECK(calculator_apply(c, Mul, 3.0, &out, &e));
+    CHECK(e == NULL);
+
+    uint32_t *ctx = malloc(sizeof *ctx);
+    *ctx = CB_CTX_MAGIC;
+    closure_value_t f = {ctx, cb_call, cb_drop};
+
+    calculator_for_each(c, f);
+
+    /* One upcall per recorded value, in application order, and the context
+     * released once the call returned. */
+    CHECK(g_seen_n == 2);
+    CHECK(g_seen[0] == 2.0);
+    CHECK(g_seen[1] == 6.0);
+    CHECK(g_drops == 1);
+
+    calculator_drop(c);
+}
+
+/* Plain values: a `data_struct` and a fieldless enum crossing both ways. `Foo`'s
+ * field SET is target- and feature-dependent (only `id` is universal), so the
+ * checks are on `id` and on the round trip, not on a fixed layout. `caption_t`
+ * is the data struct with an owned `char *` field — no destructor is generated
+ * for a data struct, so the field is released by hand. */
+static void test_value_types(void) {
+    foo_t f = foo_new(9);
+    CHECK(f.id == 9);
+    CHECK(foo_get_id(f) == 9);
+
+    /* The discriminants differ per target arch, so compare against the
+     * enumerator the header defines for THIS build rather than a literal. */
+    enum inside_foo_t d = inside_foo_default();
+    CHECK(d == DouddleDee);
+    CHECK(inside_foo_value(d) == (int32_t)DouddleDee);
+    CHECK(inside_foo_value(DouddleDum) == (int32_t)DouddleDum);
+
+    caption_t cap = caption_new(3, "caption", true);
+    CHECK(cap.id == 3);
+    CHECK(strcmp(cap.text, "caption") == 0);
+    CHECK(cap.emphatic == true);
+    example_free(cap.text);
+
+    caption_t plain = caption_new(4, "", false);
+    CHECK(strcmp(plain.text, "") == 0);
+    CHECK(plain.emphatic == false);
+    example_free(plain.text);
+}
+
 int main(void) {
     test_each_arm();
     test_struct_field();
@@ -355,6 +572,11 @@ int main(void) {
     test_out_of_domain_bool_data_struct_field();
     test_nested_union_payload();
     test_alias_preflight();
+    test_handle_lifecycle();
+    test_error_channel();
+    test_owned_returns();
+    test_callback();
+    test_value_types();
 
     if (failures != 0) {
         fprintf(stderr, "FAILED - %d check(s)\n", failures);
@@ -362,6 +584,8 @@ int main(void) {
     }
     printf("PASS - tagged union: every arm, every position, drop, invalid tag, "
            "converter-derived payloads, out-of-domain bool payload and "
-           "data-struct field, nested union payload, alias preflight\n");
+           "data-struct field, nested union payload, alias preflight; "
+           "handle lifecycle, error channel, owned returns, closure struct, "
+           "by-value structs and enums\n");
     return 0;
 }

--- a/examples/perftest-c/c/perftest.c
+++ b/examples/perftest-c/c/perftest.c
@@ -203,7 +203,9 @@ static void correctness(struct storage_t *s) {
  * pattern); for a null label there is nothing to re-provide and `p` is reused as-is. */
 static double bench_put_by_take(struct storage_t *s, const char *label, uint64_t *sink) {
     (void)sink;
-    struct payload_t p = make_payload(42, 7, label);
+    /* NULL label even in the `.str` variant: the loop provides one per iteration, so
+     * seeding a string here would just be overwritten unfreed on the first iteration. */
+    struct payload_t p = make_payload(42, 7, NULL);
     double t0 = now_ns();
     for (uint64_t i = 0; i < g_n; i++) {
         if (label) p.label = string_new(label); /* re-provide the moved-out string */

--- a/examples/smoke-asan.sh
+++ b/examples/smoke-asan.sh
@@ -1,7 +1,19 @@
 #!/usr/bin/env bash
 #
-# Run the C smoke test against the generated `example_flat` ABI under
-# AddressSanitizer + LeakSanitizer + UndefinedBehaviorSanitizer.
+# Run the C behaviour tests against the generated ABIs under AddressSanitizer +
+# LeakSanitizer + UndefinedBehaviorSanitizer.
+#
+# Two programs, two generated surfaces:
+#
+#   example-cbindgen `c/smoke.c`  — the handle / tagged-union / error-channel /
+#                                   owned-return / closure surface, asserted
+#                                   value by value.
+#   perftest-c `c/perftest.c`     — the by-value `.repr_c_struct()` surface: its
+#                                   `correctness()` asserts the five
+#                                   parameter-passing semantics. Those asserts
+#                                   already existed but only ran when somebody
+#                                   benchmarked by hand; here they run at a tiny
+#                                   iteration count so CI executes them.
 #
 # `c/smoke.c` is the test that exists to prove the ownership contract — every
 # arm C receives is C's to release, and the typed drops release exactly the live
@@ -40,18 +52,10 @@ case "$arch" in
         ;;
 esac
 
-echo "== cargo build -p example-cbindgen (cdylib + regenerated header)"
-cargo build -p example-cbindgen
+echo "== cargo build -p example-cbindgen -p perftest-c (cdylibs + regenerated headers)"
+cargo build -p example-cbindgen -p perftest-c
 
 lib_dir="$repo_root/target/debug"
-case "$(uname -s)" in
-    Darwin) dylib="$lib_dir/libexample_cbindgen.dylib" ;;
-    *) dylib="$lib_dir/libexample_cbindgen.so" ;;
-esac
-if [[ ! -f "$dylib" ]]; then
-    echo "expected cdylib at $dylib" >&2
-    exit 1
-fi
 
 # `-fno-sanitize-recover=all` turns every UBSan finding into a non-zero exit;
 # without it an unaligned load or a signed overflow only prints and continues.
@@ -61,17 +65,50 @@ sanitizers=(
     -fno-omit-frame-pointer
 )
 
-echo "== compiling c/smoke.c for $header_arch under ASan/LSan/UBSan"
-"$cc" "${sanitizers[@]}" -g -O1 -std=c11 -Wall -Wextra -Werror \
-    -I "$repo_root/examples/example-cbindgen/include" \
+# Compile one C program against one generated cdylib and run it under the
+# sanitizers: $1 = cdylib crate name, $2 = C source, $3 = include dir.
+run_under_sanitizers() {
+    local libname="$1" src="$2" incdir="$3"
+    local name dylib
+    name="$(basename "${src%.c}")"
+
+    case "$(uname -s)" in
+        Darwin) dylib="$lib_dir/lib${libname}.dylib" ;;
+        *) dylib="$lib_dir/lib${libname}.so" ;;
+    esac
+    if [[ ! -f "$dylib" ]]; then
+        echo "expected cdylib at $dylib" >&2
+        exit 1
+    fi
+
+    # `-std=c11` is strict ISO, which hides POSIX declarations `perftest.c`
+    # needs (`clock_gettime`); `_POSIX_C_SOURCE` puts them back without
+    # loosening the language dialect to `gnu11`.
+    echo "== compiling $src under ASan/LSan/UBSan"
+    "$cc" "${sanitizers[@]}" -g -O1 -std=c11 -D_POSIX_C_SOURCE=200809L \
+        -Wall -Wextra -Werror \
+        -I "$incdir" "$src" -o "$out_dir/$name" \
+        -L "$lib_dir" -l"$libname" -lm \
+        -Wl,-rpath,"$lib_dir"
+
+    echo "== running $name"
+    ASAN_OPTIONS="detect_leaks=1:detect_stack_use_after_return=1:strict_string_checks=1" \
+        UBSAN_OPTIONS="print_stacktrace=1:halt_on_error=1" \
+        "$out_dir/$name"
+}
+
+echo "== example_flat header variant: $header_arch"
+run_under_sanitizers example_cbindgen \
     "$repo_root/examples/example-cbindgen/c/smoke.c" \
-    -o "$out_dir/smoke" \
-    -L "$lib_dir" -lexample_cbindgen -lm \
-    -Wl,-rpath,"$lib_dir"
+    "$repo_root/examples/example-cbindgen/include"
 
-echo "== running"
-ASAN_OPTIONS="detect_leaks=1:detect_stack_use_after_return=1:strict_string_checks=1" \
-    UBSAN_OPTIONS="print_stacktrace=1:halt_on_error=1" \
-    "$out_dir/smoke"
+# The benchmark's timings are meaningless under ASan and at this iteration
+# count — `correctness()` and the leak detector are what this run is for, so the
+# measured block goes to /dev/null and only the asserts (and any sanitizer
+# report) decide the exit status.
+export PERFTEST_N="${PERFTEST_N:-200}"
+run_under_sanitizers perftest_c \
+    "$repo_root/examples/perftest-c/c/perftest.c" \
+    "$repo_root/examples/perftest-c/include" >/dev/null
 
-echo "PASS - C smoke test clean under ASan/LSan/UBSan"
+echo "PASS - C behaviour tests clean under ASan/LSan/UBSan"


### PR DESCRIPTION
Closes #387.

The Kotlin half of #387 turned out to be covered already: `covertest-kotlin` is a
52-section assert harness and the `covertest` CI job runs it on a real JVM. The C half
was not — `smoke.c` exercised the tagged union thoroughly and left the rest of the
declared surface compile-checked only, and `perftest-c`'s `correctness()` asserts ran
only when somebody benchmarked by hand.

### `smoke.c`: five new sections

| section | what crosses |
|---|---|
| handle lifecycle | state written through the `&mut` route, read back through the borrow accessors; a clone that diverges from the original |
| error channel | a rejected `&str` parse, a domain error, and an `operation_t` discriminant no variant has — the union tag's validate-before-materialise rule one type down |
| owned returns | a `char *` and a malloc'd `double[]` + length, released by the single universal `example_free`; an empty `Vec` is the `(NULL, 0)` pair, not a block |
| closure struct | `call` once per item in order, `drop` exactly once — the context is a malloc'd block, so LeakSanitizer enforces the second half rather than the count alone |
| by-value types | `foo_t` / `inside_foo_t` both ways, and `caption_t`, whose owned `char *` field a data struct leaves to the caller |

### `smoke-asan.sh`: run `perftest-c` too

Its `correctness()` already asserted the five parameter-passing semantics of the by-value
`.repr_c_struct()` surface; this is about executing them in CI under the leak detector,
not about the timings (meaningless under ASan at `PERFTEST_N=200`, so the measured block
goes to `/dev/null` and only the asserts and any sanitizer report decide the exit status).

Doing so immediately found a leak: `bench_put_by_take` seeded its payload with a label
that the first loop iteration overwrote unfreed. Seeded NULL now — the loop provides one
per iteration anyway.

### Verified locally

- `examples/smoke-asan.sh` — both programs clean under ASan/LSan/UBSan
- `examples/covertest-kotlin && ./gradlew run` — `PASS - 52 sections`
- no Rust touched, no generated-file drift