### PR TITLE
Carry a payload's Option and collection layers (#429)

### DIFF
--- a/examples/covertest-kotlin/build.rs
+++ b/examples/covertest-kotlin/build.rs
@@ -250,6 +250,12 @@ fn main() {
                 // `close()` — that is what lets a container cascade into it
                 // with the same one-liner a handle field gets (#218).
                 .class(sealed_class!(Lookup))
+                // #429: the sum whose payloads have LAYERS — an optional
+                // scalar, an optional handle, a list of optionals — beside two
+                // controls that must not gain one. The builder that reassembles
+                // them is Kotlin, so only a compiled run says whether each
+                // layer was carried.
+                .class(sealed_class!(Layered))
                 // …and `Verdict` is that container: the sum in DATA-CLASS FIELD
                 // position, the third place a handle is reached through.
                 // `Holder` above is the plain-handle field it must match.
@@ -551,6 +557,8 @@ fn main() {
                 // handle-carrying sum arriving through a CALLBACK, and a sum
                 // returned BORROWED (`&E` / `Option<&E>`).
                 .fun(fun!(lookup_each))
+                // …and #429's layered payloads, one call per case.
+                .fun(fun!(layered_of))
                 // #218: the same handle reached through a data-class FIELD, so
                 // the JVM harness can assert the container's cascade closes it.
                 .fun(fun!(verdict_new))

--- a/examples/covertest-kotlin/kotlin/REPORT.md
+++ b/examples/covertest-kotlin/kotlin/REPORT.md
@@ -86,6 +86,8 @@ Base package: `io.prebindgen.covertest`
 - `holder_tag_or` — `fun holderTagOr(h: Holder?, fallback: Long, onError: JniErrorHandler<Long>): Long`
 - `label_reverse` — `fun labelReverse(l: String, onError: JniErrorHandler<String?>): String?`
 - `label_series_echo` — `fun labelSeriesEcho(labels: List<String>, onError: JniErrorHandler<List<String>?>): List<String>?`
+- `layered_of` — `fun layeredOf(which: Int, onError: JniErrorHandler<Layered?>): Layered?`
+  - shaped by: return `Layered` decomposed → [tag, count_v0, held_v0, many_v0, blob_v0, plain_v0] (Callback delivery)
 - `ledger_each` — `fun ledgerEach(n: Long, sink: LedgerCallback, onError: JniErrorHandler<Unit>)`
 - `ledger_new` — `fun <R> ledgerNew(n: Long, onError: JniErrorHandler<R?>, build: LedgerBuilder<R>): R?`
   - shaped by: return `Ledger` decomposed → [ledgerFiled__summary__count, ledgerFiled__summary__total, ledgerFiled__taken, ledgerFiled__origin__secs, ledgerFiled__origin__nanos, ledgerFiled__outcome__tag, ledgerFiled__outcome__found_v0, ledgerFiled__outcome__failed_v0, ledgerFiled__label, ledgerArchived__summary__count, ledgerArchived__summary__total, ledgerArchived__taken, ledgerArchived__origin__secs, ledgerArchived__origin__nanos, ledgerArchived__outcome__tag, ledgerArchived__outcome__found_v0, ledgerArchived__outcome__failed_v0, ledgerArchived__label] (Callback delivery)
@@ -211,6 +213,7 @@ Base package: `io.prebindgen.covertest`
 - `Hold`: sealed_class → `io.prebindgen.covertest.model.Hold` (wire `?`)
 - `HoldPolicy`: data_class → `io.prebindgen.covertest.model.HoldPolicy` (wire `jni :: objects :: JObject`)
 - `Holder`: data_class → `io.prebindgen.covertest.Holder` (wire `jni :: objects :: JObject`)
+- `Layered`: sealed_class → `io.prebindgen.covertest.model.Layered` (wire `?`)
 - `Lookup`: sealed_class → `io.prebindgen.covertest.model.Lookup` (wire `?`)
 - `Marker`: sealed_class → `io.prebindgen.covertest.model.Marker` (wire `?`)
 - `ObjectBoundary`: data_class → `io.prebindgen.covertest.model.ObjectBoundary` (wire `jni :: objects :: JObject`, input `JObject` opt-in)

--- a/examples/covertest-kotlin/kotlin/REPORT.md
+++ b/examples/covertest-kotlin/kotlin/REPORT.md
@@ -87,7 +87,7 @@ Base package: `io.prebindgen.covertest`
 - `label_reverse` — `fun labelReverse(l: String, onError: JniErrorHandler<String?>): String?`
 - `label_series_echo` — `fun labelSeriesEcho(labels: List<String>, onError: JniErrorHandler<List<String>?>): List<String>?`
 - `layered_of` — `fun layeredOf(which: Int, onError: JniErrorHandler<Layered?>): Layered?`
-  - shaped by: return `Layered` decomposed → [tag, count_v0, held_v0, many_v0, blob_v0, plain_v0] (Callback delivery)
+  - shaped by: return `Layered` decomposed → [tag, count_v0, held_v0, many_v0, values_v0, blob_v0, plain_v0] (Callback delivery)
 - `ledger_each` — `fun ledgerEach(n: Long, sink: LedgerCallback, onError: JniErrorHandler<Unit>)`
 - `ledger_new` — `fun <R> ledgerNew(n: Long, onError: JniErrorHandler<R?>, build: LedgerBuilder<R>): R?`
   - shaped by: return `Ledger` decomposed → [ledgerFiled__summary__count, ledgerFiled__summary__total, ledgerFiled__taken, ledgerFiled__origin__secs, ledgerFiled__origin__nanos, ledgerFiled__outcome__tag, ledgerFiled__outcome__found_v0, ledgerFiled__outcome__failed_v0, ledgerFiled__label, ledgerArchived__summary__count, ledgerArchived__summary__total, ledgerArchived__taken, ledgerArchived__origin__secs, ledgerArchived__origin__nanos, ledgerArchived__outcome__tag, ledgerArchived__outcome__found_v0, ledgerArchived__outcome__failed_v0, ledgerArchived__label] (Callback delivery)

--- a/examples/covertest-kotlin/kotlin/REPORT.md
+++ b/examples/covertest-kotlin/kotlin/REPORT.md
@@ -87,7 +87,7 @@ Base package: `io.prebindgen.covertest`
 - `label_reverse` — `fun labelReverse(l: String, onError: JniErrorHandler<String?>): String?`
 - `label_series_echo` — `fun labelSeriesEcho(labels: List<String>, onError: JniErrorHandler<List<String>?>): List<String>?`
 - `layered_of` — `fun layeredOf(which: Int, onError: JniErrorHandler<Layered?>): Layered?`
-  - shaped by: return `Layered` decomposed → [tag, count_v0, held_v0, many_v0, values_v0, blob_v0, plain_v0] (Callback delivery)
+  - shaped by: return `Layered` decomposed → [tag, count_v0, held_v0, many_v0, values_v0, nested_v0, blob_v0, plain_v0] (Callback delivery)
 - `ledger_each` — `fun ledgerEach(n: Long, sink: LedgerCallback, onError: JniErrorHandler<Unit>)`
 - `ledger_new` — `fun <R> ledgerNew(n: Long, onError: JniErrorHandler<R?>, build: LedgerBuilder<R>): R?`
   - shaped by: return `Ledger` decomposed → [ledgerFiled__summary__count, ledgerFiled__summary__total, ledgerFiled__taken, ledgerFiled__origin__secs, ledgerFiled__origin__nanos, ledgerFiled__outcome__tag, ledgerFiled__outcome__found_v0, ledgerFiled__outcome__failed_v0, ledgerFiled__label, ledgerArchived__summary__count, ledgerArchived__summary__total, ledgerArchived__taken, ledgerArchived__origin__secs, ledgerArchived__origin__nanos, ledgerArchived__outcome__tag, ledgerArchived__outcome__found_v0, ledgerArchived__outcome__failed_v0, ledgerArchived__label] (Callback delivery)

--- a/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest.kt
+++ b/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest.kt
@@ -1176,6 +1176,9 @@ internal object CovNative {
     external fun labelSeriesEcho(labels: List<String>, errorSink: Any): List<String>
 
     @JvmSynthetic
+    external fun layeredOf(which: Int, build: Any, errorSink: Any): Any?
+
+    @JvmSynthetic
     external fun ledgerEach(n: Long, sink: Any, errorSink: Any)
 
     @JvmSynthetic

--- a/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest/model.kt
+++ b/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest/model.kt
@@ -125,6 +125,16 @@ public sealed interface Layered : AutoCloseable {
     }
 
     /**
+     * A run under an `Option` — the two layers in the other order. Looking for
+     * the run without peeling the `Option` first finds none, and the element
+     * conversion lands on the list.
+     */
+    public data class Values(public val v0: List<ULong?>?) : Layered {
+        override fun close() {
+        }
+    }
+
+    /**
      * A control: a run of values that needs no element conversion, and whose
      * Kotlin type is not a `List` at all.
      */
@@ -158,6 +168,7 @@ public sealed interface Layered : AutoCloseable {
             count_v0: ULong?,
             held_v0: Summary?,
             many_v0: List<ULong?>,
+            values_v0: List<ULong?>?,
             blob_v0: ByteArray,
             plain_v0: Long,
         ): Layered =
@@ -165,8 +176,9 @@ public sealed interface Layered : AutoCloseable {
                 0 -> Count(count_v0)
                 1 -> Held(held_v0)
                 2 -> Many(many_v0)
-                3 -> Blob(blob_v0)
-                4 -> Plain(plain_v0)
+                3 -> Values(values_v0)
+                4 -> Blob(blob_v0)
+                5 -> Plain(plain_v0)
                 else -> throw IllegalArgumentException("Layered: invalid tag $tag")
             }
     }
@@ -1293,6 +1305,7 @@ internal fun interface LayeredBuilderRaw<out R> {
         count_v0: Long?,
         held_v0: Long?,
         many_v0: List<Long?>?,
+        values_v0: List<Long?>?,
         blob_v0: ByteArray?,
         plain_v0: Long,
     ): R
@@ -1300,8 +1313,8 @@ internal fun interface LayeredBuilderRaw<out R> {
 
 @get:JvmSynthetic
 internal val __LayeredBuilderRaw: LayeredBuilderRaw<Layered> =
-LayeredBuilderRaw { tag, count_v0, held_v0, many_v0, blob_v0, plain_v0 ->
-    when (tag) { 0 -> Layered.Count(count_v0?.toULong()); 1 -> Layered.Held(held_v0?.let { Summary.fromRawPtr(it) }); 2 -> Layered.Many(many_v0!!.map { it?.toULong() }); 3 -> Layered.Blob(blob_v0!!); 4 -> Layered.Plain(plain_v0); else -> throw IllegalArgumentException("Layered: invalid tag $tag") }
+LayeredBuilderRaw { tag, count_v0, held_v0, many_v0, values_v0, blob_v0, plain_v0 ->
+    when (tag) { 0 -> Layered.Count(count_v0?.toULong()); 1 -> Layered.Held(held_v0?.let { Summary.fromRawPtr(it) }); 2 -> Layered.Many(many_v0!!.map { it?.toULong() }); 3 -> Layered.Values(values_v0?.map { it?.toULong() }); 4 -> Layered.Blob(blob_v0!!); 5 -> Layered.Plain(plain_v0); else -> throw IllegalArgumentException("Layered: invalid tag $tag") }
 }
 
 internal fun interface LookupBuilderRaw<out R> {
@@ -1902,9 +1915,10 @@ public fun lookupEach(n: Long, total: Double, sink: LookupCallback, onError: Jni
 /**
  * Build a [`Layered`], one `which` per alternative and per case within it:
  * `0` absent count, `1` present count, `2` absent handle, `3` present handle,
- * `4` a list mixing present and absent, `5` a byte run, anything else `Plain`.
+ * `4` a list mixing present and absent, `5` an absent run, `6` a present run,
+ * `7` a byte run, anything else `Plain`.
  *
- * The Rust `Layered` result is delivered decomposed: the builder callback receives (`tag`, `count_v0`, `held_v0`, `many_v0`, `blob_v0`, `plain_v0`).
+ * The Rust `Layered` result is delivered decomposed: the builder callback receives (`tag`, `count_v0`, `held_v0`, `many_v0`, `values_v0`, `blob_v0`, `plain_v0`).
  */
 @Suppress("UNCHECKED_CAST")
 public fun layeredOf(which: Int, onError: JniErrorHandler<Layered?>): Layered? {

--- a/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest/model.kt
+++ b/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest/model.kt
@@ -75,6 +75,104 @@ public sealed interface Hold {
 }
 
 /**
+ * The payload shapes whose **layers** a sum's raw builder has to carry.
+ *
+ * Between a wire slot and the property there can be a collection, an `Option`,
+ * and the leaf the wrap knows about, and the builder applied the leaf's
+ * conversion straight to the slot — so a null was dropped, a handle was minted
+ * from a nullable slot, and an element conversion ran on the list itself
+ * (#429). Every one of those is a Kotlin compile error; the Rust half is
+ * identical either way, which is why only a compiled harness can hold the
+ * line.
+ *
+ * The last two alternatives are the controls, and they matter as much as the
+ * first three: distributing over a collection is right only when its elements
+ * convert. `Vec<u8>` surfaces as a Kotlin `ByteArray`, and mapping the
+ * identity over one produces a `List<Byte>` — the property's type replaced
+ * rather than preserved.
+ *
+ * JVM-side surface for the native Rust `Layered` sum: exactly one alternative is live.
+ *
+ * The live alternative may carry a native handle, so this value is `AutoCloseable`: closing it closes whatever the live alternative holds, and is a no-op for the alternatives that hold nothing native.
+ */
+public sealed interface Layered : AutoCloseable {
+    /**
+     * `Option<u64>` — JVM null is the absent case, so the unsigned conversion
+     * has to be null-safe rather than applied through it.
+     */
+    public data class Count(public val v0: ULong?) : Layered {
+        override fun close() {
+        }
+    }
+
+    /**
+     * `Option<Summary>` — the same, over a handle that must be **minted** in
+     * the present case and left alone in the absent one.
+     */
+    public data class Held(public val v0: Summary?) : Layered {
+        override fun close() {
+            v0?.close()
+        }
+    }
+
+    /**
+     * `Vec<Option<u64>>` — the absences are *inside* the list, so the slot is
+     * un-inerted and the conversion runs per element.
+     */
+    public data class Many(public val v0: List<ULong?>) : Layered {
+        override fun close() {
+        }
+    }
+
+    /**
+     * A control: a run of values that needs no element conversion, and whose
+     * Kotlin type is not a `List` at all.
+     */
+    public data class Blob(public val v0: ByteArray) : Layered {
+        override fun equals(other: Any?): Boolean {
+            if (this === other) return true
+            if (other !is Blob) return false
+            return v0.contentEquals(other.v0)
+        }
+
+        override fun hashCode(): Int {
+            return v0.contentHashCode()
+        }
+
+        override fun toString(): String = "Blob(v0=${v0.contentToString()})"
+
+        override fun close() {
+        }
+    }
+
+    /** A control: no layer between the slot and the property. */
+    public data class Plain(public val v0: Long) : Layered {
+        override fun close() {
+        }
+    }
+
+    public companion object {
+        @JvmStatic
+        public fun fromParts(
+            tag: Int,
+            count_v0: ULong?,
+            held_v0: Summary?,
+            many_v0: List<ULong?>,
+            blob_v0: ByteArray,
+            plain_v0: Long,
+        ): Layered =
+            when (tag) {
+                0 -> Count(count_v0)
+                1 -> Held(held_v0)
+                2 -> Many(many_v0)
+                3 -> Blob(blob_v0)
+                4 -> Plain(plain_v0)
+                else -> throw IllegalArgumentException("Layered: invalid tag $tag")
+            }
+    }
+}
+
+/**
  * A sum whose alternatives are a **payload-less** variant and one carrying an
  * opaque **handle** — the shape a real lookup/reply result takes, and the one
  * that proves a tag-gated group can own a native resource: the live group
@@ -1189,6 +1287,23 @@ HoldBuilderRaw { tag, for_v0 ->
     when (tag) { 0 -> Hold.Indefinite; 1 -> Hold.For(for_v0.toULong()); else -> throw IllegalArgumentException("Hold: invalid tag $tag") }
 }
 
+internal fun interface LayeredBuilderRaw<out R> {
+    public fun run(
+        tag: Int,
+        count_v0: Long?,
+        held_v0: Long?,
+        many_v0: List<Long?>?,
+        blob_v0: ByteArray?,
+        plain_v0: Long,
+    ): R
+}
+
+@get:JvmSynthetic
+internal val __LayeredBuilderRaw: LayeredBuilderRaw<Layered> =
+LayeredBuilderRaw { tag, count_v0, held_v0, many_v0, blob_v0, plain_v0 ->
+    when (tag) { 0 -> Layered.Count(count_v0?.toULong()); 1 -> Layered.Held(held_v0?.let { Summary.fromRawPtr(it) }); 2 -> Layered.Many(many_v0!!.map { it?.toULong() }); 3 -> Layered.Blob(blob_v0!!); 4 -> Layered.Plain(plain_v0); else -> throw IllegalArgumentException("Layered: invalid tag $tag") }
+}
+
 internal fun interface LookupBuilderRaw<out R> {
     public fun run(tag: Int, found_v0: Long, failed_v0: String?): R
 }
@@ -1782,6 +1897,21 @@ public fun lookupEach(n: Long, total: Double, sink: LookupCallback, onError: Jni
     val __bcap = JniErrorHandlerCapture.acquire()
     CovNative.lookupEach(n, total, sink.asRaw(), __bcap)
     if (__bcap.failed) return onError.run(__bcap.ze0)
+}
+
+/**
+ * Build a [`Layered`], one `which` per alternative and per case within it:
+ * `0` absent count, `1` present count, `2` absent handle, `3` present handle,
+ * `4` a list mixing present and absent, `5` a byte run, anything else `Plain`.
+ *
+ * The Rust `Layered` result is delivered decomposed: the builder callback receives (`tag`, `count_v0`, `held_v0`, `many_v0`, `blob_v0`, `plain_v0`).
+ */
+@Suppress("UNCHECKED_CAST")
+public fun layeredOf(which: Int, onError: JniErrorHandler<Layered?>): Layered? {
+    val __bcap = JniErrorHandlerCapture.acquire()
+    val __ret = CovNative.layeredOf(which, __LayeredBuilderRaw, __bcap)
+    if (__bcap.failed) return onError.run(__bcap.ze0)
+    return __ret as Layered
 }
 
 /** Build a [`Verdict`] whose outcome comes from [`lookup_of`]. */

--- a/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest/model.kt
+++ b/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest/model.kt
@@ -135,6 +135,16 @@ public sealed interface Layered : AutoCloseable {
     }
 
     /**
+     * Layers nest: the element of this run is another run, so the leaf's
+     * conversion belongs two levels down and a walk that unrolls a fixed two
+     * applies it one level too high.
+     */
+    public data class Nested(public val v0: List<List<ULong?>>) : Layered {
+        override fun close() {
+        }
+    }
+
+    /**
      * A control: a run of values that needs no element conversion, and whose
      * Kotlin type is not a `List` at all.
      */
@@ -169,6 +179,7 @@ public sealed interface Layered : AutoCloseable {
             held_v0: Summary?,
             many_v0: List<ULong?>,
             values_v0: List<ULong?>?,
+            nested_v0: List<List<ULong?>>,
             blob_v0: ByteArray,
             plain_v0: Long,
         ): Layered =
@@ -177,8 +188,9 @@ public sealed interface Layered : AutoCloseable {
                 1 -> Held(held_v0)
                 2 -> Many(many_v0)
                 3 -> Values(values_v0)
-                4 -> Blob(blob_v0)
-                5 -> Plain(plain_v0)
+                4 -> Nested(nested_v0)
+                5 -> Blob(blob_v0)
+                6 -> Plain(plain_v0)
                 else -> throw IllegalArgumentException("Layered: invalid tag $tag")
             }
     }
@@ -1306,6 +1318,7 @@ internal fun interface LayeredBuilderRaw<out R> {
         held_v0: Long?,
         many_v0: List<Long?>?,
         values_v0: List<Long?>?,
+        nested_v0: List<List<Long?>>?,
         blob_v0: ByteArray?,
         plain_v0: Long,
     ): R
@@ -1313,8 +1326,8 @@ internal fun interface LayeredBuilderRaw<out R> {
 
 @get:JvmSynthetic
 internal val __LayeredBuilderRaw: LayeredBuilderRaw<Layered> =
-LayeredBuilderRaw { tag, count_v0, held_v0, many_v0, values_v0, blob_v0, plain_v0 ->
-    when (tag) { 0 -> Layered.Count(count_v0?.toULong()); 1 -> Layered.Held(held_v0?.let { Summary.fromRawPtr(it) }); 2 -> Layered.Many(many_v0!!.map { it?.toULong() }); 3 -> Layered.Values(values_v0?.map { it?.toULong() }); 4 -> Layered.Blob(blob_v0!!); 5 -> Layered.Plain(plain_v0); else -> throw IllegalArgumentException("Layered: invalid tag $tag") }
+LayeredBuilderRaw { tag, count_v0, held_v0, many_v0, values_v0, nested_v0, blob_v0, plain_v0 ->
+    when (tag) { 0 -> Layered.Count(count_v0?.toULong()); 1 -> Layered.Held(held_v0?.let { Summary.fromRawPtr(it) }); 2 -> Layered.Many(many_v0!!.map { it?.toULong() }); 3 -> Layered.Values(values_v0?.map { it?.toULong() }); 4 -> Layered.Nested(nested_v0!!.map { it.map { __e1 -> __e1?.toULong() } }); 5 -> Layered.Blob(blob_v0!!); 6 -> Layered.Plain(plain_v0); else -> throw IllegalArgumentException("Layered: invalid tag $tag") }
 }
 
 internal fun interface LookupBuilderRaw<out R> {
@@ -1916,9 +1929,9 @@ public fun lookupEach(n: Long, total: Double, sink: LookupCallback, onError: Jni
  * Build a [`Layered`], one `which` per alternative and per case within it:
  * `0` absent count, `1` present count, `2` absent handle, `3` present handle,
  * `4` a list mixing present and absent, `5` an absent run, `6` a present run,
- * `7` a byte run, anything else `Plain`.
+ * `7` a run of runs, `8` a byte run, anything else `Plain`.
  *
- * The Rust `Layered` result is delivered decomposed: the builder callback receives (`tag`, `count_v0`, `held_v0`, `many_v0`, `values_v0`, `blob_v0`, `plain_v0`).
+ * The Rust `Layered` result is delivered decomposed: the builder callback receives (`tag`, `count_v0`, `held_v0`, `many_v0`, `values_v0`, `nested_v0`, `blob_v0`, `plain_v0`).
  */
 @Suppress("UNCHECKED_CAST")
 public fun layeredOf(which: Int, onError: JniErrorHandler<Layered?>): Layered? {

--- a/examples/covertest-kotlin/kotlin/io/prebindgen/covertest/Test.kt
+++ b/examples/covertest-kotlin/kotlin/io/prebindgen/covertest/Test.kt
@@ -952,9 +952,15 @@ fun main() {
         // arrives element by element rather than as one null.
         check((layeredOf(4, boom).orThrow() as Layered.Many).v0 == listOf(1uL, null, 3uL))
 
+        // …and the same two layers in the other order. An absent run is null
+        // rather than an empty list, and a present one still converts element by
+        // element.
+        check((layeredOf(5, boom).orThrow() as Layered.Values).v0 == null)
+        check((layeredOf(6, boom).orThrow() as Layered.Values).v0 == listOf(5uL, null))
+
         // The controls. A `Vec<u8>` payload is a `ByteArray`, and a payload with
         // no layer is passed straight through.
-        check((layeredOf(5, boom).orThrow() as Layered.Blob).v0.toList() == listOf<Byte>(1, 2, 3))
+        check((layeredOf(7, boom).orThrow() as Layered.Blob).v0.toList() == listOf<Byte>(1, 2, 3))
         check((layeredOf(9, boom).orThrow() as Layered.Plain).v0 == 7L)
     }
 

--- a/examples/covertest-kotlin/kotlin/io/prebindgen/covertest/Test.kt
+++ b/examples/covertest-kotlin/kotlin/io/prebindgen/covertest/Test.kt
@@ -958,9 +958,15 @@ fun main() {
         check((layeredOf(5, boom).orThrow() as Layered.Values).v0 == null)
         check((layeredOf(6, boom).orThrow() as Layered.Values).v0 == listOf(5uL, null))
 
+        // Layers nest, and the conversion belongs at the bottom of the stack.
+        check(
+            (layeredOf(7, boom).orThrow() as Layered.Nested).v0 ==
+                listOf(listOf(6uL, null), emptyList())
+        )
+
         // The controls. A `Vec<u8>` payload is a `ByteArray`, and a payload with
         // no layer is passed straight through.
-        check((layeredOf(7, boom).orThrow() as Layered.Blob).v0.toList() == listOf<Byte>(1, 2, 3))
+        check((layeredOf(8, boom).orThrow() as Layered.Blob).v0.toList() == listOf<Byte>(1, 2, 3))
         check((layeredOf(9, boom).orThrow() as Layered.Plain).v0 == 7L)
     }
 

--- a/examples/covertest-kotlin/kotlin/io/prebindgen/covertest/Test.kt
+++ b/examples/covertest-kotlin/kotlin/io/prebindgen/covertest/Test.kt
@@ -37,6 +37,7 @@ import io.prebindgen.covertest.model.ObjectBoundaryLeaf
 import io.prebindgen.covertest.model.Priority
 import io.prebindgen.covertest.model.Hold
 import io.prebindgen.covertest.model.HoldPolicy
+import io.prebindgen.covertest.model.Layered
 import io.prebindgen.covertest.model.Lookup
 import io.prebindgen.covertest.model.Reading
 import io.prebindgen.covertest.model.Stamp
@@ -89,6 +90,7 @@ import io.prebindgen.covertest.model.reportEach
 import io.prebindgen.covertest.model.probeEach
 import io.prebindgen.covertest.model.probeNew
 import io.prebindgen.covertest.model.lookupOf
+import io.prebindgen.covertest.model.layeredOf
 import io.prebindgen.covertest.model.verdictNew
 import io.prebindgen.covertest.model.dossierNew
 import io.prebindgen.covertest.model.archiveReading
@@ -923,6 +925,37 @@ fun main() {
         check(taggedRank(Tagged(1L, markerOf(0, boom).orThrow()), boom) == -1)
         check(taggedRank(Tagged(1L, markerOf(1, boom).orThrow()), boom) == 0)
         check(taggedRank(Tagged(1L, markerOf(2, boom).orThrow()), boom) == 10)
+    }
+
+    // The sum whose payloads have LAYERS. The class that reassembles a variant
+    // from wire slots is Kotlin, and between a slot and the property there can
+    // be a collection, an `Option`, and the leaf conversion. Applying the leaf's
+    // conversion straight to the slot compiled nothing at all (#429), and the
+    // Rust half is identical either way — so a compiled run is the only thing
+    // that holds this line. The two controls at the end are half of it: a run
+    // that needs no element conversion must NOT be distributed over, or a
+    // `ByteArray` property comes back a `List<Byte>`.
+    section("a sum payload carries its Option and collection layers") {
+        // `Option<u64>`: JVM null is the absent case, not an error.
+        check((layeredOf(0, boom).orThrow() as Layered.Count).v0 == null)
+        check((layeredOf(1, boom).orThrow() as Layered.Count).v0 == 4uL)
+
+        // `Option<handle>` — `Layered.Held` — is COMPILED here and not called:
+        // its slot is declared a boxed `Long?` while the Rust side writes a
+        // primitive into it, so invoking either case throws (#433). That is a
+        // defect in the wire under this one, not in the layer carrying that
+        // #429 fixed, and the builder line above is compiled either way, which
+        // is the guard this section is for. Add the two calls here when #433
+        // lands.
+
+        // `Vec<Option<u64>>`: the absences are inside the list, so a mixed one
+        // arrives element by element rather than as one null.
+        check((layeredOf(4, boom).orThrow() as Layered.Many).v0 == listOf(1uL, null, 3uL))
+
+        // The controls. A `Vec<u8>` payload is a `ByteArray`, and a payload with
+        // no layer is passed straight through.
+        check((layeredOf(5, boom).orThrow() as Layered.Blob).v0.toList() == listOf<Byte>(1, 2, 3))
+        check((layeredOf(9, boom).orThrow() as Layered.Plain).v0 == 7L)
     }
 
     // ── value_class: by-value bytes, instance accessors, Vec<value> → List ────

--- a/examples/covertest-kotlin/src/generated_bindings.rs
+++ b/examples/covertest-kotlin/src/generated_bindings.rs
@@ -2224,159 +2224,6 @@ pub(crate) unsafe fn JObject_to_Holder_c36a9705<'env, 'v>(
     clippy::nonminimal_bool,
     clippy::eq_op
 )]
-pub(crate) unsafe fn JObject_to_Layered_ed4c30e9<'env, 'v>(
-    env: &mut jni::JNIEnv<'env>,
-    v: &jni::objects::JObject<'v>,
-) -> ::core::result::Result<perftest_flat::Layered, __JniErr> {
-    Ok({
-        let __obj = v;
-        (|| -> ::core::result::Result<perftest_flat::Layered, __JniErr> {
-            if __obj.is_null() {
-                return ::core::result::Result::Err(
-                    <__JniErr as ::core::convert::From<
-                        String,
-                    >>::from(
-                        "Layered: null value where a variant was required".to_string(),
-                    ),
-                );
-            }
-            if env
-                .is_instance_of(__obj, "io/prebindgen/covertest/model/Layered$Count")
-                .map_err(|e| <__JniErr as ::core::convert::From<
-                    String,
-                >>::from(
-                    format!(
-                        concat!("Layered", ": instanceof ",
-                        "io/prebindgen/covertest/model/Layered$Count", ": {}"), e
-                    ),
-                ))?
-            {
-                let __p_v0_raw: jni::objects::JObject = env
-                    .get_field(__obj, "v0", "Ljava/lang/Object;")
-                    .and_then(|val| val.l())
-                    .map_err(|e| <__JniErr as ::core::convert::From<
-                        String,
-                    >>::from(format!("Layered.Count.v0: {}", e)))?;
-                let __p_v0 = JObject_to_Option_u64_32be16a2(env, &__p_v0_raw)?;
-                return ::core::result::Result::Ok(perftest_flat::Layered::Count(__p_v0));
-            }
-            if env
-                .is_instance_of(__obj, "io/prebindgen/covertest/model/Layered$Held")
-                .map_err(|e| <__JniErr as ::core::convert::From<
-                    String,
-                >>::from(
-                    format!(
-                        concat!("Layered", ": instanceof ",
-                        "io/prebindgen/covertest/model/Layered$Held", ": {}"), e
-                    ),
-                ))?
-            {
-                let __p_v0_obj: jni::objects::JObject = env
-                    .get_field(
-                        __obj,
-                        "v0",
-                        "Lio/prebindgen/covertest/analytics/Summary;",
-                    )
-                    .and_then(|val| val.l())
-                    .map_err(|e| <__JniErr as ::core::convert::From<
-                        String,
-                    >>::from(format!("Layered.Held.v0: {}", e)))?;
-                let __p_v0_raw: jni::sys::jlong = if __p_v0_obj.is_null() {
-                    0
-                } else {
-                    env.call_method(&__p_v0_obj, "peek", "()J", &[])
-                        .and_then(|val| val.j())
-                        .map_err(|e| <__JniErr as ::core::convert::From<
-                            String,
-                        >>::from(format!("Layered.Held.v0: {}", e)))?
-                };
-                let __p_v0 = jlong_to_Option_Summary_252ef2ba(env, &__p_v0_raw)?;
-                return ::core::result::Result::Ok(perftest_flat::Layered::Held(__p_v0));
-            }
-            if env
-                .is_instance_of(__obj, "io/prebindgen/covertest/model/Layered$Many")
-                .map_err(|e| <__JniErr as ::core::convert::From<
-                    String,
-                >>::from(
-                    format!(
-                        concat!("Layered", ": instanceof ",
-                        "io/prebindgen/covertest/model/Layered$Many", ": {}"), e
-                    ),
-                ))?
-            {
-                let __p_v0_raw: jni::objects::JObject = env
-                    .get_field(__obj, "v0", "Ljava/util/List;")
-                    .and_then(|val| val.l())
-                    .map_err(|e| <__JniErr as ::core::convert::From<
-                        String,
-                    >>::from(format!("Layered.Many.v0: {}", e)))?;
-                let __p_v0 = JObject_to_Vec_Option_u64_a34190e7(env, &__p_v0_raw)?;
-                return ::core::result::Result::Ok(perftest_flat::Layered::Many(__p_v0));
-            }
-            if env
-                .is_instance_of(__obj, "io/prebindgen/covertest/model/Layered$Blob")
-                .map_err(|e| <__JniErr as ::core::convert::From<
-                    String,
-                >>::from(
-                    format!(
-                        concat!("Layered", ": instanceof ",
-                        "io/prebindgen/covertest/model/Layered$Blob", ": {}"), e
-                    ),
-                ))?
-            {
-                let __p_v0_obj: jni::objects::JObject = env
-                    .get_field(__obj, "v0", "[B")
-                    .and_then(|val| val.l())
-                    .map_err(|e| <__JniErr as ::core::convert::From<
-                        String,
-                    >>::from(format!("Layered.Blob.v0: {}", e)))?;
-                let __p_v0_raw: jni::objects::JByteArray = __p_v0_obj.into();
-                let __p_v0 = JByteArray_to_Vec_u8_7936d5de(env, &__p_v0_raw)?;
-                return ::core::result::Result::Ok(perftest_flat::Layered::Blob(__p_v0));
-            }
-            if env
-                .is_instance_of(__obj, "io/prebindgen/covertest/model/Layered$Plain")
-                .map_err(|e| <__JniErr as ::core::convert::From<
-                    String,
-                >>::from(
-                    format!(
-                        concat!("Layered", ": instanceof ",
-                        "io/prebindgen/covertest/model/Layered$Plain", ": {}"), e
-                    ),
-                ))?
-            {
-                let __p_v0_raw: jni::sys::jlong = env
-                    .get_field(__obj, "v0", "J")
-                    .and_then(|val| val.j())
-                    .map_err(|e| <__JniErr as ::core::convert::From<
-                        String,
-                    >>::from(format!("Layered.Plain.v0: {}", e)))? as _;
-                let __p_v0 = jlong_to_i64_fbf9a9bc(env, &__p_v0_raw)?;
-                return ::core::result::Result::Ok(perftest_flat::Layered::Plain(__p_v0));
-            }
-            ::core::result::Result::Err(
-                <__JniErr as ::core::convert::From<
-                    String,
-                >>::from(
-                    "Layered: value is not one of its declared variants".to_string(),
-                ),
-            )
-        })()?
-    })
-}
-#[allow(
-    non_snake_case,
-    unused_mut,
-    unused_variables,
-    unused_braces,
-    unused_parens,
-    dead_code,
-    clippy::useless_conversion,
-    clippy::needless_question_mark,
-    clippy::let_and_return,
-    clippy::nonminimal_bool,
-    clippy::eq_op
-)]
 pub(crate) unsafe fn JObject_to_Lookup_94ada15e<'env, 'v>(
     env: &mut jni::JNIEnv<'env>,
     v: &jni::objects::JObject<'v>,
@@ -9274,6 +9121,33 @@ pub(crate) unsafe fn Option_Summary_to_jlong_828826f3<'a>(
     clippy::nonminimal_bool,
     clippy::eq_op
 )]
+pub(crate) unsafe fn Option_Vec_Option_u64_to_JObject_006312b6<'a>(
+    env: &mut jni::JNIEnv<'a>,
+    v: Option<Vec<Option<u64>>>,
+) -> ::core::result::Result<jni::objects::JObject<'a>, __JniErr> {
+    Ok({
+        let v: Option<Vec<Option<u64>>> = v;
+        {
+            match v {
+                Some(value) => Vec_Option_u64_to_JObject_a34190e7(env, value)?,
+                None => jni::objects::JObject::null().into(),
+            }
+        }
+    })
+}
+#[allow(
+    non_snake_case,
+    unused_mut,
+    unused_variables,
+    unused_braces,
+    unused_parens,
+    dead_code,
+    clippy::useless_conversion,
+    clippy::needless_question_mark,
+    clippy::let_and_return,
+    clippy::nonminimal_bool,
+    clippy::eq_op
+)]
 pub(crate) unsafe fn Option_Vec_Payload_to_JObject_b9a4637e<'a>(
     env: &mut jni::JNIEnv<'a>,
     v: Option<Vec<perftest_flat::Payload>>,
@@ -15749,14 +15623,15 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_layeredOf<'a>(
     #[allow(non_upper_case_globals)]
     static __CB_MID: ::prebindgen_jni_runtime::CachedIfaceMethod = ::prebindgen_jni_runtime::CachedIfaceMethod::new();
     const __CB_FQN: &str = "io/prebindgen/covertest/model/LayeredBuilderRaw";
-    const __CB_DESCR: &str = "(ILjava/lang/Long;Ljava/lang/Long;Ljava/util/List;[BJ)Ljava/lang/Object;";
+    const __CB_DESCR: &str = "(ILjava/lang/Long;Ljava/lang/Long;Ljava/util/List;Ljava/util/List;[BJ)Ljava/lang/Object;";
     let __out = perftest_flat::layered_of(which);
     let __obj0: jni::sys::jvalue;
     let __obj1: jni::objects::JObject;
     let __obj2: jni::sys::jvalue;
     let __obj3: jni::objects::JObject;
     let __obj4: jni::objects::JObject;
-    let __obj5: jni::sys::jvalue;
+    let __obj5: jni::objects::JObject;
+    let __obj6: jni::sys::jvalue;
     match &__out {
         perftest_flat::Layered::Count(__sv0) => {
             let __enc___obj1 = match Option_u64_to_JObject_32be16a2(
@@ -15781,7 +15656,8 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_layeredOf<'a>(
             __obj2 = jni::sys::jvalue { j: 0i64 };
             __obj3 = jni::objects::JObject::null();
             __obj4 = jni::objects::JObject::null();
-            __obj5 = jni::sys::jvalue { j: 0i64 };
+            __obj5 = jni::objects::JObject::null();
+            __obj6 = jni::sys::jvalue { j: 0i64 };
         }
         perftest_flat::Layered::Held(__sv0) => {
             let __enc___obj2 = match Option_Summary_to_jlong_252ef2ba(
@@ -15808,7 +15684,8 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_layeredOf<'a>(
             __obj1 = jni::objects::JObject::null();
             __obj3 = jni::objects::JObject::null();
             __obj4 = jni::objects::JObject::null();
-            __obj5 = jni::sys::jvalue { j: 0i64 };
+            __obj5 = jni::objects::JObject::null();
+            __obj6 = jni::sys::jvalue { j: 0i64 };
         }
         perftest_flat::Layered::Many(__sv0) => {
             let __enc___obj3 = match Vec_Option_u64_to_JObject_a34190e7(
@@ -15833,10 +15710,11 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_layeredOf<'a>(
             __obj1 = jni::objects::JObject::null();
             __obj2 = jni::sys::jvalue { j: 0i64 };
             __obj4 = jni::objects::JObject::null();
-            __obj5 = jni::sys::jvalue { j: 0i64 };
+            __obj5 = jni::objects::JObject::null();
+            __obj6 = jni::sys::jvalue { j: 0i64 };
         }
-        perftest_flat::Layered::Blob(__sv0) => {
-            let __enc___obj4 = match Vec_u8_to_JByteArray_7936d5de(
+        perftest_flat::Layered::Values(__sv0) => {
+            let __enc___obj4 = match Option_Vec_Option_u64_to_JObject_006312b6(
                 &mut env,
                 __sv0.clone(),
             ) {
@@ -15853,15 +15731,19 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_layeredOf<'a>(
                     return jni::objects::JObject::null().into();
                 }
             };
-            __obj4 = __enc___obj4.into();
+            __obj4 = __enc___obj4;
             __obj0 = jni::sys::jvalue { i: 3 };
             __obj1 = jni::objects::JObject::null();
             __obj2 = jni::sys::jvalue { j: 0i64 };
             __obj3 = jni::objects::JObject::null();
-            __obj5 = jni::sys::jvalue { j: 0i64 };
+            __obj5 = jni::objects::JObject::null();
+            __obj6 = jni::sys::jvalue { j: 0i64 };
         }
-        perftest_flat::Layered::Plain(__sv0) => {
-            let __enc___obj5 = match i64_to_jlong_fbf9a9bc(&mut env, __sv0.clone()) {
+        perftest_flat::Layered::Blob(__sv0) => {
+            let __enc___obj5 = match Vec_u8_to_JByteArray_7936d5de(
+                &mut env,
+                __sv0.clone(),
+            ) {
                 ::core::result::Result::Ok(__w) => __w,
                 ::core::result::Result::Err(__e) => {
                     signal_binding_error(
@@ -15875,14 +15757,38 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_layeredOf<'a>(
                     return jni::objects::JObject::null().into();
                 }
             };
-            __obj5 = jni::sys::jvalue {
-                j: __enc___obj5,
-            };
+            __obj5 = __enc___obj5.into();
             __obj0 = jni::sys::jvalue { i: 4 };
             __obj1 = jni::objects::JObject::null();
             __obj2 = jni::sys::jvalue { j: 0i64 };
             __obj3 = jni::objects::JObject::null();
             __obj4 = jni::objects::JObject::null();
+            __obj6 = jni::sys::jvalue { j: 0i64 };
+        }
+        perftest_flat::Layered::Plain(__sv0) => {
+            let __enc___obj6 = match i64_to_jlong_fbf9a9bc(&mut env, __sv0.clone()) {
+                ::core::result::Result::Ok(__w) => __w,
+                ::core::result::Result::Err(__e) => {
+                    signal_binding_error(
+                        &mut env,
+                        &__error_sink,
+                        &__SINK_MID,
+                        __SINK_FQN,
+                        __SINK_DESCR,
+                        &__e.to_string(),
+                    );
+                    return jni::objects::JObject::null().into();
+                }
+            };
+            __obj6 = jni::sys::jvalue {
+                j: __enc___obj6,
+            };
+            __obj0 = jni::sys::jvalue { i: 5 };
+            __obj1 = jni::objects::JObject::null();
+            __obj2 = jni::sys::jvalue { j: 0i64 };
+            __obj3 = jni::objects::JObject::null();
+            __obj4 = jni::objects::JObject::null();
+            __obj5 = jni::objects::JObject::null();
         }
     }
     match __CB_MID
@@ -15904,7 +15810,10 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_layeredOf<'a>(
                 jni::sys::jvalue {
                     l: __obj4.as_raw(),
                 },
-                __obj5,
+                jni::sys::jvalue {
+                    l: __obj5.as_raw(),
+                },
+                __obj6,
             ],
         )
     {

--- a/examples/covertest-kotlin/src/generated_bindings.rs
+++ b/examples/covertest-kotlin/src/generated_bindings.rs
@@ -2224,6 +2224,159 @@ pub(crate) unsafe fn JObject_to_Holder_c36a9705<'env, 'v>(
     clippy::nonminimal_bool,
     clippy::eq_op
 )]
+pub(crate) unsafe fn JObject_to_Layered_ed4c30e9<'env, 'v>(
+    env: &mut jni::JNIEnv<'env>,
+    v: &jni::objects::JObject<'v>,
+) -> ::core::result::Result<perftest_flat::Layered, __JniErr> {
+    Ok({
+        let __obj = v;
+        (|| -> ::core::result::Result<perftest_flat::Layered, __JniErr> {
+            if __obj.is_null() {
+                return ::core::result::Result::Err(
+                    <__JniErr as ::core::convert::From<
+                        String,
+                    >>::from(
+                        "Layered: null value where a variant was required".to_string(),
+                    ),
+                );
+            }
+            if env
+                .is_instance_of(__obj, "io/prebindgen/covertest/model/Layered$Count")
+                .map_err(|e| <__JniErr as ::core::convert::From<
+                    String,
+                >>::from(
+                    format!(
+                        concat!("Layered", ": instanceof ",
+                        "io/prebindgen/covertest/model/Layered$Count", ": {}"), e
+                    ),
+                ))?
+            {
+                let __p_v0_raw: jni::objects::JObject = env
+                    .get_field(__obj, "v0", "Ljava/lang/Object;")
+                    .and_then(|val| val.l())
+                    .map_err(|e| <__JniErr as ::core::convert::From<
+                        String,
+                    >>::from(format!("Layered.Count.v0: {}", e)))?;
+                let __p_v0 = JObject_to_Option_u64_32be16a2(env, &__p_v0_raw)?;
+                return ::core::result::Result::Ok(perftest_flat::Layered::Count(__p_v0));
+            }
+            if env
+                .is_instance_of(__obj, "io/prebindgen/covertest/model/Layered$Held")
+                .map_err(|e| <__JniErr as ::core::convert::From<
+                    String,
+                >>::from(
+                    format!(
+                        concat!("Layered", ": instanceof ",
+                        "io/prebindgen/covertest/model/Layered$Held", ": {}"), e
+                    ),
+                ))?
+            {
+                let __p_v0_obj: jni::objects::JObject = env
+                    .get_field(
+                        __obj,
+                        "v0",
+                        "Lio/prebindgen/covertest/analytics/Summary;",
+                    )
+                    .and_then(|val| val.l())
+                    .map_err(|e| <__JniErr as ::core::convert::From<
+                        String,
+                    >>::from(format!("Layered.Held.v0: {}", e)))?;
+                let __p_v0_raw: jni::sys::jlong = if __p_v0_obj.is_null() {
+                    0
+                } else {
+                    env.call_method(&__p_v0_obj, "peek", "()J", &[])
+                        .and_then(|val| val.j())
+                        .map_err(|e| <__JniErr as ::core::convert::From<
+                            String,
+                        >>::from(format!("Layered.Held.v0: {}", e)))?
+                };
+                let __p_v0 = jlong_to_Option_Summary_252ef2ba(env, &__p_v0_raw)?;
+                return ::core::result::Result::Ok(perftest_flat::Layered::Held(__p_v0));
+            }
+            if env
+                .is_instance_of(__obj, "io/prebindgen/covertest/model/Layered$Many")
+                .map_err(|e| <__JniErr as ::core::convert::From<
+                    String,
+                >>::from(
+                    format!(
+                        concat!("Layered", ": instanceof ",
+                        "io/prebindgen/covertest/model/Layered$Many", ": {}"), e
+                    ),
+                ))?
+            {
+                let __p_v0_raw: jni::objects::JObject = env
+                    .get_field(__obj, "v0", "Ljava/util/List;")
+                    .and_then(|val| val.l())
+                    .map_err(|e| <__JniErr as ::core::convert::From<
+                        String,
+                    >>::from(format!("Layered.Many.v0: {}", e)))?;
+                let __p_v0 = JObject_to_Vec_Option_u64_a34190e7(env, &__p_v0_raw)?;
+                return ::core::result::Result::Ok(perftest_flat::Layered::Many(__p_v0));
+            }
+            if env
+                .is_instance_of(__obj, "io/prebindgen/covertest/model/Layered$Blob")
+                .map_err(|e| <__JniErr as ::core::convert::From<
+                    String,
+                >>::from(
+                    format!(
+                        concat!("Layered", ": instanceof ",
+                        "io/prebindgen/covertest/model/Layered$Blob", ": {}"), e
+                    ),
+                ))?
+            {
+                let __p_v0_obj: jni::objects::JObject = env
+                    .get_field(__obj, "v0", "[B")
+                    .and_then(|val| val.l())
+                    .map_err(|e| <__JniErr as ::core::convert::From<
+                        String,
+                    >>::from(format!("Layered.Blob.v0: {}", e)))?;
+                let __p_v0_raw: jni::objects::JByteArray = __p_v0_obj.into();
+                let __p_v0 = JByteArray_to_Vec_u8_7936d5de(env, &__p_v0_raw)?;
+                return ::core::result::Result::Ok(perftest_flat::Layered::Blob(__p_v0));
+            }
+            if env
+                .is_instance_of(__obj, "io/prebindgen/covertest/model/Layered$Plain")
+                .map_err(|e| <__JniErr as ::core::convert::From<
+                    String,
+                >>::from(
+                    format!(
+                        concat!("Layered", ": instanceof ",
+                        "io/prebindgen/covertest/model/Layered$Plain", ": {}"), e
+                    ),
+                ))?
+            {
+                let __p_v0_raw: jni::sys::jlong = env
+                    .get_field(__obj, "v0", "J")
+                    .and_then(|val| val.j())
+                    .map_err(|e| <__JniErr as ::core::convert::From<
+                        String,
+                    >>::from(format!("Layered.Plain.v0: {}", e)))? as _;
+                let __p_v0 = jlong_to_i64_fbf9a9bc(env, &__p_v0_raw)?;
+                return ::core::result::Result::Ok(perftest_flat::Layered::Plain(__p_v0));
+            }
+            ::core::result::Result::Err(
+                <__JniErr as ::core::convert::From<
+                    String,
+                >>::from(
+                    "Layered: value is not one of its declared variants".to_string(),
+                ),
+            )
+        })()?
+    })
+}
+#[allow(
+    non_snake_case,
+    unused_mut,
+    unused_variables,
+    unused_braces,
+    unused_parens,
+    dead_code,
+    clippy::useless_conversion,
+    clippy::needless_question_mark,
+    clippy::let_and_return,
+    clippy::nonminimal_bool,
+    clippy::eq_op
+)]
 pub(crate) unsafe fn JObject_to_Lookup_94ada15e<'env, 'v>(
     env: &mut jni::JNIEnv<'env>,
     v: &jni::objects::JObject<'v>,
@@ -3635,6 +3788,47 @@ pub(crate) unsafe fn JObject_to_Vec_Label_3fdf860d<'env, 'v>(
                     >>::from(__e.to_string()))?;
                 __inner_s1
             };
+            __out.push(__elem);
+        }
+        __out
+    })
+}
+#[allow(
+    non_snake_case,
+    unused_mut,
+    unused_variables,
+    unused_braces,
+    unused_parens,
+    dead_code,
+    clippy::useless_conversion,
+    clippy::needless_question_mark,
+    clippy::let_and_return,
+    clippy::nonminimal_bool,
+    clippy::eq_op
+)]
+pub(crate) unsafe fn JObject_to_Vec_Option_u64_a34190e7<'env, 'v>(
+    env: &mut jni::JNIEnv<'env>,
+    v: &jni::objects::JObject<'v>,
+) -> ::core::result::Result<Vec<Option<u64>>, __JniErr> {
+    Ok({
+        let __list = jni::objects::JList::from_env(env, v)
+            .map_err(|e| <__JniErr as ::core::convert::From<
+                String,
+            >>::from(format!("Vec<_>: list-from-env: {}", e)))?;
+        let mut __it = __list
+            .iter(env)
+            .map_err(|e| <__JniErr as ::core::convert::From<
+                String,
+            >>::from(format!("Vec<_>: list-iter: {}", e)))?;
+        let mut __out: Vec<Option<u64>> = Vec::new();
+        while let Some(__obj) = __it
+            .next(env)
+            .map_err(|e| <__JniErr as ::core::convert::From<
+                String,
+            >>::from(format!("Vec<_>: list-next: {}", e)))?
+        {
+            let __elem_wire: jni::objects::JObject = __obj.into();
+            let __elem: Option<u64> = JObject_to_Option_u64_32be16a2(env, &__elem_wire)?;
             __out.push(__elem);
         }
         __out
@@ -9026,6 +9220,33 @@ pub(crate) unsafe fn Option_String_to_JString_56d5e304<'a>(
     clippy::nonminimal_bool,
     clippy::eq_op
 )]
+pub(crate) unsafe fn Option_Summary_to_jlong_252ef2ba<'a>(
+    env: &mut jni::JNIEnv<'a>,
+    v: Option<perftest_flat::Summary>,
+) -> ::core::result::Result<jni::sys::jlong, __JniErr> {
+    Ok({
+        let v: Option<perftest_flat::Summary> = v;
+        {
+            match v {
+                Some(value) => Summary_to_jlong_3cb103b9(env, value)?,
+                None => 0i64,
+            }
+        }
+    })
+}
+#[allow(
+    non_snake_case,
+    unused_mut,
+    unused_variables,
+    unused_braces,
+    unused_parens,
+    dead_code,
+    clippy::useless_conversion,
+    clippy::needless_question_mark,
+    clippy::let_and_return,
+    clippy::nonminimal_bool,
+    clippy::eq_op
+)]
 pub(crate) unsafe fn Option_Summary_to_jlong_828826f3<'a>(
     env: &mut jni::JNIEnv<'a>,
     v: Option<&perftest_flat::Summary>,
