### PR TITLE
JniGen: allow nullable error recovery for reference returns

### DIFF
--- a/examples/covertest-kotlin/kotlin/REPORT.md
+++ b/examples/covertest-kotlin/kotlin/REPORT.md
@@ -4,7 +4,7 @@ Base package: `io.prebindgen.covertest`
 
 ## package `io.prebindgen.covertest`
 
-- `string_new` — `fun stringNew(s: String, onError: JniErrorHandler<String>): String`
+- `string_new` — `fun stringNew(s: String, onError: JniErrorHandler<String?>): String?`
 - `val COVER_BANNER: String` — binding expression
 - `val COVER_MAGIC` — `#[prebindgen]` const `COVER_MAGIC`
 - `val COVER_TAG_RUNTIME` — nullary `#[prebindgen]` fn `cover_tag_runtime`
@@ -14,30 +14,30 @@ Base package: `io.prebindgen.covertest`
 ## package `io.prebindgen.covertest.analytics`
 
 - `archive_latest` — `fun archiveLatest(a: SummaryVault, onError: JniErrorHandler<Summary?>): Summary?`
-- `archive_new` — `fun archiveNew(onError: JniErrorHandler<SummaryVault>): SummaryVault`
+- `archive_new` — `fun archiveNew(onError: JniErrorHandler<SummaryVault?>): SummaryVault?`
 - `archive_store` — `fun archiveStore(a: SummaryVault, sSel: Int, s00: Long?, s01: Double?, s1: Summary?, onError: JniErrorHandler<Unit>)`
   - shaped by: param `s` expanded from `Summary` — variants [summary_new, self]
 - `storage_expect_summary` — `fun storageExpectSummary(s: Storage, expectedSel: Int, expected00: Long?, expected01: Double?, expected1: Summary?, onError: JniErrorHandler<Boolean>): Boolean`
   - shaped by: param `expected` expanded from `Summary` — variants [summary_new, self]
 - `storage_matches_summary` — `fun storageMatchesSummary(s: Storage, expectedSel: Int, expected00: Long?, expected01: Double?, expected1: Summary?, onError: JniErrorHandler<Boolean>): Boolean`
   - shaped by: param `expected` expanded from `Summary` — variants [summary_new, self]
-- `storage_summary` — `fun <R> storageSummary(s: Storage, onError: JniErrorHandler<R>, build: SummaryBuilder<R>): R`
+- `storage_summary` — `fun <R> storageSummary(s: Storage, onError: JniErrorHandler<R?>, build: SummaryBuilder<R>): R?`
   - shaped by: return `Summary` decomposed → [count, total] (Callback delivery)
-- `storage_summary_full` — `fun <R> storageSummaryFull(s: Storage, onError: JniErrorHandler<R>, build: SummaryStorageSummaryFullBuilder<R>): R`
+- `storage_summary_full` — `fun <R> storageSummaryFull(s: Storage, onError: JniErrorHandler<R?>, build: SummaryStorageSummaryFullBuilder<R>): R?`
   - shaped by: return `Summary` decomposed → [count, total, handle] (Callback delivery)
-- `storage_summary_handle` — `fun storageSummaryHandle(s: Storage, onError: JniErrorHandler<Summary>): Summary`
-- `storage_summary_probe` — `fun <R> storageSummaryProbe(s: Storage, onError: JniErrorHandler<R>, build: SummaryStorageSummaryProbeBuilder<R>): R`
+- `storage_summary_handle` — `fun storageSummaryHandle(s: Storage, onError: JniErrorHandler<Summary?>): Summary?`
+- `storage_summary_probe` — `fun <R> storageSummaryProbe(s: Storage, onError: JniErrorHandler<R?>, build: SummaryStorageSummaryProbeBuilder<R>): R?`
   - shaped by: return `Summary` decomposed → [count, total, handle] (Callback delivery)
-- `summary_describe` — `fun describeSummary(sSel: Int, s00: Long?, s01: Double?, s1: Summary?, verbose: Boolean, onError: JniErrorHandler<String>): String`
+- `summary_describe` — `fun describeSummary(sSel: Int, s00: Long?, s01: Double?, s1: Summary?, verbose: Boolean, onError: JniErrorHandler<String?>): String?`
   - shaped by: param `s` expanded from `Summary` — variants [summary_new, self]
-- `summary_merge` — `fun <R> summaryMerge(primarySel: Int, primary00: Long?, primary01: Double?, primary1: Summary?, fallbackSel: Int, fallback00: Long?, fallback01: Double?, fallback1: Summary?, onError: JniErrorHandler<R>, build: SummaryBuilder<R>): R`
+- `summary_merge` — `fun <R> summaryMerge(primarySel: Int, primary00: Long?, primary01: Double?, primary1: Summary?, fallbackSel: Int, fallback00: Long?, fallback01: Double?, fallback1: Summary?, onError: JniErrorHandler<R?>, build: SummaryBuilder<R>): R?`
   - shaped by: param `fallback` expanded from `Summary` — variants [summary_new, self]
   - shaped by: param `primary` expanded from `Summary` — variants [summary_new, self]
   - shaped by: return `Summary` decomposed → [count, total] (Callback delivery)
 - `summary_prefer` — `fun summaryPrefer(primarySel: Int, primary00: Long?, primary01: Double?, primary1: Summary?, fallbackSel: Int, fallback00: Long?, fallback01: Double?, fallback1: Summary?, onError: JniErrorHandler<Long>): Long`
   - shaped by: param `fallback` expanded from `Summary` — variants [summary_new, self]
   - shaped by: param `primary` expanded from `Summary` — variants [summary_new, self]
-- `summary_series` — `fun <A> summarySeries(count: Long, start: Long, acc: A, onError: JniErrorHandler<A>, fold: SummaryFolder<A>): A`
+- `summary_series` — `fun <A> summarySeries(count: Long, start: Long, acc: A, onError: JniErrorHandler<A?>, fold: SummaryFolder<A>): A?`
   - shaped by: return `Summary` decomposed → [count, total] (Callback delivery)
 - `summary_series_opt` — `fun <A> summarySeriesOpt(count: Long, start: Long, acc: A, onError: JniErrorHandler<A?>, fold: SummaryFolder<A>): A?`
   - shaped by: return `Summary` decomposed → [count, total] (Callback delivery)
@@ -48,20 +48,20 @@ Base package: `io.prebindgen.covertest`
 ## package `io.prebindgen.covertest.model`
 
 - `annotated_alternate_value` — `fun annotatedAlternateValue(a: Annotated, onError: JniErrorHandler<Double?>): Double?`
-- `annotated_new` — `fun annotatedNew(payload: Payload, ttl: Long?, priority: Priority?, onError: JniErrorHandler<Annotated>): Annotated`
+- `annotated_new` — `fun annotatedNew(payload: Payload, ttl: Long?, priority: Priority?, onError: JniErrorHandler<Annotated?>): Annotated?`
 - `annotated_payload_value` — `fun annotatedPayloadValue(a: Annotated, onError: JniErrorHandler<Double>): Double`
 - `annotated_priority` — `fun annotatedPriority(a: Annotated, onError: JniErrorHandler<Priority?>): Priority?`
 - `annotated_ttl` — `fun annotatedTtl(a: Annotated, onError: JniErrorHandler<Long?>): Long?`
-- `archive_reading` — `fun archiveReading(a: SummaryVault, onError: JniErrorHandler<Reading>): Reading`
+- `archive_reading` — `fun archiveReading(a: SummaryVault, onError: JniErrorHandler<Reading?>): Reading?`
   - shaped by: return `Reading` decomposed → [tag, exact_v0, range_low, range_high, tagged_v0, tagged_v1, companion_v0] (Callback delivery)
 - `archive_reading_maybe` — `fun archiveReadingMaybe(a: SummaryVault, onError: JniErrorHandler<Reading?>): Reading?`
   - shaped by: return `Reading` decomposed → [tag, exact_v0, range_low, range_high, tagged_v0, tagged_v1, companion_v0] (Callback delivery)
 - `archive_set_reading` — `fun archiveSetReading(a: SummaryVault, which: Int, onError: JniErrorHandler<Unit>)`
-- `arrays_echo` — `fun arraysEcho(a: Arrays, onError: JniErrorHandler<Arrays>): Arrays`
+- `arrays_echo` — `fun arraysEcho(a: Arrays, onError: JniErrorHandler<Arrays?>): Arrays?`
   - shaped by: return `Arrays` decomposed → [bytes, shorts, ints, longs, doubles, flags, raw] (Callback delivery)
-- `blob_value_echo` — `fun blobValueEcho(value: BlobValue, onError: JniErrorHandler<BlobValue>): BlobValue`
+- `blob_value_echo` — `fun blobValueEcho(value: BlobValue, onError: JniErrorHandler<BlobValue?>): BlobValue?`
   - shaped by: return `BlobValue` decomposed → [stamp__secs, stamp__nanos, id, chunks] (Callback delivery)
-- `blob_value_new` — `fun blobValueNew(secs: Long, id: ByteArray, chunks: List<ByteArray>, onError: JniErrorHandler<BlobValue>): BlobValue`
+- `blob_value_new` — `fun blobValueNew(secs: Long, id: ByteArray, chunks: List<ByteArray>, onError: JniErrorHandler<BlobValue?>): BlobValue?`
   - shaped by: return `BlobValue` decomposed → [stamp__secs, stamp__nanos, id, chunks] (Callback delivery)
 - `boxed_duration_echo` — `fun boxedDurationEcho(value: ULong, onError: JniErrorHandler<ULong>): ULong`
 - `boxed_elem_id_sum` — `fun boxedElemIdSum(ps: List<Payload>, onError: JniErrorHandler<Long>): Long`
@@ -74,72 +74,72 @@ Base package: `io.prebindgen.covertest`
 - `boxed_run_id_sum` — `fun boxedRunIdSum(ps: List<Payload>, onError: JniErrorHandler<Long>): Long`
 - `cache_config_weight` — `fun cacheConfigWeight(cache: CacheConfig?, onError: JniErrorHandler<Int>): Int`
 - `celsius_double` — `fun celsiusDouble(c: Int, onError: JniErrorHandler<Int>): Int`
-- `dossier_new` — `fun dossierNew(note: Long, tag: Long, count: Long, total: Double, onError: JniErrorHandler<Dossier>): Dossier`
-- `duration_boundary_echo` — `fun durationBoundaryEcho(value: DurationBoundary, onError: JniErrorHandler<DurationBoundary>): DurationBoundary`
+- `dossier_new` — `fun dossierNew(note: Long, tag: Long, count: Long, total: Double, onError: JniErrorHandler<Dossier?>): Dossier?`
+- `duration_boundary_echo` — `fun durationBoundaryEcho(value: DurationBoundary, onError: JniErrorHandler<DurationBoundary?>): DurationBoundary?`
   - shaped by: return `DurationBoundary` decomposed → [required, delay] (Callback delivery)
 - `duration_emit` — `fun durationEmit(value: ULong, f: DurationCallback, onError: JniErrorHandler<Unit>)`
 - `duration_optional` — `fun durationOptional(value: ULong?, onError: JniErrorHandler<ULong?>): ULong?`
 - `duration_out_of_range` — `fun durationOutOfRange(onError: JniErrorHandler<ULong?>): ULong?`
-- `hold_echo` — `fun holdEcho(h: Hold, onError: JniErrorHandler<Hold>): Hold`
+- `hold_echo` — `fun holdEcho(h: Hold, onError: JniErrorHandler<Hold?>): Hold?`
   - shaped by: return `Hold` decomposed → [tag, for_v0] (Callback delivery)
-- `hold_policy_echo` — `fun holdPolicyEcho(p: HoldPolicy, onError: JniErrorHandler<HoldPolicy>): HoldPolicy`
+- `hold_policy_echo` — `fun holdPolicyEcho(p: HoldPolicy, onError: JniErrorHandler<HoldPolicy?>): HoldPolicy?`
 - `holder_tag_or` — `fun holderTagOr(h: Holder?, fallback: Long, onError: JniErrorHandler<Long>): Long`
-- `label_reverse` — `fun labelReverse(l: String, onError: JniErrorHandler<String>): String`
-- `label_series_echo` — `fun labelSeriesEcho(labels: List<String>, onError: JniErrorHandler<List<String>>): List<String>`
+- `label_reverse` — `fun labelReverse(l: String, onError: JniErrorHandler<String?>): String?`
+- `label_series_echo` — `fun labelSeriesEcho(labels: List<String>, onError: JniErrorHandler<List<String>?>): List<String>?`
 - `ledger_each` — `fun ledgerEach(n: Long, sink: LedgerCallback, onError: JniErrorHandler<Unit>)`
-- `ledger_new` — `fun <R> ledgerNew(n: Long, onError: JniErrorHandler<R>, build: LedgerBuilder<R>): R`
+- `ledger_new` — `fun <R> ledgerNew(n: Long, onError: JniErrorHandler<R?>, build: LedgerBuilder<R>): R?`
   - shaped by: return `Ledger` decomposed → [ledgerFiled__summary__count, ledgerFiled__summary__total, ledgerFiled__taken, ledgerFiled__origin__secs, ledgerFiled__origin__nanos, ledgerFiled__outcome__tag, ledgerFiled__outcome__found_v0, ledgerFiled__outcome__failed_v0, ledgerFiled__label, ledgerArchived__summary__count, ledgerArchived__summary__total, ledgerArchived__taken, ledgerArchived__origin__secs, ledgerArchived__origin__nanos, ledgerArchived__outcome__tag, ledgerArchived__outcome__found_v0, ledgerArchived__outcome__failed_v0, ledgerArchived__label] (Callback delivery)
 - `lookup_each` — `fun lookupEach(n: Long, total: Double, sink: LookupCallback, onError: JniErrorHandler<Unit>)`
-- `lookup_of` — `fun lookupOf(count: Long, total: Double, onError: JniErrorHandler<Lookup>): Lookup`
+- `lookup_of` — `fun lookupOf(count: Long, total: Double, onError: JniErrorHandler<Lookup?>): Lookup?`
   - shaped by: return `Lookup` decomposed → [tag, found_v0, failed_v0] (Callback delivery)
-- `marker_of` — `fun markerOf(which: Int, onError: JniErrorHandler<Marker>): Marker`
+- `marker_of` — `fun markerOf(which: Int, onError: JniErrorHandler<Marker?>): Marker?`
   - shaped by: return `Marker` decomposed → [tag, ranked_v0] (Callback delivery)
 - `object_boundary_value` — `fun objectBoundaryValue(value: ObjectBoundary, onError: JniErrorHandler<Long>): Long`
-- `observation_new` — `fun observationNew(which: Int, withFallback: Boolean, onError: JniErrorHandler<Observation>): Observation`
+- `observation_new` — `fun observationNew(which: Int, withFallback: Boolean, onError: JniErrorHandler<Observation?>): Observation?`
 - `observation_which` — `fun observationWhich(o: Observation, onError: JniErrorHandler<Int>): Int`
-- `payload_priority` — `fun payloadPriority(p: Payload, onError: JniErrorHandler<Priority>): Priority`
+- `payload_priority` — `fun payloadPriority(p: Payload, onError: JniErrorHandler<Priority?>): Priority?`
 - `percent_invalid_output` — `fun percentInvalidOutput(onError: JniErrorHandler<Int?>): Int?`
 - `percent_optional` — `fun percentOptional(p: Int?, onError: JniErrorHandler<Int?>): Int?`
 - `percent_scale` — `fun percentScale(p: Int, factor: Int, onError: JniErrorHandler<Int>): Int`
 - `plain_note_echo` — `fun plainNoteEcho(note: String?, onError: JniErrorHandler<String?>): String?`
-- `priority_or` — `fun priorityOr(p: Priority?, fallback: Priority, onError: JniErrorHandler<Priority>): Priority`
+- `priority_or` — `fun priorityOr(p: Priority?, fallback: Priority, onError: JniErrorHandler<Priority?>): Priority?`
 - `priority_weight` — `fun priorityWeight(p: Priority, onError: JniErrorHandler<Int>): Int`
 - `probe_each` — `fun probeEach(n: Long, total: Double, sink: ProbeCallback, onError: JniErrorHandler<Unit>)`
-- `probe_new` — `fun <R> probeNew(seq: Long, count: Long, total: Double, onError: JniErrorHandler<R>, build: ProbeBuilder<R>): R`
+- `probe_new` — `fun <R> probeNew(seq: Long, count: Long, total: Double, onError: JniErrorHandler<R?>, build: ProbeBuilder<R>): R?`
   - shaped by: return `Probe` decomposed → [seq, outcome__tag, outcome__found_v0, outcome__failed_v0] (Callback delivery)
 - `reading_each` — `fun readingEach(n: Int, sink: ReadingCallback, onError: JniErrorHandler<Unit>)`
 - `reading_maybe` — `fun readingMaybe(which: Int, onError: JniErrorHandler<Reading?>): Reading?`
   - shaped by: return `Reading` decomposed → [tag, exact_v0, range_low, range_high, tagged_v0, tagged_v1, companion_v0] (Callback delivery)
-- `reading_of` — `fun readingOf(which: Int, onError: JniErrorHandler<Reading>): Reading`
+- `reading_of` — `fun readingOf(which: Int, onError: JniErrorHandler<Reading?>): Reading?`
   - shaped by: return `Reading` decomposed → [tag, exact_v0, range_low, range_high, tagged_v0, tagged_v1, companion_v0] (Callback delivery)
-- `reading_series` — `fun readingSeries(n: Int, onError: JniErrorHandler<List<Reading>>): List<Reading>`
+- `reading_series` — `fun readingSeries(n: Int, onError: JniErrorHandler<List<Reading>?>): List<Reading>?`
   - shaped by: return `Reading` decomposed → [tag, exact_v0, range_low, range_high, tagged_v0, tagged_v1, companion_v0] (Callback delivery)
 - `ref_vec_id_sum` — `fun refVecIdSum(ps: List<Payload>, onError: JniErrorHandler<Long>): Long`
 - `report_each` — `fun reportEach(n: Long, sink: ReportCallback, onError: JniErrorHandler<Unit>)`
 - `slice_id_sum` — `fun sliceIdSum(ps: List<Payload>, onError: JniErrorHandler<Long>): Long`
