### PR TITLE
Remove stale JniGen value-blob references

### DIFF
--- a/docs/sum-types.md
+++ b/docs/sum-types.md
@@ -55,7 +55,7 @@ hand-rolling a different simulation.
 > every other group is inert.
 
 Nothing else is new. A group's leaves are ordinary leaves: scalars, `String`, `enum_class`
-discriminants, opaque handles, value blobs, nested data classes. The two adapters differ only in
+discriminants, opaque handles, fixed-size primitive arrays, nested data classes. The two adapters differ only in
 *where* the groups are overlaid:
 
 | Adapter | Groups overlaid in | Inert groups |
@@ -133,8 +133,8 @@ from it**, so the surface stays self-consistent; the running example below keeps
 each snippet reads as one contract. `examples/covertest-kotlin` exercises the rename
 (`variant!(Labeled).name("Tagged")` ⇒ the class `Tagged` and the slots `tagged_v0` / `tagged_v1`).
 
-`sealed_class!(E)` is a fifth class kind beside `ptr_class!` / `data_class!` / `enum_class!` /
-`value_class!`: one simple argument, sub-builder, `.name()`, per-variant `.variant(variant!(V))`, and
+`sealed_class!(E)` is a fourth class kind beside `ptr_class!` / `data_class!` /
+`enum_class!`: one simple argument, sub-builder, `.name()`, per-variant `.variant(variant!(V))`, and
 the shared `class_interface_methods!` (`.interface()`, `.interface_name()`, `.implements()`). Like
 `enum_class!` it has no `.method` / `.constructor`: a sum value has no object identity Rust-side, so
 a "method" on it is a free function taking it.

--- a/examples/covertest-kotlin/README.md
+++ b/examples/covertest-kotlin/README.md
@@ -90,13 +90,13 @@ for the full table; in brief:
 - **type mappings:** primitives, `String`/`&str` (incl. a bare `String`
   return), `Option<T>` (param / return / **field**, incl. `Option<enum>` in
   all three positions and `Option<Payload>` in both directions),
-  `Vec<T>`/`&[T]`, `Vec<String>`, `Vec<value_class>` → `List<ByteArray>`,
+  `Vec<T>`/`&[T]`, `Vec<String>`, `Vec<Stamp>` → `List<Stamp>`,
   `Vec<handle>` / `Option<Vec<handle>>` (Kotlin-side handle fold),
   borrowed-opaque returns (`Option<&T>` → cloned owned handle),
-  `Result<_, E>` → `onError`, enums, value classes, `impl Fn` callbacks
+  `Result<_, E>` → `onError`, enums, data/sealed classes, fixed-size primitive arrays, `impl Fn` callbacks
   (single + slice + **owned-handle**), N-ary sorted handle locking (3 handles,
   hammered from 4 threads), the `je != null` binding-error channel (malformed
-  value-class bytes), the callback no-throw contract (exceptions described +
+  wrong-length fixed-size arrays), the callback no-throw contract (exceptions described +
   cleared per upcall), and per-upcall local-frame hygiene (20k-upcall
   pressure run).
 

