### PR TITLE
Address captures by content, not by the process that wrote them (#201)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,4 +52,3 @@ itertools = "0.14.0"
 if_rust_version = "1.0"
 konst = "0.3.0" # consumer crates need konst too: the generated file emits a konst::assertc_eq! guard
 toml = "0.9.5"
-rand = "0.9.2"

--- a/prebindgen-proc-macro/Cargo.toml
+++ b/prebindgen-proc-macro/Cargo.toml
@@ -26,7 +26,6 @@ syn = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 prebindgen = { workspace = true }
-rand = { workspace = true }
 
 [features]
 debug = ["prebindgen/debug"]

--- a/prebindgen-proc-macro/src/lib.rs
+++ b/prebindgen-proc-macro/src/lib.rs
@@ -36,11 +36,9 @@
 //!
 //! See also: [`prebindgen`](https://docs.rs/prebindgen) for the main processing library.
 //!
-use std::{cell::RefCell, collections::HashSet};
-
 use prebindgen::{
     get_prebindgen_out_dir,
-    layout::{capture_file_name, group_dir_name, GROUP_NAME_FILE},
+    layout::{capture_file_name, group_dir_name, MAX_COMPONENT_LEN},
     utils::publish_file,
     Record, RecordKind, SourceLocation, DEFAULT_GROUP_NAME,
 };
@@ -140,11 +138,10 @@ impl Parse for PrebindgenArgs {
     }
 }
 
-/// Publish `record` under the path its own contents determine, and make sure
-/// the group directory records the group's exact name.
+/// Publish `record` under the path its own contents determine.
 ///
 /// The path is derived from the **record**, never from the process or the
-/// compilation that produced it: `{OUT_DIR}/prebindgen/{digest(group)}_{group}/
+/// compilation that produced it: `{OUT_DIR}/prebindgen/g_{group}/
 /// {name}_{digest(record)}.jsonl` (see `prebindgen::layout`). Every compiler
 /// that captures this item computes this same path and writes these same
 /// bytes, so repeated compilations — `cargo check`, `build`, `test`, `clippy`,