-- `span_holder_new` — `fun <R> spanHolderNew(seq: Long, requiredMs: ULong, delayMs: Long, onError: JniErrorHandler<R>, build: SpanHolderBuilder<R>): R`
+- `span_holder_new` — `fun <R> spanHolderNew(seq: Long, requiredMs: ULong, delayMs: Long, onError: JniErrorHandler<R?>, build: SpanHolderBuilder<R>): R?`
   - shaped by: return `SpanHolder` decomposed → [spanHolderSpan__required, spanHolderSpan__delay] (Callback delivery)
-- `stamp_new` — `fun stampNew(secs: Long, nanos: Long, onError: JniErrorHandler<Stamp>): Stamp`
+- `stamp_new` — `fun stampNew(secs: Long, nanos: Long, onError: JniErrorHandler<Stamp?>): Stamp?`
   - shaped by: return `Stamp` decomposed → [secs, nanos] (Callback delivery)
-- `stamp_series` — `fun stampSeries(count: Long, onError: JniErrorHandler<List<Stamp>>): List<Stamp>`
+- `stamp_series` — `fun stampSeries(count: Long, onError: JniErrorHandler<List<Stamp>?>): List<Stamp>?`
   - shaped by: return `Stamp` decomposed → [secs, nanos] (Callback delivery)
-- `tagged_new` — `fun taggedNew(which: Int, onError: JniErrorHandler<Tagged>): Tagged`
+- `tagged_new` — `fun taggedNew(which: Int, onError: JniErrorHandler<Tagged?>): Tagged?`
 - `tagged_rank` — `fun taggedRank(t: Tagged, onError: JniErrorHandler<Int>): Int`
 - `unsigned_data_maybe` — `fun unsignedDataMaybe(value: Unsigned, onError: JniErrorHandler<ULong?>): ULong?`
 - `unsigned_emit` — `fun unsignedEmit(value: ULong, f: u64Callback, onError: JniErrorHandler<Unit>)`
 - `unsigned_optional` — `fun unsignedOptional(value: ULong?, onError: JniErrorHandler<ULong?>): ULong?`
-- `unsigned_round_trip` — `fun unsignedRoundTrip(byte: Int, short: Int, int: Long, long: ULong, maybeLong: ULong?, onError: JniErrorHandler<Unsigned>): Unsigned`
+- `unsigned_round_trip` — `fun unsignedRoundTrip(byte: Int, short: Int, int: Long, long: ULong, maybeLong: ULong?, onError: JniErrorHandler<Unsigned?>): Unsigned?`
   - shaped by: return `Unsigned` decomposed → [byte, short, int, long, maybeLong] (Callback delivery)
-- `unsigned_series` — `fun unsignedSeries(onError: JniErrorHandler<List<ULong>>): List<ULong>`
+- `unsigned_series` — `fun unsignedSeries(onError: JniErrorHandler<List<ULong>?>): List<ULong>?`
   - shaped by: return `u64` decomposed → [] (Callback delivery)
-- `verdict_new` — `fun verdictNew(id: Long, count: Long, total: Double, onError: JniErrorHandler<Verdict>): Verdict`
+- `verdict_new` — `fun verdictNew(id: Long, count: Long, total: Double, onError: JniErrorHandler<Verdict?>): Verdict?`
 - `wrapped_fields_sum` — `fun wrappedFieldsSum(w: WrappedFields, onError: JniErrorHandler<Long>): Long`
 
 ## package `io.prebindgen.covertest.storage`
 
 - `millis_add` — `fun addMillis(a: Long, b: Long, onError: JniErrorHandler<Long>): Long`
-- `payload_handler_new` — `fun payloadHandlerNew(f: PayloadCallback, onError: JniErrorHandler<PayloadHandler>): PayloadHandler`
-- `payload_vec_handler_new` — `fun payloadVecHandlerNew(f: PayloadListCallback, onError: JniErrorHandler<PayloadVecHandler>): PayloadVecHandler`
+- `payload_handler_new` — `fun payloadHandlerNew(f: PayloadCallback, onError: JniErrorHandler<PayloadHandler?>): PayloadHandler?`
+- `payload_vec_handler_new` — `fun payloadVecHandlerNew(f: PayloadListCallback, onError: JniErrorHandler<PayloadVecHandler?>): PayloadVecHandler?`
 - `storage_callback` — `fun storageCallback(s: Storage, handler: PayloadHandler, onError: JniErrorHandler<Unit>)`
 - `storage_callback_vec` — `fun storageCallbackVec(s: Storage, handler: PayloadVecHandler, onError: JniErrorHandler<Unit>)`
 - `storage_emit` — `fun storageEmit(n: Long, h: StorageHandler, onError: JniErrorHandler<Unit>)`
@@ -147,27 +147,27 @@ Base package: `io.prebindgen.covertest`
   - shaped by: return `Payload` decomposed → [id, seq, value, flag, label] (Callback delivery)
 - `storage_get_vec` — `fun storageGetVec(s: Storage, onError: JniErrorHandler<List<Payload>?>): List<Payload>?`
   - shaped by: return `Payload` decomposed → [id, seq, value, flag, label] (Callback delivery)
-- `storage_handler_new` — `fun storageHandlerNew(f: StorageCallback, onError: JniErrorHandler<StorageHandler>): StorageHandler`
-- `storage_labels` — `fun storageLabels(s: Storage, onError: JniErrorHandler<List<String>>): List<String>`
+- `storage_handler_new` — `fun storageHandlerNew(f: StorageCallback, onError: JniErrorHandler<StorageHandler?>): StorageHandler?`
+- `storage_labels` — `fun storageLabels(s: Storage, onError: JniErrorHandler<List<String>?>): List<String>?`
   - shaped by: return `String` decomposed → [] (Callback delivery)
-- `storage_new` — `fun storageNew(onError: JniErrorHandler<Storage>): Storage`
+- `storage_new` — `fun storageNew(onError: JniErrorHandler<Storage?>): Storage?`
 - `storage_put_by_read` — `fun storagePutByRead(s: Storage, payload: Payload, onError: JniErrorHandler<Unit>)`
 - `storage_put_by_take` — `fun storagePutByTake(s: Storage, payload: Payload, onError: JniErrorHandler<Unit>)`
 - `storage_put_opt` — `fun storagePutOpt(s: Storage, p: Payload?, onError: JniErrorHandler<Boolean>): Boolean`
 - `storage_put_slice` — `fun storagePutSlice(s: Storage, payloads: List<Payload>, onError: JniErrorHandler<Unit>)`
-- `storage_shards` — `fun storageShards(count: Long, each: Long, onError: JniErrorHandler<List<Storage>>): List<Storage>`
+- `storage_shards` — `fun storageShards(count: Long, each: Long, onError: JniErrorHandler<List<Storage>?>): List<Storage>?`
   - shaped by: return `Storage` decomposed → [] (Callback delivery)
 - `storage_shards_opt` — `fun storageShardsOpt(count: Long, each: Long, onError: JniErrorHandler<List<Storage>?>): List<Storage>?`
   - shaped by: return `Storage` decomposed → [] (Callback delivery)
 - `storage_total_len` — `fun storageTotalLen(a: Storage, b: Storage, c: Storage, onError: JniErrorHandler<Long>): Long`
-- `storage_try_from_stamp` — `fun storageTryFromStamp(s: Stamp, tag: ByteArray, onBindingError: JniErrorHandler<Storage>, onError: StorageErrorHandler<Storage>): Storage`
+- `storage_try_from_stamp` — `fun storageTryFromStamp(s: Stamp, tag: ByteArray, onBindingError: JniErrorHandler<Storage?>, onError: StorageErrorHandler<Storage?>): Storage?`
   - shaped by: domain error `StorageError` decomposed → onError [message, handle] (binding failures → onBindingError)
-- `storage_try_with_label` — `fun storageTryWithLabel(label: String, onBindingError: JniErrorHandler<Storage>, onError: StorageErrorHandler<Storage>): Storage`
+- `storage_try_with_label` — `fun storageTryWithLabel(label: String, onBindingError: JniErrorHandler<Storage?>, onError: StorageErrorHandler<Storage?>): Storage?`
   - shaped by: domain error `StorageError` decomposed → onError [message, handle] (binding failures → onBindingError)
 
 ## class `io.prebindgen.covertest.esc_pkg.Esc_Probe` (ptr_class, Rust `EscapeProbe`)
 
-- `escape_probe_new` — `fun escapeProbeNew(value: Long, onError: JniErrorHandler<Esc_Probe>): Esc_Probe`
+- `escape_probe_new` — `fun escapeProbeNew(value: Long, onError: JniErrorHandler<Esc_Probe?>): Esc_Probe?`
 - `escape_probe_value` — `fun escapeProbeValue(onError: JniErrorHandler<Long>): Long`
 
 ## class `io.prebindgen.covertest.Payload` (data_class, Rust `Payload`)
@@ -183,18 +183,18 @@ Base package: `io.prebindgen.covertest`
 
 - `storage_contains` — `fun contains(id: Long, onError: JniErrorHandler<Boolean>): Boolean`
 - `storage_len` — `fun len(onError: JniErrorHandler<Long>): Long`
-- `storage_with_payload` — `fun withPayload(payload: Payload, onError: JniErrorHandler<Storage>): Storage`
+- `storage_with_payload` — `fun withPayload(payload: Payload, onError: JniErrorHandler<Storage?>): Storage?`
 
 ## class `io.prebindgen.covertest.errors.StorageError` (ptr_class, Rust `StorageError`)
 
-- `storage_error_message` — `fun message(onError: JniErrorHandler<String>): String`
+- `storage_error_message` — `fun message(onError: JniErrorHandler<String?>): String?`
 
 ## class `io.prebindgen.covertest.analytics.Summary` (ptr_class, Rust `Summary`)
 
 - `summary_count` — `fun count(onError: JniErrorHandler<Long>): Long`
-- `summary_from_mean` — `fun fromMean(count: Long, mean: Double, onError: JniErrorHandler<Summary>): Summary`
+- `summary_from_mean` — `fun fromMean(count: Long, mean: Double, onError: JniErrorHandler<Summary?>): Summary?`
 - `summary_mean` — `fun mean(onError: JniErrorHandler<Double>): Double`
-- `summary_new` — `fun of(count: Long, total: Double, onError: JniErrorHandler<Summary>): Summary`
+- `summary_new` — `fun of(count: Long, total: Double, onError: JniErrorHandler<Summary?>): Summary?`
 - `summary_scaled` — `fun scaled(factor: Double, onError: JniErrorHandler<Double>): Double`
 - `summary_total` — `fun total(onError: JniErrorHandler<Double>): Double`
 

--- a/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest.kt
+++ b/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest.kt
@@ -812,10 +812,11 @@ internal object __u64FolderRawHolder {
  * converter in the chain may fail, or a handle may be closed). `je` is the
  * failure message. For an infallible wrapper this is the sole `onError`; a
  * fallible wrapper takes it as `onBindingError` alongside the typed domain
