### PR TITLE
Describe a capture directory, in a format that says which format it is

### DIFF
--- a/prebindgen-proc-macro/src/lib.rs
+++ b/prebindgen-proc-macro/src/lib.rs
@@ -36,9 +36,12 @@
 //!
 //! See also: [`prebindgen`](https://docs.rs/prebindgen) for the main processing library.
 //!
+use std::sync::OnceLock;
+
 use prebindgen::{
     get_prebindgen_out_dir,
     layout::{capture_file_name, group_dir_name, MAX_COMPONENT_LEN},
+    output::check_writer,
     utils::publish_file,
     Record, RecordKind, SourceLocation, DEFAULT_GROUP_NAME,
 };
@@ -157,6 +160,8 @@ fn publish_record(
     record: &Record,
     serialized: &str,
 ) -> std::result::Result<(), String> {
+    writer_format_checked()?;
+
     let group_dir = group_dir_name(group);
     if group_dir.len() > MAX_COMPONENT_LEN {
         return Err(format!(
@@ -173,6 +178,22 @@ fn publish_record(
         &format!("{serialized}\n"),
     )
     .map_err(|error| format!("prebindgen: {error}"))
+}
+
+/// Whether the capture directory is described in the format this macro writes,
+/// decided once per compilation.
+///
+/// This macro and the `init_prebindgen_out_dir()` that prepared the directory
+/// are two packages — `prebindgen-proc-macro` and `prebindgen` — and a manifest
+/// may name versions of them that lay captures out differently. Nothing else
+/// compares those two, so the check happens here, where the disagreement can
+/// still be reported against the source crate that declared both. One rustc
+/// process compiles one crate, so once is enough.
+fn writer_format_checked() -> std::result::Result<(), String> {
+    static CHECKED: OnceLock<std::result::Result<(), String>> = OnceLock::new();
+    CHECKED
+        .get_or_init(|| check_writer(&get_prebindgen_out_dir()))
+        .clone()
 }
 
 /// Attribute macro that exports FFI definitions for use in language-specific binding crates.

--- a/prebindgen-registry/src/registry/tests.rs
+++ b/prebindgen-registry/src/registry/tests.rs
@@ -332,10 +332,6 @@ fn duplicate_name_across_sources_names_both_crates() {
     use prebindgen::{Record, RecordKind, SourceLocation};
 
     let make_source = |crate_name: &str| -> prebindgen::Source {
-        let dir = crate::test_util::unique_test_dir(&format!("dup_src_{crate_name}"));
-        let _ = std::fs::remove_dir_all(&dir);
-        std::fs::create_dir_all(&dir).unwrap();
-        std::fs::write(dir.join("crate_name.txt"), crate_name).unwrap();
         let record = Record::new(
             RecordKind::Function,
             "same_name".to_string(),
@@ -348,7 +344,11 @@ fn duplicate_name_across_sources_names_both_crates() {
             },
             None,
         );
-        prebindgen::utils::write_to_jsonl_file(dir.join("default_1.jsonl"), &[&record]).unwrap();
+        let dir = crate::test_util::write_capture_dir(
+            &format!("dup_src_{crate_name}"),
+            crate_name,
+            &[&record],
+        );
         prebindgen::Source::new(&dir)
     };
 
@@ -628,10 +628,6 @@ fn foreign_qualified_declared_type_stays_supported() {
 fn write_source_dir(tag: &str, crate_name: &str, fn_name: &str) -> std::path::PathBuf {
     use prebindgen::{Record, RecordKind, SourceLocation};
 
-    let dir = crate::test_util::unique_test_dir(&format!("builder_{tag}"));
-    let _ = std::fs::remove_dir_all(&dir);
-    std::fs::create_dir_all(&dir).unwrap();
-    std::fs::write(dir.join("crate_name.txt"), crate_name).unwrap();
     let record = Record::new(
         RecordKind::Function,
         fn_name.to_string(),
@@ -644,8 +640,7 @@ fn write_source_dir(tag: &str, crate_name: &str, fn_name: &str) -> std::path::Pa
         },
         None,
     );
-    prebindgen::utils::write_to_jsonl_file(dir.join("default_1.jsonl"), &[&record]).unwrap();
-    dir
+    crate::test_util::write_capture_dir(&format!("builder_{tag}"), crate_name, &[&record])
 }
 
 /// Render a module path the way the other origin tests in this file do.

--- a/prebindgen-registry/src/test_util.rs
+++ b/prebindgen-registry/src/test_util.rs
@@ -118,3 +118,31 @@ pub(crate) fn unique_test_dir(prefix: &str) -> PathBuf {
     let seq = SEQ.fetch_add(1, Ordering::Relaxed);
     std::env::temp_dir().join(format!("{prefix}_{}_{}", std::process::id(), seq))
 }
+
+/// Write a capture directory holding `records`, the way a source crate's build
+/// script and the `#[prebindgen]` macro write one: a `prebindgen_output.toml`
+/// naming the crate, and the captures under the `default` group's directory.
+///
+/// The description is spelled out here rather than produced by prebindgen,
+/// which writes it only from a build script. If its format number moves, this
+/// fixture stops matching and the tests below say so — which is the point of
+/// the number.
+pub(crate) fn write_capture_dir(
+    tag: &str,
+    crate_name: &str,
+    records: &[&prebindgen::Record],
+) -> PathBuf {
+    let dir = unique_test_dir(tag);
+    let _ = std::fs::remove_dir_all(&dir);
+    let group_dir = dir.join(prebindgen::layout::group_dir_name(
+        prebindgen::DEFAULT_GROUP_NAME,
+    ));
+    std::fs::create_dir_all(&group_dir).unwrap();
+    std::fs::write(
+        dir.join("prebindgen_output.toml"),
+        format!("format = 1\n\n[package]\nname = \"{crate_name}\"\nfeatures = []\n"),
+    )
+    .unwrap();
+    prebindgen::utils::write_to_jsonl_file(group_dir.join("captures.jsonl"), records).unwrap();
+    dir
+}

--- a/prebindgen/build.rs
+++ b/prebindgen/build.rs
@@ -12,7 +12,9 @@
 // expansion itself touches:
 //
 //   - the `prebindgen` subdirectory, which `#[prebindgen]` opens with
-//     `create_new` to write its JSONL into;
+//     `create_new` to write its JSONL into, and the description file the macro
+//     checks the format against before it writes (`api::output`) — spelled out
+//     here because a crate cannot call its own build-dependency;
 //   - `PREBINDGEN_FEATURES`, which `features!()` reads. Empty is correct here:
 //     the doctests assert nothing about its contents.
 //
@@ -28,5 +30,13 @@ fn main() {
             prebindgen_dir.display()
         )
     });
+    // Format 1, as `api::output::FORMAT` defines it. Written by hand for the
+    // reason above; if the number moves, the doctests that run `#[prebindgen]`
+    // fail with the mismatch this file is here to avoid faking.
+    std::fs::write(
+        prebindgen_dir.join("prebindgen_output.toml"),
+        "format = 1\n\n[package]\nname = \"prebindgen\"\nfeatures = []\n",
+    )
+    .unwrap_or_else(|e| panic!("failed to describe the prebindgen output directory: {e}"));
     println!("cargo:rustc-env=PREBINDGEN_FEATURES=");
 }

--- a/prebindgen/build.rs
+++ b/prebindgen/build.rs
@@ -5,7 +5,7 @@
 // examples had to be ```ignore — never compiled, free to rot.
 //
 // This is *not* `init_prebindgen_out_dir` in miniature. That function also
-// cleans the output directory, writes `crate_name.txt` and `features.txt`, and
+// cleans the output directory, writes `prebindgen_output.toml`, and
 // exports the crate's real feature list — all of which exist so a *downstream*
 // crate can later read this one's captured surface through `Source`. Nothing
 // reads prebindgen's own output, so this supplies only the two things macro

--- a/prebindgen/src/api/buildrs.rs
+++ b/prebindgen/src/api/buildrs.rs
@@ -1,6 +1,6 @@
 use std::{collections::BTreeSet, env, fs, path::Path};
 
-use crate::{CRATE_NAME_FILE, FEATURES_FILE};
+use crate::api::output::Output;
 
 /// Initialize the prebindgen output directory for the current crate
 ///
@@ -62,32 +62,12 @@ pub fn init_prebindgen_out_dir() {
         });
     }
 
