### PR TITLE
Mint an optional handle field through the factory (#430)

### DIFF
--- a/examples/covertest-kotlin/build.rs
+++ b/examples/covertest-kotlin/build.rs
@@ -218,6 +218,12 @@ fn main() {
         // harness is what ties the two decisions together, since an emission
         // test never compiles the inner class.
         .package(package!().class(data_class!(Dossier)))
+        // #430: the same handle field with an `Option` in front of it. The
+        // present arm mints the handle, and it has to do so through the
+        // generated factory — the constructor is private (#404). Only a
+        // compiled run says which one the factory names, so the shape lives
+        // here rather than only in an emission test.
+        .package(package!().class(data_class!(MaybeHolder)))
         // A data class whose FIELDS carry transparent wrappers (#289 + #292):
         // `boxed: Box<Option<i64>>` must cross exactly as `plain: Option<i64>`
         // does — the decoupled `(present, value)` pair — with the `Box` put back
@@ -557,6 +563,10 @@ fn main() {
                 // …and reached one level deeper still, through a nested data
                 // class rather than a sum.
                 .fun(fun!(dossier_new))
+                // #430: the handle field with an `Option` in front of it. The
+                // return is what runs the factory, so both arms — minted and
+                // absent — are compiled and exercised.
+                .fun(fun!(maybe_holder_new))
                 // #213: the output boundary DERIVED from the type's value form
                 // rather than restated. `report_each` delivers the decomposed
                 // `Report` in one crossing; the leaf list comes from

--- a/examples/covertest-kotlin/kotlin/REPORT.md
+++ b/examples/covertest-kotlin/kotlin/REPORT.md
@@ -94,6 +94,7 @@ Base package: `io.prebindgen.covertest`
   - shaped by: return `Lookup` decomposed → [tag, found_v0, failed_v0] (Callback delivery)
 - `marker_of` — `fun markerOf(which: Int, onError: JniErrorHandler<Marker?>): Marker?`
   - shaped by: return `Marker` decomposed → [tag, ranked_v0] (Callback delivery)
+- `maybe_holder_new` — `fun maybeHolderNew(tag: Long, count: Long, total: Double, present: Boolean, onError: JniErrorHandler<MaybeHolder?>): MaybeHolder?`
 - `object_boundary_value` — `fun objectBoundaryValue(value: ObjectBoundary, onError: JniErrorHandler<Long>): Long`
 - `observation_new` — `fun observationNew(which: Int, withFallback: Boolean, onError: JniErrorHandler<Observation?>): Observation?`
 - `observation_which` — `fun observationWhich(o: Observation, onError: JniErrorHandler<Int>): Int`
@@ -213,6 +214,7 @@ Base package: `io.prebindgen.covertest`
 - `Holder`: data_class → `io.prebindgen.covertest.Holder` (wire `jni :: objects :: JObject`)
 - `Lookup`: sealed_class → `io.prebindgen.covertest.model.Lookup` (wire `?`)
 - `Marker`: sealed_class → `io.prebindgen.covertest.model.Marker` (wire `?`)
+- `MaybeHolder`: data_class → `io.prebindgen.covertest.MaybeHolder` (wire `jni :: objects :: JObject`)
 - `ObjectBoundary`: data_class → `io.prebindgen.covertest.model.ObjectBoundary` (wire `jni :: objects :: JObject`, input `JObject` opt-in)
 - `ObjectBoundary16`: data_class → `io.prebindgen.covertest.model.ObjectBoundary16` (wire `jni :: objects :: JObject`)
 - `ObjectBoundary2`: data_class → `io.prebindgen.covertest.model.ObjectBoundary2` (wire `jni :: objects :: JObject`)

--- a/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest.kt
+++ b/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest.kt
@@ -245,6 +245,34 @@ public data class Holder(val tag: Long, val summary: Summary) : AutoCloseable {
     }
 }
 
+/**
+ * [`Holder`]'s optional twin: the handle field may be **absent**.
+ *
+ * The two are the same shape with one `Option` between the field and the
+ * handle, and the factory that rebuilds them on the Kotlin side takes a
+ * different arm for each. The present arm has to mint the handle through the
+ * generated factory, because #404 made the constructor `private` — and the
+ * optional arm went on naming the constructor, so this shape emitted Kotlin
+ * that does not compile at all (#430).
+ *
+ * Nothing in this crate had the shape, which is why an emission test was the
+ * only thing that could have caught it, and why it is here: a `MaybeHolder`
+ * returned to the JVM is built by that factory, so both arms are compiled and
+ * both are run.
+ */
+public data class MaybeHolder(val tag: Long, val summary: Summary?) : AutoCloseable {
+    override fun close() {
+        summary?.close()
+    }
+
+    public companion object {
+        @JvmSynthetic
+        @io.prebindgen.covertest.UnsafeNativeApi
+        @JvmStatic
+        public fun fromParts(tag: Long, summary: Long): MaybeHolder = MaybeHolder(tag, if (summary == 0L) null else Summary.fromRawPtr(summary))
+    }
+}
+
 public interface PayloadApi {
     val id: Long
 
@@ -1189,6 +1217,15 @@ internal object CovNative {
 
     @JvmSynthetic
     external fun markerOf(which: Int, build: Any, errorSink: Any): Any?
+
+    @JvmSynthetic
+    external fun maybeHolderNew(
+        tag: Long,
+        count: Long,
+        total: Double,
+        present: Boolean,
+        errorSink: Any,
+    ): MaybeHolder
 
     @JvmSynthetic
     external fun millisAdd(a: Long, b: Long, errorSink: Any): Long

--- a/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest/model.kt
+++ b/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest/model.kt
@@ -10,6 +10,7 @@ import io.prebindgen.covertest.JniErrorHandler
 import io.prebindgen.covertest.JniErrorHandlerCapture
 import io.prebindgen.covertest.LedgerBuilder
 import io.prebindgen.covertest.LedgerCallback
+import io.prebindgen.covertest.MaybeHolder
 import io.prebindgen.covertest.NativeHandle
 import io.prebindgen.covertest.Payload
 import io.prebindgen.covertest.Ranked
@@ -1807,6 +1808,20 @@ public fun dossierNew(
 ): Dossier? {
     val __bcap = JniErrorHandlerCapture.acquire()
     val __ret = CovNative.dossierNew(note, tag, count, total, __bcap)
+    if (__bcap.failed) return onError.run(__bcap.ze0)
+    return __ret
+}
+
+/** Build a [`MaybeHolder`] with the handle present or absent. */
+public fun maybeHolderNew(
+    tag: Long,
+    count: Long,
+    total: Double,
+    present: Boolean,
+    onError: JniErrorHandler<MaybeHolder?>,
+): MaybeHolder? {
+    val __bcap = JniErrorHandlerCapture.acquire()
+    val __ret = CovNative.maybeHolderNew(tag, count, total, present, __bcap)
     if (__bcap.failed) return onError.run(__bcap.ze0)
     return __ret
 }

--- a/examples/covertest-kotlin/kotlin/io/prebindgen/covertest/Test.kt
+++ b/examples/covertest-kotlin/kotlin/io/prebindgen/covertest/Test.kt
@@ -101,6 +101,7 @@ import io.prebindgen.covertest.model.readingSeries
 import io.prebindgen.covertest.model.Marker
 import io.prebindgen.covertest.model.Tagged
 import io.prebindgen.covertest.model.markerOf
+import io.prebindgen.covertest.model.maybeHolderNew
 import io.prebindgen.covertest.model.taggedNew
 import io.prebindgen.covertest.model.taggedRank
 import io.prebindgen.covertest.model.payloadPriority
@@ -684,6 +685,31 @@ fun main() {
         // Two levels down, closed by one `close()` at the top.
         d.close()
         check(summary.isClosed())
+    }
+
+    // The same handle field with an `Option` in front of it. The factory that
+    // rebuilds the class takes a different arm per case, and the present arm has
+    // to MINT a handle — through the generated factory, since #404 made the
+    // constructor private. The optional arm went on naming the constructor, so
+    // this class did not compile at all (#430), which no emission test could
+    // say: the Rust half is identical either way. This section is the tie —
+    // it does not compile if the arm names something private, and the checks
+    // fail if either case rebuilds the wrong thing.
+    section("an optional handle field is minted through the factory, present and absent") {
+        val present = maybeHolderNew(3L, 4L, 8.0, true, boom).orThrow()
+        check(present.tag == 3L)
+        val held = present.summary ?: error("the present arm dropped the handle")
+        check(!held.isClosed())
+        check(held.count(boom) == 4L)
+        present.close()
+        check(held.isClosed())
+
+        // …and the absent arm produces `null` rather than a handle over pointer
+        // 0, so closing the container is a no-op with nothing to free.
+        val absentHolder = maybeHolderNew(7L, 4L, 8.0, false, boom).orThrow()
+        check(absentHolder.tag == 7L)
+        check(absentHolder.summary == null)
+        absentHolder.close()
     }
 
     // An output boundary DERIVED from the type's value form

--- a/examples/covertest-kotlin/src/generated_bindings.rs
+++ b/examples/covertest-kotlin/src/generated_bindings.rs
@@ -2419,6 +2419,53 @@ pub(crate) unsafe fn JObject_to_Marker_3dc81334<'env, 'v>(
     clippy::nonminimal_bool,
     clippy::eq_op
 )]
+pub(crate) unsafe fn JObject_to_MaybeHolder_1c68fbac<'env, 'v>(
+    env: &mut jni::JNIEnv<'env>,
+    v: &jni::objects::JObject<'v>,
+) -> ::core::result::Result<perftest_flat::MaybeHolder, __JniErr> {
+    Ok({
+        let __tag_raw: jni::sys::jlong = env
+            .get_field(v, "tag", "J")
+            .and_then(|val| val.j())
+            .map_err(|e| <__JniErr as ::core::convert::From<
+                String,
+            >>::from(format!("MaybeHolder.tag: {}", e)))? as _;
+        let tag = jlong_to_i64_fbf9a9bc(env, &__tag_raw)?;
+        let __summary_jobj: jni::objects::JObject = env
+            .get_field(v, "summary", "Lio/prebindgen/covertest/analytics/Summary;")
+            .and_then(|val| val.l())
+            .map_err(|e| <__JniErr as ::core::convert::From<
+                String,
+            >>::from(format!("MaybeHolder.summary: {}", e)))?;
+        let __summary_raw: jni::sys::jlong = if __summary_jobj.is_null() {
+            0
+        } else {
+            env.call_method(&__summary_jobj, "peek", "()J", &[])
+                .and_then(|val| val.j())
+                .map_err(|e| <__JniErr as ::core::convert::From<
+                    String,
+                >>::from(format!("MaybeHolder.summary: {}", e)))?
+        };
+        let summary = jlong_to_Option_Summary_252ef2ba(env, &__summary_raw)?;
+        perftest_flat::MaybeHolder {
+            tag,
+            summary,
+        }
+    })
+}
+#[allow(
+    non_snake_case,
+    unused_mut,
+    unused_variables,
+    unused_braces,
+    unused_parens,
+    dead_code,
+    clippy::useless_conversion,
+    clippy::needless_question_mark,
+    clippy::let_and_return,
+    clippy::nonminimal_bool,
+    clippy::eq_op
+)]
 pub(crate) unsafe fn JObject_to_ObjectBoundary16_e9d41606<'env, 'v>(
     env: &mut jni::JNIEnv<'env>,
     v: &jni::objects::JObject<'v>,
@@ -6312,6 +6359,46 @@ pub(crate) unsafe fn Label_to_String_63dec766<'a>(
     clippy::nonminimal_bool,
     clippy::eq_op
 )]
