### PR TITLE
A floor per cell: shapes may improve, and may not quietly get worse (#198, step 3)

### DIFF
--- a/docs/shape-matrix.md
+++ b/docs/shape-matrix.md
@@ -47,7 +47,7 @@ not a rewrite.
 | 2 | Receipts: rustc accepts the emitted Rust | **landed** ([#403](https://github.com/milyin/prebindgen/pull/403)) |
 | 2b | Kotlin emitted, and cbindgen asked for the header | **landed** ([#405](https://github.com/milyin/prebindgen/pull/405)) |
 | 2c | The Kotlin compiler, and `RuntimeExercised` | not started |
-| 3 | The minimum-guarantees table | not started |
+| 3 | The guarantee ratchet — a floor per cell | **landed** ([#406](https://github.com/milyin/prebindgen/pull/406)) |
 | 4 | Multi-parameter aliasing fixtures | not started |
 | 5 | The adapter-policy axis | JNI half ready; C half blocked |
 | 6 | Plan-level invariants | blocked |
@@ -116,15 +116,22 @@ receipt rule — a fixture emits its cell id only *after* the relevant assertion
 has executed, and a cell with no receipt keeps the weaker state whatever any
 table claims.
 
-### 3. The minimum-guarantees table
+### 3. The guarantee ratchet — landed
 
-A committed table of `must plan` / `must compile` / `must execute` for shapes
-already shipped. A cell listed `must execute` that reports only `PlanSupported`
-fails the build. Seeded from what downstream depends on and from every cell the
-covertest already touches.
+A floor per cell, in a committed `GUARANTEES.md`: the level it has been seen to
+reach. Rising is free; falling fails a test naming the cell and both levels.
 
-This is the second gate on top of the committed report: the report catches a
-*changed* answer, this catches an answer that was never strong enough.
+This is the gate the report cannot be. A byte-identity diff shows a cell getting
+worse in the same shade as one getting better, so it catches a regression only if
+a reviewer reads the diff and knows which direction is which. A floor does not
+need a reviewer.
+
+**Raising is automatic (`--update-guarantees`); lowering is a hand edit.** Giving
+up on a shape that used to work should cost a visible line in a diff, not a
+silently regenerated artifact.
+
+The `must execute` level the issue also asks for waits on step 2c — there is no
+runtime state for a floor to stand on yet.
 
 ### 4. Aliasing fixtures
 

--- a/examples/shape-matrix/GUARANTEES.md
+++ b/examples/shape-matrix/GUARANTEES.md
@@ -1,0 +1,148 @@
+<!-- Floors are raised by `cargo run -p shape-matrix -- --update-guarantees`.
+     Lowering one is a hand edit, on purpose. -->
+# Guaranteed levels
+
+The level each cell has been seen to reach. A cell may rise above its floor
+freely; falling below it fails `no_cell_falls_below_its_guarantee`, which names
+the cell and both levels.
+
+This is the gate the committed `REPORT.md` cannot be: a byte-identity diff shows
+a cell getting worse in exactly the same shade as one getting better, so it
+catches a regression only if a reviewer reads the diff and knows which direction
+is which. A floor does not need a reviewer.
+
+`header` is the top of C's ladder and `compiles` the top of Kotlin/JNI's, since
+this crate does not run the Kotlin compiler yet.
+
+| Cell | Floor |
+|---|---|
+| `array_scalar__field__jni` | `compiles` |
+| `array_scalar__param__jni` | `compiles` |
+| `array_scalar__payload__jni` | `compiles` |
+| `array_scalar__ret__jni` | `compiles` |
+| `bool__field__c` | `header` |
+| `bool__field__jni` | `compiles` |
+| `bool__param__c` | `header` |
+| `bool__param__jni` | `compiles` |
+| `bool__payload__c` | `header` |
+| `bool__payload__jni` | `compiles` |
+| `bool__ret__c` | `header` |
+| `bool__ret__jni` | `compiles` |
+| `callback__param__jni` | `compiles` |
+| `callback_handle__param__jni` | `compiles` |
+| `cow_str__field__jni` | `generates` |
+| `cow_str__param__jni` | `generates` |
+| `cow_str__payload__jni` | `generates` |
+| `cow_str__ret__jni` | `compiles` |
+| `exclusive_ref__param__jni` | `generates` |
+| `handle__field__jni` | `compiles` |
+| `handle__param__c` | `header` |
+| `handle__param__jni` | `compiles` |
+| `handle__payload__c` | `header` |
+| `handle__payload__jni` | `compiles` |
+| `handle__ret__c` | `header` |
+| `handle__ret__jni` | `compiles` |
+| `handle_ref__param__c` | `header` |
+| `handle_ref__param__jni` | `compiles` |
+| `handle_ref__ret__c` | `header` |
+| `handle_ref__ret__jni` | `compiles` |
+| `opt_handle__field__jni` | `compiles` |
+| `opt_handle__param__c` | `header` |
+| `opt_handle__param__jni` | `compiles` |
+| `opt_handle__payload__c` | `generates` |
+| `opt_handle__payload__jni` | `compiles` |
+| `opt_handle__ret__c` | `header` |
+| `opt_handle__ret__jni` | `compiles` |
+| `opt_record__field__jni` | `compiles` |
+| `opt_record__param__c` | `generates` |
+| `opt_record__param__jni` | `compiles` |
+| `opt_record__payload__jni` | `compiles` |
+| `opt_record__ret__c` | `header` |
+| `opt_record__ret__jni` | `compiles` |
+| `opt_ref__param__c` | `header` |
+| `opt_ref__param__jni` | `compiles` |
+| `opt_ref__ret__c` | `header` |
+| `opt_ref__ret__jni` | `compiles` |
+| `opt_scalar__field__jni` | `compiles` |
+| `opt_scalar__param__c` | `header` |
+| `opt_scalar__param__jni` | `compiles` |
+| `opt_scalar__payload__jni` | `compiles` |
+| `opt_scalar__ret__c` | `header` |
+| `opt_scalar__ret__jni` | `compiles` |
+| `opt_sum__field__jni` | `compiles` |
+| `opt_sum__param__c` | `generates` |
+| `opt_sum__param__jni` | `compiles` |
+| `opt_sum__ret__c` | `header` |
+| `opt_sum__ret__jni` | `compiles` |
+| `opt_vec__ret__c` | `header` |
+| `opt_vec__ret__jni` | `compiles` |
+| `out_param__param__jni` | `generates` |
+| `record__field__jni` | `compiles` |
+| `record__param__c` | `header` |
+| `record__param__jni` | `compiles` |
+| `record__payload__c` | `header` |
+| `record__payload__jni` | `compiles` |
+| `record__ret__c` | `header` |
+| `record__ret__jni` | `compiles` |
+| `result_handle__payload__jni` | `compiles` |
+| `result_handle__ret__c` | `header` |
+| `result_handle__ret__jni` | `compiles` |
+| `result_scalar__payload__jni` | `compiles` |
+| `result_scalar__ret__c` | `header` |
+| `result_scalar__ret__jni` | `compiles` |
+| `result_sum_err__payload__jni` | `compiles` |
+| `scalar__field__c` | `header` |
+| `scalar__field__jni` | `compiles` |
+| `scalar__param__c` | `header` |
+| `scalar__param__jni` | `compiles` |
+| `scalar__payload__c` | `header` |
+| `scalar__payload__jni` | `compiles` |
+| `scalar__ret__c` | `header` |
+| `scalar__ret__jni` | `compiles` |
+| `shared_ref__param__jni` | `compiles` |
+| `slice_scalar__param__c` | `header` |
+| `slice_scalar__ret__c` | `generates` |
+| `str_ref__param__c` | `header` |
+| `str_ref__param__jni` | `compiles` |
+| `str_ref__ret__jni` | `compiles` |
+| `string__field__c` | `header` |
+| `string__field__jni` | `compiles` |
+| `string__param__c` | `header` |
+| `string__param__jni` | `compiles` |
+| `string__payload__c` | `header` |
+| `string__payload__jni` | `compiles` |
+| `string__ret__c` | `header` |
+| `string__ret__jni` | `compiles` |
+| `sum__field__c` | `header` |
+| `sum__field__jni` | `compiles` |
+| `sum__param__c` | `header` |
+| `sum__param__jni` | `compiles` |
+| `sum__payload__c` | `header` |
+| `sum__ret__c` | `header` |
+| `sum__ret__jni` | `compiles` |
+| `unit__ret__c` | `header` |
+| `unit__ret__jni` | `compiles` |
+| `unit_enum__field__jni` | `compiles` |
+| `unit_enum__param__c` | `header` |
+| `unit_enum__param__jni` | `compiles` |
+| `unit_enum__payload__c` | `header` |
+| `unit_enum__payload__jni` | `compiles` |
+| `unit_enum__ret__c` | `header` |
+| `unit_enum__ret__jni` | `compiles` |
+| `vec_handle__ret__c` | `header` |
+| `vec_handle__ret__jni` | `compiles` |
+| `vec_opt__param__jni` | `compiles` |
+| `vec_opt__payload__jni` | `compiles` |
+| `vec_opt__ret__jni` | `compiles` |
+| `vec_record__field__jni` | `compiles` |
+| `vec_record__param__jni` | `compiles` |
+| `vec_record__payload__jni` | `compiles` |
+| `vec_record__ret__c` | `header` |
+| `vec_record__ret__jni` | `compiles` |
+| `vec_ref__ret__c` | `generates` |
+| `vec_ref__ret__jni` | `compiles` |
+| `vec_scalar__ret__c` | `header` |
+| `vec_scalar__ret__jni` | `compiles` |
+| `vec_sum__param__jni` | `compiles` |
+| `vec_sum__ret__c` | `header` |
+| `vec_sum__ret__jni` | `compiles` |

--- a/examples/shape-matrix/src/guarantees.rs
+++ b/examples/shape-matrix/src/guarantees.rs
@@ -1,0 +1,191 @@
+//! The ratchet: cells may improve, and may not quietly get worse.
+//!
+//! The committed report already makes every changed answer a reviewed diff. That
+//! catches a regression only if somebody reads the diff and knows which
+//! direction is bad — and a diff shows `header` becoming `rejected` in exactly
+//! the same shade as the reverse.
+//!
+//! So each cell that produces something carries a **floor**: the level it has
+//! been seen to reach. Rising above it is free and silent. Falling below it
+//! fails a test that names the cell and both levels. The two gates answer
+//! different questions — *"did anything move?"* and *"did anything move
+//! **down**?"* — and only the second can be enforced without a reviewer.
+//!
+//! # Raising is automatic, lowering is a hand edit
+//!
+//! `cargo run -p shape-matrix -- --update-guarantees` raises floors to what the
+//! run just achieved and **never lowers one**. Removing a guarantee means
+//! editing this file by hand, which is the point: giving up on a shape that used
+//! to work should cost a line in a diff that a reviewer can see and argue with,
+//! not a silently regenerated artifact.
+
+use std::{collections::BTreeMap, fmt::Write as _};
+
+use crate::report::Cell;
+
+/// How far a cell got, as an ordered ladder.
+///
+/// `Ord` is the whole mechanism: a floor is a `>=` comparison, so the ladder's
+/// order is a load-bearing property rather than a presentation detail.
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug)]
+pub enum Level {
+    /// The generator refused the shape, panicked, or the placement is not Rust.
+    /// No floor is recorded for these — a cell that never worked is not a
+    /// regression waiting to happen.
+    Nothing,
+    /// Something was generated, and rustc has not accepted it.
+    Generates,
+    /// The emitted Rust compiles.
+    Compiles,
+    /// C only: cbindgen declares the wrapper. The top of C's ladder; JNI's ends
+    /// at [`Level::Compiles`] until the Kotlin compiler runs.
+    Header,
+}
+
+impl Level {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Level::Nothing => "nothing",
+            Level::Generates => "generates",
+            Level::Compiles => "compiles",
+            Level::Header => "header",
+        }
+    }
+
+    fn parse(text: &str) -> Option<Level> {
+        [
+            Level::Nothing,
+            Level::Generates,
+            Level::Compiles,
+            Level::Header,
+        ]
+        .into_iter()
+        .find(|level| level.as_str() == text)
+    }
+}
+
+/// Where the committed floors live, relative to this crate.
+pub const PATH: &str = "GUARANTEES.md";
+
+/// One cell falling below its floor.
+pub struct Regression {
+    pub id: String,
+    pub floor: Level,
+    pub now: Level,
+}
+
+impl std::fmt::Display for Regression {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}: was guaranteed to reach `{}`, now reaches only `{}`",
+            self.id,
+            self.floor.as_str(),
+            self.now.as_str()
+        )
+    }
+}
+
+/// Every floor the committed file records.
+pub fn committed() -> BTreeMap<String, Level> {
+    parse(&read())
+}
+
+fn read() -> String {
+    std::fs::read_to_string(std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join(PATH))
+        .unwrap_or_default()
+}
+
+fn parse(text: &str) -> BTreeMap<String, Level> {
+    let mut floors = BTreeMap::new();
+    for line in text.lines() {
+        // Table rows only: `| cell | level |`. Everything else in the file is
+        // prose, and prose is not data.
+        let mut columns = line.split('|').map(str::trim).filter(|c| !c.is_empty());
+        let (Some(id), Some(level)) = (columns.next(), columns.next()) else {
+            continue;
+        };
+        let id = id.trim_matches('`');
+        if let Some(level) = Level::parse(level.trim_matches('`')) {
+            floors.insert(id.to_string(), level);
+        }
+    }
+    floors
+}
+
+/// What a survey achieved, per cell.
+pub fn observed(cells: &[Cell]) -> BTreeMap<String, Level> {
+    cells.iter().map(|cell| (cell.id(), cell.level())).collect()
+}
+
+/// The cells that have fallen below their floor.
+///
+/// Split from [`committed`] so the rule can be tested against floors this crate
+/// states rather than only against the ones on disk — a gate whose behaviour can
+/// only be observed by breaking the repository is a gate nobody checks.
+pub fn regressions_of(
+    floors: &BTreeMap<String, Level>,
+    observed: &BTreeMap<String, Level>,
+) -> Vec<Regression> {
+    floors
+        .iter()
+        .filter_map(|(id, floor)| {
+            let now = *observed.get(id)?;
+            (now < *floor).then_some(Regression {
+                id: id.clone(),
+                floor: *floor,
+                now,
+            })
+        })
+        .collect()
+}
+
+/// The cells that have fallen below their committed floor.
+pub fn regressions(cells: &[Cell]) -> Vec<Regression> {
+    regressions_of(&committed(), &observed(cells))
+}
+
+/// Floors raised to what a run achieved. **Never lowered** — that is the
+/// ratchet, and the reason this is not simply "write down what happened".
+pub fn raised(
+    mut floors: BTreeMap<String, Level>,
+    observed: &BTreeMap<String, Level>,
+) -> BTreeMap<String, Level> {
+    for (id, level) in observed {
+        let entry = floors.entry(id.clone()).or_insert(Level::Nothing);
+        *entry = (*entry).max(*level);
+    }
+    floors.retain(|_, level| *level > Level::Nothing);
+    floors
+}
+
+/// The file's contents after this run.
+pub fn updated(cells: &[Cell]) -> String {
+    let floors = raised(committed(), &observed(cells));
+
+    let mut out = String::from(HEADER);
+    out.push_str("| Cell | Floor |\n|---|---|\n");
+    for (id, level) in &floors {
+        let _ = writeln!(out, "| `{id}` | `{}` |", level.as_str());
+    }
+    out
+}
+
+const HEADER: &str = "\
+<!-- Floors are raised by `cargo run -p shape-matrix -- --update-guarantees`.
+     Lowering one is a hand edit, on purpose. -->
+# Guaranteed levels
+
+The level each cell has been seen to reach. A cell may rise above its floor
+freely; falling below it fails `no_cell_falls_below_its_guarantee`, which names
+the cell and both levels.
+
+This is the gate the committed `REPORT.md` cannot be: a byte-identity diff shows
+a cell getting worse in exactly the same shade as one getting better, so it
+catches a regression only if a reviewer reads the diff and knows which direction
+is which. A floor does not need a reviewer.
+
+`header` is the top of C's ladder and `compiles` the top of Kotlin/JNI's, since
+this crate does not run the Kotlin compiler yet.
+
+";