@@ -160,29 +157,22 @@ fn publish_record(
     record: &Record,
     serialized: &str,
 ) -> std::result::Result<(), String> {
-    let group_dir = get_prebindgen_out_dir().join(group_dir_name(group));
-
-    // The directory digests the group name, which is not reversible; the name
-    // itself goes beside the records so `Source` can report the group a
-    // consumer selects by. Written before the first record of the group, so a
-    // directory holding captures always names itself.
-    let group_name_file = group_dir.join(GROUP_NAME_FILE);
-    let is_first_record_of_group =
-        GROUPS.with(|groups| groups.borrow_mut().insert(group.to_string()));
-    if is_first_record_of_group {
-        publish_file(&group_name_file, group).map_err(|error| format!("prebindgen: {error}"))?;
+    let group_dir = group_dir_name(group);
+    if group_dir.len() > MAX_COMPONENT_LEN {
+        return Err(format!(
+            "#[prebindgen] group name {group:?} is too long: it encodes to {} bytes, \
+             and a directory name may hold {MAX_COMPONENT_LEN}",
+            group_dir.len()
+        ));
     }
 
     publish_file(
-        group_dir.join(capture_file_name(&record.name, serialized)),
+        get_prebindgen_out_dir()
+            .join(group_dir)
+            .join(capture_file_name(&record.name, serialized)),
         &format!("{serialized}\n"),
     )
     .map_err(|error| format!("prebindgen: {error}"))
-}
-
-thread_local! {
-    /// Groups whose name file this thread has already published.
-    static GROUPS: RefCell<HashSet<String>> = RefCell::new(HashSet::new());
 }
 
 /// Attribute macro that exports FFI definitions for use in language-specific binding crates.

--- a/prebindgen-proc-macro/src/lib.rs
+++ b/prebindgen-proc-macro/src/lib.rs
@@ -36,12 +36,14 @@
 //!
 //! See also: [`prebindgen`](https://docs.rs/prebindgen) for the main processing library.
 //!
-use std::{
-    collections::hash_map::DefaultHasher,
-    hash::{Hash, Hasher},
-};
+use std::{cell::RefCell, collections::HashSet};
 
-use prebindgen::{get_prebindgen_out_dir, Record, RecordKind, SourceLocation, DEFAULT_GROUP_NAME};
+use prebindgen::{
+    get_prebindgen_out_dir,
+    layout::{capture_file_name, group_dir_name, GROUP_NAME_FILE},
+    utils::publish_file,
+    Record, RecordKind, SourceLocation, DEFAULT_GROUP_NAME,
+};
 use proc_macro::TokenStream;
 use quote::quote;
 use syn::{
@@ -138,84 +140,49 @@ impl Parse for PrebindgenArgs {
     }
 }
 
-/// Longest run of a record's name kept in its file name; the digest that
-/// follows carries the identity, this part is only there to be read by a human.
-const NAME_STEM_LIMIT: usize = 48;
-
-/// Where a record is stored: `{OUT_DIR}/prebindgen/{group}/{name}_{digest}.jsonl`.
+/// Publish `record` under the path its own contents determine, and make sure
+/// the group directory records the group's exact name.
 ///
 /// The path is derived from the **record**, never from the process or the
-/// compilation that produced it. Every compiler that captures this item
-/// computes this same path and writes these same bytes, so repeated
-/// compilations — `cargo check`, `build`, `test`, `clippy`, and the doctest
-/// rustdoc run Cargo never caches — rewrite one file instead of accumulating a
-/// copy each (#201).
+/// compilation that produced it: `{OUT_DIR}/prebindgen/{digest(group)}_{group}/
+/// {name}_{digest(record)}.jsonl` (see `prebindgen::layout`). Every compiler
+/// that captures this item computes this same path and writes these same
+/// bytes, so repeated compilations — `cargo check`, `build`, `test`, `clippy`,
+/// and the doctest rustdoc run Cargo never caches — rewrite one file instead of
+/// accumulating a copy each (#201).
 ///
-/// It also makes the layout loss-proof by construction rather than by careful
-/// key derivation: the file name determines the contents, so two writers either
-/// write identical bytes to one path or different bytes to different paths.
-/// There is no third case in which one compilation can overwrite another's
-/// records.
-///
-/// The digest is what makes that hold, so it is not decoration:
-///
-/// - `#[cfg(test)] fn f` and the crate's own `fn f` are different records with
-///   one name, and their units compile in parallel.
-/// - macOS and Windows fold case, and Rust is happy to have both `struct Foo`
-///   and `fn foo`.
-fn get_prebindgen_jsonl_path(group: &str, name: &str, serialized: &str) -> std::path::PathBuf {
-    get_prebindgen_out_dir()
-        .join(group)
-        .join(capture_file_name(name, serialized))
+/// That also makes the layout loss-proof by construction rather than by careful
+/// key derivation: a name determines its contents, so two writers either write
+/// identical bytes to one path or different bytes to different paths. There is
+/// no third case in which one compilation overwrites another's records.
+fn publish_record(
+    group: &str,
+    record: &Record,
+    serialized: &str,
+) -> std::result::Result<(), String> {
+    let group_dir = get_prebindgen_out_dir().join(group_dir_name(group));
+
+    // The directory digests the group name, which is not reversible; the name
+    // itself goes beside the records so `Source` can report the group a
+    // consumer selects by. Written before the first record of the group, so a
+    // directory holding captures always names itself.
+    let group_name_file = group_dir.join(GROUP_NAME_FILE);
+    let is_first_record_of_group =
+        GROUPS.with(|groups| groups.borrow_mut().insert(group.to_string()));
+    if is_first_record_of_group {
+        publish_file(&group_name_file, group).map_err(|error| format!("prebindgen: {error}"))?;
+    }
+
+    publish_file(
+        group_dir.join(capture_file_name(&record.name, serialized)),
+        &format!("{serialized}\n"),
+    )
+    .map_err(|error| format!("prebindgen: {error}"))
 }
 
-/// `{name}_{digest}.jsonl` — the part of the path this crate decides.
-fn capture_file_name(name: &str, serialized: &str) -> String {
-    let mut file_name = String::with_capacity(NAME_STEM_LIMIT + 23);
-    for character in name.chars().take(NAME_STEM_LIMIT) {
-        // Rust identifiers admit non-ASCII characters, which filesystems then
-        // normalize differently; keep the readable part strictly boring.
-        file_name.push(if character.is_ascii_alphanumeric() {
-            character
-        } else {
-            '_'
-        });
-    }
-    file_name.push('_');
-    file_name.push_str(&digest(serialized));
-    file_name.push_str(".jsonl");
-    file_name
-}
-
-/// 16 hexadecimal digits over the record's serialized form — the same bytes the
-/// capture file holds, so equal digests mean equal files.
-fn digest(serialized: &str) -> String {
-    let mut hasher = DefaultHasher::new();
-    serialized.hash(&mut hasher);
-    format!("{:016x}", hasher.finish())
-}
-
-/// Groups become directories, so a name has to be one path component.
-///
-/// Rejecting the rest is what lets `Source` recover the group from the
-/// directory name. The previous flat layout spelled the group as a file-name
-/// prefix up to the first `_`, which silently truncated any group containing
-/// one (`"my_group"` was discovered as `"my"`) and would have let a `/` in a
-/// group name write outside the capture directory.
-fn validate_group(group: &str) -> std::result::Result<(), String> {
-    if group.is_empty() {
-        return Err("#[prebindgen] group name must not be empty".to_string());
-    }
-    if let Some(character) = group
-        .chars()
-        .find(|character| !character.is_ascii_alphanumeric() && !matches!(character, '_' | '-'))
-    {
-        return Err(format!(
-            "#[prebindgen] group name {group:?} contains {character:?}; \
-             group names become directory names and may only use ASCII letters, digits, `_` and `-`"
-        ));
-    }
-    Ok(())
+thread_local! {
+    /// Groups whose name file this thread has already published.
+    static GROUPS: RefCell<HashSet<String>> = RefCell::new(HashSet::new());
 }
 
 /// Attribute macro that exports FFI definitions for use in language-specific binding crates.
@@ -275,11 +242,6 @@ pub fn prebindgen(args: TokenStream, input: TokenStream) -> TokenStream {
     let parsed_args = syn::parse::<PrebindgenArgs>(args).expect("Invalid #[prebindgen] arguments");
 
     let group = parsed_args.group;
-    if let Err(error) = validate_group(&group) {
-        return syn::Error::new(proc_macro2::Span::call_site(), error)
-            .to_compile_error()
-            .into();
-    }
 
     // Try to parse as different item types
     let (kind, name, content, span) = if let Ok(parsed) = syn::parse::<DeriveInput>(input.clone()) {
@@ -359,11 +321,8 @@ pub fn prebindgen(args: TokenStream, input: TokenStream) -> TokenStream {
                 .into()
         }
     };
-    let file_path = get_prebindgen_jsonl_path(&group, &new_record.name, &serialized);
-    if let Err(error) = prebindgen::utils::write_record_file(&file_path, &serialized) {
-        return syn::Error::new(span, format!("prebindgen: {error}"))
-            .to_compile_error()
-            .into();
+    if let Err(error) = publish_record(&group, &new_record, &serialized) {
+        return syn::Error::new(span, error).to_compile_error().into();
     }
 
     // Re-emit the original item, optionally prepending `#[cfg(...)]` (from the
@@ -489,67 +448,4 @@ pub fn manifest_dir(_input: TokenStream) -> TokenStream {
         .expect("CARGO_MANIFEST_DIR environment variable not set");
     let lit = syn::LitStr::new(&dir, proc_macro2::Span::call_site());
     TokenStream::from(quote! { #lit })
-}
-
-#[cfg(test)]
-mod tests {
-    use super::{capture_file_name, validate_group, NAME_STEM_LIMIT};
-
-    const DIGEST_LEN: usize = 16;
-
-    #[test]
-    fn the_file_name_is_determined_by_the_record() {
-        // Same record, any number of compilations: one path, one file.
-        assert_eq!(
-            capture_file_name("Foo", r#"{"name":"Foo"}"#),
-            capture_file_name("Foo", r#"{"name":"Foo"}"#)
-        );
-        // Changed record: a different file, so no writer can ever overwrite a
-        // capture that holds something else.
-        assert_ne!(
-            capture_file_name("Foo", r#"{"name":"Foo"}"#),
-            capture_file_name("Foo", r#"{"name":"Foo","cfg":"test"}"#)
-        );
-    }
-
-    #[test]
-    fn case_folding_filesystems_do_not_collide() {
-        // macOS and Windows fold case, and `struct Foo` may live beside `fn foo`.
-        let struct_foo = capture_file_name("Foo", r#"{"kind":"struct","name":"Foo"}"#);
-        let fn_foo = capture_file_name("foo", r#"{"kind":"function","name":"foo"}"#);
-        assert_ne!(struct_foo.to_lowercase(), fn_foo.to_lowercase());
-    }
-
-    #[test]
-    fn the_readable_part_is_ascii_and_bounded() {
-        let unicode = capture_file_name("\u{dc}n\u{ef}c\u{f6}d\u{e9}", r#"{"name":"unicode"}"#);
-        assert!(unicode.is_ascii(), "{unicode}");
-
-        let long = capture_file_name(&"a".repeat(NAME_STEM_LIMIT * 4), r#"{"name":"long"}"#);
-        assert_eq!(
-            long.len(),
-            NAME_STEM_LIMIT + 1 + DIGEST_LEN + ".jsonl".len()
-        );
-    }
-
-    #[test]
-    fn group_names_must_be_one_path_component() {
-        for accepted in ["default", "structs", "my_group", "with-dash", "v2"] {
-            assert!(validate_group(accepted).is_ok(), "{accepted}");
-        }
-        // A group becomes a directory: anything that could escape it, name a
-        // parent, or vary by filesystem is refused at the item.
-        for rejected in [
-            "",
-            "a/b",
-            "a\\b",
-            "..",
-            ".",
-            "gr\u{fc}ppe",
-            "with space",
-            "a:b",
-        ] {
-            assert!(validate_group(rejected).is_err(), "{rejected:?}");
-        }
-    }
 }

--- a/prebindgen-proc-macro/src/lib.rs
+++ b/prebindgen-proc-macro/src/lib.rs
@@ -36,7 +36,10 @@
 //!
 //! See also: [`prebindgen`](https://docs.rs/prebindgen) for the main processing library.
 //!
-use std::{collections::HashMap, fs::OpenOptions};
+use std::{
+    collections::hash_map::DefaultHasher,
+    hash::{Hash, Hasher},
+};
 
 use prebindgen::{get_prebindgen_out_dir, Record, RecordKind, SourceLocation, DEFAULT_GROUP_NAME};
 use proc_macro::TokenStream;
@@ -135,51 +138,84 @@ impl Parse for PrebindgenArgs {
     }
 }
 
-thread_local! {
-    static THREAD_ID: std::cell::RefCell<Option<u64>> = const { std::cell::RefCell::new(None) };
-    static JSONL_PATHS: std::cell::RefCell<HashMap<String, std::path::PathBuf>> = std::cell::RefCell::new(HashMap::new());
+/// Longest run of a record's name kept in its file name; the digest that
+/// follows carries the identity, this part is only there to be read by a human.
+const NAME_STEM_LIMIT: usize = 48;
+
+/// Where a record is stored: `{OUT_DIR}/prebindgen/{group}/{name}_{digest}.jsonl`.
+///
+/// The path is derived from the **record**, never from the process or the
+/// compilation that produced it. Every compiler that captures this item
+/// computes this same path and writes these same bytes, so repeated
+/// compilations — `cargo check`, `build`, `test`, `clippy`, and the doctest
+/// rustdoc run Cargo never caches — rewrite one file instead of accumulating a
+/// copy each (#201).
+///
+/// It also makes the layout loss-proof by construction rather than by careful
+/// key derivation: the file name determines the contents, so two writers either
+/// write identical bytes to one path or different bytes to different paths.
+/// There is no third case in which one compilation can overwrite another's
+/// records.
+///
+/// The digest is what makes that hold, so it is not decoration:
+///
+/// - `#[cfg(test)] fn f` and the crate's own `fn f` are different records with
+///   one name, and their units compile in parallel.
+/// - macOS and Windows fold case, and Rust is happy to have both `struct Foo`
+///   and `fn foo`.
+fn get_prebindgen_jsonl_path(group: &str, name: &str, serialized: &str) -> std::path::PathBuf {
+    get_prebindgen_out_dir()
+        .join(group)
+        .join(capture_file_name(name, serialized))
 }
 
-/// Get the full path to `{group}_{pid}_{thread_id}.jsonl` generated in OUT_DIR.
-fn get_prebindgen_jsonl_path(group: &str) -> std::path::PathBuf {
-    if let Some(p) = JSONL_PATHS.with(|path| path.borrow().get(group).cloned()) {
-        return p;
-    }
-    let process_id = std::process::id();
-    let thread_id = if let Some(in_thread_id) = THREAD_ID.with(|id| *id.borrow()) {
-        in_thread_id
-    } else {
-        let new_id = rand::random::<u64>();
-        THREAD_ID.with(|id| *id.borrow_mut() = Some(new_id));
-        new_id
-    };
-    let mut random_value = None;
-    // Try to really create file and repeat until success
-    // to avoid collisions in extremely rare case when two threads got
-    // the same random value
-    let new_path = loop {
-        let postfix = if let Some(rv) = random_value {
-            format!("_{rv}")
+/// `{name}_{digest}.jsonl` — the part of the path this crate decides.
+fn capture_file_name(name: &str, serialized: &str) -> String {
+    let mut file_name = String::with_capacity(NAME_STEM_LIMIT + 23);
+    for character in name.chars().take(NAME_STEM_LIMIT) {
+        // Rust identifiers admit non-ASCII characters, which filesystems then
+        // normalize differently; keep the readable part strictly boring.
+        file_name.push(if character.is_ascii_alphanumeric() {
+            character
         } else {
-            "".to_string()
-        };
-        let path = get_prebindgen_out_dir()
-            .join(format!("{group}_{process_id}_{thread_id}{postfix}.jsonl"));
-        if OpenOptions::new()
-            .create_new(true)
-            .write(true)
-            .open(&path)
-            .is_ok()
-        {
-            break path;
-        }
-        random_value = Some(rand::random::<u32>());
-    };
-    JSONL_PATHS.with(|path| {
-        path.borrow_mut()
-            .insert(group.to_string(), new_path.clone());
-    });
-    new_path
+            '_'
+        });
+    }
+    file_name.push('_');
+    file_name.push_str(&digest(serialized));
+    file_name.push_str(".jsonl");
+    file_name
+}
+
+/// 16 hexadecimal digits over the record's serialized form — the same bytes the
+/// capture file holds, so equal digests mean equal files.
+fn digest(serialized: &str) -> String {
+    let mut hasher = DefaultHasher::new();
+    serialized.hash(&mut hasher);
+    format!("{:016x}", hasher.finish())
+}
+
+/// Groups become directories, so a name has to be one path component.
+///
+/// Rejecting the rest is what lets `Source` recover the group from the
+/// directory name. The previous flat layout spelled the group as a file-name
+/// prefix up to the first `_`, which silently truncated any group containing
+/// one (`"my_group"` was discovered as `"my"`) and would have let a `/` in a
+/// group name write outside the capture directory.
+fn validate_group(group: &str) -> std::result::Result<(), String> {
+    if group.is_empty() {
+        return Err("#[prebindgen] group name must not be empty".to_string());
+    }
+    if let Some(character) = group
+        .chars()
+        .find(|character| !character.is_ascii_alphanumeric() && !matches!(character, '_' | '-'))
+    {
+        return Err(format!(
+            "#[prebindgen] group name {group:?} contains {character:?}; \
+             group names become directory names and may only use ASCII letters, digits, `_` and `-`"
+        ));
+    }
+    Ok(())
 }
 
 /// Attribute macro that exports FFI definitions for use in language-specific binding crates.
@@ -239,6 +275,11 @@ pub fn prebindgen(args: TokenStream, input: TokenStream) -> TokenStream {
     let parsed_args = syn::parse::<PrebindgenArgs>(args).expect("Invalid #[prebindgen] arguments");
 
     let group = parsed_args.group;
+    if let Err(error) = validate_group(&group) {
+        return syn::Error::new(proc_macro2::Span::call_site(), error)
+            .to_compile_error()
+            .into();
+    }
 
     // Try to parse as different item types
     let (kind, name, content, span) = if let Ok(parsed) = syn::parse::<DeriveInput>(input.clone()) {
@@ -307,12 +348,22 @@ pub fn prebindgen(args: TokenStream, input: TokenStream) -> TokenStream {
         parsed_args.cfg.clone(),
     );
 
-    // Get the full path to the JSONL file
-    let file_path = get_prebindgen_jsonl_path(&group);
-    if prebindgen::utils::write_to_jsonl_file(&file_path, &[&new_record]).is_err() {
-        return TokenStream::from(quote! {
-            compile_error!("Failed to write prebindgen record");
-        });
+    // Publish the record under the path its own contents determine. Failures
+    // are reported at the item, not swallowed: a capture that is silently short
+    // makes the consumer generate incomplete bindings.
+    let serialized = match new_record.to_jsonl_string() {
+        Ok(serialized) => serialized,
+        Err(error) => {
+            return syn::Error::new(span, format!("prebindgen: {error}"))
+                .to_compile_error()
+                .into()
+        }
+    };
+    let file_path = get_prebindgen_jsonl_path(&group, &new_record.name, &serialized);
+    if let Err(error) = prebindgen::utils::write_record_file(&file_path, &serialized) {
+        return syn::Error::new(span, format!("prebindgen: {error}"))
+            .to_compile_error()
+            .into();
     }
 
     // Re-emit the original item, optionally prepending `#[cfg(...)]` (from the
@@ -438,4 +489,67 @@ pub fn manifest_dir(_input: TokenStream) -> TokenStream {
         .expect("CARGO_MANIFEST_DIR environment variable not set");
     let lit = syn::LitStr::new(&dir, proc_macro2::Span::call_site());
     TokenStream::from(quote! { #lit })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{capture_file_name, validate_group, NAME_STEM_LIMIT};
+
+    const DIGEST_LEN: usize = 16;
+
+    #[test]
+    fn the_file_name_is_determined_by_the_record() {
+        // Same record, any number of compilations: one path, one file.
+        assert_eq!(
+            capture_file_name("Foo", r#"{"name":"Foo"}"#),
+            capture_file_name("Foo", r#"{"name":"Foo"}"#)
+        );
+        // Changed record: a different file, so no writer can ever overwrite a
+        // capture that holds something else.
+        assert_ne!(
+            capture_file_name("Foo", r#"{"name":"Foo"}"#),
+            capture_file_name("Foo", r#"{"name":"Foo","cfg":"test"}"#)
+        );
+    }
+
+    #[test]
+    fn case_folding_filesystems_do_not_collide() {
+        // macOS and Windows fold case, and `struct Foo` may live beside `fn foo`.
+        let struct_foo = capture_file_name("Foo", r#"{"kind":"struct","name":"Foo"}"#);
+        let fn_foo = capture_file_name("foo", r#"{"kind":"function","name":"foo"}"#);
+        assert_ne!(struct_foo.to_lowercase(), fn_foo.to_lowercase());
+    }
+
+    #[test]
+    fn the_readable_part_is_ascii_and_bounded() {
+        let unicode = capture_file_name("\u{dc}n\u{ef}c\u{f6}d\u{e9}", r#"{"name":"unicode"}"#);
+        assert!(unicode.is_ascii(), "{unicode}");
+
+        let long = capture_file_name(&"a".repeat(NAME_STEM_LIMIT * 4), r#"{"name":"long"}"#);
+        assert_eq!(
+            long.len(),
+            NAME_STEM_LIMIT + 1 + DIGEST_LEN + ".jsonl".len()
+        );
+    }
+
+    #[test]
+    fn group_names_must_be_one_path_component() {
+        for accepted in ["default", "structs", "my_group", "with-dash", "v2"] {
+            assert!(validate_group(accepted).is_ok(), "{accepted}");
+        }
+        // A group becomes a directory: anything that could escape it, name a
+        // parent, or vary by filesystem is refused at the item.
+        for rejected in [
+            "",
+            "a/b",
+            "a\\b",
+            "..",
+            ".",
+            "gr\u{fc}ppe",
+            "with space",
+            "a:b",
+        ] {
+            assert!(validate_group(rejected).is_err(), "{rejected:?}");
+        }
+    }
 }

--- a/prebindgen/src/api/buildrs.rs
+++ b/prebindgen/src/api/buildrs.rs
@@ -33,17 +33,24 @@ pub fn init_prebindgen_out_dir() {
     // For doctests, use "source_ffi" even if CARGO_PKG_NAME is set to "prebindgen"
     let crate_name = env::var("CARGO_PKG_NAME").expect("CARGO_PKG_NAME environment variable not set. This function should be called from build.rs.");
 
-    // delete all files in the prebindgen directory
+    // Delete everything in the prebindgen directory. This is the generation
+    // boundary: the captures below it describe the crate as it was, and the
+    // compilations that follow rewrite them. Group *directories* have to go
+    // with the files — leaving them would keep records for items this revision
+    // renamed or removed.
     let prebindgen_dir = get_prebindgen_out_dir();
     if prebindgen_dir.exists() {
         for entry in fs::read_dir(&prebindgen_dir).unwrap() {
             let entry = entry.unwrap();
             let path = entry.path();
-            if path.is_file() {
-                fs::remove_file(&path).unwrap_or_else(|e| {
-                    panic!("Failed to delete {}: {}", path.display(), e);
-                });
-            }
+            let removed = if path.is_dir() {
+                fs::remove_dir_all(&path)
+            } else {
+                fs::remove_file(&path)
+            };
+            removed.unwrap_or_else(|e| {
+                panic!("Failed to delete {}: {}", path.display(), e);
+            });
         }
     } else {
         fs::create_dir_all(&prebindgen_dir).unwrap_or_else(|e| {

--- a/prebindgen/src/api/layout.rs
+++ b/prebindgen/src/api/layout.rs
@@ -96,6 +96,14 @@ pub fn group_dir_name(group: &str) -> String {
 
 /// The group name a directory produced by [`group_dir_name`] stands for, or
 /// `None` if it was not produced by it.
+///
+/// Only the **canonical** spelling of a name is accepted: the encoding admits
+/// redundant forms (`g_-61` decodes to `a`, as does `g_a`; `-4a` and `-4A` name
+/// one byte), and accepting a redundant one would be worse than rejecting it.
+/// Discovery would report group `a` while [`group_dir_name`] sends
+/// `Source::read_group` to `g_a`, so the records in `g_-61` would be dropped
+/// with nothing to show for it — the failure the caller's damage check exists
+/// to catch.
 pub fn decode_group_dir_name(dir_name: &str) -> Option<String> {
     let encoded = dir_name.strip_prefix(GROUP_DIR_PREFIX)?;
 
@@ -116,7 +124,9 @@ pub fn decode_group_dir_name(dir_name: &str) -> Option<String> {
             _ => return None,
         }
     }
-    String::from_utf8(bytes).ok()
+
+    let decoded = String::from_utf8(bytes).ok()?;
+    (group_dir_name(&decoded) == dir_name).then_some(decoded)
 }
 
 /// The file holding one record: `{name}_{digest}.jsonl`.

--- a/prebindgen/src/api/layout.rs
+++ b/prebindgen/src/api/layout.rs
@@ -4,53 +4,63 @@
 //! {OUT_DIR}/prebindgen/
 //!     crate_name.txt
 //!     features.txt
-//!     {digest(group)}_{group}/          <- one directory per group
-//!         group.txt                     <- the group's exact name
+//!     g_{group}/                        <- one directory per group, encoded
 //!         {name}_{digest(record)}.jsonl <- one file per captured record
 //! ```
 //!
-//! Both name components follow the same rule: **a digest carries the identity
-//! and a sanitized spelling carries the readability.** The proc-macro computes
-//! these paths when writing and [`Source`](crate::Source) computes them when
-//! reading, so they live here rather than in either crate.
+//! Nothing here is named after the process or the compilation that wrote it:
+//! every path is derived from the data it holds. The proc-macro computes these
+//! paths when writing and [`Source`](crate::Source) computes them when reading,
+//! so they live here rather than in either crate.
 //!
-//! Deriving a name from the data it holds is what keeps the layout loss-proof:
-//! the name determines the contents, so two writers either write identical
-//! bytes to one path or different bytes to different paths — never a partial
-//! overwrite of one record's capture by another's.
+//! That is what keeps the layout loss-proof: a name determines its contents, so
+//! two writers either write identical bytes to one path or different bytes to
+//! different paths — never a partial overwrite of one record's capture by
+//! another's.
 //!
-//! The digest is what makes that hold on real filesystems, which are far more
-//! opinionated about names than Rust is about identifiers:
+//! Real filesystems are far more opinionated about names than Rust is about
+//! identifiers and string literals, and a group name is an arbitrary string
+//! literal. Four hazards have to be closed, or two distinct groups end up in
+//! one directory on somebody's machine:
 //!
 //! - **Case folding.** macOS (APFS by default) and Windows treat `Foo` and
-//!   `foo` as one name. Rust has both `struct Foo` and `fn foo`, and
-//!   `#[prebindgen("Foo")]` and `#[prebindgen("foo")]` are two groups.
+//!   `foo` as one name, while `#[prebindgen("Foo")]` and `#[prebindgen("foo")]`
+//!   are two groups.
 //! - **Reserved names.** Windows cannot create `CON`, `PRN`, `AUX`, `NUL`,
-//!   `COM1`…`LPT9`, with or without an extension. A digest prefix means no
-//!   component is ever a bare device name.
-//! - **Separators and traversal.** A group name is an arbitrary string literal:
-//!   `"a/b"` or `".."` must not escape the capture directory or name its
-//!   parent.
-//! - **Unicode normalization.** Rust identifiers and string literals admit
-//!   non-ASCII characters, which filesystems normalize inconsistently
-//!   (macOS stores NFD). The readable part is reduced to ASCII so a name's
-//!   spelling never depends on the host.
+//!   `COM1`…`LPT9`, with or without an extension, nor a component ending in a
+//!   dot or a space.
+//! - **Separators and traversal.** `"a/b"` or `".."` must not escape the
+//!   capture directory or name its parent.
+//! - **Unicode normalization.** Non-ASCII names are stored decomposed on macOS
+//!   and composed elsewhere, so one literal would spell two directories.
+//!
+//! [`group_dir_name`] closes all four by encoding rather than by restricting
+//! what a group may be called: only `a-z`, `0-9` and `_` survive verbatim,
+//! every other byte becomes `-` plus two lowercase hex digits, and the whole
+//! sits behind a `g_` prefix. The result holds no uppercase (so case folding
+//! cannot merge two encodings), no separator, no dot, and is never a bare
+//! device name.
+//!
+//! The encoding is reversible, which is what lets [`decode_group_dir_name`]
+//! recover the exact group name a consumer selects by — no sidecar file, and no
+//! way for a directory and the name it claims to disagree.
 
 use std::{
     collections::hash_map::DefaultHasher,
     hash::{Hash, Hasher},
 };
 
-/// Name of the file inside a group directory holding the group's exact name.
-///
-/// The directory name digests the group, which is not reversible, so the name
-/// is recorded next to the records that belong to it. This is what lets
-/// `Source` report the group a consumer selects by (`items_in_groups`) rather
-/// than an approximation of it.
-pub const GROUP_NAME_FILE: &str = "group.txt";
+/// Marks a subdirectory as a group's captures, and keeps the encoded name off
+/// the reserved-device list (`CON` encodes to `con`, which Windows refuses).
+const GROUP_DIR_PREFIX: &str = "g_";
 
-/// Longest run of a name kept in a path component; the digest beside it carries
-/// the identity, this part is only there to be read by a human.
+/// Bytes a single path component may hold. 255 is the limit on ext4, APFS and
+/// NTFS alike; the encoding inflates a name at most threefold, so it is only
+/// reachable with a deliberately absurd group name.
+pub const MAX_COMPONENT_LEN: usize = 255;
+
+/// Longest run of a record's name kept in its file name; the digest beside it
+/// carries the identity, this part is only there to be read by a human.
 const READABLE_LIMIT: usize = 48;
 
 /// 16 lowercase hexadecimal digits identifying `value`.
@@ -60,10 +70,66 @@ fn digest(value: &str) -> String {
     format!("{:016x}", hasher.finish())
 }
 
-/// The readable half of a path component: ASCII alphanumerics kept, everything
-/// else folded to `_`, truncated to [`READABLE_LIMIT`] characters.
-fn readable(value: &str) -> String {
-    value
+/// The directory holding one group's captures: `g_` plus the encoded name.
+///
+/// Escaping to `-XX` rather than to `_XX` is what keeps the common case
+/// readable: `default` stays `g_default` and `my_group` stays `g_my_group`,
+/// because `_` is the character group names actually contain. `Foo` becomes
+/// `g_-46oo`.
+///
+/// See the module docs for why this encodes instead of validating.
+pub fn group_dir_name(group: &str) -> String {
+    use std::fmt::Write;
+
+    let mut encoded = String::from(GROUP_DIR_PREFIX);
+    for byte in group.bytes() {
+        match byte {
+            b'a'..=b'z' | b'0'..=b'9' | b'_' => encoded.push(byte as char),
+            _ => {
+                // Infallible: writing to a String.
+                let _ = write!(encoded, "-{byte:02x}");
+            }
+        }
+    }
+    encoded
+}
+
+/// The group name a directory produced by [`group_dir_name`] stands for, or
+/// `None` if it was not produced by it.
+pub fn decode_group_dir_name(dir_name: &str) -> Option<String> {
+    let encoded = dir_name.strip_prefix(GROUP_DIR_PREFIX)?;
+
+    let mut bytes = Vec::with_capacity(encoded.len());
+    let mut rest = encoded.as_bytes();
+    while let Some((&byte, tail)) = rest.split_first() {
+        match byte {
+            b'a'..=b'z' | b'0'..=b'9' | b'_' => {
+                bytes.push(byte);
+                rest = tail;
+            }
+            b'-' if tail.len() >= 2 => {
+                let (hex, tail) = tail.split_at(2);
+                bytes.push(u8::from_str_radix(std::str::from_utf8(hex).ok()?, 16).ok()?);
+                rest = tail;
+            }
+            // Anything else cannot have come out of `group_dir_name`.
+            _ => return None,
+        }
+    }
+    String::from_utf8(bytes).ok()
+}
+
+/// The file holding one record: `{name}_{digest}.jsonl`.
+///
+/// `serialized` is the record's JSON form — the exact bytes the file will
+/// hold — so equal names mean equal files. Unlike a group name, a record name
+/// never has to be recovered from its path, so the readable part is a lossy
+/// ASCII reduction and the digest beside it carries the identity. The digest is
+/// what keeps `#[cfg(test)] fn f` apart from the crate's own `fn f`, whose
+/// units compile in parallel, and `struct Foo` apart from `fn foo` on a
+/// case-folding filesystem.
+pub fn capture_file_name(name: &str, serialized: &str) -> String {
+    let readable: String = name
         .chars()
         .take(READABLE_LIMIT)
         .map(|character| {
@@ -73,24 +139,8 @@ fn readable(value: &str) -> String {
                 '_'
             }
         })
-        .collect()
-}
-
-/// The directory holding one group's captures: `{digest}_{group}`.
-///
-/// Leading with the digest makes the component collision-free for any two
-/// distinct group names, on any filesystem — see the module docs for the four
-/// ways a group name would otherwise be unrepresentable.
-pub fn group_dir_name(group: &str) -> String {
-    format!("{}_{}", digest(group), readable(group))
-}
-
-/// The file holding one record: `{name}_{digest}.jsonl`.
-///
-/// `serialized` is the record's JSON form — the exact bytes the file will
-/// hold — so equal names mean equal files.
-pub fn capture_file_name(name: &str, serialized: &str) -> String {
-    format!("{}_{}.jsonl", readable(name), digest(serialized))
+        .collect();
+    format!("{readable}_{}.jsonl", digest(serialized))
 }
 
 #[cfg(test)]
@@ -100,6 +150,71 @@ mod tests {
     /// Names Windows refuses as a path component, with or without extension.
     const WINDOWS_DEVICE_NAMES: [&str; 8] =
         ["CON", "PRN", "AUX", "NUL", "COM1", "COM9", "LPT1", "LPT9"];
+
+    /// Group names a filesystem would otherwise refuse, mangle, or merge.
+    const HOSTILE_GROUP_NAMES: [&str; 16] = [
+        "Foo",
+        "foo",
+        "CON",
+        "NUL",
+        "a/b",
+        "a\\b",
+        "..",
+        ".",
+        "../../etc",
+        "",
+        "  ",
+        "a:b",
+        "a\0b",
+        "trailing.",
+        "grüppe",
+        "🙂",
+    ];
+
+    #[test]
+    fn a_group_name_survives_the_round_trip() {
+        for group in HOSTILE_GROUP_NAMES
+            .iter()
+            .copied()
+            .chain(["default", "structs", "my_group", "my-group"])
+        {
+            let dir = group_dir_name(group);
+            assert_eq!(
+                decode_group_dir_name(&dir).as_deref(),
+                Some(group),
+                "{dir} decoded wrong"
+            );
+        }
+    }
+
+    #[test]
+    fn every_char_survives_the_round_trip() {
+        for code_point in (0..=0x2ff_u32).chain([0x1f600, 0x10ffff]) {
+            let Some(character) = char::from_u32(code_point) else {
+                continue;
+            };
+            let group = format!("a{character}b");
+            assert_eq!(
+                decode_group_dir_name(&group_dir_name(&group)).as_deref(),
+                Some(group.as_str())
+            );
+        }
+    }
+
+    #[test]
+    fn only_directories_this_produced_decode() {
+        for foreign in [
+            "default",
+            "incremental",
+            "g",
+            "g_A",
+            "g_a-",
+            "g_a-zz",
+            "g_a.",
+        ] {
+            assert_eq!(decode_group_dir_name(foreign), None, "{foreign}");
+        }
+    }
 
     #[test]
     fn groups_differing_only_in_case_get_different_directories() {
@@ -125,49 +240,32 @@ mod tests {
                 !base.eq_ignore_ascii_case(device),
                 "{dir} would be refused on Windows"
             );
-            // Every component starts with the digest, so none can be a device.
-            assert!(dir[..16].chars().all(|c| c.is_ascii_hexdigit()), "{dir}");
-            assert_eq!(&dir[16..17], "_", "{dir}");
         }
     }
 
     #[test]
     fn group_directories_are_one_contained_component() {
-        for hostile in [
-            "a/b",
-            "a\\b",
-            "..",
-            ".",
-            "../../etc",
-            "",
-            "  ",
-            "a:b",
-            "a\0b",
-        ] {
+        for hostile in HOSTILE_GROUP_NAMES {
             let dir = group_dir_name(hostile);
+            assert!(dir.is_ascii(), "{dir:?} from {hostile:?}");
             assert!(
-                !dir.contains(['/', '\\', ':', '\0']),
+                !dir.contains(['/', '\\', ':', '.', ' ', '\0']),
                 "{dir:?} from {hostile:?}"
             );
+            assert!(
+                !dir.chars().any(char::is_uppercase),
+                "{dir:?} folds on a case-insensitive filesystem"
+            );
             assert!(dir != "." && dir != "..", "{dir:?}");
-            assert!(dir.is_ascii(), "{dir:?}");
         }
     }
 
     #[test]
-    fn distinct_group_names_get_distinct_directories() {
-        let long = "a".repeat(READABLE_LIMIT * 2);
-        let longer = "a".repeat(READABLE_LIMIT * 2 + 1);
-        let names = [
-            "default", "structs", "my_group", "my-group", "Grüppe", "grüppe", "", &long, &longer,
-        ];
-        let mut seen = std::collections::HashSet::new();
-        for name in names {
-            // Lowercased: two directories that fold together are a collision.
-            assert!(
-                seen.insert(group_dir_name(name).to_lowercase()),
-                "{name:?} collides"
-            );
+    fn the_encoding_inflates_a_name_at_most_threefold() {
+        // What keeps MAX_COMPONENT_LEN out of reach of any sane group name.
+        for group in HOSTILE_GROUP_NAMES {
+            let encoded = group_dir_name(group).len() - GROUP_DIR_PREFIX.len();
+            assert!(encoded <= group.len() * 3, "{group:?} -> {encoded}");
         }
     }
 
@@ -189,11 +287,12 @@ mod tests {
     }
 
     #[test]
-    fn the_readable_part_is_ascii_and_bounded() {
+    fn a_capture_file_name_is_ascii_and_bounded() {
         let unicode = capture_file_name("Ünïcödé", r#"{"name":"unicode"}"#);
         assert!(unicode.is_ascii(), "{unicode}");
 
         let long = capture_file_name(&"a".repeat(READABLE_LIMIT * 4), r#"{"name":"long"}"#);
         assert_eq!(long.len(), READABLE_LIMIT + 1 + 16 + ".jsonl".len());
+        assert!(long.len() <= MAX_COMPONENT_LEN);
     }
 }

--- a/prebindgen/src/api/layout.rs
+++ b/prebindgen/src/api/layout.rs
@@ -1,0 +1,199 @@
+//! Where a captured record lives inside the prebindgen output directory.
+//!
+//! ```text
+//! {OUT_DIR}/prebindgen/
+//!     crate_name.txt
+//!     features.txt
+//!     {digest(group)}_{group}/          <- one directory per group
+//!         group.txt                     <- the group's exact name
+//!         {name}_{digest(record)}.jsonl <- one file per captured record
+//! ```
+//!
+//! Both name components follow the same rule: **a digest carries the identity
+//! and a sanitized spelling carries the readability.** The proc-macro computes
+//! these paths when writing and [`Source`](crate::Source) computes them when
+//! reading, so they live here rather than in either crate.
+//!
+//! Deriving a name from the data it holds is what keeps the layout loss-proof:
+//! the name determines the contents, so two writers either write identical
+//! bytes to one path or different bytes to different paths — never a partial
+//! overwrite of one record's capture by another's.
+//!
+//! The digest is what makes that hold on real filesystems, which are far more
+//! opinionated about names than Rust is about identifiers:
+//!
+//! - **Case folding.** macOS (APFS by default) and Windows treat `Foo` and
+//!   `foo` as one name. Rust has both `struct Foo` and `fn foo`, and
+//!   `#[prebindgen("Foo")]` and `#[prebindgen("foo")]` are two groups.
+//! - **Reserved names.** Windows cannot create `CON`, `PRN`, `AUX`, `NUL`,
+//!   `COM1`…`LPT9`, with or without an extension. A digest prefix means no
+//!   component is ever a bare device name.
+//! - **Separators and traversal.** A group name is an arbitrary string literal:
+//!   `"a/b"` or `".."` must not escape the capture directory or name its
+//!   parent.
+//! - **Unicode normalization.** Rust identifiers and string literals admit
+//!   non-ASCII characters, which filesystems normalize inconsistently
+//!   (macOS stores NFD). The readable part is reduced to ASCII so a name's
+//!   spelling never depends on the host.
+
+use std::{
+    collections::hash_map::DefaultHasher,
+    hash::{Hash, Hasher},
+};
+
+/// Name of the file inside a group directory holding the group's exact name.
+///
+/// The directory name digests the group, which is not reversible, so the name
+/// is recorded next to the records that belong to it. This is what lets
+/// `Source` report the group a consumer selects by (`items_in_groups`) rather
+/// than an approximation of it.
+pub const GROUP_NAME_FILE: &str = "group.txt";
+
+/// Longest run of a name kept in a path component; the digest beside it carries
+/// the identity, this part is only there to be read by a human.
+const READABLE_LIMIT: usize = 48;
+
+/// 16 lowercase hexadecimal digits identifying `value`.
+fn digest(value: &str) -> String {
+    let mut hasher = DefaultHasher::new();
+    value.hash(&mut hasher);
+    format!("{:016x}", hasher.finish())
+}
+
+/// The readable half of a path component: ASCII alphanumerics kept, everything
+/// else folded to `_`, truncated to [`READABLE_LIMIT`] characters.
+fn readable(value: &str) -> String {
+    value
+        .chars()
+        .take(READABLE_LIMIT)
+        .map(|character| {
+            if character.is_ascii_alphanumeric() {
+                character
+            } else {
+                '_'
+            }
+        })
+        .collect()
+}
+
+/// The directory holding one group's captures: `{digest}_{group}`.
+///
+/// Leading with the digest makes the component collision-free for any two
+/// distinct group names, on any filesystem — see the module docs for the four
+/// ways a group name would otherwise be unrepresentable.
+pub fn group_dir_name(group: &str) -> String {
+    format!("{}_{}", digest(group), readable(group))
+}
+
+/// The file holding one record: `{name}_{digest}.jsonl`.
+///
+/// `serialized` is the record's JSON form — the exact bytes the file will
+/// hold — so equal names mean equal files.
+pub fn capture_file_name(name: &str, serialized: &str) -> String {
+    format!("{}_{}.jsonl", readable(name), digest(serialized))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Names Windows refuses as a path component, with or without extension.
+    const WINDOWS_DEVICE_NAMES: [&str; 8] =
+        ["CON", "PRN", "AUX", "NUL", "COM1", "COM9", "LPT1", "LPT9"];
+
+    #[test]
+    fn groups_differing_only_in_case_get_different_directories() {
+        // The collision this guards: `.join(group)` puts `Foo` and `foo` in one
+        // directory on macOS and Windows, merging two groups whose records the
+        // API keeps apart.
+        let upper = group_dir_name("Foo");
+        let lower = group_dir_name("foo");
+        assert_ne!(upper, lower);
+        assert_ne!(
+            upper.to_lowercase(),
+            lower.to_lowercase(),
+            "must differ on a case-insensitive filesystem too"
+        );
+    }
+
+    #[test]
+    fn group_directories_are_never_windows_device_names() {
+        for device in WINDOWS_DEVICE_NAMES {
+            let dir = group_dir_name(device);
+            let base = dir.split('.').next().unwrap();
+            assert!(
+                !base.eq_ignore_ascii_case(device),
+                "{dir} would be refused on Windows"
+            );
+            // Every component starts with the digest, so none can be a device.
+            assert!(dir[..16].chars().all(|c| c.is_ascii_hexdigit()), "{dir}");
+            assert_eq!(&dir[16..17], "_", "{dir}");
+        }
+    }
+
+    #[test]
+    fn group_directories_are_one_contained_component() {
+        for hostile in [
+            "a/b",
+            "a\\b",
+            "..",
+            ".",
+            "../../etc",
+            "",
+            "  ",
+            "a:b",
+            "a\0b",
+        ] {
+            let dir = group_dir_name(hostile);
+            assert!(
+                !dir.contains(['/', '\\', ':', '\0']),
+                "{dir:?} from {hostile:?}"
+            );
+            assert!(dir != "." && dir != "..", "{dir:?}");
+            assert!(dir.is_ascii(), "{dir:?}");
+        }
+    }
+
+    #[test]
+    fn distinct_group_names_get_distinct_directories() {
+        let long = "a".repeat(READABLE_LIMIT * 2);
+        let longer = "a".repeat(READABLE_LIMIT * 2 + 1);
+        let names = [
+            "default", "structs", "my_group", "my-group", "Grüppe", "grüppe", "", &long, &longer,
+        ];
+        let mut seen = std::collections::HashSet::new();
+        for name in names {
+            // Lowercased: two directories that fold together are a collision.
+            assert!(
+                seen.insert(group_dir_name(name).to_lowercase()),
+                "{name:?} collides"
+            );
+        }
+    }
+
+    #[test]
+    fn a_capture_file_name_is_determined_by_the_record() {
+        assert_eq!(
+            capture_file_name("Foo", r#"{"name":"Foo"}"#),
+            capture_file_name("Foo", r#"{"name":"Foo"}"#)
+        );
+        assert_ne!(
+            capture_file_name("Foo", r#"{"name":"Foo"}"#),
+            capture_file_name("Foo", r#"{"name":"Foo","cfg":"test"}"#)
+        );
+        // macOS and Windows fold case, and `struct Foo` may live beside `fn foo`.
+        assert_ne!(
+            capture_file_name("Foo", r#"{"kind":"struct","name":"Foo"}"#).to_lowercase(),
+            capture_file_name("foo", r#"{"kind":"function","name":"foo"}"#).to_lowercase()
+        );
+    }
+
+    #[test]
+    fn the_readable_part_is_ascii_and_bounded() {
+        let unicode = capture_file_name("Ünïcödé", r#"{"name":"unicode"}"#);
+        assert!(unicode.is_ascii(), "{unicode}");
+
+        let long = capture_file_name(&"a".repeat(READABLE_LIMIT * 4), r#"{"name":"long"}"#);
+        assert_eq!(long.len(), READABLE_LIMIT + 1 + 16 + ".jsonl".len());
+    }
+}

--- a/prebindgen/src/api/mod.rs
+++ b/prebindgen/src/api/mod.rs
@@ -1,5 +1,6 @@
 pub(crate) mod batching;
 pub(crate) mod buildrs;
+pub(crate) mod layout;
 pub(crate) mod record;
 pub(crate) mod source;
 pub(crate) mod utils;

--- a/prebindgen/src/api/source.rs
+++ b/prebindgen/src/api/source.rs
@@ -11,7 +11,7 @@ use roxygen::roxygen;
 use crate::{
     api::{
         batching::cfg_filter,
-        layout::{group_dir_name, GROUP_NAME_FILE},
+        layout::{decode_group_dir_name, group_dir_name},
         record::Record,
         utils::jsonl::read_jsonl_file,
     },
@@ -403,10 +403,10 @@ impl Source {
 
     /// Internal method to discover all available groups from the directory
     ///
-    /// A group is a subdirectory whose name digests the group (so that two
-    /// groups differing only in case, or named after a Windows device, still
-    /// get one directory each). The digest is not reversible, so the exact name
-    /// comes from the [`GROUP_NAME_FILE`] the macro writes beside the records.
+    /// A group is a subdirectory whose name encodes the group reversibly (so
+    /// that two groups differing only in case, or named after a Windows device,
+    /// still get one directory each), and the exact name is decoded back out of
+    /// it — see [`layout`](crate::layout).
     ///
     /// The flat layout of prebindgen ≤ 0.5.0 spelled the group as the file-name
     /// prefix up to the first `_`, and is still honoured for a capture
@@ -422,8 +422,15 @@ impl Source {
                     continue;
                 };
                 if path.is_dir() {
-                    if let Some(group) = read_group_name(&path) {
+                    if let Some(group) = decode_group_dir_name(file_name) {
                         groups.insert(group);
+                    } else {
+                        assert!(
+                            !holds_captures(&path),
+                            "{} holds prebindgen captures but is not a group directory; \
+                             the capture directory is damaged — rebuild the source crate",
+                            path.display()
+                        );
                     }
                 } else if file_name.ends_with(JSONL_EXTENSION) {
                     // Legacy flat layout: everything before the first underscore.
@@ -438,33 +445,20 @@ impl Source {
     }
 }
 
-/// The exact name of the group whose captures live in `group_dir`.
+/// Whether a directory holds capture files.
 ///
-/// A directory holding captures always names itself: the macro publishes the
-/// name file before the group's first record. One that does not is not a group
-/// directory — unless it holds records anyway, which would mean dropping them
-/// silently.
-fn read_group_name(group_dir: &Path) -> Option<String> {
-    match fs::read_to_string(group_dir.join(GROUP_NAME_FILE)) {
-        Ok(group) => Some(group.trim_end_matches(['\n', '\r']).to_string()),
-        Err(_) => {
-            let holds_captures = fs::read_dir(group_dir).is_ok_and(|entries| {
-                entries.flatten().any(|entry| {
-                    entry
-                        .file_name()
-                        .to_str()
-                        .is_some_and(|name| name.ends_with(JSONL_EXTENSION))
-                })
-            });
-            assert!(
-                !holds_captures,
-                "{} holds prebindgen captures but no {GROUP_NAME_FILE}; \
-                 the capture directory is damaged — rebuild the source crate",
-                group_dir.display()
-            );
-            None
-        }
-    }
+/// Used to tell a directory that is not a group's — Cargo puts other things in
+/// `OUT_DIR` — from one whose name this build cannot decode, which would mean
+/// dropping records silently.
+fn holds_captures(dir: &Path) -> bool {
+    fs::read_dir(dir).is_ok_and(|entries| {
+        entries.flatten().any(|entry| {
+            entry
+                .file_name()
+                .to_str()
+                .is_some_and(|name| name.ends_with(JSONL_EXTENSION))
+        })
+    })
 }
 
 /// Read the crate name from the stored file
@@ -644,7 +638,6 @@ mod tests {
     fn write(dir: &Path, group: &str, name: &str) {
         let group_dir = dir.join(group_dir_name(group));
         fs::create_dir_all(&group_dir).unwrap();
-        fs::write(group_dir.join(GROUP_NAME_FILE), group).unwrap();
         let record = Record::new(
             RecordKind::Struct,
             name.to_string(),
@@ -760,14 +753,13 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "holds prebindgen captures but no group.txt")]
-    fn captures_without_a_group_name_are_not_silently_dropped() {
+    #[should_panic(expected = "is not a group directory")]
+    fn captures_in_an_undecodable_directory_are_not_silently_dropped() {
         let dir = tempfile::tempdir().unwrap();
         write(dir.path(), "default", "Alpha");
-        fs::remove_file(
-            dir.path()
-                .join(group_dir_name("default"))
-                .join(GROUP_NAME_FILE),
+        fs::rename(
+            dir.path().join(group_dir_name("default")),
+            dir.path().join("default"),
         )
         .unwrap();
 

--- a/prebindgen/src/api/source.rs
+++ b/prebindgen/src/api/source.rs
@@ -323,38 +323,34 @@ impl Source {
         builder.build()
     }
 
-    /// Internal method to read all exported files matching the group name pattern `<group>_*`
+    /// Read every capture file of one group: `<input_dir>/<group>/*.jsonl`.
+    ///
+    /// The proc-macro names each file after the record it holds, so a file that
+    /// two compilations both produced exists once. Records that only *some*
+    /// compilations see — a `#[cfg(test)]` item, say — arrive as extra files and
+    /// are merged here, which is why this deduplicates by name (plus `cfg`)
+    /// rather than trusting the file set.
     fn read_group<P: AsRef<Path>>(input_dir: P, group: &str) -> Vec<Record> {
-        let pattern = format!("{group}_");
         let mut record_map = HashMap::new();
 
-        // Read the directory and find all matching files
-        if let Ok(entries) = fs::read_dir(&input_dir) {
-            for entry in entries.flatten() {
-                let path = entry.path();
-                if let Some(file_name) = path.file_name().and_then(|n| n.to_str()) {
-                    if file_name.starts_with(&pattern) && file_name.ends_with(JSONL_EXTENSION) {
-                        #[cfg(feature = "debug")]
-                        println!("Reading exported file: {}", path.display());
-                        let path_clone = path.clone();
+        for path in Self::group_files(input_dir.as_ref(), group) {
+            #[cfg(feature = "debug")]
+            println!("Reading exported file: {}", path.display());
 
-                        match read_jsonl_file(&path) {
-                            Ok(records) => {
-                                for record in records {
-                                    // Use a HashMap to deduplicate records by name and cfg
-                                    let key = if let Some(cfg) = &record.cfg {
-                                        format!("{}#{}", record.name, cfg)
-                                    } else {
-                                        record.name.clone()
-                                    };
-                                    record_map.insert(key, record);
-                                }
-                            }
-                            Err(e) => {
-                                panic!("Failed to read {}: {}", path_clone.display(), e);
-                            }
-                        }
+            match read_jsonl_file(&path) {
+                Ok(records) => {
+                    for record in records {
+                        // Use a HashMap to deduplicate records by name and cfg
+                        let key = if let Some(cfg) = &record.cfg {
+                            format!("{}#{}", record.name, cfg)
+                        } else {
+                            record.name.clone()
+                        };
+                        record_map.insert(key, record);
                     }
+                }
+                Err(e) => {
+                    panic!("Failed to read {}: {}", path.display(), e);
                 }
             }
         }
@@ -363,21 +359,64 @@ impl Source {
         record_map.into_values().collect::<Vec<_>>()
     }
 
-    /// Internal method to discover all available groups from the directory
-    fn discover_groups<P: AsRef<Path>>(input_dir: P) -> HashSet<String> {
-        let mut groups = HashSet::new();
+    /// The capture files belonging to `group`, from the group's directory and
+    /// from the flat `<group>_*.jsonl` layout written by prebindgen ≤ 0.5.0.
+    fn group_files(input_dir: &Path, group: &str) -> Vec<PathBuf> {
+        let mut files = Vec::new();
 
-        // Discover all available groups
+        if let Ok(entries) = fs::read_dir(input_dir.join(group)) {
+            for entry in entries.flatten() {
+                let path = entry.path();
+                if path
+                    .file_name()
+                    .and_then(|name| name.to_str())
+                    .is_some_and(|name| name.ends_with(JSONL_EXTENSION))
+                {
+                    files.push(path);
+                }
+            }
+        }
+
+        let legacy_prefix = format!("{group}_");
         if let Ok(entries) = fs::read_dir(input_dir) {
             for entry in entries.flatten() {
                 let path = entry.path();
-                if let Some(file_name) = path.file_name().and_then(|n| n.to_str()) {
-                    if file_name.ends_with(JSONL_EXTENSION) {
-                        // Extract group name from filename (everything before the first underscore)
-                        if let Some(underscore_pos) = file_name.find('_') {
-                            let group_name = &file_name[..underscore_pos];
-                            groups.insert(group_name.to_string());
-                        }
+                if path
+                    .file_name()
+                    .and_then(|name| name.to_str())
+                    .is_some_and(|name| {
+                        name.starts_with(&legacy_prefix) && name.ends_with(JSONL_EXTENSION)
+                    })
+                {
+                    files.push(path);
+                }
+            }
+        }
+
+        files
+    }
+
+    /// Internal method to discover all available groups from the directory
+    ///
+    /// A group is a subdirectory. The flat layout of prebindgen ≤ 0.5.0 spelled
+    /// it as the file-name prefix up to the first `_`, which is still honoured
+    /// for a capture directory written by an older macro — and is why group
+    /// names may no longer contain `_`.
+    fn discover_groups<P: AsRef<Path>>(input_dir: P) -> HashSet<String> {
+        let mut groups = HashSet::new();
+
+        if let Ok(entries) = fs::read_dir(input_dir) {
+            for entry in entries.flatten() {
+                let path = entry.path();
+                let Some(file_name) = path.file_name().and_then(|n| n.to_str()) else {
+                    continue;
+                };
+                if path.is_dir() {
+                    groups.insert(file_name.to_string());
+                } else if file_name.ends_with(JSONL_EXTENSION) {
+                    // Legacy flat layout: everything before the first underscore.
+                    if let Some(underscore_pos) = file_name.find('_') {
+                        groups.insert(file_name[..underscore_pos].to_string());
                     }
                 }
             }
@@ -550,5 +589,99 @@ impl Builder {
             self.target_triple,
             self.crate_name,
         )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use super::*;
+    use crate::api::record::RecordKind;
+
+    fn write(dir: &Path, relative: &str, name: &str) {
+        let path = dir.join(relative);
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        let record = Record::new(
+            RecordKind::Struct,
+            name.to_string(),
+            format!("pub struct {name};"),
+            Default::default(),
+            None,
+        );
+        fs::write(&path, format!("{}\n", record.to_jsonl_string().unwrap())).unwrap();
+    }
+
+    #[test]
+    fn groups_are_directories() {
+        let dir = tempfile::tempdir().unwrap();
+        write(dir.path(), "default/Alpha_0000000000000001.jsonl", "Alpha");
+        write(dir.path(), "default/Beta_0000000000000002.jsonl", "Beta");
+        write(dir.path(), "structs/Gamma_0000000000000003.jsonl", "Gamma");
+
+        assert_eq!(
+            Source::discover_groups(dir.path()),
+            ["default", "structs"]
+                .map(str::to_string)
+                .into_iter()
+                .collect::<HashSet<_>>()
+        );
+
+        let mut names = Source::read_group(dir.path(), "default")
+            .into_iter()
+            .map(|record| record.name)
+            .collect::<Vec<_>>();
+        names.sort();
+        assert_eq!(names, ["Alpha", "Beta"]);
+    }
+
+    #[test]
+    fn a_group_name_may_contain_an_underscore() {
+        // The flat layout spelled the group as the file-name prefix up to the
+        // first `_`, so `my_group` was discovered as `my`. A directory has no
+        // such ambiguity.
+        let dir = tempfile::tempdir().unwrap();
+        write(dir.path(), "my_group/Alpha_0000000000000001.jsonl", "Alpha");
+
+        assert_eq!(
+            Source::discover_groups(dir.path()),
+            ["my_group".to_string()].into_iter().collect::<HashSet<_>>()
+        );
+        assert_eq!(Source::read_group(dir.path(), "my_group").len(), 1);
+    }
+
+    #[test]
+    fn the_flat_layout_of_older_captures_is_still_read() {
+        // A capture directory written by prebindgen <= 0.5.0, or one holding
+        // both layouts while a build is in flight.
+        let dir = tempfile::tempdir().unwrap();
+        write(dir.path(), "default_1234_5678.jsonl", "Legacy");
+        write(dir.path(), "default/Alpha_0000000000000001.jsonl", "Alpha");
+
+        assert_eq!(
+            Source::discover_groups(dir.path()),
+            ["default".to_string()].into_iter().collect::<HashSet<_>>()
+        );
+        let mut names = Source::read_group(dir.path(), "default")
+            .into_iter()
+            .map(|record| record.name)
+            .collect::<Vec<_>>();
+        names.sort();
+        assert_eq!(names, ["Alpha", "Legacy"]);
+    }
+
+    #[test]
+    fn non_capture_entries_are_ignored() {
+        let dir = tempfile::tempdir().unwrap();
+        write(dir.path(), "default/Alpha_0000000000000001.jsonl", "Alpha");
+        fs::write(dir.path().join("crate_name.txt"), "example-flat").unwrap();
+        fs::write(dir.path().join("features.txt"), "unstable\n").unwrap();
+        fs::write(dir.path().join("default/notes.txt"), "scratch").unwrap();
+
+        assert_eq!(
+            Source::discover_groups(dir.path()),
+            ["default".to_string()].into_iter().collect::<HashSet<_>>()
+        );
+        assert_eq!(Source::read_group(dir.path(), "default").len(), 1);
     }
 }

--- a/prebindgen/src/api/source.rs
+++ b/prebindgen/src/api/source.rs
@@ -9,7 +9,12 @@ use itertools::Itertools;
 use roxygen::roxygen;
 
 use crate::{
-    api::{batching::cfg_filter, record::Record, utils::jsonl::read_jsonl_file},
+    api::{
+        batching::cfg_filter,
+        layout::{group_dir_name, GROUP_NAME_FILE},
+        record::Record,
+        utils::jsonl::read_jsonl_file,
+    },
     SourceLocation, TargetTriple, CRATE_NAME_FILE, FEATURES_FILE,
 };
 
@@ -364,7 +369,7 @@ impl Source {
     fn group_files(input_dir: &Path, group: &str) -> Vec<PathBuf> {
         let mut files = Vec::new();
 
-        if let Ok(entries) = fs::read_dir(input_dir.join(group)) {
+        if let Ok(entries) = fs::read_dir(input_dir.join(group_dir_name(group))) {
             for entry in entries.flatten() {
                 let path = entry.path();
                 if path
@@ -398,11 +403,16 @@ impl Source {
 
     /// Internal method to discover all available groups from the directory
     ///
-    /// A group is a subdirectory. The flat layout of prebindgen ≤ 0.5.0 spelled
-    /// it as the file-name prefix up to the first `_`, which is still honoured
-    /// for a capture directory written by an older macro — and is why group
-    /// names may no longer contain `_`.
+    /// A group is a subdirectory whose name digests the group (so that two
+    /// groups differing only in case, or named after a Windows device, still
+    /// get one directory each). The digest is not reversible, so the exact name
+    /// comes from the [`GROUP_NAME_FILE`] the macro writes beside the records.
+    ///
+    /// The flat layout of prebindgen ≤ 0.5.0 spelled the group as the file-name
+    /// prefix up to the first `_`, and is still honoured for a capture
+    /// directory written by an older macro.
     fn discover_groups<P: AsRef<Path>>(input_dir: P) -> HashSet<String> {
+        let input_dir = input_dir.as_ref();
         let mut groups = HashSet::new();
 
         if let Ok(entries) = fs::read_dir(input_dir) {
@@ -412,7 +422,9 @@ impl Source {
                     continue;
                 };
                 if path.is_dir() {
-                    groups.insert(file_name.to_string());
+                    if let Some(group) = read_group_name(&path) {
+                        groups.insert(group);
+                    }
                 } else if file_name.ends_with(JSONL_EXTENSION) {
                     // Legacy flat layout: everything before the first underscore.
                     if let Some(underscore_pos) = file_name.find('_') {
@@ -423,6 +435,35 @@ impl Source {
         }
 
         groups
+    }
+}
+
+/// The exact name of the group whose captures live in `group_dir`.
+///
+/// A directory holding captures always names itself: the macro publishes the
+/// name file before the group's first record. One that does not is not a group
+/// directory — unless it holds records anyway, which would mean dropping them
+/// silently.
+fn read_group_name(group_dir: &Path) -> Option<String> {
+    match fs::read_to_string(group_dir.join(GROUP_NAME_FILE)) {
+        Ok(group) => Some(group.trim_end_matches(['\n', '\r']).to_string()),
+        Err(_) => {
+            let holds_captures = fs::read_dir(group_dir).is_ok_and(|entries| {
+                entries.flatten().any(|entry| {
+                    entry
+                        .file_name()
+                        .to_str()
+                        .is_some_and(|name| name.ends_with(JSONL_EXTENSION))
+                })
+            });
+            assert!(
+                !holds_captures,
+                "{} holds prebindgen captures but no {GROUP_NAME_FILE}; \
+                 the capture directory is damaged — rebuild the source crate",
+                group_dir.display()
+            );
+            None
+        }
     }
 }
 
@@ -599,9 +640,11 @@ mod tests {
     use super::*;
     use crate::api::record::RecordKind;
 
-    fn write(dir: &Path, relative: &str, name: &str) {
-        let path = dir.join(relative);
-        fs::create_dir_all(path.parent().unwrap()).unwrap();
+    /// Publish a record into `group`'s directory the way the macro does.
+    fn write(dir: &Path, group: &str, name: &str) {
+        let group_dir = dir.join(group_dir_name(group));
+        fs::create_dir_all(&group_dir).unwrap();
+        fs::write(group_dir.join(GROUP_NAME_FILE), group).unwrap();
         let record = Record::new(
             RecordKind::Struct,
             name.to_string(),
@@ -609,79 +652,125 @@ mod tests {
             Default::default(),
             None,
         );
-        fs::write(&path, format!("{}\n", record.to_jsonl_string().unwrap())).unwrap();
+        let serialized = record.to_jsonl_string().unwrap();
+        fs::write(
+            group_dir.join(crate::api::layout::capture_file_name(name, &serialized)),
+            format!("{serialized}\n"),
+        )
+        .unwrap();
+    }
+
+    fn names_of(dir: &Path, group: &str) -> Vec<String> {
+        let mut names = Source::read_group(dir, group)
+            .into_iter()
+            .map(|record| record.name)
+            .collect::<Vec<_>>();
+        names.sort();
+        names
+    }
+
+    fn groups(dir: &Path) -> Vec<String> {
+        let mut groups = Source::discover_groups(dir).into_iter().collect::<Vec<_>>();
+        groups.sort();
+        groups
     }
 
     #[test]
     fn groups_are_directories() {
         let dir = tempfile::tempdir().unwrap();
-        write(dir.path(), "default/Alpha_0000000000000001.jsonl", "Alpha");
-        write(dir.path(), "default/Beta_0000000000000002.jsonl", "Beta");
-        write(dir.path(), "structs/Gamma_0000000000000003.jsonl", "Gamma");
+        write(dir.path(), "default", "Alpha");
+        write(dir.path(), "default", "Beta");
+        write(dir.path(), "structs", "Gamma");
 
-        assert_eq!(
-            Source::discover_groups(dir.path()),
-            ["default", "structs"]
-                .map(str::to_string)
-                .into_iter()
-                .collect::<HashSet<_>>()
-        );
-
-        let mut names = Source::read_group(dir.path(), "default")
-            .into_iter()
-            .map(|record| record.name)
-            .collect::<Vec<_>>();
-        names.sort();
-        assert_eq!(names, ["Alpha", "Beta"]);
+        assert_eq!(groups(dir.path()), ["default", "structs"]);
+        assert_eq!(names_of(dir.path(), "default"), ["Alpha", "Beta"]);
+        assert_eq!(names_of(dir.path(), "structs"), ["Gamma"]);
     }
 
     #[test]
-    fn a_group_name_may_contain_an_underscore() {
-        // The flat layout spelled the group as the file-name prefix up to the
-        // first `_`, so `my_group` was discovered as `my`. A directory has no
-        // such ambiguity.
+    fn groups_differing_only_in_case_stay_apart() {
+        // `.join(group)` would merge these on macOS and Windows, so the
+        // directory name leads with a digest of the group.
         let dir = tempfile::tempdir().unwrap();
-        write(dir.path(), "my_group/Alpha_0000000000000001.jsonl", "Alpha");
+        write(dir.path(), "Foo", "Upper");
+        write(dir.path(), "foo", "Lower");
 
-        assert_eq!(
-            Source::discover_groups(dir.path()),
-            ["my_group".to_string()].into_iter().collect::<HashSet<_>>()
-        );
-        assert_eq!(Source::read_group(dir.path(), "my_group").len(), 1);
+        assert_eq!(groups(dir.path()), ["Foo", "foo"]);
+        assert_eq!(names_of(dir.path(), "Foo"), ["Upper"]);
+        assert_eq!(names_of(dir.path(), "foo"), ["Lower"]);
+    }
+
+    #[test]
+    fn a_group_may_be_named_anything_a_string_literal_can_hold() {
+        // Including names a filesystem would otherwise refuse or mangle:
+        // Windows devices, path separators, `..`, and non-ASCII.
+        let dir = tempfile::tempdir().unwrap();
+        let hostile = [
+            "CON", "NUL", "COM1", "LPT1", "my_group", "a/b", "..", "grüppe", "",
+        ];
+        for (index, group) in hostile.iter().enumerate() {
+            write(dir.path(), group, &format!("Item{index}"));
+        }
+
+        let mut expected = hostile.map(str::to_string).to_vec();
+        expected.sort();
+        assert_eq!(groups(dir.path()), expected);
+        for (index, group) in hostile.iter().enumerate() {
+            assert_eq!(names_of(dir.path(), group), [format!("Item{index}")]);
+        }
     }
 
     #[test]
     fn the_flat_layout_of_older_captures_is_still_read() {
-        // A capture directory written by prebindgen <= 0.5.0, or one holding
-        // both layouts while a build is in flight.
+        // A capture directory written by prebindgen <= 0.5.0.
         let dir = tempfile::tempdir().unwrap();
-        write(dir.path(), "default_1234_5678.jsonl", "Legacy");
-        write(dir.path(), "default/Alpha_0000000000000001.jsonl", "Alpha");
-
-        assert_eq!(
-            Source::discover_groups(dir.path()),
-            ["default".to_string()].into_iter().collect::<HashSet<_>>()
+        let record = Record::new(
+            RecordKind::Struct,
+            "Legacy".to_string(),
+            "pub struct Legacy;".to_string(),
+            Default::default(),
+            None,
         );
-        let mut names = Source::read_group(dir.path(), "default")
-            .into_iter()
-            .map(|record| record.name)
-            .collect::<Vec<_>>();
-        names.sort();
-        assert_eq!(names, ["Alpha", "Legacy"]);
+        fs::write(
+            dir.path().join("default_1234_5678.jsonl"),
+            format!("{}\n", record.to_jsonl_string().unwrap()),
+        )
+        .unwrap();
+        write(dir.path(), "default", "Alpha");
+
+        assert_eq!(groups(dir.path()), ["default"]);
+        assert_eq!(names_of(dir.path(), "default"), ["Alpha", "Legacy"]);
     }
 
     #[test]
     fn non_capture_entries_are_ignored() {
         let dir = tempfile::tempdir().unwrap();
-        write(dir.path(), "default/Alpha_0000000000000001.jsonl", "Alpha");
-        fs::write(dir.path().join("crate_name.txt"), "example-flat").unwrap();
-        fs::write(dir.path().join("features.txt"), "unstable\n").unwrap();
-        fs::write(dir.path().join("default/notes.txt"), "scratch").unwrap();
+        write(dir.path(), "default", "Alpha");
+        fs::write(dir.path().join(CRATE_NAME_FILE), "example-flat").unwrap();
+        fs::write(dir.path().join(FEATURES_FILE), "unstable\n").unwrap();
+        fs::write(
+            dir.path().join(group_dir_name("default")).join("notes.txt"),
+            "scratch",
+        )
+        .unwrap();
+        fs::create_dir_all(dir.path().join("not-a-group")).unwrap();
 
-        assert_eq!(
-            Source::discover_groups(dir.path()),
-            ["default".to_string()].into_iter().collect::<HashSet<_>>()
-        );
-        assert_eq!(Source::read_group(dir.path(), "default").len(), 1);
+        assert_eq!(groups(dir.path()), ["default"]);
+        assert_eq!(names_of(dir.path(), "default"), ["Alpha"]);
+    }
+
+    #[test]
+    #[should_panic(expected = "holds prebindgen captures but no group.txt")]
+    fn captures_without_a_group_name_are_not_silently_dropped() {
+        let dir = tempfile::tempdir().unwrap();
+        write(dir.path(), "default", "Alpha");
+        fs::remove_file(
+            dir.path()
+                .join(group_dir_name("default"))
+                .join(GROUP_NAME_FILE),
+        )
+        .unwrap();
+
+        Source::discover_groups(dir.path());
     }
 }

--- a/prebindgen/src/api/source.rs
+++ b/prebindgen/src/api/source.rs
@@ -418,24 +418,28 @@ impl Source {
         if let Ok(entries) = fs::read_dir(input_dir) {
             for entry in entries.flatten() {
                 let path = entry.path();
-                let Some(file_name) = path.file_name().and_then(|n| n.to_str()) else {
-                    continue;
-                };
+                // A group directory is ASCII, so a name that is not UTF-8 is
+                // not one — but it still has to face the damage check below
+                // rather than being skipped with its captures inside.
+                let file_name = path.file_name().and_then(|name| name.to_str());
                 if path.is_dir() {
-                    if let Some(group) = decode_group_dir_name(file_name) {
-                        groups.insert(group);
-                    } else {
-                        assert!(
+                    match file_name.and_then(decode_group_dir_name) {
+                        Some(group) => {
+                            groups.insert(group);
+                        }
+                        None => assert!(
                             !holds_captures(&path),
                             "{} holds prebindgen captures but is not a group directory; \
                              the capture directory is damaged — rebuild the source crate",
                             path.display()
-                        );
+                        ),
                     }
-                } else if file_name.ends_with(JSONL_EXTENSION) {
-                    // Legacy flat layout: everything before the first underscore.
-                    if let Some(underscore_pos) = file_name.find('_') {
-                        groups.insert(file_name[..underscore_pos].to_string());
+                } else if let Some(file_name) = file_name {
+                    if file_name.ends_with(JSONL_EXTENSION) {
+                        // Legacy flat layout: everything before the first underscore.
+                        if let Some(underscore_pos) = file_name.find('_') {
+                            groups.insert(file_name[..underscore_pos].to_string());
+                        }
                     }
                 }
             }
@@ -750,6 +754,42 @@ mod tests {
 
         assert_eq!(groups(dir.path()), ["default"]);
         assert_eq!(names_of(dir.path(), "default"), ["Alpha"]);
+    }
+
+    #[test]
+    #[should_panic(expected = "is not a group directory")]
+    fn captures_under_a_non_canonical_spelling_are_not_silently_dropped() {
+        // `g_-61` decodes to `a`, but `a` canonicalizes to `g_a`, so reporting
+        // the group would send `read_group` to an empty directory and lose
+        // these records.
+        let dir = tempfile::tempdir().unwrap();
+        write(dir.path(), "a", "Alpha");
+        fs::rename(
+            dir.path().join(group_dir_name("a")),
+            dir.path().join("g_-61"),
+        )
+        .unwrap();
+
+        Source::discover_groups(dir.path());
+    }
+
+    // Linux only: APFS refuses to create a name that is not valid UTF-8, which
+    // is why macOS cannot reach this case in the first place. CI runs Linux.
+    #[cfg(target_os = "linux")]
+    #[test]
+    #[should_panic(expected = "is not a group directory")]
+    fn captures_under_a_non_utf8_directory_are_not_silently_dropped() {
+        use std::os::unix::ffi::OsStrExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        write(dir.path(), "default", "Alpha");
+        fs::rename(
+            dir.path().join(group_dir_name("default")),
+            dir.path().join(std::ffi::OsStr::from_bytes(b"g_\xff\xfe")),
+        )
+        .unwrap();
+
+        Source::discover_groups(dir.path());
     }
 
     #[test]

--- a/prebindgen/src/api/utils/jsonl.rs
+++ b/prebindgen/src/api/utils/jsonl.rs
@@ -5,9 +5,76 @@ use std::{
     fs::{self, OpenOptions},
     io::Write,
     path::Path,
+    sync::atomic::{AtomicU64, Ordering},
 };
 
 use crate::api::record::Record;
+
+/// Serialize one record and publish it at `file_path` atomically.
+///
+/// The capture file name is derived from the record itself (see
+/// `prebindgen_proc_macro`), so any writer producing this path produces these
+/// exact bytes. Two compilations of the same source therefore write the same
+/// file rather than two copies of it — but they may do so concurrently, so the
+/// content is written to a private temporary file in the same directory and
+/// `rename`d over the destination. A reader consequently sees either the
+/// previous complete file or the new complete file, never a partial one, and a
+/// lost race costs nothing because the loser wrote identical bytes.
+pub fn write_record_file<P: AsRef<Path>>(
+    file_path: P,
+    jsonl_line: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let file_path = file_path.as_ref();
+
+    // The name determines the content, so an existing file is already this
+    // record: skip the write rather than re-publishing identical bytes. Only a
+    // complete file can exist at this path (they arrive by rename), but a
+    // zero-length one from an older layout or a truncated copy is rewritten.
+    if fs::metadata(file_path).is_ok_and(|metadata| metadata.len() > 0) {
+        return Ok(());
+    }
+
+    let directory = file_path
+        .parent()
+        .ok_or_else(|| format!("capture path {} has no parent", file_path.display()))?;
+    fs::create_dir_all(directory)?;
+
+    let mut contents = String::with_capacity(jsonl_line.len() + 1);
+    contents.push_str(jsonl_line);
+    contents.push('\n');
+
+    // Unique per process and per call: two writers must never share a temporary.
+    static SEQUENCE: AtomicU64 = AtomicU64::new(0);
+    let temporary = directory.join(format!(
+        ".{}.{}.{}.tmp",
+        file_path
+            .file_name()
+            .map(|name| name.to_string_lossy().into_owned())
+            .unwrap_or_default(),
+        std::process::id(),
+        SEQUENCE.fetch_add(1, Ordering::Relaxed)
+    ));
+
+    let write_temporary = || -> std::io::Result<()> {
+        let mut file = OpenOptions::new()
+            .create(true)
+            .truncate(true)
+            .write(true)
+            .open(&temporary)?;
+        file.write_all(contents.as_bytes())?;
+        file.sync_all()
+    };
+    if let Err(error) = write_temporary() {
+        let _ = fs::remove_file(&temporary);
+        return Err(format!("failed to write {}: {error}", temporary.display()).into());
+    }
+
+    if let Err(error) = fs::rename(&temporary, file_path) {
+        let _ = fs::remove_file(&temporary);
+        return Err(format!("failed to publish {}: {error}", file_path.display()).into());
+    }
+    Ok(())
+}
 
 /// Write a collection of records to a file in JSON-lines format
 pub fn write_to_jsonl_file<P: AsRef<Path>, R: Borrow<Record>>(

--- a/prebindgen/src/api/utils/jsonl.rs
+++ b/prebindgen/src/api/utils/jsonl.rs
@@ -10,26 +10,26 @@ use std::{
 
 use crate::api::record::Record;
 
-/// Serialize one record and publish it at `file_path` atomically.
+/// Publish `contents` at `file_path` atomically, once.
 ///
-/// The capture file name is derived from the record itself (see
-/// `prebindgen_proc_macro`), so any writer producing this path produces these
+/// Every path in the capture directory is named after what it holds (see
+/// [`layout`](crate::layout)), so any writer producing this path produces these
 /// exact bytes. Two compilations of the same source therefore write the same
 /// file rather than two copies of it — but they may do so concurrently, so the
 /// content is written to a private temporary file in the same directory and
 /// `rename`d over the destination. A reader consequently sees either the
 /// previous complete file or the new complete file, never a partial one, and a
 /// lost race costs nothing because the loser wrote identical bytes.
-pub fn write_record_file<P: AsRef<Path>>(
+pub fn publish_file<P: AsRef<Path>>(
     file_path: P,
-    jsonl_line: &str,
+    contents: &str,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let file_path = file_path.as_ref();
 
-    // The name determines the content, so an existing file is already this
-    // record: skip the write rather than re-publishing identical bytes. Only a
-    // complete file can exist at this path (they arrive by rename), but a
-    // zero-length one from an older layout or a truncated copy is rewritten.
+    // The name determines the content, so an existing file already holds it:
+    // skip the write rather than re-publishing identical bytes. Only a complete
+    // file can exist at this path (they arrive by rename), but a zero-length
+    // one from an older layout or a truncated copy is rewritten.
     if fs::metadata(file_path).is_ok_and(|metadata| metadata.len() > 0) {
         return Ok(());
     }
@@ -38,10 +38,6 @@ pub fn write_record_file<P: AsRef<Path>>(
         .parent()
         .ok_or_else(|| format!("capture path {} has no parent", file_path.display()))?;
     fs::create_dir_all(directory)?;
-
-    let mut contents = String::with_capacity(jsonl_line.len() + 1);
-    contents.push_str(jsonl_line);
-    contents.push('\n');
 
     // Unique per process and per call: two writers must never share a temporary.
     static SEQUENCE: AtomicU64 = AtomicU64::new(0);

--- a/prebindgen/src/api/utils/jsonl/tests.rs
+++ b/prebindgen/src/api/utils/jsonl/tests.rs
@@ -99,3 +99,111 @@ fn test_jsonl_file_format() {
     let parsed: Record = serde_json::from_str(lines[1]).unwrap();
     assert_eq!(parsed.cfg, Some("feature = \"unstable\"".to_string()));
 }
+
+fn a_record(name: &str, content: &str) -> Record {
+    Record::new(
+        RecordKind::Struct,
+        name.to_string(),
+        content.to_string(),
+        Default::default(),
+        None,
+    )
+}
+
+fn line_of(record: &Record) -> String {
+    record.to_jsonl_string().unwrap()
+}
+
+#[test]
+fn write_record_file_creates_the_group_directory_and_one_line() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir
+        .path()
+        .join("structs")
+        .join("Test_0123456789abcdef.jsonl");
+    let record = a_record("Test", "pub struct Test;");
+
+    write_record_file(&path, &line_of(&record)).unwrap();
+
+    let read = read_jsonl_file(&path).unwrap();
+    assert_eq!(read, vec![record]);
+    assert_eq!(fs::read_to_string(&path).unwrap().lines().count(), 1);
+}
+
+#[test]
+fn write_record_file_leaves_no_temporaries_behind() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("group").join("Test_0123456789abcdef.jsonl");
+
+    write_record_file(&path, &line_of(&a_record("Test", "pub struct Test;"))).unwrap();
+
+    let leftovers = fs::read_dir(path.parent().unwrap())
+        .unwrap()
+        .flatten()
+        .map(|entry| entry.file_name().to_string_lossy().into_owned())
+        .filter(|name| name != "Test_0123456789abcdef.jsonl")
+        .collect::<Vec<_>>();
+    assert!(leftovers.is_empty(), "{leftovers:?}");
+}
+
+#[test]
+fn concurrent_identical_writes_leave_one_complete_file() {
+    // The file name is derived from the contents, so every writer of a given
+    // path writes these same bytes: the losers of the rename race cost nothing,
+    // and no reader can observe a partial file.
+    const WRITERS: usize = 32;
+
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir
+        .path()
+        .join("default")
+        .join("Test_0123456789abcdef.jsonl");
+    let record = a_record("Test", "pub struct Test;");
+    let line = line_of(&record);
+
+    let barrier = std::sync::Arc::new(std::sync::Barrier::new(WRITERS));
+    let handles = (0..WRITERS)
+        .map(|_| {
+            let barrier = std::sync::Arc::clone(&barrier);
+            let path = path.clone();
+            let line = line.clone();
+            std::thread::spawn(move || {
+                barrier.wait();
+                write_record_file(&path, &line).unwrap();
+            })
+        })
+        .collect::<Vec<_>>();
+    for handle in handles {
+        handle.join().unwrap();
+    }
+
+    let files = fs::read_dir(path.parent().unwrap())
+        .unwrap()
+        .flatten()
+        .map(|entry| entry.path())
+        .collect::<Vec<_>>();
+    assert_eq!(
+        files,
+        vec![path.clone()],
+        "exactly one file, no temporaries"
+    );
+    assert_eq!(read_jsonl_file(&path).unwrap(), vec![record]);
+}
+
+#[test]
+fn write_record_file_rewrites_an_empty_file() {
+    // A zero-length file is not a record this layout could have published, so
+    // it must not suppress the real one.
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir
+        .path()
+        .join("default")
+        .join("Test_0123456789abcdef.jsonl");
+    fs::create_dir_all(path.parent().unwrap()).unwrap();
+    fs::write(&path, "").unwrap();
+
+    let record = a_record("Test", "pub struct Test;");
+    write_record_file(&path, &line_of(&record)).unwrap();
+
+    assert_eq!(read_jsonl_file(&path).unwrap(), vec![record]);
+}

--- a/prebindgen/src/api/utils/jsonl/tests.rs
+++ b/prebindgen/src/api/utils/jsonl/tests.rs
@@ -111,11 +111,11 @@ fn a_record(name: &str, content: &str) -> Record {
 }
 
 fn line_of(record: &Record) -> String {
-    record.to_jsonl_string().unwrap()
+    format!("{}\n", record.to_jsonl_string().unwrap())
 }
 
 #[test]
-fn write_record_file_creates_the_group_directory_and_one_line() {
+fn publish_file_creates_the_group_directory_and_one_line() {
     let dir = tempfile::tempdir().unwrap();
     let path = dir
         .path()
@@ -123,7 +123,7 @@ fn write_record_file_creates_the_group_directory_and_one_line() {
         .join("Test_0123456789abcdef.jsonl");
     let record = a_record("Test", "pub struct Test;");
 
-    write_record_file(&path, &line_of(&record)).unwrap();
+    publish_file(&path, &line_of(&record)).unwrap();
 
     let read = read_jsonl_file(&path).unwrap();
     assert_eq!(read, vec![record]);
@@ -131,11 +131,11 @@ fn write_record_file_creates_the_group_directory_and_one_line() {
 }
 
 #[test]
-fn write_record_file_leaves_no_temporaries_behind() {
+fn publish_file_leaves_no_temporaries_behind() {
     let dir = tempfile::tempdir().unwrap();
     let path = dir.path().join("group").join("Test_0123456789abcdef.jsonl");
 
-    write_record_file(&path, &line_of(&a_record("Test", "pub struct Test;"))).unwrap();
+    publish_file(&path, &line_of(&a_record("Test", "pub struct Test;"))).unwrap();
 
     let leftovers = fs::read_dir(path.parent().unwrap())
         .unwrap()
@@ -169,7 +169,7 @@ fn concurrent_identical_writes_leave_one_complete_file() {
             let line = line.clone();
             std::thread::spawn(move || {
                 barrier.wait();
-                write_record_file(&path, &line).unwrap();
+                publish_file(&path, &line).unwrap();
             })
         })
         .collect::<Vec<_>>();
@@ -191,7 +191,7 @@ fn concurrent_identical_writes_leave_one_complete_file() {
 }
 
 #[test]
-fn write_record_file_rewrites_an_empty_file() {
+fn publish_file_rewrites_an_empty_file() {
     // A zero-length file is not a record this layout could have published, so
     // it must not suppress the real one.
     let dir = tempfile::tempdir().unwrap();
@@ -203,7 +203,7 @@ fn write_record_file_rewrites_an_empty_file() {
     fs::write(&path, "").unwrap();
 
     let record = a_record("Test", "pub struct Test;");
-    write_record_file(&path, &line_of(&record)).unwrap();
+    publish_file(&path, &line_of(&record)).unwrap();
 
     assert_eq!(read_jsonl_file(&path).unwrap(), vec![record]);
 }

--- a/prebindgen/src/lib.rs
+++ b/prebindgen/src/lib.rs
@@ -204,7 +204,9 @@ pub use crate::api::{
 pub mod layout {
     //! Capture-directory layout, shared by the proc-macro (writing) and
     //! [`Source`](crate::Source) (reading).
-    pub use crate::api::layout::{capture_file_name, group_dir_name, GROUP_NAME_FILE};
+    pub use crate::api::layout::{
+        capture_file_name, decode_group_dir_name, group_dir_name, MAX_COMPONENT_LEN,
+    };
 }
 
 pub mod utils {

--- a/prebindgen/src/lib.rs
+++ b/prebindgen/src/lib.rs
@@ -200,9 +200,16 @@ pub use crate::api::{
 // `prebindgen-registry`, and re-exports its own decl macros' support types at
 // its own root — see `prebindgen-jni`'s docs for the JNI / Kotlin workflow.
 
+#[doc(hidden)]
+pub mod layout {
+    //! Capture-directory layout, shared by the proc-macro (writing) and
+    //! [`Source`](crate::Source) (reading).
+    pub use crate::api::layout::{capture_file_name, group_dir_name, GROUP_NAME_FILE};
+}
+
 pub mod utils {
     #[doc(hidden)]
-    pub use crate::api::utils::jsonl::{read_jsonl_file, write_record_file, write_to_jsonl_file};
+    pub use crate::api::utils::jsonl::{publish_file, read_jsonl_file, write_to_jsonl_file};
     pub use crate::api::utils::target_triple::TargetTriple;
 }
 

--- a/prebindgen/src/lib.rs
+++ b/prebindgen/src/lib.rs
@@ -202,7 +202,7 @@ pub use crate::api::{
 
 pub mod utils {
     #[doc(hidden)]
-    pub use crate::api::utils::jsonl::{read_jsonl_file, write_to_jsonl_file};
+    pub use crate::api::utils::jsonl::{read_jsonl_file, write_record_file, write_to_jsonl_file};
     pub use crate::api::utils::target_triple::TargetTriple;
 }
 


### PR DESCRIPTION
Closes #201.

## The leak

`#[prebindgen]` named each capture `{group}_{pid}_{thread}.jsonl`, so every rustc process wrote another full copy of the same records. Nothing removes them: `init_prebindgen_out_dir()` clears the directory only when Cargo re-runs the build script, which happens on a source change — and rustc/rustdoc run far more often than that.

Doctests make it unbounded, because Cargo never caches them. With no edit at all:

| | before | this PR |
|---|---|---|
| `cargo build -p example-flat` | 2 files | 2 |
| `cargo test -p example-flat` #1 | 6 | 47 |
| #2 | 8 | 47 |
| #3 | 10 | 47 |
| #4 | 12 | 47 |
| #5 | 14 | 47 |

(The jump to 47 is the layout change — one file per record instead of one per process. The point is the column: it stops moving.)

## The fix: name the file after the data

```
{OUT_DIR}/prebindgen/{group}/{name}_{digest}.jsonl
```

The digest covers the record's serialized form. Any compilation that captures an item computes the same path and writes the same bytes, so repeated compilations rewrite one file instead of accumulating a copy each. The file set is a function of the source, not of build history.

**This is what makes the layout loss-proof, and it is the main argument for it.** The previous approach to bounding growth was to derive a key for the *writer* — the compilation unit — and let each writer reset its own file. That only holds while the key is exactly as fine-grained as the unit, and getting it wrong loses records rather than leaking files. Deriving the name from the data removes the question: the name determines the contents, so two writers either write identical bytes to one path or different bytes to different paths. There is no third case where one compilation resets another's records.

It also stops depending on the compiler's command line, which the unit-keyed approach had to parse (`-C metadata`, and an argument filter for rustdoc). Nothing here reads argv, so a build driven by a compiler that doesn't distinguish invocations that way is not a special case.

### Why the digest is load-bearing

Not decoration — it is what keeps the "name determines contents" property true:

- `#[cfg(test)] fn f` and the crate's own `fn f` are different records with one name, and their units compile **in parallel** under `cargo test`.
- macOS and Windows fold filename case, and Rust is happy to have both `struct Foo` and `fn foo`.

The readable part is capped at 48 characters and forced to ASCII, since Rust identifiers admit characters filesystems normalize differently.

### Publishing

Each record is serialized, written to a temporary file in the destination directory, and `rename`d over the target. A reader sees a complete file or no file; a lost race costs nothing because the loser wrote identical bytes. An existing non-empty file at the path is left alone. Write failures are now reported at the item as compiler diagnostics rather than a bare `compile_error!`.

## Groups become directories

A group is now a subdirectory rather than a filename prefix. That fixes a latent bug: the flat layout recovered the group as the prefix up to the first `_`, so `#[prebindgen("my_group")]` was discovered as group `my` and `items_in_groups(&["my_group"])` returned nothing.

- Group names are validated at the item (ASCII letters, digits, `_`, `-`), since they now name a directory.
- `Source` reads the group directory **and** still reads the flat layout, so a capture directory written by an older macro is not orphaned.
- `init_prebindgen_out_dir()` now removes directories as well as files. Leaving them would keep records for items the new revision renamed or deleted — the one way this layout could go stale.

## Scenarios

| who compiles | before | now |
|---|---|---|
| `cargo check` / `build` / `test` units | one file per process, forever | same files rewritten |
| doctest rustdoc (never cached) | **+2 files per run, unbounded** | same files rewritten |
| `cargo doc` rustdoc | one file per process | same files rewritten |
| units with different item sets (`#[cfg(test)]`) | union across files | union across files, unchanged |
| parallel units, same item | two files | one file, identical bytes |
| parallel units, same name, different item | two files | two files (digest differs) |
| a compiler that doesn't distinguish its invocations | one file per process | same files rewritten |

## Verification

- **Growth**: `build`, then `test` ×5, `test --doc alpha`, `test --doc beta`, `clippy --all-targets`, `doc` — the file set in each build-hash directory is byte-identical after every command (47 files: 44 `default` + 3 `structs`).
- **No loss across units**: with a temporary `#[cfg(test)] #[prebindgen] fn test_only_probe()` in `example-flat`, `cargo test --lib` followed by `cargo build` leaves 48 files and the probe survives. (Under the flat layout this is the case that a unit-keyed name gets wrong when the key is too coarse.)
- **Concurrency**: 32 threads racing on one path leave exactly one complete file and no temporaries.
- **Case folding**: `struct Foo` and `fn foo` produce names that differ after `to_lowercase()`.
- **Reader**: group directories, a group name containing `_`, the legacy flat layout, and non-capture entries (`crate_name.txt`, stray files) are covered by unit tests.
- `cargo test --all --all-features`, `cargo clippy --all-targets --all-features -- --deny warnings`, `cargo fmt --check`, on **1.85.0** (MSRV) and **1.97.1**.
- `examples/regen-check.sh`: committed generated output is byte-identical, i.e. consumers produce the same bindings from the new layout.

## Relationship to #396 and #398

- **#396** fixes the same issue by keying the file to the compilation unit, parsed out of rustc's `-C metadata` with an argument filter for rustdoc. It is correct as far as it goes — and it carries a reproduced record-loss regression fix for the metadata list. This PR supersedes that approach: it deletes the need for a unit key at all, so #396's `unit_id`, metadata parsing and runtime-option deny-list have no counterpart here. Either can land; they should not both.
- **#398** (`cargo prebindgen clean`) is unaffected and still wanted: it addresses stale `target/*/build/<pkg>-<hash>/` directories, which are Cargo's and which this PR deliberately does not touch. Note the counts above are *per* build-hash directory — `clippy` and `doc` still mint their own.

`rand` is dropped from the workspace, since nothing generates names any more.