+pub(crate) unsafe fn MaybeHolder_to_JObject_1c68fbac<'a>(
+    env: &mut jni::JNIEnv<'a>,
+    v: perftest_flat::MaybeHolder,
+) -> ::core::result::Result<jni::objects::JObject<'a>, __JniErr> {
+    Ok({
+        let ___tag: jni::sys::jlong = i64_to_jlong_fbf9a9bc(env, v.tag.clone())?;
+        let ___summary: jni::sys::jlong = Option_Summary_to_jlong_252ef2ba(
+            env,
+            v.summary.clone(),
+        )?;
+        let __obj = env
+            .call_static_method(
+                "io/prebindgen/covertest/MaybeHolder",
+                "fromParts",
+                "(JJ)Lio/prebindgen/covertest/MaybeHolder;",
+                &[
+                    jni::objects::JValue::from(___tag),
+                    jni::objects::JValue::from(___summary),
+                ],
+            )
+            .and_then(|__v| __v.l())
+            .map_err(|e| <__JniErr as ::core::convert::From<
+                String,
+            >>::from(format!("encode struct via fromParts: {}", e)))?;
+        __obj
+    })
+}
+#[allow(
+    non_snake_case,
+    unused_mut,
+    unused_variables,
+    unused_braces,
+    unused_parens,
+    dead_code,
+    clippy::useless_conversion,
+    clippy::needless_question_mark,
+    clippy::let_and_return,
+    clippy::nonminimal_bool,
+    clippy::eq_op
+)]
 pub(crate) unsafe fn Millis_to_i64_61ecf054<'a>(
     env: &mut jni::JNIEnv<'a>,
     v: perftest_flat::Millis,