-    // Store the crate name in a separate file
-    let crate_name_path = prebindgen_dir.join(CRATE_NAME_FILE);
-    fs::write(&crate_name_path, &crate_name).unwrap_or_else(|e| {
-        panic!(
-            "Failed to write crate name to {}: {}",
-            crate_name_path.display(),
-            e
-        );
-    });
-
     let features = get_enabled_features();
 
-    // Save features list to features.txt (one per line)
-    let features_path = prebindgen_dir.join(FEATURES_FILE);
-    let mut feature_contents = String::new();
-    for feature in &features {
-        feature_contents += feature;
-        feature_contents.push('\n');
-    }
-    fs::write(&features_path, feature_contents).unwrap_or_else(|e| {
-        panic!(
-            "Failed to write features to {}: {}",
-            features_path.display(),
-            e
-        );
-    });
+    // Describe what this directory holds, and in what format, so a reader can
+    // tell that it reads the same prebindgen that wrote it — see
+    // `api::output`.
+    Output::new(crate_name.clone(), features.iter().cloned()).write(&prebindgen_dir);
 
     // Export features list to the main crate as an env variable
     // Accessible via env!("PREBINDGEN_FEATURES") or std::env::var at compile time/runtime

--- a/prebindgen/src/api/layout.rs
+++ b/prebindgen/src/api/layout.rs
@@ -2,8 +2,7 @@
 //!
 //! ```text
 //! {OUT_DIR}/prebindgen/
-//!     crate_name.txt
-//!     features.txt
+//!     prebindgen_output.toml            <- what wrote this, and in what format
 //!     g_{group}/                        <- one directory per group, encoded
 //!         {name}_{digest(record)}.jsonl <- one file per captured record
 //! ```

--- a/prebindgen/src/api/mod.rs
+++ b/prebindgen/src/api/mod.rs
@@ -1,6 +1,7 @@
 pub(crate) mod batching;
 pub(crate) mod buildrs;
 pub(crate) mod layout;
+pub(crate) mod output;
 pub(crate) mod record;
 pub(crate) mod source;
 pub(crate) mod utils;

