### PR TITLE
Refuse an exclusive-borrow parameter with no write-back (#411)

### DIFF
--- a/prebindgen-jni/src/jni/selector.rs
+++ b/prebindgen-jni/src/jni/selector.rs
@@ -162,16 +162,39 @@ impl Declarations {
                     return None;
                 }
             }
-            let mutable = ty.is_exclusive_borrow();
-            if let Some(mut c) = self.input_wrapper_shape(
-                WrapperShape::Borrow { mutable },
-                &produced,
-                inner,
-                registry,
-                emit,
-            ) {
-                c.subs = vec![inner.key()];
-                return Some(c);
+            // An exclusive borrow crosses only when the borrowed value LIVES on
+            // the Rust side. A handle's input converter hands back an
+            // `OwnedObject<T>` that derefs to the object the JVM holds a
+            // pointer to, so a write through the `&mut` is still there once the
+            // wrapper returns. Every other input converter decodes a fresh
+            // value onto the Rust stack — a `data_class`'s fields, a scalar, an
+            // out-parameter's slot — and the callee's writes to that value are
+            // dropped with the wrapper's frame. Declining is what the `&mut [T]`
+            // branch above already does, for the same reason (#411).
+            //
+            // `mutable` off the `Ref` kind rather than through
+            // `is_exclusive_borrow`, which answers `false` for a
+            // `&mut MaybeUninit<T>` out-parameter — a slot whose writes are lost
+            // exactly as an exclusive borrow's are.
+            //
+            // An inner with no entry yet is not a refusal: the resolver runs to
+            // a fixed point and asks again once that rank resolves.
+            let writes_reach_the_caller = !*mutable
+                || registry
+                    .input_entry(inner)
+                    .is_some_and(|e| e.metadata.is_direct_handle());
+            if writes_reach_the_caller {
+                let mutable = ty.is_exclusive_borrow();
+                if let Some(mut c) = self.input_wrapper_shape(
+                    WrapperShape::Borrow { mutable },
+                    &produced,
+                    inner,
+                    registry,
+                    emit,
+                ) {
+                    c.subs = vec![inner.key()];
+                    return Some(c);
+                }
             }
         }
         // 4. Last resort: the spelling differs from something convertible only

--- a/prebindgen-jni/src/jni/selector.rs
+++ b/prebindgen-jni/src/jni/selector.rs
@@ -107,7 +107,12 @@ impl Declarations {
             }
             return None;
         }
