### PR TITLE
Peel a callback argument's layers with the same walk (#438)

### DIFF
--- a/examples/covertest-kotlin/build.rs
+++ b/examples/covertest-kotlin/build.rs
@@ -157,6 +157,16 @@ fn main() {
                 .input(fun!(millis_from_long))
                 .output(fun!(millis_value)),
         )
+        // `Ticks`: a `u64` representation, so its Kotlin view is `ULong` and its
+        // wire a `Long` — a leaf with a real conversion, which is what
+        // `ticks_emit` needs to show that a callback argument's LAYERS are
+        // peeled (#438). `u64` itself would have been the obvious leaf and
+        // collides with the existing `impl Fn(u64)` interface name (#440).
+        .convert(
+            convert!(Ticks)
+                .input(fun!(ticks_from_raw))
+                .output(fun!(ticks_value)),
+        )
         // `Celsius`: canonical conversion via `From`/`Into` impls in the flat
         // crate — the repr (`i32`) is stated, the impls do the work.
         .convert(convert!(Celsius).input(from!(i32)).output(into!(i32)))
@@ -575,6 +585,9 @@ fn main() {
                 .fun(fun!(lookup_each))
                 // …and #429's layered payloads, one call per case.
                 .fun(fun!(layered_of))
+                // #438: the same layers as a CALLBACK ARGUMENT, which is a
+                // different emitter and kept its own one-shot wrap.
+                .fun(fun!(ticks_emit))
                 // #218: the same handle reached through a data-class FIELD, so
                 // the JVM harness can assert the container's cascade closes it.
                 .fun(fun!(verdict_new))

--- a/examples/covertest-kotlin/kotlin/REPORT.md
+++ b/examples/covertest-kotlin/kotlin/REPORT.md
@@ -128,6 +128,7 @@ Base package: `io.prebindgen.covertest`
   - shaped by: return `Stamp` decomposed → [secs, nanos] (Callback delivery)
 - `tagged_new` — `fun taggedNew(which: Int, onError: JniErrorHandler<Tagged?>): Tagged?`
 - `tagged_rank` — `fun taggedRank(t: Tagged, onError: JniErrorHandler<Int>): Int`
+- `ticks_emit` — `fun ticksEmit(f: TicksCallback, onError: JniErrorHandler<Unit>)`
 - `unsigned_data_maybe` — `fun unsignedDataMaybe(value: Unsigned, onError: JniErrorHandler<ULong?>): ULong?`
 - `unsigned_emit` — `fun unsignedEmit(value: ULong, f: u64Callback, onError: JniErrorHandler<Unit>)`
 - `unsigned_optional` — `fun unsignedOptional(value: ULong?, onError: JniErrorHandler<ULong?>): ULong?`
@@ -264,6 +265,7 @@ Base package: `io.prebindgen.covertest`
 - `convert!(Label)`: input `#[prebindgen]` fn `label_in`, output `#[prebindgen]` fn `label_out`
 - `convert!(Millis)`: input `#[prebindgen]` fn `millis_from_long`, output `#[prebindgen]` fn `millis_value`
 - `convert!(Percent)`: input `TryInto` ⇄ `i32`, output `#[prebindgen]` fn `percent_out`
+- `convert!(Ticks)`: input `#[prebindgen]` fn `ticks_from_raw`, output `#[prebindgen]` fn `ticks_value`
 
 ## rust-side-only types
 

--- a/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest.kt
+++ b/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest.kt
@@ -677,6 +677,23 @@ internal fun StorageCallback.asRaw(): StorageCallbackRaw =
         }
     }
 
+public fun interface TicksCallback {
+    public fun run(vec: List<ULong?>)
+}
+
+internal fun interface TicksCallbackRaw {
+    public fun run(vec: List<Long?>)
+}
+
+@JvmSynthetic
+internal fun TicksCallback.asRaw(): TicksCallbackRaw =
+    TicksCallbackRaw {
+        vec ->
+        run(
+            vec.map { it?.toULong() }
+        )
+    }
+
 public fun interface u64Callback {
     public fun run(u64: ULong)
 }