--- a/prebindgen/src/api/output.rs
+++ b/prebindgen/src/api/output.rs
@@ -1,0 +1,220 @@
+//! The description file a capture directory carries, and the compatibility
+//! rule that goes with it.
+//!
+//! ```toml
+//! # {OUT_DIR}/prebindgen/prebindgen_output.toml
+//! format = 1
+//!
+//! [package]
+//! name = "example-flat"
+//! features = ["unstable"]
+//! ```
+//!
+//! [`init_prebindgen_out_dir`](crate::init_prebindgen_out_dir) writes it when
+//! it prepares the directory, and [`Source`](crate::Source) reads it before it
+//! reads a single capture. `[package]` spells the source crate the way
+//! `Cargo.toml` does — its `name`, and the `features` that were enabled for the
+//! compilation that captured.
+//!
+//! # Why the format number is here
+//!
+//! The two halves of prebindgen meet on this directory and nowhere else. The
+//! source crate names the half that writes (the `#[prebindgen]` proc-macro,
+//! plus this crate in its `build.rs`); the binding crate names the half that
+//! reads. They are separate dependency edges in separate manifests, so nothing
+//! makes Cargo compare them — two copies of prebindgen at different versions,
+//! or at one version from different sources, is a legal graph and a silent one.
+//!
+//! [`FORMAT`] is what closes that. It describes the on-disk contract — the
+//! directory layout, the names of the files in it, and the schema of a captured
+//! record — and changes when any of those change, independently of the crate
+//! version. A reader that meets a number it does not know says so and stops,
+//! rather than reporting a capture directory it cannot read as an empty one.
+//!
+//! **A reader accepts exactly [`FORMAT`].** There is no window of older formats
+//! kept alive: the two halves come from one library, and the fix for a mismatch
+//! is to say so in the manifest that named the other one.
+
+use std::{fs, path::Path};
+
+use serde::{Deserialize, Serialize};
+
+/// Name of the description file inside the capture directory.
+pub(crate) const OUTPUT_FILE: &str = "prebindgen_output.toml";
+
+/// The on-disk contract this prebindgen writes and reads.
+///
+/// 1 — `prebindgen_output.toml`, and captures at
+/// `g_{group}/{name}_{digest}.jsonl`. prebindgen ≤ 0.5.0 wrote no description
+/// file at all (`crate_name.txt` and `features.txt` instead, and captures at
+/// `{group}_{pid}_{thread}.jsonl`); it is recognised only to name itself in the
+/// error.
+pub(crate) const FORMAT: u32 = 1;
+
+/// The description of a capture directory: what wrote it, and in what format.
+#[derive(Debug, Serialize, Deserialize)]
+pub(crate) struct Output {
+    /// See [`FORMAT`].
+    pub(crate) format: u32,
+    pub(crate) package: Package,
+}
+
+/// The source crate, spelled as `Cargo.toml` spells it.
+#[derive(Debug, Serialize, Deserialize)]
+pub(crate) struct Package {
+    /// `CARGO_PKG_NAME` of the crate that captured.
+    pub(crate) name: String,
+    /// The features enabled for the compilation that captured, sorted.
+    #[serde(default)]
+    pub(crate) features: Vec<String>,
+}
+
+impl Output {
+    /// The description of a crate captured under `features`.
+    pub(crate) fn new(crate_name: String, features: impl IntoIterator<Item = String>) -> Self {
+        let mut features = features.into_iter().collect::<Vec<_>>();
+        features.sort();
+        features.dedup();
+        Self {
+            format: FORMAT,
+            package: Package {
+                name: crate_name,
+                features,
+            },
+        }
+    }
+
+    /// Write the description into a prepared capture directory.
+    ///
+    /// # Panics
+    ///
+    /// If the file cannot be serialized or written — either means the build
+    /// script cannot produce a directory anyone may read.
+    pub(crate) fn write(&self, dir: &Path) {
+        let path = dir.join(OUTPUT_FILE);
+        let body = toml::to_string(self)
+            .unwrap_or_else(|e| panic!("Failed to describe the prebindgen output: {e}"));
+        fs::write(&path, body)
+            .unwrap_or_else(|e| panic!("Failed to write {}: {}", path.display(), e));
+    }
+
+    /// Read the description of `dir` and check that this prebindgen can read
+    /// what it describes.
+    ///
+    /// # Panics
+    ///
+    /// If the directory carries no description, carries one that cannot be
+    /// parsed, or was written in a format other than [`FORMAT`]. Each is a
+    /// build that would otherwise produce bindings for a surface nobody
+    /// captured.
+    pub(crate) fn read(dir: &Path) -> Self {
+        let path = dir.join(OUTPUT_FILE);
+        let body = fs::read_to_string(&path).unwrap_or_else(|_| {
+            // `crate_name.txt` is prebindgen <= 0.5.0's own marker for "this
+            // directory was initialized", so its presence tells the two cases
+            // apart: an older writer, or no writer at all.
+            assert!(
+                !dir.join("crate_name.txt").exists(),
+                "The directory {} was written by prebindgen <= 0.5.0, which this prebindgen \
+                 cannot read: the capture layout changed and carries a format number now \
+                 ({OUTPUT_FILE}). The source crate's prebindgen and this build script's \
+                 prebindgen have to be the same version — they are separate dependencies, \
+                 so Cargo does not check it.",
+                dir.display()
+            );
+            panic!(
+                "The directory {} was not initialized with init_prebindgen_out_dir(). \
+                 Please ensure that init_prebindgen_out_dir() is called in the build.rs \
+                 of the source crate.",
+                dir.display()
+            )
+        });
+        let output: Self = toml::from_str(&body).unwrap_or_else(|e| {
+            panic!(
+                "Failed to read {} as prebindgen output: {e}. The capture directory is \
+                 damaged — rebuild the source crate.",
+                path.display()
+            )
+        });
+        assert!(
+            output.format == FORMAT,
+            "The captures in {} are in prebindgen output format {}, and this prebindgen \
+             reads format {FORMAT}. The source crate and this build script resolve to \
+             different prebindgen versions; name the same one in both manifests.",
+            dir.display(),
+            output.format,
+        );
+        output
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_written_description_reads_back() {
+        let dir = tempfile::tempdir().unwrap();
+        Output::new(
+            "example-flat".to_string(),
+            ["unstable".to_string(), "extra".to_string()],
+        )
+        .write(dir.path());
+
+        let read = Output::read(dir.path());
+        assert_eq!(read.format, FORMAT);
+        assert_eq!(read.package.name, "example-flat");
+        assert_eq!(read.package.features, ["extra", "unstable"]);
+    }
+
+    #[test]
+    fn the_description_spells_the_crate_the_way_cargo_does() {
+        let toml = toml::to_string(&Output::new(
+            "example-flat".to_string(),
+            ["unstable".to_string()],
+        ))
+        .unwrap();
+        assert_eq!(
+            toml,
+            "format = 1\n\n[package]\nname = \"example-flat\"\nfeatures = [\"unstable\"]\n"
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "was not initialized with init_prebindgen_out_dir()")]
+    fn a_directory_no_build_script_prepared_says_so() {
+        let dir = tempfile::tempdir().unwrap();
+        Output::read(dir.path());
+    }
+
+    #[test]
+    #[should_panic(expected = "written by prebindgen <= 0.5.0")]
+    fn an_unstamped_directory_names_the_prebindgen_that_wrote_it() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(dir.path().join("crate_name.txt"), "example-flat").unwrap();
+        Output::read(dir.path());
+    }
+
+    #[test]
+    #[should_panic(expected = "resolve to different prebindgen versions")]
+    fn a_format_this_prebindgen_does_not_know_is_not_read() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(
+            dir.path().join(OUTPUT_FILE),
+            format!(
+                "format = {}\n\n[package]\nname = \"example-flat\"\n",
+                FORMAT + 1
+            ),
+        )
+        .unwrap();
+        Output::read(dir.path());
+    }
+
+    #[test]
+    #[should_panic(expected = "capture directory is damaged")]
+    fn a_description_that_does_not_parse_is_not_guessed_at() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(dir.path().join(OUTPUT_FILE), "format = 1\n[package]\n").unwrap();
+        Output::read(dir.path());
+    }
+}

