### PR TITLE
Emit a working C return for a slice and for a Vec of borrows (#413)

### DIFF
--- a/prebindgen-c/src/emit.rs
+++ b/prebindgen-c/src/emit.rs
@@ -750,9 +750,17 @@ impl CbindgenBuilder {
                 niches: Niches::empty(),
             };
         }
-        // `Cow<'_, [T]>` → `T_wire* + size_t`. The C side receives an owned
-        // malloc'd copy, just like `Vec<T>` outputs.
-        if let Some(elem) = r_cow_slice_elem(ty) {
+        // `Cow<'_, [T]>` and `&[T]` → `T_wire* + size_t`. The C side receives an
+        // owned malloc'd copy, just like `Vec<T>` outputs.
+        //
+        // A shared slice reaches this only as a RETURN: a slice parameter is a
+        // pointer pair the caller supplies, and a slice callback argument is
+        // lowered by `prereq_callback_structs`. Without the second predicate a
+        // slice return fell through to the base-value path and took the `()`
+        // destination of the marker converter that exists for that callback
+        // lowering, so the wrapper returned nothing and called the marker with
+        // an argument it does not take (#413).
+        if let Some(elem) = r_cow_slice_elem(ty).or_else(|| r_scalar_slice_elem(ty)) {
             let entry = registry.output_entry(elem).unwrap_or_else(|| {
                 panic!(
                     "Cbindgen: `Cow` slice element `{}` has no output converter",
@@ -833,6 +841,7 @@ impl CbindgenBuilder {
         if let TypeKind::Vec(elem) = ty.kind() {
             let entry = registry.output_entry(elem).expect("Vec element converter");
             let elem_conv = entry.function.sig.ident.clone();
+            let elem_map = map_arg(&elem_conv, entry.function.sig.unsafety.is_some());
             let elem_wire = entry.destination.clone();
             let t_ptr = &targets[0];
             let t_len = &targets[1];
@@ -850,18 +859,19 @@ impl CbindgenBuilder {
             } else {
                 return quote!(
                     let __arr: ::std::vec::Vec<#elem_wire> =
-                        #val.into_iter().map(#elem_conv).collect();
+                        #val.into_iter().map(#elem_map).collect();
                     let (__p, __n) = __cbg_alloc_array(__arr);
                     #t_ptr = __p;
                     #t_len = __n;
                 );
             }
         }
-        if let Some(elem) = r_cow_slice_elem(ty) {
+        if let Some(elem) = r_cow_slice_elem(ty).or_else(|| r_scalar_slice_elem(ty)) {
             let entry = registry
                 .output_entry(elem)
-                .expect("Cow slice element converter");
+                .expect("slice element converter");
             let elem_conv = entry.function.sig.ident.clone();
+            let elem_map = map_arg(&elem_conv, entry.function.sig.unsafety.is_some());
             let elem_wire = entry.destination.clone();
             let t_ptr = &targets[0];
             let t_len = &targets[1];
@@ -879,7 +889,7 @@ impl CbindgenBuilder {
             } else {
                 return quote!(
                     let __arr: ::std::vec::Vec<#elem_wire> =
-                        #val.iter().copied().map(#elem_conv).collect();
+                        #val.iter().copied().map(#elem_map).collect();
                     let (__p, __n) = __cbg_alloc_array(__arr);
                     #t_ptr = __p;
                     #t_len = __n;
@@ -932,6 +942,7 @@ impl CbindgenBuilder {
             .optional_inner()
             .or(vec_elem)
             .or_else(|| r_cow_slice_elem(ty))
+            .or_else(|| r_scalar_slice_elem(ty))
         {
             return Self::output_is_fallible(inner, registry);
         }

--- a/prebindgen-c/src/lib.rs
+++ b/prebindgen-c/src/lib.rs
@@ -803,3 +803,19 @@ fn route_result(call: TokenStream, route: &ErrRoute<'_>) -> TokenStream {
         },
     }
 }
+
+/// The element converter as something `Iterator::map` accepts.
+///
+/// A safe `fn` item is itself a `FnMut`, and is passed by name — which is what
+/// every sequence return emitted before, and what the borrowed-element
+/// converters broke: `unsafe fn(&T) -> *const t` implements no `Fn` trait at
+/// all, so `Vec<&T>` built a `map` that did not type-check (#413). Calling it
+/// inside a closure is the call site the `unsafe fn` needs, and the wrapper's
+/// body is already an unsafe context.
+fn map_arg(conv: &syn::Ident, is_unsafe: bool) -> TokenStream {
+    if is_unsafe {
+        quote!(|__value| #conv(__value))
+    } else {
+        quote!(#conv)
+    }
+}

--- a/prebindgen-c/src/tests/returns.rs
+++ b/prebindgen-c/src/tests/returns.rs
@@ -286,6 +286,83 @@ fn cow_u8_returns_scalar_array() {
     assert!(compact.contains("__cbg_alloc_array(__arr)"), "{src}");
 }
 
+/// `&[u64]` returns the same owned scalar array as `Cow<'_, [u8]>` above.
+///
+/// A shared slice already had an output entry, for the callback-argument
+/// lowering, whose destination is a marker with no wire. As a RETURN that made
+/// the wrapper give C nothing at all and call the marker with an argument it
+/// does not take (#413), so the exported signature is what this pins.
+#[test]
+fn slice_returns_scalar_array() {
+    let loc = SourceLocation::default();
+    let func: syn::ItemFn = syn::parse_quote!(
+        pub fn z_ids(z: &ZZBytes) -> &'static [u64] {
+            unimplemented!()
+        }
+    );
+    let registry =
+        crate::test_util::reg_from_items(declare_referenced([(syn::Item::Fn(func), loc.clone())]))
+            .expect("index items");
+
+    let cbindgen = CbindgenBuilder::new()
+        .source_module(syn::parse_quote!(zenoh_flat))
+        .free_memory_function("z_free")
+        .opaque_ptr(syn::parse_quote!(ZZBytes))
+        .function(syn::parse_quote!(z_ids))
+        .panic();
+
+    let src = write(cbindgen, registry, "slice_ret");
+    let compact: String = src.split_whitespace().collect();
+
+    assert!(compact.contains("->*mutu64"), "{src}");
+    assert!(compact.contains("len:*mutusize"), "{src}");
+    assert!(
+        compact.contains(".iter().copied().map(__cbg_out_u64).collect()"),
+        "{src}"
+    );
+    assert!(compact.contains("__cbg_alloc_array(__arr)"), "{src}");
+}
+
+/// `Vec<&T>` maps its elements through the borrow converter, which is an
+/// `unsafe fn` — and an `unsafe fn` item implements no `Fn` trait, so passing
+/// it to `map` by name did not type-check (#413). It is called in a closure
+/// instead. A safe element converter is still passed by name.
+#[test]
+fn vec_of_borrows_calls_the_unsafe_element_converter() {
+    let loc = SourceLocation::default();
+    let handle: syn::ItemStruct = syn::parse_quote!(
+        pub struct ZHandle {
+            id: u64,
+        }
+    );
+    let func: syn::ItemFn = syn::parse_quote!(
+        pub fn z_handles() -> Vec<&'static ZHandle> {
+            unimplemented!()
+        }
+    );
+    let registry = crate::test_util::reg_from_items(declare_referenced([
+        (syn::Item::Struct(handle), loc.clone()),
+        (syn::Item::Fn(func), loc.clone()),
+    ]))
+    .expect("index items");
+
+    let cbindgen = CbindgenBuilder::new()
+        .source_module(syn::parse_quote!(zenoh_flat))
+        .free_memory_function("z_free")
+        .opaque_ptr(syn::parse_quote!(ZHandle))
+        .function(syn::parse_quote!(z_handles))
+        .panic();
+
+    let src = write(cbindgen, registry, "vec_of_borrows");
+    let compact: String = src.split_whitespace().collect();
+
+    assert!(compact.contains("->*mut*constz_handle"), "{src}");
+    assert!(
+        compact.contains(".map(|__value|__cbg_out_ref_ZHandle(__value))"),
+        "{src}"
+    );
+}
+
 /// `Result<Vec<T>, E>` has no free niche (the array NULL means *empty*), so
 /// it takes `bool f(T** out, size_t* out_len, <inputs>, E* e)`.
 #[test]


### PR DESCRIPTION
Fixes #413, found by the shape matrix on #402. Two returns of borrowed elements, two mechanisms, both in `prebindgen-c`.

## `&[T]` — the wrapper returned nothing and called a marker

A shared slice already had an output entry: a marker function with a `()` destination, which exists so that a slice **callback argument** resolves while `prereq_callback_structs` lowers it structurally as a pointer/length pair. Nothing claimed the shape in **return** position, so the wrapper took the base-value path and inherited that `()`:

```rust
pub unsafe extern "C" fn probe() -> () {
    let __v = flat::probe();
    let __ret: ();
    __ret = __cbg_outmark_slice_u64(__v);
    __ret
}
```

The C caller receives nothing, and the marker takes no arguments (`error[E0061]`). The compile error is the fortunate half: without it this is a wrapper that discards its return value.

`lower_shape` and `encode_value` already lower `Cow<'_, [T]>` to `T_wire* + size_t`, an owned malloc'd copy the C side frees — the same ABI as a `Vec<T>` return. A shared slice now takes that arm, so `&[u64]` returns `u64*` plus a `len` out-parameter. `lower_shape` and `encode_value` are reached only from the function-wrapper return path, so the callback lowering is untouched.

## `Vec<&T>` — an `unsafe fn` item is not a `FnMut`

```
error[E0277]: expected a `FnMut(&flat::Handle)` closure,
              found `unsafe fn(&Handle) -> *const handle {__cbg_out_ref_Handle}`
```

The borrow converter is `unsafe fn`, and an `unsafe fn` item implements no `Fn` trait, so the `map`/`collect` the sequence arms build cannot type-check. The new `map_arg` helper calls such a converter inside a closure — the call site an `unsafe fn` needs, inside a wrapper body that is already an unsafe context.

A **safe** element converter is still passed to `map` by name. That keeps every sequence return that compiled before byte-identical, which is why `examples/regen-check.sh` still reports no drift.

## What this does not change

`__cbg_out_ref_Handle` produces a non-owning `*const`, so a `Vec<&T>` return hands C an array of pointers that live exactly as long as the referents do. That is the policy a single `&T` return already has; this fix makes the emission compile and leaves the policy alone.

A shared-slice return whose element is not a scalar (a value-opaque element, say) still takes the old base-value path. No cell covers it and no declaration in the tree produces one; it is a separate shape, not a half-applied fix.

## Verification

- Two new tests in `prebindgen-c/src/tests/returns.rs`: `slice_returns_scalar_array` pins the exported signature and the copy for a `&'static [u64]` return, and `vec_of_borrows_calls_the_unsafe_element_converter` pins the closure for a `Vec<&'static ZHandle>` return.
- `cargo test --workspace --all-features` passes, including the two existing tests that assert a safe element converter is passed by name.
- `examples/regen-check.sh` reports the in-repo generated output byte-identical.
- Applied to a checkout of the `shape-coverage` branch and re-ran `cargo run -p shape-matrix`: `slice_scalar__ret__c` and `vec_ref__ret__c` rise from `bad rust` to `header`, C's top state. No other cell moves. That report lives on `shape-coverage`, so it is not updated here.