@@ -1598,6 +1615,9 @@ internal object CovNative {
 
     @JvmSynthetic
     external fun taggedRank(tId: Long, tMarker: Marker, errorSink: Any): Int
+
+    @JvmSynthetic
+    external fun ticksEmit(f: Any, errorSink: Any)
 
     @JvmSynthetic
     external fun unsignedDataMaybe(

--- a/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest/model.kt
+++ b/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest/model.kt
@@ -14,6 +14,7 @@ import io.prebindgen.covertest.MaybeHolder
 import io.prebindgen.covertest.NativeHandle
 import io.prebindgen.covertest.Payload
 import io.prebindgen.covertest.Ranked
+import io.prebindgen.covertest.TicksCallback
 import io.prebindgen.covertest.WrappedFields
 import io.prebindgen.covertest.__u64FolderRawHolder
 import io.prebindgen.covertest.analytics.Summary
@@ -2061,6 +2062,23 @@ public fun layeredOf(which: Int, onError: JniErrorHandler<Layered?>): Layered? {
     val __ret = CovNative.layeredOf(which, __LayeredBuilderRaw, __bcap)
     if (__bcap.failed) return onError.run(__bcap.ze0)
     return __ret as Layered
+}
+
+/**
+ * A value with LAYERS as a **callback argument** — the direction #429's fix
+ * did not reach.
+ *
+ * A sum payload and a callback argument are converted by different emitters,
+ * and each peeled the layers between a wire value and its leaf its own way:
+ * #432 taught the first, and the second went on applying the leaf's conversion
+ * to the whole value until #438. Fires with a list mixing present and absent
+ * elements, then with an empty one, so the per-element conversion and the
+ * empty case both cross.
+ */
+public fun ticksEmit(f: TicksCallback, onError: JniErrorHandler<Unit>) {
+    val __bcap = JniErrorHandlerCapture.acquire()
+    CovNative.ticksEmit(f.asRaw(), __bcap)
+    if (__bcap.failed) return onError.run(__bcap.ze0)
 }
 
 /** Build a [`Verdict`] whose outcome comes from [`lookup_of`]. */

--- a/examples/covertest-kotlin/kotlin/io/prebindgen/covertest/Test.kt
+++ b/examples/covertest-kotlin/kotlin/io/prebindgen/covertest/Test.kt
@@ -66,6 +66,7 @@ import io.prebindgen.covertest.model.boxedDurationEcho
 import io.prebindgen.covertest.model.durationOptional
 import io.prebindgen.covertest.model.durationBoundaryEcho
 import io.prebindgen.covertest.model.spanHolderNew
+import io.prebindgen.covertest.model.ticksEmit
 import io.prebindgen.covertest.model.vaultHolderNew
 import io.prebindgen.covertest.model.durationEmit
 import io.prebindgen.covertest.model.durationOutOfRange
@@ -996,6 +997,27 @@ fun main() {
             check(m.isClosed())
             total
         } == 12L)
+    }
+
+    // The same layers as a CALLBACK ARGUMENT — the direction #429's fix did not
+    // reach.
+    //
+    // A sum payload and a callback argument are converted by different
+    // emitters, and each peeled the layers its own way: #432 taught the first,
+    // and the `asRaw` proxy went on applying the leaf's conversion to the whole
+    // value until #438. Both run one walk now, and this is the half a compiler
+    // cannot check — that the list arrives element by element, absences and all,
+    // rather than as one converted thing.
+    section("a callback argument carries its Option and collection layers") {
+        val seen = mutableListOf<List<ULong?>>()
+        ticksEmit({ vec -> seen.add(vec) }, boom)
+
+        check(seen.size == 2)
+        // A mixed list: each element converted, the absence preserved in place
+        // rather than collapsing the list or the value.
+        check(seen[0] == listOf(4uL, null, 6uL))
+        // …and an empty one is empty, not null.
+        check(seen[1].isEmpty())
     }
 
     // The sum whose payloads have LAYERS. The class that reassembles a variant

--- a/examples/covertest-kotlin/src/generated_bindings.rs
+++ b/examples/covertest-kotlin/src/generated_bindings.rs
@@ -6229,6 +6229,124 @@ pub(crate) unsafe fn JObject_to_impl_Fn_Storage_Send_Sync_static_2f26edcf<'env, 
     clippy::nonminimal_bool,
     clippy::eq_op
 )]