--- a/prebindgen/src/api/output.rs
+++ b/prebindgen/src/api/output.rs
@@ -18,22 +18,40 @@
 //!
 //! # Why the format number is here
 //!
-//! The two halves of prebindgen meet on this directory and nowhere else. The
-//! source crate names the half that writes (the `#[prebindgen]` proc-macro,
-//! plus this crate in its `build.rs`); the binding crate names the half that
-//! reads. They are separate dependency edges in separate manifests, so nothing
-//! makes Cargo compare them — two copies of prebindgen at different versions,
-//! or at one version from different sources, is a legal graph and a silent one.
+//! Three participants meet on this directory and nowhere else, and each is
+//! named by a different manifest entry:
+//!
+//! - the source crate's `prebindgen` **build-dependency** prepares the
+//!   directory and writes this file;
+//! - the source crate's `prebindgen-proc-macro` **dependency** writes the
+//!   captures into it;
+//! - the binding crate's `prebindgen` **build-dependency** reads them.
+//!
+//! Nothing makes Cargo compare those. Two copies of prebindgen at different
+//! versions, or at one version from different sources, is a legal graph — and
+//! the first two are not even the same package, so a manifest can pair a
+//! current `prebindgen` with a published `prebindgen-proc-macro` without a
+//! word from anyone.
 //!
 //! [`FORMAT`] is what closes that. It describes the on-disk contract — the
 //! directory layout, the names of the files in it, and the schema of a captured
 //! record — and changes when any of those change, independently of the crate
-//! version. A reader that meets a number it does not know says so and stops,
-//! rather than reporting a capture directory it cannot read as an empty one.
+//! version. It is checked twice, because two different packages write here:
+//!
+//! - [`Output::check_writer`] runs in the proc-macro before it captures, so a
+//!   macro that writes some other layout fails while compiling the source
+//!   crate, naming the two dependencies that disagree;
+//! - [`Output::read`] runs in the reader before it reads a capture, and refuses
+//!   anything but [`FORMAT`].
+//!
+//! A macro too old to run the first check cannot be made to announce itself, so
+//! the reader recognises what it leaves behind instead: captures outside the
+//! layout [`FORMAT`] describes are an error, not files to skip
+//! ([`Source::discover_groups`](crate::Source)).
 //!
 //! **A reader accepts exactly [`FORMAT`].** There is no window of older formats
-//! kept alive: the two halves come from one library, and the fix for a mismatch
-//! is to say so in the manifest that named the other one.
+//! kept alive: every participant comes from one library, and the fix for a
+//! mismatch is to say so in the manifest that named the odd one out.
 
 use std::{fs, path::Path};
 
@@ -41,6 +59,9 @@ use serde::{Deserialize, Serialize};
 
 /// Name of the description file inside the capture directory.
 pub(crate) const OUTPUT_FILE: &str = "prebindgen_output.toml";
+
+/// What prebindgen <= 0.5.0 wrote instead, kept only to recognise its output.
+const LEGACY_CRATE_NAME_FILE: &str = "crate_name.txt";
 
 /// The on-disk contract this prebindgen writes and reads.
 ///
@@ -65,7 +86,10 @@ pub(crate) struct Package {
     /// `CARGO_PKG_NAME` of the crate that captured.
     pub(crate) name: String,
     /// The features enabled for the compilation that captured, sorted.
-    #[serde(default)]
+    ///
+    /// Required, not defaulted: this list drives `cfg` filtering, so a
+    /// description that lost it would quietly filter feature-gated captures
+    /// away rather than report a damaged directory.
     pub(crate) features: Vec<String>,
 }
 
