### PR TITLE
Qualify a prelude constructor and its arguments apart (#414)

### DIFF
--- a/prebindgen-c/src/builder.rs
+++ b/prebindgen-c/src/builder.rs
@@ -598,41 +598,60 @@ impl CbindgenBuilder {
 
     // ── Internal helpers ───────────────────────────────────────────────
 
-    /// Fully-qualify a bare single-segment source type against
+    /// Fully-qualify every bare single-segment source type inside `ty` against
     /// [`Self::source_module`] (e.g. `ZKeyExpr` → `zenoh_flat::ZKeyExpr`).
     /// Anything already qualified, or with no `source_module` set, is returned
     /// unchanged.
+    ///
+    /// **Every** path node in the type, not the outermost one: a source type
+    /// can sit under any accepted shape — `Option<&Handle>` in a callback
+    /// argument, `&[Payload]`, `(Rec, Rec)` — and a name left bare there does
+    /// not resolve in the consumer crate the generated file is included into
+    /// (#414). The walk is what makes one rule apply everywhere; the rule per
+    /// node is below.
     pub(super) fn src_ty(&self, ty: &syn::Type) -> syn::Type {
+        use syn::visit_mut::VisitMut;
+        struct Qualifier<'a>(&'a CbindgenBuilder);
+        impl VisitMut for Qualifier<'_> {
+            fn visit_type_path_mut(&mut self, tp: &mut syn::TypePath) {
+                self.0.qualify_path(tp);
+                // The node's own arguments, after it: `Option<Handle>` is the
+                // language's `Option` over the source crate's `Handle`, and the
+                // two halves resolve against different roots.
+                syn::visit_mut::visit_type_path_mut(self, tp);
+            }
+        }
+        // A trait bound is a `syn::Path` and not a `Type::Path`, so overriding
+        // only the type-path visit leaves `impl Fn(..) + Send` alone and still
+        // reaches the argument types written inside it.
+        let mut out = ty.clone();
+        Qualifier(self).visit_type_mut(&mut out);
+        out
+    }
+
+    /// One path node of [`Self::src_ty`]: what root it resolves against.
+    fn qualify_path(&self, tp: &mut syn::TypePath) {
+        if tp.qself.is_some() {
+            return;
+        }
+        let as_ty = syn::Type::Path(tp.clone());
         // Built-in scalar primitives (`f64`, `i32`, …) live in no source module;
         // qualifying them would produce invalid paths like `zenoh_flat::f64` (hit by
         // callback args, e.g. `impl Fn(f64)`). Leave them bare.
-        if is_scalar(ty) {
-            return ty.clone();
+        if is_scalar(&as_ty) {
+            return;
         }
         // Std `String` likewise lives in no source module — qualifying it would
         // produce `zenoh_flat::String`. It can be declared `opaque_ptr` (a boxed
         // pointer the C side holds as `string_t *`), so resolve it to the std path.
-        if is_string(ty) {
-            return syn::parse_quote!(::std::string::String);
+        if is_string(&as_ty) {
+            tp.path = syn::parse_quote!(::std::string::String);
+            return;
         }
-        let syn::Type::Path(tp) = ty else {
-            return ty.clone();
-        };
-        if tp.qself.is_some() || tp.path.leading_colon.is_some() || tp.path.segments.len() != 1 {
-            return ty.clone();
+        if tp.path.leading_colon.is_some() || tp.path.segments.len() != 1 {
+            return;
         }
-        // The arguments are qualified first, and separately: `Option<Handle>`
-        // is the language's `Option` over the source crate's `Handle`, so the
-        // two halves resolve against different roots and a single prefix over
-        // the whole path gets one of them wrong whichever way it goes (#414).
-        let mut seg = tp.path.segments[0].clone();
-        if let syn::PathArguments::AngleBracketed(args) = &mut seg.arguments {
-            for arg in args.args.iter_mut() {
-                if let syn::GenericArgument::Type(t) = arg {
-                    *t = self.src_ty(t);
-                }
-            }
-        }
+        let seg = tp.path.segments[0].clone();
         // A name the language pre-declares is no source crate's, whatever the
         // source module is — spelled in full, since the generated file is
         // included into a crate that need not have imported it.
@@ -640,15 +659,13 @@ impl CbindgenBuilder {
             let mut path: syn::Path =
                 syn::parse_str(full).expect("a path literal in `prelude_path`");
             path.segments.last_mut().expect("non-empty").arguments = seg.arguments;
-            return syn::Type::Path(syn::TypePath { qself: None, path });
+            tp.path = path;
+            return;
         }
-        match &self.source_module {
-            Some(m) => {
-                let mut path = m.clone();
-                path.segments.push(seg);
-                syn::Type::Path(syn::TypePath { qself: None, path })
-            }
-            None => ty.clone(),
+        if let Some(m) = &self.source_module {
+            let mut path = m.clone();
+            path.segments.push(seg);
+            tp.path = path;
         }
     }
 

--- a/prebindgen-c/src/builder.rs
+++ b/prebindgen-c/src/builder.rs
@@ -615,15 +615,41 @@ impl CbindgenBuilder {
         if is_string(ty) {
             return syn::parse_quote!(::std::string::String);
         }
-        if let (Some(m), syn::Type::Path(tp)) = (&self.source_module, ty) {
-            if tp.qself.is_none() && tp.path.leading_colon.is_none() && tp.path.segments.len() == 1
-            {
-                let mut path = m.clone();
-                path.segments.push(tp.path.segments[0].clone());
-                return syn::Type::Path(syn::TypePath { qself: None, path });
+        let syn::Type::Path(tp) = ty else {
+            return ty.clone();
+        };
+        if tp.qself.is_some() || tp.path.leading_colon.is_some() || tp.path.segments.len() != 1 {
+            return ty.clone();
+        }
+        // The arguments are qualified first, and separately: `Option<Handle>`
+        // is the language's `Option` over the source crate's `Handle`, so the
+        // two halves resolve against different roots and a single prefix over
+        // the whole path gets one of them wrong whichever way it goes (#414).
+        let mut seg = tp.path.segments[0].clone();
+        if let syn::PathArguments::AngleBracketed(args) = &mut seg.arguments {
+            for arg in args.args.iter_mut() {
+                if let syn::GenericArgument::Type(t) = arg {
+                    *t = self.src_ty(t);
+                }
             }
         }
-        ty.clone()
+        // A name the language pre-declares is no source crate's, whatever the
+        // source module is — spelled in full, since the generated file is
+        // included into a crate that need not have imported it.
+        if let Some(full) = prelude_path(&seg.ident) {
+            let mut path: syn::Path =
+                syn::parse_str(full).expect("a path literal in `prelude_path`");
+            path.segments.last_mut().expect("non-empty").arguments = seg.arguments;
+            return syn::Type::Path(syn::TypePath { qself: None, path });
+        }
+        match &self.source_module {
+            Some(m) => {
+                let mut path = m.clone();
+                path.segments.push(seg);
+                syn::Type::Path(syn::TypePath { qself: None, path })
+            }
+            None => ty.clone(),
+        }
     }
 
     /// [`Self::src_ty`] off the **identity** — the type peer of

--- a/prebindgen-c/src/lib.rs
+++ b/prebindgen-c/src/lib.rs
@@ -624,6 +624,32 @@ fn is_string(ty: &syn::Type) -> bool {
     type_path_tail(ty).map(|i| i == "String").unwrap_or(false)
 }
 
+/// The full path for a bare name the **language** pre-declares, or `None` for a
+/// name only the source crate can be declaring.
+///
+/// Ingest reduces a captured type's spelling to the bare name the language
+/// knows the constructor by (`std::option::Option<T>` and `Option<T>` are one
+/// type), so by the time an emitter spells a type, a prelude constructor and a
+/// source-crate item look alike: both are one segment. Qualifying either
+/// against the source module produces a path that does not exist — see
+/// [`Cbindgen::src_ty`], which is the only caller.
+///
+/// The paths are spelled in full rather than left bare because the generated
+/// file is `include!`d into a consumer crate, and `MaybeUninit` is not in
+/// Rust's prelude.
+fn prelude_path(ident: &syn::Ident) -> Option<&'static str> {
+    Some(match ident.to_string().as_str() {
+        "Option" => "::core::option::Option",
+        "Result" => "::core::result::Result",
+        "Vec" => "::std::vec::Vec",
+        "Box" => "::std::boxed::Box",
+        "String" => "::std::string::String",
+        "Cow" => "::std::borrow::Cow",
+        "MaybeUninit" => "::core::mem::MaybeUninit",
+        _ => return None,
+    })
+}
+
 /// The C wire for a `bool` in any position C can write: `MaybeUninit<bool>`.
 ///
 /// `bool` is the one FFI-safe scalar with a restricted domain — only `0` and

--- a/prebindgen-c/src/tests/callbacks.rs
+++ b/prebindgen-c/src/tests/callbacks.rs
@@ -249,3 +249,52 @@ fn callback_struct_name_defaults_generically() {
     assert!(compact.contains("structclosure_z_sample_t"), "{src}");
     assert!(compact.contains("callback:closure_z_sample_t"), "{src}");
 }
+
+/// A source type under any accepted shape is qualified, not just an outermost
+/// one: a callback argument spelled `Option<&Handle>` names the language's
+/// `Option` and the source crate's `Handle`, each against its own root (#414).
+///
+/// The closure the trampoline builds is where a bare name shows: both the
+/// returned `impl Fn(..)` and the closure's own parameter ascription are
+/// written into the generated file, and neither resolves in a consumer crate
+/// that has not imported `Handle`.
+#[test]
+fn callback_arg_qualifies_a_source_type_under_a_wrapper() {
+    let loc = SourceLocation::default();
+    let st: syn::ItemStruct = syn::parse_quote!(
+        pub struct Handle {
+            pub _0: u64,
+        }
+    );
+    let func: syn::ItemFn = syn::parse_quote!(
+        pub fn z_declare_sub(cb: impl Fn(Option<&Handle>) + Send + Sync + 'static) {
+            unimplemented!()
+        }
+    );
+    let registry = crate::test_util::reg_from_items(declare_referenced([
+        (syn::Item::Struct(st), loc.clone()),
+        (syn::Item::Fn(func), loc.clone()),
+    ]))
+    .expect("index items");
+
+    let cbindgen = CbindgenBuilder::new()
+        .source_module(syn::parse_quote!(zenoh_flat))
+        .opaque_ptr(syn::parse_quote!(Handle))
+        .callback(syn::parse_quote!(
+            impl Fn(Option<&Handle>) + Send + Sync + 'static
+        ))
+        .base_name("z_closure_handle_t")
+        .function(syn::parse_quote!(z_declare_sub));
+
+    let src = write(cbindgen, registry, "cb_optref_qualified");
+    let compact: String = src.split_whitespace().collect();
+
+    assert!(
+        compact.contains("implFn(::core::option::Option<&zenoh_flat::Handle>)"),
+        "{src}"
+    );
+    assert!(
+        compact.contains("move|__a0:::core::option::Option<&zenoh_flat::Handle>|"),
+        "{src}"
+    );
+}

--- a/prebindgen-c/src/tests/tagged_unions.rs
+++ b/prebindgen-c/src/tests/tagged_unions.rs
@@ -838,3 +838,53 @@ fn one_kind_presents_one_c_type_however_it_is_spelled() {
         "a bare optional handle is boxed by the converter:\n{src}"
     );
 }
+
+/// A payload's typed drop names both halves of `Option<Handle>` against the
+/// right root: `Option` is the language's and never the source module's, and
+/// `Handle` is the source module's and never bare (#414). Both come out of one
+/// expression, so a fix that only qualifies the outer path swaps one error for
+/// the other.
+#[test]
+fn a_payload_drop_qualifies_the_language_and_the_source_crate_apart() {
+    let loc = SourceLocation::default();
+    let probe: syn::ItemEnum = syn::parse_quote!(
+        pub enum Probe {
+            Carried(Option<Handle>),
+            Empty,
+        }
+    );
+    let handle: syn::ItemStruct = syn::parse_quote!(
+        pub struct Handle {
+            inner: u64,
+        }
+    );
+    let make: syn::ItemFn = syn::parse_quote!(
+        pub fn probe_new() -> Probe {
+            unimplemented!()
+        }
+    );
+    let registry = crate::test_util::reg_from_items(declare_referenced([
+        (syn::Item::Enum(probe), loc.clone()),
+        (syn::Item::Struct(handle), loc.clone()),
+        (syn::Item::Fn(make), loc.clone()),
+    ]))
+    .expect("index items");
+
+    let cbindgen = CbindgenBuilder::new()
+        .source_module(syn::parse_quote!(myflat))
+        .free_memory_function("myflat_free")
+        .mangle_type_name(|base| format!("{base}_t"))
+        .mangle_destructor(|base| format!("{base}_drop"))
+        .opaque_ptr(syn::parse_quote!(Handle))
+        .tagged_union(syn::parse_quote!(Probe))
+        .function(syn::parse_quote!(probe_new))
+        .panic();
+
+    let src = write(cbindgen, registry, "payload_drop_qualification");
+    let compact: String = src.split_whitespace().collect();
+
+    assert!(
+        compact.contains("*__f0as*mut::core::option::Option<myflat::Handle>"),
+        "{src}"
+    );
+}


### PR DESCRIPTION
Fixes #414, found by the shape matrix on #402.

## What was wrong

`Cbindgen::src_ty` (`prebindgen-c/src/builder.rs`) resolves a captured type's spelling for generated Rust: it prefixes a bare single-segment path with the declared `.source_module(…)`, so `ZKeyExpr` becomes `zenoh_flat::ZKeyExpr`. Ingest normalizes `std::option::Option<T>` to `Option<T>`, so by the time an emitter spells a type, a prelude constructor and a source-crate item look alike — both are one segment.

`src_ty` treated `Option<Handle>` as the latter and did not descend into the arguments, so the typed drop for an `Option<Handle>` payload came out as:

```rust
drop(::std::boxed::Box::from_raw(*__f0 as *mut flat::Option<Handle>));
```

```
error[E0412]: cannot find type `Option` in module `flat`
error[E0412]: cannot find type `Handle` in this scope
```

One expression, both halves wrong in opposite directions: `Option` was qualified into a module that does not declare it, and `Handle`, which that module does declare, was left bare.

## The fix

`src_ty` now qualifies the arguments first and separately — they resolve against a different root than the constructor does — and then routes the constructor itself. The new `prelude_path` helper (`prebindgen-c/src/lib.rs`) names the seven constructors ingest reduces to a bare name and gives each its full path, so they resolve against the language rather than against the source module. Everything still one segment after that is the source crate's, and is prefixed as before.

The paths are spelled in full (`::core::option::Option`) rather than left bare, for the reason `is_string` already spelled `::std::string::String`: a generated file is `include!`d into a consumer crate, and `MaybeUninit` is not in Rust's prelude.

`is_string`'s early return is left in place — it matches a multi-segment `std::string::String` too, which the single-segment path below it does not reach.

## Verification

- New test `a_payload_drop_qualifies_the_language_and_the_source_crate_apart` (`prebindgen-c/src/tests/tagged_unions.rs`): a `tagged_union` with an `Option<Handle>` payload over an `opaque_ptr` `Handle`, asserting the drop names `::core::option::Option<myflat::Handle>`. It fails on `main` with the old spelling.
- `cargo test --workspace --all-features` passes.
- `examples/regen-check.sh` reports the in-repo generated output byte-identical, so no committed artifact moves.
- Applied to a checkout of the `shape-coverage` branch and re-ran `cargo run -p shape-matrix`: `opt_handle__payload__c` rises from `bad rust` to `header`, C's top state, and no other cell moves. That report lives on `shape-coverage`, so it is not updated here.