@@ -9803,6 +10024,46 @@ pub(crate) unsafe fn Vec_Label_to_JObject_3fdf860d<'a>(
                     >>::from(__e.to_string()))?;
                 String_to_JString_c7f3ca43(env, __inner_s0)?
             };
+            let __elem_obj: jni::objects::JObject = __elem_wire.into();
+            __list
+                .add(env, &__elem_obj)
+                .map_err(|e| <__JniErr as ::core::convert::From<
+                    String,
+                >>::from(format!("Vec<_>: list-add: {}", e)))?;
+        }
+        __list_obj
+    })
+}
+#[allow(
+    non_snake_case,
+    unused_mut,
+    unused_variables,
+    unused_braces,
+    unused_parens,
+    dead_code,
+    clippy::useless_conversion,
+    clippy::needless_question_mark,
+    clippy::let_and_return,
+    clippy::nonminimal_bool,
+    clippy::eq_op
+)]
+pub(crate) unsafe fn Vec_Option_u64_to_JObject_a34190e7<'a>(
+    env: &mut jni::JNIEnv<'a>,
+    v: Vec<Option<u64>>,
+) -> ::core::result::Result<jni::objects::JObject<'a>, __JniErr> {
+    Ok({
+        let v: Vec<Option<u64>> = v;
+        let __list_obj = env
+            .new_object("java/util/ArrayList", "()V", &[])
+            .map_err(|e| <__JniErr as ::core::convert::From<
+                String,
+            >>::from(format!("Vec<_>: new ArrayList: {}", e)))?;
+        let __list = jni::objects::JList::from_env(env, &__list_obj)
+            .map_err(|e| <__JniErr as ::core::convert::From<
+                String,
+            >>::from(format!("Vec<_>: list-from-env: {}", e)))?;
+        for __elem in v.into_iter() {
+            let __elem_wire = Option_u64_to_JObject_32be16a2(env, __elem)?;
             let __elem_obj: jni::objects::JObject = __elem_wire.into();
             __list
                 .add(env, &__elem_obj)
@@ -15453,6 +15714,213 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_labelSeriesEcho<
                 __SINK_FQN,
                 __SINK_DESCR,
                 &__e.to_string(),
+            );
+            jni::objects::JObject::null().into()
+        }
+    }
+}
+#[no_mangle]
+#[allow(non_snake_case, unused_mut, unused_variables, dead_code)]
+pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_layeredOf<'a>(
+    mut env: jni::JNIEnv<'a>,
+    _class: jni::objects::JClass<'a>,
+    which: jni::sys::jint,
+    __builder: jni::objects::JObject<'a>,
+    __error_sink: jni::objects::JObject<'a>,
+) -> jni::objects::JObject<'a> {
+    #[allow(non_upper_case_globals)]
+    static __SINK_MID: ::prebindgen_jni_runtime::CachedIfaceMethod = ::prebindgen_jni_runtime::CachedIfaceMethod::new();
+    const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
+    const __SINK_DESCR: &str = "(Ljava/lang/String;)Ljava/lang/Object;";
+    let which = match jint_to_i32_a3e3b6ef(&mut env, &which) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__e) => {
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e.to_string(),
+            );
+            return jni::objects::JObject::null().into();
+        }
+    };
+    #[allow(non_upper_case_globals)]
+    static __CB_MID: ::prebindgen_jni_runtime::CachedIfaceMethod = ::prebindgen_jni_runtime::CachedIfaceMethod::new();
+    const __CB_FQN: &str = "io/prebindgen/covertest/model/LayeredBuilderRaw";
+    const __CB_DESCR: &str = "(ILjava/lang/Long;Ljava/lang/Long;Ljava/util/List;[BJ)Ljava/lang/Object;";
+    let __out = perftest_flat::layered_of(which);
+    let __obj0: jni::sys::jvalue;
+    let __obj1: jni::objects::JObject;
+    let __obj2: jni::sys::jvalue;
+    let __obj3: jni::objects::JObject;
+    let __obj4: jni::objects::JObject;
+    let __obj5: jni::sys::jvalue;
+    match &__out {
+        perftest_flat::Layered::Count(__sv0) => {
+            let __enc___obj1 = match Option_u64_to_JObject_32be16a2(
+                &mut env,
+                __sv0.clone(),
+            ) {
+                ::core::result::Result::Ok(__w) => __w,
+                ::core::result::Result::Err(__e) => {
+                    signal_binding_error(
+                        &mut env,
+                        &__error_sink,
+                        &__SINK_MID,
+                        __SINK_FQN,
+                        __SINK_DESCR,
+                        &__e.to_string(),
+                    );
+                    return jni::objects::JObject::null().into();
+                }
+            };
+            __obj1 = __enc___obj1;
+            __obj0 = jni::sys::jvalue { i: 0 };
+            __obj2 = jni::sys::jvalue { j: 0i64 };
+            __obj3 = jni::objects::JObject::null();
+            __obj4 = jni::objects::JObject::null();
+            __obj5 = jni::sys::jvalue { j: 0i64 };
+        }
+        perftest_flat::Layered::Held(__sv0) => {
+            let __enc___obj2 = match Option_Summary_to_jlong_252ef2ba(
+                &mut env,
+                __sv0.clone(),
+            ) {
+                ::core::result::Result::Ok(__w) => __w,
+                ::core::result::Result::Err(__e) => {
+                    signal_binding_error(
+                        &mut env,
+                        &__error_sink,
+                        &__SINK_MID,
+                        __SINK_FQN,
+                        __SINK_DESCR,
+                        &__e.to_string(),
+                    );
+                    return jni::objects::JObject::null().into();
+                }
+            };
+            __obj2 = jni::sys::jvalue {
+                j: __enc___obj2,
+            };
+            __obj0 = jni::sys::jvalue { i: 1 };
+            __obj1 = jni::objects::JObject::null();
+            __obj3 = jni::objects::JObject::null();
+            __obj4 = jni::objects::JObject::null();
+            __obj5 = jni::sys::jvalue { j: 0i64 };
+        }
+        perftest_flat::Layered::Many(__sv0) => {
+            let __enc___obj3 = match Vec_Option_u64_to_JObject_a34190e7(
+                &mut env,
+                __sv0.clone(),
+            ) {
+                ::core::result::Result::Ok(__w) => __w,
+                ::core::result::Result::Err(__e) => {
+                    signal_binding_error(
+                        &mut env,
+                        &__error_sink,
+                        &__SINK_MID,
+                        __SINK_FQN,
+                        __SINK_DESCR,
+                        &__e.to_string(),
+                    );
+                    return jni::objects::JObject::null().into();
+                }
+            };
+            __obj3 = __enc___obj3;
+            __obj0 = jni::sys::jvalue { i: 2 };
+            __obj1 = jni::objects::JObject::null();
+            __obj2 = jni::sys::jvalue { j: 0i64 };
+            __obj4 = jni::objects::JObject::null();
+            __obj5 = jni::sys::jvalue { j: 0i64 };
+        }
+        perftest_flat::Layered::Blob(__sv0) => {
+            let __enc___obj4 = match Vec_u8_to_JByteArray_7936d5de(
+                &mut env,
+                __sv0.clone(),
+            ) {
+                ::core::result::Result::Ok(__w) => __w,
+                ::core::result::Result::Err(__e) => {
+                    signal_binding_error(
+                        &mut env,
+                        &__error_sink,
+                        &__SINK_MID,
+                        __SINK_FQN,
+                        __SINK_DESCR,
+                        &__e.to_string(),
+                    );
+                    return jni::objects::JObject::null().into();
+                }
+            };
+            __obj4 = __enc___obj4.into();
+            __obj0 = jni::sys::jvalue { i: 3 };
+            __obj1 = jni::objects::JObject::null();
+            __obj2 = jni::sys::jvalue { j: 0i64 };
+            __obj3 = jni::objects::JObject::null();
+            __obj5 = jni::sys::jvalue { j: 0i64 };
+        }
+        perftest_flat::Layered::Plain(__sv0) => {
+            let __enc___obj5 = match i64_to_jlong_fbf9a9bc(&mut env, __sv0.clone()) {
+                ::core::result::Result::Ok(__w) => __w,
+                ::core::result::Result::Err(__e) => {
+                    signal_binding_error(
+                        &mut env,
+                        &__error_sink,
+                        &__SINK_MID,
+                        __SINK_FQN,
+                        __SINK_DESCR,
+                        &__e.to_string(),
+                    );
+                    return jni::objects::JObject::null().into();
+                }
+            };
+            __obj5 = jni::sys::jvalue {
+                j: __enc___obj5,
+            };
+            __obj0 = jni::sys::jvalue { i: 4 };
+            __obj1 = jni::objects::JObject::null();
+            __obj2 = jni::sys::jvalue { j: 0i64 };
+            __obj3 = jni::objects::JObject::null();
+            __obj4 = jni::objects::JObject::null();
+        }
+    }
+    match __CB_MID
+        .call_object(
+            &mut env,
+            __CB_FQN,
+            "run",
+            __CB_DESCR,
+            &__builder,
+            &[
+                __obj0,
+                jni::sys::jvalue {
+                    l: __obj1.as_raw(),
+                },
+                __obj2,
+                jni::sys::jvalue {
+                    l: __obj3.as_raw(),
+                },
+                jni::sys::jvalue {
+                    l: __obj4.as_raw(),
+                },
+                __obj5,
+            ],
+        )
+    {
+        ::core::result::Result::Ok(__o) => __o,
+        ::core::result::Result::Err(__e) => {
+            let _ = env.exception_describe();
+            let __e2 = <__JniErr as ::core::convert::From<
+                String,
+            >>::from(__e.to_string());
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e2.to_string(),
             );
             jni::objects::JObject::null().into()
         }