@@ -104,48 +128,103 @@ impl Output {
     /// # Panics
     ///
     /// If the directory carries no description, carries one that cannot be
-    /// parsed, or was written in a format other than [`FORMAT`]. Each is a
-    /// build that would otherwise produce bindings for a surface nobody
+    /// read or parsed, or was written in a format other than [`FORMAT`]. Each
+    /// is a build that would otherwise produce bindings for a surface nobody
     /// captured.
     pub(crate) fn read(dir: &Path) -> Self {
-        let path = dir.join(OUTPUT_FILE);
-        let body = fs::read_to_string(&path).unwrap_or_else(|_| {
-            // `crate_name.txt` is prebindgen <= 0.5.0's own marker for "this
-            // directory was initialized", so its presence tells the two cases
-            // apart: an older writer, or no writer at all.
-            assert!(
-                !dir.join("crate_name.txt").exists(),
-                "The directory {} was written by prebindgen <= 0.5.0, which this prebindgen \
-                 cannot read: the capture layout changed and carries a format number now \
-                 ({OUTPUT_FILE}). The source crate's prebindgen and this build script's \
-                 prebindgen have to be the same version — they are separate dependencies, \
-                 so Cargo does not check it.",
-                dir.display()
-            );
-            panic!(
-                "The directory {} was not initialized with init_prebindgen_out_dir(). \
-                 Please ensure that init_prebindgen_out_dir() is called in the build.rs \
-                 of the source crate.",
-                dir.display()
-            )
-        });
-        let output: Self = toml::from_str(&body).unwrap_or_else(|e| {
+        let body = read_description(dir).unwrap_or_else(|e| panic!("{e}"));
+        check_format(dir, &body).unwrap_or_else(|e| panic!("{e}"));
+        toml::from_str(&body).unwrap_or_else(|e| {
             panic!(
                 "Failed to read {} as prebindgen output: {e}. The capture directory is \
                  damaged — rebuild the source crate.",
-                path.display()
+                dir.join(OUTPUT_FILE).display()
             )
-        });
-        assert!(
-            output.format == FORMAT,
-            "The captures in {} are in prebindgen output format {}, and this prebindgen \
-             reads format {FORMAT}. The source crate and this build script resolve to \
-             different prebindgen versions; name the same one in both manifests.",
-            dir.display(),
-            output.format,
-        );
-        output
+        })
     }
+
+    /// Check, from the `#[prebindgen]` macro, that the directory it is about to
+    /// capture into is described in the format this macro writes.
+    ///
+    /// The macro and the build script that prepared the directory are two
+    /// packages — `prebindgen-proc-macro` and `prebindgen` — so a manifest can
+    /// pair versions that do not agree on the layout. Returns the reason as a
+    /// string; the macro turns it into a compile error on the captured item.
+    pub(crate) fn check_writer(dir: &Path) -> Result<(), String> {
+        let body = read_description(dir)?;
+        check_format(dir, &body)
+    }
+}
+
+/// The description text, or why there is none to read.
+fn read_description(dir: &Path) -> Result<String, String> {
+    let path = dir.join(OUTPUT_FILE);
+    match fs::read_to_string(&path) {
+        Ok(body) => Ok(body),
+        // Only "there is no such file" is a directory nobody described. Every
+        // other failure — a permission, a directory in its place, bytes that
+        // are not UTF-8 — is a directory that cannot be read, and saying
+        // "initialize it" about one of those sends the reader after the wrong
+        // thing.
+        Err(e) if e.kind() != std::io::ErrorKind::NotFound => Err(format!(
+            "Failed to read {}: {e}. The capture directory is damaged — rebuild \
+             the source crate.",
+            path.display()
+        )),
+        // `crate_name.txt` is prebindgen <= 0.5.0's own marker for "this
+        // directory was initialized", so its presence tells the two cases
+        // apart: an older writer, or no writer at all.
+        Err(_) if dir.join(LEGACY_CRATE_NAME_FILE).exists() => Err(format!(
+            "The directory {} was written by prebindgen <= 0.5.0, which this prebindgen \
+             cannot read: the capture layout changed and carries a format number now \
+             ({OUTPUT_FILE}). Every prebindgen that touches one capture directory has to \
+             agree on the format — they are separate dependencies, so Cargo does not \
+             check it.",
+            dir.display()
+        )),
+        Err(_) => Err(format!(
+            "The directory {} was not initialized with init_prebindgen_out_dir(). \
+             Please ensure that init_prebindgen_out_dir() is called in the build.rs \
+             of the source crate.",
+            dir.display()
+        )),
+    }
+}
+
+/// Whether the description in `body` is written in the format this prebindgen
+/// understands.
+///
+/// The number is read on its own first, so that a description whose *schema*
+/// this prebindgen does not know is still reported as the format mismatch it
+/// is, rather than as a parse failure.
+fn check_format(dir: &Path, body: &str) -> Result<(), String> {
+    /// Just the format number, out of a description whose remaining shape may
+    /// belong to another format.
+    #[derive(Deserialize)]
+    struct FormatOnly {
+        format: u32,
+    }
+
+    let found = toml::from_str::<FormatOnly>(body)
+        .map_err(|e| {
+            format!(
+                "Failed to read the format of {}: {e}. The capture directory is damaged — \
+                 rebuild the source crate.",
+                dir.join(OUTPUT_FILE).display()
+            )
+        })?
+        .format;
+    if found == FORMAT {
+        return Ok(());
+    }
+    Err(format!(
+        "The captures in {} are in prebindgen output format {found}, and this prebindgen \
+         reads format {FORMAT}. The packages that write a capture directory and the one \
+         that reads it are separate dependencies — `prebindgen-proc-macro` and \
+         `prebindgen`, in the source crate and in the crate reading it — and these are \
+         not the same prebindgen. Name one prebindgen in all of them.",
+        dir.display(),
+    ))
 }
 
 #[cfg(test)]
@@ -196,15 +275,30 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "resolve to different prebindgen versions")]
+    #[should_panic(expected = "not the same prebindgen")]
     fn a_format_this_prebindgen_does_not_know_is_not_read() {
         let dir = tempfile::tempdir().unwrap();
         fs::write(
             dir.path().join(OUTPUT_FILE),
             format!(
-                "format = {}\n\n[package]\nname = \"example-flat\"\n",
+                "format = {}\n\n[package]\nname = \"example-flat\"\nfeatures = []\n",
                 FORMAT + 1
             ),
+        )
+        .unwrap();
+        Output::read(dir.path());
+    }
+
+    #[test]
+    #[should_panic(expected = "not the same prebindgen")]
+    fn a_format_this_prebindgen_does_not_know_is_reported_by_its_number_alone() {
+        // A future format may hold anything at all besides the number. Reading
+        // the number on its own is what keeps this a version mismatch rather
+        // than a parse failure the reader cannot act on.
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(
+            dir.path().join(OUTPUT_FILE),
+            format!("format = {}\n\n[crate]\nwho = \"knows\"\n", FORMAT + 1),
         )
         .unwrap();
         Output::read(dir.path());
@@ -216,5 +310,48 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         fs::write(dir.path().join(OUTPUT_FILE), "format = 1\n[package]\n").unwrap();
         Output::read(dir.path());
+    }
+
+    #[test]
+    #[should_panic(expected = "capture directory is damaged")]
+    fn a_description_missing_its_feature_list_is_damaged_not_featureless() {
+        // Defaulting the list to empty would filter every feature-gated capture
+        // away and call the result a build.
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(
+            dir.path().join(OUTPUT_FILE),
+            "format = 1\n\n[package]\nname = \"example-flat\"\n",
+        )
+        .unwrap();
+        Output::read(dir.path());
+    }
+
+    #[test]
+    #[should_panic(expected = "capture directory is damaged")]
+    fn a_description_that_cannot_be_read_is_not_a_missing_one() {
+        // A directory where the file belongs: readable metadata, unreadable
+        // contents, and nothing to do with whether a build script ever ran.
+        let dir = tempfile::tempdir().unwrap();
+        fs::create_dir(dir.path().join(OUTPUT_FILE)).unwrap();
+        Output::read(dir.path());
+    }
+
+    #[test]
+    fn the_macro_checks_the_format_it_is_about_to_write_into() {
+        let dir = tempfile::tempdir().unwrap();
+        Output::new("example-flat".to_string(), []).write(dir.path());
+        assert!(Output::check_writer(dir.path()).is_ok());
+
+        let stale = tempfile::tempdir().unwrap();
+        fs::write(
+            stale.path().join(OUTPUT_FILE),
+            format!(
+                "format = {}\n\n[package]\nname = \"x\"\nfeatures = []\n",
+                FORMAT + 1
+            ),
+        )
+        .unwrap();
+        let err = Output::check_writer(stale.path()).unwrap_err();
+        assert!(err.contains("not the same prebindgen"), "{err}");
     }
 }

