### PR TITLE
Lower a composite callback argument instead of calling its marker (#428)

### DIFF
--- a/examples/example-cbindgen/build.rs
+++ b/examples/example-cbindgen/build.rs
@@ -145,6 +145,14 @@ fn generate_ffi_bindings() -> PathBuf {
         .callback(pq!(impl Fn(Option<f64>) + Send + Sync + 'static))
         .base_name("maybe_value");
 
+    // …and the same over an enum whose discriminants skip zero, which is what
+    // says the absent slot is left UNWRITTEN rather than filled: the wire is the
+    // Rust enum itself, so a fabricated zero would be an invalid value of it.
+    cbindgen = cbindgen.enum_type(pq!(Grade));
+    cbindgen = cbindgen
+        .callback(pq!(impl Fn(Option<Grade>) + Send + Sync + 'static))
+        .base_name("maybe_grade");
+
     // Constructors / `Result`-returning ops (fallible inputs route through the
     // error out-param), plus the infallible by-value `Foo` accessors and the
     // `InsideFoo` producer — none need `.panic()`. `calculator_apply` takes an
@@ -215,6 +223,7 @@ fn generate_ffi_bindings() -> PathBuf {
         pq!(calculator_get_history),
         pq!(calculator_for_each),
         pq!(calculator_last_or_none),
+        pq!(calculator_grade_or_none),
         // `&str` label input is fallible (null-checked) with no `Result`.
         pq!(shape_new_labeled),
     ] {

--- a/examples/example-cbindgen/build.rs
+++ b/examples/example-cbindgen/build.rs
@@ -137,6 +137,14 @@ fn generate_ffi_bindings() -> PathBuf {
         .callback(pq!(impl Fn(f64) + Send + Sync + 'static))
         .base_name("value");
 
+    // The OPTIONAL argument -> a `closure_maybe_value_t` whose `call` takes the
+    // fields the shape lowers to: an `Option<f64>` has no spare bit pattern, so
+    // that is a `bool` beside the value. A composite has no converter of its
+    // own, and calling the marker that stands in for one is #428.
+    cbindgen = cbindgen
+        .callback(pq!(impl Fn(Option<f64>) + Send + Sync + 'static))
+        .base_name("maybe_value");
+
     // Constructors / `Result`-returning ops (fallible inputs route through the
     // error out-param), plus the infallible by-value `Foo` accessors and the
     // `InsideFoo` producer — none need `.panic()`. `calculator_apply` takes an
@@ -206,6 +214,7 @@ fn generate_ffi_bindings() -> PathBuf {
         pq!(calculator_to_string),
         pq!(calculator_get_history),
         pq!(calculator_for_each),
+        pq!(calculator_last_or_none),
         // `&str` label input is fallible (null-checked) with no `Result`.
         pq!(shape_new_labeled),
     ] {

--- a/examples/example-cbindgen/build.rs
+++ b/examples/example-cbindgen/build.rs
@@ -148,6 +148,13 @@ fn generate_ffi_bindings() -> PathBuf {
     // …and the same over an enum whose discriminants skip zero, which is what
     // says the absent slot is left UNWRITTEN rather than filled: the wire is the
     // Rust enum itself, so a fabricated zero would be an invalid value of it.
+    // The composite whose lowering ALLOCATES: `Vec<f64>` crosses as a malloc'd
+    // `(double *, size_t)` the C side owns and frees. A closure with a NULL
+    // `call` must therefore convert nothing at all.
+    cbindgen = cbindgen
+        .callback(pq!(impl Fn(Vec<f64>) + Send + Sync + 'static))
+        .base_name("history_batch");
+
     cbindgen = cbindgen.enum_type(pq!(Grade));
     cbindgen = cbindgen
         .callback(pq!(impl Fn(Option<Grade>) + Send + Sync + 'static))
@@ -224,6 +231,7 @@ fn generate_ffi_bindings() -> PathBuf {
         pq!(calculator_for_each),
         pq!(calculator_last_or_none),
         pq!(calculator_grade_or_none),
+        pq!(calculator_history_batch),
         // `&str` label input is fallible (null-checked) with no `Result`.
         pq!(shape_new_labeled),
     ] {

--- a/examples/example-cbindgen/c/smoke.c
+++ b/examples/example-cbindgen/c/smoke.c
@@ -374,6 +374,49 @@ static void on_maybe_value(bool present, double value, void *ctx) {
     calls->fired++;
 }
 
+/* The same shape over an enum whose discriminants skip zero — the case
+ * `Option<double>` cannot detect.
+ *
+ * A declared `enum_type`'s wire is the Rust enum itself, so filling the absent
+ * slot with any fabricated value builds an invalid one. The slot is left
+ * unwritten instead, and C reads it only when the flag says to. */
+struct maybe_grades {
+    int fired;
+    bool present[2];
+    enum grade_t value;
+};
+
+static void on_maybe_grade(bool present, enum grade_t value, void *ctx) {
+    struct maybe_grades *calls = (struct maybe_grades *)ctx;
+    if (calls->fired < 2) {
+        calls->present[calls->fired] = present;
+        if (present) {
+            calls->value = value;
+        }
+    }
+    calls->fired++;
+}
+
+static void test_optional_enum_callback_arg(void) {
+    char *e = NULL;
+    calculator_t *c = calculator_new();
+    double applied = -1.0;
+    CHECK(calculator_apply(c, Add, 20.0, &applied, &e));
+    CHECK(e == NULL);
+
+    struct maybe_grades calls = {0, {false, false}, Low};
+    struct closure_maybe_grade_t closure = {
+        .context = &calls, .call = on_maybe_grade, .drop = NULL};
+    calculator_grade_or_none(c, closure);
+
+    CHECK(calls.fired == 2);
+    CHECK(calls.present[0]);
+    CHECK(calls.value == High);
+    CHECK(!calls.present[1]);
+
+    calculator_drop(c);
+}
+
 static void test_optional_callback_arg(void) {
     char *e = NULL;
     calculator_t *c = calculator_new();
@@ -407,6 +450,7 @@ int main(void) {
     test_nested_union_payload();
     test_alias_preflight();
     test_optional_callback_arg();
+    test_optional_enum_callback_arg();
 
     if (failures != 0) {
         fprintf(stderr, "FAILED - %d check(s)\n", failures);
@@ -415,6 +459,6 @@ int main(void) {
     printf("PASS - tagged union: every arm, every position, drop, invalid tag, "
            "converter-derived payloads, out-of-domain bool payload and "
            "data-struct field, nested union payload, alias preflight, "
-           "optional callback argument\n");
+           "optional callback argument (scalar and zero-less enum)\n");
     return 0;
 }

--- a/examples/example-cbindgen/c/smoke.c
+++ b/examples/example-cbindgen/c/smoke.c
@@ -417,6 +417,50 @@ static void test_optional_enum_callback_arg(void) {
     calculator_drop(c);
 }
 
+/* A composite whose lowering ALLOCATES, delivered to a closure that cannot
+ * receive it.
+ *
+ * `Vec<f64>` crosses as a malloc'd `(double *, size_t)` the C side owns. A
+ * closure struct whose `call` is NULL receives nothing, so converting the
+ * argument at all would hand that block to nobody — a leak on every
+ * invocation, and one only a leak detector can see (#428 review). This section
+ * is why `smoke-asan.sh` runs under LSan: with the encode outside the call
+ * guard, the block below is reported and the run fails.
+ *
+ * The live case is beside it, so the same fixture shows the array still
+ * arrives when there IS a callback — a guard that skipped the call as well
+ * would pass a leak check and be useless. */
+static void on_history_batch(double *values, uintptr_t len, void *ctx) {
+    double *sum = (double *)ctx;
+    for (uintptr_t i = 0; i < len; i++) {
+        *sum += values[i];
+    }
+    example_free(values); /* the array is C's to free */
+}
+
+static void test_allocating_callback_arg(void) {
+    char *e = NULL;
+    calculator_t *c = calculator_new();
+    double applied = -1.0;
+    CHECK(calculator_apply(c, Add, 4.0, &applied, &e));
+    CHECK(calculator_apply(c, Add, 6.0, &applied, &e));
+    CHECK(e == NULL);
+
+    /* Live: the batch arrives and is freed by the receiver. */
+    double sum = 0.0;
+    struct closure_history_batch_t live = {
+        .context = &sum, .call = on_history_batch, .drop = NULL};
+    calculator_history_batch(c, live);
+    CHECK(sum == 14.0); /* 4 + 10 */
+
+    /* No `call`: nothing may be allocated, because nothing could free it. */
+    struct closure_history_batch_t silent = {
+        .context = NULL, .call = NULL, .drop = NULL};
+    calculator_history_batch(c, silent);
+
+    calculator_drop(c);
+}
+
 static void test_optional_callback_arg(void) {
     char *e = NULL;
     calculator_t *c = calculator_new();
@@ -451,6 +495,7 @@ int main(void) {
     test_alias_preflight();
     test_optional_callback_arg();
     test_optional_enum_callback_arg();
+    test_allocating_callback_arg();
 
     if (failures != 0) {
         fprintf(stderr, "FAILED - %d check(s)\n", failures);
@@ -459,6 +504,7 @@ int main(void) {
     printf("PASS - tagged union: every arm, every position, drop, invalid tag, "
            "converter-derived payloads, out-of-domain bool payload and "
            "data-struct field, nested union payload, alias preflight, "
-           "optional callback argument (scalar and zero-less enum)\n");
+           "optional callback argument (scalar and zero-less enum), "
+           "allocating callback argument with and without a call\n");
     return 0;
 }

--- a/examples/example-cbindgen/c/smoke.c
+++ b/examples/example-cbindgen/c/smoke.c
@@ -345,6 +345,57 @@ static void test_alias_preflight(void) {
     calculator_drop(merged);
 }
 
+/* A composite in ARGUMENT position: `impl Fn(Option<f64>)`.
+ *
+ * A composite has no converter of its own — `Option`/`Vec`/`Cow` resolve to a
+ * marker whose destination is `()` — and the real ABI is the shape it lowers
+ * to. The callback-argument path used to call that marker as if it were a
+ * converter, and a marker takes no arguments, so this shape emitted a binding
+ * that did not build (#428).
+ *
+ * `Option<f64>` has no spare bit pattern, so the shape is a `bool` beside the
+ * value and the C `call` takes both. When the flag is false the value is
+ * unspecified — the same contract a `Result`'s out-param carries — so this
+ * reads it only in the present case. */
+struct maybe_calls {
+    int fired;
+    bool present[2];
+    double value;
+};
+
+static void on_maybe_value(bool present, double value, void *ctx) {
+    struct maybe_calls *calls = (struct maybe_calls *)ctx;
+    if (calls->fired < 2) {
+        calls->present[calls->fired] = present;
+        if (present) {
+            calls->value = value;
+        }
+    }
+    calls->fired++;
+}
+
+static void test_optional_callback_arg(void) {
+    char *e = NULL;
+    calculator_t *c = calculator_new();
+    double applied = -1.0;
+    CHECK(calculator_apply(c, Add, 7.0, &applied, &e));
+    CHECK(applied == 7.0);
+    CHECK(e == NULL);
+
+    struct maybe_calls calls = {0, {false, false}, -1.0};
+    struct closure_maybe_value_t closure = {
+        .context = &calls, .call = on_maybe_value, .drop = NULL};
+    calculator_last_or_none(c, closure);
+
+    /* Fires twice from one call: the recorded value, then `None`. */
+    CHECK(calls.fired == 2);
+    CHECK(calls.present[0]);
+    CHECK(calls.value == 7.0);
+    CHECK(!calls.present[1]);
+
+    calculator_drop(c);
+}
+
 int main(void) {
     test_each_arm();
     test_struct_field();
@@ -355,6 +406,7 @@ int main(void) {
     test_out_of_domain_bool_data_struct_field();
     test_nested_union_payload();
     test_alias_preflight();
+    test_optional_callback_arg();
 
     if (failures != 0) {
         fprintf(stderr, "FAILED - %d check(s)\n", failures);
@@ -362,6 +414,7 @@ int main(void) {
     }
     printf("PASS - tagged union: every arm, every position, drop, invalid tag, "
            "converter-derived payloads, out-of-domain bool payload and "
-           "data-struct field, nested union payload, alias preflight\n");
+           "data-struct field, nested union payload, alias preflight, "
+           "optional callback argument\n");
     return 0;
 }

--- a/examples/example-cbindgen/generated/example_flat_aarch64.rs
+++ b/examples/example-cbindgen/generated/example_flat_aarch64.rs
@@ -516,8 +516,8 @@ pub(crate) unsafe fn __cbg_in_closure_history_batch_t(
     });
     move |__a0: ::std::vec::Vec<f64>| {
         if let ::core::option::Option::Some(__f) = __call {
-            let mut __w0_0 = ::core::mem::MaybeUninit::<*mut f64>::uninit();
-            let mut __w0_1 = ::core::mem::MaybeUninit::<usize>::uninit();
+            let mut __w0_0 = ::core::mem::MaybeUninit::<*mut f64>::zeroed();
+            let mut __w0_1 = ::core::mem::MaybeUninit::<usize>::zeroed();
             let __arr: ::std::vec::Vec<f64> = __a0
                 .into_iter()
                 .map(__cbg_out_f64)
@@ -553,8 +553,8 @@ pub(crate) unsafe fn __cbg_in_closure_maybe_grade_t(
     });
     move |__a0: ::core::option::Option<example_flat::Grade>| {
         if let ::core::option::Option::Some(__f) = __call {
-            let mut __w0_0 = ::core::mem::MaybeUninit::<bool>::uninit();
-            let mut __w0_1 = ::core::mem::MaybeUninit::<grade_t>::uninit();
+            let mut __w0_0 = ::core::mem::MaybeUninit::<bool>::zeroed();
+            let mut __w0_1 = ::core::mem::MaybeUninit::<grade_t>::zeroed();
             match __a0 {
                 ::core::option::Option::Some(__x) => {
                     *__w0_0.as_mut_ptr() = true;
@@ -592,8 +592,8 @@ pub(crate) unsafe fn __cbg_in_closure_maybe_value_t(
     });
     move |__a0: ::core::option::Option<f64>| {
         if let ::core::option::Option::Some(__f) = __call {
-            let mut __w0_0 = ::core::mem::MaybeUninit::<bool>::uninit();
-            let mut __w0_1 = ::core::mem::MaybeUninit::<f64>::uninit();
+            let mut __w0_0 = ::core::mem::MaybeUninit::<bool>::zeroed();
+            let mut __w0_1 = ::core::mem::MaybeUninit::<f64>::zeroed();
             match __a0 {
                 ::core::option::Option::Some(__x) => {
                     *__w0_0.as_mut_ptr() = true;

--- a/examples/example-cbindgen/generated/example_flat_aarch64.rs
+++ b/examples/example-cbindgen/generated/example_flat_aarch64.rs
@@ -70,6 +70,13 @@ pub struct foo_t {
 #[repr(C)]
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 #[allow(non_camel_case_types)]
+pub enum grade_t {
+    Low = 1,
+    High = 2,
+}
+#[repr(C)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[allow(non_camel_case_types)]
 pub enum inside_foo_t {
     DouddleDee = 14,
     DouddleDum = 88,
@@ -159,6 +166,45 @@ pub unsafe extern "C" fn shape_drop(this_: *mut ::core::mem::MaybeUninit<shape_t
 }
 #[repr(C)]
 #[allow(non_camel_case_types)]
+pub struct closure_history_batch_t {
+    pub context: *mut ::core::ffi::c_void,
+    pub call: ::core::option::Option<
+        unsafe extern "C" fn(
+            ::core::mem::MaybeUninit<*mut f64>,
+            ::core::mem::MaybeUninit<usize>,
+            *mut ::core::ffi::c_void,
+        ),
+    >,
+    pub drop: ::core::option::Option<unsafe extern "C" fn(*mut ::core::ffi::c_void)>,
+}
+#[repr(C)]
+#[allow(non_camel_case_types)]
+pub struct closure_maybe_grade_t {
+    pub context: *mut ::core::ffi::c_void,
+    pub call: ::core::option::Option<
+        unsafe extern "C" fn(
+            ::core::mem::MaybeUninit<bool>,
+            ::core::mem::MaybeUninit<grade_t>,
+            *mut ::core::ffi::c_void,
+        ),
+    >,
+    pub drop: ::core::option::Option<unsafe extern "C" fn(*mut ::core::ffi::c_void)>,
+}
+#[repr(C)]
+#[allow(non_camel_case_types)]
+pub struct closure_maybe_value_t {
+    pub context: *mut ::core::ffi::c_void,
+    pub call: ::core::option::Option<
+        unsafe extern "C" fn(
+            ::core::mem::MaybeUninit<bool>,
+            ::core::mem::MaybeUninit<f64>,
+            *mut ::core::ffi::c_void,
+        ),
+    >,
+    pub drop: ::core::option::Option<unsafe extern "C" fn(*mut ::core::ffi::c_void)>,
+}
+#[repr(C)]
+#[allow(non_camel_case_types)]
 pub struct closure_value_t {
     pub context: *mut ::core::ffi::c_void,
     pub call: ::core::option::Option<
@@ -207,6 +253,35 @@ pub(crate) unsafe fn __cbg_in_Foo(v: foo_t) -> example_flat::Foo {
         aarch64_field: v.aarch64_field,
         stable_field: v.stable_field,
     }
+}
+#[allow(non_snake_case, unused_variables, dead_code)]
+pub(crate) unsafe fn __cbg_in_Grade(
+    v: ::core::mem::MaybeUninit<grade_t>,
+) -> ::core::result::Result<example_flat::Grade, ::std::string::String> {
+    const _: () = {
+        assert!(
+            ::core::mem::size_of:: < grade_t > () == ::core::mem::size_of:: <
+            ::core::ffi::c_int > (),
+            "`grade_t`: a #[repr(C)] enum must have the size of a C `int`"
+        );
+        assert!(
+            ::core::mem::align_of:: < grade_t > () == ::core::mem::align_of:: <
+            ::core::ffi::c_int > (),
+            "`grade_t`: a #[repr(C)] enum must have the alignment of a C `int`"
+        );
+    };
+    let __raw: ::core::ffi::c_int = ::core::ptr::read(
+        v.as_ptr() as *const ::core::ffi::c_int,
+    );
+    if __raw == grade_t::Low as ::core::ffi::c_int {
+        return ::core::result::Result::Ok(example_flat::Grade::Low);
+    }
+    if __raw == grade_t::High as ::core::ffi::c_int {
+        return ::core::result::Result::Ok(example_flat::Grade::High);
+    }
+    ::core::result::Result::Err(
+        ::std::format!("invalid discriminant {} for `grade_t`", __raw),
+    )
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
 pub(crate) unsafe fn __cbg_in_InsideFoo(
@@ -418,6 +493,121 @@ pub(crate) unsafe fn __cbg_in_bool(v: ::core::mem::MaybeUninit<bool>) -> bool {
     ::core::ptr::read(v.as_ptr() as *const u8) != 0
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
+pub(crate) unsafe fn __cbg_in_closure_history_batch_t(
+    c: closure_history_batch_t,
+) -> impl Fn(::std::vec::Vec<f64>) + Send + Sync + 'static {
+    struct __Ctx {
+        context: *mut ::core::ffi::c_void,
+        drop: ::core::option::Option<unsafe extern "C" fn(*mut ::core::ffi::c_void)>,
+    }
+    unsafe impl ::core::marker::Send for __Ctx {}
+    unsafe impl ::core::marker::Sync for __Ctx {}
+    impl ::core::ops::Drop for __Ctx {
+        fn drop(&mut self) {
+            if let ::core::option::Option::Some(__d) = self.drop {
+                unsafe { __d(self.context) }
+            }
+        }
+    }
+    let __call = c.call;
+    let __ctx = ::std::sync::Arc::new(__Ctx {
+        context: c.context,
+        drop: c.drop,
+    });
+    move |__a0: ::std::vec::Vec<f64>| {
+        if let ::core::option::Option::Some(__f) = __call {
+            let mut __w0_0 = ::core::mem::MaybeUninit::<*mut f64>::uninit();
+            let mut __w0_1 = ::core::mem::MaybeUninit::<usize>::uninit();
+            let __arr: ::std::vec::Vec<f64> = __a0
+                .into_iter()
+                .map(__cbg_out_f64)
+                .collect();
+            let (__p, __n) = __cbg_alloc_array(__arr);
+            *__w0_0.as_mut_ptr() = __p;
+            *__w0_1.as_mut_ptr() = __n;
+            unsafe { __f(__w0_0, __w0_1, __ctx.context) }
+        }
+    }
+}
+#[allow(non_snake_case, unused_variables, dead_code)]
+pub(crate) unsafe fn __cbg_in_closure_maybe_grade_t(
+    c: closure_maybe_grade_t,
+) -> impl Fn(::core::option::Option<example_flat::Grade>) + Send + Sync + 'static {
+    struct __Ctx {
+        context: *mut ::core::ffi::c_void,
+        drop: ::core::option::Option<unsafe extern "C" fn(*mut ::core::ffi::c_void)>,
+    }
+    unsafe impl ::core::marker::Send for __Ctx {}
+    unsafe impl ::core::marker::Sync for __Ctx {}
+    impl ::core::ops::Drop for __Ctx {
+        fn drop(&mut self) {
+            if let ::core::option::Option::Some(__d) = self.drop {
+                unsafe { __d(self.context) }
+            }
+        }
+    }
+    let __call = c.call;
+    let __ctx = ::std::sync::Arc::new(__Ctx {
+        context: c.context,
+        drop: c.drop,
+    });
+    move |__a0: ::core::option::Option<example_flat::Grade>| {
+        if let ::core::option::Option::Some(__f) = __call {
+            let mut __w0_0 = ::core::mem::MaybeUninit::<bool>::uninit();
+            let mut __w0_1 = ::core::mem::MaybeUninit::<grade_t>::uninit();
+            match __a0 {
+                ::core::option::Option::Some(__x) => {
+                    *__w0_0.as_mut_ptr() = true;
+                    *__w0_1.as_mut_ptr() = __cbg_out_Grade(__x);
+                }
+                ::core::option::Option::None => {
+                    *__w0_0.as_mut_ptr() = false;
+                }
+            }
+            unsafe { __f(__w0_0, __w0_1, __ctx.context) }
+        }
+    }
+}
+#[allow(non_snake_case, unused_variables, dead_code)]
+pub(crate) unsafe fn __cbg_in_closure_maybe_value_t(
+    c: closure_maybe_value_t,
+) -> impl Fn(::core::option::Option<f64>) + Send + Sync + 'static {
+    struct __Ctx {
+        context: *mut ::core::ffi::c_void,
+        drop: ::core::option::Option<unsafe extern "C" fn(*mut ::core::ffi::c_void)>,
+    }
+    unsafe impl ::core::marker::Send for __Ctx {}
+    unsafe impl ::core::marker::Sync for __Ctx {}
+    impl ::core::ops::Drop for __Ctx {
+        fn drop(&mut self) {
+            if let ::core::option::Option::Some(__d) = self.drop {
+                unsafe { __d(self.context) }
+            }
+        }
+    }
+    let __call = c.call;
+    let __ctx = ::std::sync::Arc::new(__Ctx {
+        context: c.context,
+        drop: c.drop,
+    });
+    move |__a0: ::core::option::Option<f64>| {
+        if let ::core::option::Option::Some(__f) = __call {
+            let mut __w0_0 = ::core::mem::MaybeUninit::<bool>::uninit();
+            let mut __w0_1 = ::core::mem::MaybeUninit::<f64>::uninit();
+            match __a0 {
+                ::core::option::Option::Some(__x) => {
+                    *__w0_0.as_mut_ptr() = true;
+                    *__w0_1.as_mut_ptr() = __cbg_out_f64(__x);
+                }
+                ::core::option::Option::None => {
+                    *__w0_0.as_mut_ptr() = false;
+                }
+            }
+            unsafe { __f(__w0_0, __w0_1, __ctx.context) }
+        }
+    }
+}
+#[allow(non_snake_case, unused_variables, dead_code)]
 pub(crate) unsafe fn __cbg_in_closure_value_t(
     c: closure_value_t,
 ) -> impl Fn(f64) + Send + Sync + 'static {
@@ -440,8 +630,8 @@ pub(crate) unsafe fn __cbg_in_closure_value_t(
         drop: c.drop,
     });
     move |__a0: f64| {
-        let __w0 = __cbg_out_f64(__a0);
         if let ::core::option::Option::Some(__f) = __call {
+            let __w0 = __cbg_out_f64(__a0);
             unsafe { __f(__w0, __ctx.context) }
         }
     }
@@ -485,6 +675,13 @@ pub(crate) fn __cbg_out_Foo(v: example_flat::Foo) -> foo_t {
         id: v.id,
         aarch64_field: v.aarch64_field,
         stable_field: v.stable_field,
+    }
+}
+#[allow(non_snake_case, unused_variables, dead_code)]
+pub(crate) fn __cbg_out_Grade(v: example_flat::Grade) -> grade_t {
+    match v {
+        example_flat::Grade::Low => grade_t::Low,
+        example_flat::Grade::High => grade_t::High,
     }
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
@@ -568,6 +765,10 @@ pub(crate) fn __cbg_out_u64(v: u64) -> u64 {
 }
 #[allow(non_snake_case, dead_code, unused_variables)]
 pub(crate) fn __cbg_out_unit(v: ()) {}
+#[allow(non_snake_case, dead_code, unused)]
+pub(crate) fn __cbg_outmark_option_Grade() {}
+#[allow(non_snake_case, dead_code, unused)]
+pub(crate) fn __cbg_outmark_option_f64() {}
 #[allow(non_snake_case, dead_code, unused)]
 pub(crate) fn __cbg_outmark_vec_f64() {}
 #[allow(non_snake_case, dead_code, unused)]
@@ -748,6 +949,36 @@ pub unsafe extern "C" fn calculator_get_value(c: *const calculator_t) -> f64 {
 }
 #[no_mangle]
 #[allow(non_snake_case, unused_mut, unused_variables, unused_unsafe, dead_code)]
+pub unsafe extern "C" fn calculator_grade_or_none(
+    c: *const calculator_t,
+    f: closure_maybe_grade_t,
+) {
+    let c = match __cbg_in___Calculator(c) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__msg) => {
+            panic!("{}", __msg);
+        }
+    };
+    let f = __cbg_in_closure_maybe_grade_t(f);
+    example_flat::calculator_grade_or_none(c, f);
+}
+#[no_mangle]
+#[allow(non_snake_case, unused_mut, unused_variables, unused_unsafe, dead_code)]
+pub unsafe extern "C" fn calculator_history_batch(
+    c: *const calculator_t,
+    f: closure_history_batch_t,
+) {
+    let c = match __cbg_in___Calculator(c) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__msg) => {
+            panic!("{}", __msg);
+        }
+    };
+    let f = __cbg_in_closure_history_batch_t(f);
+    example_flat::calculator_history_batch(c, f);
+}
+#[no_mangle]
+#[allow(non_snake_case, unused_mut, unused_variables, unused_unsafe, dead_code)]
 pub unsafe extern "C" fn calculator_is(c: *const calculator_t, value: f64) -> bool {
     let c = match __cbg_in___Calculator(c) {
         ::core::result::Result::Ok(__v) => __v,
@@ -760,6 +991,21 @@ pub unsafe extern "C" fn calculator_is(c: *const calculator_t, value: f64) -> bo
     let __ret: bool;
     __ret = __cbg_out_bool(__v);
     __ret
+}
+#[no_mangle]
+#[allow(non_snake_case, unused_mut, unused_variables, unused_unsafe, dead_code)]
+pub unsafe extern "C" fn calculator_last_or_none(
+    c: *const calculator_t,
+    f: closure_maybe_value_t,
+) {
+    let c = match __cbg_in___Calculator(c) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__msg) => {
+            panic!("{}", __msg);
+        }
+    };
+    let f = __cbg_in_closure_maybe_value_t(f);
+    example_flat::calculator_last_or_none(c, f);
 }
 #[no_mangle]
 #[allow(non_snake_case, unused_mut, unused_variables, unused_unsafe, dead_code)]

--- a/examples/example-cbindgen/generated/example_flat_aarch64_internal_unstable.rs
+++ b/examples/example-cbindgen/generated/example_flat_aarch64_internal_unstable.rs
@@ -516,8 +516,8 @@ pub(crate) unsafe fn __cbg_in_closure_history_batch_t(
     });
     move |__a0: ::std::vec::Vec<f64>| {
         if let ::core::option::Option::Some(__f) = __call {
-            let mut __w0_0 = ::core::mem::MaybeUninit::<*mut f64>::uninit();
-            let mut __w0_1 = ::core::mem::MaybeUninit::<usize>::uninit();
+            let mut __w0_0 = ::core::mem::MaybeUninit::<*mut f64>::zeroed();
+            let mut __w0_1 = ::core::mem::MaybeUninit::<usize>::zeroed();
             let __arr: ::std::vec::Vec<f64> = __a0
                 .into_iter()
                 .map(__cbg_out_f64)
@@ -553,8 +553,8 @@ pub(crate) unsafe fn __cbg_in_closure_maybe_grade_t(
     });
     move |__a0: ::core::option::Option<example_flat::Grade>| {
         if let ::core::option::Option::Some(__f) = __call {
-            let mut __w0_0 = ::core::mem::MaybeUninit::<bool>::uninit();
-            let mut __w0_1 = ::core::mem::MaybeUninit::<grade_t>::uninit();
+            let mut __w0_0 = ::core::mem::MaybeUninit::<bool>::zeroed();
+            let mut __w0_1 = ::core::mem::MaybeUninit::<grade_t>::zeroed();
             match __a0 {
                 ::core::option::Option::Some(__x) => {
                     *__w0_0.as_mut_ptr() = true;
@@ -592,8 +592,8 @@ pub(crate) unsafe fn __cbg_in_closure_maybe_value_t(
     });
     move |__a0: ::core::option::Option<f64>| {
         if let ::core::option::Option::Some(__f) = __call {
-            let mut __w0_0 = ::core::mem::MaybeUninit::<bool>::uninit();
-            let mut __w0_1 = ::core::mem::MaybeUninit::<f64>::uninit();
+            let mut __w0_0 = ::core::mem::MaybeUninit::<bool>::zeroed();
+            let mut __w0_1 = ::core::mem::MaybeUninit::<f64>::zeroed();
             match __a0 {
                 ::core::option::Option::Some(__x) => {
                     *__w0_0.as_mut_ptr() = true;

--- a/examples/example-cbindgen/generated/example_flat_aarch64_internal_unstable.rs
+++ b/examples/example-cbindgen/generated/example_flat_aarch64_internal_unstable.rs
@@ -70,6 +70,13 @@ pub struct foo_t {
 #[repr(C)]
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 #[allow(non_camel_case_types)]
+pub enum grade_t {
+    Low = 1,
+    High = 2,
+}
+#[repr(C)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[allow(non_camel_case_types)]
 pub enum inside_foo_t {
     DouddleDee = 14,
     DouddleDum = 88,
@@ -159,6 +166,45 @@ pub unsafe extern "C" fn shape_drop(this_: *mut ::core::mem::MaybeUninit<shape_t
 }
 #[repr(C)]
 #[allow(non_camel_case_types)]
+pub struct closure_history_batch_t {
+    pub context: *mut ::core::ffi::c_void,
+    pub call: ::core::option::Option<
+        unsafe extern "C" fn(
+            ::core::mem::MaybeUninit<*mut f64>,
+            ::core::mem::MaybeUninit<usize>,
+            *mut ::core::ffi::c_void,
+        ),
+    >,
+    pub drop: ::core::option::Option<unsafe extern "C" fn(*mut ::core::ffi::c_void)>,
+}
+#[repr(C)]
+#[allow(non_camel_case_types)]
+pub struct closure_maybe_grade_t {
+    pub context: *mut ::core::ffi::c_void,
+    pub call: ::core::option::Option<
+        unsafe extern "C" fn(
+            ::core::mem::MaybeUninit<bool>,
+            ::core::mem::MaybeUninit<grade_t>,
+            *mut ::core::ffi::c_void,
+        ),
+    >,
+    pub drop: ::core::option::Option<unsafe extern "C" fn(*mut ::core::ffi::c_void)>,
+}
+#[repr(C)]
+#[allow(non_camel_case_types)]
+pub struct closure_maybe_value_t {
+    pub context: *mut ::core::ffi::c_void,
+    pub call: ::core::option::Option<
+        unsafe extern "C" fn(
+            ::core::mem::MaybeUninit<bool>,
+            ::core::mem::MaybeUninit<f64>,
+            *mut ::core::ffi::c_void,
+        ),
+    >,
+    pub drop: ::core::option::Option<unsafe extern "C" fn(*mut ::core::ffi::c_void)>,
+}
+#[repr(C)]
+#[allow(non_camel_case_types)]
 pub struct closure_value_t {
     pub context: *mut ::core::ffi::c_void,
     pub call: ::core::option::Option<
@@ -207,6 +253,35 @@ pub(crate) unsafe fn __cbg_in_Foo(v: foo_t) -> example_flat::Foo {
         aarch64_field: v.aarch64_field,
         unstable_field: v.unstable_field,
     }
+}
+#[allow(non_snake_case, unused_variables, dead_code)]
+pub(crate) unsafe fn __cbg_in_Grade(
+    v: ::core::mem::MaybeUninit<grade_t>,
+) -> ::core::result::Result<example_flat::Grade, ::std::string::String> {
+    const _: () = {
+        assert!(
+            ::core::mem::size_of:: < grade_t > () == ::core::mem::size_of:: <
+            ::core::ffi::c_int > (),
+            "`grade_t`: a #[repr(C)] enum must have the size of a C `int`"
+        );
+        assert!(
+            ::core::mem::align_of:: < grade_t > () == ::core::mem::align_of:: <
+            ::core::ffi::c_int > (),
+            "`grade_t`: a #[repr(C)] enum must have the alignment of a C `int`"
+        );
+    };
+    let __raw: ::core::ffi::c_int = ::core::ptr::read(
+        v.as_ptr() as *const ::core::ffi::c_int,
+    );
+    if __raw == grade_t::Low as ::core::ffi::c_int {
+        return ::core::result::Result::Ok(example_flat::Grade::Low);
+    }
+    if __raw == grade_t::High as ::core::ffi::c_int {
+        return ::core::result::Result::Ok(example_flat::Grade::High);
+    }
+    ::core::result::Result::Err(
+        ::std::format!("invalid discriminant {} for `grade_t`", __raw),
+    )
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
 pub(crate) unsafe fn __cbg_in_InsideFoo(
@@ -418,6 +493,121 @@ pub(crate) unsafe fn __cbg_in_bool(v: ::core::mem::MaybeUninit<bool>) -> bool {
     ::core::ptr::read(v.as_ptr() as *const u8) != 0
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
+pub(crate) unsafe fn __cbg_in_closure_history_batch_t(
+    c: closure_history_batch_t,
+) -> impl Fn(::std::vec::Vec<f64>) + Send + Sync + 'static {
+    struct __Ctx {
+        context: *mut ::core::ffi::c_void,
+        drop: ::core::option::Option<unsafe extern "C" fn(*mut ::core::ffi::c_void)>,
+    }
+    unsafe impl ::core::marker::Send for __Ctx {}
+    unsafe impl ::core::marker::Sync for __Ctx {}
+    impl ::core::ops::Drop for __Ctx {
+        fn drop(&mut self) {
+            if let ::core::option::Option::Some(__d) = self.drop {
+                unsafe { __d(self.context) }
+            }
+        }
+    }
+    let __call = c.call;
+    let __ctx = ::std::sync::Arc::new(__Ctx {
+        context: c.context,
+        drop: c.drop,
+    });
+    move |__a0: ::std::vec::Vec<f64>| {
+        if let ::core::option::Option::Some(__f) = __call {
+            let mut __w0_0 = ::core::mem::MaybeUninit::<*mut f64>::uninit();
+            let mut __w0_1 = ::core::mem::MaybeUninit::<usize>::uninit();
+            let __arr: ::std::vec::Vec<f64> = __a0
+                .into_iter()
+                .map(__cbg_out_f64)
+                .collect();
+            let (__p, __n) = __cbg_alloc_array(__arr);
+            *__w0_0.as_mut_ptr() = __p;
+            *__w0_1.as_mut_ptr() = __n;
+            unsafe { __f(__w0_0, __w0_1, __ctx.context) }
+        }
+    }
+}
+#[allow(non_snake_case, unused_variables, dead_code)]
+pub(crate) unsafe fn __cbg_in_closure_maybe_grade_t(
+    c: closure_maybe_grade_t,
+) -> impl Fn(::core::option::Option<example_flat::Grade>) + Send + Sync + 'static {
+    struct __Ctx {
+        context: *mut ::core::ffi::c_void,
+        drop: ::core::option::Option<unsafe extern "C" fn(*mut ::core::ffi::c_void)>,
+    }
+    unsafe impl ::core::marker::Send for __Ctx {}
+    unsafe impl ::core::marker::Sync for __Ctx {}
+    impl ::core::ops::Drop for __Ctx {
+        fn drop(&mut self) {
+            if let ::core::option::Option::Some(__d) = self.drop {
+                unsafe { __d(self.context) }
+            }
+        }
+    }
+    let __call = c.call;
+    let __ctx = ::std::sync::Arc::new(__Ctx {
+        context: c.context,
+        drop: c.drop,
+    });
+    move |__a0: ::core::option::Option<example_flat::Grade>| {
+        if let ::core::option::Option::Some(__f) = __call {
+            let mut __w0_0 = ::core::mem::MaybeUninit::<bool>::uninit();
+            let mut __w0_1 = ::core::mem::MaybeUninit::<grade_t>::uninit();
+            match __a0 {
+                ::core::option::Option::Some(__x) => {
+                    *__w0_0.as_mut_ptr() = true;
+                    *__w0_1.as_mut_ptr() = __cbg_out_Grade(__x);
+                }
+                ::core::option::Option::None => {
+                    *__w0_0.as_mut_ptr() = false;
+                }
+            }
+            unsafe { __f(__w0_0, __w0_1, __ctx.context) }
+        }
+    }
+}
+#[allow(non_snake_case, unused_variables, dead_code)]
+pub(crate) unsafe fn __cbg_in_closure_maybe_value_t(
+    c: closure_maybe_value_t,
+) -> impl Fn(::core::option::Option<f64>) + Send + Sync + 'static {
+    struct __Ctx {
+        context: *mut ::core::ffi::c_void,
+        drop: ::core::option::Option<unsafe extern "C" fn(*mut ::core::ffi::c_void)>,
+    }
+    unsafe impl ::core::marker::Send for __Ctx {}
+    unsafe impl ::core::marker::Sync for __Ctx {}
+    impl ::core::ops::Drop for __Ctx {
+        fn drop(&mut self) {
+            if let ::core::option::Option::Some(__d) = self.drop {
+                unsafe { __d(self.context) }
+            }
+        }
+    }
+    let __call = c.call;
+    let __ctx = ::std::sync::Arc::new(__Ctx {
+        context: c.context,
+        drop: c.drop,
+    });
+    move |__a0: ::core::option::Option<f64>| {
+        if let ::core::option::Option::Some(__f) = __call {
+            let mut __w0_0 = ::core::mem::MaybeUninit::<bool>::uninit();
+            let mut __w0_1 = ::core::mem::MaybeUninit::<f64>::uninit();
+            match __a0 {
+                ::core::option::Option::Some(__x) => {
+                    *__w0_0.as_mut_ptr() = true;
+                    *__w0_1.as_mut_ptr() = __cbg_out_f64(__x);
+                }
+                ::core::option::Option::None => {
+                    *__w0_0.as_mut_ptr() = false;
+                }
+            }
+            unsafe { __f(__w0_0, __w0_1, __ctx.context) }
+        }
+    }
+}
+#[allow(non_snake_case, unused_variables, dead_code)]
 pub(crate) unsafe fn __cbg_in_closure_value_t(
     c: closure_value_t,
 ) -> impl Fn(f64) + Send + Sync + 'static {
@@ -440,8 +630,8 @@ pub(crate) unsafe fn __cbg_in_closure_value_t(
         drop: c.drop,
     });
     move |__a0: f64| {
-        let __w0 = __cbg_out_f64(__a0);
         if let ::core::option::Option::Some(__f) = __call {
+            let __w0 = __cbg_out_f64(__a0);
             unsafe { __f(__w0, __ctx.context) }
         }
     }
@@ -485,6 +675,13 @@ pub(crate) fn __cbg_out_Foo(v: example_flat::Foo) -> foo_t {
         id: v.id,
         aarch64_field: v.aarch64_field,
         unstable_field: v.unstable_field,
+    }
+}
+#[allow(non_snake_case, unused_variables, dead_code)]
+pub(crate) fn __cbg_out_Grade(v: example_flat::Grade) -> grade_t {
+    match v {
+        example_flat::Grade::Low => grade_t::Low,
+        example_flat::Grade::High => grade_t::High,
     }
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
@@ -568,6 +765,10 @@ pub(crate) fn __cbg_out_u64(v: u64) -> u64 {
 }
 #[allow(non_snake_case, dead_code, unused_variables)]
 pub(crate) fn __cbg_out_unit(v: ()) {}
+#[allow(non_snake_case, dead_code, unused)]
+pub(crate) fn __cbg_outmark_option_Grade() {}
+#[allow(non_snake_case, dead_code, unused)]
+pub(crate) fn __cbg_outmark_option_f64() {}
 #[allow(non_snake_case, dead_code, unused)]
 pub(crate) fn __cbg_outmark_vec_f64() {}
 #[allow(non_snake_case, dead_code, unused)]
@@ -748,6 +949,36 @@ pub unsafe extern "C" fn calculator_get_value(c: *const calculator_t) -> f64 {
 }
 #[no_mangle]
 #[allow(non_snake_case, unused_mut, unused_variables, unused_unsafe, dead_code)]
+pub unsafe extern "C" fn calculator_grade_or_none(
+    c: *const calculator_t,
+    f: closure_maybe_grade_t,
+) {
+    let c = match __cbg_in___Calculator(c) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__msg) => {
+            panic!("{}", __msg);
+        }
+    };
+    let f = __cbg_in_closure_maybe_grade_t(f);
+    example_flat::calculator_grade_or_none(c, f);
+}
+#[no_mangle]
+#[allow(non_snake_case, unused_mut, unused_variables, unused_unsafe, dead_code)]
+pub unsafe extern "C" fn calculator_history_batch(
+    c: *const calculator_t,
+    f: closure_history_batch_t,
+) {
+    let c = match __cbg_in___Calculator(c) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__msg) => {
+            panic!("{}", __msg);
+        }
+    };
+    let f = __cbg_in_closure_history_batch_t(f);
+    example_flat::calculator_history_batch(c, f);
+}
+#[no_mangle]
+#[allow(non_snake_case, unused_mut, unused_variables, unused_unsafe, dead_code)]
 pub unsafe extern "C" fn calculator_is(c: *const calculator_t, value: f64) -> bool {
     let c = match __cbg_in___Calculator(c) {
         ::core::result::Result::Ok(__v) => __v,
@@ -760,6 +991,21 @@ pub unsafe extern "C" fn calculator_is(c: *const calculator_t, value: f64) -> bo
     let __ret: bool;
     __ret = __cbg_out_bool(__v);
     __ret
+}
+#[no_mangle]
+#[allow(non_snake_case, unused_mut, unused_variables, unused_unsafe, dead_code)]
+pub unsafe extern "C" fn calculator_last_or_none(
+    c: *const calculator_t,
+    f: closure_maybe_value_t,
+) {
+    let c = match __cbg_in___Calculator(c) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__msg) => {
+            panic!("{}", __msg);
+        }
+    };
+    let f = __cbg_in_closure_maybe_value_t(f);
+    example_flat::calculator_last_or_none(c, f);
 }
 #[no_mangle]
 #[allow(non_snake_case, unused_mut, unused_variables, unused_unsafe, dead_code)]

--- a/examples/example-cbindgen/generated/example_flat_aarch64_unstable.rs
+++ b/examples/example-cbindgen/generated/example_flat_aarch64_unstable.rs
@@ -516,8 +516,8 @@ pub(crate) unsafe fn __cbg_in_closure_history_batch_t(
     });
     move |__a0: ::std::vec::Vec<f64>| {
         if let ::core::option::Option::Some(__f) = __call {
-            let mut __w0_0 = ::core::mem::MaybeUninit::<*mut f64>::uninit();
-            let mut __w0_1 = ::core::mem::MaybeUninit::<usize>::uninit();
+            let mut __w0_0 = ::core::mem::MaybeUninit::<*mut f64>::zeroed();
+            let mut __w0_1 = ::core::mem::MaybeUninit::<usize>::zeroed();
             let __arr: ::std::vec::Vec<f64> = __a0
                 .into_iter()
                 .map(__cbg_out_f64)
@@ -553,8 +553,8 @@ pub(crate) unsafe fn __cbg_in_closure_maybe_grade_t(
     });
     move |__a0: ::core::option::Option<example_flat::Grade>| {
         if let ::core::option::Option::Some(__f) = __call {
-            let mut __w0_0 = ::core::mem::MaybeUninit::<bool>::uninit();
-            let mut __w0_1 = ::core::mem::MaybeUninit::<grade_t>::uninit();
+            let mut __w0_0 = ::core::mem::MaybeUninit::<bool>::zeroed();
+            let mut __w0_1 = ::core::mem::MaybeUninit::<grade_t>::zeroed();
             match __a0 {
                 ::core::option::Option::Some(__x) => {
                     *__w0_0.as_mut_ptr() = true;
@@ -592,8 +592,8 @@ pub(crate) unsafe fn __cbg_in_closure_maybe_value_t(
     });
     move |__a0: ::core::option::Option<f64>| {
         if let ::core::option::Option::Some(__f) = __call {
-            let mut __w0_0 = ::core::mem::MaybeUninit::<bool>::uninit();
-            let mut __w0_1 = ::core::mem::MaybeUninit::<f64>::uninit();
+            let mut __w0_0 = ::core::mem::MaybeUninit::<bool>::zeroed();
+            let mut __w0_1 = ::core::mem::MaybeUninit::<f64>::zeroed();
             match __a0 {
                 ::core::option::Option::Some(__x) => {
                     *__w0_0.as_mut_ptr() = true;

--- a/examples/example-cbindgen/generated/example_flat_aarch64_unstable.rs
+++ b/examples/example-cbindgen/generated/example_flat_aarch64_unstable.rs
@@ -70,6 +70,13 @@ pub struct foo_t {
 #[repr(C)]
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 #[allow(non_camel_case_types)]
+pub enum grade_t {
+    Low = 1,
+    High = 2,
+}
+#[repr(C)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[allow(non_camel_case_types)]
 pub enum inside_foo_t {
     DouddleDee = 14,
     DouddleDum = 88,
@@ -159,6 +166,45 @@ pub unsafe extern "C" fn shape_drop(this_: *mut ::core::mem::MaybeUninit<shape_t
 }
 #[repr(C)]
 #[allow(non_camel_case_types)]
+pub struct closure_history_batch_t {
+    pub context: *mut ::core::ffi::c_void,
+    pub call: ::core::option::Option<
+        unsafe extern "C" fn(
+            ::core::mem::MaybeUninit<*mut f64>,
+            ::core::mem::MaybeUninit<usize>,
+            *mut ::core::ffi::c_void,
+        ),
+    >,
+    pub drop: ::core::option::Option<unsafe extern "C" fn(*mut ::core::ffi::c_void)>,
+}
+#[repr(C)]
+#[allow(non_camel_case_types)]
+pub struct closure_maybe_grade_t {
+    pub context: *mut ::core::ffi::c_void,
+    pub call: ::core::option::Option<
+        unsafe extern "C" fn(
+            ::core::mem::MaybeUninit<bool>,
+            ::core::mem::MaybeUninit<grade_t>,
+            *mut ::core::ffi::c_void,
+        ),
+    >,
+    pub drop: ::core::option::Option<unsafe extern "C" fn(*mut ::core::ffi::c_void)>,
+}
+#[repr(C)]
+#[allow(non_camel_case_types)]
+pub struct closure_maybe_value_t {
+    pub context: *mut ::core::ffi::c_void,
+    pub call: ::core::option::Option<
+        unsafe extern "C" fn(
+            ::core::mem::MaybeUninit<bool>,
+            ::core::mem::MaybeUninit<f64>,
+            *mut ::core::ffi::c_void,
+        ),
+    >,
+    pub drop: ::core::option::Option<unsafe extern "C" fn(*mut ::core::ffi::c_void)>,
+}
+#[repr(C)]
+#[allow(non_camel_case_types)]
 pub struct closure_value_t {
     pub context: *mut ::core::ffi::c_void,
     pub call: ::core::option::Option<
@@ -207,6 +253,35 @@ pub(crate) unsafe fn __cbg_in_Foo(v: foo_t) -> example_flat::Foo {
         aarch64_field: v.aarch64_field,
         unstable_field: v.unstable_field,
     }
+}
+#[allow(non_snake_case, unused_variables, dead_code)]
+pub(crate) unsafe fn __cbg_in_Grade(
+    v: ::core::mem::MaybeUninit<grade_t>,
+) -> ::core::result::Result<example_flat::Grade, ::std::string::String> {
+    const _: () = {
+        assert!(
+            ::core::mem::size_of:: < grade_t > () == ::core::mem::size_of:: <
+            ::core::ffi::c_int > (),
+            "`grade_t`: a #[repr(C)] enum must have the size of a C `int`"
+        );
+        assert!(
+            ::core::mem::align_of:: < grade_t > () == ::core::mem::align_of:: <
+            ::core::ffi::c_int > (),
+            "`grade_t`: a #[repr(C)] enum must have the alignment of a C `int`"
+        );
+    };
+    let __raw: ::core::ffi::c_int = ::core::ptr::read(
+        v.as_ptr() as *const ::core::ffi::c_int,
+    );
+    if __raw == grade_t::Low as ::core::ffi::c_int {
+        return ::core::result::Result::Ok(example_flat::Grade::Low);
+    }
+    if __raw == grade_t::High as ::core::ffi::c_int {
+        return ::core::result::Result::Ok(example_flat::Grade::High);
+    }
+    ::core::result::Result::Err(
+        ::std::format!("invalid discriminant {} for `grade_t`", __raw),
+    )
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
 pub(crate) unsafe fn __cbg_in_InsideFoo(
@@ -418,6 +493,121 @@ pub(crate) unsafe fn __cbg_in_bool(v: ::core::mem::MaybeUninit<bool>) -> bool {
     ::core::ptr::read(v.as_ptr() as *const u8) != 0
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
+pub(crate) unsafe fn __cbg_in_closure_history_batch_t(
+    c: closure_history_batch_t,
+) -> impl Fn(::std::vec::Vec<f64>) + Send + Sync + 'static {
+    struct __Ctx {
+        context: *mut ::core::ffi::c_void,
+        drop: ::core::option::Option<unsafe extern "C" fn(*mut ::core::ffi::c_void)>,
+    }
+    unsafe impl ::core::marker::Send for __Ctx {}
+    unsafe impl ::core::marker::Sync for __Ctx {}
+    impl ::core::ops::Drop for __Ctx {
+        fn drop(&mut self) {
+            if let ::core::option::Option::Some(__d) = self.drop {
+                unsafe { __d(self.context) }
+            }
+        }
+    }
+    let __call = c.call;
+    let __ctx = ::std::sync::Arc::new(__Ctx {
+        context: c.context,
+        drop: c.drop,
+    });
+    move |__a0: ::std::vec::Vec<f64>| {
+        if let ::core::option::Option::Some(__f) = __call {
+            let mut __w0_0 = ::core::mem::MaybeUninit::<*mut f64>::uninit();
+            let mut __w0_1 = ::core::mem::MaybeUninit::<usize>::uninit();
+            let __arr: ::std::vec::Vec<f64> = __a0
+                .into_iter()
+                .map(__cbg_out_f64)
+                .collect();
+            let (__p, __n) = __cbg_alloc_array(__arr);
+            *__w0_0.as_mut_ptr() = __p;
+            *__w0_1.as_mut_ptr() = __n;
+            unsafe { __f(__w0_0, __w0_1, __ctx.context) }
+        }
+    }
+}
+#[allow(non_snake_case, unused_variables, dead_code)]
+pub(crate) unsafe fn __cbg_in_closure_maybe_grade_t(
+    c: closure_maybe_grade_t,
+) -> impl Fn(::core::option::Option<example_flat::Grade>) + Send + Sync + 'static {
+    struct __Ctx {
+        context: *mut ::core::ffi::c_void,
+        drop: ::core::option::Option<unsafe extern "C" fn(*mut ::core::ffi::c_void)>,
+    }
+    unsafe impl ::core::marker::Send for __Ctx {}
+    unsafe impl ::core::marker::Sync for __Ctx {}
+    impl ::core::ops::Drop for __Ctx {
+        fn drop(&mut self) {
+            if let ::core::option::Option::Some(__d) = self.drop {
+                unsafe { __d(self.context) }
+            }
+        }
+    }
+    let __call = c.call;
+    let __ctx = ::std::sync::Arc::new(__Ctx {
+        context: c.context,
+        drop: c.drop,
+    });
+    move |__a0: ::core::option::Option<example_flat::Grade>| {
+        if let ::core::option::Option::Some(__f) = __call {
+            let mut __w0_0 = ::core::mem::MaybeUninit::<bool>::uninit();
+            let mut __w0_1 = ::core::mem::MaybeUninit::<grade_t>::uninit();
+            match __a0 {
+                ::core::option::Option::Some(__x) => {
+                    *__w0_0.as_mut_ptr() = true;
+                    *__w0_1.as_mut_ptr() = __cbg_out_Grade(__x);
+                }
+                ::core::option::Option::None => {
+                    *__w0_0.as_mut_ptr() = false;
+                }
+            }
+            unsafe { __f(__w0_0, __w0_1, __ctx.context) }
+        }
+    }
+}
+#[allow(non_snake_case, unused_variables, dead_code)]
+pub(crate) unsafe fn __cbg_in_closure_maybe_value_t(
+    c: closure_maybe_value_t,
+) -> impl Fn(::core::option::Option<f64>) + Send + Sync + 'static {
+    struct __Ctx {
+        context: *mut ::core::ffi::c_void,
+        drop: ::core::option::Option<unsafe extern "C" fn(*mut ::core::ffi::c_void)>,
+    }
+    unsafe impl ::core::marker::Send for __Ctx {}
+    unsafe impl ::core::marker::Sync for __Ctx {}
+    impl ::core::ops::Drop for __Ctx {
+        fn drop(&mut self) {
+            if let ::core::option::Option::Some(__d) = self.drop {
+                unsafe { __d(self.context) }
+            }
+        }
+    }
+    let __call = c.call;
+    let __ctx = ::std::sync::Arc::new(__Ctx {
+        context: c.context,
+        drop: c.drop,
+    });
+    move |__a0: ::core::option::Option<f64>| {
+        if let ::core::option::Option::Some(__f) = __call {
+            let mut __w0_0 = ::core::mem::MaybeUninit::<bool>::uninit();
+            let mut __w0_1 = ::core::mem::MaybeUninit::<f64>::uninit();
+            match __a0 {
+                ::core::option::Option::Some(__x) => {
+                    *__w0_0.as_mut_ptr() = true;
+                    *__w0_1.as_mut_ptr() = __cbg_out_f64(__x);
+                }
+                ::core::option::Option::None => {
+                    *__w0_0.as_mut_ptr() = false;
+                }
+            }
+            unsafe { __f(__w0_0, __w0_1, __ctx.context) }
+        }
+    }
+}
+#[allow(non_snake_case, unused_variables, dead_code)]
 pub(crate) unsafe fn __cbg_in_closure_value_t(
     c: closure_value_t,
 ) -> impl Fn(f64) + Send + Sync + 'static {
@@ -440,8 +630,8 @@ pub(crate) unsafe fn __cbg_in_closure_value_t(
         drop: c.drop,
     });
     move |__a0: f64| {
-        let __w0 = __cbg_out_f64(__a0);
         if let ::core::option::Option::Some(__f) = __call {
+            let __w0 = __cbg_out_f64(__a0);
             unsafe { __f(__w0, __ctx.context) }
         }
     }
@@ -485,6 +675,13 @@ pub(crate) fn __cbg_out_Foo(v: example_flat::Foo) -> foo_t {
         id: v.id,
         aarch64_field: v.aarch64_field,
         unstable_field: v.unstable_field,
+    }
+}
+#[allow(non_snake_case, unused_variables, dead_code)]
+pub(crate) fn __cbg_out_Grade(v: example_flat::Grade) -> grade_t {
+    match v {
+        example_flat::Grade::Low => grade_t::Low,
+        example_flat::Grade::High => grade_t::High,
     }
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
@@ -568,6 +765,10 @@ pub(crate) fn __cbg_out_u64(v: u64) -> u64 {
 }
 #[allow(non_snake_case, dead_code, unused_variables)]
 pub(crate) fn __cbg_out_unit(v: ()) {}
+#[allow(non_snake_case, dead_code, unused)]
+pub(crate) fn __cbg_outmark_option_Grade() {}
+#[allow(non_snake_case, dead_code, unused)]
+pub(crate) fn __cbg_outmark_option_f64() {}
 #[allow(non_snake_case, dead_code, unused)]
 pub(crate) fn __cbg_outmark_vec_f64() {}
 #[allow(non_snake_case, dead_code, unused)]
@@ -748,6 +949,36 @@ pub unsafe extern "C" fn calculator_get_value(c: *const calculator_t) -> f64 {
 }
 #[no_mangle]
 #[allow(non_snake_case, unused_mut, unused_variables, unused_unsafe, dead_code)]
+pub unsafe extern "C" fn calculator_grade_or_none(
+    c: *const calculator_t,
+    f: closure_maybe_grade_t,
+) {
+    let c = match __cbg_in___Calculator(c) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__msg) => {
+            panic!("{}", __msg);
+        }
+    };
+    let f = __cbg_in_closure_maybe_grade_t(f);
+    example_flat::calculator_grade_or_none(c, f);
+}
+#[no_mangle]
+#[allow(non_snake_case, unused_mut, unused_variables, unused_unsafe, dead_code)]
+pub unsafe extern "C" fn calculator_history_batch(
+    c: *const calculator_t,
+    f: closure_history_batch_t,
+) {
+    let c = match __cbg_in___Calculator(c) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__msg) => {
+            panic!("{}", __msg);
+        }
+    };
+    let f = __cbg_in_closure_history_batch_t(f);
+    example_flat::calculator_history_batch(c, f);
+}
+#[no_mangle]
+#[allow(non_snake_case, unused_mut, unused_variables, unused_unsafe, dead_code)]
 pub unsafe extern "C" fn calculator_is(c: *const calculator_t, value: f64) -> bool {
     let c = match __cbg_in___Calculator(c) {
         ::core::result::Result::Ok(__v) => __v,
@@ -760,6 +991,21 @@ pub unsafe extern "C" fn calculator_is(c: *const calculator_t, value: f64) -> bo
     let __ret: bool;
     __ret = __cbg_out_bool(__v);
     __ret
+}
+#[no_mangle]
+#[allow(non_snake_case, unused_mut, unused_variables, unused_unsafe, dead_code)]
+pub unsafe extern "C" fn calculator_last_or_none(
+    c: *const calculator_t,
+    f: closure_maybe_value_t,
+) {
+    let c = match __cbg_in___Calculator(c) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__msg) => {
+            panic!("{}", __msg);
+        }
+    };
+    let f = __cbg_in_closure_maybe_value_t(f);
+    example_flat::calculator_last_or_none(c, f);
 }
 #[no_mangle]
 #[allow(non_snake_case, unused_mut, unused_variables, unused_unsafe, dead_code)]

--- a/examples/example-cbindgen/generated/example_flat_x86_64.rs
+++ b/examples/example-cbindgen/generated/example_flat_x86_64.rs
@@ -516,8 +516,8 @@ pub(crate) unsafe fn __cbg_in_closure_history_batch_t(
     });
     move |__a0: ::std::vec::Vec<f64>| {
         if let ::core::option::Option::Some(__f) = __call {
-            let mut __w0_0 = ::core::mem::MaybeUninit::<*mut f64>::uninit();
-            let mut __w0_1 = ::core::mem::MaybeUninit::<usize>::uninit();
+            let mut __w0_0 = ::core::mem::MaybeUninit::<*mut f64>::zeroed();
+            let mut __w0_1 = ::core::mem::MaybeUninit::<usize>::zeroed();
             let __arr: ::std::vec::Vec<f64> = __a0
                 .into_iter()
                 .map(__cbg_out_f64)
@@ -553,8 +553,8 @@ pub(crate) unsafe fn __cbg_in_closure_maybe_grade_t(
     });
     move |__a0: ::core::option::Option<example_flat::Grade>| {
         if let ::core::option::Option::Some(__f) = __call {
-            let mut __w0_0 = ::core::mem::MaybeUninit::<bool>::uninit();
-            let mut __w0_1 = ::core::mem::MaybeUninit::<grade_t>::uninit();
+            let mut __w0_0 = ::core::mem::MaybeUninit::<bool>::zeroed();
+            let mut __w0_1 = ::core::mem::MaybeUninit::<grade_t>::zeroed();
             match __a0 {
                 ::core::option::Option::Some(__x) => {
                     *__w0_0.as_mut_ptr() = true;
@@ -592,8 +592,8 @@ pub(crate) unsafe fn __cbg_in_closure_maybe_value_t(
     });
     move |__a0: ::core::option::Option<f64>| {
         if let ::core::option::Option::Some(__f) = __call {
-            let mut __w0_0 = ::core::mem::MaybeUninit::<bool>::uninit();
-            let mut __w0_1 = ::core::mem::MaybeUninit::<f64>::uninit();
+            let mut __w0_0 = ::core::mem::MaybeUninit::<bool>::zeroed();
+            let mut __w0_1 = ::core::mem::MaybeUninit::<f64>::zeroed();
             match __a0 {
                 ::core::option::Option::Some(__x) => {
                     *__w0_0.as_mut_ptr() = true;

--- a/examples/example-cbindgen/generated/example_flat_x86_64.rs
+++ b/examples/example-cbindgen/generated/example_flat_x86_64.rs
@@ -70,6 +70,13 @@ pub struct foo_t {
 #[repr(C)]
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 #[allow(non_camel_case_types)]
+pub enum grade_t {
+    Low = 1,
+    High = 2,
+}
+#[repr(C)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[allow(non_camel_case_types)]
 pub enum inside_foo_t {
     DouddleDee = 42,
     DouddleDum = 24,
@@ -159,10 +166,27 @@ pub unsafe extern "C" fn shape_drop(this_: *mut ::core::mem::MaybeUninit<shape_t
 }
 #[repr(C)]
 #[allow(non_camel_case_types)]
+pub struct closure_maybe_grade_t {
+    pub context: *mut ::core::ffi::c_void,
+    pub call: ::core::option::Option<
+        unsafe extern "C" fn(
+            ::core::mem::MaybeUninit<bool>,
+            ::core::mem::MaybeUninit<grade_t>,
+            *mut ::core::ffi::c_void,
+        ),
+    >,
+    pub drop: ::core::option::Option<unsafe extern "C" fn(*mut ::core::ffi::c_void)>,
+}
+#[repr(C)]
+#[allow(non_camel_case_types)]
 pub struct closure_maybe_value_t {
     pub context: *mut ::core::ffi::c_void,
     pub call: ::core::option::Option<
-        unsafe extern "C" fn(bool, f64, *mut ::core::ffi::c_void),
+        unsafe extern "C" fn(
+            ::core::mem::MaybeUninit<bool>,
+            ::core::mem::MaybeUninit<f64>,
+            *mut ::core::ffi::c_void,
+        ),
     >,
     pub drop: ::core::option::Option<unsafe extern "C" fn(*mut ::core::ffi::c_void)>,
 }
@@ -216,6 +240,35 @@ pub(crate) unsafe fn __cbg_in_Foo(v: foo_t) -> example_flat::Foo {
         x86_64_field: v.x86_64_field,
         stable_field: v.stable_field,
     }
+}
+#[allow(non_snake_case, unused_variables, dead_code)]
+pub(crate) unsafe fn __cbg_in_Grade(
+    v: ::core::mem::MaybeUninit<grade_t>,
+) -> ::core::result::Result<example_flat::Grade, ::std::string::String> {
+    const _: () = {
+        assert!(
+            ::core::mem::size_of:: < grade_t > () == ::core::mem::size_of:: <
+            ::core::ffi::c_int > (),
+            "`grade_t`: a #[repr(C)] enum must have the size of a C `int`"
+        );
+        assert!(
+            ::core::mem::align_of:: < grade_t > () == ::core::mem::align_of:: <
+            ::core::ffi::c_int > (),
+            "`grade_t`: a #[repr(C)] enum must have the alignment of a C `int`"
+        );
+    };
+    let __raw: ::core::ffi::c_int = ::core::ptr::read(
+        v.as_ptr() as *const ::core::ffi::c_int,
+    );
+    if __raw == grade_t::Low as ::core::ffi::c_int {
+        return ::core::result::Result::Ok(example_flat::Grade::Low);
+    }
+    if __raw == grade_t::High as ::core::ffi::c_int {
+        return ::core::result::Result::Ok(example_flat::Grade::High);
+    }
+    ::core::result::Result::Err(
+        ::std::format!("invalid discriminant {} for `grade_t`", __raw),
+    )
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
 pub(crate) unsafe fn __cbg_in_InsideFoo(
@@ -427,6 +480,45 @@ pub(crate) unsafe fn __cbg_in_bool(v: ::core::mem::MaybeUninit<bool>) -> bool {
     ::core::ptr::read(v.as_ptr() as *const u8) != 0
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
+pub(crate) unsafe fn __cbg_in_closure_maybe_grade_t(
+    c: closure_maybe_grade_t,
+) -> impl Fn(::core::option::Option<example_flat::Grade>) + Send + Sync + 'static {
+    struct __Ctx {
+        context: *mut ::core::ffi::c_void,
+        drop: ::core::option::Option<unsafe extern "C" fn(*mut ::core::ffi::c_void)>,
+    }
+    unsafe impl ::core::marker::Send for __Ctx {}
+    unsafe impl ::core::marker::Sync for __Ctx {}
+    impl ::core::ops::Drop for __Ctx {
+        fn drop(&mut self) {
+            if let ::core::option::Option::Some(__d) = self.drop {
+                unsafe { __d(self.context) }
+            }
+        }
+    }
+    let __call = c.call;
+    let __ctx = ::std::sync::Arc::new(__Ctx {
+        context: c.context,
+        drop: c.drop,
+    });
+    move |__a0: ::core::option::Option<example_flat::Grade>| {
+        let mut __w0_0 = ::core::mem::MaybeUninit::<bool>::uninit();
+        let mut __w0_1 = ::core::mem::MaybeUninit::<grade_t>::uninit();
+        match __a0 {
+            ::core::option::Option::Some(__x) => {
+                *__w0_0.as_mut_ptr() = true;
+                *__w0_1.as_mut_ptr() = __cbg_out_Grade(__x);
+            }
+            ::core::option::Option::None => {
+                *__w0_0.as_mut_ptr() = false;
+            }
+        }
+        if let ::core::option::Option::Some(__f) = __call {
+            unsafe { __f(__w0_0, __w0_1, __ctx.context) }
+        }
+    }
+}
+#[allow(non_snake_case, unused_variables, dead_code)]
 pub(crate) unsafe fn __cbg_in_closure_maybe_value_t(
     c: closure_maybe_value_t,
 ) -> impl Fn(::core::option::Option<f64>) + Send + Sync + 'static {
@@ -449,15 +541,15 @@ pub(crate) unsafe fn __cbg_in_closure_maybe_value_t(
         drop: c.drop,
     });
     move |__a0: ::core::option::Option<f64>| {
-        let mut __w0_0: bool = ::core::mem::zeroed();
-        let mut __w0_1: f64 = ::core::mem::zeroed();
+        let mut __w0_0 = ::core::mem::MaybeUninit::<bool>::uninit();
+        let mut __w0_1 = ::core::mem::MaybeUninit::<f64>::uninit();
         match __a0 {
             ::core::option::Option::Some(__x) => {
-                __w0_0 = true;
-                __w0_1 = __cbg_out_f64(__x);
+                *__w0_0.as_mut_ptr() = true;
+                *__w0_1.as_mut_ptr() = __cbg_out_f64(__x);
             }
             ::core::option::Option::None => {
-                __w0_0 = false;
+                *__w0_0.as_mut_ptr() = false;
             }
         }
         if let ::core::option::Option::Some(__f) = __call {
@@ -533,6 +625,13 @@ pub(crate) fn __cbg_out_Foo(v: example_flat::Foo) -> foo_t {
         id: v.id,
         x86_64_field: v.x86_64_field,
         stable_field: v.stable_field,
+    }
+}
+#[allow(non_snake_case, unused_variables, dead_code)]
+pub(crate) fn __cbg_out_Grade(v: example_flat::Grade) -> grade_t {
+    match v {
+        example_flat::Grade::Low => grade_t::Low,
+        example_flat::Grade::High => grade_t::High,
     }
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
@@ -616,6 +715,8 @@ pub(crate) fn __cbg_out_u64(v: u64) -> u64 {
 }
 #[allow(non_snake_case, dead_code, unused_variables)]
 pub(crate) fn __cbg_out_unit(v: ()) {}
+#[allow(non_snake_case, dead_code, unused)]
+pub(crate) fn __cbg_outmark_option_Grade() {}
 #[allow(non_snake_case, dead_code, unused)]
 pub(crate) fn __cbg_outmark_option_f64() {}
 #[allow(non_snake_case, dead_code, unused)]
@@ -795,6 +896,21 @@ pub unsafe extern "C" fn calculator_get_value(c: *const calculator_t) -> f64 {
     let __ret: f64;
     __ret = __cbg_out_f64(__v);
     __ret
+}
+#[no_mangle]
+#[allow(non_snake_case, unused_mut, unused_variables, unused_unsafe, dead_code)]
+pub unsafe extern "C" fn calculator_grade_or_none(
+    c: *const calculator_t,
+    f: closure_maybe_grade_t,
+) {
+    let c = match __cbg_in___Calculator(c) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__msg) => {
+            panic!("{}", __msg);
+        }
+    };
+    let f = __cbg_in_closure_maybe_grade_t(f);
+    example_flat::calculator_grade_or_none(c, f);
 }
 #[no_mangle]
 #[allow(non_snake_case, unused_mut, unused_variables, unused_unsafe, dead_code)]

--- a/examples/example-cbindgen/generated/example_flat_x86_64.rs
+++ b/examples/example-cbindgen/generated/example_flat_x86_64.rs
@@ -159,6 +159,15 @@ pub unsafe extern "C" fn shape_drop(this_: *mut ::core::mem::MaybeUninit<shape_t
 }
 #[repr(C)]
 #[allow(non_camel_case_types)]
+pub struct closure_maybe_value_t {
+    pub context: *mut ::core::ffi::c_void,
+    pub call: ::core::option::Option<
+        unsafe extern "C" fn(bool, f64, *mut ::core::ffi::c_void),
+    >,
+    pub drop: ::core::option::Option<unsafe extern "C" fn(*mut ::core::ffi::c_void)>,
+}
+#[repr(C)]
+#[allow(non_camel_case_types)]
 pub struct closure_value_t {
     pub context: *mut ::core::ffi::c_void,
     pub call: ::core::option::Option<
@@ -418,6 +427,45 @@ pub(crate) unsafe fn __cbg_in_bool(v: ::core::mem::MaybeUninit<bool>) -> bool {
     ::core::ptr::read(v.as_ptr() as *const u8) != 0
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
+pub(crate) unsafe fn __cbg_in_closure_maybe_value_t(
+    c: closure_maybe_value_t,
+) -> impl Fn(::core::option::Option<f64>) + Send + Sync + 'static {
+    struct __Ctx {
+        context: *mut ::core::ffi::c_void,
+        drop: ::core::option::Option<unsafe extern "C" fn(*mut ::core::ffi::c_void)>,
+    }
+    unsafe impl ::core::marker::Send for __Ctx {}
+    unsafe impl ::core::marker::Sync for __Ctx {}
+    impl ::core::ops::Drop for __Ctx {
+        fn drop(&mut self) {
+            if let ::core::option::Option::Some(__d) = self.drop {
+                unsafe { __d(self.context) }
+            }
+        }
+    }
+    let __call = c.call;
+    let __ctx = ::std::sync::Arc::new(__Ctx {
+        context: c.context,
+        drop: c.drop,
+    });
+    move |__a0: ::core::option::Option<f64>| {
+        let mut __w0_0: bool = ::core::mem::zeroed();
+        let mut __w0_1: f64 = ::core::mem::zeroed();
+        match __a0 {
+            ::core::option::Option::Some(__x) => {
+                __w0_0 = true;
+                __w0_1 = __cbg_out_f64(__x);
+            }
+            ::core::option::Option::None => {
+                __w0_0 = false;
+            }
+        }
+        if let ::core::option::Option::Some(__f) = __call {
+            unsafe { __f(__w0_0, __w0_1, __ctx.context) }
+        }
+    }
+}
+#[allow(non_snake_case, unused_variables, dead_code)]
 pub(crate) unsafe fn __cbg_in_closure_value_t(
     c: closure_value_t,
 ) -> impl Fn(f64) + Send + Sync + 'static {
@@ -568,6 +616,8 @@ pub(crate) fn __cbg_out_u64(v: u64) -> u64 {
 }
 #[allow(non_snake_case, dead_code, unused_variables)]
 pub(crate) fn __cbg_out_unit(v: ()) {}
+#[allow(non_snake_case, dead_code, unused)]
+pub(crate) fn __cbg_outmark_option_f64() {}
 #[allow(non_snake_case, dead_code, unused)]
 pub(crate) fn __cbg_outmark_vec_f64() {}
 #[allow(non_snake_case, dead_code, unused)]
@@ -760,6 +810,21 @@ pub unsafe extern "C" fn calculator_is(c: *const calculator_t, value: f64) -> bo
     let __ret: bool;
     __ret = __cbg_out_bool(__v);
     __ret
+}
+#[no_mangle]
+#[allow(non_snake_case, unused_mut, unused_variables, unused_unsafe, dead_code)]
+pub unsafe extern "C" fn calculator_last_or_none(
+    c: *const calculator_t,
+    f: closure_maybe_value_t,
+) {
+    let c = match __cbg_in___Calculator(c) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__msg) => {
+            panic!("{}", __msg);
+        }
+    };
+    let f = __cbg_in_closure_maybe_value_t(f);
+    example_flat::calculator_last_or_none(c, f);
 }
 #[no_mangle]
 #[allow(non_snake_case, unused_mut, unused_variables, unused_unsafe, dead_code)]

--- a/examples/example-cbindgen/generated/example_flat_x86_64.rs
+++ b/examples/example-cbindgen/generated/example_flat_x86_64.rs
@@ -166,6 +166,19 @@ pub unsafe extern "C" fn shape_drop(this_: *mut ::core::mem::MaybeUninit<shape_t
 }
 #[repr(C)]
 #[allow(non_camel_case_types)]
+pub struct closure_history_batch_t {
+    pub context: *mut ::core::ffi::c_void,
+    pub call: ::core::option::Option<
+        unsafe extern "C" fn(
+            ::core::mem::MaybeUninit<*mut f64>,
+            ::core::mem::MaybeUninit<usize>,
+            *mut ::core::ffi::c_void,
+        ),
+    >,
+    pub drop: ::core::option::Option<unsafe extern "C" fn(*mut ::core::ffi::c_void)>,
+}
+#[repr(C)]
+#[allow(non_camel_case_types)]
 pub struct closure_maybe_grade_t {
     pub context: *mut ::core::ffi::c_void,
     pub call: ::core::option::Option<
@@ -480,6 +493,43 @@ pub(crate) unsafe fn __cbg_in_bool(v: ::core::mem::MaybeUninit<bool>) -> bool {
     ::core::ptr::read(v.as_ptr() as *const u8) != 0
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
+pub(crate) unsafe fn __cbg_in_closure_history_batch_t(
+    c: closure_history_batch_t,
+) -> impl Fn(::std::vec::Vec<f64>) + Send + Sync + 'static {
+    struct __Ctx {
+        context: *mut ::core::ffi::c_void,
+        drop: ::core::option::Option<unsafe extern "C" fn(*mut ::core::ffi::c_void)>,
+    }
+    unsafe impl ::core::marker::Send for __Ctx {}
+    unsafe impl ::core::marker::Sync for __Ctx {}
+    impl ::core::ops::Drop for __Ctx {
+        fn drop(&mut self) {
+            if let ::core::option::Option::Some(__d) = self.drop {
+                unsafe { __d(self.context) }
+            }
+        }
+    }
+    let __call = c.call;
+    let __ctx = ::std::sync::Arc::new(__Ctx {
+        context: c.context,
+        drop: c.drop,
+    });
+    move |__a0: ::std::vec::Vec<f64>| {
+        if let ::core::option::Option::Some(__f) = __call {
+            let mut __w0_0 = ::core::mem::MaybeUninit::<*mut f64>::uninit();
+            let mut __w0_1 = ::core::mem::MaybeUninit::<usize>::uninit();
+            let __arr: ::std::vec::Vec<f64> = __a0
+                .into_iter()
+                .map(__cbg_out_f64)
+                .collect();
+            let (__p, __n) = __cbg_alloc_array(__arr);
+            *__w0_0.as_mut_ptr() = __p;
+            *__w0_1.as_mut_ptr() = __n;
+            unsafe { __f(__w0_0, __w0_1, __ctx.context) }
+        }
+    }
+}
+#[allow(non_snake_case, unused_variables, dead_code)]
 pub(crate) unsafe fn __cbg_in_closure_maybe_grade_t(
     c: closure_maybe_grade_t,
 ) -> impl Fn(::core::option::Option<example_flat::Grade>) + Send + Sync + 'static {
@@ -502,18 +552,18 @@ pub(crate) unsafe fn __cbg_in_closure_maybe_grade_t(
         drop: c.drop,
     });
     move |__a0: ::core::option::Option<example_flat::Grade>| {
-        let mut __w0_0 = ::core::mem::MaybeUninit::<bool>::uninit();
-        let mut __w0_1 = ::core::mem::MaybeUninit::<grade_t>::uninit();
-        match __a0 {
-            ::core::option::Option::Some(__x) => {
-                *__w0_0.as_mut_ptr() = true;
-                *__w0_1.as_mut_ptr() = __cbg_out_Grade(__x);
-            }
-            ::core::option::Option::None => {
-                *__w0_0.as_mut_ptr() = false;
-            }
-        }
         if let ::core::option::Option::Some(__f) = __call {
+            let mut __w0_0 = ::core::mem::MaybeUninit::<bool>::uninit();
+            let mut __w0_1 = ::core::mem::MaybeUninit::<grade_t>::uninit();
+            match __a0 {
+                ::core::option::Option::Some(__x) => {
+                    *__w0_0.as_mut_ptr() = true;
+                    *__w0_1.as_mut_ptr() = __cbg_out_Grade(__x);
+                }
+                ::core::option::Option::None => {
+                    *__w0_0.as_mut_ptr() = false;
+                }
+            }
             unsafe { __f(__w0_0, __w0_1, __ctx.context) }
         }
     }
@@ -541,18 +591,18 @@ pub(crate) unsafe fn __cbg_in_closure_maybe_value_t(
         drop: c.drop,
     });
     move |__a0: ::core::option::Option<f64>| {
-        let mut __w0_0 = ::core::mem::MaybeUninit::<bool>::uninit();
-        let mut __w0_1 = ::core::mem::MaybeUninit::<f64>::uninit();
-        match __a0 {
-            ::core::option::Option::Some(__x) => {
-                *__w0_0.as_mut_ptr() = true;
-                *__w0_1.as_mut_ptr() = __cbg_out_f64(__x);
-            }
-            ::core::option::Option::None => {
-                *__w0_0.as_mut_ptr() = false;
-            }
-        }
         if let ::core::option::Option::Some(__f) = __call {
+            let mut __w0_0 = ::core::mem::MaybeUninit::<bool>::uninit();
+            let mut __w0_1 = ::core::mem::MaybeUninit::<f64>::uninit();
+            match __a0 {
+                ::core::option::Option::Some(__x) => {
+                    *__w0_0.as_mut_ptr() = true;
+                    *__w0_1.as_mut_ptr() = __cbg_out_f64(__x);
+                }
+                ::core::option::Option::None => {
+                    *__w0_0.as_mut_ptr() = false;
+                }
+            }
             unsafe { __f(__w0_0, __w0_1, __ctx.context) }
         }
     }
@@ -580,8 +630,8 @@ pub(crate) unsafe fn __cbg_in_closure_value_t(
         drop: c.drop,
     });
     move |__a0: f64| {
-        let __w0 = __cbg_out_f64(__a0);
         if let ::core::option::Option::Some(__f) = __call {
+            let __w0 = __cbg_out_f64(__a0);
             unsafe { __f(__w0, __ctx.context) }
         }
     }
@@ -911,6 +961,21 @@ pub unsafe extern "C" fn calculator_grade_or_none(
     };
     let f = __cbg_in_closure_maybe_grade_t(f);
     example_flat::calculator_grade_or_none(c, f);
+}
+#[no_mangle]
+#[allow(non_snake_case, unused_mut, unused_variables, unused_unsafe, dead_code)]
+pub unsafe extern "C" fn calculator_history_batch(
+    c: *const calculator_t,
+    f: closure_history_batch_t,
+) {
+    let c = match __cbg_in___Calculator(c) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__msg) => {
+            panic!("{}", __msg);
+        }
+    };
+    let f = __cbg_in_closure_history_batch_t(f);
+    example_flat::calculator_history_batch(c, f);
 }
 #[no_mangle]
 #[allow(non_snake_case, unused_mut, unused_variables, unused_unsafe, dead_code)]

--- a/examples/example-cbindgen/generated/example_flat_x86_64_internal_unstable.rs
+++ b/examples/example-cbindgen/generated/example_flat_x86_64_internal_unstable.rs
@@ -516,8 +516,8 @@ pub(crate) unsafe fn __cbg_in_closure_history_batch_t(
     });
     move |__a0: ::std::vec::Vec<f64>| {
         if let ::core::option::Option::Some(__f) = __call {
-            let mut __w0_0 = ::core::mem::MaybeUninit::<*mut f64>::uninit();
-            let mut __w0_1 = ::core::mem::MaybeUninit::<usize>::uninit();
+            let mut __w0_0 = ::core::mem::MaybeUninit::<*mut f64>::zeroed();
+            let mut __w0_1 = ::core::mem::MaybeUninit::<usize>::zeroed();
             let __arr: ::std::vec::Vec<f64> = __a0
                 .into_iter()
                 .map(__cbg_out_f64)
@@ -553,8 +553,8 @@ pub(crate) unsafe fn __cbg_in_closure_maybe_grade_t(
     });
     move |__a0: ::core::option::Option<example_flat::Grade>| {
         if let ::core::option::Option::Some(__f) = __call {
-            let mut __w0_0 = ::core::mem::MaybeUninit::<bool>::uninit();
-            let mut __w0_1 = ::core::mem::MaybeUninit::<grade_t>::uninit();
+            let mut __w0_0 = ::core::mem::MaybeUninit::<bool>::zeroed();
+            let mut __w0_1 = ::core::mem::MaybeUninit::<grade_t>::zeroed();
             match __a0 {
                 ::core::option::Option::Some(__x) => {
                     *__w0_0.as_mut_ptr() = true;
@@ -592,8 +592,8 @@ pub(crate) unsafe fn __cbg_in_closure_maybe_value_t(
     });
     move |__a0: ::core::option::Option<f64>| {
         if let ::core::option::Option::Some(__f) = __call {
-            let mut __w0_0 = ::core::mem::MaybeUninit::<bool>::uninit();
-            let mut __w0_1 = ::core::mem::MaybeUninit::<f64>::uninit();
+            let mut __w0_0 = ::core::mem::MaybeUninit::<bool>::zeroed();
+            let mut __w0_1 = ::core::mem::MaybeUninit::<f64>::zeroed();
             match __a0 {
                 ::core::option::Option::Some(__x) => {
                     *__w0_0.as_mut_ptr() = true;

--- a/examples/example-cbindgen/generated/example_flat_x86_64_internal_unstable.rs
+++ b/examples/example-cbindgen/generated/example_flat_x86_64_internal_unstable.rs
@@ -70,6 +70,13 @@ pub struct foo_t {
 #[repr(C)]
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 #[allow(non_camel_case_types)]
+pub enum grade_t {
+    Low = 1,
+    High = 2,
+}
+#[repr(C)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[allow(non_camel_case_types)]
 pub enum inside_foo_t {
     DouddleDee = 42,
     DouddleDum = 24,
@@ -159,10 +166,27 @@ pub unsafe extern "C" fn shape_drop(this_: *mut ::core::mem::MaybeUninit<shape_t
 }
 #[repr(C)]
 #[allow(non_camel_case_types)]
+pub struct closure_maybe_grade_t {
+    pub context: *mut ::core::ffi::c_void,
+    pub call: ::core::option::Option<
+        unsafe extern "C" fn(
+            ::core::mem::MaybeUninit<bool>,
+            ::core::mem::MaybeUninit<grade_t>,
+            *mut ::core::ffi::c_void,
+        ),
+    >,
+    pub drop: ::core::option::Option<unsafe extern "C" fn(*mut ::core::ffi::c_void)>,
+}
+#[repr(C)]
+#[allow(non_camel_case_types)]
 pub struct closure_maybe_value_t {
     pub context: *mut ::core::ffi::c_void,
     pub call: ::core::option::Option<
-        unsafe extern "C" fn(bool, f64, *mut ::core::ffi::c_void),
+        unsafe extern "C" fn(
+            ::core::mem::MaybeUninit<bool>,
+            ::core::mem::MaybeUninit<f64>,
+            *mut ::core::ffi::c_void,
+        ),
     >,
     pub drop: ::core::option::Option<unsafe extern "C" fn(*mut ::core::ffi::c_void)>,
 }
@@ -216,6 +240,35 @@ pub(crate) unsafe fn __cbg_in_Foo(v: foo_t) -> example_flat::Foo {
         x86_64_field: v.x86_64_field,
         unstable_field: v.unstable_field,
     }
+}
+#[allow(non_snake_case, unused_variables, dead_code)]
+pub(crate) unsafe fn __cbg_in_Grade(
+    v: ::core::mem::MaybeUninit<grade_t>,
+) -> ::core::result::Result<example_flat::Grade, ::std::string::String> {
+    const _: () = {
+        assert!(
+            ::core::mem::size_of:: < grade_t > () == ::core::mem::size_of:: <
+            ::core::ffi::c_int > (),
+            "`grade_t`: a #[repr(C)] enum must have the size of a C `int`"
+        );
+        assert!(
+            ::core::mem::align_of:: < grade_t > () == ::core::mem::align_of:: <
+            ::core::ffi::c_int > (),
+            "`grade_t`: a #[repr(C)] enum must have the alignment of a C `int`"
+        );
+    };
+    let __raw: ::core::ffi::c_int = ::core::ptr::read(
+        v.as_ptr() as *const ::core::ffi::c_int,
+    );
+    if __raw == grade_t::Low as ::core::ffi::c_int {
+        return ::core::result::Result::Ok(example_flat::Grade::Low);
+    }
+    if __raw == grade_t::High as ::core::ffi::c_int {
+        return ::core::result::Result::Ok(example_flat::Grade::High);
+    }
+    ::core::result::Result::Err(
+        ::std::format!("invalid discriminant {} for `grade_t`", __raw),
+    )
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
 pub(crate) unsafe fn __cbg_in_InsideFoo(
@@ -427,6 +480,45 @@ pub(crate) unsafe fn __cbg_in_bool(v: ::core::mem::MaybeUninit<bool>) -> bool {
     ::core::ptr::read(v.as_ptr() as *const u8) != 0
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
+pub(crate) unsafe fn __cbg_in_closure_maybe_grade_t(
+    c: closure_maybe_grade_t,
+) -> impl Fn(::core::option::Option<example_flat::Grade>) + Send + Sync + 'static {
+    struct __Ctx {
+        context: *mut ::core::ffi::c_void,
+        drop: ::core::option::Option<unsafe extern "C" fn(*mut ::core::ffi::c_void)>,
+    }
+    unsafe impl ::core::marker::Send for __Ctx {}
+    unsafe impl ::core::marker::Sync for __Ctx {}
+    impl ::core::ops::Drop for __Ctx {
+        fn drop(&mut self) {
+            if let ::core::option::Option::Some(__d) = self.drop {
+                unsafe { __d(self.context) }
+            }
+        }
+    }
+    let __call = c.call;
+    let __ctx = ::std::sync::Arc::new(__Ctx {
+        context: c.context,
+        drop: c.drop,
+    });
+    move |__a0: ::core::option::Option<example_flat::Grade>| {
+        let mut __w0_0 = ::core::mem::MaybeUninit::<bool>::uninit();
+        let mut __w0_1 = ::core::mem::MaybeUninit::<grade_t>::uninit();
+        match __a0 {
+            ::core::option::Option::Some(__x) => {
+                *__w0_0.as_mut_ptr() = true;
+                *__w0_1.as_mut_ptr() = __cbg_out_Grade(__x);
+            }
+            ::core::option::Option::None => {
+                *__w0_0.as_mut_ptr() = false;
+            }
+        }
+        if let ::core::option::Option::Some(__f) = __call {
+            unsafe { __f(__w0_0, __w0_1, __ctx.context) }
+        }
+    }
+}
+#[allow(non_snake_case, unused_variables, dead_code)]
 pub(crate) unsafe fn __cbg_in_closure_maybe_value_t(
     c: closure_maybe_value_t,
 ) -> impl Fn(::core::option::Option<f64>) + Send + Sync + 'static {
@@ -449,15 +541,15 @@ pub(crate) unsafe fn __cbg_in_closure_maybe_value_t(
         drop: c.drop,
     });
     move |__a0: ::core::option::Option<f64>| {
-        let mut __w0_0: bool = ::core::mem::zeroed();
-        let mut __w0_1: f64 = ::core::mem::zeroed();
+        let mut __w0_0 = ::core::mem::MaybeUninit::<bool>::uninit();
+        let mut __w0_1 = ::core::mem::MaybeUninit::<f64>::uninit();
         match __a0 {
             ::core::option::Option::Some(__x) => {
-                __w0_0 = true;
-                __w0_1 = __cbg_out_f64(__x);
+                *__w0_0.as_mut_ptr() = true;
+                *__w0_1.as_mut_ptr() = __cbg_out_f64(__x);
             }
             ::core::option::Option::None => {
-                __w0_0 = false;
+                *__w0_0.as_mut_ptr() = false;
             }
         }
         if let ::core::option::Option::Some(__f) = __call {
@@ -533,6 +625,13 @@ pub(crate) fn __cbg_out_Foo(v: example_flat::Foo) -> foo_t {
         id: v.id,
         x86_64_field: v.x86_64_field,
         unstable_field: v.unstable_field,
+    }
+}
+#[allow(non_snake_case, unused_variables, dead_code)]
+pub(crate) fn __cbg_out_Grade(v: example_flat::Grade) -> grade_t {
+    match v {
+        example_flat::Grade::Low => grade_t::Low,
+        example_flat::Grade::High => grade_t::High,
     }
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
@@ -616,6 +715,8 @@ pub(crate) fn __cbg_out_u64(v: u64) -> u64 {
 }
 #[allow(non_snake_case, dead_code, unused_variables)]
 pub(crate) fn __cbg_out_unit(v: ()) {}
+#[allow(non_snake_case, dead_code, unused)]
+pub(crate) fn __cbg_outmark_option_Grade() {}
 #[allow(non_snake_case, dead_code, unused)]
 pub(crate) fn __cbg_outmark_option_f64() {}
 #[allow(non_snake_case, dead_code, unused)]
@@ -795,6 +896,21 @@ pub unsafe extern "C" fn calculator_get_value(c: *const calculator_t) -> f64 {
     let __ret: f64;
     __ret = __cbg_out_f64(__v);
     __ret
+}
+#[no_mangle]
+#[allow(non_snake_case, unused_mut, unused_variables, unused_unsafe, dead_code)]
+pub unsafe extern "C" fn calculator_grade_or_none(
+    c: *const calculator_t,
+    f: closure_maybe_grade_t,
+) {
+    let c = match __cbg_in___Calculator(c) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__msg) => {
+            panic!("{}", __msg);
+        }
+    };
+    let f = __cbg_in_closure_maybe_grade_t(f);
+    example_flat::calculator_grade_or_none(c, f);
 }
 #[no_mangle]
 #[allow(non_snake_case, unused_mut, unused_variables, unused_unsafe, dead_code)]

--- a/examples/example-cbindgen/generated/example_flat_x86_64_internal_unstable.rs
+++ b/examples/example-cbindgen/generated/example_flat_x86_64_internal_unstable.rs
@@ -159,6 +159,15 @@ pub unsafe extern "C" fn shape_drop(this_: *mut ::core::mem::MaybeUninit<shape_t
 }
 #[repr(C)]
 #[allow(non_camel_case_types)]
+pub struct closure_maybe_value_t {
+    pub context: *mut ::core::ffi::c_void,
+    pub call: ::core::option::Option<
+        unsafe extern "C" fn(bool, f64, *mut ::core::ffi::c_void),
+    >,
+    pub drop: ::core::option::Option<unsafe extern "C" fn(*mut ::core::ffi::c_void)>,
+}
+#[repr(C)]
+#[allow(non_camel_case_types)]
 pub struct closure_value_t {
     pub context: *mut ::core::ffi::c_void,
     pub call: ::core::option::Option<
@@ -418,6 +427,45 @@ pub(crate) unsafe fn __cbg_in_bool(v: ::core::mem::MaybeUninit<bool>) -> bool {
     ::core::ptr::read(v.as_ptr() as *const u8) != 0
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
+pub(crate) unsafe fn __cbg_in_closure_maybe_value_t(
+    c: closure_maybe_value_t,
+) -> impl Fn(::core::option::Option<f64>) + Send + Sync + 'static {
+    struct __Ctx {
+        context: *mut ::core::ffi::c_void,
+        drop: ::core::option::Option<unsafe extern "C" fn(*mut ::core::ffi::c_void)>,
+    }
+    unsafe impl ::core::marker::Send for __Ctx {}
+    unsafe impl ::core::marker::Sync for __Ctx {}
+    impl ::core::ops::Drop for __Ctx {
+        fn drop(&mut self) {
+            if let ::core::option::Option::Some(__d) = self.drop {
+                unsafe { __d(self.context) }
+            }
+        }
+    }
+    let __call = c.call;
+    let __ctx = ::std::sync::Arc::new(__Ctx {
+        context: c.context,
+        drop: c.drop,
+    });
+    move |__a0: ::core::option::Option<f64>| {
+        let mut __w0_0: bool = ::core::mem::zeroed();
+        let mut __w0_1: f64 = ::core::mem::zeroed();
+        match __a0 {
+            ::core::option::Option::Some(__x) => {
+                __w0_0 = true;
+                __w0_1 = __cbg_out_f64(__x);
+            }
+            ::core::option::Option::None => {
+                __w0_0 = false;
+            }
+        }
+        if let ::core::option::Option::Some(__f) = __call {
+            unsafe { __f(__w0_0, __w0_1, __ctx.context) }
+        }
+    }
+}
+#[allow(non_snake_case, unused_variables, dead_code)]
 pub(crate) unsafe fn __cbg_in_closure_value_t(
     c: closure_value_t,
 ) -> impl Fn(f64) + Send + Sync + 'static {
@@ -568,6 +616,8 @@ pub(crate) fn __cbg_out_u64(v: u64) -> u64 {
 }
 #[allow(non_snake_case, dead_code, unused_variables)]
 pub(crate) fn __cbg_out_unit(v: ()) {}
+#[allow(non_snake_case, dead_code, unused)]
+pub(crate) fn __cbg_outmark_option_f64() {}
 #[allow(non_snake_case, dead_code, unused)]
 pub(crate) fn __cbg_outmark_vec_f64() {}
 #[allow(non_snake_case, dead_code, unused)]
@@ -760,6 +810,21 @@ pub unsafe extern "C" fn calculator_is(c: *const calculator_t, value: f64) -> bo
     let __ret: bool;
     __ret = __cbg_out_bool(__v);
     __ret
+}
+#[no_mangle]
+#[allow(non_snake_case, unused_mut, unused_variables, unused_unsafe, dead_code)]
+pub unsafe extern "C" fn calculator_last_or_none(
+    c: *const calculator_t,
+    f: closure_maybe_value_t,
+) {
+    let c = match __cbg_in___Calculator(c) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__msg) => {
+            panic!("{}", __msg);
+        }
+    };
+    let f = __cbg_in_closure_maybe_value_t(f);
+    example_flat::calculator_last_or_none(c, f);
 }
 #[no_mangle]
 #[allow(non_snake_case, unused_mut, unused_variables, unused_unsafe, dead_code)]

--- a/examples/example-cbindgen/generated/example_flat_x86_64_internal_unstable.rs
+++ b/examples/example-cbindgen/generated/example_flat_x86_64_internal_unstable.rs
@@ -166,6 +166,19 @@ pub unsafe extern "C" fn shape_drop(this_: *mut ::core::mem::MaybeUninit<shape_t
 }
 #[repr(C)]
 #[allow(non_camel_case_types)]
+pub struct closure_history_batch_t {
+    pub context: *mut ::core::ffi::c_void,
+    pub call: ::core::option::Option<
+        unsafe extern "C" fn(
+            ::core::mem::MaybeUninit<*mut f64>,
+            ::core::mem::MaybeUninit<usize>,
+            *mut ::core::ffi::c_void,
+        ),
+    >,
+    pub drop: ::core::option::Option<unsafe extern "C" fn(*mut ::core::ffi::c_void)>,
+}
+#[repr(C)]
+#[allow(non_camel_case_types)]
 pub struct closure_maybe_grade_t {
     pub context: *mut ::core::ffi::c_void,
     pub call: ::core::option::Option<
@@ -480,6 +493,43 @@ pub(crate) unsafe fn __cbg_in_bool(v: ::core::mem::MaybeUninit<bool>) -> bool {
     ::core::ptr::read(v.as_ptr() as *const u8) != 0
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
+pub(crate) unsafe fn __cbg_in_closure_history_batch_t(
+    c: closure_history_batch_t,
+) -> impl Fn(::std::vec::Vec<f64>) + Send + Sync + 'static {
+    struct __Ctx {
+        context: *mut ::core::ffi::c_void,
+        drop: ::core::option::Option<unsafe extern "C" fn(*mut ::core::ffi::c_void)>,
+    }
+    unsafe impl ::core::marker::Send for __Ctx {}
+    unsafe impl ::core::marker::Sync for __Ctx {}
+    impl ::core::ops::Drop for __Ctx {
+        fn drop(&mut self) {
+            if let ::core::option::Option::Some(__d) = self.drop {
+                unsafe { __d(self.context) }
+            }
+        }
+    }
+    let __call = c.call;
+    let __ctx = ::std::sync::Arc::new(__Ctx {
+        context: c.context,
+        drop: c.drop,
+    });
+    move |__a0: ::std::vec::Vec<f64>| {
+        if let ::core::option::Option::Some(__f) = __call {
+            let mut __w0_0 = ::core::mem::MaybeUninit::<*mut f64>::uninit();
+            let mut __w0_1 = ::core::mem::MaybeUninit::<usize>::uninit();
+            let __arr: ::std::vec::Vec<f64> = __a0
+                .into_iter()
+                .map(__cbg_out_f64)
+                .collect();
+            let (__p, __n) = __cbg_alloc_array(__arr);
+            *__w0_0.as_mut_ptr() = __p;
+            *__w0_1.as_mut_ptr() = __n;
+            unsafe { __f(__w0_0, __w0_1, __ctx.context) }
+        }
+    }
+}
+#[allow(non_snake_case, unused_variables, dead_code)]
 pub(crate) unsafe fn __cbg_in_closure_maybe_grade_t(
     c: closure_maybe_grade_t,
 ) -> impl Fn(::core::option::Option<example_flat::Grade>) + Send + Sync + 'static {
@@ -502,18 +552,18 @@ pub(crate) unsafe fn __cbg_in_closure_maybe_grade_t(
         drop: c.drop,
     });
     move |__a0: ::core::option::Option<example_flat::Grade>| {
-        let mut __w0_0 = ::core::mem::MaybeUninit::<bool>::uninit();
-        let mut __w0_1 = ::core::mem::MaybeUninit::<grade_t>::uninit();
-        match __a0 {
-            ::core::option::Option::Some(__x) => {
-                *__w0_0.as_mut_ptr() = true;
-                *__w0_1.as_mut_ptr() = __cbg_out_Grade(__x);
-            }
-            ::core::option::Option::None => {
-                *__w0_0.as_mut_ptr() = false;
-            }
-        }
         if let ::core::option::Option::Some(__f) = __call {
+            let mut __w0_0 = ::core::mem::MaybeUninit::<bool>::uninit();
+            let mut __w0_1 = ::core::mem::MaybeUninit::<grade_t>::uninit();
+            match __a0 {
+                ::core::option::Option::Some(__x) => {
+                    *__w0_0.as_mut_ptr() = true;
+                    *__w0_1.as_mut_ptr() = __cbg_out_Grade(__x);
+                }
+                ::core::option::Option::None => {
+                    *__w0_0.as_mut_ptr() = false;
+                }
+            }
             unsafe { __f(__w0_0, __w0_1, __ctx.context) }
         }
     }
@@ -541,18 +591,18 @@ pub(crate) unsafe fn __cbg_in_closure_maybe_value_t(
         drop: c.drop,
     });
     move |__a0: ::core::option::Option<f64>| {
-        let mut __w0_0 = ::core::mem::MaybeUninit::<bool>::uninit();
-        let mut __w0_1 = ::core::mem::MaybeUninit::<f64>::uninit();
-        match __a0 {
-            ::core::option::Option::Some(__x) => {
-                *__w0_0.as_mut_ptr() = true;
-                *__w0_1.as_mut_ptr() = __cbg_out_f64(__x);
-            }
-            ::core::option::Option::None => {
-                *__w0_0.as_mut_ptr() = false;
-            }
-        }
         if let ::core::option::Option::Some(__f) = __call {
+            let mut __w0_0 = ::core::mem::MaybeUninit::<bool>::uninit();
+            let mut __w0_1 = ::core::mem::MaybeUninit::<f64>::uninit();
+            match __a0 {
+                ::core::option::Option::Some(__x) => {
+                    *__w0_0.as_mut_ptr() = true;
+                    *__w0_1.as_mut_ptr() = __cbg_out_f64(__x);
+                }
+                ::core::option::Option::None => {
+                    *__w0_0.as_mut_ptr() = false;
+                }
+            }
             unsafe { __f(__w0_0, __w0_1, __ctx.context) }
         }
     }
@@ -580,8 +630,8 @@ pub(crate) unsafe fn __cbg_in_closure_value_t(
         drop: c.drop,
     });
     move |__a0: f64| {
-        let __w0 = __cbg_out_f64(__a0);
         if let ::core::option::Option::Some(__f) = __call {
+            let __w0 = __cbg_out_f64(__a0);
             unsafe { __f(__w0, __ctx.context) }
         }
     }
@@ -911,6 +961,21 @@ pub unsafe extern "C" fn calculator_grade_or_none(
     };
     let f = __cbg_in_closure_maybe_grade_t(f);
     example_flat::calculator_grade_or_none(c, f);
+}
+#[no_mangle]
+#[allow(non_snake_case, unused_mut, unused_variables, unused_unsafe, dead_code)]
+pub unsafe extern "C" fn calculator_history_batch(
+    c: *const calculator_t,
+    f: closure_history_batch_t,
+) {
+    let c = match __cbg_in___Calculator(c) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__msg) => {
+            panic!("{}", __msg);
+        }
+    };
+    let f = __cbg_in_closure_history_batch_t(f);
+    example_flat::calculator_history_batch(c, f);
 }
 #[no_mangle]
 #[allow(non_snake_case, unused_mut, unused_variables, unused_unsafe, dead_code)]

--- a/examples/example-cbindgen/include/example_flat_aarch64.h
+++ b/examples/example-cbindgen/include/example_flat_aarch64.h
@@ -19,6 +19,11 @@ typedef enum operation_t {
   Div = 3,
 } operation_t;
 
+typedef enum grade_t {
+  Low = 1,
+  High = 2,
+} grade_t;
+
 typedef enum inside_foo_t {
   DouddleDee = 14,
   DouddleDum = 88,
@@ -99,6 +104,24 @@ typedef struct closure_value_t {
   void (*drop)(void*);
 } closure_value_t;
 
+typedef struct closure_maybe_grade_t {
+  void *context;
+  void (*call)(bool, enum grade_t, void*);
+  void (*drop)(void*);
+} closure_maybe_grade_t;
+
+typedef struct closure_history_batch_t {
+  void *context;
+  void (*call)(double*, uintptr_t, void*);
+  void (*drop)(void*);
+} closure_history_batch_t;
+
+typedef struct closure_maybe_value_t {
+  void *context;
+  void (*call)(bool, double, void*);
+  void (*drop)(void*);
+} closure_maybe_value_t;
+
 typedef struct foo_t {
   uint64_t id;
   uint64_t aarch64_field;
@@ -133,7 +156,13 @@ double *calculator_get_history(const struct calculator_t *c, uintptr_t *len);
 
 double calculator_get_value(const struct calculator_t *c);
 
+void calculator_grade_or_none(const struct calculator_t *c, struct closure_maybe_grade_t f);
+
+void calculator_history_batch(const struct calculator_t *c, struct closure_history_batch_t f);
+
 bool calculator_is(const struct calculator_t *c, double value);
+
+void calculator_last_or_none(const struct calculator_t *c, struct closure_maybe_value_t f);
 
 struct calculator_t *calculator_merge(struct calculator_t *a, struct calculator_t *b, char **e);
 

--- a/examples/example-cbindgen/include/example_flat_aarch64_internal_unstable.h
+++ b/examples/example-cbindgen/include/example_flat_aarch64_internal_unstable.h
@@ -19,6 +19,11 @@ typedef enum operation_t {
   Div = 3,
 } operation_t;
 
+typedef enum grade_t {
+  Low = 1,
+  High = 2,
+} grade_t;
+
 typedef enum inside_foo_t {
   DouddleDee = 14,
   DouddleDum = 88,
@@ -99,6 +104,24 @@ typedef struct closure_value_t {
   void (*drop)(void*);
 } closure_value_t;
 
+typedef struct closure_maybe_grade_t {
+  void *context;
+  void (*call)(bool, enum grade_t, void*);
+  void (*drop)(void*);
+} closure_maybe_grade_t;
+
+typedef struct closure_history_batch_t {
+  void *context;
+  void (*call)(double*, uintptr_t, void*);
+  void (*drop)(void*);
+} closure_history_batch_t;
+
+typedef struct closure_maybe_value_t {
+  void *context;
+  void (*call)(bool, double, void*);
+  void (*drop)(void*);
+} closure_maybe_value_t;
+
 typedef struct foo_t {
   uint64_t id;
   uint64_t aarch64_field;
@@ -133,7 +156,13 @@ double *calculator_get_history(const struct calculator_t *c, uintptr_t *len);
 
 double calculator_get_value(const struct calculator_t *c);
 
+void calculator_grade_or_none(const struct calculator_t *c, struct closure_maybe_grade_t f);
+
+void calculator_history_batch(const struct calculator_t *c, struct closure_history_batch_t f);
+
 bool calculator_is(const struct calculator_t *c, double value);
+
+void calculator_last_or_none(const struct calculator_t *c, struct closure_maybe_value_t f);
 
 struct calculator_t *calculator_merge(struct calculator_t *a, struct calculator_t *b, char **e);
 

--- a/examples/example-cbindgen/include/example_flat_aarch64_unstable.h
+++ b/examples/example-cbindgen/include/example_flat_aarch64_unstable.h
@@ -19,6 +19,11 @@ typedef enum operation_t {
   Div = 3,
 } operation_t;
 
+typedef enum grade_t {
+  Low = 1,
+  High = 2,
+} grade_t;
+
 typedef enum inside_foo_t {
   DouddleDee = 14,
   DouddleDum = 88,
@@ -99,6 +104,24 @@ typedef struct closure_value_t {
   void (*drop)(void*);
 } closure_value_t;
 
+typedef struct closure_maybe_grade_t {
+  void *context;
+  void (*call)(bool, enum grade_t, void*);
+  void (*drop)(void*);
+} closure_maybe_grade_t;
+
+typedef struct closure_history_batch_t {
+  void *context;
+  void (*call)(double*, uintptr_t, void*);
+  void (*drop)(void*);
+} closure_history_batch_t;
+
+typedef struct closure_maybe_value_t {
+  void *context;
+  void (*call)(bool, double, void*);
+  void (*drop)(void*);
+} closure_maybe_value_t;
+
 typedef struct foo_t {
   uint64_t id;
   uint64_t aarch64_field;
@@ -133,7 +156,13 @@ double *calculator_get_history(const struct calculator_t *c, uintptr_t *len);
 
 double calculator_get_value(const struct calculator_t *c);
 
+void calculator_grade_or_none(const struct calculator_t *c, struct closure_maybe_grade_t f);
+
+void calculator_history_batch(const struct calculator_t *c, struct closure_history_batch_t f);
+
 bool calculator_is(const struct calculator_t *c, double value);
+
+void calculator_last_or_none(const struct calculator_t *c, struct closure_maybe_value_t f);
 
 struct calculator_t *calculator_merge(struct calculator_t *a, struct calculator_t *b, char **e);
 

--- a/examples/example-cbindgen/include/example_flat_x86_64.h
+++ b/examples/example-cbindgen/include/example_flat_x86_64.h
@@ -110,6 +110,12 @@ typedef struct closure_maybe_grade_t {
   void (*drop)(void*);
 } closure_maybe_grade_t;
 
+typedef struct closure_history_batch_t {
+  void *context;
+  void (*call)(double*, uintptr_t, void*);
+  void (*drop)(void*);
+} closure_history_batch_t;
+
 typedef struct closure_maybe_value_t {
   void *context;
   void (*call)(bool, double, void*);
@@ -151,6 +157,8 @@ double *calculator_get_history(const struct calculator_t *c, uintptr_t *len);
 double calculator_get_value(const struct calculator_t *c);
 
 void calculator_grade_or_none(const struct calculator_t *c, struct closure_maybe_grade_t f);
+
+void calculator_history_batch(const struct calculator_t *c, struct closure_history_batch_t f);
 
 bool calculator_is(const struct calculator_t *c, double value);
 

--- a/examples/example-cbindgen/include/example_flat_x86_64.h
+++ b/examples/example-cbindgen/include/example_flat_x86_64.h
@@ -19,6 +19,11 @@ typedef enum operation_t {
   Div = 3,
 } operation_t;
 
+typedef enum grade_t {
+  Low = 1,
+  High = 2,
+} grade_t;
+
 typedef enum inside_foo_t {
   DouddleDee = 42,
   DouddleDum = 24,
@@ -99,6 +104,12 @@ typedef struct closure_value_t {
   void (*drop)(void*);
 } closure_value_t;
 
+typedef struct closure_maybe_grade_t {
+  void *context;
+  void (*call)(bool, enum grade_t, void*);
+  void (*drop)(void*);
+} closure_maybe_grade_t;
+
 typedef struct closure_maybe_value_t {
   void *context;
   void (*call)(bool, double, void*);
@@ -138,6 +149,8 @@ uint64_t calculator_get_count(const struct calculator_t *c);
 double *calculator_get_history(const struct calculator_t *c, uintptr_t *len);
 
 double calculator_get_value(const struct calculator_t *c);
+
+void calculator_grade_or_none(const struct calculator_t *c, struct closure_maybe_grade_t f);
 
 bool calculator_is(const struct calculator_t *c, double value);
 

--- a/examples/example-cbindgen/include/example_flat_x86_64.h
+++ b/examples/example-cbindgen/include/example_flat_x86_64.h
@@ -99,6 +99,12 @@ typedef struct closure_value_t {
   void (*drop)(void*);
 } closure_value_t;
 
+typedef struct closure_maybe_value_t {
+  void *context;
+  void (*call)(bool, double, void*);
+  void (*drop)(void*);
+} closure_maybe_value_t;
+
 typedef struct foo_t {
   uint64_t id;
   uint64_t x86_64_field;
@@ -134,6 +140,8 @@ double *calculator_get_history(const struct calculator_t *c, uintptr_t *len);
 double calculator_get_value(const struct calculator_t *c);
 
 bool calculator_is(const struct calculator_t *c, double value);
+
+void calculator_last_or_none(const struct calculator_t *c, struct closure_maybe_value_t f);
 
 struct calculator_t *calculator_merge(struct calculator_t *a, struct calculator_t *b, char **e);
 

--- a/examples/example-cbindgen/include/example_flat_x86_64_internal_unstable.h
+++ b/examples/example-cbindgen/include/example_flat_x86_64_internal_unstable.h
@@ -110,6 +110,12 @@ typedef struct closure_maybe_grade_t {
   void (*drop)(void*);
 } closure_maybe_grade_t;
 
+typedef struct closure_history_batch_t {
+  void *context;
+  void (*call)(double*, uintptr_t, void*);
+  void (*drop)(void*);
+} closure_history_batch_t;
+
 typedef struct closure_maybe_value_t {
   void *context;
   void (*call)(bool, double, void*);
@@ -151,6 +157,8 @@ double *calculator_get_history(const struct calculator_t *c, uintptr_t *len);
 double calculator_get_value(const struct calculator_t *c);
 
 void calculator_grade_or_none(const struct calculator_t *c, struct closure_maybe_grade_t f);
+
+void calculator_history_batch(const struct calculator_t *c, struct closure_history_batch_t f);
 
 bool calculator_is(const struct calculator_t *c, double value);
 

--- a/examples/example-cbindgen/include/example_flat_x86_64_internal_unstable.h
+++ b/examples/example-cbindgen/include/example_flat_x86_64_internal_unstable.h
@@ -19,6 +19,11 @@ typedef enum operation_t {
   Div = 3,
 } operation_t;
 
+typedef enum grade_t {
+  Low = 1,
+  High = 2,
+} grade_t;
+
 typedef enum inside_foo_t {
   DouddleDee = 42,
   DouddleDum = 24,
@@ -99,6 +104,12 @@ typedef struct closure_value_t {
   void (*drop)(void*);
 } closure_value_t;
 
+typedef struct closure_maybe_grade_t {
+  void *context;
+  void (*call)(bool, enum grade_t, void*);
+  void (*drop)(void*);
+} closure_maybe_grade_t;
+
 typedef struct closure_maybe_value_t {
   void *context;
   void (*call)(bool, double, void*);
@@ -138,6 +149,8 @@ uint64_t calculator_get_count(const struct calculator_t *c);
 double *calculator_get_history(const struct calculator_t *c, uintptr_t *len);
 
 double calculator_get_value(const struct calculator_t *c);
+
+void calculator_grade_or_none(const struct calculator_t *c, struct closure_maybe_grade_t f);
 
 bool calculator_is(const struct calculator_t *c, double value);
 

--- a/examples/example-cbindgen/include/example_flat_x86_64_internal_unstable.h
+++ b/examples/example-cbindgen/include/example_flat_x86_64_internal_unstable.h
@@ -99,6 +99,12 @@ typedef struct closure_value_t {
   void (*drop)(void*);
 } closure_value_t;
 
+typedef struct closure_maybe_value_t {
+  void *context;
+  void (*call)(bool, double, void*);
+  void (*drop)(void*);
+} closure_maybe_value_t;
+
 typedef struct foo_t {
   uint64_t id;
   uint64_t x86_64_field;
@@ -134,6 +140,8 @@ double *calculator_get_history(const struct calculator_t *c, uintptr_t *len);
 double calculator_get_value(const struct calculator_t *c);
 
 bool calculator_is(const struct calculator_t *c, double value);
+
+void calculator_last_or_none(const struct calculator_t *c, struct closure_maybe_value_t f);
 
 struct calculator_t *calculator_merge(struct calculator_t *a, struct calculator_t *b, char **e);
 

--- a/examples/example-flat/src/lib.rs
+++ b/examples/example-flat/src/lib.rs
@@ -423,6 +423,24 @@ pub fn calculator_for_each(c: &Calculator, f: impl Fn(f64) + Send + Sync + 'stat
     }
 }
 
+/// The same delivery with an **optional** argument — a composite in argument
+/// position.
+///
+/// `Option`/`Vec`/`Cow` have no converter of their own: each resolves to a
+/// marker whose destination is `()`, and the real ABI is the shape it lowers
+/// to. The return path has always lowered them; the callback-argument path
+/// called that marker as if it were a converter, and a marker takes no
+/// arguments — so this shape emitted a binding that did not build (#428).
+///
+/// Fires once with the last recorded value and once with `None`, so both arms
+/// of the lowering reach C from a single call: an `Option<f64>` has no spare
+/// bit pattern, so it crosses as a `bool` beside the value.
+#[prebindgen]
+pub fn calculator_last_or_none(c: &Calculator, f: impl Fn(Option<f64>) + Send + Sync + 'static) {
+    f(c.history.last().copied());
+    f(None);
+}
+
 /// Reset the accumulator to zero (feature-gated, mirroring zenoh-flat's
 /// `unstable` slices of the API).
 #[cfg(feature = "unstable")]

--- a/examples/example-flat/src/lib.rs
+++ b/examples/example-flat/src/lib.rs
@@ -57,6 +57,23 @@ pub enum Operation {
     Div = 3,
 }
 
+/// An enum whose discriminants **skip zero** — the case an all-zero fill cannot
+/// be checked against.
+///
+/// A declared `enum_type`'s discriminants are the source's own, re-emitted
+/// verbatim, so the wire is this very enum and zero need not name a variant at
+/// all. Anything that fabricates a value for an absent slot builds an invalid
+/// one here, which is undefined behaviour whether or not the C side reads it
+/// (#428 review). `Option<f64>` cannot show that: every bit pattern is a legal
+/// `f64`.
+#[prebindgen]
+#[repr(i32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Grade {
+    Low = 1,
+    High = 2,
+}
+
 /// A **data-carrying enum** (a sum type): exactly one alternative is live, and it
 /// carries that alternative's payload. Written as plain Rust — the invariant is in
 /// the type, not in a doc comment on a struct of optional fields.
@@ -438,6 +455,21 @@ pub fn calculator_for_each(c: &Calculator, f: impl Fn(f64) + Send + Sync + 'stat
 #[prebindgen]
 pub fn calculator_last_or_none(c: &Calculator, f: impl Fn(Option<f64>) + Send + Sync + 'static) {
     f(c.history.last().copied());
+    f(None);
+}
+
+/// The same shape over a [`Grade`], whose discriminants skip zero.
+///
+/// The absent arm must leave the value slot alone rather than fill it: the wire
+/// IS the Rust enum, so a fabricated zero would be an invalid value of it. Fires
+/// present then absent, like its sibling.
+#[prebindgen]
+pub fn calculator_grade_or_none(c: &Calculator, f: impl Fn(Option<Grade>) + Send + Sync + 'static) {
+    f((c.value > 0.0).then_some(if c.value > 10.0 {
+        Grade::High
+    } else {
+        Grade::Low
+    }));
     f(None);
 }
 

--- a/examples/example-flat/src/lib.rs
+++ b/examples/example-flat/src/lib.rs
@@ -458,6 +458,19 @@ pub fn calculator_last_or_none(c: &Calculator, f: impl Fn(Option<f64>) + Send + 
     f(None);
 }
 
+/// Deliver the whole history as an owned array — the composite whose lowering
+/// **allocates**.
+///
+/// A `Vec<T>` argument crosses as a malloc'd `(ptr, len)` pair the C side owns,
+/// so a closure whose `call` is NULL must not convert at all: nobody would
+/// receive that block, and nobody could free it (#428 review). Its sibling
+/// callbacks allocate nothing, so only this one can say whether the encode is
+/// inside the guard.
+#[prebindgen]
+pub fn calculator_history_batch(c: &Calculator, f: impl Fn(Vec<f64>) + Send + Sync + 'static) {
+    f(c.history.clone());
+}
+
 /// The same shape over a [`Grade`], whose discriminants skip zero.
 ///
 /// The absent arm must leave the value slot alone rather than fill it: the wire

--- a/examples/perftest-c/generated/perftest.rs
+++ b/examples/perftest-c/generated/perftest.rs
@@ -361,8 +361,8 @@ pub(crate) unsafe fn __cbg_in_closure_payload_t(
         drop: c.drop,
     });
     move |__a0: &perftest_flat::Payload| {
-        let __w0 = __cbg_out_ref_Payload(__a0);
         if let ::core::option::Option::Some(__f) = __call {
+            let __w0 = __cbg_out_ref_Payload(__a0);
             unsafe { __f(__w0, __ctx.context) }
         }
     }

--- a/prebindgen-c/src/emit.rs
+++ b/prebindgen-c/src/emit.rs
@@ -708,7 +708,7 @@ impl CbindgenBuilder {
     /// available for enclosing `Option`/`Result` layers. Mirrors the
     /// niche-stacking model in `core::niches`.
     #[allow(clippy::only_used_in_recursion)]
-    pub(super) fn lower_shape(&self, ty: &TypeRef, registry: &Registry<()>) -> ValueShape {
+    pub(super) fn lower_shape(&self, ty: &TypeRef, registry: &impl Conversions<()>) -> ValueShape {
         if matches!(ty.kind(), TypeKind::Unit) {
             return ValueShape {
                 fields: vec![],
@@ -832,7 +832,7 @@ impl CbindgenBuilder {
         ty: &TypeRef,
         val: TokenStream,
         targets: &[TokenStream],
-        registry: &Registry<()>,
+        registry: &impl Conversions<()>,
         route: &ErrRoute,
     ) -> TokenStream {
         if matches!(ty.kind(), TypeKind::Unit) {
@@ -933,7 +933,7 @@ impl CbindgenBuilder {
         }
     }
 
-    fn output_is_fallible(ty: &TypeRef, registry: &Registry<()>) -> bool {
+    fn output_is_fallible(ty: &TypeRef, registry: &impl Conversions<()>) -> bool {
         let vec_elem = match ty.kind() {
             TypeKind::Vec(e) => Some(&**e),
             _ => None,

--- a/prebindgen-c/src/emit.rs
+++ b/prebindgen-c/src/emit.rs
@@ -952,17 +952,26 @@ impl CbindgenBuilder {
     }
 
     fn output_is_fallible(ty: &TypeRef, registry: &impl Conversions<()>) -> bool {
-        let vec_elem = match ty.kind() {
-            TypeKind::Vec(e) => Some(&**e),
-            _ => None,
-        };
-        if let Some(inner) = ty
-            .optional_inner()
-            .or(vec_elem)
-            .or_else(|| r_cow_slice_elem(ty))
-            .or_else(|| r_scalar_slice_elem(ty))
-        {
-            return Self::output_is_fallible(inner, registry);
+        // The third walk over the same value, and it stops where the other two
+        // do: a node with a wire of its own is encoded by its own converter, so
+        // whether the encode can fail is THAT converter's answer. Peeling past
+        // it asks about a converter that never runs — which decides whether the
+        // binding needs `.panic()`, so the two disagreeing is a wrapper that
+        // aborts where nothing opted in, or an opt-in demanded for a conversion
+        // that cannot fail (#428 review).
+        if !r_has_own_wire(ty, registry) {
+            let vec_elem = match ty.kind() {
+                TypeKind::Vec(e) => Some(&**e),
+                _ => None,
+            };
+            if let Some(inner) = ty
+                .optional_inner()
+                .or(vec_elem)
+                .or_else(|| r_cow_slice_elem(ty))
+                .or_else(|| r_scalar_slice_elem(ty))
+            {
+                return Self::output_is_fallible(inner, registry);
+            }
         }
         registry
             .output_entry(ty)

--- a/prebindgen-c/src/emit.rs
+++ b/prebindgen-c/src/emit.rs
@@ -715,93 +715,105 @@ impl CbindgenBuilder {
                 niches: Niches::empty(),
             };
         }
-        // `Vec<T>` → `T_wire* + size_t`. The element must lower to a single C
-        // value (one converter); a composite element is unsupported.
-        // `TypeKind::Vec` and not `sequence_elem`: that reading peels the
-        // erased wrappers first, so a `Cow<'_, [u8]>` would answer here and
-        // take the `Vec` lowering instead of its own arm below.
-        if let TypeKind::Vec(elem) = ty.kind() {
-            assert!(
-                elem.optional_inner().is_none()
-                    && elem.sequence_elem().is_none()
-                    && elem.fallible_parts().is_none(),
-                "Cbindgen: `Vec<{}>` element must be a single-value type \
-                 (scalar, data struct, String, or handle), not a composite",
-                elem.key(),
-            );
-            let entry = registry.output_entry(elem).unwrap_or_else(|| {
-                panic!(
-                    "Cbindgen: `Vec` element `{}` has no output converter",
-                    elem.key()
-                )
-            });
-            let elem_wire = entry.destination.clone();
-            return ValueShape {
-                fields: vec![
-                    WireField {
-                        suffix: "",
-                        wire: syn::parse_quote!(*mut #elem_wire),
-                    },
-                    WireField {
-                        suffix: "_len",
-                        wire: syn::parse_quote!(usize),
-                    },
-                ],
-                niches: Niches::empty(),
-            };
-        }
-        // `Cow<'_, [T]>` and `&[T]` → `T_wire* + size_t`. The C side receives an
-        // owned malloc'd copy, just like `Vec<T>` outputs.
-        //
-        // A shared slice reaches this only as a RETURN: a slice parameter is a
-        // pointer pair the caller supplies, and a slice callback argument is
-        // lowered by `prereq_callback_structs`. Without the second predicate a
-        // slice return fell through to the base-value path and took the `()`
-        // destination of the marker converter that exists for that callback
-        // lowering, so the wrapper returned nothing and called the marker with
-        // an argument it does not take (#413).
-        if let Some(elem) = r_cow_slice_elem(ty).or_else(|| r_scalar_slice_elem(ty)) {
-            let entry = registry.output_entry(elem).unwrap_or_else(|| {
-                panic!(
-                    "Cbindgen: `Cow` slice element `{}` has no output converter",
-                    elem.key()
-                )
-            });
-            let elem_wire = entry.destination.clone();
-            return ValueShape {
-                fields: vec![
-                    WireField {
-                        suffix: "",
-                        wire: syn::parse_quote!(*mut #elem_wire),
-                    },
-                    WireField {
-                        suffix: "_len",
-                        wire: syn::parse_quote!(usize),
-                    },
-                ],
-                niches: Niches::empty(),
-            };
-        }
-        // `Option<T>` consumes one available inner niche. This includes NULL
-        // pointers and invalid scalar values declared by `convert!`; without a
-        // niche it prepends an explicit `present: bool`.
-        if let Some(inner_ty) = ty.optional_inner() {
-            let inner = self.lower_shape(inner_ty, registry);
-            if let Some((_slot, rest)) = inner.niches.clone().carve() {
+        // A DECLARED conversion beats the shape, at every level and not only the
+        // outermost. `select_output_type` tries `out_custom` before
+        // `out_wrappers`, so a `convert!`-declared `Option<T>` has a wire of its
+        // own; decomposing it anyway would describe a different ABI from the one
+        // the converter table hands out, and the two must agree (#428 review).
+        // The base case below already does this for a type with no shape arm.
+        if !r_has_own_wire(ty, registry) {
+            // `Vec<T>` → `T_wire* + size_t`. The element must lower to a single C
+            // value (one converter); a composite element is unsupported.
+            // `TypeKind::Vec` and not `sequence_elem`: that reading peels the
+            // erased wrappers first, so a `Cow<'_, [u8]>` would answer here and
+            // take the `Vec` lowering instead of its own arm below.
+            if let TypeKind::Vec(elem) = ty.kind() {
+                let entry = registry.output_entry(elem).unwrap_or_else(|| {
+                    panic!(
+                        "Cbindgen: `Vec` element `{}` has no output converter",
+                        elem.key()
+                    )
+                });
+                // The element must lower to ONE C value, and that is the converter
+                // table's answer rather than a list of shapes: a marker destination
+                // means "no wire of its own", whatever put it there — an `Option`, a
+                // shared slice, another run, the unit. A composite element WITH a
+                // declared conversion has a wire and is fine.
+                assert!(
+                    !marker_destination(&entry.destination),
+                    "Cbindgen: `Vec<{}>` element has no wire of its own, so there is \
+                 nothing for the array to hold — give it a `convert!` \
+                 declaration or deliver its parts separately",
+                    elem.key(),
+                );
+                let elem_wire = entry.destination.clone();
                 return ValueShape {
-                    fields: inner.fields,
-                    niches: rest,
+                    fields: vec![
+                        WireField {
+                            suffix: "",
+                            wire: syn::parse_quote!(*mut #elem_wire),
+                        },
+                        WireField {
+                            suffix: "_len",
+                            wire: syn::parse_quote!(usize),
+                        },
+                    ],
+                    niches: Niches::empty(),
                 };
             }
-            let mut fields = vec![WireField {
-                suffix: "_present",
-                wire: syn::parse_quote!(bool),
-            }];
-            fields.extend(inner.fields);
-            return ValueShape {
-                fields,
-                niches: Niches::empty(),
-            };
+            // `Cow<'_, [T]>` and `&[T]` → `T_wire* + size_t`. The C side receives an
+            // owned malloc'd copy, just like `Vec<T>` outputs.
+            //
+            // A shared slice reaches this only as a RETURN: a slice parameter is a
+            // pointer pair the caller supplies, and a slice callback argument is
+            // lowered by `prereq_callback_structs`. Without the second predicate a
+            // slice return fell through to the base-value path and took the `()`
+            // destination of the marker converter that exists for that callback
+            // lowering, so the wrapper returned nothing and called the marker with
+            // an argument it does not take (#413).
+            if let Some(elem) = r_cow_slice_elem(ty).or_else(|| r_scalar_slice_elem(ty)) {
+                let entry = registry.output_entry(elem).unwrap_or_else(|| {
+                    panic!(
+                        "Cbindgen: `Cow` slice element `{}` has no output converter",
+                        elem.key()
+                    )
+                });
+                let elem_wire = entry.destination.clone();
+                return ValueShape {
+                    fields: vec![
+                        WireField {
+                            suffix: "",
+                            wire: syn::parse_quote!(*mut #elem_wire),
+                        },
+                        WireField {
+                            suffix: "_len",
+                            wire: syn::parse_quote!(usize),
+                        },
+                    ],
+                    niches: Niches::empty(),
+                };
+            }
+            // `Option<T>` consumes one available inner niche. This includes NULL
+            // pointers and invalid scalar values declared by `convert!`; without a
+            // niche it prepends an explicit `present: bool`.
+            if let Some(inner_ty) = ty.optional_inner() {
+                let inner = self.lower_shape(inner_ty, registry);
+                if let Some((_slot, rest)) = inner.niches.clone().carve() {
+                    return ValueShape {
+                        fields: inner.fields,
+                        niches: rest,
+                    };
+                }
+                let mut fields = vec![WireField {
+                    suffix: "_present",
+                    wire: syn::parse_quote!(bool),
+                }];
+                fields.extend(inner.fields);
+                return ValueShape {
+                    fields,
+                    niches: Niches::empty(),
+                };
+            }
         }
         // Base value: one wire component from its rank-0/1 converter. Custom
         // conversions may declare scalar niches; otherwise a pointer wire
@@ -838,88 +850,94 @@ impl CbindgenBuilder {
         if matches!(ty.kind(), TypeKind::Unit) {
             return quote!();
         }
-        if let TypeKind::Vec(elem) = ty.kind() {
-            let entry = registry.output_entry(elem).expect("Vec element converter");
-            let elem_conv = entry.function.sig.ident.clone();
-            let elem_map = map_arg(&elem_conv, entry.function.sig.unsafety.is_some());
-            let elem_wire = entry.destination.clone();
-            let t_ptr = &targets[0];
-            let t_len = &targets[1];
-            if returns_result(&entry.function.sig.output) {
-                let converted = route_result(quote!(#elem_conv(__value)), route);
-                return quote!(
-                    let mut __arr: ::std::vec::Vec<#elem_wire> = ::std::vec::Vec::new();
-                    for __value in #val {
-                        __arr.push(#converted);
-                    }
-                    let (__p, __n) = __cbg_alloc_array(__arr);
-                    #t_ptr = __p;
-                    #t_len = __n;
-                );
-            } else {
-                return quote!(
-                    let __arr: ::std::vec::Vec<#elem_wire> =
-                        #val.into_iter().map(#elem_map).collect();
-                    let (__p, __n) = __cbg_alloc_array(__arr);
-                    #t_ptr = __p;
-                    #t_len = __n;
-                );
+        // The peer of `lower_shape`'s guard: a node with a wire of its own is
+        // encoded by its own converter, whatever its shape. The two walk the
+        // same value and must stop at the same places (#428 review).
+        if !r_has_own_wire(ty, registry) {
+            if let TypeKind::Vec(elem) = ty.kind() {
+                let entry = registry.output_entry(elem).expect("Vec element converter");
+                let elem_conv = entry.function.sig.ident.clone();
+                let elem_map = map_arg(&elem_conv, entry.function.sig.unsafety.is_some());
+                let elem_wire = entry.destination.clone();
+                let t_ptr = &targets[0];
+                let t_len = &targets[1];
+                if returns_result(&entry.function.sig.output) {
+                    let converted = route_result(quote!(#elem_conv(__value)), route);
+                    return quote!(
+                        let mut __arr: ::std::vec::Vec<#elem_wire> = ::std::vec::Vec::new();
+                        for __value in #val {
+                            __arr.push(#converted);
+                        }
+                        let (__p, __n) = __cbg_alloc_array(__arr);
+                        #t_ptr = __p;
+                        #t_len = __n;
+                    );
+                } else {
+                    return quote!(
+                        let __arr: ::std::vec::Vec<#elem_wire> =
+                            #val.into_iter().map(#elem_map).collect();
+                        let (__p, __n) = __cbg_alloc_array(__arr);
+                        #t_ptr = __p;
+                        #t_len = __n;
+                    );
+                }
             }
-        }
-        if let Some(elem) = r_cow_slice_elem(ty).or_else(|| r_scalar_slice_elem(ty)) {
-            let entry = registry
-                .output_entry(elem)
-                .expect("slice element converter");
-            let elem_conv = entry.function.sig.ident.clone();
-            let elem_map = map_arg(&elem_conv, entry.function.sig.unsafety.is_some());
-            let elem_wire = entry.destination.clone();
-            let t_ptr = &targets[0];
-            let t_len = &targets[1];
-            if returns_result(&entry.function.sig.output) {
-                let converted = route_result(quote!(#elem_conv(__value)), route);
-                return quote!(
-                    let mut __arr: ::std::vec::Vec<#elem_wire> = ::std::vec::Vec::new();
-                    for __value in #val.iter().copied() {
-                        __arr.push(#converted);
-                    }
-                    let (__p, __n) = __cbg_alloc_array(__arr);
-                    #t_ptr = __p;
-                    #t_len = __n;
-                );
-            } else {
-                return quote!(
-                    let __arr: ::std::vec::Vec<#elem_wire> =
-                        #val.iter().copied().map(#elem_map).collect();
-                    let (__p, __n) = __cbg_alloc_array(__arr);
-                    #t_ptr = __p;
-                    #t_len = __n;
-                );
+            if let Some(elem) = r_cow_slice_elem(ty).or_else(|| r_scalar_slice_elem(ty)) {
+                let entry = registry
+                    .output_entry(elem)
+                    .expect("slice element converter");
+                let elem_conv = entry.function.sig.ident.clone();
+                let elem_map = map_arg(&elem_conv, entry.function.sig.unsafety.is_some());
+                let elem_wire = entry.destination.clone();
+                let t_ptr = &targets[0];
+                let t_len = &targets[1];
+                if returns_result(&entry.function.sig.output) {
+                    let converted = route_result(quote!(#elem_conv(__value)), route);
+                    return quote!(
+                        let mut __arr: ::std::vec::Vec<#elem_wire> = ::std::vec::Vec::new();
+                        for __value in #val.iter().copied() {
+                            __arr.push(#converted);
+                        }
+                        let (__p, __n) = __cbg_alloc_array(__arr);
+                        #t_ptr = __p;
+                        #t_len = __n;
+                    );
+                } else {
+                    return quote!(
+                        let __arr: ::std::vec::Vec<#elem_wire> =
+                            #val.iter().copied().map(#elem_map).collect();
+                        let (__p, __n) = __cbg_alloc_array(__arr);
+                        #t_ptr = __p;
+                        #t_len = __n;
+                    );
+                }
             }
-        }
-        if let Some(inner_ty) = ty.optional_inner() {
-            let inner = self.lower_shape(inner_ty, registry);
-            if let Some((slot, _rest)) = inner.niches.clone().carve() {
-                // None reuses the next inner niche; Some encodes inline.
-                let inner_enc = self.encode_value(inner_ty, quote!(__x), targets, registry, route);
-                let null = &slot.value;
-                let t0 = &targets[0];
+            if let Some(inner_ty) = ty.optional_inner() {
+                let inner = self.lower_shape(inner_ty, registry);
+                if let Some((slot, _rest)) = inner.niches.clone().carve() {
+                    // None reuses the next inner niche; Some encodes inline.
+                    let inner_enc =
+                        self.encode_value(inner_ty, quote!(__x), targets, registry, route);
+                    let null = &slot.value;
+                    let t0 = &targets[0];
+                    return quote!(
+                        match #val {
+                            ::core::option::Option::Some(__x) => { #inner_enc }
+                            ::core::option::Option::None => { #t0 = #null; }
+                        }
+                    );
+                }
+                // Explicit `present` flag in targets[0]; inner value follows.
+                let present = &targets[0];
+                let inner_enc =
+                    self.encode_value(inner_ty, quote!(__x), &targets[1..], registry, route);
                 return quote!(
                     match #val {
-                        ::core::option::Option::Some(__x) => { #inner_enc }
-                        ::core::option::Option::None => { #t0 = #null; }
+                        ::core::option::Option::Some(__x) => { #present = true; #inner_enc }
+                        ::core::option::Option::None => { #present = false; }
                     }
                 );
             }
-            // Explicit `present` flag in targets[0]; inner value follows.
-            let present = &targets[0];
-            let inner_enc =
-                self.encode_value(inner_ty, quote!(__x), &targets[1..], registry, route);
-            return quote!(
-                match #val {
-                    ::core::option::Option::Some(__x) => { #present = true; #inner_enc }
-                    ::core::option::Option::None => { #present = false; }
-                }
-            );
         }
         // Base value: run its output converter into the single target.
         let entry = registry.output_entry(ty).expect("base value converter");

--- a/prebindgen-c/src/lib.rs
+++ b/prebindgen-c/src/lib.rs
@@ -625,6 +625,19 @@ fn r_is_lowered_composite(t: &TypeRef, registry: &impl Conversions<()>) -> bool 
     composite && r_shape_is_lowerable(t, registry)
 }
 
+/// Whether this node already has a wire of its own: a real converter rather
+/// than the marker that stands in for a shape with none.
+///
+/// `select_output_type` tries `out_custom` before `out_wrappers`, so a declared
+/// conversion answers here — and the shape lowering has to agree with the
+/// converter table at **every** level, not only the outermost, or the two
+/// describe different ABIs for the same argument (#428 review).
+fn r_has_own_wire(t: &TypeRef, registry: &impl Conversions<()>) -> bool {
+    registry
+        .output_entry(t)
+        .is_some_and(|e| !marker_destination(&e.destination))
+}
+
 /// Whether [`Cbindgen::lower_shape`] decomposes `t` **all the way down**.
 ///
 /// Asking only about the outermost layer is not enough: `Option<Result<T, E>>`
@@ -639,15 +652,19 @@ fn r_is_lowered_composite(t: &TypeRef, registry: &impl Conversions<()>) -> bool 
 /// element is a plain borrow by every shape test and a shared-slice marker in
 /// the table (#428 review).
 fn r_shape_is_lowerable(t: &TypeRef, registry: &impl Conversions<()>) -> bool {
+    // A node with a wire of its own IS the bottom: `lower_shape` stops there
+    // too, so the recursion must not walk past it into a shape that node no
+    // longer describes.
+    if r_has_own_wire(t, registry) {
+        return true;
+    }
     if let Some(inner) = t.optional_inner() {
         return r_shape_is_lowerable(inner, registry);
     }
     // A run's element must lower to one wire of its own — the same rule
     // `lower_shape` asserts when it builds the `(ptr, len)` pair.
     let leaf = r_vec_elem(t).or_else(|| r_cow_slice_elem(t)).unwrap_or(t);
-    registry
-        .output_entry(leaf)
-        .is_some_and(|e| !marker_destination(&e.destination))
+    r_has_own_wire(leaf, registry)
 }
 
 /// The element of a `Vec<E>`.

--- a/prebindgen-c/src/lib.rs
+++ b/prebindgen-c/src/lib.rs
@@ -607,6 +607,23 @@ fn r_is_vec(t: &TypeRef) -> bool {
     matches!(t.kind(), TypeKind::Vec(_))
 }
 
+/// A converter destination that is the unit — the mark `out_wrappers` puts on a
+/// type with no wire of its own.
+fn marker_destination(ty: &syn::Type) -> bool {
+    matches!(ty, syn::Type::Tuple(t) if t.elems.is_empty())
+}
+
+/// The composite shapes [`Cbindgen::lower_shape`] decomposes: a value with no
+/// wire of its own, whose ABI is the fields it lowers to.
+///
+/// Read off the model rather than off the marker converter's `()` destination.
+/// `out_wrappers` gives that destination to a `Result` too, and no arm lowers
+/// one — so a destination test answers `yes` for a shape nothing can emit, and
+/// the caller ends up calling the marker it was trying to avoid (#428 review).
+fn r_is_lowered_composite(t: &TypeRef) -> bool {
+    t.optional_inner().is_some() || r_is_vec(t) || r_cow_slice_elem(t).is_some()
+}
+
 /// The opaque-pointer payload shape — `Box<T>` or `Option<Box<T>>` — off the
 /// classification, returning the reading of `T`.
 ///

--- a/prebindgen-c/src/lib.rs
+++ b/prebindgen-c/src/lib.rs
@@ -621,7 +621,42 @@ fn marker_destination(ty: &syn::Type) -> bool {
 /// one — so a destination test answers `yes` for a shape nothing can emit, and
 /// the caller ends up calling the marker it was trying to avoid (#428 review).
 fn r_is_lowered_composite(t: &TypeRef) -> bool {
-    t.optional_inner().is_some() || r_is_vec(t) || r_cow_slice_elem(t).is_some()
+    let composite = t.optional_inner().is_some() || r_is_vec(t) || r_cow_slice_elem(t).is_some();
+    composite && r_shape_is_lowerable(t)
+}
+
+/// Whether [`Cbindgen::lower_shape`] decomposes `t` **all the way down**.
+///
+/// Asking only about the outermost layer is not enough: `Option<Result<T, E>>`
+/// is an optional, so a shallow test admits it, and then the lowering reaches
+/// the `Result` as a base field and emits a call to *its* marker — the same
+/// failure one layer in (#428 review).
+fn r_shape_is_lowerable(t: &TypeRef) -> bool {
+    // No arm lowers a `Result`, in any position.
+    if t.fallible_parts().is_some() {
+        return false;
+    }
+    if let Some(inner) = t.optional_inner() {
+        return r_shape_is_lowerable(inner);
+    }
+    // A run's element must be a single value — the same rule `lower_shape`
+    // asserts when it builds the `(ptr, len)` pair.
+    if let Some(elem) = r_vec_elem(t).or_else(|| r_cow_slice_elem(t)) {
+        return elem.optional_inner().is_none()
+            && r_vec_elem(elem).is_none()
+            && r_cow_slice_elem(elem).is_none()
+            && elem.fallible_parts().is_none();
+    }
+    // A base value: its own converter is the wire.
+    true
+}
+
+/// The element of a `Vec<E>`.
+fn r_vec_elem(t: &TypeRef) -> Option<&TypeRef> {
+    match t.kind() {
+        TypeKind::Vec(elem) => Some(elem),
+        _ => None,
+    }
 }
 
 /// The opaque-pointer payload shape — `Box<T>` or `Option<Box<T>>` — off the

--- a/prebindgen-c/src/lib.rs
+++ b/prebindgen-c/src/lib.rs
@@ -620,9 +620,9 @@ fn marker_destination(ty: &syn::Type) -> bool {
 /// `out_wrappers` gives that destination to a `Result` too, and no arm lowers
 /// one — so a destination test answers `yes` for a shape nothing can emit, and
 /// the caller ends up calling the marker it was trying to avoid (#428 review).
-fn r_is_lowered_composite(t: &TypeRef) -> bool {
+fn r_is_lowered_composite(t: &TypeRef, registry: &impl Conversions<()>) -> bool {
     let composite = t.optional_inner().is_some() || r_is_vec(t) || r_cow_slice_elem(t).is_some();
-    composite && r_shape_is_lowerable(t)
+    composite && r_shape_is_lowerable(t, registry)
 }
 
 /// Whether [`Cbindgen::lower_shape`] decomposes `t` **all the way down**.
@@ -631,24 +631,23 @@ fn r_is_lowered_composite(t: &TypeRef) -> bool {
 /// is an optional, so a shallow test admits it, and then the lowering reaches
 /// the `Result` as a base field and emits a call to *its* marker — the same
 /// failure one layer in (#428 review).
-fn r_shape_is_lowerable(t: &TypeRef) -> bool {
-    // No arm lowers a `Result`, in any position.
-    if t.fallible_parts().is_some() {
-        return false;
-    }
+///
+/// Every layer below the composite has to end at a value with a **wire of its
+/// own**, and that is a question for the converter table rather than a list of
+/// shapes: a marker destination means "no wire", whatever put it there.
+/// Enumerating the wrapper kinds instead missed `Vec<&'static [u8]>`, whose
+/// element is a plain borrow by every shape test and a shared-slice marker in
+/// the table (#428 review).
+fn r_shape_is_lowerable(t: &TypeRef, registry: &impl Conversions<()>) -> bool {
     if let Some(inner) = t.optional_inner() {
-        return r_shape_is_lowerable(inner);
+        return r_shape_is_lowerable(inner, registry);
     }
-    // A run's element must be a single value — the same rule `lower_shape`
-    // asserts when it builds the `(ptr, len)` pair.
-    if let Some(elem) = r_vec_elem(t).or_else(|| r_cow_slice_elem(t)) {
-        return elem.optional_inner().is_none()
-            && r_vec_elem(elem).is_none()
-            && r_cow_slice_elem(elem).is_none()
-            && elem.fallible_parts().is_none();
-    }
-    // A base value: its own converter is the wire.
-    true
+    // A run's element must lower to one wire of its own — the same rule
+    // `lower_shape` asserts when it builds the `(ptr, len)` pair.
+    let leaf = r_vec_elem(t).or_else(|| r_cow_slice_elem(t)).unwrap_or(t);
+    registry
+        .output_entry(leaf)
+        .is_some_and(|e| !marker_destination(&e.destination))
 }
 
 /// The element of a `Vec<E>`.

--- a/prebindgen-c/src/tests/callbacks.rs
+++ b/prebindgen-c/src/tests/callbacks.rs
@@ -357,6 +357,57 @@ fn callback_arg_lowers_an_optional_structurally() {
     );
 }
 
+/// …and so is a `Result` **under** an `Option`, which is the same defect one
+/// layer in.
+///
+/// `Option<Result<T, E>>` is an optional, so a test that looks only at the
+/// outermost layer admits it — and then the lowering reaches the `Result` as a
+/// base field and calls *its* marker (#428 review). Lowerability is a property
+/// of the whole shape, so the check recurses.
+#[test]
+fn a_result_under_an_option_is_refused_too() {
+    let loc = SourceLocation::default();
+    let st: syn::ItemStruct = syn::parse_quote!(
+        pub struct Handle {
+            pub _0: u64,
+        }
+    );
+    let err: syn::ItemStruct = syn::parse_quote!(
+        pub struct Error {
+            pub _0: u64,
+        }
+    );
+    let func: syn::ItemFn = syn::parse_quote!(
+        pub fn z_declare_sub(cb: impl Fn(Option<Result<Handle, Error>>) + Send + Sync + 'static) {
+            unimplemented!()
+        }
+    );
+    let registry = crate::test_util::reg_from_items(declare_referenced([
+        (syn::Item::Struct(st), loc.clone()),
+        (syn::Item::Struct(err), loc.clone()),
+        (syn::Item::Fn(func), loc.clone()),
+    ]))
+    .expect("index items");
+
+    let cbindgen = CbindgenBuilder::new()
+        .source_module(syn::parse_quote!(zenoh_flat))
+        .opaque_ptr(syn::parse_quote!(Handle))
+        .opaque_error(syn::parse_quote!(Error), syn::parse_quote!(error_message))
+        .callback(syn::parse_quote!(
+            impl Fn(Option<Result<Handle, Error>>) + Send + Sync + 'static
+        ))
+        .base_name("z_closure_opt_result_t")
+        .function(syn::parse_quote!(z_declare_sub));
+
+    let message = catch_msg(|| {
+        let _ = write(cbindgen, registry, "cb_opt_result_arg");
+    });
+    assert!(
+        message.contains("has no C ABI"),
+        "a shape whose inner layer cannot be lowered is refused whole: {message}"
+    );
+}
+
 /// A `Result` callback argument is refused where it is declared, not emitted as
 /// a call to the marker that stands in for it.
 ///

--- a/prebindgen-c/src/tests/callbacks.rs
+++ b/prebindgen-c/src/tests/callbacks.rs
@@ -345,9 +345,66 @@ fn callback_arg_lowers_an_optional_structurally() {
         "the composite marker is called as if it were a converter:\n{src}"
     );
     // `Option<&T>` over an opaque handle carries its absence in the pointer, so
-    // the C `call` takes one `*const handle` and NULL is `None`.
+    // the C `call` takes one `*const handle` and NULL is `None`. The slot is
+    // `MaybeUninit`, which is `#[repr(transparent)]` and so is neither an ABI
+    // nor a header change — it is what lets an absent value leave its slot
+    // unwritten instead of being filled with a fabricated one.
     assert!(
-        compact.contains("call:::core::option::Option<unsafeextern\"C\"fn(*consthandle,"),
+        compact.contains(
+            "call:::core::option::Option<unsafeextern\"C\"fn(::core::mem::MaybeUninit<*consthandle>,"
+        ),
         "the closure `call` takes the borrowed pointer:\n{src}"
+    );
+}
+
+/// A `Result` callback argument is refused where it is declared, not emitted as
+/// a call to the marker that stands in for it.
+///
+/// `out_wrappers` gives `Result<T, E>` the same `()` destination it gives
+/// `Option`/`Vec`/`Cow`, and no arm of `lower_shape` lowers one. So a rule that
+/// asked the *destination* whether a shape can be lowered structurally answered
+/// yes for this one and produced the very `E0061` #428 is about (#428 review).
+/// The question is the model's: which shapes does `lower_shape` decompose.
+#[test]
+fn a_result_callback_arg_is_refused_at_its_declaration() {
+    let loc = SourceLocation::default();
+    let st: syn::ItemStruct = syn::parse_quote!(
+        pub struct Handle {
+            pub _0: u64,
+        }
+    );
+    let err: syn::ItemStruct = syn::parse_quote!(
+        pub struct Error {
+            pub _0: u64,
+        }
+    );
+    let func: syn::ItemFn = syn::parse_quote!(
+        pub fn z_declare_sub(cb: impl Fn(Result<Handle, Error>) + Send + Sync + 'static) {
+            unimplemented!()
+        }
+    );
+    let registry = crate::test_util::reg_from_items(declare_referenced([
+        (syn::Item::Struct(st), loc.clone()),
+        (syn::Item::Struct(err), loc.clone()),
+        (syn::Item::Fn(func), loc.clone()),
+    ]))
+    .expect("index items");
+
+    let cbindgen = CbindgenBuilder::new()
+        .source_module(syn::parse_quote!(zenoh_flat))
+        .opaque_ptr(syn::parse_quote!(Handle))
+        .opaque_error(syn::parse_quote!(Error), syn::parse_quote!(error_message))
+        .callback(syn::parse_quote!(
+            impl Fn(Result<Handle, Error>) + Send + Sync + 'static
+        ))
+        .base_name("z_closure_result_t")
+        .function(syn::parse_quote!(z_declare_sub));
+
+    let message = catch_msg(|| {
+        let _ = write(cbindgen, registry, "cb_result_arg");
+    });
+    assert!(
+        message.contains("has no C ABI") && message.contains("Result"),
+        "the refusal names the shape and why: {message}"
     );
 }

--- a/prebindgen-c/src/tests/callbacks.rs
+++ b/prebindgen-c/src/tests/callbacks.rs
@@ -447,6 +447,100 @@ fn a_run_of_markers_is_refused() {
     );
 }
 
+/// A composite with a `convert!` of its own keeps that ABI: it is not
+/// decomposed just because its *shape* is one the lowering knows.
+///
+/// `select_output_type` tries `out_custom` before `out_wrappers`, so a declared
+/// conversion gives `Option<T>` a real wire and no marker. The struct emitter
+/// reads the destination and emits that one wire; a dispatcher that decided from
+/// the model shape alone would pass two arguments to a `call` declared with one
+/// (#428 review). Both halves ask the same question now.
+#[test]
+fn a_converted_optional_callback_arg_keeps_its_declared_wire() {
+    let loc = SourceLocation::default();
+    let items: Vec<(syn::Item, SourceLocation)> = [
+        "#[prebindgen] pub type Duration = std::time::Duration;",
+        "pub fn duration_from_millis(v: u64) -> Duration { unimplemented!() }",
+        "pub fn duration_to_millis(v: &Duration) -> u64 { unimplemented!() }",
+        "pub fn maybe_from_millis(v: i64) -> Option<Duration> { unimplemented!() }",
+        "pub fn maybe_to_millis(v: &Option<Duration>) -> i64 { unimplemented!() }",
+        "pub fn duration_each(cb: impl Fn(Option<Duration>) + Send + Sync + 'static) { unimplemented!() }",
+    ]
+    .into_iter()
+    .map(|source| {
+        let item: syn::Item = syn::parse_str(source).unwrap();
+        (item, loc.clone())
+    })
+    .collect();
+    let registry = crate::test_util::reg_from_items(declare_referenced(items)).unwrap();
+
+    let cbindgen = CbindgenBuilder::new()
+        .source_module(syn::parse_quote!(myflat))
+        // Both are declared, which is what makes this a real test of the gate:
+        // the inner type has a converter, so the shape IS lowerable, and only
+        // the marker test can tell that it must not be lowered.
+        .convert(
+            prebindgen_registry::convert!(Duration)
+                .input(prebindgen_registry::fun!(duration_from_millis))
+                .output(prebindgen_registry::fun!(duration_to_millis)),
+        )
+        .convert(
+            prebindgen_registry::convert!(Option<Duration>)
+                .input(prebindgen_registry::fun!(maybe_from_millis))
+                .output(prebindgen_registry::fun!(maybe_to_millis)),
+        )
+        .callback(syn::parse_quote!(
+            impl Fn(Option<Duration>) + Send + Sync + 'static
+        ))
+        .base_name("z_closure_maybe_duration_t")
+        .function(syn::parse_quote!(duration_each));
+
+    let src = write(cbindgen, registry, "cb_converted_optional");
+    let compact: String = src.split_whitespace().collect();
+
+    // One parameter, the declared representation — not a decomposition.
+    assert!(
+        compact.contains("unsafeextern\"C\"fn(i64,*mut::core::ffi::c_void)")
+            && compact.contains("__cbg_out_Option___Duration__(__a0)"),
+        "the declared wire survives in the closure struct:\n{src}"
+    );
+    // …and the closure calls that converter rather than filling lowered slots.
+    assert!(
+        !compact.contains("MaybeUninit::<i64>::zeroed()"),
+        "a converted composite must not be decomposed:\n{src}"
+    );
+}
+
+/// A `Vec<()>` is refused for the same reason as a run of slices: the unit has
+/// no storage to be an element, so there is nothing for the `(ptr, len)` pair
+/// to point at (#428 review).
+#[test]
+fn a_run_of_units_is_refused() {
+    let loc = SourceLocation::default();
+    let func: syn::ItemFn = syn::parse_quote!(
+        pub fn z_declare_sub(cb: impl Fn(Vec<()>) + Send + Sync + 'static) {
+            unimplemented!()
+        }
+    );
+    let registry =
+        crate::test_util::reg_from_items(declare_referenced([(syn::Item::Fn(func), loc.clone())]))
+            .expect("index items");
+
+    let cbindgen = CbindgenBuilder::new()
+        .source_module(syn::parse_quote!(zenoh_flat))
+        .callback(syn::parse_quote!(impl Fn(Vec<()>) + Send + Sync + 'static))
+        .base_name("z_closure_units_t")
+        .function(syn::parse_quote!(z_declare_sub));
+
+    let message = catch_msg(|| {
+        let _ = write(cbindgen, registry, "cb_vec_unit_arg");
+    });
+    assert!(
+        message.contains("has no C ABI"),
+        "a run whose element has no storage is refused whole: {message}"
+    );
+}
+
 /// A `Result` callback argument is refused where it is declared, not emitted as
 /// a call to the marker that stands in for it.
 ///

--- a/prebindgen-c/src/tests/callbacks.rs
+++ b/prebindgen-c/src/tests/callbacks.rs
@@ -408,6 +408,45 @@ fn a_result_under_an_option_is_refused_too() {
     );
 }
 
+/// A run whose ELEMENT has no wire of its own is refused too — the case a list
+/// of shapes cannot catch.
+///
+/// `&[u8]` is a plain borrow by every shape test there is, and in the converter
+/// table it is a shared-slice **marker**: the `(ptr, len)` lowering for one is
+/// structural in the callback path, so it has no element wire to be the element
+/// of something else. `Vec<&'static [u8]>` therefore passed a check that
+/// enumerated wrapper kinds, and the lowering mapped a zero-argument marker over
+/// real slices (#428 review). Lowerability asks the table instead, so a marker
+/// disqualifies its shape whatever put it there.
+#[test]
+fn a_run_of_markers_is_refused() {
+    let loc = SourceLocation::default();
+    let func: syn::ItemFn = syn::parse_quote!(
+        pub fn z_declare_sub(cb: impl Fn(Vec<&'static [u8]>) + Send + Sync + 'static) {
+            unimplemented!()
+        }
+    );
+    let registry =
+        crate::test_util::reg_from_items(declare_referenced([(syn::Item::Fn(func), loc.clone())]))
+            .expect("index items");
+
+    let cbindgen = CbindgenBuilder::new()
+        .source_module(syn::parse_quote!(zenoh_flat))
+        .callback(syn::parse_quote!(
+            impl Fn(Vec<&'static [u8]>) + Send + Sync + 'static
+        ))
+        .base_name("z_closure_slices_t")
+        .function(syn::parse_quote!(z_declare_sub));
+
+    let message = catch_msg(|| {
+        let _ = write(cbindgen, registry, "cb_vec_slice_arg");
+    });
+    assert!(
+        message.contains("has no C ABI"),
+        "a run whose element has no wire of its own is refused whole: {message}"
+    );
+}
+
 /// A `Result` callback argument is refused where it is declared, not emitted as
 /// a call to the marker that stands in for it.
 ///

--- a/prebindgen-c/src/tests/callbacks.rs
+++ b/prebindgen-c/src/tests/callbacks.rs
@@ -298,3 +298,56 @@ fn callback_arg_qualifies_a_source_type_under_a_wrapper() {
         "{src}"
     );
 }
+
+/// An `Option<T>` callback argument is lowered like any other composite, not
+/// handed to the marker that stands in for one.
+///
+/// `out_wrappers` gives `Option`/`Vec`/`Cow` a marker converter with a `()`
+/// destination: it exists to resolve the entry and make the inner required,
+/// while the real ABI is structural. The return path lowers those shapes in
+/// `lower_shape`/`encode_value`; the callback-argument path had no case for
+/// them, so it fell back to calling the entry's converter — the marker, which
+/// takes no arguments (#428).
+#[test]
+fn callback_arg_lowers_an_optional_structurally() {
+    let loc = SourceLocation::default();
+    let st: syn::ItemStruct = syn::parse_quote!(
+        pub struct Handle {
+            pub _0: u64,
+        }
+    );
+    let func: syn::ItemFn = syn::parse_quote!(
+        pub fn z_declare_sub(cb: impl Fn(Option<&Handle>) + Send + Sync + 'static) {
+            unimplemented!()
+        }
+    );
+    let registry = crate::test_util::reg_from_items(declare_referenced([
+        (syn::Item::Struct(st), loc.clone()),
+        (syn::Item::Fn(func), loc.clone()),
+    ]))
+    .expect("index items");
+
+    let cbindgen = CbindgenBuilder::new()
+        .source_module(syn::parse_quote!(zenoh_flat))
+        .opaque_ptr(syn::parse_quote!(Handle))
+        .callback(syn::parse_quote!(
+            impl Fn(Option<&Handle>) + Send + Sync + 'static
+        ))
+        .base_name("z_closure_handle_t")
+        .function(syn::parse_quote!(z_declare_sub));
+
+    let src = write(cbindgen, registry, "cb_optional_arg");
+    let compact: String = src.split_whitespace().collect();
+
+    // The marker is never applied to anything: it takes no arguments.
+    assert!(
+        !compact.contains("__cbg_outmark_option___Handle(__a0)"),
+        "the composite marker is called as if it were a converter:\n{src}"
+    );
+    // `Option<&T>` over an opaque handle carries its absence in the pointer, so
+    // the C `call` takes one `*const handle` and NULL is `None`.
+    assert!(
+        compact.contains("call:::core::option::Option<unsafeextern\"C\"fn(*consthandle,"),
+        "the closure `call` takes the borrowed pointer:\n{src}"
+    );
+}

--- a/prebindgen-c/src/tests/callbacks.rs
+++ b/prebindgen-c/src/tests/callbacks.rs
@@ -511,6 +511,66 @@ fn a_converted_optional_callback_arg_keeps_its_declared_wire() {
     );
 }
 
+/// …and a declared conversion still beats the shape when it is **nested**.
+///
+/// `Vec<Option<Duration>>` over a declared `Option<Duration>` is a run of a
+/// composite that has a wire of its own, so it lowers to that wire's pointer and
+/// length. Before the walk stopped at a node with its own converter, the
+/// predicate said lowerable — reading the element's real `i64` entry — while
+/// `lower_shape` refused the same element for being an `Option`, so the rule did
+/// not compose under `Vec` (#428 review).
+#[test]
+fn a_run_of_converted_optionals_uses_the_declared_wire() {
+    let loc = SourceLocation::default();
+    let items: Vec<(syn::Item, SourceLocation)> = [
+        "#[prebindgen] pub type Duration = std::time::Duration;",
+        "pub fn duration_from_millis(v: u64) -> Duration { unimplemented!() }",
+        "pub fn duration_to_millis(v: &Duration) -> u64 { unimplemented!() }",
+        "pub fn maybe_from_millis(v: i64) -> Option<Duration> { unimplemented!() }",
+        "pub fn maybe_to_millis(v: &Option<Duration>) -> i64 { unimplemented!() }",
+        "pub fn duration_each(cb: impl Fn(Vec<Option<Duration>>) + Send + Sync + 'static) { unimplemented!() }",
+    ]
+    .into_iter()
+    .map(|source| {
+        let item: syn::Item = syn::parse_str(source).unwrap();
+        (item, loc.clone())
+    })
+    .collect();
+    let registry = crate::test_util::reg_from_items(declare_referenced(items)).unwrap();
+
+    let cbindgen = CbindgenBuilder::new()
+        .source_module(syn::parse_quote!(myflat))
+        .convert(
+            prebindgen_registry::convert!(Duration)
+                .input(prebindgen_registry::fun!(duration_from_millis))
+                .output(prebindgen_registry::fun!(duration_to_millis)),
+        )
+        .convert(
+            prebindgen_registry::convert!(Option<Duration>)
+                .input(prebindgen_registry::fun!(maybe_from_millis))
+                .output(prebindgen_registry::fun!(maybe_to_millis)),
+        )
+        .callback(syn::parse_quote!(
+            impl Fn(Vec<Option<Duration>>) + Send + Sync + 'static
+        ))
+        .base_name("z_closure_durations_t")
+        .function(syn::parse_quote!(duration_each));
+
+    let src = write(cbindgen, registry, "cb_vec_converted_optional");
+    let compact: String = src.split_whitespace().collect();
+
+    // The run lowers to the element's DECLARED wire, pointer and length.
+    assert!(
+        compact.contains("unsafeextern\"C\"fn(::core::mem::MaybeUninit<*muti64>,::core::mem::MaybeUninit<usize>,"),
+        "the array carries the declared element wire:\n{src}"
+    );
+    // …and each element goes through that converter, not through a decomposition.
+    assert!(
+        compact.contains("__cbg_out_Option___Duration__"),
+        "the declared element converter is what fills the array:\n{src}"
+    );
+}
+
 /// A `Vec<()>` is refused for the same reason as a run of slices: the unit has
 /// no storage to be an element, so there is nothing for the `(ptr, len)` pair
 /// to point at (#428 review).

--- a/prebindgen-c/src/tests/lowering.rs
+++ b/prebindgen-c/src/tests/lowering.rs
@@ -275,3 +275,80 @@ fn opaque_error_lowering() {
         "{src}"
     );
 }
+
+/// A declared conversion's own fallibility is the one that counts, at whatever
+/// depth it sits.
+///
+/// Three walks read one value — the shape, the encode, and whether the encode
+/// can fail — and the third used to peel `Option`/`Vec`/`Cow` before consulting
+/// the converter table. Once the first two stop at a node with a wire of its
+/// own, the third disagreeing is not cosmetic: it decides whether a non-`Result`
+/// binding must opt into `.panic()`. Reading past a fallible custom converter
+/// says "infallible", and the emitted wrapper aborts where nobody opted in
+/// (#428 review).
+///
+/// Here `Option<Duration>` has a **fallible** declared output converter over an
+/// **infallible** `Duration` one, so the two answers differ and only the outer
+/// one is right.
+#[test]
+fn a_declared_conversion_owns_its_own_fallibility() {
+    let items = || {
+        let loc = SourceLocation::default();
+        [
+            "#[prebindgen] pub type Duration = std::time::Duration;",
+            "pub fn duration_from_millis(v: u64) -> Duration { unimplemented!() }",
+            "pub fn duration_to_millis(v: &Duration) -> u64 { unimplemented!() }",
+            "pub fn maybe_from_millis(v: i64) -> Option<Duration> { unimplemented!() }",
+            "pub fn maybe_to_millis(v: &Option<Duration>) -> Result<i64, String> { unimplemented!() }",
+            "pub fn maybe_get() -> Option<Duration> { unimplemented!() }",
+        ]
+        .into_iter()
+        .map(|source| {
+            let item: syn::Item = syn::parse_str(source).unwrap();
+            (item, loc.clone())
+        })
+        .collect::<Vec<_>>()
+    };
+    let declare = || {
+        CbindgenBuilder::new()
+            .source_module(syn::parse_quote!(myflat))
+            .convert(
+                prebindgen_registry::convert!(Duration)
+                    .input(prebindgen_registry::fun!(duration_from_millis))
+                    .output(prebindgen_registry::fun!(duration_to_millis)),
+            )
+            .convert(
+                prebindgen_registry::convert!(Option<Duration>)
+                    .input(prebindgen_registry::fun!(maybe_from_millis))
+                    .output(prebindgen_registry::fun!(maybe_to_millis)),
+            )
+    };
+
+    // No `.panic()`: the outer converter can fail and the function returns no
+    // `Result`, so there is nowhere for the error to go and the declaration is
+    // refused.
+    let registry = crate::test_util::reg_from_items(declare_referenced(items())).unwrap();
+    let message = catch_msg(|| {
+        let _ = write(
+            declare().function(syn::parse_quote!(maybe_get)),
+            registry,
+            "fallible_custom_option",
+        );
+    });
+    assert!(
+        message.contains("fallible binding conversion") && message.contains(".panic()"),
+        "the refusal names the missing opt-in: {message}"
+    );
+
+    // …and with the opt-in, the same declaration generates.
+    let registry = crate::test_util::reg_from_items(declare_referenced(items())).unwrap();
+    let src = write(
+        declare().function(syn::parse_quote!(maybe_get)).panic(),
+        registry,
+        "fallible_custom_option_panic",
+    );
+    assert!(
+        src.contains("__cbg_out_Option___Duration__"),
+        "the declared converter is what the wrapper calls:\n{src}"
+    );
+}

--- a/prebindgen-c/src/trait_impl.rs
+++ b/prebindgen-c/src/trait_impl.rs
@@ -1519,9 +1519,14 @@ impl CbindgenBuilder {
                     arg_wires.push(syn::parse_quote!(usize));
                     continue;
                 }
+                let reading = registry.reading_of(a).unwrap_or_else(|| {
+                    panic!(
+                        "Cbindgen: callback arg `{}` was never classified",
+                        a.to_token_stream()
+                    )
+                });
                 let wire = registry
-                    .reading_of(a)
-                    .and_then(|tr| registry.output_entry(&tr))
+                    .output_entry(&reading)
                     .unwrap_or_else(|| {
                         panic!(
                             "Cbindgen: callback arg `{}` has no output converter (declare it \
@@ -1534,9 +1539,18 @@ impl CbindgenBuilder {
                 // Takeable params are delivered as an owned pointer.
                 if takeable.contains(&i) {
                     arg_wires.push(syn::parse_quote!(*mut #wire));
-                } else {
-                    arg_wires.push(wire);
+                    continue;
                 }
+                // A composite has no wire of its own — a `()` destination is the
+                // marker saying so — so its C params are the fields its shape
+                // lowers to, exactly as `dispatch_fn_input` fills them (#428).
+                if matches!(&wire, syn::Type::Tuple(t) if t.elems.is_empty()) {
+                    for field in self.lower_shape(&reading, registry).fields {
+                        arg_wires.push(field.wire);
+                    }
+                    continue;
+                }
+                arg_wires.push(wire);
             }
             let c_struct = self.callback_c_ident(key);
             items.push(syn::parse_quote!(
@@ -1711,8 +1725,62 @@ impl CbindgenBuilder {
             let src = self.src_ty_deep_of(arg);
             let ai = format_ident!("__a{}", i);
             let wi = format_ident!("__w{}", i);
-            closure_params.push(quote!(#ai: #src));
             let is_takeable = takeable.contains(&i);
+            // A COMPOSITE argument — `Option<T>`, `Vec<T>`, `Cow<'_, [T]>` — has
+            // no converter of its own: `out_wrappers` gives it a marker with a
+            // `()` destination, which exists to resolve the entry and make the
+            // inner required while the real ABI is structural. The return path
+            // lowers those in `lower_shape` / `encode_value`; this one used to
+            // call the marker as if it were a converter, which takes no
+            // arguments (#428). Same lowering, so the two directions cannot
+            // disagree about which shapes they know.
+            //
+            // A takeable argument is a whole-value policy over an opaque handle
+            // and never a composite, so it keeps the by-reference path below.
+            //
+            // A marker is recognised by its `()` destination, which is what
+            // `out_wrappers` gives one and what says "this type has no converter
+            // of its own". Field COUNT cannot say it: `Option<&T>` carves the
+            // pointer's niche and lowers to a single `*const` — one field, and
+            // still nothing a converter call can produce.
+            let composite = !is_takeable
+                && matches!(&entry.destination, syn::Type::Tuple(t) if t.elems.is_empty());
+            if composite {
+                let shape = self.lower_shape(arg, registry);
+                closure_params.push(quote!(#ai: #src));
+                let mut targets = Vec::new();
+                for (f, field) in shape.fields.iter().enumerate() {
+                    let fi = if shape.fields.len() == 1 {
+                        wi.clone()
+                    } else {
+                        format_ident!("__w{}_{}", i, f)
+                    };
+                    let wire = &field.wire;
+                    // Zeroed, not merely declared: a shape with a `present` flag
+                    // writes only the flag when the value is absent, which is
+                    // right for a RETURN — those fields are the caller's
+                    // out-params and it must not read them. A callback has to
+                    // pass something, and every wire here is a `#[repr(C)]`
+                    // POD whose all-zero pattern is valid: a null pointer, a
+                    // `false`, a `0`. The C side must not read it, which is the
+                    // same contract the out-param carries.
+                    encode_stmts.push(quote!(let mut #fi: #wire = ::core::mem::zeroed();));
+                    targets.push(quote!(#fi));
+                    call_args.push(quote!(#fi));
+                }
+                // A firing callback has no error channel, so a fallible
+                // converter aborts — the same answer the single-value path
+                // below gives, spelled by the route the emitters share.
+                encode_stmts.push(self.encode_value(
+                    arg,
+                    quote!(#ai),
+                    &targets,
+                    registry,
+                    &ErrRoute::Panic,
+                ));
+                continue;
+            }
+            closure_params.push(quote!(#ai: #src));
             let mut_kw = if is_takeable { quote!(mut) } else { quote!() };
             if fallible {
                 encode_stmts.push(quote!(

--- a/prebindgen-c/src/trait_impl.rs
+++ b/prebindgen-c/src/trait_impl.rs
@@ -1854,11 +1854,19 @@ impl CbindgenBuilder {
                 let __call = c.call;
                 let __ctx = ::std::sync::Arc::new(__Ctx { context: c.context, drop: c.drop });
                 move |#(#closure_params),*| {
-                    #(#encode_stmts)*
+                    // Encode INSIDE the guard: a closure struct whose `call` is
+                    // NULL receives nothing, and a converter that allocates —
+                    // `Vec`/`Cow` into a malloc'd array, a `String` into a
+                    // malloc'd `char *` — would hand that allocation to nobody
+                    // on every invocation (#428 review). Not converting at all
+                    // is also what the argument's own `Drop` expects: the value
+                    // is simply dropped, which is neither a leak nor a double
+                    // free.
                     if let ::core::option::Option::Some(__f) = __call {
+                        #(#encode_stmts)*
                         unsafe { __f(#(#call_args,)* __ctx.context) }
+                        #(#post_drops)*
                     }
-                    #(#post_drops)*
                 }
             }
         );

--- a/prebindgen-c/src/trait_impl.rs
+++ b/prebindgen-c/src/trait_impl.rs
@@ -1760,7 +1760,16 @@ impl CbindgenBuilder {
                     arg,
                 );
             }
-            let composite = !is_takeable && r_is_lowered_composite(arg, registry);
+            // Both halves of the marker test, and both are load-bearing. The
+            // MODEL says which shapes `lower_shape` decomposes; the marker says
+            // this type has no wire of its own — and a `convert!`-declared
+            // `Option<T>` has one, because `out_custom` is tried before
+            // `out_wrappers`. Decomposing that from its shape alone would pass
+            // several arguments to a `call` the struct declared with one
+            // (#428 review).
+            let composite = !is_takeable
+                && marker_destination(&entry.destination)
+                && r_is_lowered_composite(arg, registry);
             if composite {
                 let shape = self.lower_shape(arg, registry);
                 closure_params.push(quote!(#ai: #src));
@@ -1772,21 +1781,27 @@ impl CbindgenBuilder {
                         format_ident!("__w{}_{}", i, f)
                     };
                     let wire = &field.wire;
-                    // `MaybeUninit`, not a zeroed value: a shape with a `present`
-                    // flag writes only the flag when the value is absent, which
-                    // is right for a RETURN — those fields are the caller's
-                    // out-params and it must not read them — but a callback has
-                    // to pass the slot along. Materialising a value to fill it
-                    // is what must not happen: not every wire's all-zero pattern
-                    // is a legal value of its type, and a declared `enum_type`'s
-                    // discriminants are the source's own, so zero need not name
-                    // a variant at all (#428 review).
+                    // A `MaybeUninit`, zeroed. Two things it must not be.
                     //
-                    // This makes no assumption about WHICH fields the encode
+                    // Not a `wire` value: a shape with a `present` flag writes
+                    // only the flag when the value is absent, and materialising
+                    // something to fill the slot is undefined for a wire whose
+                    // all-zero pattern is not a legal value of its type — a
+                    // declared `enum_type`'s discriminants are the source's own,
+                    // so zero need not name a variant at all.
+                    //
+                    // And not left indeterminate: the slot is passed BY VALUE to
+                    // foreign code, so whatever the stack or register held is
+                    // handed to a C callback that reads it despite the flag.
+                    // Zeroing costs a store and discloses nothing, while
+                    // `MaybeUninit` keeps it from ever being a `wire` (#428
+                    // review).
+                    //
+                    // Neither assumes anything about WHICH fields the encode
                     // writes, which is the encoder's business and not this
                     // caller's.
                     encode_stmts
-                        .push(quote!(let mut #fi = ::core::mem::MaybeUninit::<#wire>::uninit();));
+                        .push(quote!(let mut #fi = ::core::mem::MaybeUninit::<#wire>::zeroed();));
                     targets.push(quote!(*#fi.as_mut_ptr()));
                     call_args.push(quote!(#fi));
                 }

--- a/prebindgen-c/src/trait_impl.rs
+++ b/prebindgen-c/src/trait_impl.rs
@@ -1541,12 +1541,16 @@ impl CbindgenBuilder {
                     arg_wires.push(syn::parse_quote!(*mut #wire));
                     continue;
                 }
-                // A composite has no wire of its own — a `()` destination is the
-                // marker saying so — so its C params are the fields its shape
-                // lowers to, exactly as `dispatch_fn_input` fills them (#428).
-                if matches!(&wire, syn::Type::Tuple(t) if t.elems.is_empty()) {
+                // A composite has no wire of its own, so its C params are the
+                // fields its shape lowers to — exactly as `dispatch_fn_input`
+                // fills them (#428). Each is `MaybeUninit`: an absent value
+                // leaves its slot unwritten, and the wrapper must not build a
+                // Rust value to fill it with. `#[repr(transparent)]` keeps both
+                // the C ABI and the header spelling.
+                if marker_destination(&wire) && r_is_lowered_composite(&reading) {
                     for field in self.lower_shape(&reading, registry).fields {
-                        arg_wires.push(field.wire);
+                        let w = field.wire;
+                        arg_wires.push(syn::parse_quote!(::core::mem::MaybeUninit<#w>));
                     }
                     continue;
                 }
@@ -1738,13 +1742,25 @@ impl CbindgenBuilder {
             // A takeable argument is a whole-value policy over an opaque handle
             // and never a composite, so it keeps the by-reference path below.
             //
-            // A marker is recognised by its `()` destination, which is what
-            // `out_wrappers` gives one and what says "this type has no converter
-            // of its own". Field COUNT cannot say it: `Option<&T>` carves the
-            // pointer's niche and lowers to a single `*const` — one field, and
-            // still nothing a converter call can produce.
-            let composite = !is_takeable
-                && matches!(&entry.destination, syn::Type::Tuple(t) if t.elems.is_empty());
+            // Which shapes those are is the MODEL's answer, not the marker's: a
+            // `()` destination says the type has no wire of its own, and a
+            // `Result` has one of those too while no arm lowers it. Field COUNT
+            // cannot say it either — `Option<&T>` carves the pointer's niche and
+            // lowers to a single `*const`, one field and still nothing a
+            // converter call can produce.
+            if !is_takeable
+                && marker_destination(&entry.destination)
+                && !r_is_lowered_composite(arg)
+            {
+                panic!(
+                    "Cbindgen: callback argument `{}` has no C ABI — it resolves to a marker \
+                     converter and is not one of the shapes lowered structurally (`Option<T>`, \
+                     `Vec<T>`, `Cow<'_, [T]>`). Deliver its parts as separate callback \
+                     arguments instead.",
+                    arg,
+                );
+            }
+            let composite = !is_takeable && r_is_lowered_composite(arg);
             if composite {
                 let shape = self.lower_shape(arg, registry);
                 closure_params.push(quote!(#ai: #src));
@@ -1756,16 +1772,22 @@ impl CbindgenBuilder {
                         format_ident!("__w{}_{}", i, f)
                     };
                     let wire = &field.wire;
-                    // Zeroed, not merely declared: a shape with a `present` flag
-                    // writes only the flag when the value is absent, which is
-                    // right for a RETURN — those fields are the caller's
-                    // out-params and it must not read them. A callback has to
-                    // pass something, and every wire here is a `#[repr(C)]`
-                    // POD whose all-zero pattern is valid: a null pointer, a
-                    // `false`, a `0`. The C side must not read it, which is the
-                    // same contract the out-param carries.
-                    encode_stmts.push(quote!(let mut #fi: #wire = ::core::mem::zeroed();));
-                    targets.push(quote!(#fi));
+                    // `MaybeUninit`, not a zeroed value: a shape with a `present`
+                    // flag writes only the flag when the value is absent, which
+                    // is right for a RETURN — those fields are the caller's
+                    // out-params and it must not read them — but a callback has
+                    // to pass the slot along. Materialising a value to fill it
+                    // is what must not happen: not every wire's all-zero pattern
+                    // is a legal value of its type, and a declared `enum_type`'s
+                    // discriminants are the source's own, so zero need not name
+                    // a variant at all (#428 review).
+                    //
+                    // This makes no assumption about WHICH fields the encode
+                    // writes, which is the encoder's business and not this
+                    // caller's.
+                    encode_stmts
+                        .push(quote!(let mut #fi = ::core::mem::MaybeUninit::<#wire>::uninit();));
+                    targets.push(quote!(*#fi.as_mut_ptr()));
                     call_args.push(quote!(#fi));
                 }
                 // A firing callback has no error channel, so a fallible

--- a/prebindgen-c/src/trait_impl.rs
+++ b/prebindgen-c/src/trait_impl.rs
@@ -1547,7 +1547,7 @@ impl CbindgenBuilder {
                 // leaves its slot unwritten, and the wrapper must not build a
                 // Rust value to fill it with. `#[repr(transparent)]` keeps both
                 // the C ABI and the header spelling.
-                if marker_destination(&wire) && r_is_lowered_composite(&reading) {
+                if marker_destination(&wire) && r_is_lowered_composite(&reading, registry) {
                     for field in self.lower_shape(&reading, registry).fields {
                         let w = field.wire;
                         arg_wires.push(syn::parse_quote!(::core::mem::MaybeUninit<#w>));
@@ -1750,7 +1750,7 @@ impl CbindgenBuilder {
             // converter call can produce.
             if !is_takeable
                 && marker_destination(&entry.destination)
-                && !r_is_lowered_composite(arg)
+                && !r_is_lowered_composite(arg, registry)
             {
                 panic!(
                     "Cbindgen: callback argument `{}` has no C ABI — it resolves to a marker \
@@ -1760,7 +1760,7 @@ impl CbindgenBuilder {
                     arg,
                 );
             }
-            let composite = !is_takeable && r_is_lowered_composite(arg);
+            let composite = !is_takeable && r_is_lowered_composite(arg, registry);
             if composite {
                 let shape = self.lower_shape(arg, registry);
                 closure_params.push(quote!(#ai: #src));


### PR DESCRIPTION
Fixes #428, found while reproducing #414's callback case by hand.

## What was wrong

`out_wrappers` gives `Option`/`Vec`/`Cow` a **marker** converter whose destination is `()`. Its own doc says what it is for: it resolves the entry and makes the inner type required, while the real ABI is structural. The **return** path lowers those shapes in `lower_shape` / `encode_value`. The callback-argument path had no case for them, so it fell through to "call the entry's converter":

```rust
move |__a0: ::core::option::Option<&zenoh_flat::Handle>| {
    let __w0 = __cbg_outmark_option___Handle(__a0);
```

```
error[E0061]: this function takes 0 arguments but 1 argument was supplied
```

This is #413 with the directions swapped: there, a slice had a marker for the callback direction and no lowering in return position. The two paths each covered a hole the other left.

## The fix

Both halves of the callback now read the same lowering the return path does — `prereq_callback_structs` takes the shape's fields as the C `call` params, and `dispatch_fn_input` fills them through `encode_value`. So a composite is lowered in one place for both directions.

A marker is recognised by its `()` destination, which is the thing that says *"this type has no converter of its own"*. Field count cannot say it: `Option<&T>` carves the pointer's niche and lowers to a single `*const`, which is one field and still nothing a converter call can produce.

`lower_shape`, `encode_value` and `output_is_fallible` now take the `Conversions` view rather than a concrete `Registry` — that is all they ever used, and it is what the callback resolver has.

## Two things worth review

**An absent field is left unwritten.** A shape with a `present` flag writes only the flag when the value is absent. For a return that is right: those fields are the caller's out-params and it must not read them. A callback has to pass the slot along, so each lowered field is a `MaybeUninit<wire>` — `#[repr(transparent)]`, so neither the C ABI nor the header spelling changes, and no Rust value is fabricated to fill it. That matters because not every wire has a valid all-zero pattern: a declared `enum_type`'s wire is the source's own enum with the source's own discriminants, so zero need not name a variant at all. It also assumes nothing about *which* targets the encode writes, which is the encoder's business.

**Encoding happens inside the call guard.** A closure struct whose `call` is NULL receives nothing, and a `Vec`/`Cow` argument's encode mallocs an array the C side owns — so converting unconditionally handed a block to nobody, on every invocation. The same was already true of a `String` argument before this PR. An unconverted argument is simply dropped, which is what its own `Drop` expects.

**What is refused, and where.** A callback argument that resolves to a marker and is not a shape `lower_shape` decomposes *all the way down* is refused where it is declared, naming the shape. Lowerability asks the converter table rather than listing wrapper kinds: a marker destination means "no wire of its own", whatever put it there. That covers `Result<T, E>`, `Option<Result<T, E>>` and `Vec<&'static [u8]>`, each with its own test.

## Verification

- New emission test `callback_arg_lowers_an_optional_structurally` (`prebindgen-c/src/tests/callbacks.rs`), asserting the marker is never applied and the `call` takes the borrowed pointer.
- **Compiled and run in C.** `example-flat` gains `calculator_last_or_none(c, impl Fn(Option<f64>))`, declared in `example-cbindgen`, so the generated Rust is built by the workspace and the header declares `void (*call)(bool, double, void*)` — the present flag beside the value. `smoke.c` fires it and checks both arms from one call: the recorded value, then `None`. That runs in the `smoke-asan` job under ASan/LSan/UBSan.
- Checked against the unfixed emission: the ASan gate fails with `this function takes 0 arguments but 1 argument was supplied`.
- `Option<f64>` is deliberately a fixture rather than only `Option<&T>`: it has no spare bit pattern, so it exercises the multi-field lowering, where the reported shape would only have exercised the niche. `Grade { Low = 1, High = 2 }` is beside it because an absent slot's contract cannot be checked against a type whose every bit pattern is legal — a zero-less enum is what says the slot is left unwritten rather than filled. `calculator_history_batch(c, impl Fn(Vec<f64>))` is the allocating shape, called once with a receiver and once with `call = NULL`; putting the encode back outside the guard makes LSan report the leak.
- All five tracked generated variants are regenerated, not only the host's. `regen-check.sh` rebuilds the host architecture alone, so it cannot catch a stale cross-arch artifact — worth fixing separately.
- `cargo test --workspace --all-features`, `clippy --deny warnings`, `fmt --check` and `examples/regen-check.sh` all pass.
