### PR TITLE
Spell Cow and MaybeUninit in full in generated Rust (#410)

### DIFF
--- a/prebindgen-flat/src/flat/spelling.rs
+++ b/prebindgen-flat/src/flat/spelling.rs
@@ -273,3 +273,47 @@ fn reduce_flat_path(path: &mut syn::Path, against: &Normalization) {
         path.segments = std::iter::once(last).collect();
     }
 }
+
+/// The [`Normalization::PRELUDE`] entries the **language** does not
+/// pre-declare, and the paths that always resolve.
+///
+/// Normalization reduces every prelude constructor to its bare name, which is
+/// what keys agree on. For `Vec`/`Option`/`Result`/`String`/`Box` that name is
+/// in scope in any crate, so a generated signature may spell it. `Cow` and
+/// `MaybeUninit` are in this model's prelude and not in Rust's — see
+/// [`Normalization::PRELUDE`]'s doc, which says so — and generated Rust is
+/// `include!`d into a consumer that need not have imported either.
+const EMISSION_PATHS: &[(&str, &str)] = &[
+    ("Cow", "::std::borrow::Cow"),
+    ("MaybeUninit", "::std::mem::MaybeUninit"),
+];
+
+/// Undo the reduction for [`EMISSION_PATHS`], so a spelling compiles wherever
+/// the generated file is included.
+///
+/// The emission-side inverse of [`normalize_type`], and deliberately only for
+/// the names whose reduced form a consumer crate may not have in scope: every
+/// other spelling stays the source's own, which is what makes a generated
+/// signature name the type the way the source crate does.
+pub(crate) fn qualify_for_emission(ty: &syn::Type) -> syn::Type {
+    use syn::visit_mut::VisitMut;
+    struct Qualifier;
+    impl VisitMut for Qualifier {
+        fn visit_type_path_mut(&mut self, tp: &mut syn::TypePath) {
+            if tp.qself.is_none() && tp.path.segments.len() == 1 {
+                let seg = tp.path.segments.first().expect("len checked");
+                if let Some((_, full)) = EMISSION_PATHS.iter().find(|(name, _)| seg.ident == name) {
+                    let args = seg.arguments.clone();
+                    let mut path: syn::Path =
+                        syn::parse_str(full).expect("a path literal in EMISSION_PATHS");
+                    path.segments.last_mut().expect("non-empty").arguments = args;
+                    tp.path = path;
+                }
+            }
+            syn::visit_mut::visit_type_path_mut(self, tp);
+        }
+    }
+    let mut out = ty.clone();
+    Qualifier.visit_type_mut(&mut out);
+    out
+}

--- a/prebindgen-flat/src/flat/tests/roundtrip.rs
+++ b/prebindgen-flat/src/flat/tests/roundtrip.rs
@@ -590,3 +590,36 @@ fn an_element_answers_for_its_docs() {
     ));
     assert_eq!(as_fn(&bare).docs(), None);
 }
+
+/// A spelling names `Cow` and `MaybeUninit` in full, because the model's
+/// prelude has them and Rust's does not — normalization reduces both to a bare
+/// name, and generated Rust is `include!`d into a consumer crate that need not
+/// have imported either (#410). Everything else stays the source's own tokens,
+/// which is the whole point of spelling off the origin.
+#[test]
+fn a_spelling_qualifies_what_rusts_prelude_does_not_declare() {
+    let f: syn::ItemFn = syn::parse_quote!(
+        pub fn probe(
+            a: Cow<'static, str>,
+            b: std::borrow::Cow<'a, [u8]>,
+            c: &mut MaybeUninit<u64>,
+            d: Option<Vec<String>>,
+        ) {
+        }
+    );
+    let element = parse_one(syn::Item::Fn(f));
+    let func = as_fn(&element);
+
+    assert_eq!(
+        func.params
+            .iter()
+            .map(|p| tokens(&p.ty.spell()))
+            .collect::<Vec<_>>(),
+        vec![
+            ":: std :: borrow :: Cow < 'static , str >",
+            ":: std :: borrow :: Cow < 'a , [u8] >",
+            "& mut :: std :: mem :: MaybeUninit < u64 >",
+            "Option < Vec < String > >",
+        ]
+    );
+}