--- a/prebindgen/src/api/source.rs
+++ b/prebindgen/src/api/source.rs
@@ -385,6 +385,15 @@ impl Source {
     /// that two groups differing only in case, or named after a Windows device,
     /// still get one directory each), and the exact name is decoded back out of
     /// it — see [`layout`](crate::layout).
+    ///
+    /// A capture that is *not* under such a directory is refused rather than
+    /// skipped. The description file says which format this directory is in,
+    /// but the macro that wrote the captures is a different package from the
+    /// build script that wrote the description
+    /// ([`output`](crate::api::output)), so a capture outside the layout is how
+    /// a macro that never learned the format announces itself — prebindgen ≤
+    /// 0.5.0 leaves `{group}_{pid}_{thread}.jsonl` here. Skipping those is the
+    /// silent empty binding this whole file exists to prevent.
     fn discover_groups<P: AsRef<Path>>(input_dir: P) -> HashSet<String> {
         let input_dir = input_dir.as_ref();
         let mut groups = HashSet::new();
@@ -404,10 +413,22 @@ impl Source {
                         None => assert!(
                             !holds_captures(&path),
                             "{} holds prebindgen captures but is not a group directory; \
-                             the capture directory is damaged — rebuild the source crate",
+                             the capture directory is damaged, or was written by a \
+                             prebindgen that lays captures out differently — rebuild the \
+                             source crate",
                             path.display()
                         ),
                     }
+                } else {
+                    assert!(
+                        !file_name.is_some_and(|name| name.ends_with(JSONL_EXTENSION)),
+                        "{} is a prebindgen capture outside any group directory. The \
+                         `#[prebindgen]` macro that wrote it does not write the layout \
+                         this prebindgen reads: `prebindgen-proc-macro` and `prebindgen` \
+                         are separate dependencies of the source crate, and Cargo does \
+                         not check that they agree. Name one prebindgen in both.",
+                        path.display()
+                    );
                 }
             }
         }
@@ -660,10 +681,13 @@ mod tests {
     }
 
     #[test]
-    fn the_flat_layout_of_older_captures_is_not_a_group() {
-        // A capture directory written by prebindgen <= 0.5.0. Reading one is
-        // refused outright — `Output::read` stops on the description file it
-        // does not carry — so the file left here names no group.
+    #[should_panic(expected = "capture outside any group directory")]
+    fn a_capture_written_by_an_older_macro_is_not_skipped() {
+        // What a source crate produces when its `prebindgen` build-dependency
+        // writes the description but its `prebindgen-proc-macro` is <= 0.5.0:
+        // a directory that describes itself correctly, holding captures in the
+        // flat layout of an older macro. Skipping them is the silent empty
+        // binding this refuses.
         let dir = tempfile::tempdir().unwrap();
         let record = Record::new(
             RecordKind::Struct,
@@ -679,8 +703,7 @@ mod tests {
         .unwrap();
         write(dir.path(), "default", "Alpha");
 
-        assert_eq!(groups(dir.path()), ["default"]);
-        assert_eq!(names_of(dir.path(), "default"), ["Alpha"]);
+        Source::discover_groups(dir.path());
     }
 
     #[test]

--- a/prebindgen/src/api/source.rs
+++ b/prebindgen/src/api/source.rs
@@ -12,10 +12,11 @@ use crate::{
     api::{
         batching::cfg_filter,
         layout::{decode_group_dir_name, group_dir_name},
+        output::Output,
         record::Record,
         utils::jsonl::read_jsonl_file,
     },
-    SourceLocation, TargetTriple, CRATE_NAME_FILE, FEATURES_FILE,
+    SourceLocation, TargetTriple,
 };
 
 /// File extension for data files
@@ -76,7 +77,7 @@ pub struct Source {
     // Configuration needed to build a CfgFilter at iteration time
     features_constant: Option<String>,
     target_triple: Option<String>,
-    features_list: Vec<String>, // normalized list from features.txt
+    features_list: Vec<String>, // enabled features, from the description file
 }
 
 impl Source {
@@ -112,18 +113,13 @@ impl Source {
                 input_dir.display()
             );
         }
-        // The stored name (CARGO_PKG_NAME at capture time) doubles as the
-        // "directory was initialized" check, so it is read even when
-        // overridden. The override wins: it is the name THIS crate
-        // references the source crate by (a Cargo.toml dependency rename).
-        let stored_crate_name = read_stored_crate_name(input_dir).unwrap_or_else(|| {
-            panic!(
-                "The directory {} was not initialized with init_prebindgen_out_dir(). \
-                Please ensure that init_prebindgen_out_dir() is called in the build.rs of the source crate.",
-                input_dir.display()
-            )
-        });
-        let crate_name = crate_name_override.unwrap_or(stored_crate_name);
+        // The description also carries the format these captures are in, and
+        // reading it is what verifies that this prebindgen wrote them — so it
+        // is read even when the name it holds is overridden. The override
+        // wins: it is the name THIS crate references the source crate by (a
+        // Cargo.toml dependency rename).
+        let output = Output::read(input_dir);
+        let crate_name = crate_name_override.unwrap_or(output.package.name);
 
         let groups = Self::discover_groups(input_dir);
         let mut items = HashMap::new();
@@ -146,8 +142,7 @@ impl Source {
             items.insert(group, group_items);
         }
 
-        // Read features list once and store normalized list
-        let features_list = read_features_from_out_dir(input_dir);
+        let features_list = output.package.features;
 
         Self {
             crate_name,
@@ -364,8 +359,7 @@ impl Source {
         record_map.into_values().collect::<Vec<_>>()
     }
 
-    /// The capture files belonging to `group`, from the group's directory and
-    /// from the flat `<group>_*.jsonl` layout written by prebindgen ≤ 0.5.0.
+    /// The capture files belonging to `group`.
     fn group_files(input_dir: &Path, group: &str) -> Vec<PathBuf> {
         let mut files = Vec::new();
 
@@ -382,22 +376,6 @@ impl Source {
             }
         }
 
-        let legacy_prefix = format!("{group}_");
-        if let Ok(entries) = fs::read_dir(input_dir) {
-            for entry in entries.flatten() {
-                let path = entry.path();
-                if path
-                    .file_name()
-                    .and_then(|name| name.to_str())
-                    .is_some_and(|name| {
-                        name.starts_with(&legacy_prefix) && name.ends_with(JSONL_EXTENSION)
-                    })
-                {
-                    files.push(path);
-                }
-            }
-        }
-
         files
     }
 
@@ -407,10 +385,6 @@ impl Source {
     /// that two groups differing only in case, or named after a Windows device,
     /// still get one directory each), and the exact name is decoded back out of
     /// it — see [`layout`](crate::layout).
-    ///
-    /// The flat layout of prebindgen ≤ 0.5.0 spelled the group as the file-name
-    /// prefix up to the first `_`, and is still honoured for a capture
-    /// directory written by an older macro.
     fn discover_groups<P: AsRef<Path>>(input_dir: P) -> HashSet<String> {
         let input_dir = input_dir.as_ref();
         let mut groups = HashSet::new();
@@ -434,13 +408,6 @@ impl Source {
                             path.display()
                         ),
                     }
-                } else if let Some(file_name) = file_name {
-                    if file_name.ends_with(JSONL_EXTENSION) {
-                        // Legacy flat layout: everything before the first underscore.
-                        if let Some(underscore_pos) = file_name.find('_') {
-                            groups.insert(file_name[..underscore_pos].to_string());
-                        }
-                    }
                 }
             }
         }
@@ -463,31 +430,6 @@ fn holds_captures(dir: &Path) -> bool {
                 .is_some_and(|name| name.ends_with(JSONL_EXTENSION))
         })
     })
