### PR TITLE
Add concurrency-safe stale capture cleanup

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,3 +52,5 @@ itertools = "0.14.0"
 if_rust_version = "1.0"
 konst = "0.3.0" # consumer crates need konst too: the generated file emits a konst::assertc_eq! guard
 toml = "0.9.5"
+fs2 = "0.4.3"
+libc = "0.2"

--- a/README.md
+++ b/README.md
@@ -149,6 +149,51 @@ fn main() {
 }
 ```
 
+#### Cleaning stale Cargo build hashes
+
+Cargo may retain several legitimate `target/<profile>/build/<package>-<hash>`
+directories for different features, targets, profiles, toolchains, or dependency
+fingerprints. Prebindgen does not delete sibling hashes from `build.rs` because
+another Cargo build may still be using them.
+
+Install the package's Cargo subcommand and invoke cleanup explicitly:
+
+```console
+cargo install prebindgen
+cargo prebindgen clean --dry-run
+cargo prebindgen clean
+```
+
+Cleanup has no age or “newest hash” heuristic. It discovers every profile below
+Cargo's target directory, acquires all of their build locks before changing
+anything, then removes only state-validated `out/prebindgen` directories. If
+any profile is active, the whole operation exits without deleting a capture.
+NFS detected on Linux is rejected because Cargo itself skips its build locks
+there; on other platforms, use cleanup only on filesystems with reliable local
+advisory locks.
+
+Before each removal, cleanup durably advances one of two small state files in
+the parent `OUT_DIR`. Those files are rustc input dependencies, so selecting a
+cleaned feature/target/toolchain variant later recompiles that exact producer
+and recreates its capture before a downstream `Source` can read it. The
+alternating slots also leave one valid state if cleanup is interrupted while
+writing the other. The slots intentionally remain after cleanup; Cargo owns the
+surrounding build-hash directory.
+
+Useful options:
+
+- `--target-dir <path>` scans an explicit Cargo target directory.
+- `--build-dir <path>` scans a separately configured Cargo build directory and
+  may be repeated.
+- `--manifest-path <path>` selects the workspace used by `cargo metadata`.
+- `--dry-run` takes the same locks and performs the same validation without
+  changing files.
+
+Capture directories made by older prebindgen versions do not have the two
+state slots and are deliberately skipped: deleting one could leave Cargo's
+producer artifact falsely fresh. Use a one-time ordinary `cargo clean` for
+those legacy, untracked captures.
+
 ### 2. Experimental C Binding Crate (e.g., `example-cbindgen`)
 
 Add the source FFI library and `prebindgen-c-runtime` as regular dependencies

--- a/prebindgen-proc-macro/src/lib.rs
+++ b/prebindgen-proc-macro/src/lib.rs
@@ -44,7 +44,7 @@ use std::{
     sync::{Arc, Mutex, OnceLock},
 };
 
-use prebindgen::{get_prebindgen_out_dir, Record, RecordKind, SourceLocation, DEFAULT_GROUP_NAME};
+use prebindgen::{Record, RecordKind, SourceLocation, DEFAULT_GROUP_NAME};
 use proc_macro::TokenStream;
 use quote::quote;
 use syn::{
@@ -201,9 +201,33 @@ fn hash_unit_id(value: &(impl Hash + ?Sized)) -> String {
     format!("{:016x}", hasher.finish())
 }
 
+fn capture_output_dir() -> std::result::Result<&'static PathBuf, String> {
+    static CAPTURE_OUTPUT_DIR: OnceLock<std::result::Result<PathBuf, String>> = OnceLock::new();
+    match CAPTURE_OUTPUT_DIR.get_or_init(|| {
+        prebindgen::capture_protocol::ensure_capture_dir()
+            .map_err(|error| format!("failed to prepare prebindgen capture directory: {error}"))
+    }) {
+        Ok(path) => Ok(path),
+        Err(error) => Err(error.clone()),
+    }
+}
+
+fn capture_dependency_tokens() -> std::result::Result<proc_macro2::TokenStream, String> {
+    let [a, b] = prebindgen::capture_protocol::get_state_slot_paths()
+        .map_err(|error| format!("failed to locate prebindgen capture state: {error}"))?;
+    let a = syn::LitStr::new(&a.to_string_lossy(), proc_macro2::Span::call_site());
+    let b = syn::LitStr::new(&b.to_string_lossy(), proc_macro2::Span::call_site());
+    Ok(quote! {
+        const _: (&[u8], &[u8]) = (
+            include_bytes!(#a),
+            include_bytes!(#b),
+        );
+    })
+}
+
 /// Get the full path to `{group}_{unit_id}.jsonl` in OUT_DIR.
-fn get_prebindgen_jsonl_path(group: &str) -> std::path::PathBuf {
-    get_prebindgen_out_dir().join(format!("{group}_{}.jsonl", unit_id()))
+fn get_prebindgen_jsonl_path(group: &str) -> std::result::Result<PathBuf, String> {
+    Ok(capture_output_dir()?.join(format!("{group}_{}.jsonl", unit_id())))
 }
 
 fn capture_state(file_path: &Path) -> std::result::Result<SharedCaptureState, String> {
@@ -373,18 +397,23 @@ pub fn prebindgen(args: TokenStream, input: TokenStream) -> TokenStream {
         parsed_args.cfg.clone(),
     );
 
-    let file_path = get_prebindgen_jsonl_path(&group);
+    let file_path = match get_prebindgen_jsonl_path(&group) {
+        Ok(path) => path,
+        Err(error) => return syn::Error::new(span, error).to_compile_error().into(),
+    };
     if let Err(error) = write_capture_record(&file_path, &new_record) {
         return syn::Error::new(span, error).to_compile_error().into();
     }
+    let capture_dependency = match capture_dependency_tokens() {
+        Ok(tokens) => tokens,
+        Err(error) => return syn::Error::new(span, error).to_compile_error().into(),
+    };
 
     // Re-emit the original item, optionally prepending `#[cfg(...)]` (from the
-    // macro argument) and `#[inline]` (when the `inline` feature is on, functions
-    // only). When neither applies, the original tokens are returned unchanged.
+    // macro argument) and `#[inline]` (when the `inline` feature is on,
+    // functions only). The anonymous const makes both state slots rustc input
+    // dependencies without changing the item's public surface.
     let add_inline = cfg!(feature = "inline") && is_function;