@@ -9009,6 +9096,33 @@ pub(crate) unsafe fn Option_String_to_JString_56d5e304<'a>(
             match v {
                 Some(value) => String_to_JString_c7f3ca43(env, value)?,
                 None => jni::objects::JObject::null().into(),
+            }
+        }
+    })
+}
+#[allow(
+    non_snake_case,
+    unused_mut,
+    unused_variables,
+    unused_braces,
+    unused_parens,
+    dead_code,
+    clippy::useless_conversion,
+    clippy::needless_question_mark,
+    clippy::let_and_return,
+    clippy::nonminimal_bool,
+    clippy::eq_op
+)]
+pub(crate) unsafe fn Option_Summary_to_jlong_252ef2ba<'a>(
+    env: &mut jni::JNIEnv<'a>,
+    v: Option<perftest_flat::Summary>,
+) -> ::core::result::Result<jni::sys::jlong, __JniErr> {
+    Ok({
+        let v: Option<perftest_flat::Summary> = v;
+        {
+            match v {
+                Some(value) => Summary_to_jlong_3cb103b9(env, value)?,
+                None => 0i64,
             }
         }
     })
@@ -16565,6 +16679,93 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_markerOf<'a>(
                 __SINK_FQN,
                 __SINK_DESCR,
                 &__e2.to_string(),
+            );
+            jni::objects::JObject::null().into()
+        }
+    }
+}
+#[no_mangle]
+#[allow(non_snake_case, unused_mut, unused_variables, dead_code)]
+pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_maybeHolderNew<'a>(
+    mut env: jni::JNIEnv<'a>,
+    _class: jni::objects::JClass<'a>,
+    tag: jni::sys::jlong,
+    count: jni::sys::jlong,
+    total: jni::sys::jdouble,
+    present: jni::sys::jboolean,
+    __error_sink: jni::objects::JObject<'a>,
+) -> jni::objects::JObject<'a> {
+    #[allow(non_upper_case_globals)]
+    static __SINK_MID: ::prebindgen_jni_runtime::CachedIfaceMethod = ::prebindgen_jni_runtime::CachedIfaceMethod::new();
+    const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
+    const __SINK_DESCR: &str = "(Ljava/lang/String;)Ljava/lang/Object;";
+    let tag = match jlong_to_i64_fbf9a9bc(&mut env, &tag) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__e) => {
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e.to_string(),
+            );
+            return jni::objects::JObject::null().into();
+        }
+    };
+    let count = match jlong_to_i64_fbf9a9bc(&mut env, &count) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__e) => {
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e.to_string(),
+            );
+            return jni::objects::JObject::null().into();
+        }
+    };
+    let total = match jdouble_to_f64_9e4a8f70(&mut env, &total) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__e) => {
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e.to_string(),
+            );
+            return jni::objects::JObject::null().into();
+        }
+    };
+    let present = match jboolean_to_bool_31306d98(&mut env, &present) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__e) => {
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e.to_string(),
+            );
+            return jni::objects::JObject::null().into();
+        }
+    };
+    let __out = perftest_flat::maybe_holder_new(tag, count, total, present);
+    match MaybeHolder_to_JObject_1c68fbac(&mut env, __out) {
+        ::core::result::Result::Ok(__w) => __w,
+        ::core::result::Result::Err(__e) => {
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e.to_string(),
             );
             jni::objects::JObject::null().into()
         }