--- a/examples/shape-matrix/src/lib.rs
+++ b/examples/shape-matrix/src/lib.rs
@@ -42,10 +42,17 @@
 //! [`header`] asks cbindgen whether that file becomes a header actually
 //! declaring the wrapper, since a header is what a C caller is given.
 //!
-//! Run it with `cargo run -p shape-matrix`, which rewrites `REPORT.md`.
+//! What a cell reached is then held as a floor ([`guarantees`]): rising is free,
+//! falling fails a test that names the cell. The committed report says *"an
+//! answer moved"*; the floor says *"an answer moved **down**"*, which is the
+//! half that does not need a reviewer to catch it.
+//!
+//! Run it with `cargo run -p shape-matrix`, which rewrites `REPORT.md`; add
+//! `-- --update-guarantees` to raise the floors to what the run achieved.
 
 pub mod check;
 pub mod corpus;
+pub mod guarantees;
 pub mod header;
 pub mod report;
 pub mod run;

--- a/examples/shape-matrix/src/main.rs
+++ b/examples/shape-matrix/src/main.rs
@@ -11,8 +11,20 @@
 use std::path::PathBuf;
 
 fn main() {
-    let dest = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(shape_matrix::REPORT_PATH);
+    let here = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+
+    let dest = here.join(shape_matrix::REPORT_PATH);
     let report = shape_matrix::report::render();
     std::fs::write(&dest, &report).expect("write REPORT.md");
     eprintln!("shape-matrix: wrote {}", dest.display());
+
+    // Raising a floor is a deliberate act, so it takes a flag. Doing it on every
+    // run would let a cell's floor follow it downwards — the ratchet would hold
+    // nothing.
+    if std::env::args().any(|arg| arg == "--update-guarantees") {
+        let dest = here.join(shape_matrix::guarantees::PATH);
+        let updated = shape_matrix::guarantees::updated(shape_matrix::report::survey());
+        std::fs::write(&dest, &updated).expect("write GUARANTEES.md");
+        eprintln!("shape-matrix: raised floors in {}", dest.display());
+    }
 }

