### PR TITLE
Read the pointee for an Option over a by-value inner (#412)

### DIFF
--- a/prebindgen-c/src/tests/inputs.rs
+++ b/prebindgen-c/src/tests/inputs.rs
@@ -102,7 +102,7 @@ fn option_scalar_input_boxed_pointer() {
     let src = write(cbindgen, registry, "option_in_scalar");
     let compact: String = src.split_whitespace().collect();
 
-    // Boxed behind a const pointer; NULL ⇒ None, else `Some(*v)`.
+    // Boxed behind a const pointer; NULL ⇒ None, else `Some` of the pointee, read.
     assert!(compact.contains("timestamp_ntp64:*consti64"), "{src}");
     assert!(
         compact.contains("ifv.is_null(){::core::option::Option::None}"),

--- a/prebindgen-c/src/tests/inputs.rs
+++ b/prebindgen-c/src/tests/inputs.rs
@@ -82,7 +82,7 @@ fn option_opaque_input_reuses_pointer() {
 }
 
 /// `Option<i64>` input (scalar inner, no niche) is boxed behind a `*const`
-/// pointer: NULL ⇒ `None`, else `*v`. Infallible.
+/// pointer: NULL ⇒ `None`, else the pointee, read. Infallible.
 #[test]
 fn option_scalar_input_boxed_pointer() {
     let loc = SourceLocation::default();
@@ -111,6 +111,45 @@ fn option_scalar_input_boxed_pointer() {
     assert!(compact.contains("::core::option::Option::Some"), "{src}");
     // Infallible ⇒ no error param.
     assert!(!compact.contains("e:*mut"), "{src}");
+}
+
+/// `Option<Rec>` over a `data_struct` inner takes the same `*const` wire as the
+/// scalar above, and reaches the inner converter by `ptr::read`. A mirror
+/// struct is not `Copy`, so dereferencing the pointer instead would be a move
+/// out of it and the binding would not build (#412).
+#[test]
+fn option_data_struct_input_reads_the_pointee() {
+    let loc = SourceLocation::default();
+    let rec: syn::ItemStruct = syn::parse_quote!(
+        pub struct Rec {
+            pub id: u64,
+            pub tag: u32,
+        }
+    );
+    let func: syn::ItemFn = syn::parse_quote!(
+        pub fn z_op(v: Option<Rec>) {
+            unimplemented!()
+        }
+    );
+    let registry = crate::test_util::reg_from_items(declare_referenced([
+        (syn::Item::Struct(rec), loc.clone()),
+        (syn::Item::Fn(func), loc.clone()),
+    ]))
+    .expect("index items");
+
+    let cbindgen = CbindgenBuilder::new()
+        .source_module(syn::parse_quote!(zenoh_flat))
+        .data_struct(syn::parse_quote!(Rec))
+        .function(syn::parse_quote!(z_op));
+
+    let src = write(cbindgen, registry, "option_in_data_struct");
+    let compact: String = src.split_whitespace().collect();
+
+    assert!(compact.contains("v:*constrec"), "{src}");
+    assert!(
+        compact.contains("__cbg_in_Rec(::core::ptr::read(v))"),
+        "{src}"
+    );
 }
 
 /// `&str` inputs decode directly from `const char *` and can be used by

--- a/prebindgen-c/src/trait_impl.rs
+++ b/prebindgen-c/src/trait_impl.rs
@@ -2183,7 +2183,15 @@ impl CbindgenBuilder {
             } else {
                 syn::parse_quote!(*const #inner_wire)
             };
-            let read = if is_ptr { quote!(v) } else { quote!(*v) };
+            // A by-value inner is reached through a `*const` the C caller
+            // supplied, and reaches the inner converter by COPY: `*v` is a move
+            // out of a raw pointer, which is only accepted for a `Copy` wire —
+            // a scalar mirror compiled and a struct mirror did not (#412).
+            let read = if is_ptr {
+                quote!(v)
+            } else {
+                quote!(::core::ptr::read(v))
+            };
             let name = format_ident!("__cbg_in_option_{}", sanitize(&inner.key()));
             let lt: TokenStream = if inner.borrow_target().is_some() {
                 quote!(<'a>)


### PR DESCRIPTION
Fixes #412, found by the shape matrix on #402.

## What was wrong

The `Option<T>` input converter in `prebindgen-c/src/trait_impl.rs` has two branches over the inner type's wire. A pointer wire is passed straight to the inner converter; a **by-value** wire is boxed behind a `*const` the C caller supplies, and the converter dereferenced it:

```rust
::core::option::Option::Some(__cbg_in_Rec(*v))
```

`*v` on a raw pointer is a move, which the compiler accepts only when the pointee is `Copy`. A scalar mirror is, so `Option<i64>` compiled; a mirror struct is not, so `Option<Rec>` and `Option<Sum>` did not:

```
error[E0507]: cannot move out of `*v` which is behind a raw pointer
```

The declaration-policy axis of the matrix is what narrowed this: the same cell with `Rec` declared as an opaque handle rather than a value struct produces a header, because that declaration takes the pointer-wire branch. So the defect is the by-value branch, not `Option` and not the type.

## The fix

The by-value branch reaches the inner converter through `::core::ptr::read(v)`. It copies whatever the C caller pointed at, which is what a by-value crossing means, and it is the same ownership transfer `*v` expressed — just spelled in a way that does not require the wire to be `Copy`. The wire type does not change, so no header moves.

## Verification

- New test `option_data_struct_input_reads_the_pointee` (`prebindgen-c/src/tests/inputs.rs`): an `Option<Rec>` parameter over a `data_struct` `Rec`, asserting the wire is still `*const rec` and the inner converter is reached through `ptr::read`.
- `cargo test --workspace --all-features` passes.
- `examples/regen-check.sh` reports the in-repo generated output byte-identical.
- Applied to a checkout of the `shape-coverage` branch and re-ran `cargo run -p shape-matrix`: `opt_record__param__c` and `opt_sum__param__c` rise from `bad rust` to `header`, and the call-axis cell `opt_record` / parameter / opaque handle rises with them. No other cell moves. That report lives on `shape-coverage`, so it is not updated here.