--- a/examples/covertest-kotlin/src/generated_bindings.rs
+++ b/examples/covertest-kotlin/src/generated_bindings.rs
@@ -3738,6 +3738,50 @@ pub(crate) unsafe fn JObject_to_Vec_Payload_8b7084d2<'env, 'v>(
     clippy::nonminimal_bool,
     clippy::eq_op
 )]
+pub(crate) unsafe fn JObject_to_Vec_Vec_Option_u64_342a76c6<'env, 'v>(
+    env: &mut jni::JNIEnv<'env>,
+    v: &jni::objects::JObject<'v>,
+) -> ::core::result::Result<Vec<Vec<Option<u64>>>, __JniErr> {
+    Ok({
+        let __list = jni::objects::JList::from_env(env, v)
+            .map_err(|e| <__JniErr as ::core::convert::From<
+                String,
+            >>::from(format!("Vec<_>: list-from-env: {}", e)))?;
+        let mut __it = __list
+            .iter(env)
+            .map_err(|e| <__JniErr as ::core::convert::From<
+                String,
+            >>::from(format!("Vec<_>: list-iter: {}", e)))?;
+        let mut __out: Vec<Vec<Option<u64>>> = Vec::new();
+        while let Some(__obj) = __it
+            .next(env)
+            .map_err(|e| <__JniErr as ::core::convert::From<
+                String,
+            >>::from(format!("Vec<_>: list-next: {}", e)))?
+        {
+            let __elem_wire: jni::objects::JObject = __obj.into();
+            let __elem: Vec<Option<u64>> = JObject_to_Vec_Option_u64_a34190e7(
+                env,
+                &__elem_wire,
+            )?;
+            __out.push(__elem);
+        }
+        __out
+    })
+}
+#[allow(
+    non_snake_case,
+    unused_mut,
+    unused_variables,
+    unused_braces,
+    unused_parens,
+    dead_code,
+    clippy::useless_conversion,
+    clippy::needless_question_mark,
+    clippy::let_and_return,
+    clippy::nonminimal_bool,
+    clippy::eq_op
+)]
 pub(crate) unsafe fn JObject_to_Vec_Vec_u8_43404875<'env, 'v>(
     env: &mut jni::JNIEnv<'env>,
     v: &jni::objects::JObject<'v>,
@@ -10081,6 +10125,46 @@ pub(crate) unsafe fn Vec_String_to_JObject_1e282499<'a>(
     clippy::nonminimal_bool,
     clippy::eq_op
 )]