--- a/examples/shape-matrix/src/report.rs
+++ b/examples/shape-matrix/src/report.rs
@@ -14,16 +14,27 @@ use crate::{
     tag::TypeTag,
 };
 
+/// Every cell's outcome, computed once per process.
+///
+/// Memoized because two consumers want it — the report and the guarantee
+/// ratchet — and a survey costs a full pass over both generators plus a cargo
+/// check. Running it twice in one test binary would double the suite's time to
+/// produce the same answer.
+pub fn survey() -> &'static [Cell] {
+    static SURVEY: std::sync::OnceLock<Vec<Cell>> = std::sync::OnceLock::new();
+    SURVEY.get_or_init(run_all)
+}
+
 /// The whole report.
 pub fn render() -> String {
     let mut out = String::new();
     out.push_str(HEADER);
 
-    let results = run_all();
+    let results = survey();
 
-    render_summary(&mut out, &results);
+    render_summary(&mut out, results);
     for position in Position::ALL {
-        render_position(&mut out, &results, *position);
+        render_position(&mut out, results, *position);
     }
     render_coverage(&mut out);
     render_class_coverage(&mut out);
@@ -32,7 +43,7 @@ pub fn render() -> String {
 }
 
 /// One row of the run: every cell, in corpus order.
-struct Cell {
+pub struct Cell {
     shape: &'static Shape,
     position: Position,
     target: Target,
@@ -51,7 +62,7 @@ struct Cell {
 impl Cell {
     /// `<shape>__<position>__<target>` — the receipt key, and the name of the
     /// file rustc reports against.
-    fn id(&self) -> String {
+    pub fn id(&self) -> String {
         format!(
             "{}__{}__{}",
             self.shape.id,
@@ -76,6 +87,25 @@ impl Cell {
             },
             (State::PlanSupported, Some(false)) => "**bad rust**".to_string(),
             (state, _) => state.cell(),
+        }
+    }
+
+    /// How far this cell got, on the ladder the guarantee ratchet compares.
+    ///
+    /// Derived from the same fields the table prints, so a cell cannot be
+    /// guaranteed at a level the report does not show.
+    pub fn level(&self) -> crate::guarantees::Level {
+        use crate::guarantees::Level;
+        match (&self.state, self.compiled) {
+            (State::PlanSupported, Some(true)) => match &self.header {
+                None => Level::Compiles,
+                Some(h) if h.is_ok() => Level::Header,
+                // A header stage that ran and failed is *worse* than not having
+                // run: the Rust compiles and the C caller still gets nothing.
+                Some(_) => Level::Compiles,
+            },
+            (State::PlanSupported, _) => Level::Generates,
+            _ => Level::Nothing,
         }
     }
 

--- a/examples/shape-matrix/src/tests.rs
+++ b/examples/shape-matrix/src/tests.rs
@@ -1,7 +1,9 @@
+use std::collections::BTreeMap;
+
 use super::*;
 use crate::{
     corpus::{Position, SHAPES},
-    header,
+    guarantees, header,
     run::{declarations, kind_of, not_applicable, ClassKind, Target},
 };
 
@@ -206,6 +208,87 @@ fn the_header_stage_requires_a_declaration() {
         !header::generate(not_exported, "probe").is_ok(),
         "a function C cannot call was reported as declared — the stage is \
          reporting a state it did not establish"
+    );
+}
+
+/// The ratchet, against the floors this repository actually commits.
+#[test]
+fn no_cell_falls_below_its_guarantee() {
+    let regressions = guarantees::regressions(report::survey());
+    assert!(
+        regressions.is_empty(),
+        "cells got worse:\n{}\n\nIf this is deliberate — a shape given up on, \
+         or a declaration that changed meaning — lower the floor in {} by hand \
+         in the same commit, so the decision appears in the diff.",
+        regressions
+            .iter()
+            .map(|r| format!("  {r}"))
+            .collect::<Vec<_>>()
+            .join("\n"),
+        guarantees::PATH
+    );
+}
+
+/// The ratchet must catch a fall, and must not catch a rise.
+///
+/// Otherwise it is a file nobody can tell is working: the committed floors are
+/// all satisfied, so the passing gate above proves only that nothing regressed
+/// *today*, not that a regression would be noticed.
+#[test]
+fn the_ratchet_catches_a_fall_and_ignores_a_rise() {
+    use guarantees::Level;
+    let floors = BTreeMap::from([
+        ("fell__param__c".to_string(), Level::Header),
+        ("rose__param__jni".to_string(), Level::Generates),
+        ("held__param__jni".to_string(), Level::Compiles),
+    ]);
+    let observed = BTreeMap::from([
+        ("fell__param__c".to_string(), Level::Compiles),
+        ("rose__param__jni".to_string(), Level::Compiles),
+        ("held__param__jni".to_string(), Level::Compiles),
+    ]);
+
+    let found = guarantees::regressions_of(&floors, &observed);
+    let ids: Vec<&str> = found.iter().map(|r| r.id.as_str()).collect();
+    assert_eq!(
+        ids,
+        vec!["fell__param__c"],
+        "the ratchet must report exactly the cell that fell"
+    );
+}
+
+/// Raising is automatic; lowering is not. A run that does worse than the
+/// committed floor must leave that floor standing, or the ratchet would follow
+/// the regression down and hold nothing.
+#[test]
+fn updating_never_lowers_a_floor() {
+    use guarantees::Level;
+    let floors = BTreeMap::from([("cell__param__c".to_string(), Level::Header)]);
+    let observed = BTreeMap::from([("cell__param__c".to_string(), Level::Generates)]);
+
+    let after = guarantees::raised(floors, &observed);
+    assert_eq!(
+        after.get("cell__param__c"),
+        Some(&Level::Header),
+        "a floor followed a cell downwards"
+    );
+}
+
+/// Every floor must name a cell the matrix actually enumerates. A stale entry —
+/// a renamed shape, a dropped position — would sit in the file being satisfied
+/// by nothing at all.
+#[test]
+fn every_guarantee_names_a_live_cell() {
+    let observed = guarantees::observed(report::survey());
+    let committed = guarantees::committed();
+    let stale: Vec<&String> = committed
+        .keys()
+        .filter(|id| !observed.contains_key(*id))
+        .collect();
+    assert!(
+        stale.is_empty(),
+        "these floors name cells that no longer exist: {stale:?}\n\
+         Remove them, or restore the cell they were about."
     );
 }
 


### PR DESCRIPTION
Step 3 of #198, on `shape-coverage` (#402).

## Why the committed report is not enough

`REPORT.md` makes every changed answer a reviewed diff. But it shows a cell going `header` → `rejected` in **exactly the same shade** as one going the other way, so it catches a regression only if a reviewer reads the diff and knows which direction is which.

Two different questions:

| Gate | Question | Needs a reviewer? |
|---|---|---|
| committed `REPORT.md` | did anything move? | yes |
| `GUARANTEES.md` | did anything move **down**? | no |

## The ratchet

Each cell that produces something carries a **floor** — the level it has been seen to reach. 130 floors: 45 at `header`, 75 at `compiles`, 10 at `generates` (50 C cells, 80 JNI).

Rising above a floor is free and silent. Falling below it fails a test that names the cell, the floor, and where it is now:

```
cells got worse:
  array_scalar__field__jni: was guaranteed to reach `header`, now reaches only `compiles`
```

**Raising is automatic, lowering is a hand edit.** `cargo run -p shape-matrix -- --update-guarantees` raises floors and never lowers one. That asymmetry is the whole mechanism: if the file were rewritten on every run, a floor would follow its cell downwards and the ratchet would hold nothing. Giving up on a shape that used to work should cost a line in a diff a reviewer can argue with.

The ladder is **per target**, because C runs one stage further: `header` is C's ceiling, `compiles` is JNI's until the Kotlin compiler runs. A shared ceiling would let a C cell lose its header without falling below any floor.

## Tests

Four, and three of them exist because a gate nobody has seen fail is a gate nobody can trust:

- the ratchet reports exactly the cell that fell and ignores the one that rose;
- `--update-guarantees` leaves a floor standing when the run does worse — the ratchet's integrity, tested directly;
- every floor names a cell the matrix still enumerates, so a renamed shape cannot leave an entry behind being satisfied by nothing at all;
- and the live gate, against the floors this repository commits.

The first three run on synthetic floors rather than on the repository's, deliberately: a rule whose behaviour can only be observed by breaking the repo is a rule nobody checks. I also verified it end-to-end by hand — claiming `header` for a JNI cell produces the failure above — and reverted.

## Exit: answer-preserving

`REPORT.md` is byte-identical. This stage adds a second gate over the same measurements and moves none of them.

One performance note: `report::survey()` is now memoized, so the report and the ratchet share one pass over both generators plus one `cargo check`, rather than doubling the suite's cost to compute the same answer twice. The suite runs in ~4s.

## Not in this step

The issue also asks for a `must execute` level. There is no runtime state for a floor to stand on until step 2c, so the ladder stops at `header`.

## Checks

`cargo test -p shape-matrix` (14 tests), clippy `-D warnings` over all targets and features, `cargo fmt --check` with CI's config, `RUSTDOCFLAGS=-D warnings cargo doc`, and `REPORT.md` unchanged.