--- a/examples/perftest-flat/src/ext.rs
+++ b/examples/perftest-flat/src/ext.rs
@@ -1857,6 +1857,34 @@ pub fn holder_tag_or(h: Option<Holder>, fallback: i64) -> i64 {
     }
 }
 
+/// [`Holder`]'s optional twin: the handle field may be **absent**.
+///
+/// The two are the same shape with one `Option` between the field and the
+/// handle, and the factory that rebuilds them on the Kotlin side takes a
+/// different arm for each. The present arm has to mint the handle through the
+/// generated factory, because #404 made the constructor `private` — and the
+/// optional arm went on naming the constructor, so this shape emitted Kotlin
+/// that does not compile at all (#430).
+///
+/// Nothing in this crate had the shape, which is why an emission test was the
+/// only thing that could have caught it, and why it is here: a `MaybeHolder`
+/// returned to the JVM is built by that factory, so both arms are compiled and
+/// both are run.
+#[prebindgen]
+pub struct MaybeHolder {
+    pub tag: i64,
+    pub summary: Option<Summary>,
+}
+
+/// Build a [`MaybeHolder`] with the handle present or absent.
+#[prebindgen]
+pub fn maybe_holder_new(tag: i64, count: i64, total: f64, present: bool) -> MaybeHolder {
+    MaybeHolder {
+        tag,
+        summary: present.then_some(Summary { count, total }),
+    }
+}
+
 /// A data class whose **fields** carry transparent wrappers.
 ///
 /// This is what #289 changes and why it could not land alone. The field walk

