### PR TITLE
Emit the Kotlin too, and ask cbindgen for the header (#198, step 2b)

### DIFF
--- a/docs/shape-matrix.md
+++ b/docs/shape-matrix.md
@@ -45,7 +45,8 @@ not a rewrite.
 |---|---|---|
 | 1 | The enumerator, both targets, committed report + regen gate | **landed** ([#400](https://github.com/milyin/prebindgen/pull/400)) |
 | 2 | Receipts: rustc accepts the emitted Rust | **landed** ([#403](https://github.com/milyin/prebindgen/pull/403)) |
-| 2b | The rest of `ToolchainCompiled`, and `RuntimeExercised` | not started |
+| 2b | Kotlin emitted, and cbindgen asked for the header | **landed** ([#404](https://github.com/milyin/prebindgen/pull/404)) |
+| 2c | The Kotlin compiler, and `RuntimeExercised` | not started |
 | 3 | The minimum-guarantees table | not started |
 | 4 | Multi-parameter aliasing fixtures | not started |
 | 5 | The adapter-policy axis | JNI half ready; C half blocked |
@@ -92,13 +93,28 @@ compile, and three defects in this harness — each of which had been reporting 
 confident wrong answer. That is the argument for this step in one sentence:
 `plan` was worth less than it looked.
 
-### 2b. The rest of the toolchain
+### 2b. Both halves, and the header — landed
 
-`cbindgen` does not run, so a C cell that compiles has not been shown to produce
-a valid header; the Kotlin compiler does not run either. `RuntimeExercised` needs
-the JVM covertest and the C smoke tests, and the same receipt rule applies — a
-fixture emits its cell id only *after* the relevant assertion has executed, and a
-cell with no receipt keeps the weaker state whatever any table claims.
+Two stages cells were passing without reaching. **JNI produced no Kotlin at all**
+— the driver wrote the Rust and stopped, so a passing cell had shown the half a
+Kotlin caller never sees. And **C stopped at rustc**, which is the wrong finish
+line: what a C consumer gets is a header, and a signature rustc accepts can be
+one cbindgen skips or cannot name.
+
+The header receipt is that the wrapper is *declared*, not that cbindgen returned
+`Ok` — it returns `Ok` for a header declaring nothing.
+
+The ladders differ by target now, and the report says so rather than levelling to
+the shorter one: `header` for C, `rustc` for JNI.
+
+### 2c. The Kotlin compiler, and the runtime
+
+The Kotlin emitted in 2b is written but never compiled, so the JNI ladder still
+ends one stage short of C's; closing it needs kotlinc in CI.
+`RuntimeExercised` needs the JVM covertest and the C smoke tests, under the same
+receipt rule — a fixture emits its cell id only *after* the relevant assertion
+has executed, and a cell with no receipt keeps the weaker state whatever any
+table claims.
 
 ### 3. The minimum-guarantees table
 

--- a/docs/shape-matrix.md
+++ b/docs/shape-matrix.md
@@ -45,7 +45,7 @@ not a rewrite.
 |---|---|---|
 | 1 | The enumerator, both targets, committed report + regen gate | **landed** ([#400](https://github.com/milyin/prebindgen/pull/400)) |
 | 2 | Receipts: rustc accepts the emitted Rust | **landed** ([#403](https://github.com/milyin/prebindgen/pull/403)) |
-| 2b | Kotlin emitted, and cbindgen asked for the header | **landed** ([#404](https://github.com/milyin/prebindgen/pull/404)) |
+| 2b | Kotlin emitted, and cbindgen asked for the header | **landed** ([#405](https://github.com/milyin/prebindgen/pull/405)) |
 | 2c | The Kotlin compiler, and `RuntimeExercised` | not started |
 | 3 | The minimum-guarantees table | not started |
 | 4 | Multi-parameter aliasing fixtures | not started |

--- a/examples/shape-matrix/Cargo.toml
+++ b/examples/shape-matrix/Cargo.toml
@@ -13,3 +13,6 @@ prebindgen-jni = { workspace = true }
 syn = { workspace = true }
 quote = { workspace = true }
 tempfile = { workspace = true }
+# The C side's second half: the same version `examples/example-cbindgen`
+# pins, so a header this crate judges is the header that example produces.
+cbindgen = "=0.29.4"

--- a/examples/shape-matrix/REPORT.md
+++ b/examples/shape-matrix/REPORT.md
@@ -10,7 +10,10 @@ never by a hand-written list of what is supposed to work. See
 
 | Cell | Meaning |
 |---|---|
-| `rustc` | the generator produced Rust **and rustc accepted it**. Neither cbindgen nor the Kotlin compiler has seen it. |
+| `header` | C only: rustc accepted the Rust **and cbindgen declared the wrapper in a header**. The furthest any cell gets today. |
+| `rustc` | the generator produced Rust and rustc accepted it. For JNI this is the top of the ladder — the Kotlin compiler does not run here, though the Kotlin **is** generated, and a cell whose Kotlin cannot be written is `rejected`. |
+| **`no decl`** | cbindgen produced a header that does not declare the wrapper — nothing a C program can call. |
+| **`bad header`** | cbindgen refused the emitted Rust, or panicked on it. |
 | **`bad rust`** | the generator produced Rust that does not compile. Green unit tests can coexist with this — that is why the check exists. |
 | `plan` | generation succeeded and the compile check did not run (see the run's stderr). |
 | `rejected` | the generator refused the shape **and said why**. The intended outcome for anything unsupported. |
@@ -28,38 +31,40 @@ failing cell prints its diagnostics on the run's stderr.
 
 ## Summary
 
-| Target | rustc | bad rust | plan only | rejected | panic | n/a |
-|---|---:|---:|---:|---:|---:|---:|
-| C | 45 | 5 | 0 | 41 | 31 | 22 |
-| Kotlin/JNI | 75 | 5 | 0 | 34 | 8 | 22 |
+| Target | header | rustc | bad header | bad rust | rejected | panic | n/a |
+|---|---:|---:|---:|---:|---:|---:|---:|
+| C | 45 | 0 | 0 | 5 | 41 | 31 | 22 |
+| Kotlin/JNI | 0 | 75 | 0 | 5 | 34 | 8 | 22 |
+
+The two targets stop at different stages: a C cell goes on to cbindgen, a Kotlin/JNI cell stops at rustc because this crate does not run the Kotlin compiler. `rustc` is therefore the top state for JNI and an intermediate one for C.
 
 ## Position: parameter
 
 | Shape | Rust | C | Kotlin/JNI |
 |---|---|---|---|
-| `scalar` | `u64` | rustc | rustc |
-| `bool` | `bool` | rustc | rustc |
+| `scalar` | `u64` | header | rustc |
+| `bool` | `bool` | header | rustc |
 | `unit` | `()` | rejected | rejected |
-| `string` | `String` | rustc | rustc |
-| `str_ref` | `&str` | rustc | rustc |
-| `record` | `Rec` | rustc | rustc |
-| `handle` | `Handle` | rustc | rustc |
-| `sum` | `Sum` | rustc | rustc |
-| `unit_enum` | `Mode` | rustc | rustc |
+| `string` | `String` | header | rustc |
+| `str_ref` | `&str` | header | rustc |
+| `record` | `Rec` | header | rustc |
+| `handle` | `Handle` | header | rustc |
+| `sum` | `Sum` | header | rustc |
+| `unit_enum` | `Mode` | header | rustc |
 | `shared_ref` | `&Rec` | rejected | rustc |
 | `exclusive_ref` | `&mut Rec` | rejected | **bad rust** |
-| `handle_ref` | `&Handle` | rustc | rustc |
+| `handle_ref` | `&Handle` | header | rustc |
 | `out_param` | `&mut MaybeUninit<u64>` | rejected | **bad rust** |
-| `opt_scalar` | `Option<u64>` | rustc | rustc |
+| `opt_scalar` | `Option<u64>` | header | rustc |
 | `vec_scalar` | `Vec<u64>` | rejected | rejected |
-| `slice_scalar` | `&[u64]` | rustc | rejected |
+| `slice_scalar` | `&[u64]` | header | rejected |
 | `slice_mut_scalar` | `&mut [u64]` | rejected | rejected |
 | `array_scalar` | `[u8; 4]` | rejected | rustc |
 | `boxed_scalar` | `Box<u64>` | rejected | rejected |
 | `cow_str` | `Cow<'static, str>` | rejected | **bad rust** |
 | `opt_record` | `Option<Rec>` | **bad rust** | rustc |
-| `opt_handle` | `Option<Handle>` | rustc | rustc |
-| `opt_ref` | `Option<&Handle>` | rustc | rustc |
+| `opt_handle` | `Option<Handle>` | header | rustc |
+| `opt_ref` | `Option<&Handle>` | header | rustc |
 | `vec_record` | `Vec<Rec>` | rejected | rustc |
 | `vec_handle` | `Vec<Handle>` | rejected | **panic** |
 | `vec_ref` | `Vec<&Handle>` | rejected | **panic** |
@@ -116,39 +121,39 @@ failing cell prints its diagnostics on the run's stderr.
 
 | Shape | Rust | C | Kotlin/JNI |
 |---|---|---|---|
-| `scalar` | `u64` | rustc | rustc |
-| `bool` | `bool` | rustc | rustc |
-| `unit` | `()` | rustc | rustc |
-| `string` | `String` | rustc | rustc |
+| `scalar` | `u64` | header | rustc |
+| `bool` | `bool` | header | rustc |
+| `unit` | `()` | header | rustc |
+| `string` | `String` | header | rustc |
 | `str_ref` | `&str` | rejected | rustc |
-| `record` | `Rec` | rustc | rustc |
-| `handle` | `Handle` | rustc | rustc |
-| `sum` | `Sum` | rustc | rustc |
-| `unit_enum` | `Mode` | rustc | rustc |
+| `record` | `Rec` | header | rustc |
+| `handle` | `Handle` | header | rustc |
+| `sum` | `Sum` | header | rustc |
+| `unit_enum` | `Mode` | header | rustc |
 | `shared_ref` | `&Rec` | rejected | rejected |
 | `exclusive_ref` | `&mut Rec` | rejected | rejected |
-| `handle_ref` | `&Handle` | rustc | rustc |
+| `handle_ref` | `&Handle` | header | rustc |
 | `out_param` | `&mut MaybeUninit<u64>` | rejected | rejected |
-| `opt_scalar` | `Option<u64>` | rustc | rustc |
-| `vec_scalar` | `Vec<u64>` | rustc | rustc |
+| `opt_scalar` | `Option<u64>` | header | rustc |
+| `vec_scalar` | `Vec<u64>` | header | rustc |
 | `slice_scalar` | `&[u64]` | **bad rust** | rejected |
 | `slice_mut_scalar` | `&mut [u64]` | rejected | rejected |
 | `array_scalar` | `[u8; 4]` | rejected | rustc |
 | `boxed_scalar` | `Box<u64>` | rejected | rejected |
 | `cow_str` | `Cow<'static, str>` | rejected | rustc |
-| `opt_record` | `Option<Rec>` | rustc | rustc |
-| `opt_handle` | `Option<Handle>` | rustc | rustc |
-| `opt_ref` | `Option<&Handle>` | rustc | rustc |
-| `vec_record` | `Vec<Rec>` | rustc | rustc |
-| `vec_handle` | `Vec<Handle>` | rustc | rustc |
+| `opt_record` | `Option<Rec>` | header | rustc |
+| `opt_handle` | `Option<Handle>` | header | rustc |
+| `opt_ref` | `Option<&Handle>` | header | rustc |
+| `vec_record` | `Vec<Rec>` | header | rustc |
+| `vec_handle` | `Vec<Handle>` | header | rustc |
 | `vec_ref` | `Vec<&Handle>` | **bad rust** | rustc |
-| `vec_sum` | `Vec<Sum>` | rustc | rustc |
-| `opt_sum` | `Option<Sum>` | rustc | rustc |
+| `vec_sum` | `Vec<Sum>` | header | rustc |
+| `opt_sum` | `Option<Sum>` | header | rustc |
 | `array_record` | `[Rec; 2]` | rejected | rejected |
-| `opt_vec` | `Option<Vec<u64>>` | rustc | rustc |
+| `opt_vec` | `Option<Vec<u64>>` | header | rustc |
 | `vec_opt` | `Vec<Option<u64>>` | **panic** | rustc |
-| `result_scalar` | `Result<u64, ZError>` | rustc | rustc |
-| `result_handle` | `Result<Handle, ZError>` | rustc | rustc |
+| `result_scalar` | `Result<u64, ZError>` | header | rustc |
+| `result_handle` | `Result<Handle, ZError>` | header | rustc |
 | `result_sum_err` | `Result<u64, Sum>` | **panic** | rejected |
 | `callback` | `impl Fn(u64) + Send + Sync + 'static` | rejected | rejected |
 | `callback_handle` | `impl Fn(Handle) + Send + Sync + 'static` | rejected | rejected |
@@ -185,14 +190,14 @@ failing cell prints its diagnostics on the run's stderr.
 
 | Shape | Rust | C | Kotlin/JNI |
 |---|---|---|---|
-| `scalar` | `u64` | rustc | rustc |
-| `bool` | `bool` | rustc | rustc |
+| `scalar` | `u64` | header | rustc |
+| `bool` | `bool` | header | rustc |
 | `unit` | `()` | **panic** | rejected |
-| `string` | `String` | rustc | rustc |
+| `string` | `String` | header | rustc |
 | `str_ref` | `&str` | — | — |
 | `record` | `Rec` | **panic** | rustc |
 | `handle` | `Handle` | **panic** | rustc |
-| `sum` | `Sum` | rustc | rustc |
+| `sum` | `Sum` | header | rustc |
 | `unit_enum` | `Mode` | **panic** | rustc |
 | `shared_ref` | `&Rec` | — | — |
 | `exclusive_ref` | `&mut Rec` | — | — |
@@ -263,15 +268,15 @@ failing cell prints its diagnostics on the run's stderr.
 
 | Shape | Rust | C | Kotlin/JNI |
 |---|---|---|---|
-| `scalar` | `u64` | rustc | rustc |
-| `bool` | `bool` | rustc | rustc |
+| `scalar` | `u64` | header | rustc |
+| `bool` | `bool` | header | rustc |
 | `unit` | `()` | rejected | **panic** |
-| `string` | `String` | rustc | rustc |
+| `string` | `String` | header | rustc |
 | `str_ref` | `&str` | — | — |
-| `record` | `Rec` | rustc | rustc |
-| `handle` | `Handle` | rustc | rustc |
-| `sum` | `Sum` | rustc | **panic** |
-| `unit_enum` | `Mode` | rustc | rustc |
+| `record` | `Rec` | header | rustc |
+| `handle` | `Handle` | header | rustc |
+| `sum` | `Sum` | header | **panic** |
+| `unit_enum` | `Mode` | header | rustc |
 | `shared_ref` | `&Rec` | — | — |
 | `exclusive_ref` | `&mut Rec` | — | — |
 | `handle_ref` | `&Handle` | — | — |
@@ -303,8 +308,8 @@ failing cell prints its diagnostics on the run's stderr.
 <details><summary>What the generators said</summary>
 
 - `unit` / C: 2 required type(s) could not be resolved: — error: unresolved prebindgen input type `Probe` — error: unresolved prebindgen input type `()`
-- `unit` / Kotlin/JNI: builder interface spec derivable for a registered declaration
-- `sum` / Kotlin/JNI: builder interface spec derivable for a registered declaration
+- `unit` / Kotlin/JNI: sealed_class!(Probe) payload `Carried.v0`: `()` has no Kotlin type mapping on its output converter
+- `sum` / Kotlin/JNI: sealed_class!(Probe) payload `Carried.v0`: `Sum` has no resolved OUTPUT converter, so the Kotlin surface for it cannot be derived — register converters for the payload type before declaring the sealed class
 - `opt_scalar` / C: Cbindgen::tagged_union: payload `Probe::Carried` of type `Option < u64 >` cannot cross: its input and output converters disagree on the wire (`* const u64` in, `()` out) and one union field serves both directions
 - `vec_scalar` / C: Cbindgen::tagged_union: payload `Probe::Carried` of type `Vec < u64 >` cannot cross: a `Vec` needs TWO C wires (pointer + length) and one union field carries only one, so its length would be silently dropped — hand the sequence over thro…
 - `vec_scalar` / Kotlin/JNI: 1 required type(s) could not be resolved: — error: unresolved prebindgen output type `Vec < u64 >`

--- a/examples/shape-matrix/src/header.rs
+++ b/examples/shape-matrix/src/header.rs
@@ -1,0 +1,120 @@
+//! Does the emitted Rust become a C header a caller can use?
+//!
+//! rustc accepting the file is the wrong finish line for the C target. What a C
+//! consumer gets is a **header**, produced from that file by `cbindgen`, and the
+//! two can disagree: an `extern "C"` signature rustc is perfectly happy with can
+//! be one cbindgen skips, renders as an opaque it never defines, or cannot name
+//! at all. A cell whose function is missing from the header is a cell no C
+//! program can call.
+//!
+//! # The receipt
+//!
+//! Not "cbindgen returned `Ok`" — it returns `Ok` for a header that declares
+//! nothing. The receipt is that **the wrapper this cell exists to export is
+//! declared in the output**, which is the weakest claim a C caller actually
+//! depends on.
+//!
+//! The pinned cbindgen version is the one `examples/example-cbindgen` pins, so
+//! this judges the same header that example produces rather than a different
+//! tool's opinion of the same Rust.
+
+use std::panic::AssertUnwindSafe;
+
+/// What became of one cell's header.
+pub enum Header {
+    /// cbindgen declared the exported wrapper.
+    Declared,
+    /// cbindgen ran and the wrapper is not in the output.
+    Missing,
+    /// cbindgen refused the file, or panicked on it.
+    Failed(String),
+}
+
+impl Header {
+    pub fn is_ok(&self) -> bool {
+        matches!(self, Header::Declared)
+    }
+
+    /// What to print when it is not `Declared`.
+    pub fn detail(&self) -> Option<String> {
+        match self {
+            Header::Declared => None,
+            Header::Missing => {
+                Some("cbindgen produced a header that does not declare the wrapper".to_string())
+            }
+            Header::Failed(why) => Some(why.clone()),
+        }
+    }
+}
+
+/// Run cbindgen over one cell's emitted Rust.
+///
+/// `exported` is the symbol a C caller would link against — the wrapper's name
+/// after the binding's own mangling, since that is what ends up in the header.
+pub fn generate(emitted: &str, exported: &str) -> Header {
+    let dir = match tempfile::tempdir() {
+        Ok(dir) => dir,
+        Err(e) => return Header::Failed(format!("creating a temporary directory: {e}")),
+    };
+    let src = dir.path().join("generated.rs");
+    if let Err(e) = std::fs::write(&src, emitted) {
+        return Header::Failed(format!("writing the emitted Rust: {e}"));
+    }
+
+    // cbindgen parses source it was not given a crate for, and is entitled to
+    // give up loudly. A panic here is an answer about the cell, exactly as it is
+    // for the generators themselves.
+    let previous = std::panic::take_hook();
+    std::panic::set_hook(Box::new(|_| {}));
+    let outcome = std::panic::catch_unwind(AssertUnwindSafe(|| {
+        cbindgen::Builder::new()
+            .with_src(&src)
+            .with_language(cbindgen::Language::C)
+            .generate()
+            .map(|bindings| {
+                let mut header = Vec::new();
+                bindings.write(&mut header);
+                String::from_utf8_lossy(&header).into_owned()
+            })
+    }));
+    std::panic::set_hook(previous);
+
+    match outcome {
+        Ok(Ok(header)) => {
+            if declares(&header, exported) {
+                Header::Declared
+            } else {
+                Header::Missing
+            }
+        }
+        Ok(Err(e)) => Header::Failed(format!("cbindgen: {e:?}")),
+        Err(payload) => Header::Failed(format!("cbindgen panicked: {}", panic_text(payload))),
+    }
+}
+
+/// Whether the header declares `exported` as a function.
+///
+/// The name followed by an open parenthesis, not merely the name: cbindgen
+/// carries doc comments through, so a header that only *mentions* the wrapper
+/// would otherwise count as declaring it — a receipt that passes on prose is
+/// not a receipt.
+fn declares(header: &str, exported: &str) -> bool {
+    header.match_indices(exported).any(|(at, _)| {
+        let before_is_boundary = header[..at]
+            .chars()
+            .next_back()
+            .is_none_or(|c| !c.is_alphanumeric() && c != '_');
+        let after = header[at + exported.len()..].trim_start();
+        before_is_boundary && after.starts_with('(')
+    })
+}
+
+fn panic_text(payload: Box<dyn std::any::Any + Send>) -> String {
+    if let Some(s) = payload.downcast_ref::<&str>() {
+        (*s).to_string()
+    } else if let Some(s) = payload.downcast_ref::<String>() {
+        s.clone()
+    } else {
+        "a non-string payload".to_string()
+    }
+}

--- a/examples/shape-matrix/src/lib.rs
+++ b/examples/shape-matrix/src/lib.rs
@@ -38,12 +38,15 @@
 //!
 //! Every cell that produces Rust is then handed to rustc ([`check`]), because
 //! "the generator produced a file" and "the file compiles" are different claims
-//! and only the second is worth much.
+//! and only the second is worth much. For the C target there is a third:
+//! [`header`] asks cbindgen whether that file becomes a header actually
+//! declaring the wrapper, since a header is what a C caller is given.
 //!
 //! Run it with `cargo run -p shape-matrix`, which rewrites `REPORT.md`.
 
 pub mod check;
 pub mod corpus;
+pub mod header;
 pub mod report;
 pub mod run;
 pub mod tag;

--- a/examples/shape-matrix/src/report.rs
+++ b/examples/shape-matrix/src/report.rs
@@ -9,6 +9,7 @@ use std::fmt::Write as _;
 use crate::{
     check::{self, Unit},
     corpus::{Position, Shape, SHAPES},
+    header::{self, Header},
     run::{declarations, run, ClassKind, State, Target},
     tag::TypeTag,
 };
@@ -40,6 +41,11 @@ struct Cell {
     /// to check — the generator refused the cell, or the check could not run at
     /// all, which is not a verdict about the cell either.
     compiled: Option<bool>,
+    /// What cbindgen made of it. `None` for every JNI cell — that target's next
+    /// stage is the Kotlin compiler, which this crate does not run — and for
+    /// any cell whose Rust did not compile, since there would be nothing sound
+    /// to hand on.
+    header: Option<Header>,
 }
 
 impl Cell {
@@ -54,13 +60,30 @@ impl Cell {
         )
     }
 
-    /// What the table prints.
+    /// What the table prints: the furthest stage this cell reached.
+    ///
+    /// The ladders differ by target and say so, rather than being levelled to
+    /// the shorter one: C runs one stage further than JNI does here, and
+    /// printing `rustc` for a C cell whose header is fine would throw away the
+    /// stronger evidence.
     fn text(&self) -> String {
         match (&self.state, self.compiled) {
-            (State::PlanSupported, Some(true)) => "rustc".to_string(),
+            (State::PlanSupported, Some(true)) => match &self.header {
+                None => "rustc".to_string(),
+                Some(Header::Declared) => "header".to_string(),
+                Some(Header::Missing) => "**no decl**".to_string(),
+                Some(Header::Failed(_)) => "**bad header**".to_string(),
+            },
             (State::PlanSupported, Some(false)) => "**bad rust**".to_string(),
             (state, _) => state.cell(),
         }
+    }
+
+    /// The line the diagnostics list carries for this cell, if any.
+    fn detail(&self) -> Option<String> {
+        self.state
+            .detail()
+            .or_else(|| self.header.as_ref().and_then(Header::detail))
     }
 }
 
@@ -82,6 +105,7 @@ fn run_all() -> Vec<Cell> {
                     target: *target,
                     state: outcome.state,
                     compiled: None,
+                    header: None,
                 };
                 if let Some(emitted) = outcome.emitted {
                     units.push(Unit {
@@ -107,6 +131,18 @@ fn run_all() -> Vec<Cell> {
                     cell.compiled = Some(checked.compiled.contains(&cell.id()));
                 }
             }
+            // Only what compiles goes on to cbindgen: a header derived from
+            // Rust that does not build says nothing about the cell.
+            for cell in &mut cells {
+                if cell.target == Target::C && cell.compiled == Some(true) {
+                    let emitted = units
+                        .iter()
+                        .find(|u| u.id == cell.id())
+                        .map(|u| u.emitted.as_str())
+                        .unwrap_or_default();
+                    cell.header = Some(header::generate(emitted, crate::run::PROBE_FN));
+                }
+            }
             for (id, messages) in &checked.failed {
                 eprintln!("shape-matrix: {id} emitted Rust that does not compile:");
                 for message in messages {
@@ -122,8 +158,8 @@ fn run_all() -> Vec<Cell> {
 
 fn render_summary(out: &mut String, results: &[Cell]) {
     out.push_str("## Summary\n\n");
-    out.push_str("| Target | rustc | bad rust | plan only | rejected | panic | n/a |\n");
-    out.push_str("|---|---:|---:|---:|---:|---:|---:|\n");
+    out.push_str("| Target | header | rustc | bad header | bad rust | rejected | panic | n/a |\n");
+    out.push_str("|---|---:|---:|---:|---:|---:|---:|---:|\n");
     for target in Target::ALL {
         let of = |f: fn(&Cell) -> bool| {
             results
@@ -133,16 +169,23 @@ fn render_summary(out: &mut String, results: &[Cell]) {
         };
         let _ = writeln!(
             out,
-            "| {} | {} | {} | {} | {} | {} | {} |",
+            "| {} | {} | {} | {} | {} | {} | {} | {} |",
             target.as_str(),
-            of(|c| c.compiled == Some(true)),
+            of(|c| c.header.as_ref().is_some_and(Header::is_ok)),
+            of(|c| c.compiled == Some(true) && c.header.is_none()),
+            of(|c| c.header.as_ref().is_some_and(|h| !h.is_ok())),
             of(|c| c.compiled == Some(false)),
-            of(|c| matches!(c.state, State::PlanSupported) && c.compiled.is_none()),
             of(|c| matches!(c.state, State::Rejected(_))),
             of(|c| matches!(c.state, State::Panicked(_))),
             of(|c| matches!(c.state, State::NotApplicable(_))),
         );
     }
+    out.push_str(
+        "\nThe two targets stop at different stages: a C cell goes on to cbindgen, \
+         a Kotlin/JNI cell stops at rustc because this crate does not run the Kotlin \
+         compiler. `rustc` is therefore the top state for JNI and an intermediate \
+         one for C.\n",
+    );
     out.push('\n');
 }
 
@@ -173,7 +216,7 @@ fn render_position(out: &mut String, results: &[Cell], position: Position) {
 
     let mut notes: Vec<String> = Vec::new();
     for cell in results.iter().filter(|c| c.position == position) {
-        if let Some(detail) = cell.state.detail() {
+        if let Some(detail) = cell.detail() {
             notes.push(format!(
                 "- `{}` / {}: {}",
                 cell.shape.id,
@@ -272,7 +315,10 @@ never by a hand-written list of what is supposed to work. See
 
 | Cell | Meaning |
 |---|---|
-| `rustc` | the generator produced Rust **and rustc accepted it**. Neither cbindgen nor the Kotlin compiler has seen it. |
+| `header` | C only: rustc accepted the Rust **and cbindgen declared the wrapper in a header**. The furthest any cell gets today. |
+| `rustc` | the generator produced Rust and rustc accepted it. For JNI this is the top of the ladder — the Kotlin compiler does not run here, though the Kotlin **is** generated, and a cell whose Kotlin cannot be written is `rejected`. |
+| **`no decl`** | cbindgen produced a header that does not declare the wrapper — nothing a C program can call. |
+| **`bad header`** | cbindgen refused the emitted Rust, or panicked on it. |
 | **`bad rust`** | the generator produced Rust that does not compile. Green unit tests can coexist with this — that is why the check exists. |
 | `plan` | generation succeeded and the compile check did not run (see the run\'s stderr). |
 | `rejected` | the generator refused the shape **and said why**. The intended outcome for anything unsupported. |

--- a/examples/shape-matrix/src/run.rs
+++ b/examples/shape-matrix/src/run.rs
@@ -25,8 +25,9 @@ use crate::corpus::{Need, Position, Shape};
 /// out by conflating them.
 pub const SOURCE_CRATE: &str = "flat";
 
-/// The function every fixture declares to the target.
-const PROBE_FN: &str = "probe";
+/// The function every fixture declares to the target, and — since neither
+/// binding renames it — the symbol a C caller links against.
+pub const PROBE_FN: &str = "probe";
 
 /// The struct or enum a `Field` / `Payload` fixture wraps the shape in.
 const PROBE_TY: &str = "Probe";
@@ -448,6 +449,17 @@ fn run_jni(source: &str, decls: &[Decl]) -> Result<String, String> {
         builder = builder.expand(decl);
     }
     let generation = builder.build().map_err(|e| e.to_string())?;
+
+    // Kotlin is half of what this target produces, and until it is asked for,
+    // a cell reporting success has shown only the Rust half. A binding whose
+    // Kotlin cannot be written is not a binding.
+    let kotlin_dir = tempfile::tempdir().map_err(|e| e.to_string())?;
+    let written = generation
+        .write_kotlin(kotlin_dir.path())
+        .map_err(|e| e.to_string())?;
+    if written.is_empty() {
+        return Err("the binding produced no Kotlin at all".to_string());
+    }
 
     read_back(|path| generation.write_rust(path).map_err(|e| e.to_string()))
 }

--- a/examples/shape-matrix/src/tests.rs
+++ b/examples/shape-matrix/src/tests.rs
@@ -1,6 +1,7 @@
 use super::*;
 use crate::{
     corpus::{Position, SHAPES},
+    header,
     run::{declarations, kind_of, not_applicable, ClassKind, Target},
 };
 
@@ -183,6 +184,28 @@ fn the_compile_check_separates_good_from_bad() {
         checked.failed.contains_key("selftest_bad__param__jni"),
         "the failing unit produced no attributed diagnostic, so nothing links a \
          compiler error to the cell it belongs to"
+    );
+}
+
+/// The header stage must discriminate, and on the right thing.
+///
+/// "cbindgen returned `Ok`" would pass for a header declaring nothing at all,
+/// so the receipt is that the wrapper is *declared*. The negative control is
+/// the same Rust with the `extern "C"` removed: still valid Rust, still parsed
+/// happily, and of no use whatsoever to a C caller.
+#[test]
+fn the_header_stage_requires_a_declaration() {
+    let exported = r#"#[no_mangle] pub unsafe extern "C" fn probe(v: u64) -> u64 { v }"#;
+    assert!(
+        header::generate(exported, "probe").is_ok(),
+        "an exported wrapper was not found in the header cbindgen produced"
+    );
+
+    let not_exported = "pub fn probe(v: u64) -> u64 { v }";
+    assert!(
+        !header::generate(not_exported, "probe").is_ok(),
+        "a function C cannot call was reported as declared — the stage is \
+         reporting a state it did not establish"
     );
 }
 


### PR DESCRIPTION
Step 2b of #198, on `shape-coverage` (#402). Two stages cells were passing without ever reaching.

## JNI produced no Kotlin at all

The driver called `write_rust` and stopped. So a `rustc` cell had shown half of what the target emits — and not the half a Kotlin caller ever sees. The binding now writes its Kotlin too, and a binding whose Kotlin cannot be written (or that produces none) is a rejection like any other.

**No cell moved.** Every JNI cell that emits Rust also emits Kotlin, so this buys no new state today. It closes the hole where one would otherwise have hidden — a Kotlin-emission regression was previously invisible to every cell in the table.

## C stopped at rustc, which is the wrong finish line

What a C consumer is given is a **header**, produced from the emitted Rust by cbindgen, and the two can disagree: a signature rustc is perfectly happy with can be one cbindgen skips, renders as an opaque it never defines, or cannot name. A cell whose wrapper is missing from the header is a cell no C program can call.

`header` is now the top C state, pinned to the same cbindgen version `example-cbindgen` uses — so this judges the header *that example produces*, not another tool's opinion of the same Rust.

## The receipt is a declaration, not an `Ok`

cbindgen returns `Ok` for a header that declares nothing, so "it ran" would have been a state established by nothing. The receipt is that the wrapper is **declared**: the exported name at a word boundary followed by an open parenthesis, because cbindgen carries doc comments through and a receipt that can pass on prose is not a receipt.

`the_header_stage_requires_a_declaration` is the discrimination check. The negative control is the same Rust with `extern "C"` removed — still valid Rust, still parsed happily, still useless to a C caller:

```
extern fn: declared=true  detail=None
plain fn:  declared=false detail=Some("cbindgen produced a header that does not declare the wrapper")
```

## Exit: answers move — one class, 45 cells

| Transition | n |
|---|---:|
| `rustc` → `header` | 45 |

Every C cell whose Rust compiles also yields a header declaring its wrapper. So this stage adds **evidence, not findings** — which is worth having on its own terms: it is the difference between *"no C cell is known to be broken here"* and *"no C cell has been asked"*.

## The ladders differ by target now

C runs one stage further than JNI, and the report says so rather than levelling to the shorter one — printing `rustc` for a C cell whose header is fine would throw away the stronger evidence.

| Target | header | rustc | bad rust | rejected | panic | n/a |
|---|---:|---:|---:|---:|---:|---:|
| C | 45 | 0 | 5 | 41 | 31 | 22 |
| Kotlin/JNI | 0 | 75 | 5 | 34 | 8 | 22 |

## Left for 2c

The Kotlin is written but never compiled, so the JNI ladder still ends one stage short of C's; closing it needs kotlinc in CI. `RuntimeExercised` needs the JVM covertest and the C smoke tests, under the same receipt rule.

## Checks

`cargo test -p shape-matrix` (10 tests), clippy `-D warnings` on all targets and features, `cargo fmt --check` with CI's config, `RUSTDOCFLAGS=-D warnings cargo doc`, and `examples/regen-check.sh` clean with every other committed artifact byte-identical.