+pub(crate) unsafe fn JObject_to_impl_Fn_Vec_Option_Ticks_Send_Sync_static_26c17cf0<
+    'env,
+    'v,
+>(
+    env: &mut jni::JNIEnv<'env>,
+    v: &jni::objects::JObject<'v>,
+) -> ::core::result::Result<
+    impl Fn(Vec<Option<perftest_flat::Ticks>>) + Send + Sync + 'static,
+    __JniErr,
+> {
+    Ok({
+        use std::sync::Arc;
+        let java_vm = Arc::new(
+            env
+                .get_java_vm()
+                .map_err(|e| <__JniErr as ::core::convert::From<
+                    String,
+                >>::from(format!("Unable to retrieve JVM: {}", e)))?,
+        );
+        let callback_global_ref = env
+            .new_global_ref(&v)
+            .map_err(|e| <__JniErr as ::core::convert::From<
+                String,
+            >>::from(format!("Unable to global-ref callback: {}", e)))?;
+        let __invoke_class = env
+            .get_object_class(&v)
+            .map_err(|e| <__JniErr as ::core::convert::From<
+                String,
+            >>::from(
+                format!(
+                    "Unable to get callback class for {}: {}",
+                    "Fn(Vec < Option < Ticks > >)", e
+                ),
+            ))?;
+        let __invoke_id = env
+            .get_method_id(&__invoke_class, "run", "(Ljava/util/List;)V")
+            .map_err(|e| <__JniErr as ::core::convert::From<
+                String,
+            >>::from(
+                format!(
+                    "Unable to resolve run for {}: {}", "Fn(Vec < Option < Ticks > >)", e
+                ),
+            ))?;
+        Box::new(move |__cb_arg0: Vec<Option<perftest_flat::Ticks>>| {
+            let _ = (|| -> ::core::result::Result<(), __JniErr> {
+                let mut env = java_vm
+                    .attach_current_thread_as_daemon()
+                    .map_err(|e| <__JniErr as ::core::convert::From<
+                        String,
+                    >>::from(
+                        format!(
+                            "Attach thread for {}: {}", "Fn(Vec < Option < Ticks > >)", e
+                        ),
+                    ))?;
+                env.push_local_frame(16)
+                    .map_err(|e| <__JniErr as ::core::convert::From<
+                        String,
+                    >>::from(
+                        format!(
+                            "push local frame for {}: {}",
+                            "Fn(Vec < Option < Ticks > >)", e
+                        ),
+                    ))?;
+                let __frame_res = (|| -> ::core::result::Result<(), __JniErr> {
+                    let __cb0_enc = Vec_Option_Ticks_to_JObject_2f4b03da(
+                        &mut env,
+                        __cb_arg0,
+                    )?;
+                    let __cb0_obj: jni::objects::JObject = __cb0_enc;
+                    let __call_res: ::core::result::Result<(), __JniErr> = unsafe {
+                        env.call_method_unchecked(
+                            &callback_global_ref,
+                            __invoke_id,
+                            jni::signature::ReturnType::Primitive(
+                                jni::signature::Primitive::Void,
+                            ),
+                            &[
+                                jni::sys::jvalue {
+                                    l: __cb0_obj.as_raw(),
+                                },
+                            ],
+                        )
+                    }
+                        .map(|_| ())
+                        .map_err(|e| {
+                            let _ = env.exception_describe();
+                            <__JniErr as ::core::convert::From<
+                                String,
+                            >>::from(e.to_string())
+                        });
+                    __call_res?;
+                    Ok(())
+                })();
+                let _ = unsafe { env.pop_local_frame(&jni::objects::JObject::null()) };
+                __frame_res?;
+                Ok(())
+            })()
+                .map_err(|e| {
+                    tracing::error!(
+                        "{} callback error: {e}", "Fn(Vec < Option < Ticks > >)"
+                    )
+                });
+        })
+    })
+}
+#[allow(
+    non_snake_case,
+    unused_mut,
+    unused_variables,
+    unused_braces,
+    unused_parens,
+    dead_code,
+    clippy::useless_conversion,
+    clippy::needless_question_mark,
+    clippy::let_and_return,
+    clippy::nonminimal_bool,
+    clippy::eq_op
+)]
 pub(crate) unsafe fn JObject_to_impl_Fn_u64_Send_Sync_static_c7830b57<'env, 'v>(
     env: &mut jni::JNIEnv<'env>,
     v: &jni::objects::JObject<'v>,
@@ -9346,6 +9464,45 @@ pub(crate) unsafe fn Option_Summary_to_jlong_828826f3<'a>(
     clippy::nonminimal_bool,
     clippy::eq_op
 )]
+pub(crate) unsafe fn Option_Ticks_to_JObject_95efad57<'a>(
+    env: &mut jni::JNIEnv<'a>,
+    v: Option<perftest_flat::Ticks>,
+) -> ::core::result::Result<jni::objects::JObject<'a>, __JniErr> {
+    Ok({
+        let v: Option<perftest_flat::Ticks> = v;
+        {
+            match v {
+                Some(value) => {
+                    let __raw: jni::sys::jlong = {
+                        let __inner_s0 = Ticks_to_u64_78fe2120(env, value)
+                            .map_err(|__e| <__JniErr as ::core::convert::From<
+                                String,
+                            >>::from(__e.to_string()))?;
+                        u64_to_jlong_4384a5d6(env, __inner_s0)?
+                    };
+                    ::prebindgen_jni_runtime::box_jlong(env, __raw)
+                        .map_err(|e| <__JniErr as ::core::convert::From<
+                            String,
+                        >>::from(format!("Option box: {}", e)))?
+                }
+                None => jni::objects::JObject::null(),
+            }
+        }
+    })
+}
+#[allow(
+    non_snake_case,
+    unused_mut,
+    unused_variables,
+    unused_braces,
+    unused_parens,
+    dead_code,
+    clippy::useless_conversion,
+    clippy::needless_question_mark,
+    clippy::let_and_return,
+    clippy::nonminimal_bool,
+    clippy::eq_op
+)]
 pub(crate) unsafe fn Option_Vec_Option_u64_to_JObject_006312b6<'a>(
     env: &mut jni::JNIEnv<'a>,
     v: Option<Vec<Option<u64>>>,