- * handler. The wrapper returns whatever `run` returns;
- * the handler firing is the error discriminator: null can also be a successful optional
- * result, while a non-null value can be a handler-supplied fallback.
- * throwing from `run` is safe (it executes after the native call has returned).
+ * handler. The wrapper returns whatever `run` returns. Where that type is nullable you may
+ * return `null` to decline — you are not required to fabricate a result. Consequently the
+ * handler firing, not the returned value, is the error discriminator: `null` can also be a
+ * successful optional result, and a non-null value can be a fallback you supplied. Throwing
+ * from `run` is safe (it executes after the native call has returned).
  */
 public fun interface JniErrorHandler<out R> {
     public fun run(je: String?): R

--- a/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest.kt
+++ b/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest.kt
@@ -451,7 +451,7 @@ public class Storage private constructor(initialPtr: Long) : NativeHandle(initia
          * Build a storage holding a single payload (a **constructor** / companion
          * factory on `Storage`).
          */
-        public fun withPayload(payload: Payload, onError: JniErrorHandler<Storage>): Storage {
+        public fun withPayload(payload: Payload, onError: JniErrorHandler<Storage?>): Storage? {
             val __bcap = JniErrorHandlerCapture.acquire()
             val __ret = CovNative.storageWithPayload(
                 payload.id,
@@ -813,6 +813,8 @@ internal object __u64FolderRawHolder {
  * failure message. For an infallible wrapper this is the sole `onError`; a
  * fallible wrapper takes it as `onBindingError` alongside the typed domain
  * handler. The wrapper returns whatever `run` returns;
+ * the handler firing is the error discriminator: null can also be a successful optional
+ * result, while a non-null value can be a handler-supplied fallback.
  * throwing from `run` is safe (it executes after the native call has returned).
  */
 public fun interface JniErrorHandler<out R> {
@@ -837,7 +839,7 @@ internal class JniErrorHandlerCapture : JniErrorHandler<Unit> {
  * Build the opaque string the C side stores in [`Payload::label`]. To C this
  * returns a `string_t *` (since `String` is declared `opaque_ptr`).
  */
-public fun stringNew(s: String, onError: JniErrorHandler<String>): String {
+public fun stringNew(s: String, onError: JniErrorHandler<String?>): String? {
     val __bcap = JniErrorHandlerCapture.acquire()
     val __ret = CovNative.stringNew(s, __bcap)
     if (__bcap.failed) return onError.run(__bcap.ze0)

--- a/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest/analytics.kt
+++ b/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest/analytics.kt
@@ -119,14 +119,14 @@ public class Summary private constructor(initialPtr: Long) : GcNativeHandle(init
          * Construct a [`Summary`] from its parts (declared a **constructor** /
          * companion factory, and the build-from **variant** of the flatten-input).
          */
-        public fun of(count: Long, total: Double, onError: JniErrorHandler<Summary>): Summary {
+        public fun of(count: Long, total: Double, onError: JniErrorHandler<Summary?>): Summary? {
             val __bcap = JniErrorHandlerCapture.acquire()
             val __ret = CovNative.summaryNew(count, total, __bcap)
             if (__bcap.failed) return onError.run(__bcap.ze0)
             return Summary.fromRawPtr(__ret)
         }
 
-        public fun fromMean(count: Long, mean: Double, onError: JniErrorHandler<Summary>): Summary {
+        public fun fromMean(count: Long, mean: Double, onError: JniErrorHandler<Summary?>): Summary? {
             val __bcap = JniErrorHandlerCapture.acquire()
             val __ret = CovNative.summaryFromMean(count, mean, __bcap)
             if (__bcap.failed) return onError.run(__bcap.ze0)
@@ -192,7 +192,11 @@ public fun interface SummaryFolder<A> {
  * The Rust `Summary` result is delivered decomposed: the builder callback receives (`count`, `total`).
  */
 @Suppress("UNCHECKED_CAST")
-public fun <R> storageSummary(s: Storage, onError: JniErrorHandler<R>, build: SummaryBuilder<R>): R {
+public fun <R> storageSummary(
+    s: Storage,
+    onError: JniErrorHandler<R?>,
+    build: SummaryBuilder<R>,
+): R? {
     if (s.isClosed()) return onError.run("Operation on a closed native handle.")
     val __bcap = JniErrorHandlerCapture.acquire()
     val __ret = withSortedHandleLocks(s) {
@@ -210,8 +214,8 @@ public fun describeSummary(
     s01: Double?,
     s1: Summary?,
     verbose: Boolean,
-    onError: JniErrorHandler<String>,
-): String {
+    onError: JniErrorHandler<String?>,
+): String? {
     if (s1?.isClosed() == true) return onError.run("Operation on a closed native handle.")
     val __bcap = JniErrorHandlerCapture.acquire()
     val __ret = run {
@@ -297,7 +301,7 @@ public fun storageMatchesSummary(
  * Like [`storage_summary`] but the binding keeps the result as a raw opaque
  * handle (per-fn **flatten-output-suppress**).
  */
-public fun storageSummaryHandle(s: Storage, onError: JniErrorHandler<Summary>): Summary {
+public fun storageSummaryHandle(s: Storage, onError: JniErrorHandler<Summary?>): Summary? {
     if (s.isClosed()) return onError.run("Operation on a closed native handle.")
     val __bcap = JniErrorHandlerCapture.acquire()
     val __ret = withSortedHandleLocks(s) {
@@ -336,9 +340,9 @@ public fun summaryTotalRaw(s: Summary, onError: JniErrorHandler<Double>): Double
 @Suppress("UNCHECKED_CAST")
 public fun <R> storageSummaryFull(
     s: Storage,
-    onError: JniErrorHandler<R>,
+    onError: JniErrorHandler<R?>,
     build: SummaryStorageSummaryFullBuilder<R>,
-): R {
+): R? {
     if (s.isClosed()) return onError.run("Operation on a closed native handle.")
     val __bcap = JniErrorHandlerCapture.acquire()
     val __ret = withSortedHandleLocks(s) {
@@ -360,9 +364,9 @@ public fun <R> storageSummaryFull(
 @Suppress("UNCHECKED_CAST")
 public fun <R> storageSummaryProbe(
     s: Storage,
-    onError: JniErrorHandler<R>,
+    onError: JniErrorHandler<R?>,
     build: SummaryStorageSummaryProbeBuilder<R>,
-): R {
+): R? {
     if (s.isClosed()) return onError.run("Operation on a closed native handle.")
     val __bcap = JniErrorHandlerCapture.acquire()
     val __ret = withSortedHandleLocks(s) {
@@ -522,35 +526,35 @@ public fun <R> summaryMerge(
     primaryTotal: Double,
     fallbackCount: Long,
     fallbackTotal: Double,
-    onError: JniErrorHandler<R>,
+    onError: JniErrorHandler<R?>,
     build: SummaryBuilder<R>,
-): R = summaryMerge(0, primaryCount, primaryTotal, null, 0, fallbackCount, fallbackTotal, null, onError, build)
+): R? = summaryMerge(0, primaryCount, primaryTotal, null, 0, fallbackCount, fallbackTotal, null, onError, build)
 
 @Suppress("UNCHECKED_CAST")
 public fun <R> summaryMerge(
     primaryCount: Long,
     primaryTotal: Double,
     fallback: Summary,
-    onError: JniErrorHandler<R>,
+    onError: JniErrorHandler<R?>,
     build: SummaryBuilder<R>,
-): R = summaryMerge(0, primaryCount, primaryTotal, null, 1, null, null, fallback, onError, build)
+): R? = summaryMerge(0, primaryCount, primaryTotal, null, 1, null, null, fallback, onError, build)
 
 @Suppress("UNCHECKED_CAST")
 public fun <R> summaryMerge(
     primary: Summary,
     fallbackCount: Long,
     fallbackTotal: Double,
-    onError: JniErrorHandler<R>,
+    onError: JniErrorHandler<R?>,
     build: SummaryBuilder<R>,
-): R = summaryMerge(1, null, null, primary, 0, fallbackCount, fallbackTotal, null, onError, build)
+): R? = summaryMerge(1, null, null, primary, 0, fallbackCount, fallbackTotal, null, onError, build)
 
 @Suppress("UNCHECKED_CAST")
 public fun <R> summaryMerge(
     primary: Summary,
     fallback: Summary,
-    onError: JniErrorHandler<R>,
+    onError: JniErrorHandler<R?>,
     build: SummaryBuilder<R>,
-): R = summaryMerge(1, null, null, primary, 1, null, null, fallback, onError, build)
+): R? = summaryMerge(1, null, null, primary, 1, null, null, fallback, onError, build)
 
 /**
  * Combine two summaries (#87 regression: BOTH parameters are splittable under
@@ -572,9 +576,9 @@ public fun <R> summaryMerge(
     fallback00: Long?,
     fallback01: Double?,
     fallback1: Summary?,
-    onError: JniErrorHandler<R>,
+    onError: JniErrorHandler<R?>,
     build: SummaryBuilder<R>,
-): R {
+): R? {
     if ((primary1?.ptr ?: 0L) != 0L && (primary1?.ptr ?: 0L) == (fallback1?.ptr ?: 0L)) return onError.run(
         "Aliasing arguments: 'primary1' and 'fallback1' are the same native resource; a consumed handle may not be passed twice in one call.",
     )
@@ -666,9 +670,9 @@ public fun <A> summarySeries(
     count: Long,
     start: Long,
     acc: A,
-    onError: JniErrorHandler<A>,
+    onError: JniErrorHandler<A?>,
     fold: SummaryFolder<A>,
-): A {
+): A? {
     val __bcap = JniErrorHandlerCapture.acquire()
     val __ret = CovNative.summarySeries(count, start, acc, fold, __bcap)
     if (__bcap.failed) return onError.run(__bcap.ze0)
@@ -697,7 +701,7 @@ public fun <A> summarySeriesOpt(
 }
 
 /** Create an empty archive. */
-public fun archiveNew(onError: JniErrorHandler<SummaryVault>): SummaryVault {
+public fun archiveNew(onError: JniErrorHandler<SummaryVault?>): SummaryVault? {
     val __bcap = JniErrorHandlerCapture.acquire()
     val __ret = CovNative.archiveNew(__bcap)
     if (__bcap.failed) return onError.run(__bcap.ze0)

--- a/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest/errors.kt
+++ b/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest/errors.kt
@@ -56,10 +56,11 @@ public class StorageError private constructor(initialPtr: Long) : NativeHandle(i
  * Domain-error callback: called only when the native function returns `Err` — the
  * parameters carry the decomposed `StorageError`. Binding/system failures go to the
  * separate `onBindingError` (`JniErrorHandler`) channel instead, so there is no `je`
- * discriminator here. The wrapper returns whatever `run` returns;
- * the handler firing is the error discriminator: null can also be a successful optional
- * result, while a non-null value can be a handler-supplied fallback.
- * throwing from `run` is safe (it executes after the native call has returned).
+ * discriminator here. The wrapper returns whatever `run` returns. Where that type is
+ * nullable you may return `null` to decline — you are not required to fabricate a result.
+ * Consequently the handler firing, not the returned value, is the error discriminator:
+ * `null` can also be a successful optional result, and a non-null value can be a fallback
+ * you supplied. Throwing from `run` is safe (it executes after the native call has returned).
  */
 public fun interface StorageErrorHandler<out R> {
     public fun run(message: String, handle: StorageError): R

--- a/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest/errors.kt
+++ b/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest/errors.kt
@@ -30,7 +30,7 @@ public class StorageError private constructor(initialPtr: Long) : NativeHandle(i
      * Render a [`StorageError`] as its message (the error's flatten-output
      * **accessor**, fed to `onError`).
      */
-    public fun message(onError: JniErrorHandler<String>): String {
+    public fun message(onError: JniErrorHandler<String?>): String? {
         if (this.isClosed()) return onError.run("Operation on a closed native handle.")
         val __bcap = JniErrorHandlerCapture.acquire()
         val __ret = withSortedHandleLocks(this) {
@@ -57,6 +57,8 @@ public class StorageError private constructor(initialPtr: Long) : NativeHandle(i
  * parameters carry the decomposed `StorageError`. Binding/system failures go to the
  * separate `onBindingError` (`JniErrorHandler`) channel instead, so there is no `je`
  * discriminator here. The wrapper returns whatever `run` returns;
+ * the handler firing is the error discriminator: null can also be a successful optional
+ * result, while a non-null value can be a handler-supplied fallback.
  * throwing from `run` is safe (it executes after the native call has returned).
  */
 public fun interface StorageErrorHandler<out R> {

--- a/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest/esc_pkg.kt
+++ b/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest/esc_pkg.kt
@@ -51,7 +51,7 @@ public class Esc_Probe private constructor(initialPtr: Long) : NativeHandle(init
         internal fun fromRawPtr(initialPtr: Long): Esc_Probe = Esc_Probe(initialPtr)
 
         /** Construct an [`EscapeProbe`] (its covertest constructor). */
-        public fun escapeProbeNew(value: Long, onError: JniErrorHandler<Esc_Probe>): Esc_Probe {
+        public fun escapeProbeNew(value: Long, onError: JniErrorHandler<Esc_Probe?>): Esc_Probe? {
             val __bcap = JniErrorHandlerCapture.acquire()
             val __ret = CovNative.escapeProbeNew(value, __bcap)
             if (__bcap.failed) return onError.run(__bcap.ze0)

--- a/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest/model.kt
+++ b/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest/model.kt
@@ -1327,7 +1327,7 @@ internal object __StampFolderRawHolder {
 }
 
 /** Classify a payload by magnitude of its `value` (enum **return**). */
-public fun payloadPriority(p: Payload, onError: JniErrorHandler<Priority>): Priority {
+public fun payloadPriority(p: Payload, onError: JniErrorHandler<Priority?>): Priority? {
     val __bcap = JniErrorHandlerCapture.acquire()
     val __ret = CovNative.payloadPriority(p.id, p.seq, p.value, p.flag, p.label, __bcap)
     if (__bcap.failed) return onError.run(__bcap.ze0)
@@ -1346,8 +1346,8 @@ public fun priorityWeight(p: Priority, onError: JniErrorHandler<Int>): Int {
 public fun priorityOr(
     p: Priority?,
     fallback: Priority,
-    onError: JniErrorHandler<Priority>,
-): Priority {
+    onError: JniErrorHandler<Priority?>,
+): Priority? {
     val __bcap = JniErrorHandlerCapture.acquire()
     val __ret = CovNative.priorityOr(p != null, p?.value ?: 0, fallback.value, __bcap)
     if (__bcap.failed) return onError.run(__bcap.ze0)
@@ -1360,7 +1360,7 @@ public fun priorityOr(
  * The Rust `Stamp` result is delivered decomposed: the builder callback receives (`secs`, `nanos`).
  */
 @Suppress("UNCHECKED_CAST")
-public fun stampNew(secs: Long, nanos: Long, onError: JniErrorHandler<Stamp>): Stamp {
+public fun stampNew(secs: Long, nanos: Long, onError: JniErrorHandler<Stamp?>): Stamp? {
     val __bcap = JniErrorHandlerCapture.acquire()
     val __ret = CovNative.stampNew(secs, nanos, __StampBuilder, __bcap)
     if (__bcap.failed) return onError.run(__bcap.ze0)
@@ -1374,7 +1374,7 @@ public fun stampNew(secs: Long, nanos: Long, onError: JniErrorHandler<Stamp>): S
  * The Rust `Stamp` result is delivered decomposed: the builder callback receives (`secs`, `nanos`).
  */
 @Suppress("UNCHECKED_CAST")
-public fun stampSeries(count: Long, onError: JniErrorHandler<List<Stamp>>): List<Stamp> {
+public fun stampSeries(count: Long, onError: JniErrorHandler<List<Stamp>?>): List<Stamp>? {
     val __bcap = JniErrorHandlerCapture.acquire()
     val __ret = CovNative.stampSeries(
         count,
@@ -1435,7 +1435,7 @@ public fun percentInvalidOutput(onError: JniErrorHandler<Int?>): Int? {
  * Reverse a label's characters (exercises the binding-local conversion on
  * a parameter and the return).
  */
-public fun labelReverse(l: String, onError: JniErrorHandler<String>): String {
+public fun labelReverse(l: String, onError: JniErrorHandler<String?>): String? {
     val __bcap = JniErrorHandlerCapture.acquire()
     val __ret = CovNative.labelReverse(l, __bcap)
     if (__bcap.failed) return onError.run(__bcap.ze0)
@@ -1455,8 +1455,8 @@ public fun labelReverse(l: String, onError: JniErrorHandler<String>): String {
  */
 public fun labelSeriesEcho(
     labels: List<String>,
-    onError: JniErrorHandler<List<String>>,
-): List<String> {
+    onError: JniErrorHandler<List<String>?>,
+): List<String>? {
     val __bcap = JniErrorHandlerCapture.acquire()
     val __ret = CovNative.labelSeriesEcho(labels, __bcap)
     if (__bcap.failed) return onError.run(__bcap.ze0)
@@ -1471,8 +1471,8 @@ public fun annotatedNew(
     payload: Payload,
     ttl: Long?,
     priority: Priority?,
-    onError: JniErrorHandler<Annotated>,
-): Annotated {
+    onError: JniErrorHandler<Annotated?>,
+): Annotated? {
     val __bcap = JniErrorHandlerCapture.acquire()
     val __ret = CovNative.annotatedNew(
         payload.id,
@@ -1608,8 +1608,8 @@ public fun annotatedPayloadValue(a: Annotated, onError: JniErrorHandler<Double>)
 public fun observationNew(
     which: Int,
     withFallback: Boolean,
-    onError: JniErrorHandler<Observation>,
-): Observation {
+    onError: JniErrorHandler<Observation?>,
+): Observation? {
     val __bcap = JniErrorHandlerCapture.acquire()
     val __ret = CovNative.observationNew(which, withFallback, __bcap)
     if (__bcap.failed) return onError.run(__bcap.ze0)
@@ -1655,7 +1655,7 @@ public fun observationWhich(o: Observation, onError: JniErrorHandler<Int>): Int 
 }
 
 /** Build a [`Tagged`]: `which` 0 = `None_`, 1 = `Ranked(None)`, 2 = `Ranked(Some(High))`. */
-public fun taggedNew(which: Int, onError: JniErrorHandler<Tagged>): Tagged {
+public fun taggedNew(which: Int, onError: JniErrorHandler<Tagged?>): Tagged? {
     val __bcap = JniErrorHandlerCapture.acquire()
     val __ret = CovNative.taggedNew(which, __bcap)
     if (__bcap.failed) return onError.run(__bcap.ze0)
@@ -1688,7 +1688,7 @@ public fun taggedRank(t: Tagged, onError: JniErrorHandler<Int>): Int {
  * The Rust `Marker` result is delivered decomposed: the builder callback receives (`tag`, `ranked_v0`).
  */
 @Suppress("UNCHECKED_CAST")
-public fun markerOf(which: Int, onError: JniErrorHandler<Marker>): Marker {
+public fun markerOf(which: Int, onError: JniErrorHandler<Marker?>): Marker? {
     val __bcap = JniErrorHandlerCapture.acquire()
     val __ret = CovNative.markerOf(which, __MarkerBuilder, __bcap)
     if (__bcap.failed) return onError.run(__bcap.ze0)
@@ -1705,7 +1705,7 @@ public fun markerOf(which: Int, onError: JniErrorHandler<Marker>): Marker {
  * The Rust `Reading` result is delivered decomposed: the builder callback receives (`tag`, `exact_v0`, `range_low`, `range_high`, `tagged_v0`, `tagged_v1`, `companion_v0`).
  */
 @Suppress("UNCHECKED_CAST")
-public fun readingOf(which: Int, onError: JniErrorHandler<Reading>): Reading {
+public fun readingOf(which: Int, onError: JniErrorHandler<Reading?>): Reading? {
     val __bcap = JniErrorHandlerCapture.acquire()
     val __ret = CovNative.readingOf(which, __ReadingBuilder, __bcap)
     if (__bcap.failed) return onError.run(__bcap.ze0)
@@ -1734,7 +1734,7 @@ public fun readingMaybe(which: Int, onError: JniErrorHandler<Reading?>): Reading
  * The Rust `Reading` result is delivered decomposed: the builder callback receives (`tag`, `exact_v0`, `range_low`, `range_high`, `tagged_v0`, `tagged_v1`, `companion_v0`).
  */
 @Suppress("UNCHECKED_CAST")
-public fun readingSeries(n: Int, onError: JniErrorHandler<List<Reading>>): List<Reading> {
+public fun readingSeries(n: Int, onError: JniErrorHandler<List<Reading>?>): List<Reading>? {
     val __bcap = JniErrorHandlerCapture.acquire()
     val __ret = CovNative.readingSeries(
         n,
@@ -1760,7 +1760,7 @@ public fun readingEach(n: Int, sink: ReadingCallback, onError: JniErrorHandler<U
  * The Rust `Lookup` result is delivered decomposed: the builder callback receives (`tag`, `found_v0`, `failed_v0`).
  */
 @Suppress("UNCHECKED_CAST")
-public fun lookupOf(count: Long, total: Double, onError: JniErrorHandler<Lookup>): Lookup {
+public fun lookupOf(count: Long, total: Double, onError: JniErrorHandler<Lookup?>): Lookup? {
     val __bcap = JniErrorHandlerCapture.acquire()
     val __ret = CovNative.lookupOf(count, total, __LookupBuilderRaw, __bcap)
     if (__bcap.failed) return onError.run(__bcap.ze0)
@@ -1789,8 +1789,8 @@ public fun verdictNew(
     id: Long,
     count: Long,
     total: Double,
-    onError: JniErrorHandler<Verdict>,
-): Verdict {
+    onError: JniErrorHandler<Verdict?>,
+): Verdict? {
     val __bcap = JniErrorHandlerCapture.acquire()
     val __ret = CovNative.verdictNew(id, count, total, __bcap)
     if (__bcap.failed) return onError.run(__bcap.ze0)
@@ -1803,8 +1803,8 @@ public fun dossierNew(
     tag: Long,
     count: Long,
     total: Double,
-    onError: JniErrorHandler<Dossier>,
-): Dossier {
+    onError: JniErrorHandler<Dossier?>,
+): Dossier? {
     val __bcap = JniErrorHandlerCapture.acquire()
     val __ret = CovNative.dossierNew(note, tag, count, total, __bcap)
     if (__bcap.failed) return onError.run(__bcap.ze0)
@@ -1834,9 +1834,9 @@ public fun <R> probeNew(
     seq: Long,
     count: Long,
     total: Double,
-    onError: JniErrorHandler<R>,
+    onError: JniErrorHandler<R?>,
     build: ProbeBuilder<R>,
-): R {
+): R? {
     val __bcap = JniErrorHandlerCapture.acquire()
     val __ret = CovNative.probeNew(seq, count, total, build.asRaw(), __bcap)
     if (__bcap.failed) return onError.run(__bcap.ze0)
@@ -1875,9 +1875,9 @@ public fun <R> spanHolderNew(
     seq: Long,
     requiredMs: ULong,
     delayMs: Long,
-    onError: JniErrorHandler<R>,
+    onError: JniErrorHandler<R?>,
     build: SpanHolderBuilder<R>,
-): R {
+): R? {
     val __bcap = JniErrorHandlerCapture.acquire()
     val __ret = CovNative.spanHolderNew(seq, requiredMs.toLong(), delayMs, build.asRaw(), __bcap)
     if (__bcap.failed) return onError.run(__bcap.ze0)
@@ -2176,7 +2176,7 @@ public fun <R> boxedLatest(
  * The Rust `Ledger` result is delivered decomposed: the builder callback receives (`ledgerFiled__summary__count`, `ledgerFiled__summary__total`, `ledgerFiled__taken`, `ledgerFiled__origin__secs`, `ledgerFiled__origin__nanos`, `ledgerFiled__outcome__tag`, `ledgerFiled__outcome__found_v0`, `ledgerFiled__outcome__failed_v0`, `ledgerFiled__label`, `ledgerArchived__summary__count`, `ledgerArchived__summary__total`, `ledgerArchived__taken`, `ledgerArchived__origin__secs`, `ledgerArchived__origin__nanos`, `ledgerArchived__outcome__tag`, `ledgerArchived__outcome__found_v0`, `ledgerArchived__outcome__failed_v0`, `ledgerArchived__label`).
  */
 @Suppress("UNCHECKED_CAST")
-public fun <R> ledgerNew(n: Long, onError: JniErrorHandler<R>, build: LedgerBuilder<R>): R {
+public fun <R> ledgerNew(n: Long, onError: JniErrorHandler<R?>, build: LedgerBuilder<R>): R? {
     val __bcap = JniErrorHandlerCapture.acquire()
     val __ret = CovNative.ledgerNew(n, build.asRaw(), __bcap)
     if (__bcap.failed) return onError.run(__bcap.ze0)
@@ -2209,7 +2209,7 @@ public fun archiveSetReading(a: SummaryVault, which: Int, onError: JniErrorHandl
  * The Rust `Reading` result is delivered decomposed: the builder callback receives (`tag`, `exact_v0`, `range_low`, `range_high`, `tagged_v0`, `tagged_v1`, `companion_v0`).
  */
 @Suppress("UNCHECKED_CAST")
-public fun archiveReading(a: SummaryVault, onError: JniErrorHandler<Reading>): Reading {
+public fun archiveReading(a: SummaryVault, onError: JniErrorHandler<Reading?>): Reading? {
     if (a.isClosed()) return onError.run("Operation on a closed native handle.")
     val __bcap = JniErrorHandlerCapture.acquire()
     val __ret = withSortedHandleLocks(a) {
@@ -2244,7 +2244,7 @@ public fun archiveReadingMaybe(a: SummaryVault, onError: JniErrorHandler<Reading
  * The Rust `Hold` result is delivered decomposed: the builder callback receives (`tag`, `for_v0`).
  */
 @Suppress("UNCHECKED_CAST")
-public fun holdEcho(h: Hold, onError: JniErrorHandler<Hold>): Hold {
+public fun holdEcho(h: Hold, onError: JniErrorHandler<Hold?>): Hold? {
     val __bcap = JniErrorHandlerCapture.acquire()
     val __ret = CovNative.holdEcho(h, __HoldBuilderRaw, __bcap)
     if (__bcap.failed) return onError.run(__bcap.ze0)
@@ -2252,7 +2252,7 @@ public fun holdEcho(h: Hold, onError: JniErrorHandler<Hold>): Hold {
 }
 
 /** Round-trip a data class carrying converted-payload sums. */
-public fun holdPolicyEcho(p: HoldPolicy, onError: JniErrorHandler<HoldPolicy>): HoldPolicy {
+public fun holdPolicyEcho(p: HoldPolicy, onError: JniErrorHandler<HoldPolicy?>): HoldPolicy? {
     val __bcap = JniErrorHandlerCapture.acquire()
     val __ret = CovNative.holdPolicyEcho(p.hold, p.grace, __bcap)
     if (__bcap.failed) return onError.run(__bcap.ze0)
@@ -2297,8 +2297,8 @@ public fun unsignedRoundTrip(
     int: Long,
     long: ULong,
     maybeLong: ULong?,
-    onError: JniErrorHandler<Unsigned>,
-): Unsigned {
+    onError: JniErrorHandler<Unsigned?>,
+): Unsigned? {
     val __bcap = JniErrorHandlerCapture.acquire()
     val __ret = CovNative.unsignedRoundTrip(
         byte,
@@ -2353,7 +2353,7 @@ public fun unsignedEmit(value: ULong, f: u64Callback, onError: JniErrorHandler<U
  * the Kotlin side.
  */
 @Suppress("UNCHECKED_CAST")
-public fun unsignedSeries(onError: JniErrorHandler<List<ULong>>): List<ULong> {
+public fun unsignedSeries(onError: JniErrorHandler<List<ULong>?>): List<ULong>? {
     val __bcap = JniErrorHandlerCapture.acquire()
     val __ret = CovNative.unsignedSeries(ArrayList<ULong>(), __u64FolderRawHolder.instance, __bcap)
     if (__bcap.failed) return onError.run(__bcap.ze0)
@@ -2370,8 +2370,8 @@ public fun blobValueNew(
     secs: Long,
     id: ByteArray,
     chunks: List<ByteArray>,
-    onError: JniErrorHandler<BlobValue>,
-): BlobValue {
+    onError: JniErrorHandler<BlobValue?>,
+): BlobValue? {
     val __bcap = JniErrorHandlerCapture.acquire()
     val __ret = CovNative.blobValueNew(secs, id, chunks, __BlobValueBuilder, __bcap)
     if (__bcap.failed) return onError.run(__bcap.ze0)
@@ -2390,7 +2390,7 @@ public fun blobValueNew(
  * The Rust `BlobValue` result is delivered decomposed: the builder callback receives (`stamp__secs`, `stamp__nanos`, `id`, `chunks`).
  */
 @Suppress("UNCHECKED_CAST")
-public fun blobValueEcho(value: BlobValue, onError: JniErrorHandler<BlobValue>): BlobValue {
+public fun blobValueEcho(value: BlobValue, onError: JniErrorHandler<BlobValue?>): BlobValue? {
     val __bcap = JniErrorHandlerCapture.acquire()
     val __ret = CovNative.blobValueEcho(value, __BlobValueBuilder, __bcap)
     if (__bcap.failed) return onError.run(__bcap.ze0)
@@ -2403,7 +2403,7 @@ public fun blobValueEcho(value: BlobValue, onError: JniErrorHandler<BlobValue>):
  * The Rust `Arrays` result is delivered decomposed: the builder callback receives (`bytes`, `shorts`, `ints`, `longs`, `doubles`, `flags`, `raw`).
  */
 @Suppress("UNCHECKED_CAST")
-public fun arraysEcho(a: Arrays, onError: JniErrorHandler<Arrays>): Arrays {
+public fun arraysEcho(a: Arrays, onError: JniErrorHandler<Arrays?>): Arrays? {
     val __bcap = JniErrorHandlerCapture.acquire()
     val __ret = CovNative.arraysEcho(
         a.bytes,
@@ -2456,8 +2456,8 @@ public fun boxedDurationEcho(value: ULong, onError: JniErrorHandler<ULong>): ULo
 @Suppress("UNCHECKED_CAST")
 public fun durationBoundaryEcho(
     value: DurationBoundary,
-    onError: JniErrorHandler<DurationBoundary>,
-): DurationBoundary {
+    onError: JniErrorHandler<DurationBoundary?>,
+): DurationBoundary? {
     val __bcap = JniErrorHandlerCapture.acquire()
     val __ret = CovNative.durationBoundaryEcho(value, __DurationBoundaryBuilderRaw, __bcap)
     if (__bcap.failed) return onError.run(__bcap.ze0)

--- a/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest/storage.kt
+++ b/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest/storage.kt
@@ -25,7 +25,7 @@ import io.prebindgen.covertest.model.Stamp
 import io.prebindgen.covertest.withSortedHandleLocks
 
 /** Create a new, empty storage handle. */
-public fun storageNew(onError: JniErrorHandler<Storage>): Storage {
+public fun storageNew(onError: JniErrorHandler<Storage?>): Storage? {
     val __bcap = JniErrorHandlerCapture.acquire()
     val __ret = CovNative.storageNew(__bcap)
     if (__bcap.failed) return onError.run(__bcap.ze0)
@@ -164,8 +164,8 @@ public fun storageGetVec(s: Storage, onError: JniErrorHandler<List<Payload>?>): 
  */
 public fun payloadHandlerNew(
     f: PayloadCallback,
-    onError: JniErrorHandler<PayloadHandler>,
-): PayloadHandler {
+    onError: JniErrorHandler<PayloadHandler?>,
+): PayloadHandler? {
     val __bcap = JniErrorHandlerCapture.acquire()
     val __ret = CovNative.payloadHandlerNew(f.asRaw(), __bcap)
     if (__bcap.failed) return onError.run(__bcap.ze0)
@@ -201,8 +201,8 @@ public fun storageCallback(s: Storage, handler: PayloadHandler, onError: JniErro
  */
 public fun payloadVecHandlerNew(
     f: PayloadListCallback,
-    onError: JniErrorHandler<PayloadVecHandler>,
-): PayloadVecHandler {
+    onError: JniErrorHandler<PayloadVecHandler?>,
+): PayloadVecHandler? {
     val __bcap = JniErrorHandlerCapture.acquire()
     val __ret = CovNative.payloadVecHandlerNew(f, __bcap)
     if (__bcap.failed) return onError.run(__bcap.ze0)
@@ -240,9 +240,9 @@ public fun storageCallbackVec(
  */
 public fun storageTryWithLabel(
     label: String,
-    onBindingError: JniErrorHandler<Storage>,
-    onError: StorageErrorHandler<Storage>,
-): Storage {
+    onBindingError: JniErrorHandler<Storage?>,
+    onError: StorageErrorHandler<Storage?>,
+): Storage? {
     val __bcap = JniErrorHandlerCapture.acquire()
     val __dcap = StorageErrorHandlerRawCapture.acquire()
     val __ret = CovNative.storageTryWithLabel(label, __bcap, __dcap)
@@ -266,9 +266,9 @@ public fun storageTryWithLabel(
 public fun storageTryFromStamp(
     s: Stamp,
     tag: ByteArray,
-    onBindingError: JniErrorHandler<Storage>,
-    onError: StorageErrorHandler<Storage>,
-): Storage {
+    onBindingError: JniErrorHandler<Storage?>,
+    onError: StorageErrorHandler<Storage?>,
+): Storage? {
     val __bcap = JniErrorHandlerCapture.acquire()
     val __dcap = StorageErrorHandlerRawCapture.acquire()
     val __ret = CovNative.storageTryFromStamp(s.secs, s.nanos, tag, __bcap, __dcap)
@@ -286,8 +286,8 @@ public fun storageTryFromStamp(
 public fun storageShards(
     count: Long,
     each: Long,
-    onError: JniErrorHandler<List<Storage>>,
-): List<Storage> {
+    onError: JniErrorHandler<List<Storage>?>,
+): List<Storage>? {
     val __bcap = JniErrorHandlerCapture.acquire()
     val __ret = CovNative.storageShards(
         count,
@@ -325,8 +325,8 @@ public fun storageShardsOpt(
 /** Wrap a `Fn(Storage)` closure into a reusable [`StorageHandler`]. */
 public fun storageHandlerNew(
     f: StorageCallback,
-    onError: JniErrorHandler<StorageHandler>,
-): StorageHandler {
+    onError: JniErrorHandler<StorageHandler?>,
+): StorageHandler? {
     val __bcap = JniErrorHandlerCapture.acquire()
     val __ret = CovNative.storageHandlerNew(f.asRaw(), __bcap)
     if (__bcap.failed) return onError.run(__bcap.ze0)
@@ -371,7 +371,7 @@ public fun storageTotalLen(a: Storage, b: Storage, c: Storage, onError: JniError
  * single-leaf string fold).
  */
 @Suppress("UNCHECKED_CAST")
-public fun storageLabels(s: Storage, onError: JniErrorHandler<List<String>>): List<String> {
+public fun storageLabels(s: Storage, onError: JniErrorHandler<List<String>?>): List<String>? {
     if (s.isClosed()) return onError.run("Operation on a closed native handle.")
     val __bcap = JniErrorHandlerCapture.acquire()
     val __ret = withSortedHandleLocks(s) {

--- a/examples/covertest-kotlin/kotlin/io/prebindgen/covertest/Test.kt
+++ b/examples/covertest-kotlin/kotlin/io/prebindgen/covertest/Test.kt
@@ -160,6 +160,10 @@ private val boomStorage = StorageErrorHandler<Nothing> { message, handle ->
 /** Thrown by the [StorageErrorHandler] used to probe the domain error channel. */
 private class LabelError(val detail: String) : RuntimeException(detail)
 
+/** Assert that a reference-returning call with a throwing handler succeeded. */
+private fun <T : Any> T?.orThrow(): T =
+    this ?: throw AssertionError("a throwing error handler returned instead of throwing")
+
 private var sectionCount = 0
 
 private inline fun section(name: String, body: () -> Unit) {
@@ -205,7 +209,7 @@ fun main() {
             ULong.MAX_VALUE,
             ULong.MAX_VALUE,
             boom,
-        )
+        ).orThrow()
         check(
             max == Unsigned(
                 UByte.MAX_VALUE.toInt(),
@@ -466,31 +470,31 @@ fun main() {
     section("sum as a data-class field (tag-gated groups on one fromParts)") {
         // Every alternative survives the crossing, including the payload-less
         // one and the two whose groups sit beside object-shaped slots.
-        check(observationNew(0, false, boom).reading == Reading.Missing)
-        check(observationNew(1, false, boom).reading == Reading.Exact(42L))
-        check(observationNew(2, false, boom).reading == Reading.Range(1L, 9L))
-        check(observationNew(3, false, boom).reading == Reading.Tagged("warm", Priority.HIGH))
-        check(observationNew(4, false, boom).reading == Reading.Companion(5L))
+        check(observationNew(0, false, boom).orThrow().reading == Reading.Missing)
+        check(observationNew(1, false, boom).orThrow().reading == Reading.Exact(42L))
+        check(observationNew(2, false, boom).orThrow().reading == Reading.Range(1L, 9L))
+        check(observationNew(3, false, boom).orThrow().reading == Reading.Tagged("warm", Priority.HIGH))
+        check(observationNew(4, false, boom).orThrow().reading == Reading.Companion(5L))
 
         // The sum sits beside ordinary flattened leaves — they must not be
         // disturbed by the tag-gated groups interleaved with them.
-        val obs = observationNew(3, false, boom)
+        val obs = observationNew(3, false, boom).orThrow()
         check(obs.id == 7L && obs.note == "obs")
 
         // `Option<sum>`: the present flag and the tag are independent facts,
         // so an absent optional is null regardless of what its tag slot holds.
-        check(observationNew(1, false, boom).fallback == null)
-        check(observationNew(1, true, boom).fallback == Reading.Range(1L, 9L))
+        check(observationNew(1, false, boom).orThrow().fallback == null)
+        check(observationNew(1, true, boom).orThrow().fallback == Reading.Range(1L, 9L))
         // …and an object-payload variant round-trips through the optional too.
-        check(observationNew(2, true, boom).fallback == Reading.Tagged("warm", Priority.HIGH))
+        check(observationNew(2, true, boom).orThrow().fallback == Reading.Tagged("warm", Priority.HIGH))
         // Both sums live at once, each with its own tag.
-        val both = observationNew(4, true, boom)
+        val both = observationNew(4, true, boom).orThrow()
         check(both.reading == Reading.Companion(5L) && both.fallback == Reading.Missing)
 
         // …and back IN as part of a data-class parameter: every alternative
         // reconstructs the same Rust variant it came from.
         for (which in 0..4) {
-            check(observationWhich(observationNew(which, false, boom), boom) == which)
+            check(observationWhich(observationNew(which, false, boom).orThrow(), boom) == which)
         }
         // A Kotlin-constructed value (not one that came from Rust) crosses in
         // just the same.
@@ -550,9 +554,9 @@ fun main() {
 
         // `Vec<E>` return: each element's tag + groups cross raw and the
         // folder singleton appends the rebuilt alternative.
-        check(readingSeries(0, boom).isEmpty())
+        check(readingSeries(0, boom).orThrow().isEmpty())
         check(
-            readingSeries(5, boom) == listOf(
+            readingSeries(5, boom).orThrow() == listOf(
                 Reading.Missing,
                 Reading.Exact(42L),
                 Reading.Range(1L, 9L),
@@ -565,7 +569,7 @@ fun main() {
         // sum while the wire still carries decoupled slots.
         val seen = ArrayList<Reading>()
         readingEach(5, { r -> seen.add(r) }, boom)
-        check(seen == readingSeries(5, boom))
+        check(seen == readingSeries(5, boom).orThrow())
     }
 
     // ── a tag-gated group that owns a native resource ─────────────────────────
@@ -641,7 +645,7 @@ fun main() {
     // is `AutoCloseable` either way and its `close()` cascades either way; the
     // walk into the alternatives lives in `Lookup`, not in `Verdict`.
     section("a data-class field reaching a handle through a sum cascades") {
-        val v = verdictNew(7L, 3L, 1.5, boom)
+        val v = verdictNew(7L, 3L, 1.5, boom).orThrow()
         check(v.id == 7L)
         val found = v.outcome
         check(found is Lookup.Found)
@@ -657,7 +661,7 @@ fun main() {
         // …and an alternative owning nothing native closes to a no-op, so the
         // cascade is safe for every value of the field, not just the live-handle
         // one.
-        val absent = verdictNew(8L, 0L, 0.0, boom)
+        val absent = verdictNew(8L, 0L, 0.0, boom).orThrow()
         check(absent.outcome === Lookup.Absent)
         absent.close()
     }
@@ -670,7 +674,7 @@ fun main() {
     // together. This section IS that tie: it would not compile if `Holder` had
     // no `close()`, and the last check fails if `Dossier` had none.
     section("a data-class field reaching a handle through a nested data class cascades") {
-        val d = dossierNew(5L, 3L, 4L, 2.0, boom)
+        val d = dossierNew(5L, 3L, 4L, 2.0, boom).orThrow()
         check(d.note == 5L)
         check(d.holder.tag == 3L)
         val summary = d.holder.summary
@@ -813,7 +817,7 @@ fun main() {
                 val filed = if (fLabel == null) "-|$fTag" else "$fLabel/$fCount/$fTag"
                 val archived = if (aLabel == null) "-|$aTag" else "$aLabel/$aCount/$aTag"
                 "$filed $archived"
-            }
+            }.orThrow()
             rows.add(row)
         }
         // `-|null`: an absent report nulls the selector too, so a receiver can
@@ -851,7 +855,7 @@ fun main() {
     // what each live group needs, so Kotlin gets an ordinary value with no
     // borrow to track and the owner can be read again afterwards (#161).
     section("borrowed sum returns") {
-        val vault = archiveNew(boom)
+        val vault = archiveNew(boom).orThrow()
 
         // Every alternative, read back through `&Reading`.
         archiveSetReading(vault, 0, boom)
@@ -886,9 +890,9 @@ fun main() {
     // reads an enum property back (bare and optional read differently: the slot
     // holds the enum OBJECT, not a boxed Int).
     section("sum with a non-leaf payload (whole-object crossing, Option<enum>)") {
-        check(taggedRank(taggedNew(0, boom), boom) == -1)
-        check(taggedRank(taggedNew(1, boom), boom) == 0)
-        check(taggedRank(taggedNew(2, boom), boom) == 10)
+        check(taggedRank(taggedNew(0, boom).orThrow(), boom) == -1)
+        check(taggedRank(taggedNew(1, boom).orThrow(), boom) == 0)
+        check(taggedRank(taggedNew(2, boom).orThrow(), boom) == 10)
 
         // Kotlin-constructed values cross identically — including the two
         // `Ranked` shapes that differ only by the optional being present.
@@ -906,31 +910,31 @@ fun main() {
     // Both arrive as a JVM null, so only the tag tells `Ranked(null)` from
     // `None_`.
     section("Option<enum> payload in a returned sum") {
-        check(markerOf(0, boom) === Marker.None_)
+        check(markerOf(0, boom).orThrow() === Marker.None_)
 
-        val absent = markerOf(1, boom)
+        val absent = markerOf(1, boom).orThrow()
         check(absent is Marker.Ranked && absent.v0 == null)
 
-        val present = markerOf(2, boom)
+        val present = markerOf(2, boom).orThrow()
         check(present is Marker.Ranked && present.v0 == Priority.HIGH)
 
         // The two nulls are distinguishable in both directions: each value the
         // return path built crosses back in and reads as itself.
-        check(taggedRank(Tagged(1L, markerOf(0, boom)), boom) == -1)
-        check(taggedRank(Tagged(1L, markerOf(1, boom)), boom) == 0)
-        check(taggedRank(Tagged(1L, markerOf(2, boom)), boom) == 10)
+        check(taggedRank(Tagged(1L, markerOf(0, boom).orThrow()), boom) == -1)
+        check(taggedRank(Tagged(1L, markerOf(1, boom).orThrow()), boom) == 0)
+        check(taggedRank(Tagged(1L, markerOf(2, boom).orThrow()), boom) == 10)
     }
 
     // ── value_class: by-value bytes, instance accessors, Vec<value> → List ────
     section("value_class Stamp") {
-        val st: Stamp = stampNew(7L, 42L, boom)
+        val st: Stamp = stampNew(7L, 42L, boom).orThrow()
         check(st.secs(boom) == 7L)
         check(st.nanos(boom) == 42L)
-        val series: List<Stamp> = stampSeries(3L, boom)
+        val series: List<Stamp> = stampSeries(3L, boom).orThrow()
         check(series.size == 3)
         check(series[0].secs(boom) == 0L)
         check(series[2].secs(boom) == 2L && series[2].nanos(boom) == 0L)
-        check(stampSeries(0L, boom).isEmpty())
+        check(stampSeries(0L, boom).orThrow().isEmpty())
     }
 
     // ── array-backed VALUE EQUALITY ─────────────────────────────────────────
@@ -945,11 +949,11 @@ fun main() {
         // The NEGATIVE case first: a data class with no array property must keep
         // the compiler's own equality. The generator emits nothing for it, so
         // this pins that the content operators do not churn ordinary classes.
-        val s1 = stampNew(7L, 42L, boom)
-        val s2 = stampNew(7L, 42L, boom)
+        val s1 = stampNew(7L, 42L, boom).orThrow()
+        val s2 = stampNew(7L, 42L, boom).orThrow()
         check(s1 == s2) { "scalar data class must compare by value: $s1 vs $s2" }
         check(s1.hashCode() == s2.hashCode())
-        check(stampNew(8L, 42L, boom) != s1) { "different content must not compare equal" }
+        check(stampNew(8L, 42L, boom).orThrow() != s1) { "different content must not compare equal" }
         check(hashSetOf(s1, s2).size == 1)
         check(s1.toString() == "Stamp(secs=7, nanos=42)") { "got $s1" }
 
@@ -958,7 +962,7 @@ fun main() {
         // this also covers the `31 * result + …contentHashCode()` fold form
         // that a real value (`Timestamp(ntp64, id)`) produces.
         fun blob(secs: Long, id: ByteArray, chunks: List<ByteArray>) =
-            blobValueNew(secs, id, chunks, boom)
+            blobValueNew(secs, id, chunks, boom).orThrow()
 
         val chunks = listOf(byteArrayOf(9), byteArrayOf(8, 7))
         val b1 = blob(7L, byteArrayOf(1, 2, 3), chunks)
@@ -1031,7 +1035,7 @@ fun main() {
         // slot is the wrapper class, not `[B` — reading the old descriptor threw
         // `NoSuchFieldError` on the first decode.
         check(blobValueEcho(b1, boom) == b1) { "jobject-input round trip must preserve the value" }
-        check(blobValueEcho(blob(0L, ByteArray(0), emptyList()), boom).chunks.isEmpty())
+        check(blobValueEcho(blob(0L, ByteArray(0), emptyList()), boom).orThrow().chunks.isEmpty())
     }
 
     // ── Option<scalar> nullable primitive return + data_class instance
@@ -1043,7 +1047,7 @@ fun main() {
 
     // ── ptr_class members + Option<Payload>/Option<Vec>/Vec round-trips ──────
     section("Storage members + Option/Vec round-trips") {
-        val s = storageNew(boom)
+        val s = storageNew(boom).orThrow()
         check(s.len(boom) == 0L)
 
         storagePutByTake(s, payload(42L, 1, 1.0, false, "a"), boom)
@@ -1068,7 +1072,7 @@ fun main() {
 
     // ── constructor (companion factory) ──────────────────────────────────────
     section("constructor Storage.withPayload") {
-        val s = Storage.withPayload(payload(99L, 0, 0.0, false, "z"), boom)
+        val s = Storage.withPayload(payload(99L, 0, 0.0, false, "z"), boom).orThrow()
         check(s.len(boom) == 1L)
         check(s.contains(99L, boom))
         s.close()
@@ -1080,7 +1084,7 @@ fun main() {
     // generated members — used here polymorphically, no generated-code edits ──
     section(".interface() hatch (Api interfaces extended by SDK interfaces)") {
         // ptr class: Storage implements StorageApi; CovResource : StorageApi.
-        val s = storageNew(boom)
+        val s = storageNew(boom).orThrow()
         val r: CovResource = s
         check(r.live)                     // default over inherited peek()/isClosed()
         check(r.isEmpty())                // default over class-specific len()
@@ -1109,7 +1113,7 @@ fun main() {
 
     // ── impl Fn callbacks: single-payload + whole-batch ──────────────────────
     section("callbacks (impl Fn single + slice)") {
-        val s = storageNew(boom)
+        val s = storageNew(boom).orThrow()
         storagePutSlice(
             s,
             listOf(payload(1L, 0, 0.0, false, null), payload(2L, 0, 0.0, false, null), payload(3L, 0, 0.0, false, null)),
@@ -1118,7 +1122,7 @@ fun main() {
 
         // payload_handler_new: closure decoded once, fires once per payload.
         var perElem = 0L
-        val h = payloadHandlerNew(PayloadCallback { p -> perElem += p.id }, boom)
+        val h = payloadHandlerNew(PayloadCallback { p -> perElem += p.id }, boom).orThrow()
         storageCallback(s, h, boom)
         check(perElem == 6L)
         h.close()
@@ -1129,7 +1133,7 @@ fun main() {
         val vh: PayloadVecHandler = payloadVecHandlerNew(
             PayloadListCallback { list -> batchSize = list.size; batchSum = list.sumOf { it.id } },
             boom,
-        )
+        ).orThrow()
         storageCallbackVec(s, vh, boom)
         check(batchSize == 3)
         check(batchSum == 6L)
@@ -1139,15 +1143,15 @@ fun main() {
 
     // ── flatten matrix on Summary: output (default/suppress/with) ────────────
     section("flatten_output (default / suppress / with)") {
-        val s = storageNew(boom)
+        val s = storageNew(boom).orThrow()
         storagePutSlice(s, listOf(payload(1L, 0, 10.0, false, null), payload(2L, 0, 30.0, false, null)), boom)
 
         // flatten_output DEFAULT: decompose into (count, total) leaves via builder.
-        val pair = storageSummary(s, boom) { count, total -> count to total }
+        val pair = storageSummary(s, boom) { count, total -> count to total }.orThrow()
         check(pair.first == 2L && pair.second == 40.0)
 
         // flatten_output_suppress: keep the raw opaque handle.
-        val raw: Summary = storageSummaryHandle(s, boom)
+        val raw: Summary = storageSummaryHandle(s, boom).orThrow()
         check(raw.count(boom) == 2L)          // accessor on handle (non-consuming)
         check(raw.total(boom) == 40.0)
         check(raw.scaled(2.0, boom) == 80.0)  // method on handle
@@ -1159,7 +1163,7 @@ fun main() {
         val full = storageSummaryFull(s, boom) { count, total, handle ->
             fullHandle = handle
             count to total
-        }
+        }.orThrow()
         check(full.first == 2L && full.second == 40.0)
         check(fullHandle!!.total(boom) == 40.0)
         fullHandle!!.close()
@@ -1176,12 +1180,12 @@ fun main() {
     // fails ⇒ the leaf is null (no native clone, no wrapper); holds ⇒ a live
     // owned handle arrives with the values.
     section("binding-local field (fun! + sig!)") {
-        val s = storageNew(boom)
+        val s = storageNew(boom).orThrow()
 
         // Empty storage: count == 0 ⇒ the predicate fails ⇒ null handle.
         val emptyProbe = storageSummaryProbe(s, boom) { count, total, handle ->
             Triple(count, total, handle)
-        }
+        }.orThrow()
         check(emptyProbe.first == 0L && emptyProbe.second == 0.0)
         check(emptyProbe.third == null) { "empty summary must arrive value-only" }
 
@@ -1189,7 +1193,7 @@ fun main() {
         storagePutSlice(s, listOf(payload(1L, 0, 10.0, false, null), payload(2L, 0, 30.0, false, null)), boom)
         val probe = storageSummaryProbe(s, boom) { count, total, handle ->
             Triple(count, total, handle)
-        }
+        }.orThrow()
         check(probe.first == 2L && probe.second == 40.0)
         val h = probe.third ?: error("non-empty summary must deliver its handle")
         check(h.count(boom) == 2L && h.total(boom) == 40.0)
@@ -1210,7 +1214,7 @@ fun main() {
         // mangling covers binding-local fns exactly like registry fns.
         // FALLIBLE companion constructor: the sig's `Result<Summary, String>`
         // return is the error channel — happy path first…
-        val m = Summary.fromMean(4L, 2.5, boom)
+        val m = Summary.fromMean(4L, 2.5, boom).orThrow()
         check(m.count(boom) == 4L && m.total(boom) == 10.0)
         // Instance method.
         check(m.mean(boom) == 2.5)
@@ -1231,11 +1235,11 @@ fun main() {
 
     // ── flatten input on Summary: default + with, both selectors ─────────────
     section("flatten_input (default / with), leaves + handle") {
-        val s = storageNew(boom)
+        val s = storageNew(boom).orThrow()
         storagePutSlice(s, listOf(payload(1L, 0, 10.0, false, null), payload(2L, 0, 30.0, false, null)), boom)
 
         // constructor + accessors + method on the analytics handle.
-        val sum = Summary.of(2L, 40.0, boom)
+        val sum = Summary.of(2L, 40.0, boom).orThrow()
         check(sum.count(boom) == 2L && sum.total(boom) == 40.0 && sum.scaled(0.5, boom) == 20.0)
         sum.close()
 
@@ -1243,14 +1247,14 @@ fun main() {
         // `Summary` variants: idiomatic typed forms delegating to the selector.
         check(storageMatchesSummary(s, 2L, 40.0, boom))       // build-from-leaves arm
         check(!storageMatchesSummary(s, 1L, 40.0, boom))
-        val h0 = Summary.of(2L, 40.0, boom)
+        val h0 = Summary.of(2L, 40.0, boom).orThrow()
         check(storageMatchesSummary(s, h0, boom))             // pass-handle arm
         // The selector form stays public underneath (raw arm dispatch).
         check(storageMatchesSummary(s, 0, 2L, 40.0, null, boom))
 
         // #52 single-param split via a per-fn `.expand_param` override.
         check(storageExpectSummary(s, 2L, 40.0, boom))        // build-from-leaves arm
-        val h1 = Summary.of(2L, 40.0, boom)
+        val h1 = Summary.of(2L, 40.0, boom).orThrow()
         check(storageExpectSummary(s, h1, boom))              // pass-handle arm
 
         // #52 CARTESIAN PRODUCT: two split params → the 2×2 grid of typed
@@ -1258,10 +1262,10 @@ fun main() {
         // with the origin parameter name (`primaryCount`, `fallbackTotal`); the
         // handle arm consumes its `Summary`, so each is a fresh handle.
         check(summaryPrefer(2L, 40.0, 1L, 1.0, boom) == 1L)                       // build / build
-        check(summaryPrefer(1L, 1.0, Summary.of(3L, 99.0, boom), boom) == 0L)     // build / handle
-        check(summaryPrefer(Summary.of(3L, 99.0, boom), 1L, 1.0, boom) == 1L)     // handle / build
+        check(summaryPrefer(1L, 1.0, Summary.of(3L, 99.0, boom).orThrow(), boom) == 0L)     // build / handle
+        check(summaryPrefer(Summary.of(3L, 99.0, boom).orThrow(), 1L, 1.0, boom) == 1L)     // handle / build
         check(
-            summaryPrefer(Summary.of(1L, 1.0, boom), Summary.of(3L, 99.0, boom), boom) == 0L,
+            summaryPrefer(Summary.of(1L, 1.0, boom).orThrow(), Summary.of(3L, 99.0, boom).orThrow(), boom) == 0L,
         )                                                                          // handle / handle
 
         // #87: split × builder-delivered return. `summaryMerge` returns a
@@ -1274,13 +1278,13 @@ fun main() {
                 (3L to 42.0),
         )                                                                          // build / build
         check(
-            summaryMerge(2L, 40.0, Summary.of(1L, 2.0, boom), boom) { count, _ -> count } == 3L,
+            summaryMerge(2L, 40.0, Summary.of(1L, 2.0, boom).orThrow(), boom) { count, _ -> count } == 3L,
         )                                                                          // build / handle
         check(
-            summaryMerge(Summary.of(2L, 40.0, boom), 1L, 2.0, boom) { _, total -> total } == 42.0,
+            summaryMerge(Summary.of(2L, 40.0, boom).orThrow(), 1L, 2.0, boom) { _, total -> total } == 42.0,
         )                                                                          // handle / build
         check(
-            summaryMerge(Summary.of(2L, 40.0, boom), Summary.of(1L, 2.0, boom), boom) {
+            summaryMerge(Summary.of(2L, 40.0, boom).orThrow(), Summary.of(1L, 2.0, boom).orThrow(), boom) {
                 count, total ->
                 count to total
             } == (3L to 42.0),
@@ -1293,7 +1297,7 @@ fun main() {
         // still open, still usable, and still ours to close. A check inside the
         // converter could not offer that: by then the first argument is gone.
         run {
-            val shared = Summary.of(5L, 55.0, boom)
+            val shared = Summary.of(5L, 55.0, boom).orThrow()
             var aliasMessage: String? = null
             val rejected = summaryPrefer(shared, shared) { je ->
                 aliasMessage = je
@@ -1309,7 +1313,7 @@ fun main() {
 
             // No false positives — two DISTINCT handles of the same class go
             // through untouched.
-            check(summaryPrefer(shared, Summary.of(3L, 99.0, boom), boom) == 0L)
+            check(summaryPrefer(shared, Summary.of(3L, 99.0, boom).orThrow(), boom) == 0L)
         }
 
         // Optional combined-selector expansion: `Option<&Summary>` under the
@@ -1317,7 +1321,7 @@ fun main() {
         // the borrow-identity arm CLONES, so the handle survives the call.
         check(summaryTotalOpt(-1, null, null, null, boom) == -1.0)     // absent
         check(summaryTotalOpt(0, 2L, 40.0, null, boom) == 40.0)        // build arm
-        val hOpt = Summary.of(3L, 99.0, boom)
+        val hOpt = Summary.of(3L, 99.0, boom).orThrow()
         check(summaryTotalOpt(1, null, null, hOpt, boom) == 99.0)      // borrow-identity arm
         check(hOpt.total(boom) == 99.0)                                // handle still live
         hOpt.close()
@@ -1334,7 +1338,7 @@ fun main() {
     // A fallible-typed wrapper takes TWO handlers: `onBindingError` (the binding
     // channel) and `onError` (the typed domain channel, no `je`). See #45.
     section("Result error channel storageTryWithLabel") {
-        val ok = storageTryWithLabel("hi", boom, boomStorage)
+        val ok = storageTryWithLabel("hi", boom, boomStorage).orThrow()
         check(ok.len(boom) == 1L)
         ok.close()
 
@@ -1357,28 +1361,28 @@ fun main() {
     // ── #45: both channels of ONE fallible wrapper, each fires independently ──
     section("two-caller split storageTryFromStamp") {
         // Happy path: neither channel fires.
-        val ok = storageTryFromStamp(stampNew(5L, 0L, boom), byteArrayOf(1, 2), boom, boomStorage)
+        val ok = storageTryFromStamp(stampNew(5L, 0L, boom).orThrow(), byteArrayOf(1, 2), boom, boomStorage).orThrow()
         check(ok.len(boom) == 1L)
         ok.close()
 
         // DOMAIN error (well-formed Stamp, rejected value): `onError` fires,
-        // `onBindingError` must NOT. The handler returns a throwaway Storage.
+        // `onBindingError` must NOT. The handler declines to fabricate a Storage.
         var domainMsg: String? = null
         val domainRet = storageTryFromStamp(
-            stampNew(-1L, 0L, boom),
+            stampNew(-1L, 0L, boom).orThrow(),
             byteArrayOf(1, 2),
-            JniErrorHandler<Storage> { je ->
+            JniErrorHandler<Storage?> { je ->
                 throw AssertionError("binding channel must not fire on a domain error: $je")
             },
-            StorageErrorHandler<Storage> { message, handle ->
+            StorageErrorHandler<Storage?> { message, handle ->
                 domainMsg = message
                 check(handle.message(boom) == "stamp secs must be positive")
                 handle.close()
-                storageNew(boom)
+                null
             },
         )
         check(domainMsg == "stamp secs must be positive") { "domain onError did not fire: $domainMsg" }
-        domainRet.close()
+        check(domainRet == null)
 
         // BINDING error (wrong-length `tag` array): `onBindingError` fires,
         // the domain `onError` must NOT.
@@ -1386,11 +1390,11 @@ fun main() {
         val bindingRet = storageTryFromStamp(
             Stamp(1L, 0L),
             byteArrayOf(1, 2, 3),   // `tag` is [u8; 2]; 3 must be rejected on decode
-            JniErrorHandler<Storage> { je ->
+            JniErrorHandler<Storage?> { je ->
                 bindingJe = je
-                storageNew(boom)
+                null
             },
-            StorageErrorHandler<Storage> { _, handle ->
+            StorageErrorHandler<Storage?> { _, handle ->
                 handle.close()
                 throw AssertionError("domain channel must not fire on a binding error")
             },
@@ -1398,7 +1402,7 @@ fun main() {
         check(bindingJe != null && bindingJe!!.contains("fixed-size array decode")) {
             "binding onBindingError did not fire: $bindingJe"
         }
-        bindingRet.close()
+        check(bindingRet == null)
     }
 
     // ── input_wrapper / output_wrapper: Millis ⇄ Long ────────────────────────
@@ -1483,13 +1487,13 @@ fun main() {
     }
 
     section("Vec<Storage> handle fold (storageShards / storageShardsOpt)") {
-        val shards = storageShards(3L, 2L, boom)
+        val shards = storageShards(3L, 2L, boom).orThrow()
         check(shards.size == 3)
         check(shards.all { it.len(boom) == 2L })
         check(shards[2].contains(2001L, boom))   // distinct, correctly-typed handles
         check(!shards[0].contains(2001L, boom))
         shards.forEach { it.close() }
-        check(storageShards(0L, 2L, boom).isEmpty())
+        check(storageShards(0L, 2L, boom).orThrow().isEmpty())
         // Option<Vec<handle>>: the same fold under the null niche.
         check(storageShardsOpt(0L, 2L, boom) == null)
         val some = storageShardsOpt(2L, 1L, boom)!!
@@ -1509,7 +1513,7 @@ fun main() {
                 escaped = st
             },
             boom,
-        )
+        ).orThrow()
         storageEmit(5L, h, boom)
         check(openInRun && seenLen == 5L)
         // close-unless-taken: the proxy closed the handle after run.
@@ -1520,13 +1524,13 @@ fun main() {
     // ── nested data_class + Option<prim>/Option<enum> FIELDS ─────────────────
     section("nested data_class Annotated + Option fields") {
         val p = payload(7L, 1, 2.5, true, "x")
-        val a = annotatedNew(p, 30L, Priority.HIGH, boom)   // output: nested fromParts
+        val a = annotatedNew(p, 30L, Priority.HIGH, boom).orThrow() // output: nested fromParts
         check(a.payload == p && a.ttl == 30L && a.priority == Priority.HIGH)
         check(annotatedTtl(a, boom) == 30L)                 // input: (present, value) pair
         check(annotatedPriority(a, boom) == Priority.HIGH)  // Option<enum> return
         check(annotatedPayloadValue(a, boom) == 2.5)        // nested field survived decode
         check(annotatedAlternateValue(a, boom) == null)     // Option<nested> absent gate
-        val none = annotatedNew(payload(1L, 0, 0.0, false, null), null, null, boom)
+        val none = annotatedNew(payload(1L, 0, 0.0, false, null), null, null, boom).orThrow()
         check(annotatedTtl(none, boom) == null && annotatedPriority(none, boom) == null)
         // Kotlin-constructed instance crosses direct + optional recursive paths.
         val c = Annotated(
@@ -1572,9 +1576,9 @@ fun main() {
     // `Archive` is renamed to `SummaryVault` via the per-class `.name()`
     // override — the explicit type annotation asserts the rename.
     section("borrowed-opaque output archiveLatest") {
-        val a: SummaryVault = archiveNew(boom)
+        val a: SummaryVault = archiveNew(boom).orThrow()
         check(archiveLatest(a, boom) == null)               // None → null
-        val s = Summary.of(2L, 40.0, boom)
+        val s = Summary.of(2L, 40.0, boom).orThrow()
         archiveStore(a, 1, null, null, s, boom)             // flatten-input, handle arm
         val first = archiveLatest(a, boom)!!
         val second = archiveLatest(a, boom)!!
@@ -1608,7 +1612,7 @@ fun main() {
         // DECOMPOSED return: no converter names the spelling — the extern binds
         // the value and matches it, so the `Box` has to come off first (#292).
         // Same delivery as `archiveLatest`, one wrapper apart.
-        val a: SummaryVault = archiveNew(boom)
+        val a: SummaryVault = archiveNew(boom).orThrow()
         check(boxedLatest(a, boom) { count, total -> count to total } == null)
         archiveStore(a, 0, 5L, 100.0, null, boom)
         check(boxedLatest(a, boom) { count, total -> count to total } == 5L to 100.0)
@@ -1669,24 +1673,24 @@ fun main() {
         // field decodes stay inside the presence gate; a fixture whose fields
         // all decode successfully cannot tell the two orders apart.
         check(holderTagOr(null, -9L, boom) == -9L)
-        val held = Summary.of(4L, 8.0, boom)
+        val held = Summary.of(4L, 8.0, boom).orThrow()
         check(holderTagOr(Holder(3L, held), -9L, boom) == 7L)  // 3 + count(4)
     }
 
     // ── Vec<String> fold + Option<data-class> input + plain String return ────
     section("Vec<String> storageLabels + Option<Payload> input + String return") {
-        val s = storageNew(boom)
-        check(storageLabels(s, boom).isEmpty())
+        val s = storageNew(boom).orThrow()
+        check(storageLabels(s, boom).orThrow().isEmpty())
         storagePutSlice(
             s,
             listOf(payload(1L, 0, 0.0, false, "a"), payload(2L, 0, 0.0, false, null), payload(3L, 0, 0.0, false, "c")),
             boom,
         )
-        check(storageLabels(s, boom) == listOf("a", "c"))
+        check(storageLabels(s, boom).orThrow() == listOf("a", "c"))
         check(storagePutOpt(s, payload(4L, 0, 0.0, false, "d"), boom))   // Some → pushed
         check(!storagePutOpt(s, null, boom))                              // None → not
         check(s.len(boom) == 4L)
-        check(storageLabels(s, boom) == listOf("a", "c", "d"))
+        check(storageLabels(s, boom).orThrow() == listOf("a", "c", "d"))
         check(stringNew("hello", boom) == "hello")
         check(stringNew("", boom) == "")
         s.close()
@@ -1696,16 +1700,16 @@ fun main() {
     section("binding error je != null (wrong-length fixed-size array)") {
         var je: String? = null
         val fallback = storageTryFromStamp(
-            stampNew(1L, 0L, boom),
+            stampNew(1L, 0L, boom).orThrow(),
             byteArrayOf(1, 2, 3),   // `tag` is [u8; 2]; 3 is rejected on decode
             JniErrorHandler { e ->
                 je = e
-                storageNew(boom)
+                storageNew(boom).orThrow()
             },
             StorageErrorHandler { _, handle ->
                 throw AssertionError("domain channel must not fire on a decode failure")
             },
-        )
+        ).orThrow()
         fallback.close()
         check(je != null && je!!.contains("fixed-size array decode")) { "unexpected je: $je" }
     }
@@ -1715,13 +1719,13 @@ fun main() {
     // trampoline describes + clears the pending exception per upcall (the stack
     // trace printed below is EXPECTED output) and delivery continues.
     section("callback exceptions are swallowed (no-throw contract)") {
-        val s = storageNew(boom)
+        val s = storageNew(boom).orThrow()
         storagePutSlice(s, listOf(payload(1L, 0, 0.0, false, null), payload(2L, 0, 0.0, false, null)), boom)
         var fired = 0
         val h = payloadHandlerNew(
             PayloadCallback { fired++; throw RuntimeException("deliberate covertest exception") },
             boom,
-        )
+        ).orThrow()
         storageCallback(s, h, boom)   // must not throw at the call site
         check(fired == 2) { "every payload must still be delivered, got $fired" }
         storageCallback(s, h, boom)   // the handler stays usable
@@ -1732,16 +1736,16 @@ fun main() {
 
     // ── 3-handle sorted locking + concurrent smoke ───────────────────────────
     section("3-handle locking + 2-thread smoke") {
-        val s1 = Storage.withPayload(payload(1L, 0, 0.0, false, null), boom)
-        val s2 = Storage.withPayload(payload(2L, 0, 0.0, false, null), boom)
-        val s3 = storageNew(boom)
+        val s1 = Storage.withPayload(payload(1L, 0, 0.0, false, null), boom).orThrow()
+        val s2 = Storage.withPayload(payload(2L, 0, 0.0, false, null), boom).orThrow()
+        val s3 = storageNew(boom).orThrow()
         check(storageTotalLen(s1, s2, s3, boom) == 2L)
         check(storageTotalLen(s3, s2, s1, boom) == 2L)   // argument order irrelevant
         // Opposite lock-acquisition orders + a writer on a shared handle: the
         // sorted N-ary locking must neither deadlock nor tear.
         val iterations = 2_000
         val errs = AtomicInteger()
-        val s4 = storageNew(boom)
+        val s4 = storageNew(boom).orThrow()
         val workers = listOf(
             thread { repeat(iterations) { if (storageTotalLen(s1, s2, s3, boom) != 2L) errs.incrementAndGet() } },
             thread { repeat(iterations) { if (storageTotalLen(s3, s2, s1, boom) != 2L) errs.incrementAndGet() } },
@@ -1769,7 +1773,7 @@ fun main() {
     section("close/take storm (lock-order stability + closed-handle race)") {
         val slots = 4
         val pool = java.util.concurrent.atomic.AtomicReferenceArray<Storage>(slots)
-        for (i in 0 until slots) pool.set(i, storageNew(boom))
+        for (i in 0 until slots) pool.set(i, storageNew(boom).orThrow())
         val stop = java.util.concurrent.atomic.AtomicBoolean(false)
         val closedRaces = AtomicInteger()
         val unexpected = java.util.concurrent.atomic.AtomicReference<String?>(null)
@@ -1794,7 +1798,7 @@ fun main() {
                 val rnd = java.util.concurrent.ThreadLocalRandom.current()
                 repeat(3_000) { n ->
                     val i = rnd.nextInt(slots)
-                    val old = pool.getAndSet(i, storageNew(boom))
+                    val old = pool.getAndSet(i, storageNew(boom).orThrow())
                     when (n % 3) {
                         0 -> old.close()
                         // take(): the twin shares the old handle's masked
@@ -1819,7 +1823,7 @@ fun main() {
     // 20k upcalls, half carrying a fresh String local each — leaked JNI local
     // refs (the historical daemon-thread OOM) would accumulate here.
     section("high-volume callback (localref pressure)") {
-        val s = storageNew(boom)
+        val s = storageNew(boom).orThrow()
         val n = 5_000
         storagePutSlice(
             s,
@@ -1828,7 +1832,7 @@ fun main() {
         )
         var count = 0L
         var sum = 0L
-        val h = payloadHandlerNew(PayloadCallback { p -> count++; sum += p.id }, boom)
+        val h = payloadHandlerNew(PayloadCallback { p -> count++; sum += p.id }, boom).orThrow()
         repeat(4) { storageCallback(s, h, boom) }
         check(count == 4L * n)
         check(sum == 4L * (n.toLong() - 1L) * n.toLong() / 2L)
@@ -1844,7 +1848,7 @@ fun main() {
     // double-settled ticket would crash the JVM in the churn loop below.
     section(".gc_managed() lifecycle (ticket + Cleaner backstop)") {
         // Explicit close stays primary and is idempotent.
-        val a = Summary.of(2L, 40.0, boom)
+        val a = Summary.of(2L, 40.0, boom).orThrow()
         check(a.total(boom) == 40.0)
         a.close()
         check(a.isClosed())
@@ -1854,7 +1858,7 @@ fun main() {
         check(closedErr != null && closedErr!!.contains("closed native handle"))
 
         // take(): ticket moves into the fresh wrapper; the source is closed.
-        val b = Summary.of(3L, 60.0, boom)
+        val b = Summary.of(3L, 60.0, boom).orThrow()
         val c = b.take()
         check(b.isClosed() && !c.isClosed())
         check(c.total(boom) == 60.0)
@@ -1863,7 +1867,7 @@ fun main() {
 
         // By-value consumption settles the ticket (markConsumed): the summary
         // is freed by Rust, and neither close nor the Cleaner may free again.
-        val d = Summary.of(2L, 40.0, boom)
+        val d = Summary.of(2L, 40.0, boom).orThrow()
         check(summaryTotalRaw(d, boom) == 40.0)
         check(d.isClosed())
         d.close()
@@ -1873,7 +1877,7 @@ fun main() {
         // then force GC so the cleaner thread settles the survivors. Any
         // double free or free-under-use aborts the JVM here.
         repeat(2_000) { i ->
-            val s = Summary.of(i.toLong(), i.toDouble(), boom)
+            val s = Summary.of(i.toLong(), i.toDouble(), boom).orThrow()
             when (i % 3) {
                 0 -> {} // dropped live: the Cleaner frees it
                 1 -> s.close()
@@ -1885,7 +1889,7 @@ fun main() {
             Thread.sleep(50)
         }
         // The world is still sane after the cleaner ran.
-        val e = Summary.of(5L, 50.0, boom)
+        val e = Summary.of(5L, 50.0, boom).orThrow()
         check(e.count(boom) == 5L)
         e.close()
     }
@@ -1896,7 +1900,7 @@ fun main() {
         // spec's `_1` escaping — `esc_1pkg` + `Esc_1Probe` in the freePtr
         // destructor, `escape_1probe_1value` on the harness extern. A raw
         // dot-to-underscore symbol would throw UnsatisfiedLinkError.
-        val p = Esc_Probe.escapeProbeNew(7L, boom)
+        val p = Esc_Probe.escapeProbeNew(7L, boom).orThrow()
         check(p.escapeProbeValue(boom) == 7L)
         p.close()
     }

--- a/examples/covertest-kotlin/kotlin/io/prebindgen/covertest/Test.kt
+++ b/examples/covertest-kotlin/kotlin/io/prebindgen/covertest/Test.kt
@@ -1168,6 +1168,21 @@ fun main() {
         check(fullHandle!!.total(boom) == 40.0)
         fullHandle!!.close()
         s.close()
+
+        // Generic R? recovery: a binding failure may deliberately decline to
+        // fabricate an R by returning null from the handler.
+        var genericRecoveryError: String? = null
+        val recovered: String? = storageSummary(
+            s,
+            JniErrorHandler<String?> { je ->
+                genericRecoveryError = je
+                null
+            },
+        ) { count, total -> "$count:$total" }
+        check(recovered == null)
+        check(genericRecoveryError?.contains("closed native handle") == true) {
+            "unexpected generic recovery error: $genericRecoveryError"
+        }
     }
 
     // ── binding-local field: fun!(crate::…).sig(sig!).name("handle") ────────

--- a/examples/perftest-kotlin/kotlin/generated/io/prebindgen/perftest.kt
+++ b/examples/perftest-kotlin/kotlin/generated/io/prebindgen/perftest.kt
@@ -580,7 +580,7 @@ public class Token private constructor(initialPtr: Long) : NativeHandle(initialP
         internal fun fromRawPtr(initialPtr: Long): Token = Token(initialPtr)
 
         /** Create a plain benchmark token. */
-        public fun tokenNew(value: Long, onError: JniErrorHandler<Token>): Token {
+        public fun tokenNew(value: Long, onError: JniErrorHandler<Token?>): Token? {
             val __bcap = JniErrorHandlerCapture.acquire()
             val __ret = JNINative.tokenNew(value, __bcap)
             if (__bcap.failed) return onError.run(__bcap.ze0)
@@ -629,7 +629,7 @@ public class TokenGc private constructor(initialPtr: Long) : GcNativeHandle(init
         internal fun fromRawPtr(initialPtr: Long): TokenGc = TokenGc(initialPtr)
 
         /** Create a gc-managed benchmark token. */
-        public fun tokenGcNew(value: Long, onError: JniErrorHandler<TokenGc>): TokenGc {
+        public fun tokenGcNew(value: Long, onError: JniErrorHandler<TokenGc?>): TokenGc? {
             val __bcap = JniErrorHandlerCapture.acquire()
             val __ret = JNINative.tokenGcNew(value, __bcap)
             if (__bcap.failed) return onError.run(__bcap.ze0)
@@ -688,6 +688,8 @@ internal object __PayloadFolderRawHolder {
  * failure message. For an infallible wrapper this is the sole `onError`; a
  * fallible wrapper takes it as `onBindingError` alongside the typed domain
  * handler. The wrapper returns whatever `run` returns;
+ * the handler firing is the error discriminator: null can also be a successful optional
+ * result, while a non-null value can be a handler-supplied fallback.
  * throwing from `run` is safe (it executes after the native call has returned).
  */
 public fun interface JniErrorHandler<out R> {

--- a/examples/perftest-kotlin/kotlin/generated/io/prebindgen/perftest.kt
+++ b/examples/perftest-kotlin/kotlin/generated/io/prebindgen/perftest.kt
@@ -687,10 +687,11 @@ internal object __PayloadFolderRawHolder {
  * converter in the chain may fail, or a handle may be closed). `je` is the
  * failure message. For an infallible wrapper this is the sole `onError`; a
  * fallible wrapper takes it as `onBindingError` alongside the typed domain
- * handler. The wrapper returns whatever `run` returns;
- * the handler firing is the error discriminator: null can also be a successful optional
- * result, while a non-null value can be a handler-supplied fallback.
- * throwing from `run` is safe (it executes after the native call has returned).
+ * handler. The wrapper returns whatever `run` returns. Where that type is nullable you may
+ * return `null` to decline — you are not required to fabricate a result. Consequently the
+ * handler firing, not the returned value, is the error discriminator: `null` can also be a
+ * successful optional result, and a non-null value can be a fallback you supplied. Throwing
+ * from `run` is safe (it executes after the native call has returned).
  */
 public fun interface JniErrorHandler<out R> {
     public fun run(je: String?): R

--- a/examples/perftest-kotlin/kotlin/generated/io/prebindgen/perftest/storage.kt
+++ b/examples/perftest-kotlin/kotlin/generated/io/prebindgen/perftest/storage.kt
@@ -17,7 +17,7 @@ import io.prebindgen.perftest.asRaw
 import io.prebindgen.perftest.withSortedHandleLocks
 
 /** Create a new, empty storage handle. */
-public fun storageNew(onError: JniErrorHandler<Storage>): Storage {
+public fun storageNew(onError: JniErrorHandler<Storage?>): Storage? {
     val __bcap = JniErrorHandlerCapture.acquire()
     val __ret = JNINative.storageNew(__bcap)
     if (__bcap.failed) return onError.run(__bcap.ze0)
@@ -100,8 +100,8 @@ public fun storagePutByRead(s: Storage, payload: Payload, onError: JniErrorHandl
  */
 public fun payloadHandlerNew(
     f: PayloadCallback,
-    onError: JniErrorHandler<PayloadHandler>,
-): PayloadHandler {
+    onError: JniErrorHandler<PayloadHandler?>,
+): PayloadHandler? {
     val __bcap = JniErrorHandlerCapture.acquire()
     val __ret = JNINative.payloadHandlerNew(f.asRaw(), __bcap)
     if (__bcap.failed) return onError.run(__bcap.ze0)
@@ -193,8 +193,8 @@ public fun storageGetVec(s: Storage, onError: JniErrorHandler<List<Payload>?>): 
  */
 public fun payloadVecHandlerNew(
     f: PayloadListCallback,
-    onError: JniErrorHandler<PayloadVecHandler>,
-): PayloadVecHandler {
+    onError: JniErrorHandler<PayloadVecHandler?>,
+): PayloadVecHandler? {
     val __bcap = JniErrorHandlerCapture.acquire()
     val __ret = JNINative.payloadVecHandlerNew(f, __bcap)
     if (__bcap.failed) return onError.run(__bcap.ze0)

--- a/examples/perftest-kotlin/kotlin/io/prebindgen/perftest/Bench.kt
+++ b/examples/perftest-kotlin/kotlin/io/prebindgen/perftest/Bench.kt
@@ -57,6 +57,9 @@ private val onError = JniErrorHandler<Nothing> { je ->
     throw RuntimeException("native error: $je")
 }
 
+private fun <T : Any> T?.orThrow(): T =
+    this ?: throw AssertionError("a throwing error handler returned instead of throwing")
+
 // One normalized result row: `<op> <variant> <ns_per_op> <mops>`.
 private fun bench(op: String, variant: String, n: Long, body: () -> Unit) {
     val start = System.nanoTime()
@@ -100,7 +103,7 @@ private fun correctness(s: Storage) {
 
     // Whole-batch callback: ONE upcall delivering the entire List<Payload>.
     var cbSum = 0L
-    val vh = payloadVecHandlerNew(PayloadListCallback { list -> cbSum += list.sumOf { it.id } }, onError)
+    val vh = payloadVecHandlerNew(PayloadListCallback { list -> cbSum += list.sumOf { it.id } }, onError).orThrow()
     storageCallbackVec(s, vh, onError)
     check(cbSum == batch.sumOf { it.id }) { "callback_vec should observe the whole batch" }
     vh.close()
@@ -114,7 +117,7 @@ private fun correctness(s: Storage) {
 }
 
 fun main() {
-    val s = storageNew(onError)
+    val s = storageNew(onError).orThrow()
 
     correctness(s)
 
@@ -134,9 +137,9 @@ fun main() {
     var sink = 0L
 
     // Single-payload callback handler, prepared ONCE (trampoline built a single time).
-    val cb = payloadHandlerNew(PayloadCallback { p -> sink += p.id }, onError)
+    val cb = payloadHandlerNew(PayloadCallback { p -> sink += p.id }, onError).orThrow()
     // Whole-batch callback handler, prepared once: one upcall delivers the whole List.
-    val vcb = payloadVecHandlerNew(PayloadListCallback { list -> sink += list.size.toLong() }, onError)
+    val vcb = payloadVecHandlerNew(PayloadListCallback { list -> sink += list.size.toLong() }, onError).orThrow()
 
     // Single-payload ops for one string category (`str` = heap `label`, `null` = none).
     fun runCategory(label: String?, cat: String) {
@@ -181,10 +184,10 @@ fun main() {
         // create + explicit close: plain = tag write + freePtr; gc adds the
         // cell alloc, Cleaner registration, CAS ticket, clean() deregistration.
         bench("handle_close", "plain", HN) {
-            Token.tokenNew(1L, onError).close()
+            Token.tokenNew(1L, onError).orThrow().close()
         }
         bench("handle_close", "gc", HN) {
-            TokenGc.tokenGcNew(1L, onError).close()
+            TokenGc.tokenGcNew(1L, onError).orThrow().close()
         }
         // create + drop (no close): plain leaks natively; gc is freed by the
         // Cleaner as the JVM collects the wrappers.
@@ -199,8 +202,8 @@ fun main() {
         Thread.sleep(200)
         // method call on a live handle: prices the open `ptr` property
         // (field-backed vs atomic-cell getter) on the call path.
-        val tp = Token.tokenNew(7L, onError)
-        val tg = TokenGc.tokenGcNew(7L, onError)
+        val tp = Token.tokenNew(7L, onError).orThrow()
+        val tg = TokenGc.tokenGcNew(7L, onError).orThrow()
         bench("handle_call", "plain", HN) {
             sink += tp.tokenValue(onError)
         }
@@ -217,8 +220,8 @@ fun main() {
     val warm = makeBatch("hello, payload")
     storagePutSlice(s, warm, onError)
     val warmN = minOf(VEC_ITERS, 50_000L)
-    val warmTp = Token.tokenNew(3L, onError)
-    val warmTg = TokenGc.tokenGcNew(3L, onError)
+    val warmTp = Token.tokenNew(3L, onError).orThrow()
+    val warmTg = TokenGc.tokenGcNew(3L, onError).orThrow()
     repeat(warmN.toInt()) {
         storagePutByTake(s, warm[0], onError)
         storageGet(s, onError)
@@ -228,8 +231,8 @@ fun main() {
         storageCallbackVec(s, vcb, onError)
         sink += largeFlatInputSum(largeFlat, onError)
         sink += largeObjectInputSum(largeObject, onError)
-        Token.tokenNew(1L, onError).close()
-        TokenGc.tokenGcNew(1L, onError).close()
+        Token.tokenNew(1L, onError).orThrow().close()
+        TokenGc.tokenGcNew(1L, onError).orThrow().close()
         sink += warmTp.tokenValue(onError)
         sink += warmTg.tokenGcValue(onError)
     }

--- a/examples/perftest-kotlin/kotlin/io/prebindgen/perftest/Bench.kt
+++ b/examples/perftest-kotlin/kotlin/io/prebindgen/perftest/Bench.kt
@@ -181,6 +181,8 @@ fun main() {
     // leak-on-drop behavior) and the Cleaner backlog.
     val HN = minOf(N, 2_000_000L)
     fun runHandleLifecycle() {
+        // The nullable recovery contract puts orThrow() in these measured paths,
+        // so both post-change rows include its null check.
         // create + explicit close: plain = tag write + freePtr; gc adds the
         // cell alloc, Cleaner registration, CAS ticket, clean() deregistration.
         bench("handle_close", "plain", HN) {

--- a/prebindgen-jni/src/jni/iface.rs
+++ b/prebindgen-jni/src/jni/iface.rs
@@ -1660,10 +1660,11 @@ pub(crate) fn error_handler_iface_spec(
         "Domain-error callback: called only when the native function returns `Err` — the\n\
          parameters carry the decomposed `{source_short}`. Binding/system failures go to the\n\
          separate `onBindingError` (`JniErrorHandler`) channel instead, so there is no `je`\n\
-         discriminator here. The wrapper returns whatever `run` returns;\n\
-         the handler firing is the error discriminator: null can also be a successful optional\n\
-         result, while a non-null value can be a handler-supplied fallback.\n\
-         throwing from `run` is safe (it executes after the native call has returned)."
+         discriminator here. The wrapper returns whatever `run` returns. Where that type is\n\
+         nullable you may return `null` to decline — you are not required to fabricate a result.\n\
+         Consequently the handler firing, not the returned value, is the error discriminator:\n\
+         `null` can also be a successful optional result, and a non-null value can be a fallback\n\
+         you supplied. Throwing from `run` is safe (it executes after the native call has returned)."
     ));
     Some(iface)
 }
@@ -1688,10 +1689,11 @@ pub(crate) fn jni_error_handler_iface_spec(ext: &Declarations) -> IfaceSpec {
          converter in the chain may fail, or a handle may be closed). `je` is the\n\
          failure message. For an infallible wrapper this is the sole `onError`; a\n\
          fallible wrapper takes it as `onBindingError` alongside the typed domain\n\
-         handler. The wrapper returns whatever `run` returns;\n\
-         the handler firing is the error discriminator: null can also be a successful optional\n\
-         result, while a non-null value can be a handler-supplied fallback.\n\
-         throwing from `run` is safe (it executes after the native call has returned)."
+         handler. The wrapper returns whatever `run` returns. Where that type is nullable you may\n\
+         return `null` to decline — you are not required to fabricate a result. Consequently the\n\
+         handler firing, not the returned value, is the error discriminator: `null` can also be a\n\
+         successful optional result, and a non-null value can be a fallback you supplied. Throwing\n\
+         from `run` is safe (it executes after the native call has returned)."
             .to_string(),
     );
     iface

--- a/prebindgen-jni/src/jni/iface.rs
+++ b/prebindgen-jni/src/jni/iface.rs
@@ -1661,6 +1661,8 @@ pub(crate) fn error_handler_iface_spec(
          parameters carry the decomposed `{source_short}`. Binding/system failures go to the\n\
          separate `onBindingError` (`JniErrorHandler`) channel instead, so there is no `je`\n\
          discriminator here. The wrapper returns whatever `run` returns;\n\
+         the handler firing is the error discriminator: null can also be a successful optional\n\
+         result, while a non-null value can be a handler-supplied fallback.\n\
          throwing from `run` is safe (it executes after the native call has returned)."
     ));
     Some(iface)
@@ -1687,6 +1689,8 @@ pub(crate) fn jni_error_handler_iface_spec(ext: &Declarations) -> IfaceSpec {
          failure message. For an infallible wrapper this is the sole `onError`; a\n\
          fallible wrapper takes it as `onBindingError` alongside the typed domain\n\
          handler. The wrapper returns whatever `run` returns;\n\
+         the handler firing is the error discriminator: null can also be a successful optional\n\
+         result, while a non-null value can be a handler-supplied fallback.\n\
          throwing from `run` is safe (it executes after the native call has returned)."
             .to_string(),
     );

--- a/prebindgen-jni/src/jni/render.rs
+++ b/prebindgen-jni/src/jni/render.rs
@@ -2485,8 +2485,9 @@ pub(crate) fn source_item_doc<M>(registry: &Registry<M>, key: &TypeKey) -> Optio
 
 #[cfg(test)]
 mod recovery_return_tests {
-    use super::nullable_recovery_type;
     use kotlin_codegen::KtType;
+
+    use super::nullable_recovery_type;
 
     fn recover(ty: KtType, generics: &[&str]) -> KtType {
         nullable_recovery_type(

--- a/prebindgen-jni/src/jni/render.rs
+++ b/prebindgen-jni/src/jni/render.rs
@@ -778,6 +778,81 @@ pub(crate) struct WrapperSurface {
     body_imports: BTreeSet<String>,
 }
 
+/// Whether an error handler may return null when it cannot manufacture the
+/// value a failed call was meant to produce.
+#[derive(Clone, Copy)]
+enum RecoveryReturn {
+    /// Public wrappers: reference-shaped returns become nullable. Types whose
+    /// nullable form has a different JVM representation (primitives and
+    /// ULong) keep their declared type.
+    NullableReferences,
+    /// Constant helpers always install a throwing handler themselves, so they
+    /// retain the constant's declared type instead of leaking nullability into
+    /// the public property.
+    Declared,
+}
+
+/// The type returned by both error handlers and, consequently, by the wrapper
+/// itself. A handler may decline to fabricate a reference result by returning
+/// null; primitive-shaped results keep their existing unboxed contract.
+fn recovery_return_type(out: &OutputPlan, policy: RecoveryReturn) -> KtType {
+    let declared = out.kt_return.clone().unwrap_or_else(KtType::unit);
+    if matches!(policy, RecoveryReturn::Declared) {
+        return declared;
+    }
+    let generics: Vec<String> = out.generic.iter().cloned().collect();
+    nullable_recovery_type(declared, &generics)
+}
+
+fn nullable_recovery_type(declared: KtType, generics: &[String]) -> KtType {
+    if declared.is_nullable() || declared == KtType::unit() {
+        return declared;
+    }
+    let nullable = declared.clone().nullable();
+    if crate::jni::symbols::erase_kt_type(generics, &declared)
+        == crate::jni::symbols::erase_kt_type(generics, &nullable)
+    {
+        nullable
+    } else {
+        declared
+    }
+}
+
+#[cfg(test)]
+mod recovery_return_tests {
+    use super::nullable_recovery_type;
+    use kotlin_codegen::KtType;
+
+    fn recover(ty: KtType, generics: &[&str]) -> KtType {
+        nullable_recovery_type(
+            ty,
+            &generics.iter().map(|g| g.to_string()).collect::<Vec<_>>(),
+        )
+    }
+
+    #[test]
+    fn only_reference_shaped_recovery_returns_become_nullable() {
+        for primitive in [
+            KtType::unit(),
+            KtType::int(),
+            KtType::long(),
+            KtType::boolean(),
+            KtType::cls("ULong"),
+        ] {
+            assert!(!recover(primitive, &[]).is_nullable());
+        }
+        for reference in [
+            KtType::string(),
+            KtType::byte_array(),
+            KtType::generic("List", [KtType::string()]),
+            KtType::cls("io.test.Handle"),
+            KtType::var_r(),
+        ] {
+            assert!(recover(reference, &["R"]).is_nullable());
+        }
+        assert!(recover(KtType::string().nullable(), &[]).is_nullable());
+    }
+}
 /// Build the [`WrapperSurface`]: everything [`render_wrapper_fn`] does up to
 /// (but not including) the body render — the single surface-signature
 /// derivation. **Pure** over `(ext, f, registry, name, receiver)`: signature
@@ -791,6 +866,24 @@ pub(crate) fn build_wrapper_surface(
     registry: &Registry<KotlinMeta>,
     kotlin_name_override: Option<&str>,
     receiver_key: Option<&TypeKey>,
+) -> Option<WrapperSurface> {
+    build_wrapper_surface_with_recovery(
+        ext,
+        f,
+        registry,
+        kotlin_name_override,
+        receiver_key,
+        RecoveryReturn::NullableReferences,
+    )
+}
+
+fn build_wrapper_surface_with_recovery(
+    ext: &Declarations,
+    f: &prebindgen_registry::flat::Function,
+    registry: &Registry<KotlinMeta>,
+    kotlin_name_override: Option<&str>,
+    receiver_key: Option<&TypeKey>,
+    recovery: RecoveryReturn,
 ) -> Option<WrapperSurface> {
     let mut body_imports = BTreeSet::new();
     let fplan = ext.fn_plan(registry, f).ok()?;
@@ -806,7 +899,7 @@ pub(crate) fn build_wrapper_surface(
     let (params, receiver_idx) =
         classify_params(ext, &fplan, registry, &mut body_imports, receiver_key)?;
     let out = classify_output(ext, f, &fplan, registry, &mut body_imports)?;
-    let r_ty = out.kt_return.clone().unwrap_or_else(KtType::unit);
+    let r_ty = recovery_return_type(&out, recovery);
     let sink = error_sink_parts(f, &fplan, registry, &mut body_imports, &r_ty)?;
 
     let mut fun = KtFun::new(&kt_name).vis(KtVis::Public);
@@ -848,8 +941,8 @@ pub(crate) fn build_wrapper_surface(
     if out.cast_return {
         fun = fun.annotation("Suppress(\"UNCHECKED_CAST\")");
     }
-    if let Some(rt) = &out.kt_return {
-        fun = fun.returns(rt.clone());
+    if out.kt_return.is_some() {
+        fun = fun.returns(r_ty);
     }
     Some(WrapperSurface {
         fun,
@@ -868,7 +961,32 @@ pub(crate) fn render_wrapper_fn(
     kotlin_name_override: Option<&str>,
     receiver_key: Option<&TypeKey>,
 ) -> Option<KtFun> {
-    let surface = build_wrapper_surface(ext, f, registry, kotlin_name_override, receiver_key)?;
+    render_wrapper_fn_with_recovery(
+        ext,
+        f,
+        registry,
+        kotlin_name_override,
+        receiver_key,
+        RecoveryReturn::NullableReferences,
+    )
+}
+
+fn render_wrapper_fn_with_recovery(
+    ext: &Declarations,
+    f: &prebindgen_registry::flat::Function,
+    registry: &Registry<KotlinMeta>,
+    kotlin_name_override: Option<&str>,
+    receiver_key: Option<&TypeKey>,
+    recovery: RecoveryReturn,
+) -> Option<KtFun> {
+    let surface = build_wrapper_surface_with_recovery(
+        ext,
+        f,
+        registry,
+        kotlin_name_override,
+        receiver_key,
+        recovery,
+    )?;
     let WrapperSurface {
         mut fun,
         params,
@@ -929,7 +1047,14 @@ pub(crate) fn render_const_val(
     let getter = const_getter_fn(c);
     let default = kt_snake_to_camel(&getter.name.to_string());
     let helper_name = ext.mangle_fun(package, &default);
-    let helper = render_wrapper_fn(ext, &getter, registry, Some(&helper_name), None)?;
+    let helper = render_wrapper_fn_with_recovery(
+        ext,
+        &getter,
+        registry,
+        Some(&helper_name),
+        None,
+        RecoveryReturn::Declared,
+    )?;
     let val_name = kotlin_name_override
         .map(str::to_string)
         .unwrap_or_else(|| c.name.to_string());
@@ -960,7 +1085,14 @@ pub(crate) fn render_constant_fn_val(
 ) -> Option<(KtFun, KtProperty)> {
     let default = kt_snake_to_camel(&f.name.to_string());
     let helper_name = ext.mangle_fun(package, &default);
-    let helper = render_wrapper_fn(ext, f, registry, Some(&helper_name), None)?;
+    let helper = render_wrapper_fn_with_recovery(
+        ext,
+        f,
+        registry,
+        Some(&helper_name),
+        None,
+        RecoveryReturn::Declared,
+    )?;
     let val_name = kotlin_name_override
         .map(str::to_string)
         .unwrap_or_else(|| f.name.to_string());
@@ -991,7 +1123,14 @@ pub(crate) fn render_const_expr_val(
     let getter = const_expr_getter_fn(&decl.kotlin_name, &decl.ty, registry);
     let default = kt_snake_to_camel(&getter.name.to_string());
     let helper_name = ext.mangle_fun(package, &default);
-    let helper = render_wrapper_fn(ext, &getter, registry, Some(&helper_name), None)?;
+    let helper = render_wrapper_fn_with_recovery(
+        ext,
+        &getter,
+        registry,
+        Some(&helper_name),
+        None,
+        RecoveryReturn::Declared,
+    )?;
     let expr = decl.expr.to_token_stream();
     let kdoc = format!(
         "Binding-defined constant: `{expr}` (evaluated lazily, once, through \

--- a/prebindgen-jni/src/jni/render.rs
+++ b/prebindgen-jni/src/jni/render.rs
@@ -818,41 +818,6 @@ fn nullable_recovery_type(declared: KtType, generics: &[String]) -> KtType {
     }
 }
 
-#[cfg(test)]
-mod recovery_return_tests {
-    use super::nullable_recovery_type;
-    use kotlin_codegen::KtType;
-
-    fn recover(ty: KtType, generics: &[&str]) -> KtType {
-        nullable_recovery_type(
-            ty,
-            &generics.iter().map(|g| g.to_string()).collect::<Vec<_>>(),
-        )
-    }
-
-    #[test]
-    fn only_reference_shaped_recovery_returns_become_nullable() {
-        for primitive in [
-            KtType::unit(),
-            KtType::int(),
-            KtType::long(),
-            KtType::boolean(),
-            KtType::cls("ULong"),
-        ] {
-            assert!(!recover(primitive, &[]).is_nullable());
-        }
-        for reference in [
-            KtType::string(),
-            KtType::byte_array(),
-            KtType::generic("List", [KtType::string()]),
-            KtType::cls("io.test.Handle"),
-            KtType::var_r(),
-        ] {
-            assert!(recover(reference, &["R"]).is_nullable());
-        }
-        assert!(recover(KtType::string().nullable(), &[]).is_nullable());
-    }
-}
 /// Build the [`WrapperSurface`]: everything [`render_wrapper_fn`] does up to
 /// (but not including) the body render — the single surface-signature
 /// derivation. **Pure** over `(ext, f, registry, name, receiver)`: signature
@@ -2515,5 +2480,41 @@ pub(crate) fn source_item_doc<M>(registry: &Registry<M>, key: &TypeKey) -> Optio
         prebindgen_registry::flat::Type::Enum(e) => e.docs(),
         prebindgen_registry::flat::Type::Variant(v) => v.docs(),
         prebindgen_registry::flat::Type::Extern(_) => None,
+    }
+}
+
+#[cfg(test)]
+mod recovery_return_tests {
+    use super::nullable_recovery_type;
+    use kotlin_codegen::KtType;
+
+    fn recover(ty: KtType, generics: &[&str]) -> KtType {
+        nullable_recovery_type(
+            ty,
+            &generics.iter().map(|g| g.to_string()).collect::<Vec<_>>(),
+        )
+    }
+
+    #[test]
+    fn only_reference_shaped_recovery_returns_become_nullable() {
+        for primitive in [
+            KtType::unit(),
+            KtType::int(),
+            KtType::long(),
+            KtType::boolean(),
+            KtType::cls("ULong"),
+        ] {
+            assert!(!recover(primitive, &[]).is_nullable());
+        }
+        for reference in [
+            KtType::string(),
+            KtType::byte_array(),
+            KtType::generic("List", [KtType::string()]),
+            KtType::cls("io.test.Handle"),
+            KtType::var_r(),
+        ] {
+            assert!(recover(reference, &["R"]).is_nullable());
+        }
+        assert!(recover(KtType::string().nullable(), &[]).is_nullable());
     }
 }

--- a/prebindgen-jni/src/jni/symbols.rs
+++ b/prebindgen-jni/src/jni/symbols.rs
@@ -375,8 +375,8 @@ impl std::fmt::Display for JvmSignature {
 /// The JVM boxed class of a Kotlin primitive — a nullable primitive crosses
 /// as its box (`Int?` → `java.lang.Integer`), a distinct JVM descriptor from
 /// the unboxed primitive, so `f(x: Int)` and `f(x: Int?)` do NOT clash.
-fn boxed_primitive(simple: &str) -> Option<&'static str> {
-    Some(match simple {
+fn boxed_primitive(builtin: &str) -> Option<&'static str> {
+    Some(match builtin {
         "Int" => "java.lang.Integer",
         "Long" => "java.lang.Long",
         "Short" => "java.lang.Short",
@@ -385,6 +385,29 @@ fn boxed_primitive(simple: &str) -> Option<&'static str> {
         "Boolean" => "java.lang.Boolean",
         "Float" => "java.lang.Float",
         "Double" => "java.lang.Double",
+        _ => return None,
+    })
+}
+
+/// The canonical short name of a Kotlin builtin represented either the way
+/// JniGen constructs it (`Int`) or by its full Kotlin identity (`kotlin.Int`).
+/// A qualified generated class such as `io.test.Int` is deliberately not a
+/// builtin merely because its last path segment has the same spelling.
+fn kotlin_builtin(fqn: &str) -> Option<&'static str> {
+    Some(match fqn {
+        "Int" | "kotlin.Int" => "Int",
+        "Long" | "kotlin.Long" => "Long",
+        "Short" | "kotlin.Short" => "Short",
+        "Byte" | "kotlin.Byte" => "Byte",
+        "Char" | "kotlin.Char" => "Char",
+        "Boolean" | "kotlin.Boolean" => "Boolean",
+        "Float" | "kotlin.Float" => "Float",
+        "Double" | "kotlin.Double" => "Double",
+        "ULong" | "kotlin.ULong" => "ULong",
+        "String" | "kotlin.String" => "String",
+        "ByteArray" | "kotlin.ByteArray" => "ByteArray",
+        "Any" | "kotlin.Any" => "Any",
+        "Unit" | "kotlin.Unit" => "Unit",
         _ => return None,
     })
 }
@@ -407,30 +430,30 @@ pub(crate) fn erase_kt_type(generics: &[String], ty: &KtType) -> ErasedJvmType {
     let token = match ty {
         KtType::Function { params, .. } => format!("kotlin.Function{}", params.len()),
         KtType::Named { fqn, nullable, .. } => {
-            let simple = ty.simple_name().unwrap_or(fqn);
+            let builtin = kotlin_builtin(fqn);
             if generics.iter().any(|g| g == fqn) {
                 "java.lang.Object".to_string()
-            } else if simple == "ULong" {
+            } else if builtin == Some("ULong") {
                 if *nullable {
                     "kotlin.ULong".to_string()
                 } else {
                     "Long".to_string()
                 }
-            } else if let Some(boxed) = boxed_primitive(simple) {
+            } else if let Some(boxed) = builtin.and_then(boxed_primitive) {
                 if *nullable {
                     boxed.to_string()
                 } else {
-                    simple.to_string()
+                    builtin.expect("boxed primitive is a builtin").to_string()
                 }
             } else {
-                match simple {
-                    "String" => "java.lang.String".to_string(),
-                    "ByteArray" => "byte[]".to_string(),
-                    "Any" => "java.lang.Object".to_string(),
-                    "Unit" => "void".to_string(),
-                    // Generic container (args erased) or a plain class: the
-                    // declared `fqn` (a generic's `fqn` is its raw name, e.g.
-                    // `List`), so `List<X>` and `List<Y>` share one token.
+                match builtin {
+                    Some("String") => "java.lang.String".to_string(),
+                    Some("ByteArray") => "byte[]".to_string(),
+                    Some("Any") => "java.lang.Object".to_string(),
+                    Some("Unit") => "void".to_string(),
+                    // Generic container (args erased) or a plain class: retain
+                    // the declared FQN. Nullability never changes an ordinary
+                    // class's JVM descriptor.
                     _ => fqn.clone(),
                 }
             }
@@ -526,5 +549,20 @@ mod tests {
             erase(&[], kt::KtType::cls("io.other.Foo")),
             "distinct FQNs stay distinct"
         );
+        for fqn in [
+            "io.test.Int",
+            "io.test.ULong",
+            "io.test.String",
+            "io.test.ByteArray",
+            "io.test.Any",
+            "io.test.Unit",
+        ] {
+            assert_eq!(erase(&[], kt::KtType::cls(fqn)), fqn);
+            assert_eq!(
+                erase(&[], kt::KtType::cls(fqn).nullable()),
+                fqn,
+                "qualified builtin-looking class `{fqn}` must stay a reference"
+            );
+        }
     }
 }

--- a/prebindgen-jni/src/jni/tests/config.rs
+++ b/prebindgen-jni/src/jni/tests/config.rs
@@ -358,7 +358,7 @@ fn per_class_name_and_base_package_fun() {
     assert!(!kc.contains("JNIZThing"), "{kotlin}");
     // Wrappers reference the renamed class.
     assert!(
-        kc.contains("funthingNew(onError:JniErrorHandler<Gadget>):Gadget"),
+        kc.contains("funthingNew(onError:JniErrorHandler<Gadget?>):Gadget?"),
         "{kotlin}"
     );
     // Base-package functions land in the base package file (which also hosts
@@ -433,7 +433,7 @@ fn setters_after_declarations_apply() {
     assert!(tc.contains("classThingprivateconstructor("), "{things}");
     assert!(!tc.contains("classZThingprivateconstructor("), "{things}");
     assert!(
-        tc.contains("funthingNew(onError:JniErrorHandler<Thing>):Thing"),
+        tc.contains("funthingNew(onError:JniErrorHandler<Thing?>):Thing?"),
         "{things}"
     );
 }

--- a/prebindgen-jni/src/jni/tests/config.rs
+++ b/prebindgen-jni/src/jni/tests/config.rs
@@ -372,6 +372,59 @@ fn per_class_name_and_base_package_fun() {
     assert!(base.contains("fun thingNew("), "{base}");
 }
 
+/// A generated reference class may legitimately have the same short name as a
+/// Kotlin builtin. Its full identity keeps it reference-shaped, so nullable
+/// recovery must not mistake `io.test.jni.thing.Int` for primitive `Int`.
+#[test]
+fn builtin_looking_class_name_keeps_nullable_recovery() {
+    use prebindgen::SourceLocation;
+    let loc = myflat_loc();
+    let items: Vec<(syn::Item, SourceLocation)> = vec![
+        (
+            syn::Item::Struct(syn::parse_quote!(
+                pub struct ZThing {
+                    _p: u8,
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn thing_new() -> ZThing {
+                    unimplemented!()
+                }
+            )),
+            loc,
+        ),
+    ];
+    let registry =
+        crate::test_util::reg_from_items(declare_referenced(items)).expect("index items");
+    let jni = JniGenBuilder::new()
+        .set_package_prefix("io.test.jni")
+        .package(
+            crate::package!("thing")
+                .class(crate::ptr_class!(ZThing).name("Int"))
+                .fun(prebindgen_registry::fun!(thing_new)),
+        );
+
+    let dir = unique_test_dir("jnigen_builtin_looking_class");
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    let gen = jni.build_with(registry).expect("resolve");
+    let paths = gen.write_kotlin(&dir.join("kotlin")).expect("write_kotlin");
+    let kotlin: String = paths
+        .iter()
+        .filter_map(|p| std::fs::read_to_string(p).ok())
+        .collect();
+    let compact: String = kotlin.split_whitespace().collect();
+
+    assert!(compact.contains("classIntprivateconstructor("), "{kotlin}");
+    assert!(
+        compact.contains("funthingNew(onError:JniErrorHandler<Int?>):Int?"),
+        "{kotlin}"
+    );
+}
+
 /// Setters are order-insensitive: declaring the package FIRST and applying
 /// `set_package_prefix` + a class mangle AFTER must produce the same output
 /// as the conventional settings-first order — the setter re-derives every

--- a/prebindgen-jni/src/jni/tests/cross_artifact.rs
+++ b/prebindgen-jni/src/jni/tests/cross_artifact.rs
@@ -523,14 +523,14 @@ fn cross_artifact_optional_iterable_fold_agrees() {
         );
     }
     // …and the Kotlin wrapper surface is the generic fold on both, returning
-    // `A` for the bare shape and `A?` for the `Optional`-wrapped one.
+    // A? for both: null is the recovery value or the optional result.
     let wrappers = kotlin
         .values()
         .find(|src| src.contains("fun <A> zThingsAll"))
         .expect("a generated file declares the fold wrappers");
     let kc: String = wrappers.chars().filter(|c| !c.is_whitespace()).collect();
     assert!(
-        kc.contains("fun<A>zThingsAll(acc:A,onError:JniErrorHandler<A>,fold:ZThingFolder<A>):A{"),
+        kc.contains("fun<A>zThingsAll(acc:A,onError:JniErrorHandler<A?>,fold:ZThingFolder<A>):A?{"),
         "bare fold wrapper surface:\n{wrappers}"
     );
     assert!(

--- a/prebindgen-jni/src/jni/tests/flatten.rs
+++ b/prebindgen-jni/src/jni/tests/flatten.rs
@@ -2099,7 +2099,7 @@ fn qualified_signature_spelling_matches_bare_ptr_class() {
     );
     assert!(ac.contains("funname(onError:"), "{all}");
     assert!(
-        ac.contains("funzThingGet(onError:JniErrorHandler<ZThing>):ZThing"),
+        ac.contains("funzThingGet(onError:JniErrorHandler<ZThing?>):ZThing?"),
         "{all}"
     );
 }

--- a/prebindgen-jni/src/jni/tests/sealed.rs
+++ b/prebindgen-jni/src/jni/tests/sealed.rs
@@ -1187,7 +1187,7 @@ fn borrowed_sum_return_matches_through_the_reference() {
     // handle, so there is nothing to close and no lifetime to track.
     assert!(
         kotlin.contains(
-            "public fun readBorrowed(p: Probe, onError: JniErrorHandler<Reading>): Reading"
+            "public fun readBorrowed(p: Probe, onError: JniErrorHandler<Reading?>): Reading?"
         ),
         "a borrowed sum arrives as an ordinary value:\n{kotlin}"
     );
@@ -1213,7 +1213,7 @@ fn sum_return_composes_with_option_and_vec() {
     );
     assert!(
         kotlin.contains(
-            "public fun readAll(n: Int, onError: JniErrorHandler<List<Reading>>): List<Reading>"
+            "public fun readAll(n: Int, onError: JniErrorHandler<List<Reading>?>): List<Reading>?"
         ) && kotlin.contains("__ReadingFolderRawHolder.instance"),
         "Vec<sum> folds through a hoisted appender singleton:\n{kotlin}"
     );

--- a/prebindgen-jni/src/jni/tests/snapshots.rs
+++ b/prebindgen-jni/src/jni/tests/snapshots.rs
@@ -375,6 +375,10 @@ fn handler_interfaces_carry_split_contract_kdoc() {
         "{shared}"
     );
     assert!(shared.contains("throwing from `run` is safe"), "{shared}");
+    assert!(
+        shared.contains("handler firing is the error discriminator"),
+        "{shared}"
+    );
 
     // A `Result<_, ZErr>` fn with a declared error decomposition emits the
     // TYPED domain handler; its KDoc states it fires only on a domain error,
@@ -416,6 +420,10 @@ fn handler_interfaces_carry_split_contract_kdoc() {
     assert!(typed.contains("decomposed `ZErr`"), "{typed}");
     assert!(typed.contains("onBindingError"), "{typed}");
     assert!(typed.contains("throwing from `run` is safe"), "{typed}");
+    assert!(
+        typed.contains("handler firing is the error discriminator"),
+        "{typed}"
+    );
 }
 
 /// A `data_class` struct with an opaque-pointer string field

--- a/prebindgen-jni/src/jni/tests/snapshots.rs
+++ b/prebindgen-jni/src/jni/tests/snapshots.rs
@@ -374,9 +374,11 @@ fn handler_interfaces_carry_split_contract_kdoc() {
         shared.contains("binding/system failure channel"),
         "{shared}"
     );
-    assert!(shared.contains("throwing from `run` is safe"), "{shared}");
+    assert!(shared.contains("from `run` is safe"), "{shared}");
+    assert!(shared.contains("nullable you may"), "{shared}");
+    assert!(shared.contains("return `null` to decline"), "{shared}");
     assert!(
-        shared.contains("handler firing is the error discriminator"),
+        shared.contains("handler firing, not the returned value, is the error discriminator"),
         "{shared}"
     );
 
@@ -419,9 +421,11 @@ fn handler_interfaces_carry_split_contract_kdoc() {
     assert!(typed.contains("Domain-error callback"), "{typed}");
     assert!(typed.contains("decomposed `ZErr`"), "{typed}");
     assert!(typed.contains("onBindingError"), "{typed}");
-    assert!(typed.contains("throwing from `run` is safe"), "{typed}");
+    assert!(typed.contains("from `run` is safe"), "{typed}");
+    assert!(typed.contains("nullable you may"), "{typed}");
+    assert!(typed.contains("return `null` to decline"), "{typed}");
     assert!(
-        typed.contains("handler firing is the error discriminator"),
+        typed.contains("handler firing, not the returned value, is the error discriminator"),
         "{typed}"
     );
 }


### PR DESCRIPTION
## Summary

- make reference-shaped JniGen wrapper returns and matching error-handler results nullable, using JVM erasure to preserve primitive and unsigned value contracts
- classify JVM erasure and recovery shapes by exact Kotlin type identity, so generated classes with built-in-looking names stay references and retain distinct overload tokens (the #89 model correction)
- keep generated constant helpers and public constant properties non-null
- document both that nullable handlers may return `null` instead of fabricating a result and that handler invocation—not its returned value—is the error discriminator
- regenerate both Kotlin examples; exercise null recovery through domain, binding, and generic `R?` paths, and migrate throwing-handler success paths explicitly
- record that the post-change handle lifecycle measurements include the generated `orThrow()` null check

## Verification

- `cargo clippy --all-targets --all-features -- --deny warnings`
- `cargo test -p prebindgen-jni` — 259 passed; doc tests 2 passed, 4 ignored
- `./gradlew run --console=plain` in `examples/covertest-kotlin` — PASS, 53 sections
- `./gradlew compileKotlin --console=plain` in `examples/perftest-kotlin`
- `./gradlew run -PperftestN=10 -PperftestVecN=2 --console=plain` — smoke passed
- `examples/regen-check.sh` — generated output is byte-identical

Closes #417

Stacked on #404; retarget to `main` after #404 merges.