--- a/prebindgen-jni/src/jni/fold.rs
+++ b/prebindgen-jni/src/jni/fold.rs
@@ -112,10 +112,16 @@ pub(crate) fn factory_projection_wire_wrap(
                 );
             }
             match proj.kind {
-                // Handle null rides the `0L` jlong sentinel.
+                // Handle null rides the `0L` jlong sentinel. The present case
+                // mints the handle through `handle_from_raw` for the same
+                // reason the `Base` arm above does: a handle's constructor is
+                // private, and the factory is the only way in (#430).
                 Handle => (
                     KtType::long(),
-                    format!("if ({name} == 0L) null else {short}({name})"),
+                    format!(
+                        "if ({name} == 0L) null else {}",
+                        handle_from_raw(short, name)
+                    ),
                 ),
                 Unsigned64 => match nullable {
                     // A bounded unsigned representation reserves an invalid

--- a/prebindgen-jni/src/jni/tests/values.rs
+++ b/prebindgen-jni/src/jni/tests/values.rs
@@ -1627,6 +1627,76 @@ fn unsigned_scalars_use_lossless_kotlin_surface_and_raw_jni_wires() {
     assert!(kc.contains("):ULong"), "{kotlin}");
 }
 
+/// An `Option<Handle>` field mints its handle through the factory, like every
+/// other site that mints one.
+///
+/// A handle's constructor is `private` — #404 sealed it so that no Java or
+/// Kotlin caller can forge a pointer — and `handle_from_raw` is the one place
+/// that names the replacement. The nullable arm of the field factory spelled the
+/// constructor instead, so the generated Kotlin did not compile at all (#430),
+/// which nothing noticed because no test here asked for the shape and the Rust
+/// half compiles either way.
+#[test]
+fn an_optional_handle_field_mints_through_the_factory() {
+    let loc = myflat_loc();
+    let items: Vec<(syn::Item, SourceLocation)> = vec![
+        (
+            syn::Item::Struct(syn::parse_quote!(
+                pub struct Handle {
+                    pub v: i64,
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Struct(syn::parse_quote!(
+                pub struct Bag {
+                    pub handle: Option<Handle>,
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn bag_make() -> Bag {
+                    unimplemented!()
+                }
+            )),
+            loc.clone(),
+        ),
+    ];
+    let registry =
+        crate::test_util::reg_from_items(declare_referenced(items)).expect("index items");
+    let jni = JniGenBuilder::new()
+        .set_package_prefix("io.test.jni")
+        .package(
+            crate::package!()
+                .class(crate::ptr_class!(Handle))
+                .class(crate::data_class!(Bag))
+                .fun(prebindgen_registry::fun!(bag_make)),
+        );
+
+    let dir = unique_test_dir("jnigen_optional_handle_field");
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    let generation = jni.build_with(registry).expect("resolve");
+    let kotlin = generation
+        .write_kotlin(&dir.join("kotlin"))
+        .unwrap()
+        .iter()
+        .map(|path| std::fs::read_to_string(path).unwrap())
+        .collect::<Vec<_>>()
+        .join("\n");
+    let kc: String = kotlin.split_whitespace().collect();
+
+    // Absent rides the `0L` jlong sentinel, and present goes through the
+    // factory — not `Handle(handle)`, which is private.
+    assert!(
+        kc.contains("if(handle==0L)nullelseHandle.fromRawPtr(handle)"),
+        "{kotlin}"
+    );
+}
+
 /// A data class's constructor property types come from the SAME
 /// [`build_struct_plan`] its `fromParts` factory walks, so a property and its
 /// own factory parameter cannot disagree (#156). Pinned across the field kinds


### PR DESCRIPTION
Fixes #430, found by the shape matrix on #402 — by its new stage, which compiles the Kotlin the JNI adapter emits.

## What was wrong

For `pub struct Bag { pub handle: Option<Handle> }` with `Handle` declared `ptr_class!`, the generated factory called the handle's constructor:

```kotlin
public fun fromParts(handle: Long): Bag = Bag(if (handle == 0L) null else Handle(handle))
```

```
error: cannot access 'constructor(initialPtr: Long): Handle': it is private in 'Handle'.
```

That constructor is private on purpose. #404 sealed it so a Java or Kotlin caller cannot forge a pointer, and `handle_from_raw` — whose doc says *"every generated site that mints a handle goes through here, so the choice of `HANDLE_FACTORY` over a constructor is made once"* — is the replacement. The `Base` arm of `factory_projection_wire_wrap` already used it; the `Optional` arm immediately below it did not.

## The fix

The `Optional{Handle}` arm calls `handle_from_raw` too, so the absent case still rides the `0L` jlong sentinel and the present case goes through the factory.

## Why nothing caught it

The Rust half compiles either way — this is Kotlin the compiler never saw. `prebindgen-jni`'s tests covered a **non-optional** handle field (`data_class_properties_match_their_from_parts_params` asserts `Bag(Handle.fromRawPtr(handle)`), and the nullable arm had no test at all.

## Verification

- New test `an_optional_handle_field_mints_through_the_factory` (`prebindgen-jni/src/jni/tests/values.rs`) asserts the emitted factory reads `if (handle == 0L) null else Handle.fromRawPtr(handle)`. It fails on `main`.
- `cargo test --workspace --all-features` passes.
- `examples/regen-check.sh` reports the in-repo generated output byte-identical, so no committed binding changes: no example declares an optional handle field, which is the same gap the test closes.
- On the `shape-coverage` branch this takes `opt_handle__field__jni` from `bad kotlin` to `kotlin`.