@@ -10054,6 +10211,25 @@ pub(crate) unsafe fn Tagged_to_JObject_641b984c<'a>(
     clippy::nonminimal_bool,
     clippy::eq_op
 )]
+pub(crate) unsafe fn Ticks_to_u64_78fe2120<'a>(
+    env: &mut jni::JNIEnv<'a>,
+    v: perftest_flat::Ticks,
+) -> ::core::result::Result<u64, __JniErr> {
+    Ok(perftest_flat::ticks_value(&v))
+}
+#[allow(
+    non_snake_case,
+    unused_mut,
+    unused_variables,
+    unused_braces,
+    unused_parens,
+    dead_code,
+    clippy::useless_conversion,
+    clippy::needless_question_mark,
+    clippy::let_and_return,
+    clippy::nonminimal_bool,
+    clippy::eq_op
+)]
 pub(crate) unsafe fn Unsigned_to_JObject_7e3cc618<'a>(
     env: &mut jni::JNIEnv<'a>,
     v: perftest_flat::Unsigned,
@@ -10161,6 +10337,46 @@ pub(crate) unsafe fn Vec_Label_to_JObject_3fdf860d<'a>(
                     >>::from(__e.to_string()))?;
                 String_to_JString_c7f3ca43(env, __inner_s0)?
             };
+            let __elem_obj: jni::objects::JObject = __elem_wire.into();
+            __list
+                .add(env, &__elem_obj)
+                .map_err(|e| <__JniErr as ::core::convert::From<
+                    String,
+                >>::from(format!("Vec<_>: list-add: {}", e)))?;
+        }
+        __list_obj
+    })
+}
+#[allow(
+    non_snake_case,
+    unused_mut,
+    unused_variables,
+    unused_braces,
+    unused_parens,
+    dead_code,
+    clippy::useless_conversion,
+    clippy::needless_question_mark,
+    clippy::let_and_return,
+    clippy::nonminimal_bool,
+    clippy::eq_op
+)]
+pub(crate) unsafe fn Vec_Option_Ticks_to_JObject_2f4b03da<'a>(
+    env: &mut jni::JNIEnv<'a>,
+    v: Vec<Option<perftest_flat::Ticks>>,
+) -> ::core::result::Result<jni::objects::JObject<'a>, __JniErr> {
+    Ok({
+        let v: Vec<Option<perftest_flat::Ticks>> = v;
+        let __list_obj = env
+            .new_object("java/util/ArrayList", "()V", &[])
+            .map_err(|e| <__JniErr as ::core::convert::From<
+                String,
+            >>::from(format!("Vec<_>: new ArrayList: {}", e)))?;
+        let __list = jni::objects::JList::from_env(env, &__list_obj)
+            .map_err(|e| <__JniErr as ::core::convert::From<
+                String,
+            >>::from(format!("Vec<_>: list-from-env: {}", e)))?;
+        for __elem in v.into_iter() {
+            let __elem_wire = Option_Ticks_to_JObject_95efad57(env, __elem)?;
             let __elem_obj: jni::objects::JObject = __elem_wire.into();
             __list
                 .add(env, &__elem_obj)
@@ -24673,6 +24889,51 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_taggedRank<'a>(
                 &__e.to_string(),
             );
             0 as jni::sys::jint
+        }
+    }
+}
+#[no_mangle]
+#[allow(non_snake_case, unused_mut, unused_variables, dead_code)]
+pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_ticksEmit<'a>(
+    mut env: jni::JNIEnv<'a>,
+    _class: jni::objects::JClass<'a>,
+    f: jni::objects::JObject<'a>,
+    __error_sink: jni::objects::JObject<'a>,
+) -> () {
+    #[allow(non_upper_case_globals)]
+    static __SINK_MID: ::prebindgen_jni_runtime::CachedIfaceMethod = ::prebindgen_jni_runtime::CachedIfaceMethod::new();
+    const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
+    const __SINK_DESCR: &str = "(Ljava/lang/String;)Ljava/lang/Object;";
+    let f = match JObject_to_impl_Fn_Vec_Option_Ticks_Send_Sync_static_26c17cf0(
+        &mut env,
+        &f,
+    ) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__e) => {
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e.to_string(),
+            );
+            return ();
+        }
+    };
+    let __out = perftest_flat::ticks_emit(f);
+    match unit_to_unit_9ecccf8e(&mut env, __out) {
+        ::core::result::Result::Ok(__w) => __w,
+        ::core::result::Result::Err(__e) => {
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e.to_string(),
+            );
+            ()
         }
     }
 }

--- a/examples/perftest-flat/src/ext.rs
+++ b/examples/perftest-flat/src/ext.rs
@@ -424,6 +424,45 @@ pub fn layered_of(which: i32) -> Layered {
     }
 }
 