-}
-
-/// Read the crate name from the stored file
-fn read_stored_crate_name(input_dir: &Path) -> Option<String> {
-    let crate_name_path = input_dir.join(CRATE_NAME_FILE);
-    fs::read_to_string(crate_name_path)
-        .ok()
-        .map(|s| s.trim().to_string())
-}
-
-/// Read enabled features list from FEATURES_FILE and normalize into a sorted, deduplicated Vec<String>
-fn read_features_from_out_dir(input_dir: &Path) -> Vec<String> {
-    let features_path = input_dir.join(FEATURES_FILE);
-    let Some(contents) = fs::read_to_string(features_path).ok() else {
-        return Vec::new();
-    };
-    let mut features: Vec<String> = contents
-        .lines()
-        .map(str::trim)
-        .filter(|l| !l.is_empty())
-        .map(|s| s.to_string())
-        .collect();
-    features.sort();
-    features.dedup();
-    features
 }
 
 /// Builder for constructing a `Source` with custom options
@@ -547,8 +489,8 @@ impl Builder {
     /// from the source crate.
     ///
     /// It's important to note that the set of features to filter is determined
-    /// not by this constant, but by file "features.txt" in
-    /// prebindgen output directory. These are features which the source crate was
+    /// not by this constant, but by the `package.features` list in
+    /// `prebindgen_output.toml` in the prebindgen output directory. These are features which the source crate was
     /// built with *as build.rs dependency*. The constant contains the features which
     /// the source crate was built *as library dependency*.
     /// The purpose of the constant is to use it in the assert in the
@@ -718,8 +660,10 @@ mod tests {
     }
 
     #[test]
-    fn the_flat_layout_of_older_captures_is_still_read() {
-        // A capture directory written by prebindgen <= 0.5.0.
+    fn the_flat_layout_of_older_captures_is_not_a_group() {
+        // A capture directory written by prebindgen <= 0.5.0. Reading one is
+        // refused outright — `Output::read` stops on the description file it
+        // does not carry — so the file left here names no group.
         let dir = tempfile::tempdir().unwrap();
         let record = Record::new(
             RecordKind::Struct,
@@ -736,15 +680,15 @@ mod tests {
         write(dir.path(), "default", "Alpha");
 
         assert_eq!(groups(dir.path()), ["default"]);
-        assert_eq!(names_of(dir.path(), "default"), ["Alpha", "Legacy"]);
+        assert_eq!(names_of(dir.path(), "default"), ["Alpha"]);
     }
 
     #[test]
     fn non_capture_entries_are_ignored() {
         let dir = tempfile::tempdir().unwrap();
         write(dir.path(), "default", "Alpha");
-        fs::write(dir.path().join(CRATE_NAME_FILE), "example-flat").unwrap();
-        fs::write(dir.path().join(FEATURES_FILE), "unstable\n").unwrap();
+        crate::api::output::Output::new("example-flat".to_string(), ["unstable".to_string()])
+            .write(dir.path());
         fs::write(
             dir.path().join(group_dir_name("default")).join("notes.txt"),
             "scratch",

--- a/prebindgen/src/lib.rs
+++ b/prebindgen/src/lib.rs
@@ -161,12 +161,6 @@
 //! `prebindgen-jni` crate, which hands the result to its `JniGenBuilder`.
 //!
 
-/// File name for storing the crate name
-const CRATE_NAME_FILE: &str = "crate_name.txt";
-
-/// File name for storing enabled Cargo features collected in build.rs
-const FEATURES_FILE: &str = "features.txt";
-
 /// Default group name for items without explicit group name
 pub const DEFAULT_GROUP_NAME: &str = "default";
 

--- a/prebindgen/src/lib.rs
+++ b/prebindgen/src/lib.rs
@@ -195,6 +195,23 @@ pub use crate::api::{
 // its own root — see `prebindgen-jni`'s docs for the JNI / Kotlin workflow.
 
 #[doc(hidden)]
+pub mod output {
+    //! The capture directory's description file, and the format number the
+    //! `#[prebindgen]` macro and [`Source`](crate::Source) both check against.
+    use std::path::Path;
+
+    /// Check that `dir` is described in the format this prebindgen writes.
+    ///
+    /// Called by the `#[prebindgen]` macro before it captures, because the
+    /// macro and the build script that prepared `dir` come from two packages
+    /// that a manifest can pair freely. `Err` carries the reason, for the macro
+    /// to report on the item it was expanding.
+    pub fn check_writer(dir: &Path) -> Result<(), String> {
+        crate::api::output::Output::check_writer(dir)
+    }
+}
+
+#[doc(hidden)]
 pub mod layout {
     //! Capture-directory layout, shared by the proc-macro (writing) and
     //! [`Source`](crate::Source) (reading).


### PR DESCRIPTION
Closes #421.

A capture directory — the `prebindgen` subdirectory of the source crate's `OUT_DIR`,
holding one JSONL file per `#[prebindgen]` item — is where prebindgen's participants
meet, and there are three of them, each named by a different manifest entry:

| participant | package | named by |
|---|---|---|
| prepares the directory (`init_prebindgen_out_dir`) | `prebindgen`, a build-dependency | the source crate |
| writes the captures | `prebindgen-proc-macro`, a dependency | the source crate |
| reads them (`Source`) | `prebindgen`, a build-dependency | the binding crate |

Nothing makes Cargo compare those. Two prebindgen versions, or one version resolved
from two sources, is a legal graph and a silent one — and the first two are not even
the same package, so one manifest can pair a current `prebindgen` with a published
`prebindgen-proc-macro` without a word from anyone.

The directory carried nothing that identified its writer either — `crate_name.txt`
and the newline-separated `features.txt`, neither of which records a format. #421
measured what that costs: 306 captures written by `main`, read by the published
0.5.0 `Source`, produced one item (the injected feature-guard `const _`) and exit
code 0.

## The description file

`crate_name.txt` and `features.txt` are replaced by one `prebindgen_output.toml`,
written by `init_prebindgen_out_dir()`:

```toml
format = 1

[package]
name = "example-flat"
features = ["internal", "unstable"]
```

`[package]` spells the source crate the way `Cargo.toml` spells it: its `name`, and
the `features` that were enabled for the compilation that captured. `format`
describes the on-disk contract — the directory layout, the names of the files in
it, and the schema of a captured record — and moves independently of the crate
version, since it is that contract, not the crate, that a reader has to understand.

## Who checks it, and when

Twice, because the package that describes the directory is not the package that
writes the captures into it.

**`#[prebindgen]`, before it captures** (`Output::check_writer`, once per
compilation). A macro whose prebindgen writes some other layout fails while
compiling the *source* crate, reported against the crate that declared both
packages. This is what the review caught: without it, a current `prebindgen`
build-dependency paired with the published 0.5.0 macro wrote a format-1
description beside flat `{group}_{pid}_{thread}.jsonl` captures, and the reader
accepted the description, found no groups and returned the synthetic feature guard
alone — the silent empty binding this PR exists to stop.

**`Source`, before it reads a capture.** Accepts exactly the format it knows:

| directory | what it means | what happens |
|---|---|---|
| no description, `crate_name.txt` present | written by prebindgen ≤ 0.5.0 | error naming the participants and why Cargo did not catch it |
| `format` this prebindgen does not read | the participants are not the same prebindgen | same conclusion, stated with both numbers |
| description unreadable or unparseable | the directory is damaged | error saying to rebuild the source crate |
| a `.jsonl` outside a group directory | captures written by a macro older than its description | error naming the two source-crate dependencies |

The last row is the reader's half of the same defence: a macro too old to run the
first check cannot announce itself, so what it leaves behind has to be recognised.

A directory with none of the above keeps the "was not initialized with
`init_prebindgen_out_dir()`" message it always had — and only `NotFound` reaches
that branch, so an unreadable description is reported as damage rather than as a
build script nobody ran.

The format number is parsed on its own before the rest of the description, so a
future format whose *schema* this prebindgen does not know is still reported as the
version mismatch it is. `package.features` is required for the same reason in
reverse: defaulting it to empty would filter every feature-gated capture away and
call the result a build.

**A reader accepts exactly one format.** There is no window of older formats kept
alive: both halves come from one library, and the fix for a mismatch is to say so
in the manifest that named the other one. That policy, the format number, and the
file it lives in are one module — `prebindgen::api::output` — so there is one place
to change when the contract does.

## What that removes

The flat `{group}_{pid}_{thread}.jsonl` layout of prebindgen ≤ 0.5.0 was still read
on a best-effort basis by `discover_groups` and `group_files`. An unstamped
directory now stops the build before either runs, so that code was unreachable and
is gone.

The registry's two hand-built fixture directories become one helper that writes what
a build script writes.

## Verification

* `cargo test --workspace` — including ten new tests in `api::output` and
  `api::source` covering the round trip, the exact TOML text, the macro-side check,
  and each refusal above
* the review's reproduction, as an artifact: a format-1 description beside a flat
  `default_<pid>_<thread>.jsonl` now stops the build naming both dependencies, where
  before it printed `items = 1` and exited 0
* `cargo clippy --all-targets --all-features -- --deny warnings` and
  `cargo fmt --check` with the repository's config, on both 1.85.0 and stable
* `examples/regen-check.sh` — every committed generated file is byte-identical, so
  the whole build-script → macro → `Source` path runs on the new description with
  no change in output