+pub(crate) unsafe fn Vec_Vec_Option_u64_to_JObject_342a76c6<'a>(
+    env: &mut jni::JNIEnv<'a>,
+    v: Vec<Vec<Option<u64>>>,
+) -> ::core::result::Result<jni::objects::JObject<'a>, __JniErr> {
+    Ok({
+        let v: Vec<Vec<Option<u64>>> = v;
+        let __list_obj = env
+            .new_object("java/util/ArrayList", "()V", &[])
+            .map_err(|e| <__JniErr as ::core::convert::From<
+                String,
+            >>::from(format!("Vec<_>: new ArrayList: {}", e)))?;
+        let __list = jni::objects::JList::from_env(env, &__list_obj)
+            .map_err(|e| <__JniErr as ::core::convert::From<
+                String,
+            >>::from(format!("Vec<_>: list-from-env: {}", e)))?;
+        for __elem in v.into_iter() {
+            let __elem_wire = Vec_Option_u64_to_JObject_a34190e7(env, __elem)?;
+            let __elem_obj: jni::objects::JObject = __elem_wire.into();
+            __list
+                .add(env, &__elem_obj)
+                .map_err(|e| <__JniErr as ::core::convert::From<
+                    String,
+                >>::from(format!("Vec<_>: list-add: {}", e)))?;
+        }
+        __list_obj
+    })
+}
+#[allow(
+    non_snake_case,
+    unused_mut,
+    unused_variables,
+    unused_braces,
+    unused_parens,
+    dead_code,
+    clippy::useless_conversion,
+    clippy::needless_question_mark,
+    clippy::let_and_return,
+    clippy::nonminimal_bool,
+    clippy::eq_op
+)]
 pub(crate) unsafe fn Vec_Vec_u8_to_JObject_43404875<'a>(
     env: &mut jni::JNIEnv<'a>,
     v: Vec<Vec<u8>>,