+/// A `convert!`-declared newtype whose representation is a `u64`, so its Kotlin
+/// view is a `ULong` and its wire a `Long` — a leaf with a real conversion.
+///
+/// It exists because the value below needs one: a callback argument's layers
+/// can only be observed when the LEAF converts, and the obvious leaf (`u64`
+/// itself) already names a callback interface here — two signatures whose
+/// layers differ derive one name (#440), which is the same "look past the
+/// layers" habit one level out.
+#[prebindgen]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Ticks(pub u64);
+
+/// `Ticks` from its representation.
+#[prebindgen]
+pub fn ticks_from_raw(v: u64) -> Ticks {
+    Ticks(v)
+}
+
+/// `Ticks` to its representation.
+#[prebindgen]
+pub fn ticks_value(t: &Ticks) -> u64 {
+    t.0
+}
+
+/// A value with LAYERS as a **callback argument** — the direction #429's fix
+/// did not reach.
+///
+/// A sum payload and a callback argument are converted by different emitters,
+/// and each peeled the layers between a wire value and its leaf its own way:
+/// #432 taught the first, and the second went on applying the leaf's conversion
+/// to the whole value until #438. Fires with a list mixing present and absent
+/// elements, then with an empty one, so the per-element conversion and the
+/// empty case both cross.
+#[prebindgen]
+pub fn ticks_emit(f: impl Fn(Vec<Option<Ticks>>) + Send + Sync + 'static) {
+    f(vec![Some(Ticks(4)), None, Some(Ticks(6))]);
+    f(vec![]);
+}
+
 /// A handle-carrying sum as a **callback argument** — the same `Lookup` that
 /// [`lookup_of`] returns, arriving through `impl Fn` instead. Alternatives are
 /// delivered in `count` order starting at `-1`, so `n >= 3` covers all three:

--- a/prebindgen-jni/src/jni/iface.rs
+++ b/prebindgen-jni/src/jni/iface.rs
@@ -139,6 +139,26 @@ pub(crate) struct IfaceParam {
     pub raw: KtType,
     /// How the proxy wraps raw → typed.
     pub wrap: WrapKind,
+    /// What the value **is**, when the param was built from a reading.
+    ///
+    /// The wrap belongs to the leaf, and a value can have layers over it — an
+    /// `Option`, a run, both, nested. The proxy applied the wrap to the whole
+    /// parameter, which is the defect #429 fixed for a sum payload and #438
+    /// found again here, in the one direction that fix did not reach. Carrying
+    /// the reading is what lets both callers run the SAME walk
+    /// ([`Declarations::carry_layers`]) rather than each deriving the layers
+    /// again.
+    ///
+    /// `None` for a param with no reading behind it — the sum tag, a
+    /// passthrough — where the leaf and the value are the same thing.
+    ///
+    /// The identity **as text**, not the reading and not a `TypeKey`: a spec is
+    /// memoized behind an `Arc`, and both a `TypeRef` and a key carry
+    /// non-`Send` interiors (`syn` nodes, an `Rc<str>`). `TypeKey::parse` and
+    /// `Conversions::reading` are the door back — the one this codebase
+    /// documents for a caller holding an identity that wants the model's
+    /// answer.
+    pub reading: Option<String>,
 }
 
 impl IfaceParam {
@@ -148,6 +168,41 @@ impl IfaceParam {
             typed: ty.clone(),
             raw: ty,
             wrap: WrapKind::None,
+            reading: None,
+        }
+    }
+
+    /// The raw → typed conversion for this parameter, as the proxy writes it.
+    ///
+    /// One rule with two callers: this and the sum builder both run
+    /// [`Declarations::carry_layers`], each with its own receiver, so the layers
+    /// over a value are peeled by one piece of code (#438).
+    pub fn conversion(
+        &self,
+        ext: &crate::jni::Declarations,
+        registry: &impl Conversions<KotlinMeta>,
+        imports: &mut std::collections::BTreeSet<String>,
+    ) -> String {
+        // A key the registry no longer knows is not a layer question — it is a
+        // param built from a type this generation never classified, and the
+        // leaf's own wrap is the whole answer there.
+        let reading = self
+            .reading
+            .as_deref()
+            .and_then(|text| TypeKey::parse(text).ok())
+            .and_then(|key| registry.reading(&key));
+        match reading {
+            Some(reading) => ext.carry_layers(
+                registry,
+                &self.wrap,
+                self.raw.is_nullable(),
+                &reading,
+                self.name.clone(),
+                self.raw.is_nullable(),
+                0,
+                imports,
+            ),
+            None => self.wrap.wrap_expr(&self.name, self.raw.is_nullable()),
         }
     }
 }