-    if parsed_args.cfg.is_none() && !add_inline {
-        return input_clone;
-    }
     let inline_attr = if add_inline {
         quote! { #[inline] }
     } else {
@@ -403,6 +432,7 @@ pub fn prebindgen(args: TokenStream, input: TokenStream) -> TokenStream {
         #cfg_attr
         #inline_attr
         #original_tokens
+        #capture_dependency
     }
     .into()
 }
@@ -432,16 +462,14 @@ pub fn prebindgen(args: TokenStream, input: TokenStream) -> TokenStream {
 /// ```
 #[proc_macro]
 pub fn prebindgen_out_dir(_input: TokenStream) -> TokenStream {
-    let out_dir = std::env::var("OUT_DIR")
-        .expect("OUT_DIR environment variable not set. Please ensure you have a build.rs file in your project.");
-    let file_path = std::path::Path::new(&out_dir).join("prebindgen");
-    let path_str = file_path.to_string_lossy();
+    let file_path = capture_output_dir().unwrap_or_else(|error| panic!("{error}"));
+    let path = syn::LitStr::new(&file_path.to_string_lossy(), proc_macro2::Span::call_site());
+    let capture_dependency = capture_dependency_tokens().unwrap_or_else(|error| panic!("{error}"));
 
-    let expanded = quote! {
-        #path_str
-    };
-
-    TokenStream::from(expanded)
+    TokenStream::from(quote! {{
+        #capture_dependency
+        #path
+    }})
 }
 
 /// Proc macro that returns the enabled features, joined by commas, as a string literal.
@@ -468,11 +496,16 @@ pub fn prebindgen_out_dir(_input: TokenStream) -> TokenStream {
 /// ```
 #[proc_macro]
 pub fn features(_input: TokenStream) -> TokenStream {
+    capture_output_dir().unwrap_or_else(|error| panic!("{error}"));
+    let capture_dependency = capture_dependency_tokens().unwrap_or_else(|error| panic!("{error}"));
     let features = std::env::var("PREBINDGEN_FEATURES").expect(
         "PREBINDGEN_FEATURES environment variable not set. Ensure prebindgen::init_prebindgen_out_dir() is called in build.rs",
     );
     let lit = syn::LitStr::new(&features, proc_macro2::Span::call_site());
-    TokenStream::from(quote! { #lit })
+    TokenStream::from(quote! {{
+        #capture_dependency
+        #lit
+    }})
 }
 
 /// Proc macro that returns the **source crate's** manifest directory as a string

--- a/prebindgen/Cargo.toml
+++ b/prebindgen/Cargo.toml
@@ -25,6 +25,10 @@ if_rust_version = { workspace = true }
 konst = { workspace = true, features = ["cmp"] }
 itertools = { workspace = true }
 toml = { workspace = true }
+fs2 = { workspace = true }
+
+[target.'cfg(target_os = "linux")'.dependencies]
+libc = { workspace = true }
 
 [features]
 debug = []

--- a/prebindgen/build.rs
+++ b/prebindgen/build.rs
@@ -4,29 +4,41 @@
 // the package has a build script. Without this, the crate-level and `Source`
 // examples had to be ```ignore — never compiled, free to rot.
 //
-// This is *not* `init_prebindgen_out_dir` in miniature. That function also
-// cleans the output directory, writes `crate_name.txt` and `features.txt`, and
-// exports the crate's real feature list — all of which exist so a *downstream*
-// crate can later read this one's captured surface through `Source`. Nothing
-// reads prebindgen's own output, so this supplies only the two things macro
-// expansion itself touches:
+// This cannot delegate to `init_prebindgen_out_dir` because a crate cannot take
+// itself as a build-dependency. Keep this bootstrap deliberately small, but
+// initialize the same files macro expansion requires:
 //
-//   - the `prebindgen` subdirectory, which `#[prebindgen]` opens with
-//     `create_new` to write its JSONL into;
-//   - `PREBINDGEN_FEATURES`, which `features!()` reads. Empty is correct here:
-//     the doctests assert nothing about its contents.
-//
-// It cannot delegate to `init_prebindgen_out_dir` in any case, because a crate
-// cannot take itself as a build-dependency.
+//   - `prebindgen/{crate_name,features}.txt` for capture recovery;
+//   - both versioned state slots tracked by rustc;
+//   - `PREBINDGEN_FEATURES`, empty because these doctests do not assert it.
 fn main() {
-    let out_dir =
-        std::env::var("OUT_DIR").expect("OUT_DIR is not set; this build script requires Cargo");
-    let prebindgen_dir = std::path::PathBuf::from(out_dir).join("prebindgen");
-    std::fs::create_dir_all(&prebindgen_dir).unwrap_or_else(|e| {
+    let out_dir = std::path::PathBuf::from(
+        std::env::var_os("OUT_DIR").expect("OUT_DIR is not set; this build script requires Cargo"),
+    );
+    let prebindgen_dir = out_dir.join("prebindgen");
+    std::fs::create_dir_all(&prebindgen_dir).unwrap_or_else(|error| {
         panic!(
-            "failed to create the prebindgen output directory {}: {e}",
+            "failed to create the prebindgen output directory {}: {error}",
             prebindgen_dir.display()
         )
     });
+
+    let crate_name = std::env::var("CARGO_PKG_NAME")
+        .expect("CARGO_PKG_NAME is not set; this build script requires Cargo");
+    std::fs::write(prebindgen_dir.join("crate_name.txt"), &crate_name)
+        .expect("failed to write doctest crate_name.txt");
+    std::fs::write(prebindgen_dir.join("features.txt"), [])
+        .expect("failed to write doctest features.txt");
+
+    let state = format!(
+        "{{\"protocol\":\"prebindgen-capture-v1\",\"generation\":0,\"crate_name\":\"{crate_name}\",\"features\":[]}}\n"
+    );
+    for slot in [
+        ".prebindgen-capture-state-v1-a.json",
+        ".prebindgen-capture-state-v1-b.json",
+    ] {
+        std::fs::write(out_dir.join(slot), &state)
+            .expect("failed to write doctest prebindgen capture state");
+    }
     println!("cargo:rustc-env=PREBINDGEN_FEATURES=");
 }

--- a/prebindgen/src/api/buildrs.rs
+++ b/prebindgen/src/api/buildrs.rs
@@ -1,6 +1,6 @@
 use std::{collections::BTreeSet, env, fs, path::Path};
 
-use crate::{CRATE_NAME_FILE, FEATURES_FILE};
+use crate::capture_protocol::{self, CRATE_NAME_FILE, FEATURES_FILE, PREBINDGEN_DIR};
 
 /// Initialize the prebindgen output directory for the current crate
 ///
@@ -26,7 +26,7 @@ use crate::{CRATE_NAME_FILE, FEATURES_FILE};
 // would supply: this shows a whole `build.rs`, and where the call sits in it.
 #[allow(clippy::needless_doctest_main)]
 pub fn init_prebindgen_out_dir() {
-    env::var("OUT_DIR").expect(
+    let out_dir = env::var("OUT_DIR").expect(
         "OUT_DIR environment variable not set. This function should be called from build.rs.",
     );
     // Get the crate name from CARGO_PKG_NAME or use fallback
@@ -81,6 +81,15 @@ pub fn init_prebindgen_out_dir() {
             e
         );
     });
+
+    // These alternating state files become rustc input dependencies through
+    // the proc-macro expansion. Scoped cleanup advances the inactive slot
+    // before removing this directory, making the exact producer unit stale and
+    // giving the macro enough state to reconstruct the directory. Do not emit
+    // `cargo:rerun-if-changed` here: any such directive would disable Cargo's
+    // default package-wide build-script change tracking.
+    capture_protocol::initialize_state(Path::new(&out_dir), &crate_name, &features)
+        .unwrap_or_else(|error| panic!("Failed to initialize prebindgen capture state: {error}"));
 
     // Export features list to the main crate as an env variable
     // Accessible via env!("PREBINDGEN_FEATURES") or std::env::var at compile time/runtime
@@ -163,9 +172,6 @@ pub fn get_enabled_features() -> BTreeSet<String> {
         .filter(|f| is_feature_enabled(f))
         .collect()
 }
-
-/// Name of the prebindgen output directory
-const PREBINDGEN_DIR: &str = "prebindgen";
 
 /// Get the full path to the prebindgen output directory in OUT_DIR.
 pub fn get_prebindgen_out_dir() -> std::path::PathBuf {

--- a/prebindgen/src/api/source.rs
+++ b/prebindgen/src/api/source.rs
@@ -10,7 +10,8 @@ use roxygen::roxygen;
 
 use crate::{
     api::{batching::cfg_filter, record::Record, utils::jsonl::read_jsonl_file},
-    SourceLocation, TargetTriple, CRATE_NAME_FILE, FEATURES_FILE,
+    capture_protocol::{CRATE_NAME_FILE, FEATURES_FILE},
+    SourceLocation, TargetTriple,
 };
 
 /// File extension for data files

--- a/prebindgen/src/bin/cargo-prebindgen.rs
+++ b/prebindgen/src/bin/cargo-prebindgen.rs
@@ -1,0 +1,686 @@
+use std::{
+    collections::BTreeSet,
+    env,
+    ffi::{OsStr, OsString},
+    fs::{self, File, OpenOptions},
+    io,
+    path::{Path, PathBuf},
+    process::Command,
+    sync::atomic::{AtomicU64, Ordering},
+};
+
+use fs2::FileExt;
+use prebindgen::capture_protocol::{advance_state, validate_capture_dir, PREBINDGEN_DIR};
+use serde::Deserialize;
+
+const CARGO_LOCKS_IN_ORDER: [&str; 2] = [".cargo-build-lock", ".cargo-lock"];
+const TOMBSTONE_PREFIX: &str = ".prebindgen-cleaning-v1-";
+static TOMBSTONE_ID: AtomicU64 = AtomicU64::new(0);
+
+fn main() {
+    if let Err(error) = run() {
+        eprintln!("cargo-prebindgen: {error}");
+        std::process::exit(2);
+    }
+}
+
+#[derive(Debug, Default)]
+struct Options {
+    dry_run: bool,
+    version_only: bool,
+    manifest_path: Option<PathBuf>,
+    roots: Vec<PathBuf>,
+}
+
+fn run() -> Result<(), Box<dyn std::error::Error>> {
+    let Some(options) = parse_args(env::args_os().skip(1).collect())? else {
+        print_help();
+        return Ok(());
+    };
+    if options.version_only {
+        return Ok(());
+    }
+
+    let roots = if options.roots.is_empty() {
+        vec![metadata_target_dir(options.manifest_path.as_deref())?]
+    } else {
+        options.roots
+    };
+    let report = clean_roots(&roots, options.dry_run)?;
+
+    let verb = if options.dry_run {
+        "Would remove"
+    } else {
+        "Removed"
+    };
+    println!(
+        "{verb} {} managed prebindgen capture director{}.",
+        report.managed,
+        if report.managed == 1 { "y" } else { "ies" }
+    );
+    if report.interrupted != 0 {
+        println!(
+            "{} interrupted cleanup tombstone{} included.",
+            report.interrupted,
+            if report.interrupted == 1 {
+                " was"
+            } else {
+                "s were"
+            }
+        );
+    }
+    if report.skipped != 0 {
+        println!(
+            "Skipped {} unrecognized or malformed prebindgen director{}.",
+            report.skipped,
+            if report.skipped == 1 { "y" } else { "ies" }
+        );
+    }
+    for path in report.paths {
+        println!("  {}", path.display());
+    }
+    Ok(())
+}
+
+fn parse_args(mut args: Vec<OsString>) -> Result<Option<Options>, String> {
+    if args.first().is_some_and(|arg| arg == "prebindgen") {
+        args.remove(0);
+    }
+    if args.is_empty()
+        || args
+            .first()
+            .is_some_and(|arg| arg == "-h" || arg == "--help")
+    {
+        return Ok(None);
+    }
+    if args
+        .first()
+        .is_some_and(|arg| arg == "-V" || arg == "--version")
+    {
+        println!("cargo-prebindgen {}", env!("CARGO_PKG_VERSION"));
+        return Ok(Some(Options {
+            version_only: true,
+            ..Options::default()
+        }));
+    }
+    if args.remove(0) != "clean" {
+        return Err("expected clean (try cargo prebindgen --help)".to_string());
+    }
+
+    let mut options = Options::default();
+    let mut index = 0;
+    while index < args.len() {
+        match args[index].to_str() {
+            Some("--dry-run") => options.dry_run = true,
+            Some("--target-dir" | "--build-dir") => {
+                index += 1;
+                let path = args.get(index).ok_or_else(|| {
+                    "missing path after target/build directory option".to_string()
+                })?;
+                options.roots.push(PathBuf::from(path));
+            }
+            Some("--manifest-path") => {
+                index += 1;
+                let path = args
+                    .get(index)
+                    .ok_or_else(|| "missing path after --manifest-path".to_string())?;
+                if options.manifest_path.replace(PathBuf::from(path)).is_some() {
+                    return Err("--manifest-path may be specified only once".to_string());
+                }
+            }
+            Some("-h" | "--help") => return Ok(None),
+            Some(other) => return Err(format!("unknown option {other}")),
+            None => return Err("command options must be valid UTF-8".to_string()),
+        }
+        index += 1;
+    }
+    if options.manifest_path.is_some() && !options.roots.is_empty() {
+        return Err(
+            "--manifest-path cannot be combined with an explicit target/build directory"
+                .to_string(),
+        );
+    }
+    Ok(Some(options))
+}
+
+fn print_help() {
+    println!(
+        "Scoped cleanup for prebindgen captures
+
+Usage:
+  cargo prebindgen clean [OPTIONS]
+
+Options:
+      --dry-run              Validate and list captures without removing them
+      --target-dir <PATH>    Scan an explicit Cargo target directory
+      --build-dir <PATH>     Scan an explicit Cargo build directory (repeatable)
+      --manifest-path <PATH> Resolve the target directory through cargo metadata
+  -h, --help                 Print help
+  -V, --version              Print version
+
+The command acquires every discovered Cargo profile lock before changing
+anything. It removes only state-validated */build/*/out/prebindgen directories.
+Cargo build directories configured separately from target-dir must be supplied
+with --build-dir."
+    );
+}
+
+#[derive(Deserialize)]
+struct Metadata {
+    target_directory: PathBuf,
+}
+
+fn metadata_target_dir(manifest_path: Option<&Path>) -> Result<PathBuf, String> {
+    let cargo = env::var_os("CARGO").unwrap_or_else(|| OsString::from("cargo"));
+    let mut command = Command::new(cargo);
+    command.args(["metadata", "--format-version=1", "--no-deps"]);
+    if let Some(path) = manifest_path {
+        command.arg("--manifest-path").arg(path);
+    }
+    let output = command
+        .output()
+        .map_err(|error| format!("failed to run cargo metadata: {error}"))?;
+    if !output.status.success() {
+        return Err(format!(
+            "cargo metadata failed: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        ));
+    }
+    serde_json::from_slice::<Metadata>(&output.stdout)
+        .map(|metadata| metadata.target_directory)
+        .map_err(|error| format!("failed to decode cargo metadata: {error}"))
+}
+
+#[derive(Debug, Default)]
+struct CleanReport {
+    managed: usize,
+    interrupted: usize,
+    skipped: usize,
+    paths: Vec<PathBuf>,
+}
+
+fn clean_roots(roots: &[PathBuf], dry_run: bool) -> io::Result<CleanReport> {
+    let profiles = discover_profiles(roots)?;
+    let _locks = lock_profiles(&profiles)?;
+
+    let mut candidates = BTreeSet::new();
+    for profile in &profiles {
+        scan_profile(profile, &mut candidates)?;
+    }
+
+    let mut managed = Vec::new();
+    let mut skipped = 0;
+    for candidate in candidates {
+        if validate_capture_dir(&candidate.path)?.is_some() {
+            managed.push(candidate);
+        } else {
+            skipped += 1;
+        }
+    }
+
+    let mut report = CleanReport {
+        managed: managed.len(),
+        skipped,
+        ..CleanReport::default()
+    };
+    for candidate in managed {
+        report.paths.push(candidate.path.clone());
+        if candidate.interrupted {
+            report.interrupted += 1;
+        }
+        if dry_run {
+            continue;
+        }
+        if candidate.interrupted {
+            fs::remove_dir_all(&candidate.path)?;
+        } else {
+            advance_state(&candidate.out_dir)?;
+            let tombstone = next_tombstone(&candidate.out_dir);
+            fs::rename(&candidate.path, &tombstone)?;
+            fs::remove_dir_all(tombstone)?;
+        }
+    }
+    Ok(report)
+}
+
+fn discover_profiles(roots: &[PathBuf]) -> io::Result<Vec<PathBuf>> {
+    let mut profiles = BTreeSet::new();
+    for root in roots {
+        let root = fs::canonicalize(root).map_err(|error| {
+            io::Error::new(
+                error.kind(),
+                format!("cannot scan build root {}: {error}", root.display()),
+            )
+        })?;
+        discover_profiles_at(&root, 0, &mut profiles)?;
+    }
+    Ok(profiles.into_iter().collect())
+}
+
+fn discover_profiles_at(
+    directory: &Path,
+    depth: usize,
+    profiles: &mut BTreeSet<PathBuf>,
+) -> io::Result<()> {
+    if has_profile_lock(directory)? {
+        profiles.insert(directory.to_path_buf());
+        return Ok(());
+    }
+    if depth == 2 {
+        return Ok(());
+    }
+
+    let mut children = fs::read_dir(directory)?.collect::<Result<Vec<_>, _>>()?;
+    children.sort_by_key(|entry| entry.file_name());
+    for child in children {
+        let metadata = child.file_type()?;
+        if metadata.is_dir() && !metadata.is_symlink() {
+            discover_profiles_at(&child.path(), depth + 1, profiles)?;
+        }
+    }
+    Ok(())
+}
+
+fn has_profile_lock(directory: &Path) -> io::Result<bool> {
+    let mut found = false;
+    for name in CARGO_LOCKS_IN_ORDER {
+        let path = directory.join(name);
+        match fs::symlink_metadata(&path) {
+            Ok(metadata) if metadata.file_type().is_symlink() || !metadata.is_file() => {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!("Cargo lock path is not a regular file: {}", path.display()),
+                ));
+            }
+            Ok(_) => found = true,
+            Err(error) if error.kind() == io::ErrorKind::NotFound => {}
+            Err(error) => return Err(error),
+        }
+    }
+    Ok(found)
+}
+
+struct LockedProfile {
+    _path: PathBuf,
+    _locks: Vec<File>,
+}
+
+fn lock_profiles(profiles: &[PathBuf]) -> io::Result<Vec<LockedProfile>> {
+    for profile in profiles {
+        if is_nfs(profile)? {
+            return Err(io::Error::new(
+                io::ErrorKind::Unsupported,
+                format!(
+                    "refusing cleanup on NFS because Cargo cannot provide a reliable build lock: {}",
+                    profile.display()
+                ),
+            ));
+        }
+    }
+
+    let mut locked = Vec::new();
+    for profile in profiles {
+        let mut files = Vec::new();
+        for name in CARGO_LOCKS_IN_ORDER {
+            let path = profile.join(name);
+            let metadata = match fs::symlink_metadata(&path) {
+                Ok(metadata) => metadata,
+                Err(error) if error.kind() == io::ErrorKind::NotFound => continue,
+                Err(error) => return Err(error),
+            };
+            if metadata.file_type().is_symlink() || !metadata.is_file() {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!("Cargo lock path is not a regular file: {}", path.display()),
+                ));
+            }
+
+            let file = OpenOptions::new().read(true).write(true).open(&path)?;
+            match FileExt::try_lock_exclusive(&file) {
+                Ok(()) => files.push(file),
+                Err(error) if error.kind() == io::ErrorKind::WouldBlock => {
+                    return Err(io::Error::new(
+                        io::ErrorKind::WouldBlock,
+                        format!(
+                            "Cargo profile is active; no captures were removed: {}",
+                            profile.display()
+                        ),
+                    ));
+                }
+                Err(error) => {
+                    return Err(io::Error::new(
+                        error.kind(),
+                        format!("cannot lock {}: {error}", path.display()),
+                    ));
+                }
+            }
+        }
+        locked.push(LockedProfile {
+            _path: profile.clone(),
+            _locks: files,
+        });
+    }
+    Ok(locked)
+}
+
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
+struct Candidate {
+    path: PathBuf,
+    out_dir: PathBuf,
+    interrupted: bool,
+}
+
+fn scan_profile(profile: &Path, candidates: &mut BTreeSet<Candidate>) -> io::Result<()> {
+    let build = profile.join("build");
+    if !is_directory(&build)? {
+        return Ok(());
+    }
+
+    for first in directory_children(&build)? {
+        if !is_directory(&first)? {
+            continue;
+        }
+        scan_out_dir(&first.join("out"), candidates)?;
+        for second in directory_children(&first)? {
+            if is_directory(&second)? {
+                scan_out_dir(&second.join("out"), candidates)?;
+            }
+        }
+    }
+    Ok(())
+}
+
+fn scan_out_dir(out_dir: &Path, candidates: &mut BTreeSet<Candidate>) -> io::Result<()> {
+    if !is_directory(out_dir)? {
+        return Ok(());
+    }
+
+    let current = out_dir.join(PREBINDGEN_DIR);
+    match fs::symlink_metadata(&current) {
+        Ok(_) => {
+            candidates.insert(Candidate {
+                path: current,
+                out_dir: out_dir.to_path_buf(),
+                interrupted: false,
+            });
+        }
+        Err(error) if error.kind() == io::ErrorKind::NotFound => {}
+        Err(error) => return Err(error),
+    }
+    for path in directory_children(out_dir)? {
+        if path
+            .file_name()
+            .and_then(OsStr::to_str)
+            .is_some_and(|name| name.starts_with(TOMBSTONE_PREFIX))
+        {
+            candidates.insert(Candidate {
+                path,
+                out_dir: out_dir.to_path_buf(),
+                interrupted: true,
+            });
+        }
+    }
+    Ok(())
+}
+
+fn directory_children(directory: &Path) -> io::Result<Vec<PathBuf>> {
+    match fs::read_dir(directory) {
+        Ok(entries) => {
+            let mut paths = entries
+                .map(|entry| entry.map(|entry| entry.path()))
+                .collect::<Result<Vec<_>, _>>()?;
+            paths.sort();
+            Ok(paths)
+        }
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(Vec::new()),
+        Err(error) => Err(error),
+    }
+}
+
+fn is_directory(path: &Path) -> io::Result<bool> {
+    match fs::symlink_metadata(path) {
+        Ok(metadata) => Ok(metadata.is_dir() && !metadata.file_type().is_symlink()),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(false),
+        Err(error) => Err(error),
+    }
+}
+
+fn next_tombstone(out_dir: &Path) -> PathBuf {
+    loop {
+        let id = TOMBSTONE_ID.fetch_add(1, Ordering::Relaxed);
+        let path = out_dir.join(format!("{TOMBSTONE_PREFIX}{}-{id}", std::process::id()));
+        if !path.exists() {
+            return path;
+        }
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn is_nfs(path: &Path) -> io::Result<bool> {
+    use std::{ffi::CString, mem, os::unix::ffi::OsStrExt};
+
+    let path = CString::new(path.as_os_str().as_bytes()).map_err(|_| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!("path contains a NUL byte: {}", path.display()),
+        )
+    })?;
+    let mut status = unsafe { mem::zeroed::<libc::statfs>() };
+    if unsafe { libc::statfs(path.as_ptr(), &mut status) } != 0 {
+        return Err(io::Error::last_os_error());
+    }
+    Ok(status.f_type as u64 == libc::NFS_SUPER_MAGIC as u64)
+}
+
+#[cfg(not(target_os = "linux"))]
+fn is_nfs(_path: &Path) -> io::Result<bool> {
+    Ok(false)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        collections::BTreeSet,
+        fs::{self, OpenOptions},
+        io,
+        path::{Path, PathBuf},
+        sync::{Arc, Barrier},
+        thread,
+    };
+
+    use fs2::FileExt;
+    use prebindgen::capture_protocol::{ensure_capture_dir_at, initialize_state, state_slot_paths};
+
+    use super::{clean_roots, TOMBSTONE_PREFIX};
+
+    fn profile(root: &Path, name: &str) -> PathBuf {
+        let profile = root.join(name);
+        fs::create_dir_all(profile.join("build")).unwrap();
+        fs::write(profile.join(".cargo-build-lock"), []).unwrap();
+        fs::write(profile.join(".cargo-lock"), []).unwrap();
+        profile
+    }
+
+    fn managed_at(out_dir: &Path, crate_name: &str) -> PathBuf {
+        fs::create_dir_all(out_dir).unwrap();
+        let features = BTreeSet::from(["feature-a".to_string()]);
+        initialize_state(out_dir, crate_name, &features).unwrap();
+        let capture = ensure_capture_dir_at(out_dir).unwrap();
+        fs::write(capture.join("default_deadbeef.jsonl"), b"{}\n").unwrap();
+        capture
+    }
+
+    fn legacy_capture(profile: &Path, unit: &str) -> PathBuf {
+        managed_at(&profile.join("build").join(unit).join("out"), "source")
+    }
+
+    #[test]
+    fn cleans_valid_legacy_new_and_cross_target_layouts_only() {
+        let root = tempfile::tempdir().unwrap();
+        let debug = profile(root.path(), "debug");
+        let legacy = legacy_capture(&debug, "source-0123456789abcdef");
+        let modern = managed_at(
+            &debug
+                .join("build")
+                .join("other-source")
+                .join("fedcba9876543210")
+                .join("out"),
+            "other-source",
+        );
+        let cross_profile = profile(&root.path().join("wasm32-unknown-unknown"), "release");
+        let cross = legacy_capture(&cross_profile, "cross-source-0123456789abcdef");
+        let degraded = legacy_capture(&debug, "degraded-0123456789abcdef");
+        let degraded_out = degraded.parent().unwrap();
+        fs::remove_file(&state_slot_paths(degraded_out)[0]).unwrap();
+
+        let malformed = debug
+            .join("build")
+            .join("malformed-0123456789abcdef")
+            .join("out")
+            .join("prebindgen");
+        fs::create_dir_all(&malformed).unwrap();
+        fs::write(malformed.join("crate_name.txt"), b"not-managed").unwrap();
+
+        let unrelated = debug.join("unrelated/out/prebindgen");
+        fs::create_dir_all(&unrelated).unwrap();
+        fs::write(unrelated.join("keep"), b"keep").unwrap();
+        let cargo_owned = legacy.parent().unwrap().join("cargo-output");
+        fs::write(&cargo_owned, b"keep").unwrap();
+
+        let report = clean_roots(&[root.path().to_path_buf()], false).unwrap();
+        assert_eq!(report.managed, 3);
+        assert_eq!(report.skipped, 2);
+        assert!(!legacy.exists());
+        assert!(!modern.exists());
+        assert!(!cross.exists());
+        assert!(malformed.exists());
+        assert!(degraded.exists());
+        assert!(unrelated.exists());
+        assert_eq!(fs::read(cargo_owned).unwrap(), b"keep");
+        for path in state_slot_paths(legacy.parent().unwrap()) {
+            assert!(path.is_file());
+        }
+    }
+
+    #[test]
+    fn active_profile_aborts_all_profiles_before_any_deletion() {
+        let root = tempfile::tempdir().unwrap();
+        let debug = profile(root.path(), "debug");
+        let release = profile(root.path(), "release");
+        let debug_capture = legacy_capture(&debug, "source-a");
+        let release_capture = legacy_capture(&release, "source-b");
+
+        let ready = Arc::new(Barrier::new(2));
+        let release_lock = Arc::new(Barrier::new(2));
+        let lock_path = debug.join(".cargo-lock");
+        let worker = {
+            let ready = Arc::clone(&ready);
+            let release_lock = Arc::clone(&release_lock);
+            thread::spawn(move || {
+                let file = OpenOptions::new()
+                    .read(true)
+                    .write(true)
+                    .open(lock_path)
+                    .unwrap();
+                FileExt::lock_shared(&file).unwrap();
+                ready.wait();
+                release_lock.wait();
+            })
+        };
+        ready.wait();
+
+        let error = clean_roots(&[root.path().to_path_buf()], false).unwrap_err();
+        assert_eq!(error.kind(), io::ErrorKind::WouldBlock);
+        assert!(debug_capture.exists());
+        assert!(release_capture.exists());
+
+        release_lock.wait();
+        worker.join().unwrap();
+        let report = clean_roots(&[root.path().to_path_buf()], false).unwrap();
+        assert_eq!(report.managed, 2);
+    }
+
+    #[test]
+    fn active_separate_build_directory_lock_blocks_cleanup() {
+        let root = tempfile::tempdir().unwrap();
+        let debug = profile(root.path(), "debug");
+        fs::remove_file(debug.join(".cargo-lock")).unwrap();
+        let capture = legacy_capture(&debug, "source-a");
+
+        let lock = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(debug.join(".cargo-build-lock"))
+            .unwrap();
+        FileExt::lock_shared(&lock).unwrap();
+
+        let error = clean_roots(&[root.path().to_path_buf()], false).unwrap_err();
+        assert_eq!(error.kind(), io::ErrorKind::WouldBlock);
+        assert!(capture.exists());
+
+        FileExt::unlock(&lock).unwrap();
+        let report = clean_roots(&[root.path().to_path_buf()], false).unwrap();
+        assert_eq!(report.managed, 1);
+        assert!(!capture.exists());
+    }
+    #[test]
+    fn dry_run_validates_and_preserves_capture_and_generation() {
+        let root = tempfile::tempdir().unwrap();
+        let debug = profile(root.path(), "debug");
+        let capture = legacy_capture(&debug, "source-a");
+        let out = capture.parent().unwrap();
+        let generation = prebindgen::capture_protocol::load_latest_state(out)
+            .unwrap()
+            .0
+            .generation;
+
+        let report = clean_roots(&[root.path().to_path_buf()], true).unwrap();
+        assert_eq!(report.managed, 1);
+        assert!(capture.exists());
+        assert_eq!(
+            prebindgen::capture_protocol::load_latest_state(out)
+                .unwrap()
+                .0
+                .generation,
+            generation
+        );
+    }
+
+    #[test]
+    fn interrupted_tombstone_is_recovered_without_touching_other_output() {
+        let root = tempfile::tempdir().unwrap();
+        let debug = profile(root.path(), "debug");
+        let capture = legacy_capture(&debug, "source-a");
+        let out = capture.parent().unwrap();
+        let tombstone = out.join(format!("{TOMBSTONE_PREFIX}old"));
+        fs::rename(&capture, &tombstone).unwrap();
+        let keep = out.join("keep");
+        fs::write(&keep, b"keep").unwrap();
+
+        let report = clean_roots(&[root.path().to_path_buf()], false).unwrap();
+        assert_eq!(report.managed, 1);
+        assert_eq!(report.interrupted, 1);
+        assert!(!tombstone.exists());
+        assert_eq!(fs::read(keep).unwrap(), b"keep");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn capture_symlink_is_never_followed() {
+        use std::os::unix::fs::symlink;
+
+        let root = tempfile::tempdir().unwrap();
+        let debug = profile(root.path(), "debug");
+        let out = debug.join("build/source-a/out");
+        fs::create_dir_all(&out).unwrap();
+        let real = root.path().join("outside");
+        fs::create_dir_all(&real).unwrap();
+        fs::write(real.join("keep"), b"keep").unwrap();
+        symlink(&real, out.join("prebindgen")).unwrap();
+
+        let report = clean_roots(&[root.path().to_path_buf()], false).unwrap();
+        assert_eq!(report.managed, 0);
+        assert_eq!(report.skipped, 1);
+        assert_eq!(fs::read(real.join("keep")).unwrap(), b"keep");
+    }
+}

--- a/prebindgen/src/capture_protocol.rs
+++ b/prebindgen/src/capture_protocol.rs
@@ -1,0 +1,361 @@
+//! Internal protocol shared by capture producers and the cargo-prebindgen binary.
+//!
+//! This module is public only so the proc-macro crate and the binary shipped in
+//! this package can share the protocol. It is not a supported user API.
+
+use std::{
+    collections::BTreeSet,
+    fs::{self, File, OpenOptions},
+    io::{self, Write},
+    path::{Path, PathBuf},
+    sync::atomic::{AtomicU64, Ordering},
+};
+
+use serde::{Deserialize, Serialize};
+
+pub const PREBINDGEN_DIR: &str = "prebindgen";
+pub const CRATE_NAME_FILE: &str = "crate_name.txt";
+pub const FEATURES_FILE: &str = "features.txt";
+pub const STATE_SLOT_FILES: [&str; 2] = [
+    ".prebindgen-capture-state-v1-a.json",
+    ".prebindgen-capture-state-v1-b.json",
+];
+
+const PROTOCOL: &str = "prebindgen-capture-v1";
+static TEMP_FILE_ID: AtomicU64 = AtomicU64::new(0);
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct CaptureState {
+    protocol: String,
+    pub generation: u64,
+    pub crate_name: String,
+    pub features: Vec<String>,
+}
+
+impl CaptureState {
+    fn new(generation: u64, crate_name: &str, features: &BTreeSet<String>) -> Self {
+        Self {
+            protocol: PROTOCOL.to_string(),
+            generation,
+            crate_name: crate_name.to_string(),
+            features: features.iter().cloned().collect(),
+        }
+    }
+
+    fn validate(&self) -> bool {
+        self.protocol == PROTOCOL
+            && !self.crate_name.is_empty()
+            && !self.crate_name.contains(['\n', '\r'])
+            && self
+                .features
+                .iter()
+                .all(|feature| !feature.is_empty() && !feature.contains(['\n', '\r']))
+            && self.features.windows(2).all(|pair| pair[0] < pair[1])
+    }
+}
+
+pub fn state_slot_paths(out_dir: &Path) -> [PathBuf; 2] {
+    STATE_SLOT_FILES.map(|file| out_dir.join(file))
+}
+
+pub fn capture_dir(out_dir: &Path) -> PathBuf {
+    out_dir.join(PREBINDGEN_DIR)
+}
+
+pub fn get_out_dir() -> io::Result<PathBuf> {
+    std::env::var_os("OUT_DIR")
+        .map(PathBuf::from)
+        .ok_or_else(|| io::Error::new(io::ErrorKind::NotFound, "OUT_DIR is not set"))
+}
+
+pub fn get_state_slot_paths() -> io::Result<[PathBuf; 2]> {
+    Ok(state_slot_paths(&get_out_dir()?))
+}
+
+fn invalid_data(message: impl Into<String>) -> io::Error {
+    io::Error::new(io::ErrorKind::InvalidData, message.into())
+}
+
+fn reject_symlink(path: &Path) -> io::Result<()> {
+    match fs::symlink_metadata(path) {
+        Ok(metadata) if metadata.file_type().is_symlink() => Err(invalid_data(format!(
+            "refusing prebindgen state symlink {}",
+            path.display()
+        ))),
+        Ok(metadata) if !metadata.is_file() => Err(invalid_data(format!(
+            "prebindgen state path is not a file: {}",
+            path.display()
+        ))),
+        Ok(_) => Ok(()),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(error),
+    }
+}
+
+fn read_slot(path: &Path) -> io::Result<Option<CaptureState>> {
+    reject_symlink(path)?;
+    let bytes = match fs::read(path) {
+        Ok(bytes) => bytes,
+        Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => return Err(error),
+    };
+    let Ok(state) = serde_json::from_slice::<CaptureState>(&bytes) else {
+        return Ok(None);
+    };
+    Ok(state.validate().then_some(state))
+}
+
+fn read_slots(out_dir: &Path) -> io::Result<[Option<CaptureState>; 2]> {
+    let [a, b] = state_slot_paths(out_dir);
+    Ok([read_slot(&a)?, read_slot(&b)?])
+}
+
+fn latest_from_slots(slots: &[Option<CaptureState>; 2]) -> io::Result<(CaptureState, usize)> {
+    let latest = slots
+        .iter()
+        .enumerate()
+        .filter_map(|(index, state)| state.as_ref().map(|state| (state, index)))
+        .max_by_key(|(state, _)| state.generation)
+        .ok_or_else(|| invalid_data("no valid prebindgen capture state slot"))?;
+
+    if let Some(other) = slots[1 - latest.1].as_ref() {
+        if other.generation == latest.0.generation && other != latest.0 {
+            return Err(invalid_data(
+                "prebindgen capture state slots disagree at the same generation",
+            ));
+        }
+    }
+    Ok((latest.0.clone(), latest.1))
+}
+
+pub fn load_latest_state(out_dir: &Path) -> io::Result<(CaptureState, usize)> {
+    latest_from_slots(&read_slots(out_dir)?)
+}
+
+fn write_slot(path: &Path, state: &CaptureState) -> io::Result<()> {
+    reject_symlink(path)?;
+    let mut bytes = serde_json::to_vec(state).map_err(|error| invalid_data(error.to_string()))?;
+    bytes.push(b'\n');
+
+    let mut file = OpenOptions::new()
+        .create(true)
+        .truncate(true)
+        .write(true)
+        .open(path)?;
+    file.write_all(&bytes)?;
+    file.sync_all()?;
+    drop(file);
+
+    let verified = read_slot(path)?;
+    if verified.as_ref() != Some(state) {
+        return Err(invalid_data(format!(
+            "failed to verify prebindgen state slot {}",
+            path.display()
+        )));
+    }
+    Ok(())
+}
+
+/// Initialize both state slots before rustc starts.
+pub fn initialize_state(
+    out_dir: &Path,
+    crate_name: &str,
+    features: &BTreeSet<String>,
+) -> io::Result<CaptureState> {
+    let generation = read_slots(out_dir)?
+        .iter()
+        .flatten()
+        .map(|state| state.generation)
+        .max()
+        .map_or(Ok(0), |generation| {
+            generation
+                .checked_add(1)
+                .ok_or_else(|| invalid_data("prebindgen capture generation overflow"))
+        })?;
+    let state = CaptureState::new(generation, crate_name, features);
+    for path in state_slot_paths(out_dir) {
+        write_slot(&path, &state)?;
+    }
+    Ok(state)
+}
+
+/// Durably change one state slot while retaining the previous valid slot.
+///
+/// Cleanup calls this before renaming a capture directory. A crash before this
+/// function returns leaves the old slot valid and the directory untouched; a
+/// crash afterwards leaves rustc with a changed input dependency.
+pub fn advance_state(out_dir: &Path) -> io::Result<CaptureState> {
+    let slots = read_slots(out_dir)?;
+    let (latest, latest_index) = latest_from_slots(&slots)?;
+    let generation = latest
+        .generation
+        .checked_add(1)
+        .ok_or_else(|| invalid_data("prebindgen capture generation overflow"))?;
+    let next = CaptureState {
+        generation,
+        ..latest
+    };
+    let target_index = 1 - latest_index;
+    write_slot(&state_slot_paths(out_dir)[target_index], &next)?;
+    Ok(next)
+}
+
+pub fn feature_file_contents(features: &[String]) -> String {
+    let mut contents = features.join("\n");
+    if !contents.is_empty() {
+        contents.push('\n');
+    }
+    contents
+}
+
+fn write_recovery_file(path: &Path, bytes: &[u8]) -> io::Result<()> {
+    if fs::read(path)
+        .map(|existing| existing == bytes)
+        .unwrap_or(false)
+    {
+        return Ok(());
+    }
+
+    let id = TEMP_FILE_ID.fetch_add(1, Ordering::Relaxed);
+    let file_name = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("metadata");
+    let temporary = path.with_file_name(format!(".{file_name}.tmp-{}-{id}", std::process::id()));
+    let mut file = File::create(&temporary)?;
+    file.write_all(bytes)?;
+    file.sync_all()?;
+    drop(file);
+
+    match fs::rename(&temporary, path) {
+        Ok(()) => Ok(()),
+        Err(error)
+            if matches!(
+                error.kind(),
+                io::ErrorKind::AlreadyExists | io::ErrorKind::PermissionDenied
+            ) && fs::read(path)
+                .map(|existing| existing == bytes)
+                .unwrap_or(false) =>
+        {
+            fs::remove_file(temporary)
+        }
+        Err(error) => {
+            let _ = fs::remove_file(temporary);
+            Err(error)
+        }
+    }
+}
+
+/// Recreate metadata after scoped cleanup without requiring the build script
+/// itself to rerun. The proc macro calls this before writing any JSONL record.
+pub fn ensure_capture_dir() -> io::Result<PathBuf> {
+    ensure_capture_dir_at(&get_out_dir()?)
+}
+
+pub fn ensure_capture_dir_at(out_dir: &Path) -> io::Result<PathBuf> {
+    let (state, _) = load_latest_state(out_dir)?;
+    let capture_dir = capture_dir(out_dir);
+    fs::create_dir_all(&capture_dir)?;
+    write_recovery_file(
+        &capture_dir.join(CRATE_NAME_FILE),
+        state.crate_name.as_bytes(),
+    )?;
+    write_recovery_file(
+        &capture_dir.join(FEATURES_FILE),
+        feature_file_contents(&state.features).as_bytes(),
+    )?;
+    Ok(capture_dir)
+}
+
+pub fn validate_capture_dir(path: &Path) -> io::Result<Option<CaptureState>> {
+    let metadata = match fs::symlink_metadata(path) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => return Err(error),
+    };
+    if metadata.file_type().is_symlink() || !metadata.is_dir() {
+        return Ok(None);
+    }
+    let Some(out_dir) = path.parent() else {
+        return Ok(None);
+    };
+    // Cleanup must update an already-existing inactive slot before deletion.
+    // Creating a missing slot would also require syncing the parent directory
+    // to make the new entry power-loss durable.
+    for state_path in state_slot_paths(out_dir) {
+        let metadata = match fs::symlink_metadata(state_path) {
+            Ok(metadata) => metadata,
+            Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(None),
+            Err(error) => return Err(error),
+        };
+        if metadata.file_type().is_symlink() || !metadata.is_file() {
+            return Ok(None);
+        }
+    }
+    let (state, _) = match load_latest_state(out_dir) {
+        Ok(state) => state,
+        Err(error) if error.kind() == io::ErrorKind::InvalidData => return Ok(None),
+        Err(error) => return Err(error),
+    };
+
+    let crate_name = path.join(CRATE_NAME_FILE);
+    let features = path.join(FEATURES_FILE);
+    for metadata_path in [&crate_name, &features] {
+        let metadata = match fs::symlink_metadata(metadata_path) {
+            Ok(metadata) => metadata,
+            Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(None),
+            Err(error) => return Err(error),
+        };
+        if metadata.file_type().is_symlink() || !metadata.is_file() {
+            return Ok(None);
+        }
+    }
+    if fs::read(&crate_name)? != state.crate_name.as_bytes()
+        || fs::read(&features)? != feature_file_contents(&state.features).as_bytes()
+    {
+        return Ok(None);
+    }
+    Ok(Some(state))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeSet;
+
+    use super::{
+        advance_state, capture_dir, ensure_capture_dir_at, initialize_state, load_latest_state,
+        CRATE_NAME_FILE, FEATURES_FILE,
+    };
+
+    #[test]
+    fn inactive_slot_advance_survives_a_corrupt_other_slot() {
+        let dir = tempfile::tempdir().unwrap();
+        let features = BTreeSet::from(["a".to_string(), "b".to_string()]);
+        let initialized = initialize_state(dir.path(), "source", &features).unwrap();
+        let advanced = advance_state(dir.path()).unwrap();
+        assert_eq!(advanced.generation, initialized.generation + 1);
+
+        let (_, latest_index) = load_latest_state(dir.path()).unwrap();
+        let other = super::state_slot_paths(dir.path())[1 - latest_index].clone();
+        std::fs::write(other, b"truncated").unwrap();
+        assert_eq!(load_latest_state(dir.path()).unwrap().0, advanced);
+    }
+
+    #[test]
+    fn macro_recovery_recreates_deleted_capture_metadata() {
+        let dir = tempfile::tempdir().unwrap();
+        let features = BTreeSet::from(["unstable".to_string()]);
+        initialize_state(dir.path(), "source", &features).unwrap();
+
+        let recovered = ensure_capture_dir_at(dir.path()).unwrap();
+        assert_eq!(recovered, capture_dir(dir.path()));
+        assert_eq!(
+            std::fs::read_to_string(recovered.join(CRATE_NAME_FILE)).unwrap(),
+            "source"
+        );
+        assert_eq!(
+            std::fs::read_to_string(recovered.join(FEATURES_FILE)).unwrap(),
+            "unstable\n"
+        );
+    }
+}

--- a/prebindgen/src/lib.rs
+++ b/prebindgen/src/lib.rs
@@ -161,16 +161,12 @@
 //! `prebindgen-jni` crate, which hands the result to its `JniGenBuilder`.
 //!
 
-/// File name for storing the crate name
-const CRATE_NAME_FILE: &str = "crate_name.txt";
-
-/// File name for storing enabled Cargo features collected in build.rs
-const FEATURES_FILE: &str = "features.txt";
-
 /// Default group name for items without explicit group name
 pub const DEFAULT_GROUP_NAME: &str = "default";
 
 pub(crate) mod api;
+#[doc(hidden)]
+pub mod capture_protocol;
 pub(crate) mod codegen;
 
 pub use crate::api::{

--- a/prebindgen/tests/cleanup_lifecycle.rs
+++ b/prebindgen/tests/cleanup_lifecycle.rs
@@ -1,0 +1,177 @@
+use std::{
+    collections::BTreeMap,
+    ffi::OsString,
+    fs,
+    path::{Path, PathBuf},
+    process::{Command, Output},
+};
+
+fn workspace_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .to_path_buf()
+}
+
+fn cargo(target: &Path, args: &[&str]) -> Output {
+    let cargo = std::env::var_os("CARGO").unwrap_or_else(|| OsString::from("cargo"));
+    Command::new(cargo)
+        .current_dir(workspace_root())
+        .env("CARGO_TARGET_DIR", target)
+        .env("CARGO_TERM_COLOR", "never")
+        .args(args)
+        .output()
+        .unwrap()
+}
+
+fn assert_success(output: &Output, operation: &str) {
+    assert!(
+        output.status.success(),
+        "{operation} failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+fn visit_directories(path: &Path, found: &mut Vec<PathBuf>) {
+    let Ok(entries) = fs::read_dir(path) else {
+        return;
+    };
+    for entry in entries {
+        let entry = entry.unwrap();
+        if entry.file_type().unwrap().is_dir() {
+            let path = entry.path();
+            if path.file_name().is_some_and(|name| name == "prebindgen")
+                && fs::read_to_string(path.join("crate_name.txt"))
+                    .map(|crate_name| crate_name == "example-flat")
+                    .unwrap_or(false)
+            {
+                found.push(path);
+            } else {
+                visit_directories(&path, found);
+            }
+        }
+    }
+}
+
+fn example_capture_dirs(target: &Path) -> Vec<PathBuf> {
+    let mut found = Vec::new();
+    visit_directories(target, &mut found);
+    found.sort();
+    found
+}
+
+fn capture_files(directory: &Path) -> BTreeMap<OsString, Vec<u8>> {
+    fs::read_dir(directory)
+        .unwrap()
+        .map(|entry| {
+            let path = entry.unwrap().path();
+            (
+                path.file_name().unwrap().to_owned(),
+                fs::read(path).unwrap(),
+            )
+        })
+        .collect()
+}
+
+#[test]
+fn feature_hashes_clean_regenerate_and_stay_warm() {
+    let target = tempfile::tempdir().unwrap();
+    for features in [None, Some("unstable"), Some("internal")] {
+        let mut args = vec!["check", "-p", "example-flat"];
+        if let Some(features) = features {
+            args.extend(["--features", features]);
+        }
+        let output = cargo(target.path(), &args);
+        assert_success(&output, &format!("initial build with {features:?}"));
+    }
+    let output = cargo(
+        target.path(),
+        &["check", "-p", "example-flat", "--all-features"],
+    );
+    assert_success(&output, "initial all-features build");
+    assert_eq!(example_capture_dirs(target.path()).len(), 4);
+
+    let cleaner = env!("CARGO_BIN_EXE_cargo-prebindgen");
+    let dry_run = Command::new(cleaner)
+        .args(["clean", "--dry-run", "--target-dir"])
+        .arg(target.path())
+        .output()
+        .unwrap();
+    assert_success(&dry_run, "cleanup dry-run");
+    assert_eq!(example_capture_dirs(target.path()).len(), 4);
+
+    let clean = Command::new(cleaner)
+        .args(["clean", "--target-dir"])
+        .arg(target.path())
+        .output()
+        .unwrap();
+    assert_success(&clean, "cleanup");
+    assert!(example_capture_dirs(target.path()).is_empty());
+
+    let rebuilt = cargo(
+        target.path(),
+        &[
+            "check",
+            "-p",
+            "example-flat",
+            "--features",
+            "unstable",
+            "-vv",
+        ],
+    );
+    assert_success(&rebuilt, "post-clean rebuild");
+    let diagnostics = String::from_utf8_lossy(&rebuilt.stderr);
+    assert!(
+        diagnostics.contains("Dirty example-flat")
+            && diagnostics.contains(".prebindgen-capture-state-v1-"),
+        "producer was not invalidated by a state slot:\n{diagnostics}"
+    );
+
+    let directories = example_capture_dirs(target.path());
+    assert_eq!(directories.len(), 1);
+    let before = capture_files(&directories[0]);
+    assert_eq!(
+        before
+            .keys()
+            .filter(|name| Path::new(name)
+                .extension()
+                .is_some_and(|ext| ext == "jsonl"))
+            .count(),
+        2
+    );
+    for (name, contents) in &before {
+        if Path::new(name)
+            .extension()
+            .is_some_and(|ext| ext == "jsonl")
+        {
+            assert!(!contents.is_empty());
+            for line in contents
+                .split(|byte| *byte == b'\n')
+                .filter(|line| !line.is_empty())
+            {
+                serde_json::from_slice::<serde_json::Value>(line).unwrap();
+            }
+        }
+    }
+
+    let warm = cargo(
+        target.path(),
+        &[
+            "check",
+            "-p",
+            "example-flat",
+            "--features",
+            "unstable",
+            "-vv",
+        ],
+    );
+    assert_success(&warm, "warm post-clean rebuild");
+    assert!(
+        String::from_utf8_lossy(&warm.stderr).contains("Fresh example-flat"),
+        "producer was unexpectedly rebuilt:\n{}",
+        String::from_utf8_lossy(&warm.stderr)
+    );
+    assert_eq!(example_capture_dirs(target.path()).len(), 1);
+    assert_eq!(capture_files(&directories[0]), before);
+}


### PR DESCRIPTION
## Summary

Adds an explicit, scoped `cargo prebindgen clean` operation for the stale prebindgen payloads tracked by #397.

This PR is stacked on #396 (`fix-201`). #396 bounds JSONL growth inside one Cargo build output; this PR handles the remaining accumulation across multiple Cargo build hashes.

- discovers legacy `build/<package>-<hash>/out/prebindgen` and Cargo's new `build/<package>/<hash>/out/prebindgen` layout across profiles and target triples
- removes only capture directories whose crate/features metadata and two state slots validate
- supports `--dry-run`, `--target-dir`, repeatable `--build-dir`, and `--manifest-path`
- leaves Cargo-owned `<package>-<hash>` directories and every unrelated artifact intact

## Build and concurrency safety

Cleanup is explicit, never automatic from `build.rs`.

Before mutation it non-blockingly acquires every discovered profile lock, in Cargo's order: current `.cargo-build-lock` first, then compatibility `.cargo-lock`. If any profile is active, all locks are released and no capture is removed. This covers current shared/fine-grained locks, current exclusive locks, and Cargo 1.85's profile lock. Detected Linux NFS mounts are refused because Cargo skips these locks there.

Each producer has two alternating state files outside `out/prebindgen`, both tracked as rustc input dependencies. Cleanup durably advances the inactive slot before atomically renaming the capture to a tombstone. Therefore:

- a later selection of that exact feature/target/toolchain unit is Dirty and regenerates the capture
- an interrupted state write retains one valid slot
- an interrupted directory removal leaves a recognized tombstone for the next cleanup
- a warm build after regeneration remains Fresh

Legacy captures created before this protocol are skipped; a one-time ordinary `cargo clean` is documented for those.

## Leakage test

Using one isolated target directory and `example-flat` with default, `unstable`, `internal`, and all features:

- before this PR: 4 retained build hashes, each with a 4-file capture set (about 79 KiB total in this small fixture)
- after `cargo prebindgen clean`: 0 `out/prebindgen` directories
- selecting `unstable` again: exactly that producer became Dirty because its state slot changed, recreated one valid capture, then remained Fresh and byte-stable on the next build

## Verification

- `cargo +1.85.0 test -p prebindgen -p prebindgen-proc-macro --all-features --no-fail-fast`
- `cargo test --all --all-features --no-fail-fast`
- `cargo clippy --all-targets --all-features -- --deny warnings`
- repository CI rustfmt configuration
- strict `prebindgen` rustdoc warnings check
- `cargo check --target aarch64-unknown-linux-gnu -p prebindgen --bin cargo-prebindgen`
- `./examples/regen-check.sh` (all committed bindings byte-identical)
- package file-list check (the Cargo subcommand and protocol are included)
- downstream `example-cbindgen` build
- synthetic legacy/new/cross-target layouts, malformed state, symlinks, dry-run, tombstone recovery, and both lock generations
- live Cargo build contention: cleanup exited before mutation, the build completed normally, cleanup succeeded afterward
- two simultaneous cleaners: one removed the captures and the other safely observed zero
- 8 rapid clean → state-dirty rebuild → fresh rebuild cycles, all successful

Closes #397