@@ -15623,7 +15707,7 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_layeredOf<'a>(
     #[allow(non_upper_case_globals)]
     static __CB_MID: ::prebindgen_jni_runtime::CachedIfaceMethod = ::prebindgen_jni_runtime::CachedIfaceMethod::new();
     const __CB_FQN: &str = "io/prebindgen/covertest/model/LayeredBuilderRaw";
-    const __CB_DESCR: &str = "(ILjava/lang/Long;Ljava/lang/Long;Ljava/util/List;Ljava/util/List;[BJ)Ljava/lang/Object;";
+    const __CB_DESCR: &str = "(ILjava/lang/Long;Ljava/lang/Long;Ljava/util/List;Ljava/util/List;Ljava/util/List;[BJ)Ljava/lang/Object;";
     let __out = perftest_flat::layered_of(which);
     let __obj0: jni::sys::jvalue;
     let __obj1: jni::objects::JObject;
@@ -15631,7 +15715,8 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_layeredOf<'a>(
     let __obj3: jni::objects::JObject;
     let __obj4: jni::objects::JObject;
     let __obj5: jni::objects::JObject;
-    let __obj6: jni::sys::jvalue;
+    let __obj6: jni::objects::JObject;
+    let __obj7: jni::sys::jvalue;
     match &__out {
         perftest_flat::Layered::Count(__sv0) => {
             let __enc___obj1 = match Option_u64_to_JObject_32be16a2(
@@ -15657,7 +15742,8 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_layeredOf<'a>(
             __obj3 = jni::objects::JObject::null();
             __obj4 = jni::objects::JObject::null();
             __obj5 = jni::objects::JObject::null();
-            __obj6 = jni::sys::jvalue { j: 0i64 };
+            __obj6 = jni::objects::JObject::null();
+            __obj7 = jni::sys::jvalue { j: 0i64 };
         }
         perftest_flat::Layered::Held(__sv0) => {
             let __enc___obj2 = match Option_Summary_to_jlong_252ef2ba(
@@ -15685,7 +15771,8 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_layeredOf<'a>(
             __obj3 = jni::objects::JObject::null();
             __obj4 = jni::objects::JObject::null();
             __obj5 = jni::objects::JObject::null();
-            __obj6 = jni::sys::jvalue { j: 0i64 };
+            __obj6 = jni::objects::JObject::null();
+            __obj7 = jni::sys::jvalue { j: 0i64 };
         }
         perftest_flat::Layered::Many(__sv0) => {
             let __enc___obj3 = match Vec_Option_u64_to_JObject_a34190e7(
@@ -15711,7 +15798,8 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_layeredOf<'a>(
             __obj2 = jni::sys::jvalue { j: 0i64 };
             __obj4 = jni::objects::JObject::null();
             __obj5 = jni::objects::JObject::null();
-            __obj6 = jni::sys::jvalue { j: 0i64 };
+            __obj6 = jni::objects::JObject::null();
+            __obj7 = jni::sys::jvalue { j: 0i64 };
         }
         perftest_flat::Layered::Values(__sv0) => {
             let __enc___obj4 = match Option_Vec_Option_u64_to_JObject_006312b6(
@@ -15737,10 +15825,11 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_layeredOf<'a>(
             __obj2 = jni::sys::jvalue { j: 0i64 };
             __obj3 = jni::objects::JObject::null();
             __obj5 = jni::objects::JObject::null();
-            __obj6 = jni::sys::jvalue { j: 0i64 };
+            __obj6 = jni::objects::JObject::null();
+            __obj7 = jni::sys::jvalue { j: 0i64 };
         }
-        perftest_flat::Layered::Blob(__sv0) => {
-            let __enc___obj5 = match Vec_u8_to_JByteArray_7936d5de(
+        perftest_flat::Layered::Nested(__sv0) => {
+            let __enc___obj5 = match Vec_Vec_Option_u64_to_JObject_342a76c6(
                 &mut env,
                 __sv0.clone(),
             ) {
@@ -15757,16 +15846,20 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_layeredOf<'a>(
                     return jni::objects::JObject::null().into();
                 }
             };
-            __obj5 = __enc___obj5.into();
+            __obj5 = __enc___obj5;
             __obj0 = jni::sys::jvalue { i: 4 };
             __obj1 = jni::objects::JObject::null();
             __obj2 = jni::sys::jvalue { j: 0i64 };
             __obj3 = jni::objects::JObject::null();
             __obj4 = jni::objects::JObject::null();
-            __obj6 = jni::sys::jvalue { j: 0i64 };
+            __obj6 = jni::objects::JObject::null();
+            __obj7 = jni::sys::jvalue { j: 0i64 };
         }
-        perftest_flat::Layered::Plain(__sv0) => {
-            let __enc___obj6 = match i64_to_jlong_fbf9a9bc(&mut env, __sv0.clone()) {
+        perftest_flat::Layered::Blob(__sv0) => {
+            let __enc___obj6 = match Vec_u8_to_JByteArray_7936d5de(
+                &mut env,
+                __sv0.clone(),
+            ) {
                 ::core::result::Result::Ok(__w) => __w,
                 ::core::result::Result::Err(__e) => {
                     signal_binding_error(
@@ -15780,15 +15873,40 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_layeredOf<'a>(
                     return jni::objects::JObject::null().into();
                 }
             };
-            __obj6 = jni::sys::jvalue {
-                j: __enc___obj6,
-            };
+            __obj6 = __enc___obj6.into();
             __obj0 = jni::sys::jvalue { i: 5 };
             __obj1 = jni::objects::JObject::null();
             __obj2 = jni::sys::jvalue { j: 0i64 };
             __obj3 = jni::objects::JObject::null();
             __obj4 = jni::objects::JObject::null();
             __obj5 = jni::objects::JObject::null();
+            __obj7 = jni::sys::jvalue { j: 0i64 };
+        }
+        perftest_flat::Layered::Plain(__sv0) => {
+            let __enc___obj7 = match i64_to_jlong_fbf9a9bc(&mut env, __sv0.clone()) {
+                ::core::result::Result::Ok(__w) => __w,
+                ::core::result::Result::Err(__e) => {
+                    signal_binding_error(
+                        &mut env,
+                        &__error_sink,
+                        &__SINK_MID,
+                        __SINK_FQN,
+                        __SINK_DESCR,
+                        &__e.to_string(),
+                    );
+                    return jni::objects::JObject::null().into();
+                }
+            };
+            __obj7 = jni::sys::jvalue {
+                j: __enc___obj7,
+            };
+            __obj0 = jni::sys::jvalue { i: 6 };
+            __obj1 = jni::objects::JObject::null();
+            __obj2 = jni::sys::jvalue { j: 0i64 };
+            __obj3 = jni::objects::JObject::null();
+            __obj4 = jni::objects::JObject::null();
+            __obj5 = jni::objects::JObject::null();
+            __obj6 = jni::objects::JObject::null();
         }
     }
     match __CB_MID
@@ -15813,7 +15931,10 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_layeredOf<'a>(
                 jni::sys::jvalue {
                     l: __obj5.as_raw(),
                 },
-                __obj6,
+                jni::sys::jvalue {
+                    l: __obj6.as_raw(),
+                },
+                __obj7,
             ],
         )
     {

--- a/examples/perftest-flat/src/ext.rs
+++ b/examples/perftest-flat/src/ext.rs
@@ -375,6 +375,10 @@ pub enum Layered {
     /// `Vec<Option<u64>>` — the absences are *inside* the list, so the slot is
     /// un-inerted and the conversion runs per element.
     Many(Vec<Option<u64>>),
+    /// A run under an `Option` — the two layers in the other order. Looking for
+    /// the run without peeling the `Option` first finds none, and the element
+    /// conversion lands on the list.
+    Values(Option<Vec<Option<u64>>>),
     /// A control: a run of values that needs no element conversion, and whose
     /// Kotlin type is not a `List` at all.
     Blob(Vec<u8>),
@@ -384,7 +388,8 @@ pub enum Layered {
 
 /// Build a [`Layered`], one `which` per alternative and per case within it:
 /// `0` absent count, `1` present count, `2` absent handle, `3` present handle,
-/// `4` a list mixing present and absent, `5` a byte run, anything else `Plain`.
+/// `4` a list mixing present and absent, `5` an absent run, `6` a present run,
+/// `7` a byte run, anything else `Plain`.
 #[prebindgen]
 pub fn layered_of(which: i32) -> Layered {
     match which {
@@ -393,7 +398,9 @@ pub fn layered_of(which: i32) -> Layered {
         2 => Layered::Held(None),
         3 => Layered::Held(Some(summary_new(4, 8.0))),
         4 => Layered::Many(vec![Some(1), None, Some(3)]),
-        5 => Layered::Blob(vec![1, 2, 3]),
+        5 => Layered::Values(None),
+        6 => Layered::Values(Some(vec![Some(5), None])),
+        7 => Layered::Blob(vec![1, 2, 3]),
         _ => Layered::Plain(7),
     }
 }

--- a/examples/perftest-flat/src/ext.rs
+++ b/examples/perftest-flat/src/ext.rs
@@ -379,6 +379,10 @@ pub enum Layered {
     /// the run without peeling the `Option` first finds none, and the element
     /// conversion lands on the list.
     Values(Option<Vec<Option<u64>>>),
+    /// Layers nest: the element of this run is another run, so the leaf's
+    /// conversion belongs two levels down and a walk that unrolls a fixed two
+    /// applies it one level too high.
+    Nested(Vec<Vec<Option<u64>>>),
     /// A control: a run of values that needs no element conversion, and whose
     /// Kotlin type is not a `List` at all.
     Blob(Vec<u8>),
@@ -389,7 +393,7 @@ pub enum Layered {
 /// Build a [`Layered`], one `which` per alternative and per case within it:
 /// `0` absent count, `1` present count, `2` absent handle, `3` present handle,
 /// `4` a list mixing present and absent, `5` an absent run, `6` a present run,
-/// `7` a byte run, anything else `Plain`.
+/// `7` a run of runs, `8` a byte run, anything else `Plain`.
 #[prebindgen]
 pub fn layered_of(which: i32) -> Layered {
     match which {
@@ -400,7 +404,8 @@ pub fn layered_of(which: i32) -> Layered {
         4 => Layered::Many(vec![Some(1), None, Some(3)]),
         5 => Layered::Values(None),
         6 => Layered::Values(Some(vec![Some(5), None])),
-        7 => Layered::Blob(vec![1, 2, 3]),
+        7 => Layered::Nested(vec![vec![Some(6), None], vec![]]),
+        8 => Layered::Blob(vec![1, 2, 3]),
         _ => Layered::Plain(7),
     }
 }

--- a/examples/perftest-flat/src/ext.rs
+++ b/examples/perftest-flat/src/ext.rs
@@ -348,6 +348,56 @@ pub fn lookup_of(count: i64, total: f64) -> Lookup {
     }
 }
 
+/// The payload shapes whose **layers** a sum's raw builder has to carry.
+///
+/// Between a wire slot and the property there can be a collection, an `Option`,
+/// and the leaf the wrap knows about, and the builder applied the leaf's
+/// conversion straight to the slot — so a null was dropped, a handle was minted
+/// from a nullable slot, and an element conversion ran on the list itself
+/// (#429). Every one of those is a Kotlin compile error; the Rust half is
+/// identical either way, which is why only a compiled harness can hold the
+/// line.
+///
+/// The last two alternatives are the controls, and they matter as much as the
+/// first three: distributing over a collection is right only when its elements
+/// convert. `Vec<u8>` surfaces as a Kotlin `ByteArray`, and mapping the
+/// identity over one produces a `List<Byte>` — the property's type replaced
+/// rather than preserved.
+#[prebindgen]
+#[derive(Clone)]
+pub enum Layered {
+    /// `Option<u64>` — JVM null is the absent case, so the unsigned conversion
+    /// has to be null-safe rather than applied through it.
+    Count(Option<u64>),
+    /// `Option<Summary>` — the same, over a handle that must be **minted** in
+    /// the present case and left alone in the absent one.
+    Held(Option<Summary>),
+    /// `Vec<Option<u64>>` — the absences are *inside* the list, so the slot is
+    /// un-inerted and the conversion runs per element.
+    Many(Vec<Option<u64>>),
+    /// A control: a run of values that needs no element conversion, and whose
+    /// Kotlin type is not a `List` at all.
+    Blob(Vec<u8>),
+    /// A control: no layer between the slot and the property.
+    Plain(i64),
+}
+
+/// Build a [`Layered`], one `which` per alternative and per case within it:
+/// `0` absent count, `1` present count, `2` absent handle, `3` present handle,
+/// `4` a list mixing present and absent, `5` a byte run, anything else `Plain`.
+#[prebindgen]
+pub fn layered_of(which: i32) -> Layered {
+    match which {
+        0 => Layered::Count(None),
+        1 => Layered::Count(Some(4)),
+        2 => Layered::Held(None),
+        3 => Layered::Held(Some(summary_new(4, 8.0))),
+        4 => Layered::Many(vec![Some(1), None, Some(3)]),
+        5 => Layered::Blob(vec![1, 2, 3]),
+        _ => Layered::Plain(7),
+    }
+}
+
 /// A handle-carrying sum as a **callback argument** — the same `Lookup` that
 /// [`lookup_of`] returns, arriving through `impl Fn` instead. Alternatives are
 /// delivered in `count` order starting at `-1`, so `n >= 3` covers all three:

--- a/prebindgen-jni/src/jni/kotlin_emit.rs
+++ b/prebindgen-jni/src/jni/kotlin_emit.rs
@@ -1619,34 +1619,18 @@ impl Declarations {
     /// The variant-constructor argument for one group leaf: its `run`
     /// parameter, un-inerted and wrapped back into the property type.
     ///
-    /// Three transforms, in this order, one per layer between the wire slot and
-    /// the property. Applying the innermost one to the slot — which is what this
-    /// did — skips the two above it and emits Kotlin that does not compile
-    /// (#429):
+    /// A payload is a stack of layers over one leaf — any number of `Vec`s and
+    /// `Option`s, in any order — and each has its own spelling in Kotlin. The
+    /// wrap belongs to the **leaf**, so it is applied there and nowhere else;
+    /// applying it to the slot instead skipped every layer above it (#429), and
+    /// unrolling a fixed two levels skipped whatever a third one was (#432
+    /// review). [`Self::carry_layers`] walks them.
     ///
-    /// 1. **Un-inert** — an object-shaped group slot is declared nullable
-    ///    (an inert group arrives as JVM null), so inside its own live arm it is
-    ///    re-asserted with `!!`. A payload that is *itself* optional
-    ///    (`Option<T>`) keeps its null: there the JVM null means `None`, and
-    ///    `!!` would turn a legitimately absent value into an exception. A
-    ///    *collection* of optionals is not itself optional — its absences are
-    ///    inside it — so that slot is re-asserted like any other.
-    ///
-    ///    The two layers occur in both orders, and the peel is outermost first:
-    ///    `Option<Vec<T>>` is an optional run, and looking for the run without
-    ///    peeling the `Option` finds none.
-    /// 2. **Distribute** — a `Vec<T>` payload arrives as a run of element slots,
-    ///    so the wrap runs per element rather than on the run. Only when the
-    ///    elements actually convert: a run that needs no conversion is already
-    ///    the property's own type, and `map` would replace it — `Vec<u8>`
-    ///    surfaces as a `ByteArray`, whose `map` is a `List<Byte>`.
-    /// 3. **Wrap** — the raw wire becomes the property: an enum discriminant
-    ///    through `fromInt`, a handle/blob/`ULong` through the interface's own
-    ///    [`WrapKind`](crate::jni::WrapKind), everything else verbatim. Each
-    ///    knows the nullable spelling of itself, which is what carries an
-    ///    `Option` through — except a **niche** representation, where absence is
-    ///    a value in a slot that is not nullable at all and `?.` would not
-    ///    compile.
+    /// This function owns only the step that is not a layer: an object-shaped
+    /// group slot is declared nullable (an inert group arrives as JVM null), so
+    /// inside its own live arm it is re-asserted with `!!`. A payload that is
+    /// *itself* optional keeps its null — there the JVM null means `None`, and
+    /// `!!` would turn a legitimately absent value into an exception.
     fn sum_ctor_arg(
         &self,
         registry: &impl Conversions<KotlinMeta>,
@@ -1656,70 +1640,97 @@ impl Declarations {
         imports: &mut BTreeSet<String>,
     ) -> String {
         // Off the leaf's own reading — no lookup, and a wrapped spelling
-        // answers as the bare one does. Peeled outermost first, because the two
-        // layers occur in both orders: `Vec<Option<T>>` and `Option<Vec<T>>` are
-        // each accepted, and detecting the collection without peeling the
-        // `Option` first sees none on the second.
-        let optional = leaf.out_ty.optional_inner();
-        let under = optional.unwrap_or(&leaf.out_ty);
-        let sequence = under.sequence_elem();
-        let element = sequence.unwrap_or(under);
-        let arg = if param.raw.is_nullable() && optional.is_none() {
+        // answers as the bare one does.
+        let arg = if param.raw.is_nullable() && leaf.out_ty.optional_inner().is_none() {
             format!("{name}!!")
         } else {
             name.to_string()
         };
-        // What the wrap has to spell nullably: inside a run, the element's own
-        // optionality; on a bare payload, the payload's — and then only when
-        // its slot is nullable at all, since a niche representation spells
-        // absence as a value and `?.` on a primitive does not compile.
-        let nullable = if sequence.is_some() {
-            element.optional_inner().is_some()
-        } else {
-            optional.is_some() && param.raw.is_nullable()
-        };
+        self.carry_layers(registry, param, &leaf.out_ty, arg, false, 0, imports)
+    }
 
+    /// One payload layer, and then the rest of them.
+    ///
+    /// `recv` is an expression for the value at this layer and `nullable` says
+    /// whether an `Option` above it left that expression nullable, so each layer
+    /// spells itself over whatever the layer above produced:
+    ///
+    /// * an **`Option`** is not a step of its own — it makes the layer under it
+    ///   nullable, and that layer knows how to say so (`?.map`, `?.let`, a
+    ///   niche's sentinel test);
+    /// * a **run** distributes the rest over its elements, and only when there
+    ///   is something to distribute: a run whose elements convert to themselves
+    ///   already has the property's type, and `map` would replace it — `Vec<u8>`
+    ///   surfaces as a `ByteArray`, whose `map` is a `List<Byte>`;
+    /// * the **leaf** is where the wrap finally applies.
+    ///
+    /// The lambda parameter is implicit at the outermost run and named below it,
+    /// because a nested `it` would shadow the one above.
+    #[allow(clippy::too_many_arguments)]
+    fn carry_layers(
+        &self,
+        registry: &impl Conversions<KotlinMeta>,
+        param: &crate::jni::IfaceParam,
+        ty: &prebindgen_registry::flat::TypeRef,
+        recv: String,
+        nullable: bool,
+        depth: usize,
+        imports: &mut BTreeSet<String>,
+    ) -> String {
+        if let Some(inner) = ty.optional_inner() {
+            return self.carry_layers(registry, param, inner, recv, true, depth, imports);
+        }
+        if let Some(elem) = ty.sequence_elem() {
+            let bound = if depth == 0 {
+                "it".to_string()
+            } else {
+                format!("__e{depth}")
+            };
+            let body = self.carry_layers(
+                registry,
+                param,
+                elem,
+                bound.clone(),
+                false,
+                depth + 1,
+                imports,
+            );
+            if body == bound {
+                return recv;
+            }
+            let lambda = if depth == 0 {
+                body
+            } else {
+                format!("{bound} -> {body}")
+            };
+            let call = if nullable { "?.map" } else { ".map" };
+            return format!("{recv}{call} {{ {lambda} }}");
+        }
+        // The leaf. A niche representation is the one place an optional value is
+        // NOT spelled nullably: absence is a value there, in a slot that is not
+        // nullable at all, and `?.` on a primitive does not compile. Only the
+        // outermost slot can be one — an element of a run is always boxed.
+        let nullable = nullable && (depth > 0 || param.raw.is_nullable());
         // An enum payload rides its `jint` discriminant, so the interface types
         // it `Int` and the wrap has to name the enum class itself — read off the
         // same output-converter metadata `factory_field` reads for an enum
         // struct field.
-        let enum_class = self.is_kotlin_enum_reading(element).then(|| {
-            // The `Option` layer peeled off the model, so the entry lookup takes
-            // the layer's own reading instead of a spelling to look back up.
-            let inner = element.optional_inner().unwrap_or(element);
+        if self.is_kotlin_enum_reading(ty) {
             let name = registry
-                .output_entry(inner)
+                .output_entry(ty)
                 .and_then(|e| e.metadata.kotlin_name.clone())
                 .and_then(|t| t.leaf_name().map(str::to_string))
                 .unwrap_or_else(|| {
-                    panic!(
-                        "sum builder: enum payload `{}` has no Kotlin type on its output converter",
-                        leaf.name
-                    )
+                    panic!("sum builder: enum payload `{ty}` has no Kotlin type on its output converter")
                 });
-            register_fqn(&name, imports)
-        });
-
-        let wrap = |x: &str| match &enum_class {
-            Some(short) if nullable => format!("{x}?.let {{ {short}.fromInt(it) }}"),
-            Some(short) => format!("{short}.fromInt({x})"),
-            None => param.wrap.wrap_expr(x, nullable),
-        };
-        if sequence.is_none() {
-            return wrap(&arg);
+            let short = register_fqn(&name, imports);
+            return if nullable {
+                format!("{recv}?.let {{ {short}.fromInt(it) }}")
+            } else {
+                format!("{short}.fromInt({recv})")
+            };
         }
-        // Distribute only when there is something to distribute. A run of
-        // values whose elements need no conversion already arrives as the
-        // property's own type, and mapping the identity over it would replace
-        // that type rather than preserve it: a `Vec<u8>` payload surfaces as a
-        // Kotlin `ByteArray`, and `ByteArray.map { it }` is a `List<Byte>`.
-        let mapped = wrap("it");
-        if mapped == "it" {
-            return arg;
-        }
-        // A run under an `Option` keeps its null through the distribution too.
-        let map = if optional.is_some() { "?.map" } else { ".map" };
-        format!("{arg}{map} {{ {mapped} }}")
+        param.wrap.wrap_expr(&recv, nullable)
     }
 
     /// The hoisted **folder-appender** singleton for a **whole single-leaf

--- a/prebindgen-jni/src/jni/kotlin_emit.rs
+++ b/prebindgen-jni/src/jni/kotlin_emit.rs
@@ -1631,6 +1631,10 @@ impl Declarations {
     ///    `!!` would turn a legitimately absent value into an exception. A
     ///    *collection* of optionals is not itself optional — its absences are
     ///    inside it — so that slot is re-asserted like any other.
+    ///
+    ///    The two layers occur in both orders, and the peel is outermost first:
+    ///    `Option<Vec<T>>` is an optional run, and looking for the run without
+    ///    peeling the `Option` finds none.
     /// 2. **Distribute** — a `Vec<T>` payload arrives as a run of element slots,
     ///    so the wrap runs per element rather than on the run. Only when the
     ///    elements actually convert: a run that needs no conversion is already
@@ -1652,28 +1656,37 @@ impl Declarations {
         imports: &mut BTreeSet<String>,
     ) -> String {
         // Off the leaf's own reading — no lookup, and a wrapped spelling
-        // answers as the bare one does.
-        let sequence = leaf.out_ty.sequence_elem();
-        let value = sequence.unwrap_or(&leaf.out_ty);
-        let optional = value.optional_inner().is_some();
-        let arg = if param.raw.is_nullable() && !(optional && sequence.is_none()) {
+        // answers as the bare one does. Peeled outermost first, because the two
+        // layers occur in both orders: `Vec<Option<T>>` and `Option<Vec<T>>` are
+        // each accepted, and detecting the collection without peeling the
+        // `Option` first sees none on the second.
+        let optional = leaf.out_ty.optional_inner();
+        let under = optional.unwrap_or(&leaf.out_ty);
+        let sequence = under.sequence_elem();
+        let element = sequence.unwrap_or(under);
+        let arg = if param.raw.is_nullable() && optional.is_none() {
             format!("{name}!!")
         } else {
             name.to_string()
         };
-        // What the wrap has to spell nullably: the element's own optionality
-        // inside a list, and for a bare payload only when the slot is nullable
-        // too.
-        let nullable = optional && (sequence.is_some() || param.raw.is_nullable());
+        // What the wrap has to spell nullably: inside a run, the element's own
+        // optionality; on a bare payload, the payload's — and then only when
+        // its slot is nullable at all, since a niche representation spells
+        // absence as a value and `?.` on a primitive does not compile.
+        let nullable = if sequence.is_some() {
+            element.optional_inner().is_some()
+        } else {
+            optional.is_some() && param.raw.is_nullable()
+        };
 
         // An enum payload rides its `jint` discriminant, so the interface types
         // it `Int` and the wrap has to name the enum class itself — read off the
         // same output-converter metadata `factory_field` reads for an enum
         // struct field.
-        let enum_class = self.is_kotlin_enum_reading(value).then(|| {
+        let enum_class = self.is_kotlin_enum_reading(element).then(|| {
             // The `Option` layer peeled off the model, so the entry lookup takes
             // the layer's own reading instead of a spelling to look back up.
-            let inner = value.optional_inner().unwrap_or(value);
+            let inner = element.optional_inner().unwrap_or(element);
             let name = registry
                 .output_entry(inner)
                 .and_then(|e| e.metadata.kotlin_name.clone())
@@ -1700,12 +1713,13 @@ impl Declarations {
         // property's own type, and mapping the identity over it would replace
         // that type rather than preserve it: a `Vec<u8>` payload surfaces as a
         // Kotlin `ByteArray`, and `ByteArray.map { it }` is a `List<Byte>`.
-        let element = wrap("it");
-        if element == "it" {
-            arg
-        } else {
-            format!("{arg}.map {{ {element} }}")
+        let mapped = wrap("it");
+        if mapped == "it" {
+            return arg;
         }
+        // A run under an `Option` keeps its null through the distribution too.
+        let map = if optional.is_some() { "?.map" } else { ".map" };
+        format!("{arg}{map} {{ {mapped} }}")
     }
 
     /// The hoisted **folder-appender** singleton for a **whole single-leaf

--- a/prebindgen-jni/src/jni/kotlin_emit.rs
+++ b/prebindgen-jni/src/jni/kotlin_emit.rs
@@ -1619,17 +1619,27 @@ impl Declarations {
     /// The variant-constructor argument for one group leaf: its `run`
     /// parameter, un-inerted and wrapped back into the property type.
     ///
-    /// Two independent transforms, in this order:
+    /// Three transforms, in this order, one per layer between the wire slot and
+    /// the property. Applying the innermost one to the slot — which is what this
+    /// did — skips the two above it and emits Kotlin that does not compile
+    /// (#429):
     ///
     /// 1. **Un-inert** — an object-shaped group slot is declared nullable
     ///    (an inert group arrives as JVM null), so inside its own live arm it is
     ///    re-asserted with `!!`. A payload that is *itself* optional
     ///    (`Option<T>`) keeps its null: there the JVM null means `None`, and
-    ///    `!!` would turn a legitimately absent value into an exception.
-    /// 2. **Wrap** — the raw wire becomes the property: an enum discriminant
+    ///    `!!` would turn a legitimately absent value into an exception. A
+    ///    *collection* of optionals is not itself optional — its absences are
+    ///    inside it — so that slot is re-asserted like any other.
+    /// 2. **Distribute** — a `Vec<T>` payload arrives as a `List` of element
+    ///    slots, so the wrap runs per element rather than on the list.
+    /// 3. **Wrap** — the raw wire becomes the property: an enum discriminant
     ///    through `fromInt`, a handle/blob/`ULong` through the interface's own
-    ///    [`WrapKind`](crate::jni::WrapKind), everything else
-    ///    verbatim.
+    ///    [`WrapKind`](crate::jni::WrapKind), everything else verbatim. Each
+    ///    knows the nullable spelling of itself, which is what carries an
+    ///    `Option` through — except a **niche** representation, where absence is
+    ///    a value in a slot that is not nullable at all and `?.` would not
+    ///    compile.
     fn sum_ctor_arg(
         &self,
         registry: &impl Conversions<KotlinMeta>,
@@ -1640,20 +1650,27 @@ impl Declarations {
     ) -> String {
         // Off the leaf's own reading — no lookup, and a wrapped spelling
         // answers as the bare one does.
-        let optional = leaf.out_ty.optional_inner().is_some();
-        let arg = if param.raw.is_nullable() && !optional {
+        let sequence = leaf.out_ty.sequence_elem();
+        let value = sequence.unwrap_or(&leaf.out_ty);
+        let optional = value.optional_inner().is_some();
+        let arg = if param.raw.is_nullable() && !(optional && sequence.is_none()) {
             format!("{name}!!")
         } else {
             name.to_string()
         };
+        // What the wrap has to spell nullably: the element's own optionality
+        // inside a list, and for a bare payload only when the slot is nullable
+        // too.
+        let nullable = optional && (sequence.is_some() || param.raw.is_nullable());
+
         // An enum payload rides its `jint` discriminant, so the interface types
         // it `Int` and the wrap has to name the enum class itself — read off the
         // same output-converter metadata `factory_field` reads for an enum
         // struct field.
-        if self.is_kotlin_enum_reading(&leaf.out_ty) {
+        let enum_class = self.is_kotlin_enum_reading(value).then(|| {
             // The `Option` layer peeled off the model, so the entry lookup takes
             // the layer's own reading instead of a spelling to look back up.
-            let inner = leaf.out_ty.optional_inner().unwrap_or(&leaf.out_ty);
+            let inner = value.optional_inner().unwrap_or(value);
             let name = registry
                 .output_entry(inner)
                 .and_then(|e| e.metadata.kotlin_name.clone())
@@ -1664,14 +1681,18 @@ impl Declarations {
                         leaf.name
                     )
                 });
-            let short = register_fqn(&name, imports);
-            return if optional {
-                format!("{arg}?.let {{ {short}.fromInt(it) }}")
-            } else {
-                format!("{short}.fromInt({arg})")
-            };
+            register_fqn(&name, imports)
+        });
+
+        let wrap = |x: &str| match &enum_class {
+            Some(short) if nullable => format!("{x}?.let {{ {short}.fromInt(it) }}"),
+            Some(short) => format!("{short}.fromInt({x})"),
+            None => param.wrap.wrap_expr(x, nullable),
+        };
+        match sequence {
+            Some(_) => format!("{arg}.map {{ {} }}", wrap("it")),
+            None => wrap(&arg),
         }
-        param.wrap.wrap_expr(&arg, false)
     }
 
     /// The hoisted **folder-appender** singleton for a **whole single-leaf

--- a/prebindgen-jni/src/jni/kotlin_emit.rs
+++ b/prebindgen-jni/src/jni/kotlin_emit.rs
@@ -1631,8 +1631,11 @@ impl Declarations {
     ///    `!!` would turn a legitimately absent value into an exception. A
     ///    *collection* of optionals is not itself optional — its absences are
     ///    inside it — so that slot is re-asserted like any other.
-    /// 2. **Distribute** — a `Vec<T>` payload arrives as a `List` of element
-    ///    slots, so the wrap runs per element rather than on the list.
+    /// 2. **Distribute** — a `Vec<T>` payload arrives as a run of element slots,
+    ///    so the wrap runs per element rather than on the run. Only when the
+    ///    elements actually convert: a run that needs no conversion is already
+    ///    the property's own type, and `map` would replace it — `Vec<u8>`
+    ///    surfaces as a `ByteArray`, whose `map` is a `List<Byte>`.
     /// 3. **Wrap** — the raw wire becomes the property: an enum discriminant
     ///    through `fromInt`, a handle/blob/`ULong` through the interface's own
     ///    [`WrapKind`](crate::jni::WrapKind), everything else verbatim. Each
@@ -1689,9 +1692,19 @@ impl Declarations {
             Some(short) => format!("{short}.fromInt({x})"),
             None => param.wrap.wrap_expr(x, nullable),
         };
-        match sequence {
-            Some(_) => format!("{arg}.map {{ {} }}", wrap("it")),
-            None => wrap(&arg),
+        if sequence.is_none() {
+            return wrap(&arg);
+        }
+        // Distribute only when there is something to distribute. A run of
+        // values whose elements need no conversion already arrives as the
+        // property's own type, and mapping the identity over it would replace
+        // that type rather than preserve it: a `Vec<u8>` payload surfaces as a
+        // Kotlin `ByteArray`, and `ByteArray.map { it }` is a `List<Byte>`.
+        let element = wrap("it");
+        if element == "it" {
+            arg
+        } else {
+            format!("{arg}.map {{ {element} }}")
         }
     }
 

--- a/prebindgen-jni/src/jni/tests/sealed.rs
+++ b/prebindgen-jni/src/jni/tests/sealed.rs
@@ -1239,8 +1239,9 @@ fn sum_return_composes_with_option_and_vec() {
 /// The fixture has more variants than the defect had shapes, because each
 /// answer needs its control: distributing over a collection is right only when
 /// its elements convert, a payload with no layer must come out exactly as it
-/// did, and the two layers occur in **both orders** — `Vec<Option<T>>` and
-/// `Option<Vec<T>>` are each accepted, and each needs the other's peel.
+/// did, and the layers occur in **both orders** and at **any depth** —
+/// `Vec<Option<T>>`, `Option<Vec<T>>` and `Vec<Vec<Option<T>>>` are all
+/// accepted, so the walk over them recurses instead of unrolling.
 #[test]
 fn a_payload_carries_its_option_and_collection_layers() {
     let loc = myflat_loc();
@@ -1263,6 +1264,7 @@ fn a_payload_carries_its_option_and_collection_layers() {
                     Blob(Vec<u8>),
                     Names(Vec<String>),
                     Values(Option<Vec<Option<u64>>>),
+                    Nested(Vec<Vec<Option<u64>>>),
                     Labels(Option<Vec<String>>),
                     Empty,
                 }
@@ -1332,6 +1334,14 @@ fn a_payload_carries_its_option_and_collection_layers() {
     assert!(
         kotlin.contains("Probe.Blob(blob_v0!!)"),
         "a byte-array payload is passed straight through:\n{kotlin}"
+    );
+    // Layers nest, so the walk over them recurses rather than unrolling a fixed
+    // two: with `Vec<Vec<Option<u64>>>` the element of the outer run is another
+    // run, and the leaf's conversion belongs at the bottom. The inner lambda
+    // names its parameter because a nested `it` would shadow the outer one.
+    assert!(
+        kotlin.contains("Probe.Nested(nested_v0!!.map { it.map { __e1 -> __e1?.toULong() } })"),
+        "nested runs distribute at every level:\n{kotlin}"
     );
     // A run under an `Option` is still a run: the layers occur in both orders,
     // and looking for the collection without peeling the `Option` first found

--- a/prebindgen-jni/src/jni/tests/sealed.rs
+++ b/prebindgen-jni/src/jni/tests/sealed.rs
@@ -1235,6 +1235,11 @@ fn sum_return_composes_with_option_and_vec() {
 /// not compile in all three shapes below (#429) — nulls dropped, and an element
 /// conversion applied to the list. Nothing caught it because the Rust half
 /// compiles and no test asked for these payloads.
+///
+/// The last three alternatives are the controls, and they are the reason this
+/// fixture has more variants than the defect had shapes: distributing over a
+/// collection is only right when its elements convert, and a payload with no
+/// layer at all must come out exactly as it did.
 #[test]
 fn a_payload_carries_its_option_and_collection_layers() {
     let loc = myflat_loc();
@@ -1254,6 +1259,8 @@ fn a_payload_carries_its_option_and_collection_layers() {
                     Held(Option<Handle>),
                     Many(Vec<Option<u64>>),
                     Owned(Handle),
+                    Blob(Vec<u8>),
+                    Names(Vec<String>),
                     Empty,
                 }
             )),
@@ -1313,6 +1320,19 @@ fn a_payload_carries_its_option_and_collection_layers() {
     assert!(
         kotlin.contains("Probe.Owned(Handle.fromRawPtr(owned_v0))"),
         "a plain handle payload is unchanged:\n{kotlin}"
+    );
+    // …and so is a run of values whose elements need no conversion. There is
+    // nothing to distribute there, and mapping the identity over one would
+    // replace the property's type rather than preserve it: `Vec<u8>` surfaces
+    // as a `ByteArray`, and `ByteArray.map { it }` is a `List<Byte>` (#432
+    // review).
+    assert!(
+        kotlin.contains("Probe.Blob(blob_v0!!)"),
+        "a byte-array payload is passed straight through:\n{kotlin}"
+    );
+    assert!(
+        kotlin.contains("Probe.Names(names_v0!!)"),
+        "a list payload whose elements convert to themselves is too:\n{kotlin}"
     );
 }
 

--- a/prebindgen-jni/src/jni/tests/sealed.rs
+++ b/prebindgen-jni/src/jni/tests/sealed.rs
@@ -1236,10 +1236,11 @@ fn sum_return_composes_with_option_and_vec() {
 /// conversion applied to the list. Nothing caught it because the Rust half
 /// compiles and no test asked for these payloads.
 ///
-/// The last three alternatives are the controls, and they are the reason this
-/// fixture has more variants than the defect had shapes: distributing over a
-/// collection is only right when its elements convert, and a payload with no
-/// layer at all must come out exactly as it did.
+/// The fixture has more variants than the defect had shapes, because each
+/// answer needs its control: distributing over a collection is right only when
+/// its elements convert, a payload with no layer must come out exactly as it
+/// did, and the two layers occur in **both orders** — `Vec<Option<T>>` and
+/// `Option<Vec<T>>` are each accepted, and each needs the other's peel.
 #[test]
 fn a_payload_carries_its_option_and_collection_layers() {
     let loc = myflat_loc();
@@ -1261,6 +1262,8 @@ fn a_payload_carries_its_option_and_collection_layers() {
                     Owned(Handle),
                     Blob(Vec<u8>),
                     Names(Vec<String>),
+                    Values(Option<Vec<Option<u64>>>),
+                    Labels(Option<Vec<String>>),
                     Empty,
                 }
             )),
@@ -1329,6 +1332,19 @@ fn a_payload_carries_its_option_and_collection_layers() {
     assert!(
         kotlin.contains("Probe.Blob(blob_v0!!)"),
         "a byte-array payload is passed straight through:\n{kotlin}"
+    );
+    // A run under an `Option` is still a run: the layers occur in both orders,
+    // and looking for the collection without peeling the `Option` first found
+    // none — so the element conversion landed on the list (#432 review).
+    assert!(
+        kotlin.contains("Probe.Values(values_v0?.map { it?.toULong() })"),
+        "an optional run distributes, and keeps its own null:\n{kotlin}"
+    );
+    // …and the identity guard holds under an `Option` too: nothing to
+    // distribute means no `?.map` either.
+    assert!(
+        kotlin.contains("Probe.Labels(labels_v0)"),
+        "an optional run of unconverted elements is passed through:\n{kotlin}"
     );
     assert!(
         kotlin.contains("Probe.Names(names_v0!!)"),

--- a/prebindgen-jni/src/jni/tests/sealed.rs
+++ b/prebindgen-jni/src/jni/tests/sealed.rs
@@ -1227,6 +1227,95 @@ fn sum_return_composes_with_option_and_vec() {
     );
 }
 
+/// A payload's layers are each carried across, not skipped.
+///
+/// The raw builder reassembles a variant from wire slots, and between a slot and
+/// the property there can be a collection, an `Option`, and the leaf the wrap
+/// knows about. Applying the wrap straight to the slot emitted Kotlin that does
+/// not compile in all three shapes below (#429) — nulls dropped, and an element
+/// conversion applied to the list. Nothing caught it because the Rust half
+/// compiles and no test asked for these payloads.
+#[test]
+fn a_payload_carries_its_option_and_collection_layers() {
+    let loc = myflat_loc();
+    let items: Vec<(syn::Item, SourceLocation)> = vec![
+        (
+            syn::Item::Struct(syn::parse_quote!(
+                pub struct Handle {
+                    v: i64,
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Enum(syn::parse_quote!(
+                pub enum Probe {
+                    Count(Option<u64>),
+                    Held(Option<Handle>),
+                    Many(Vec<Option<u64>>),
+                    Owned(Handle),
+                    Empty,
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn probe() -> Probe {
+                    unimplemented!()
+                }
+            )),
+            loc.clone(),
+        ),
+    ];
+    let registry =
+        crate::test_util::reg_from_items(declare_referenced(items)).expect("index items");
+    let jni = JniGenBuilder::new()
+        .set_package_prefix("io.test.jni")
+        .package(
+            crate::package!()
+                .class(crate::ptr_class!(Handle))
+                .class(crate::sealed_class!(Probe))
+                .fun(prebindgen_registry::fun!(probe)),
+        );
+
+    let dir = unique_test_dir("jnigen_sum_payload_layers");
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    let gen = jni.build_with(registry).expect("resolve");
+    let kotlin = gen
+        .write_kotlin(&dir.join("kotlin"))
+        .expect("write_kotlin")
+        .iter()
+        .map(|path| std::fs::read_to_string(path).unwrap())
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    // `Option<u64>`: JVM null is the absent case, so the conversion is
+    // null-safe rather than applied through it.
+    assert!(
+        kotlin.contains("Probe.Count(count_v0?.toULong())"),
+        "an optional scalar payload keeps its null:\n{kotlin}"
+    );
+    // `Option<Handle>`: same, and the handle still comes from the factory.
+    assert!(
+        kotlin.contains("Probe.Held(held_v0?.let { Handle.fromRawPtr(it) })"),
+        "an optional handle payload keeps its null:\n{kotlin}"
+    );
+    // `Vec<Option<u64>>`: the list slot is un-inerted, and the element
+    // conversion runs per element — the nulls are inside the list, not on it.
+    assert!(
+        kotlin.contains("Probe.Many(many_v0!!.map { it?.toULong() })"),
+        "a collection payload converts element by element:\n{kotlin}"
+    );
+    // The control: a payload that is neither optional nor a collection is
+    // un-inerted and wrapped exactly as before.
+    assert!(
+        kotlin.contains("Probe.Owned(Handle.fromRawPtr(owned_v0))"),
+        "a plain handle payload is unchanged:\n{kotlin}"
+    );
+}
+
 /// A variant payload may be an opaque **handle**: it rides its raw `jlong`
 /// like any other handle leaf, so its slot stays a primitive (an inert group
 /// leaves the `0L` sentinel, never a fabricated handle object).


### PR DESCRIPTION
Fixes #429, found by the shape matrix on #402 — by its new stage, which compiles the Kotlin the JNI adapter emits.

## What was wrong

A sealed class's raw builder reassembles a variant from the wire slots the native side passes up. The slot types are right: the generator declares them nullable, and generic over the collection, exactly as the payload's Rust type says. The **conversion applied to them** ignored both layers, because `sum_ctor_arg` handed the slot straight to the leaf's wrap.

| Payload | Emitted | Diagnostic |
|---|---|---|
| `Option<u64>` | `Probe.Carried(carried_v0.toULong())` | only safe or non-null asserted calls are allowed on a nullable receiver of type `Long?` |
| `Option<Handle>` | `Probe.Carried(Handle.fromRawPtr(carried_v0))` | argument type mismatch: actual type is `Long?`, but `Long` was expected |
| `Vec<Option<u64>>` | `Probe.Carried(carried_v0!!.toULong())` | unresolved reference `toULong` |

## The fix

`sum_ctor_arg` now runs one transform per layer, outermost first — un-inert the slot, distribute over a collection, then wrap:

```kotlin
Probe.Count(count_v0?.toULong())
Probe.Held(held_v0?.let { Handle.fromRawPtr(it) })
Probe.Many(many_v0!!.map { it?.toULong() })
```

Each matches the property type the variant class already declared (`ULong?`, `Handle?`, `List<ULong?>`), which is what makes these the right expressions and not merely compiling ones.

Two things this did **not** need to invent. `WrapKind::wrap_expr` already knew the nullable spelling of every kind it handles and was being passed `false` unconditionally; and the enum arm directly above already had the `?.let { … }` shape, so the other kinds now get what enums had.

## The one case that is not spelled nullably

A **niche** `Option<u64>` carries absence as a reserved value in a slot that is not nullable at all, so `?.` would not compile there. The nullable spelling is therefore asked for only when the payload is optional *and* its slot is nullable — the niche branch of `wrap_expr` keeps handling its own case, as it did.

## Not the same defect as #430

#430 is the *field* factory naming a private constructor. Between them the two paths held the complementary halves of one correct answer: the field path does the null check this builder omitted, and this builder calls the factory that path did not. They are separate PRs because they are separate call sites with separate fixes.

## Verification

- New test `a_payload_carries_its_option_and_collection_layers` (`prebindgen-jni/src/jni/tests/sealed.rs`): one sum with all three payloads plus a plain `Handle` as the control that the un-inert path is unchanged. It fails on `main`.
- `cargo test --workspace --all-features` passes.
- `examples/regen-check.sh` reports the in-repo generated output byte-identical: no in-tree binding declares these payloads, which is the same gap the test closes.
- Applied to a checkout of `shape-coverage` and re-ran `cargo run -p shape-matrix`: `opt_scalar__payload__jni`, `opt_handle__payload__jni` and `vec_opt__payload__jni` all rise from `bad kotlin` to `kotlin`, and the emitted expressions are the ones above. The only `bad kotlin` cell left is #430's.