@@ -520,7 +575,12 @@ impl IfaceSpec {
     /// <Name>Raw { raw leaves… -> run(<wraps…>) }` — constructed once per
     /// registration; per message it performs exactly the typed-object
     /// constructions the consumer needs anyway, in JVM bytecode.
-    pub fn to_as_raw_fun(&self) -> KtFun {
+    pub fn to_as_raw_fun(
+        &self,
+        ext: &crate::jni::Declarations,
+        registry: &impl Conversions<KotlinMeta>,
+        imports: &mut std::collections::BTreeSet<String>,
+    ) -> KtFun {
         let bare_generics: Vec<String> = self
             .type_params
             .iter()
@@ -568,7 +628,7 @@ impl IfaceSpec {
             self.params
                 .iter()
                 .map(|p| RunArg {
-                    expr: p.wrap.wrap_expr(&p.name, p.raw.is_nullable()),
+                    expr: p.conversion(ext, registry, imports),
                     // A wrapped handle leaf closes as itself; its nullability
                     // rides `nullable` below, exactly as for a group.
                     close: p.wrap.is_owned_handle().then_some(FoldStrategy::Base),
@@ -598,7 +658,7 @@ impl IfaceSpec {
                     None => {
                         let p = &self.params[at];
                         args.push(RunArg {
-                            expr: p.wrap.wrap_expr(&p.name, p.raw.is_nullable()),
+                            expr: p.conversion(ext, registry, imports),
                             close: p.wrap.is_owned_handle().then_some(FoldStrategy::Base),
                             nullable: p.raw.is_nullable(),
                             reassembled: false,
@@ -960,6 +1020,7 @@ fn leaf_iface_param(
                     typed: builder_kt.clone(),
                     raw,
                     wrap: WrapKind::Unsigned64 { niche_sentinel },
+                    reading: Some(out_ty.key().as_str().to_string()),
                 });
             }
             ProjectionKind::Handle => {}
@@ -996,6 +1057,7 @@ fn leaf_iface_param(
                     fqn,
                     niche_sentinel,
                 },
+                reading: Some(out_ty.key().as_str().to_string()),
             });
         }
         // Whole arg: typed class in both views (no proxy wrap).
@@ -1025,6 +1087,7 @@ fn leaf_iface_param(
                         typed: builder_kt.clone(),
                         raw,
                         wrap: WrapKind::None,
+                        reading: Some(out_ty.key().as_str().to_string()),
                     });
                 }
             }
@@ -1059,6 +1122,9 @@ pub(crate) fn owned_handle_iface_param(
         typed,
         raw,
         wrap: WrapKind::HandleOwned(fqn),
+        // A plan-less handle arg IS its leaf: there is no layer between the
+        // `jlong` and the class, so there is nothing for a walk to peel.
+        reading: None,
     })
 }
 

--- a/prebindgen-jni/src/jni/iface/tests.rs
+++ b/prebindgen-jni/src/jni/iface/tests.rs
@@ -2,10 +2,19 @@ use kotlin_codegen::{KtFile, KtType};
 
 use super::*;
 
+/// Render a spec's `asRaw` proxy.
+///
+/// Every param in these fixtures carries `reading: None` — they are leaves, and
+/// the proxy's layer walk is short-circuited for one — so an empty registry and
+/// a default declaration set are never consulted. A param WITH layers is
+/// covered where the layers come from: `prebindgen-jni/src/jni/tests`.
 fn render_as_raw(spec: IfaceSpec) -> String {
-    KtFile::new(&spec.package)
-        .decl(spec.to_as_raw_fun())
-        .render()
+    let registry = crate::test_util::reg_from_items(vec![]).expect("an empty registry");
+    let ext = crate::jni::Declarations::default();
+    let mut imports = std::collections::BTreeSet::new();
+    let fun = spec.to_as_raw_fun(&ext, &registry, &mut imports);
+    assert!(imports.is_empty(), "a leaf param imports nothing");
+    KtFile::new(&spec.package).decl(fun).render()
 }
 
 #[test]
@@ -22,6 +31,7 @@ fn as_raw_adapter_is_multiline_even_when_short() {
                 fqn: "io.test.Thing".to_string(),
                 niche_sentinel: None,
             },
+            reading: None,
         }],
         ret: KtType::unit(),
         descr: "(J)V".to_string(),
@@ -59,6 +69,7 @@ fn as_raw_adapter_breaks_wide_lambda_params_and_run_args() {
                     fqn: "io.test.ZenohId".to_string(),
                     niche_sentinel: None,
                 },
+                reading: None,
             },
             IfaceParam::same("replierEid".to_string(), KtType::int()),
             IfaceParam::same("isOk".to_string(), KtType::boolean()),
@@ -70,6 +81,7 @@ fn as_raw_adapter_breaks_wide_lambda_params_and_run_args() {
                     fqn: "io.test.KeyExpr".to_string(),
                     niche_sentinel: None,
                 },