--- a/prebindgen-flat/src/flat/ty.rs
+++ b/prebindgen-flat/src/flat/ty.rs
@@ -165,7 +165,8 @@ impl TypeRef {
     /// *is* has an answer in [`kind`](Self::kind) and in the readings beside
     /// it; the node itself never leaves the model.
     pub fn spell(&self) -> proc_macro2::TokenStream {
-        self.origin.spell()
+        use quote::ToTokens;
+        super::spelling::qualify_for_emission(self.origin.as_syn()).to_token_stream()
     }
 
     /// The type as `syn` — **the escape**. See [`Origin::as_syn`].
@@ -541,7 +542,7 @@ impl TypeRef {
     /// a wrapper under a borrow or inside an `Option` belongs to that inner
     /// node's own spelling.
     pub(crate) fn stripped_syntax(&self) -> syn::Type {
-        self.unwrapped().origin.as_syn().clone()
+        super::spelling::qualify_for_emission(self.unwrapped().origin.as_syn())
     }
 
     /// True when this is `&mut T` over a **value** — not `&mut MaybeUninit<T>`.


### PR DESCRIPTION
Fixes #410, found by the shape matrix on #402.

## What was wrong

`Normalization::PRELUDE` (`prebindgen-flat/src/flat/spelling.rs`) is the set of constructor paths ingest reduces to a bare name, so that `std::borrow::Cow<'a, str>` and `Cow<'a, str>` index as one type. Its own doc says it is deliberately not identical to Rust's prelude: it adds `MaybeUninit`, which the grammar recognises for out-parameters, and `Cow`, which it treats as transparent.

`TypeRef::spell` — the tokens generated Rust says — returned that reduced spelling unchanged. For `Vec`, `Option`, `Result`, `String` and `Box` the bare name resolves in any crate. For the other two it resolves only where the consumer happens to have imported them, and a generated file is `include!`d into a crate that need not have:

```rust
pub(crate) unsafe fn JString_to_Cow_static_str_47272020<'env, 'v>(
    …
) -> ::core::result::Result<Cow<'static, str>, __JniErr> {
```

```
error[E0412]: cannot find type `Cow` in this scope
```

## The fix

`qualify_for_emission` re-qualifies exactly the two names Rust does not pre-declare, and runs at `TypeRef::spell` and `TypeRef::stripped_syntax` — the two doors every emitted type spelling comes out of, for both the C and the JNI adapter. Every other spelling stays the source crate's own tokens, which is what makes a generated signature name a type the way the source crate does.

Fixing it at the spelling door rather than in the JNI converter builder is what makes it one fix: the same reduction feeds `prebindgen-c`, and `MaybeUninit` reaches emission by the same route `Cow` does.

Two arms in `prebindgen-jni/src/jni/trait_impl.rs` already hand-normalized a `Cow` output converter's parameter type. They are left alone: they also pin the lifetime to `'_`, and removing them would rename converters in `zenoh-flat-jni`'s committed bindings for no behaviour change.

## Verification

- New test `a_spelling_qualifies_what_rusts_prelude_does_not_declare` (`prebindgen-flat/src/flat/tests/roundtrip.rs`): a `Cow`, a `std::borrow::Cow`, a `MaybeUninit` and an `Option<Vec<String>>` parameter, asserting the first three come out qualified and the fourth unchanged.
- `cargo test --workspace --all-features` passes.
- `examples/regen-check.sh` reports the in-repo generated output byte-identical, so no committed artifact moves.
- Applied to a checkout of the `shape-coverage` branch and re-ran `cargo run -p shape-matrix`: `cow_str__param__jni`, `cow_str__field__jni` and `cow_str__payload__jni` rise from `bad rust` to `rustc`, and no other cell moves. That report lives on `shape-coverage`, so it is not updated here.