--- a/examples/covertest-kotlin/build.rs
+++ b/examples/covertest-kotlin/build.rs
@@ -224,7 +224,7 @@ fn main() {
         // on the Rust side. Peeling the field by path segment answered "not
         // optional" and boxed it instead.
         .package(package!().class(data_class!(WrappedFields)))
-        // ── Subpackage `model`: enum + value class + nested data class ──────
+        // ── Subpackage `model`: enum + data/sealed classes ─────────────────
         .package(
             package!("model")
                 // `Priority` as a Kotlin `enum class` (jint wire, `fromInt`

--- a/examples/covertest-kotlin/kotlin/io/prebindgen/covertest/Test.kt
+++ b/examples/covertest-kotlin/kotlin/io/prebindgen/covertest/Test.kt
@@ -932,8 +932,8 @@ fun main() {
     // ── array-backed VALUE EQUALITY ─────────────────────────────────────────
     // The Rust types derive `Eq`, so the Kotlin mirrors must compare by
     // content. Kotlin arrays compare by IDENTITY, which silently breaks that
-    // for every `ByteArray`-backed property — a value blob's `bytes`, a
-    // `Vec<u8>` field, and any value carrying one of those. Kotlin's own
+    // for every `ByteArray`-backed property — a `Vec<u8>` field, a fixed-size
+    // `[u8; N]` field, and any value carrying one of those. Kotlin's own
     // `data class` codegen is inconsistent here (its `hashCode`/`toString` DO
     // special-case arrays, its `equals` does not), so `==` is the assertion
     // that matters and `hashCode` alone would not have caught the defect.
@@ -949,8 +949,8 @@ fun main() {
         check(hashSetOf(s1, s2).size == 1)
         check(s1.toString() == "Stamp(secs=7, nanos=42)") { "got $s1" }
 
-        // A data class with a DIRECT `ByteArray` field plus a NESTED value
-        // blob — the two shapes that broke downstream. The bytes sit LAST, so
+        // A data class with a DIRECT `ByteArray` field plus a NESTED data
+        // class — the two shapes that broke downstream. The bytes sit LAST, so
         // this also covers the `31 * result + …contentHashCode()` fold form
         // that a real value (`Timestamp(ntp64, id)`) produces.
         fun blob(secs: Long, id: ByteArray, chunks: List<ByteArray>) =
@@ -965,7 +965,7 @@ fun main() {
         // Every component must actually participate — a comparison that ignored
         // any of them would still pass the equality checks above.
         check(blob(7L, byteArrayOf(1, 2, 4), chunks) != b1) { "id must matter" }
-        check(blob(8L, byteArrayOf(1, 2, 3), chunks) != b1) { "nested blob must matter" }
+        check(blob(8L, byteArrayOf(1, 2, 3), chunks) != b1) { "nested stamp must matter" }
         // A CONTAINER of arrays: `List<ByteArray>` inherits `ByteArray`'s
         // identity equality, so the operators must dig through the container.
         check(blob(7L, byteArrayOf(1, 2, 3), listOf(byteArrayOf(9), byteArrayOf(8, 6))) != b1) {
@@ -1014,18 +1014,16 @@ fun main() {
         check(a1.toString().contains("flags=[true, false, true]")) { "got $a1" }
 
         // Wrong length is a BINDING ERROR, not a panic — the decode's `try_into`
-        // is the length check (the fixed-size-array successor to the value
-        // blob's byte-length guard).
+        // is the fixed-size-array length check.
         var lenErr: String? = null
         arraysEcho(a1.copy(ints = intArrayOf(1, 2))) { je -> lenErr = je; a1 }
         check(lenErr?.contains("fixed-size array decode") == true) {
             "wrong-length array must report a binding error, got: $lenErr"
         }
 
-        // WHOLE-OBJECT input decode (`.jobject_input()`): the decoder reads each
-        // field off the Kotlin object by JVM descriptor. A value-blob field's
-        // slot is the wrapper class, not `[B` — reading the old descriptor threw
-        // `NoSuchFieldError` on the first decode.
+        // WHOLE-OBJECT input decode (`.jobject_input()`): the decoder reads the
+        // nested data class, direct byte array, and list of byte arrays from the
+        // Kotlin object by their JVM descriptors.
         check(blobValueEcho(b1, boom) == b1) { "jobject-input round trip must preserve the value" }
         check(blobValueEcho(blob(0L, ByteArray(0), emptyList()), boom).chunks.isEmpty())
     }

--- a/prebindgen-jni/src/jni/builder.rs
+++ b/prebindgen-jni/src/jni/builder.rs
@@ -552,23 +552,19 @@ impl JniGenBuilder {
         self.store_iface_opts(&key, decl.iface);
     }
 
-    fn data_value_name_spec(
-        subpackage: &str,
-        short: String,
-        name_override: Option<String>,
-    ) -> NameSpec {
+    fn data_name_spec(subpackage: &str, short: String, name_override: Option<String>) -> NameSpec {
         NameSpec {
             subpackage: subpackage.to_string(),
             short,
             name_override,
-            kind: NameKind::DataOrValue,
+            kind: NameKind::Data,
         }
     }
 
     fn accept_data_class(&mut self, subpackage: &str, decl: DataClassDecl) {
         let short = rust_short_name(&decl.key);
         let key = decl.key;
-        let spec = Self::data_value_name_spec(subpackage, short, decl.name_override);
+        let spec = Self::data_name_spec(subpackage, short, decl.name_override);
         self.register_class(&key, decl.rust_type, DeclaredKind::Data, spec)
             .jobject_input |= decl.jobject_input;
         self.store_iface_opts(&key, decl.iface);

--- a/prebindgen-jni/src/jni/config.rs
+++ b/prebindgen-jni/src/jni/config.rs
@@ -42,12 +42,12 @@
 use super::*;
 
 /// Which per-kind mangle hook applies when deriving a declared class's
-/// Kotlin name. Value classes reuse the data-class hook.
+/// Kotlin name.
 #[derive(Clone, Copy)]
 pub(crate) enum NameKind {
     Ptr,
     Enum,
-    DataOrValue,
+    Data,
 }
 
 /// Raw naming spec of one declared class type, stored in [`TypeConfig`] as
@@ -228,7 +228,7 @@ impl Declarations {
         let mangled = match kind {
             NameKind::Ptr => self.mangle_ptr_class(&package, short),
             NameKind::Enum => self.mangle_enum(&package, short),
-            NameKind::DataOrValue => self.mangle_data_class(&package, short),
+            NameKind::Data => self.mangle_data_class(&package, short),
         };
         self.resolve_class_fqn(subpackage, &mangled)
     }

--- a/prebindgen-jni/src/jni/emit/delivery.rs
+++ b/prebindgen-jni/src/jni/emit/delivery.rs
@@ -1506,8 +1506,8 @@ pub(crate) fn leaf_ty_is_prim(
     // No projection (plain primitive/enum wire) — or an opaque HANDLE, whose
     // converter's wire is the raw `jlong` the typed `run` declares as `Long`
     // (`J`): the receiver constructs the typed class in bytecode. A nullable
-    // handle boxes to `java.lang.Long` instead (object chunk). Value blobs
-    // stay objects (`[B`).
+    // handle boxes to `java.lang.Long` instead (object chunk). Fixed-size
+    // arrays and other object wires stay objects (for example, `[B`).
     let proj_ok = match &entry.metadata.projection {
         None => true,
         Some(p) => matches!(p.kind, ProjectionKind::Handle | ProjectionKind::Unsigned64),

--- a/prebindgen-jni/src/jni/equality.rs
+++ b/prebindgen-jni/src/jni/equality.rs
@@ -3,8 +3,8 @@
 //!
 //! A generated class mirrors a Rust type that derives `PartialEq`/`Eq`, so two
 //! values with equal contents must compare equal. Kotlin arrays compare by
-//! IDENTITY, which breaks that for every `Vec<u8>` field (`ByteArray`) and for
-//! the `ByteArray` a value blob carries:
+//! IDENTITY, which breaks that for every `Vec<u8>` or fixed-size primitive-array
+//! field that surfaces as a Kotlin array:
 //!
 //! ```text
 //! Timestamp(1uL, byteArrayOf(1,2,3)) == Timestamp(1uL, byteArrayOf(1,2,3))  // false
@@ -17,19 +17,6 @@
 //! right `HashMap` bucket and is then rejected. Both members are emitted here
 //! anyway, so the behavior is stated by the generated source rather than
 //! inherited from a compiler special case that only covers two of the three.
-//!
-//! ## Why value blobs are not `@JvmInline`
-//!
-//! Kotlin 1.9 (the version this generator targets downstream) rejects
-//! `equals`/`hashCode` members on a value class outright — *"Member with the
-//! name 'equals' is reserved for future releases"* — and its typed-equals
-//! replacement (`operator fun equals(other: T)`) is experimental, needing an
-//! opt-in flag every consumer would have to set. A `@JvmInline value class`
-//! therefore CANNOT be given value equality at this language level, so
-//! [`super::kotlin_emit`] emits value blobs as a plain `data class`. That costs
-//! one small allocation per crossing at the wrapper tier (the JNI ABI is
-//! unaffected — externs declare `ByteArray` directly and the wrapper passes
-//! `.bytes`), which is the price of the type behaving like the value it is.
 
 use kotlin_codegen::{KtCode, KtFun, KtParam, KtType};
 

--- a/prebindgen-jni/src/jni/iface.rs
+++ b/prebindgen-jni/src/jni/iface.rs
@@ -1508,8 +1508,8 @@ pub(crate) fn whole_folder_iface_spec(
     // `raw_handle = true`: an opaque-handle element crosses the JNI border as
     // its raw `jlong` (the folder wraps it into the typed handle class in Kotlin
     // bytecode — a native `new_object` per element would cost descriptor parse +
-    // FindClass + GetMethodID + NewObjectA). Value blobs / String are unaffected
-    // (they ignore the flag; see [`leaf_iface_param`]).
+    // FindClass + GetMethodID + NewObjectA). Primitive arrays and String are
+    // unaffected (they ignore the flag; see [`leaf_iface_param`]).
     params.push(leaf_iface_param(
         ext,
         registry,


### PR DESCRIPTION
## Summary

- remove obsolete `value_class!` / value-blob descriptions from the sum-type docs and Kotlin covertest
- describe fixed-size primitive arrays and data classes where those removed shapes were still named
- delete the obsolete value-blob section from the array-content equality docs
- rename the internal `NameKind::DataOrValue` / `data_value_name_spec` remnants to `Data` / `data_name_spec`
- retain the two explicit historical comments that explain why typed primitive-array conversion replaced raw-memory reconstruction

The raw-memory mechanism was removed in #209 after the soundness problem tracked by #85.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p prebindgen-jni` — 255 unit tests passed; doc tests passed

Companion workspace guidance PR: https://github.com/milyin/PREBINDGEN_WORKSPACE/pull/1  
Companion downstream terminology PR: https://github.com/eclipse-zenoh/zenoh-flat-jni/pull/42