+                reading: None,
             },
             IfaceParam {
                 name: "sample__payload".to_string(),
@@ -79,6 +91,7 @@ fn as_raw_adapter_breaks_wide_lambda_params_and_run_args() {
                     fqn: "io.test.ZBytes".to_string(),
                     niche_sentinel: None,
                 },
+                reading: None,
             },
         ],
         ret: KtType::unit(),

--- a/prebindgen-jni/src/jni/kotlin_emit.rs
+++ b/prebindgen-jni/src/jni/kotlin_emit.rs
@@ -1684,7 +1684,6 @@ impl Declarations {
     /// The lambda parameter is implicit at the outermost run and named below it,
     /// because a nested `it` would shadow the one above.
     #[allow(clippy::too_many_arguments)]
-    #[allow(clippy::too_many_arguments)]
     pub(crate) fn carry_layers(
         &self,
         registry: &impl Conversions<KotlinMeta>,

--- a/prebindgen-jni/src/jni/kotlin_emit.rs
+++ b/prebindgen-jni/src/jni/kotlin_emit.rs
@@ -1299,7 +1299,15 @@ impl Declarations {
                 if s.needs_raw() {
                     file = file.decl(s.to_raw_decl());
                     if !typed_is_dead {
-                        file = file.decl(s.to_as_raw_fun());
+                        // The proxy peels a value's layers, which can name a
+                        // class (an enum's `fromInt`), so it registers imports
+                        // like every other emitter here.
+                        let mut proxy_imports: BTreeSet<String> = BTreeSet::new();
+                        let proxy = s.to_as_raw_fun(self, registry, &mut proxy_imports);
+                        for fqn in proxy_imports {
+                            file = file.import(fqn);
+                        }
+                        file = file.decl(proxy);
                     }
                     // Kept even when the proxy is suppressed: a hoisted
                     // singleton names the same classes by short name from its
@@ -1646,7 +1654,16 @@ impl Declarations {
         } else {
             name.to_string()
         };
-        self.carry_layers(registry, param, &leaf.out_ty, arg, false, 0, imports)
+        self.carry_layers(
+            registry,
+            &param.wrap,
+            param.raw.is_nullable(),
+            &leaf.out_ty,
+            arg,
+            false,
+            0,
+            imports,
+        )
     }
 
     /// One payload layer, and then the rest of them.
@@ -1667,10 +1684,12 @@ impl Declarations {
     /// The lambda parameter is implicit at the outermost run and named below it,
     /// because a nested `it` would shadow the one above.
     #[allow(clippy::too_many_arguments)]
-    fn carry_layers(
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn carry_layers(
         &self,
         registry: &impl Conversions<KotlinMeta>,
-        param: &crate::jni::IfaceParam,
+        wrap: &crate::jni::WrapKind,
+        slot_nullable: bool,
         ty: &prebindgen_registry::flat::TypeRef,
         recv: String,
         nullable: bool,
@@ -1678,7 +1697,16 @@ impl Declarations {
         imports: &mut BTreeSet<String>,
     ) -> String {
         if let Some(inner) = ty.optional_inner() {
-            return self.carry_layers(registry, param, inner, recv, true, depth, imports);
+            return self.carry_layers(
+                registry,
+                wrap,
+                slot_nullable,
+                inner,
+                recv,
+                true,
+                depth,
+                imports,
+            );
         }
         if let Some(elem) = ty.sequence_elem() {
             let bound = if depth == 0 {
@@ -1688,7 +1716,8 @@ impl Declarations {
             };
             let body = self.carry_layers(
                 registry,
-                param,
+                wrap,
+                slot_nullable,
                 elem,
                 bound.clone(),
                 false,
@@ -1710,7 +1739,7 @@ impl Declarations {
         // NOT spelled nullably: absence is a value there, in a slot that is not
         // nullable at all, and `?.` on a primitive does not compile. Only the
         // outermost slot can be one — an element of a run is always boxed.
-        let nullable = nullable && (depth > 0 || param.raw.is_nullable());
+        let nullable = nullable && (depth > 0 || slot_nullable);
         // An enum payload rides its `jint` discriminant, so the interface types
         // it `Int` and the wrap has to name the enum class itself — read off the
         // same output-converter metadata `factory_field` reads for an enum
@@ -1730,7 +1759,7 @@ impl Declarations {
                 format!("{short}.fromInt({recv})")
             };
         }
-        param.wrap.wrap_expr(&recv, nullable)
+        wrap.wrap_expr(&recv, nullable)
     }
 
     /// The hoisted **folder-appender** singleton for a **whole single-leaf

--- a/prebindgen-jni/src/jni/tests/callbacks.rs
+++ b/prebindgen-jni/src/jni/tests/callbacks.rs
@@ -767,3 +767,57 @@ fn a_wrapped_borrow_callback_arg_declines() {
         "the refusal names the type: {err}"
     );
 }
+
+/// A callback argument's layers are peeled by the same walk a sum payload's
+/// are.
+///
+/// #429 was the sum builder applying the leaf's conversion to the whole wire
+/// value; #432 fixed it by walking the layers. The `asRaw` proxy — the other
+/// place a value is converted for delivery — kept its own one-shot wrap, so the
+/// same defect survived in the callback direction until the shape matrix gained
+/// that position (#438).
+///
+/// Both callers run `carry_layers` now, each with its own receiver, which is
+/// why this test and `a_payload_carries_its_option_and_collection_layers`
+/// assert the same expression from two directions.
+#[test]
+fn a_callback_argument_carries_its_layers() {
+    let loc = myflat_loc();
+    let items: Vec<(syn::Item, SourceLocation)> = vec![(
+        syn::Item::Fn(syn::parse_quote!(
+            pub fn probe(cb: impl Fn(Vec<Option<u64>>) + Send + Sync + 'static) {
+                unimplemented!()
+            }
+        )),
+        loc.clone(),
+    )];
+    let registry =
+        crate::test_util::reg_from_items(declare_referenced(items)).expect("index items");
+    let jni = JniGenBuilder::new()
+        .set_package_prefix("io.test.jni")
+        .package(crate::package!().fun(prebindgen_registry::fun!(probe)));
+
+    let dir = unique_test_dir("jnigen_cb_arg_layers");
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    let kotlin = jni
+        .build_with(registry)
+        .expect("resolve")
+        .write_kotlin(&dir.join("kotlin"))
+        .unwrap()
+        .iter()
+        .map(|p| std::fs::read_to_string(p).unwrap())
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    // The typed view is a list of optional `ULong`s and the raw twin a list of
+    // boxed `Long`s, so the conversion runs per element — not on the list.
+    assert!(
+        kotlin.contains("public fun run(vec: List<ULong?>)"),
+        "the typed view keeps its layers:\n{kotlin}"
+    );
+    assert!(
+        kotlin.contains("vec.map { it?.toULong() }"),
+        "the proxy converts element by element:\n{kotlin}"
+    );
+}


### PR DESCRIPTION
Fixes #438, found by the shape matrix on #402 the day it gained the callback-argument position.

## What was wrong

A value's layers — an `Option`, a run, both, nested — are peeled in **two** places: the sum builder that reassembles a variant, and the `asRaw` proxy that converts a callback argument for delivery. #429 was the first one applying the leaf's conversion to the whole wire value, and #432 fixed it by walking the layers. The proxy kept its own one-shot wrap:

```rust
expr: p.wrap.wrap_expr(&p.name, p.raw.is_nullable()),
```

so `impl Fn(Vec<Option<u64>>)` emitted

```kotlin
public fun run(vec: List<ULong?>)   // typed
public fun run(vec: List<Long?>)    // raw twin
…
    vec.toULong()                   // error: unresolved reference 'toULong'
```

Same defect, one direction over, because two emitters each carried their own copy of the rule.

## The fix

`carry_layers` becomes the only copy. It never needed an `IfaceParam` — a `WrapKind` and the slot's nullability were all it read — so it now takes those, and an `IfaceParam` carries the identity of the value it was built from. Both callers run the same walk, each with its own receiver:

```kotlin
vec.map { it?.toULong() }
```

The identity is stored as **text**. A spec is memoized behind an `Arc`, and both a `TypeRef` and a `TypeKey` carry non-`Send` interiors (`syn` nodes; an `Rc<str>`), so `TypeKey::parse` plus `Conversions::reading` is the door back — which is what that method is documented for.

## Verification

- New test `a_callback_argument_carries_its_layers` (`prebindgen-jni/src/jni/tests/callbacks.rs`): asserts the typed view keeps its layers and the proxy converts element by element. It fails on `main`.
- Applied to a `shape-coverage` checkout: `vec_opt__cbarg__jni` rises from `bad kotlin` to `kotlin`, and no other cell moves.
- `cargo test --workspace --all-features`, `clippy --deny warnings`, `fmt --check`, `regen-check.sh`, and the `covertest-kotlin` JVM harness (56 sections) all pass.

## What is NOT here, and why

There is no runtime case in `covertest-kotlin`, and the blocker is worth its own attention: **#440**. Two callback signatures whose layers differ derive one Kotlin interface name — `impl Fn(u64)` and `impl Fn(Vec<Option<u64>>)` both become `u64Callback` — and `covertest` already declares the first, so the second cannot be added. Validation catches the collision, so this is a refusal rather than silent breakage, but it means the shape has no home there yet.

I tried three ways around it before filing: an `enum_class` element (`List<Priority?>` has no raw twin, so nothing converts), a handle element (`Vec<Option<Summary>>` does not resolve), and a `convert!` element (`Millis` maps to `Long` with no wrap). None of them exercises the walk, so none would have been coverage — they would have been a green test that proves nothing, which is the failure mode I would rather report than ship.

The compile-level guard is real in the meantime: the emission test above, and #402's Kotlin compiler stage, which is what found this.