-        if let prebindgen_registry::flat::TypeKind::Ref { mutable, .. } = ty.unwrapped().kind() {
+        if let prebindgen_registry::flat::TypeKind::Ref {
+            mutable,
+            inner: borrowed,
+            ..
+        } = ty.unwrapped().kind()
+        {
             // The target through the accessor: an out-parameter's `MaybeUninit`
             // is the slot a `T` goes in, and it is the `T` that converts.
             let inner = ty.borrow_target().expect("a borrow");
@@ -172,17 +177,32 @@ impl Declarations {
             // dropped with the wrapper's frame. Declining is what the `&mut [T]`
             // branch above already does, for the same reason (#411).
             //
+            // The question is asked of `borrowed`, the node written directly
+            // under the `&`, and not of `inner`, which is the same node with an
+            // out-parameter's `MaybeUninit` already peeled off. Three spellings
+            // separate the two, and the borrowed node is the handle in none of
+            // them: `&mut MaybeUninit<Handle>` borrows a slot rather than the
+            // object, and `&mut Box<Handle>` and `&mut &Handle` borrow a decoded
+            // wrapper and a decoded reference, both locals the wrapper drops.
+            // All three still answer `is_direct_handle`, because a transparent
+            // bridge and a borrow each inherit the inner type's projection — so
+            // the shape is read off the model, where only a `Named` node is the
+            // handle itself.
+            //
             // `mutable` off the `Ref` kind rather than through
             // `is_exclusive_borrow`, which answers `false` for a
             // `&mut MaybeUninit<T>` out-parameter — a slot whose writes are lost
             // exactly as an exclusive borrow's are.
             //
-            // An inner with no entry yet is not a refusal: the resolver runs to
-            // a fixed point and asks again once that rank resolves.
+            // A borrowed node with no entry yet is not a refusal: the resolver
+            // runs to a fixed point and asks again once that rank resolves.
             let writes_reach_the_caller = !*mutable
-                || registry
-                    .input_entry(inner)
-                    .is_some_and(|e| e.metadata.is_direct_handle());
+                || (matches!(
+                    borrowed.kind(),
+                    prebindgen_registry::flat::TypeKind::Named { .. }
+                ) && registry
+                    .input_entry(borrowed)
+                    .is_some_and(|e| e.metadata.is_direct_handle()));
             if writes_reach_the_caller {
                 let mutable = ty.is_exclusive_borrow();
                 if let Some(mut c) = self.input_wrapper_shape(

--- a/prebindgen-jni/src/jni/selector.rs
+++ b/prebindgen-jni/src/jni/selector.rs
@@ -177,32 +177,35 @@ impl Declarations {
             // dropped with the wrapper's frame. Declining is what the `&mut [T]`
             // branch above already does, for the same reason (#411).
             //
-            // The question is asked of `borrowed`, the node written directly
-            // under the `&`, and not of `inner`, which is the same node with an
-            // out-parameter's `MaybeUninit` already peeled off. Three spellings
-            // separate the two, and the borrowed node is the handle in none of
-            // them: `&mut MaybeUninit<Handle>` borrows a slot rather than the
-            // object, and `&mut Box<Handle>` and `&mut &Handle` borrow a decoded
-            // wrapper and a decoded reference, both locals the wrapper drops.
-            // All three still answer `is_direct_handle`, because a transparent
-            // bridge and a borrow each inherit the inner type's projection — so
-            // the shape is read off the model, where only a `Named` node is the
-            // handle itself.
+            // The question is asked of `borrowed` — the node written directly
+            // under the `&` — and it is asked of the DECLARATION. Two things
+            // make that the only answer that holds.
+            //
+            // `inner` is the same node with an out-parameter's `MaybeUninit`
+            // already peeled off, so asking it admits `&mut MaybeUninit<T>`,
+            // which borrows a slot rather than the object.
+            //
+            // And a converter's own metadata cannot say whether the borrowed
+            // thing is the object: `is_direct_handle` reads the projection, and
+            // a transparent bridge, a borrow, and a `convert!` composed over a
+            // handle all inherit that projection from the type underneath. Each
+            // of `&mut Box<Handle>`, `&mut &Handle` and `&mut ConvertedHandle`
+            // therefore answered yes while decoding a local the wrapper drops —
+            // the last one also loses the conversion stage `input_borrow` does
+            // not carry, so the call gets an `OwnedObject<Handle>` where the
+            // declared type was expected. `ptr_class!` is the declaration that
+            // means "the JVM holds a pointer to this object", and nothing else
+            // does.
             //
             // `mutable` off the `Ref` kind rather than through
             // `is_exclusive_borrow`, which answers `false` for a
             // `&mut MaybeUninit<T>` out-parameter — a slot whose writes are lost
             // exactly as an exclusive borrow's are.
-            //
-            // A borrowed node with no entry yet is not a refusal: the resolver
-            // runs to a fixed point and asks again once that rank resolves.
             let writes_reach_the_caller = !*mutable
-                || (matches!(
-                    borrowed.kind(),
-                    prebindgen_registry::flat::TypeKind::Named { .. }
-                ) && registry
-                    .input_entry(borrowed)
-                    .is_some_and(|e| e.metadata.is_direct_handle()));
+                || self
+                    .types
+                    .get(&borrowed.key())
+                    .is_some_and(|cfg| cfg.is_opaque());
             if writes_reach_the_caller {
                 let mutable = ty.is_exclusive_borrow();
                 if let Some(mut c) = self.input_wrapper_shape(

--- a/prebindgen-jni/src/jni/tests/values.rs
+++ b/prebindgen-jni/src/jni/tests/values.rs
@@ -2462,3 +2462,95 @@ fn a_wrapped_vec_element_keeps_the_push_path_and_shares_one_trio() {
          mean consuming the Vec the arm exists to borrow:\n{kotlin}"
     );
 }
+
+/// An exclusive-borrow parameter resolves only over an opaque handle, whose
+/// object the JVM keeps alive on the Rust side. Over anything decoded onto the
+/// Rust stack the callee's writes are dropped with the wrapper's frame, so the
+/// crossing is refused instead of emitting a binding that discards them (#411).
+///
+/// Both refused spellings used to RESOLVE and emit Rust that did not compile —
+/// `&mut Rec` passed a shared borrow of the rebuilt value, and
+/// `&mut MaybeUninit<u64>` passed the decoded payload where the slot was
+/// expected. The C adapter refuses `&mut T` outright, so this also brings the
+/// two targets to the same answer for the shape.
+#[test]
+fn an_exclusive_borrow_parameter_crosses_only_over_a_handle() {
+    /// One fixture per case: the declared surface plus one function taking the
+    /// spelling under test. Returns the generated Rust, or the resolve error.
+    fn build(param: syn::Type, name: &str) -> Result<String, String> {
+        let loc = myflat_loc();
+        let items: Vec<(syn::Item, SourceLocation)> = vec![
+            (
+                syn::parse_quote!(
+                    pub struct Rec {
+                        pub id: u64,
+                    }
+                ),
+                loc.clone(),
+            ),
+            (
+                syn::parse_quote!(
+                    pub struct Handle {
+                        inner: u64,
+                    }
+                ),
+                loc.clone(),
+            ),
+            (
+                syn::Item::Fn(syn::parse_quote!(
+                    pub fn probe(v: #param) {
+                        unimplemented!()
+                    }
+                )),
+                loc.clone(),
+            ),
+        ];
+        let registry =
+            crate::test_util::reg_from_items(declare_referenced(items)).expect("index items");
+        let jni = JniGenBuilder::new()
+            .set_package_prefix("io.test.jni")
+            .package(
+                crate::package!()
+                    .class(crate::data_class!(Rec))
+                    .class(crate::ptr_class!(Handle))
+                    .fun(prebindgen_registry::fun!(probe)),
+            );
+        let dir = unique_test_dir(name);
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).expect("create test dir");
+        match jni.build_with(registry) {
+            Ok(g) => Ok(std::fs::read_to_string(
+                g.write_rust(dir.join("g.rs")).expect("write_rust"),
+            )
+            .expect("read rust")),
+            Err(e) => Err(format!("{e}")),
+        }
+    }
+
+    // A handle: the converter hands back an `OwnedObject<Handle>` over the
+    // object the JVM points at, so the call site's `&mut` reaches it.
+    let handle = build(syn::parse_quote!(&mut Handle), "jnigen_excl_handle")
+        .expect("an exclusive borrow of a handle is a write the caller keeps");
+    let hc: String = handle.split_whitespace().collect();
+    assert!(hc.contains("flat::probe(&mutv)"), "{handle}");
+
+    // A data class: the fields are rebuilt into a local, and nothing carries a
+    // write back to Kotlin.
+    let rec = build(syn::parse_quote!(&mut Rec), "jnigen_excl_rec")
+        .expect_err("an exclusive borrow of a decoded value has no write-back");
+    assert!(
+        rec.contains("could not be resolved") && rec.contains("mut Rec"),
+        "the refusal names the spelling: {rec}"
+    );
+
+    // An out-parameter's slot: the same loss, one layer down.
+    let out = build(
+        syn::parse_quote!(&mut MaybeUninit<u64>),
+        "jnigen_excl_uninit",
+    )
+    .expect_err("an out-parameter's writes are lost the same way");
+    assert!(
+        out.contains("could not be resolved") && out.contains("MaybeUninit"),
+        "the refusal names the spelling: {out}"
+    );
+}

--- a/prebindgen-jni/src/jni/tests/values.rs
+++ b/prebindgen-jni/src/jni/tests/values.rs
@@ -2553,4 +2553,33 @@ fn an_exclusive_borrow_parameter_crosses_only_over_a_handle() {
         out.contains("could not be resolved") && out.contains("MaybeUninit"),
         "the refusal names the spelling: {out}"
     );
+
+    // Three spellings that reach a handle without borrowing one. Each is
+    // refused even though the entry the borrow resolves through answers
+    // `is_direct_handle` — a slot, a decoded box and a decoded reference are
+    // locals the wrapper drops, so the write never reaches the JVM's object.
+    for (spelling, name, names) in [
+        (
+            syn::parse_quote!(&mut MaybeUninit<Handle>),
+            "jnigen_excl_uninit_handle",
+            "MaybeUninit",
+        ),
+        (
+            syn::parse_quote!(&mut Box<Handle>),
+            "jnigen_excl_boxed_handle",
+            "Box",
+        ),
+        (
+            syn::parse_quote!(&mut &Handle),
+            "jnigen_excl_ref_handle",
+            "Handle",
+        ),
+    ] {
+        let refusal = build(spelling, name)
+            .expect_err("only the handle itself carries a write back to the JVM");
+        assert!(
+            refusal.contains("could not be resolved") && refusal.contains(names),
+            "the refusal names the spelling: {refusal}"
+        );
+    }
 }

--- a/prebindgen-jni/src/jni/tests/values.rs
+++ b/prebindgen-jni/src/jni/tests/values.rs
@@ -2497,6 +2497,30 @@ fn an_exclusive_borrow_parameter_crosses_only_over_a_handle() {
                 loc.clone(),
             ),
             (
+                syn::parse_quote!(
+                    pub struct Converted {
+                        inner: u64,
+                    }
+                ),
+                loc.clone(),
+            ),
+            (
+                syn::Item::Fn(syn::parse_quote!(
+                    pub fn converted_from_handle(h: Handle) -> Converted {
+                        unimplemented!()
+                    }
+                )),
+                loc.clone(),
+            ),
+            (
+                syn::Item::Fn(syn::parse_quote!(
+                    pub fn converted_to_handle(c: Converted) -> Handle {
+                        unimplemented!()
+                    }
+                )),
+                loc.clone(),
+            ),
+            (
                 syn::Item::Fn(syn::parse_quote!(
                     pub fn probe(v: #param) {
                         unimplemented!()
@@ -2509,6 +2533,11 @@ fn an_exclusive_borrow_parameter_crosses_only_over_a_handle() {
             crate::test_util::reg_from_items(declare_referenced(items)).expect("index items");
         let jni = JniGenBuilder::new()
             .set_package_prefix("io.test.jni")
+            .convert(
+                prebindgen_registry::convert!(Converted)
+                    .input(prebindgen_registry::fun!(converted_from_handle))
+                    .output(prebindgen_registry::fun!(converted_to_handle)),
+            )
             .package(
                 crate::package!()
                     .class(crate::data_class!(Rec))
@@ -2554,10 +2583,12 @@ fn an_exclusive_borrow_parameter_crosses_only_over_a_handle() {
         "the refusal names the spelling: {out}"
     );
 
-    // Three spellings that reach a handle without borrowing one. Each is
-    // refused even though the entry the borrow resolves through answers
-    // `is_direct_handle` — a slot, a decoded box and a decoded reference are
-    // locals the wrapper drops, so the write never reaches the JVM's object.
+    // Four spellings that reach a handle without borrowing one. Each is refused
+    // even though the entry the borrow resolves through answers
+    // `is_direct_handle`: a slot, a decoded box, a decoded reference and a
+    // `convert!` composed over the handle are all locals the wrapper drops, so
+    // the write never reaches the JVM's object. The last also loses the
+    // conversion stage, which is how it produced a type mismatch as well.
     for (spelling, name, names) in [
         (
             syn::parse_quote!(&mut MaybeUninit<Handle>),
@@ -2573,6 +2604,11 @@ fn an_exclusive_borrow_parameter_crosses_only_over_a_handle() {
             syn::parse_quote!(&mut &Handle),
             "jnigen_excl_ref_handle",
             "Handle",
+        ),
+        (
+            syn::parse_quote!(&mut Converted),
+            "jnigen_excl_converted_handle",
+            "Converted",
         ),
     ] {
         let refusal = build(spelling, name)


### PR DESCRIPTION
Fixes #411, found by the shape matrix on #402.

## What was wrong

`select_input_type` (`prebindgen-jni/src/jni/selector.rs`) routed every `&T` and `&mut T` parameter through the same borrow shape, which delegates to the inner type's converter and lets the call site add the borrow. Two cells emitted Rust that did not compile:

```rust
let __out = flat::probe(&v);      // fn probe(v: &mut Rec)
//                      ^^ expected `&mut flat::Rec`, found `&flat::Rec`

let __out = flat::probe(&mut v);  // fn probe(v: &mut MaybeUninit<u64>)
//                      ^^^^^^ expected `&mut MaybeUninit<u64>`, found `&mut u64`
```

Both are `error[E0308]`. The mismatch is the visible half; the reason it cannot be fixed by spelling the call site differently is that neither parameter has anywhere for the callee's writes to go. `Rec` is a `data_class!`, so its fields are rebuilt into a local; the out-parameter's `MaybeUninit<u64>` decodes to a `u64` local. Either way the callee writes into a value that the wrapper's frame drops, and Kotlin never sees it.

## The fix

An exclusive borrow now takes the borrow shape only when the inner type resolves to a **direct handle** — a `ptr_class!`, whose input converter hands back an `OwnedObject<T>` over the object the JVM holds a pointer to. A write through that borrow is still there when the wrapper returns, so `&mut Storage` and every other handle parameter keep working exactly as before.

Everything else is declined at selection and reported as an unresolved input type, which names the spelling. That is the rule the `&mut [T]` branch immediately above already follows ("no write-back of the decoded Vec"), the rule `examples/perftest-kotlin/build.rs` states in prose where it leaves the out-parameter forms undeclared as C-only, and the answer the C adapter already gives for `&mut T`. A refusal that names the type is also strictly better than emitting unbuildable Rust, which is the argument #270 settled for `Cow`.

The mutability is read off the `Ref` kind rather than through `is_exclusive_borrow`, which answers `false` for a `&mut MaybeUninit<T>` slot — that spelling loses writes the same way, so both reach the same guard. An inner with no entry yet is not treated as a refusal: the resolver runs to a fixed point and asks again once that rank resolves.

## Verification

- New test `an_exclusive_borrow_parameter_crosses_only_over_a_handle` (`prebindgen-jni/src/jni/tests/values.rs`) covers all three cases in one fixture: `&mut Handle` over a `ptr_class!` resolves and the call site emits `&mut`; `&mut Rec` over a `data_class!` and `&mut MaybeUninit<u64>` are refused, each refusal naming the spelling. It fails on `main`.
- `cargo test --workspace --all-features` passes.
- `examples/regen-check.sh` reports the in-repo generated output byte-identical, so no declared binding loses a function.
- Applied to a checkout of the `shape-coverage` branch and re-ran `cargo run -p shape-matrix`: `exclusive_ref__param__jni` and `out_param__param__jni` move from `bad rust` to `rejected`, which is what the C column already says for both. No other cell moves. That report lives on `shape-coverage`, so it is not updated here.

## A note on the states this moves between

`rejected` is a lower state than `rustc` in the matrix, so a reader watching only the totals sees two JNI cells fall. The `bad rust` they came from is not a higher one: it is emission that resolution claimed to support and the compiler refused. Making the shape actually work means giving Kotlin an out-parameter, which is a feature and not this fix.