### PR TITLE
Run both boundary directions on one transformation tree (#442)

### DIFF
--- a/prebindgen-jni/src/jni/emit/callback.rs
+++ b/prebindgen-jni/src/jni/emit/callback.rs
@@ -80,11 +80,11 @@ pub(crate) fn callback_input(
         // interface + appender singleton, driven from the trampoline.
         if let Some(plan) = registry
             .callback_arg_plan(&arg_ty.key())
-            .filter(|p| super::render::is_iterable_fold(&p.shape))
+            .filter(|p| super::render::is_iterable_fold(p.shape()))
         {
             // Every leaf converter must already be resolved (deferral safety).
             // A synthesized leaf (a sum's tag) has no converter to wait for.
-            for leaf in plan.leaves.iter().filter(|l| l.has_converter()) {
+            for leaf in plan.leaves().iter().filter(|l| l.has_converter()) {
                 registry.output_entry(&leaf.out_ty)?;
             }
             let spec = folder_iface_for_plan(ext, registry, plan)?;
@@ -123,7 +123,7 @@ pub(crate) fn callback_input(
             // local frame so they are freed per element (the daemon-thread
             // local-ref discipline — only the `acc` ref crosses iterations).
             let acc = format_ident!("__fold{}_acc", i);
-            let obj_idents: Vec<syn::Ident> = (0..plan.leaves.len())
+            let obj_idents: Vec<syn::Ident> = (0..plan.leaves().len())
                 .map(|k| format_ident!("__cbfold{}_obj{}", i, k))
                 .collect();
             let (leaf_stmts, leaf_args) = encode_plan_leaves(
@@ -135,7 +135,7 @@ pub(crate) fn callback_input(
                 &fail,
                 emit,
             );
-            let elem_frame = std::cmp::max(16, 2 * plan.leaves.len() + 6);
+            let elem_frame = std::cmp::max(16, 2 * plan.leaves().len() + 6);
             let elem_frame_lit = syn::LitInt::new(&elem_frame.to_string(), Span::call_site());
             preludes.push(quote! {
                 let #acc: jni::objects::JObject = env
@@ -181,13 +181,13 @@ pub(crate) fn callback_input(
             // leaf (a sum's tag) has no converter to wait for: requiring one
             // would make the trampoline wait forever on an `i32` crossing the
             // binding may not have.
-            for leaf in plan.leaves.iter().filter(|l| l.has_converter()) {
+            for leaf in plan.leaves().iter().filter(|l| l.has_converter()) {
                 let e = registry.output_entry(&leaf.out_ty)?;
                 if leaf.identity && e.metadata.projection.is_none() {
                     return None;
                 }
             }
-            let obj_idents: Vec<syn::Ident> = (0..plan.leaves.len())
+            let obj_idents: Vec<syn::Ident> = (0..plan.leaves().len())
                 .map(|k| format_ident!("__cb{}_obj{}", i, k))
                 .collect();
             let (stmts, arg_exprs) = encode_plan_leaves(

--- a/prebindgen-jni/src/jni/emit/delivery.rs
+++ b/prebindgen-jni/src/jni/emit/delivery.rs
@@ -41,7 +41,7 @@ pub(crate) fn emit_unfold_delivery(
 ) -> TokenStream {
     use prebindgen_registry::unfold::UnfoldShape;
 
-    let n = plan.leaves.len();
+    let n = plan.leaves().len();
 
     // Builder-arg locals, one per leaf in declared order. The builder is a
     // generated typed `<Source>Builder<out R>` fun interface — its `run`
@@ -112,7 +112,7 @@ pub(crate) fn emit_unfold_delivery(
     // fold args are either the element WHOLE (M4) or its decomposed leaves (M5),
     // with `acc` the erased `A` (`Object`). `Option<Vec<T>>` additionally yields a
     // null result for `None` (the fold is skipped).
-    let opt_iterable = match &plan.shape {
+    let opt_iterable = match &plan.shape() {
         UnfoldShape::Iterable(_) => Some(false),
         UnfoldShape::Optional((), inner) if matches!(**inner, UnfoldShape::Iterable(_)) => {
             Some(true)
@@ -139,7 +139,7 @@ pub(crate) fn emit_unfold_delivery(
             }
         };
 
-        let loop_body = if let Some(element) = plan.element.as_ref() {
+        let loop_body = if let Some(element) = plan.element().as_ref() {
             // Whole-element (M4): encode the element via its own converter —
             // a raw typed jvalue for a primitive-wire element, a JObject
             // otherwise (mirrors `leaf_is_prim`; the folder interface
@@ -247,7 +247,7 @@ pub(crate) fn emit_unfold_delivery(
         };
     }
 
-    match &plan.shape {
+    match &plan.shape() {
         UnfoldShape::Base => {
             let statics = iface_statics(
                 iface.expect("builder interface spec derivable for a registered declaration"),
@@ -870,7 +870,7 @@ pub(crate) fn encode_plan_leaves(
     // module of the crate that defines it (multi-source bindings).
     let qualify = |id: &syn::Ident| -> syn::Path { ext.fn_module(registry, id) };
     let by_ref = plan.by_ref;
-    let n = plan.leaves.len();
+    let n = plan.leaves().len();
 
     // Typed `jvalue` argument expression per leaf, in leaf order: a non-null
     // primitive-wire leaf passes its raw primitive (`__objN` IS the jvalue);
@@ -878,7 +878,7 @@ pub(crate) fn encode_plan_leaves(
     // slot. Matches the descriptor [`crate::jni::iface`]
     // derives for the same leaf (primitive chunk vs object chunk).
     let mut arg_exprs: Vec<TokenStream> = Vec::with_capacity(n);
-    for (idx, leaf) in plan.leaves.iter().enumerate() {
+    for (idx, leaf) in plan.leaves().iter().enumerate() {
         let obj_ident = &obj_idents[idx];
         if leaf_is_prim(registry, leaf) {
             arg_exprs.push(quote!(#obj_ident));
@@ -887,7 +887,7 @@ pub(crate) fn encode_plan_leaves(
         }
     }
 
-    let hoisted = bind_hoists(&qualify, &plan.hoists, value, by_ref);
+    let hoisted = bind_hoists(&qualify, plan.hoists(), value, by_ref);
     let mut stmts = hoisted.stmts.clone();
 
     // Reach a leaf off the innermost value form it sits under, with that
@@ -916,10 +916,10 @@ pub(crate) fn encode_plan_leaves(
     // the returned value is the degenerate case of one segment covering
     // everything, while a value form contributes one per sum-typed field.
     let sum_segments: Vec<std::ops::Range<usize>> = (0..n)
-        .filter(|&i| plan.leaves[i].source == prebindgen_registry::unfold::LeafSource::SumTag)
+        .filter(|&i| plan.leaves()[i].source == prebindgen_registry::unfold::LeafSource::SumTag)
         .map(|start| {
             let end = (start + 1..n)
-                .take_while(|&i| plan.leaves[i].group.is_some())
+                .take_while(|&i| plan.leaves()[i].group.is_some())
                 .last()
                 .map_or(start + 1, |i| i + 1);
             start..end
@@ -934,11 +934,11 @@ pub(crate) fn encode_plan_leaves(
     // the arm too: emitted ahead of it, its `match` would reach a binding the
     // arm has not introduced yet.
     let mut cond_stmts: std::collections::BTreeMap<usize, TokenStream> = plan
-        .hoists
+        .hoists()
         .iter()
         .enumerate()
         .filter_map(|(i, _)| {
-            plan.leaves
+            plan.leaves()
                 .iter()
                 .any(|l| hoisted.conditional(&l.path).is_some_and(|(j, ..)| j == i))
                 .then_some((i, TokenStream::new()))
@@ -946,7 +946,7 @@ pub(crate) fn encode_plan_leaves(
         .collect();
 
     for seg in &sum_segments {
-        let leaf = &plan.leaves[seg.start];
+        let leaf = &plan.leaves()[seg.start];
         let (base, base_is_ref, path, _) = rebase(leaf);
         // The value to `match` on. The selector's own path reaches the sum
         // (empty when the sum IS the value), and a step on it MAY be optional:
@@ -1019,7 +1019,7 @@ pub(crate) fn encode_plan_leaves(
         let (group_stmts, group_args) = encode_sum_group(
             ext,
             registry,
-            &plan.leaves[seg.clone()],
+            &plan.leaves()[seg.clone()],
             &obj_idents[seg.clone()],
             matched,
             fail,
@@ -1029,7 +1029,7 @@ pub(crate) fn encode_plan_leaves(
             None => group_stmts,
             Some((k, opt_e, bind)) => {
                 let ids: Vec<&syn::Ident> = obj_idents[seg.clone()].iter().collect();
-                let slots: Vec<Slot> = plan.leaves[seg.clone()]
+                let slots: Vec<Slot> = plan.leaves()[seg.clone()]
                     .iter()
                     .map(|l| leaf_slot(registry, l))
                     .collect();
@@ -1077,12 +1077,12 @@ pub(crate) fn encode_plan_leaves(
 
     let in_sum = |i: usize| sum_segments.iter().any(|s| s.contains(&i));
     let mut order: Vec<usize> = (0..n)
-        .filter(|&i| !plan.leaves[i].identity && !in_sum(i))
+        .filter(|&i| !plan.leaves()[i].identity && !in_sum(i))
         .collect();
-    order.extend((0..n).filter(|&i| plan.leaves[i].identity && !in_sum(i)));
+    order.extend((0..n).filter(|&i| plan.leaves()[i].identity && !in_sum(i)));
 
     for idx in order {
-        let leaf = &plan.leaves[idx];
+        let leaf = &plan.leaves()[idx];
         let obj_ident = &obj_idents[idx];
         // Route this leaf's statements: into its conditional arm, or straight
         // out. Shadows `stmts` for the rest of the body, so every `extend`
@@ -1442,17 +1442,17 @@ pub(crate) fn encode_plan_leaves(
         let idxs: Vec<usize> = (0..n)
             .filter(|&k| {
                 hoisted
-                    .conditional(&plan.leaves[k].path)
+                    .conditional(&plan.leaves()[k].path)
                     .is_some_and(|(j, ..)| j == i)
             })
             .collect();
         let ids: Vec<&syn::Ident> = idxs.iter().map(|&k| &obj_idents[k]).collect();
         let tys = idxs
             .iter()
-            .map(|&k| leaf_slot(registry, &plan.leaves[k]).ty);
+            .map(|&k| leaf_slot(registry, &plan.leaves()[k]).ty);
         let defaults = idxs
             .iter()
-            .map(|&k| leaf_slot(registry, &plan.leaves[k]).default);
+            .map(|&k| leaf_slot(registry, &plan.leaves()[k]).default);
         // Matched BY VALUE: the local is this arm's alone (every leaf under the
         // hoist is in it), so a consuming value form's fields move out here
         // exactly as they do at an unconditional one.

--- a/prebindgen-jni/src/jni/emit/delivery.rs
+++ b/prebindgen-jni/src/jni/emit/delivery.rs
@@ -112,7 +112,7 @@ pub(crate) fn emit_unfold_delivery(
     // fold args are either the element WHOLE (M4) or its decomposed leaves (M5),
     // with `acc` the erased `A` (`Object`). `Option<Vec<T>>` additionally yields a
     // null result for `None` (the fold is skipped).
-    let opt_iterable = match &plan.shape() {
+    let opt_iterable = match plan.shape() {
         UnfoldShape::Iterable(_) => Some(false),
         UnfoldShape::Optional((), inner) if matches!(**inner, UnfoldShape::Iterable(_)) => {
             Some(true)
@@ -139,7 +139,7 @@ pub(crate) fn emit_unfold_delivery(
             }
         };
 
-        let loop_body = if let Some(element) = plan.element().as_ref() {
+        let loop_body = if let Some(element) = plan.element() {
             // Whole-element (M4): encode the element via its own converter —
             // a raw typed jvalue for a primitive-wire element, a JObject
             // otherwise (mirrors `leaf_is_prim`; the folder interface
@@ -247,7 +247,7 @@ pub(crate) fn emit_unfold_delivery(
         };
     }
 
-    match &plan.shape() {
+    match plan.shape() {
         UnfoldShape::Base => {
             let statics = iface_statics(
                 iface.expect("builder interface spec derivable for a registered declaration"),

--- a/prebindgen-jni/src/jni/emit/wrapper.rs
+++ b/prebindgen-jni/src/jni/emit/wrapper.rs
@@ -264,7 +264,7 @@ pub(crate) fn emit_jni_function_wrapper_with_callee(
     let call_expr: TokenStream = if is_convert {
         use prebindgen_registry::unfold::UnfoldShape;
         let uplan = unfold_plan.expect("is_convert ⇒ plan");
-        let leaf = &uplan.leaves[0];
+        let leaf = &uplan.leaves()[0];
         let by_ref = uplan.by_ref;
         // One derivation, shared with the multi-leaf encoder — the value forms
         // are bound by the same [`bind_hoists`] and the leaf reached by the
@@ -281,7 +281,7 @@ pub(crate) fn emit_jni_function_wrapper_with_callee(
         // `.map(|__inner| __inner)` (`clippy::map_identity`). Generated code
         // runs through the consumer's own lints, where both are denials.
         let compose = |base: TokenStream, base_is_ref: bool| -> Option<TokenStream> {
-            let hoisted = bind_hoists(&qualify, &uplan.hoists, &base, base_is_ref);
+            let hoisted = bind_hoists(&qualify, uplan.hoists(), &base, base_is_ref);
             let stmts = &hoisted.stmts;
             let reached = match hoisted.rebase(&leaf.path) {
                 Some((local, rest, consuming)) => {
@@ -296,7 +296,7 @@ pub(crate) fn emit_jni_function_wrapper_with_callee(
             }
             Some(quote!({ #stmts #reached }))
         };
-        match &uplan.shape {
+        match &uplan.shape() {
             UnfoldShape::Optional((), _) => match compose(quote!(__inner), by_ref) {
                 Some(inner) => quote!({
                     let __cvsrc = #raw_call;
@@ -321,7 +321,7 @@ pub(crate) fn emit_jni_function_wrapper_with_callee(
         // while ENCODING the error itself degrades to the BINDING channel
         // (`signal_binding_error`). The success `T` flows into the normal
         // output phase.
-        let eze_idents: Vec<syn::Ident> = (0..ep.leaves.len())
+        let eze_idents: Vec<syn::Ident> = (0..ep.leaves().len())
             .map(|i| format_ident!("__eze{}", i))
             .collect();
         let ze_fail = |msg: TokenStream| -> TokenStream {
@@ -889,8 +889,8 @@ pub(crate) fn emit_expanded_param(
     let mut prelude: Vec<TokenStream> = Vec::new();
     let mut leaf_locals: Vec<syn::Ident> = Vec::new();
 
-    debug_assert_eq!(plan.leaves.len(), leaves.len());
-    for (leaf, classified) in plan.leaves.iter().zip(leaves) {
+    debug_assert_eq!(plan.leaves().len(), leaves.len());
+    for (leaf, classified) in plan.leaves().iter().zip(leaves) {
         let leaf_ty = &leaf.ty;
         // The ascription generated Rust writes for this leaf's local.
         let leaf_ty_tokens = emit.spell(leaf_ty);

--- a/prebindgen-jni/src/jni/emit/wrapper.rs
+++ b/prebindgen-jni/src/jni/emit/wrapper.rs
@@ -296,7 +296,7 @@ pub(crate) fn emit_jni_function_wrapper_with_callee(
             }
             Some(quote!({ #stmts #reached }))
         };
-        match &uplan.shape() {
+        match uplan.shape() {
             UnfoldShape::Optional((), _) => match compose(quote!(__inner), by_ref) {
                 Some(inner) => quote!({
                     let __cvsrc = #raw_call;

--- a/prebindgen-jni/src/jni/fn_plan.rs
+++ b/prebindgen-jni/src/jni/fn_plan.rs
@@ -166,7 +166,7 @@ pub(crate) struct UnfoldOutputPlan {
     pub optional: bool,
     /// Synthesized fixed-singleton delivery: no caller lambda, not generic.
     pub fixed_builder: bool,
-    /// `plan.element.is_some()` — whole-element (M4) vs decomposed (M5) fold.
+    /// `plan.element().is_some()` — whole-element (M4) vs decomposed (M5) fold.
     pub whole_element: bool,
     /// Kotlin type variable of the wrapper: `None` for a fixed builder,
     /// `"A"` for an `Iterable` fold (bare or `Optional`-wrapped), `"R"`
@@ -514,7 +514,7 @@ impl JniFunctionPlan {
                 .get(&(f.name.clone(), ident.clone()))
             {
                 let mut leaves = Vec::new();
-                for leaf in &plan.leaves {
+                for leaf in plan.leaves() {
                     // The lookup that stood here is gone: the fold leaf carries
                     // its own reading now, so there is nothing to fetch and
                     // nothing that can miss.
@@ -728,8 +728,8 @@ fn build_output(
     // Callback delivery: the return is decomposed to a foreign builder/fold
     // lambda; no output converter runs and the wire is the erased `JObject`.
     if let Some(plan) = unfold_plan.filter(|p| p.delivery == Delivery::Callback) {
-        let iterable_fold = super::is_iterable_fold(&plan.shape);
-        let optional = matches!(plan.shape, UnfoldShape::Optional(..));
+        let iterable_fold = super::is_iterable_fold(plan.shape());
+        let optional = matches!(plan.shape(), UnfoldShape::Optional(..));
         let fixed_builder = plan.fixed_builder;
         // The generic-surface rule (see `classify_output`): a fixed builder
         // is not generic; an `Iterable` fold — bare or `Optional`-wrapped —
@@ -755,7 +755,7 @@ fn build_output(
             iterable_fold,
             optional,
             fixed_builder,
-            whole_element: plan.element.is_some(),
+            whole_element: plan.element().is_some(),
             generic,
             iface,
         }));

--- a/prebindgen-jni/src/jni/iface.rs
+++ b/prebindgen-jni/src/jni/iface.rs
@@ -1154,7 +1154,7 @@ pub(crate) fn fixed_leaf_element_keys(
         .values()
         .chain(registry.callback_arg_plans().values())
         .filter(|p| p.fixed_builder)
-        .filter_map(|p| p.element.as_ref())
+        .filter_map(|p| p.element())
         .map(|el| el.key())
         .collect()
 }
@@ -1340,10 +1340,10 @@ pub(crate) fn callback_iface_spec(
         let plan = registry
             .callback_arg_plans()
             .get(&t.key())
-            .filter(|p| !super::render::is_iterable_fold(&p.shape));
+            .filter(|p| !super::render::is_iterable_fold(p.shape()));
         if let Some(plan) = plan {
-            let leaf_names = plan_leaf_names(&plan.leaves);
-            for (n, l) in leaf_names.iter().zip(plan.leaves.iter()) {
+            let leaf_names = plan_leaf_names(plan.leaves());
+            for (n, l) in leaf_names.iter().zip(plan.leaves().iter()) {
                 leaf_tys.push(LeafDesc::Plan(n.clone(), l.clone()));
             }
             if plan.fixed_builder {
@@ -1353,13 +1353,13 @@ pub(crate) fn callback_iface_spec(
                 let core = t.borrow_target().unwrap_or(t);
                 let fqn = ext.kotlin_fqn(&core.key())?;
                 let (reassemble, imports) =
-                    fixed_reassembly(ext, registry, &core.key(), &plan.leaves, &fqn);
+                    fixed_reassembly(ext, registry, &core.key(), plan.leaves(), &fqn);
                 groups.push(GroupDesc {
                     name: whole_value_name(t, i),
                     typed: Some(KtType::cls(fqn.to_string())),
                     reassemble: Some(reassemble),
                     imports,
-                    leaf_count: plan.leaves.len(),
+                    leaf_count: plan.leaves().len(),
                     close: crate::jni::struct_plan::type_close_strategy(ext, registry, core, 0),
                 });
             } else {
@@ -1370,11 +1370,11 @@ pub(crate) fn callback_iface_spec(
                 // `when` over the tag. Handing those slots over raw would defeat
                 // the `sealed_class!` the sum was declared as.
                 let mut k = 0usize;
-                while k < plan.leaves.len() {
-                    let leaf = &plan.leaves[k];
+                while k < plan.leaves().len() {
+                    let leaf = &plan.leaves()[k];
                     let seg = if leaf.source == LeafSource::SumTag {
-                        (k + 1..plan.leaves.len())
-                            .take_while(|&j| plan.leaves[j].group.is_some())
+                        (k + 1..plan.leaves().len())
+                            .take_while(|&j| plan.leaves()[j].group.is_some())
                             .last()
                             .map_or(k + 1, |j| j + 1)
                     } else {
@@ -1387,7 +1387,7 @@ pub(crate) fn callback_iface_spec(
                             ext,
                             registry,
                             &leaf.out_ty.key(),
-                            &plan.leaves[k..seg],
+                            &plan.leaves()[k..seg],
                             &fqn,
                         );
                         groups.push(GroupDesc {
@@ -1618,10 +1618,10 @@ pub(crate) fn folder_iface_for_plan(
     plan: &UnfoldPlan,
 ) -> Option<std::sync::Arc<IfaceSpec>> {
     debug_assert!(
-        plan.shape.has_iterable_layer(),
+        plan.shape().has_iterable_layer(),
         "folder_iface_for_plan requires an Iterable (or Option<Iterable>) plan"
     );
-    match (&plan.element, &plan.decon) {
+    match (&plan.element(), &plan.decon) {
         (Some(el), _) => ext.iface_spec(registry, &SpecKey::whole_folder(el)),
         (None, Some(d)) => ext.iface_spec(registry, &SpecKey::Folder(d.clone())),
         (None, None) => None,

--- a/prebindgen-jni/src/jni/kotlin_emit.rs
+++ b/prebindgen-jni/src/jni/kotlin_emit.rs
@@ -1205,8 +1205,8 @@ impl Declarations {
                     .get(&func.name)
                     .filter(|p| p.delivery == Delivery::Callback)
                 {
-                    let iterable = is_iterable_fold(&plan.shape);
-                    match (iterable, &plan.element, &plan.decon) {
+                    let iterable = is_iterable_fold(plan.shape());
+                    match (iterable, &plan.element(), &plan.decon) {
                         (true, Some(el), _) => {
                             uses.insert(SpecKey::whole_folder(el));
                         }

--- a/prebindgen-jni/src/jni/overloads.rs
+++ b/prebindgen-jni/src/jni/overloads.rs
@@ -194,7 +194,7 @@ struct Split<'a> {
     plan: &'a FoldPlan,
     /// Start of this param's contiguous leaf block in `sel_fun.params`.
     start: usize,
-    /// Block length (`plan.leaves.len()`).
+    /// Block length (`plan.leaves().len()`).
     len: usize,
     /// Selector-leaf index within the block.
     sel_idx: usize,
@@ -343,7 +343,7 @@ fn resolve_split<'a>(
         f.name
     );
     let leaf_names: Vec<String> = plan
-        .leaves
+        .leaves()
         .iter()
         .map(|l| kt_param_name(&l.name.to_string()))
         .collect();

--- a/prebindgen-jni/src/jni/overloads.rs
+++ b/prebindgen-jni/src/jni/overloads.rs
@@ -630,7 +630,8 @@ mod tests {
                         node: InNode {
                             ty: p.ty.clone(),
                             kind: TransformKind::Leaf(InLeaf {
-                                leaf: i,
+                                slot: i,
+                                name: p.name.clone(),
                                 wrapped: false,
                             }),
                         },

--- a/prebindgen-jni/src/jni/overloads.rs
+++ b/prebindgen-jni/src/jni/overloads.rs
@@ -33,7 +33,7 @@
 use kotlin_codegen::KtVis;
 use kotlin_codegen::{KtBody, KtCode, KtFun, KtParam, KtType};
 use prebindgen_registry::{
-    expand::{FoldArg, FoldPlan},
+    expand::{FoldPlan, InNode},
     Conversions,
 };
 
@@ -183,11 +183,7 @@ fn rust_type_erased(
 /// outer shape is in scope — its arms are filtered to single-leaf ones by
 /// [`resolve_split`] (nullable-arm rule, see module docs).
 fn plan_in_scope(plan: &FoldPlan) -> bool {
-    plan.selector.is_some()
-        && !plan
-            .variants
-            .iter()
-            .any(|v| v.inputs.iter().any(|a| matches!(a, FoldArg::Build(_))))
+    plan.selector().is_some() && plan.core.arms().iter().all(|a| a.leaf_args().is_some())
 }
 
 /// One resolved split parameter of a function, positioned against the rendered
@@ -251,14 +247,15 @@ fn non_null(mut ty: KtType) -> KtType {
 /// Returns `None` if any input is not a flat leaf.
 fn variant_typed_params(
     registry: &impl Conversions<KotlinMeta>,
-    variant: &prebindgen_registry::expand::FoldVariant,
+    arm: &InNode,
     origin: &syn::Ident,
     block: &[KtParam],
     multi: bool,
     optional_plan: bool,
 ) -> Option<Vec<(KtParam, usize)>> {
     let origin_kt = kt_param_name(&origin.to_string());
-    let (names, optional): (Vec<String>, Vec<bool>) = match &variant.ctor {
+    let ctor = arm.ctor();
+    let (names, optional): (Vec<String>, Vec<bool>) = match ctor {
         Some(cf) => {
             let f = registry.flat().function(&cf)?;
             // `Optional` off the kind, not `is_option` off a path: the same
@@ -280,13 +277,10 @@ fn variant_typed_params(
         None => (vec![origin_kt.clone()], vec![false]),
     };
     let mut out = Vec::new();
-    for (m, arg) in variant.inputs.iter().enumerate() {
-        let FoldArg::Leaf(idx, _) = arg else {
-            return None;
-        };
-        let slot = block.get(*idx)?;
+    for (m, idx) in arm.leaf_args()?.into_iter().enumerate() {
+        let slot = block.get(idx)?;
         let base = names.get(m).cloned().unwrap_or_else(|| slot.name.clone());
-        let name = if multi && variant.ctor.is_some() {
+        let name = if multi && ctor.is_some() {
             prefixed(&origin_kt, &base)
         } else {
             base
@@ -296,7 +290,7 @@ fn variant_typed_params(
         } else {
             non_null(slot.ty.clone())
         };
-        out.push((KtParam::new(&name, ty), *idx));
+        out.push((KtParam::new(&name, ty), idx));
     }
     Some(out)
 }
@@ -337,7 +331,7 @@ fn resolve_split<'a>(
             )
         });
     assert!(
-        plan.selector.is_some(),
+        plan.selector().is_some(),
         "fun!({}).split_on_param(\"{param_name}\"): `{param_name}` has a single variant — there \
          is nothing to split (it already flattens to one signature)",
         f.name
@@ -362,18 +356,19 @@ fn resolve_split<'a>(
         )
     });
     let block = &sel_fun.params[start..start + len];
-    let sel_idx = plan.selector.expect("selector present");
+    let sel_idx = plan.selector().expect("selector present");
     // Nullable-arm rule: an `Option<…>` param is overloadable through its
     // single-leaf arms only — the arm's one nullable param doubles as the
     // presence flag (`null` = absent). Multi-leaf arms stay selector-only.
     let optional = plan.produces_option();
     let arms: Vec<(usize, Vec<(KtParam, usize)>)> = plan
-        .variants
-        .iter()
+        .core
+        .arms()
+        .into_iter()
         .enumerate()
-        .filter(|(_, v)| !optional || v.inputs.len() == 1)
-        .map(|(vi, v)| {
-            let typed = variant_typed_params(registry, v, &param, block, multi, optional)
+        .filter(|(_, a)| !optional || a.leaf_args().is_some_and(|l| l.len() == 1))
+        .map(|(vi, a)| {
+            let typed = variant_typed_params(registry, a, &param, block, multi, optional)
                 .unwrap_or_else(|| {
                     panic!(
                         "fun!({}).split_on_param(\"{param_name}\"): an arm has a non-flat input; \
@@ -458,7 +453,7 @@ pub(crate) fn render_param_overloads(
                 .iter()
                 .zip(combo)
                 .flat_map(|(s, &ai)| {
-                    let ctor = s.plan.variants[s.arms[ai].0].ctor.as_ref();
+                    let ctor = s.plan.core.arms()[s.arms[ai].0].ctor();
                     arm_erased_sig(ext, registry, &s.plan.target.key(), ctor)
                 })
                 .collect()
@@ -581,7 +576,7 @@ fn combo_label(splits: &[Split], combo: &[usize]) -> String {
         .iter()
         .zip(combo)
         .map(|(s, &ai)| {
-            let v = match &s.plan.variants[s.arms[ai].0].ctor {
+            let v = match s.plan.core.arms()[s.arms[ai].0].ctor() {
                 Some(c) => c.to_string(),
                 None => "variant_self()".to_string(),
             };
@@ -594,6 +589,10 @@ fn combo_label(splits: &[Split], combo: &[usize]) -> String {
 #[cfg(test)]
 mod tests {
     use prebindgen::SourceLocation;
+    use prebindgen_registry::{
+        expand::{InChild, InLeaf, InLink, InProduct},
+        transform::TransformKind,
+    };
 
     use super::*;
 
@@ -608,11 +607,36 @@ mod tests {
             vec![(syn::Item::Fn(ctor), SourceLocation::default())],
         ))
         .expect("index constructor");
-        let variant = prebindgen_registry::expand::FoldVariant {
-            ctor: Some(syn::parse_quote!(z_summary_optional)),
-            fallible: false,
-            clone: false,
-            inputs: vec![FoldArg::Leaf(0, false), FoldArg::Leaf(1, false)],
+        // The arm as `expand` builds it: the constructor over one flat wire
+        // slot per parameter.
+        let ctor_name: syn::Ident = syn::parse_quote!(z_summary_optional);
+        let f = registry
+            .flat()
+            .function(&ctor_name)
+            .expect("the indexed constructor");
+        let arm = InNode {
+            ty: f.ret.clone(),
+            kind: TransformKind::Product {
+                op: InProduct::Ctor {
+                    func: ctor_name.clone(),
+                    fallible: false,
+                },
+                children: f
+                    .params
+                    .iter()
+                    .enumerate()
+                    .map(|(i, p)| InChild {
+                        link: InLink { by_ref: false },
+                        node: InNode {
+                            ty: p.ty.clone(),
+                            kind: TransformKind::Leaf(InLeaf {
+                                leaf: i,
+                                wrapped: false,
+                            }),
+                        },
+                    })
+                    .collect(),
+            },
         };
         // Both slots are nullable in the selector wrapper. Only the first is
         // nullable in the constructor's actual signature.
@@ -623,7 +647,7 @@ mod tests {
 
         let params = variant_typed_params(
             &registry,
-            &variant,
+            &arm,
             &syn::parse_quote!(expected),
             &block,
             false,

--- a/prebindgen-jni/src/jni/overloads.rs
+++ b/prebindgen-jni/src/jni/overloads.rs
@@ -183,7 +183,7 @@ fn rust_type_erased(
 /// outer shape is in scope — its arms are filtered to single-leaf ones by
 /// [`resolve_split`] (nullable-arm rule, see module docs).
 fn plan_in_scope(plan: &FoldPlan) -> bool {
-    plan.selector().is_some() && plan.core.arms().iter().all(|a| a.leaf_args().is_some())
+    plan.selector().is_some() && plan.tree.arms().iter().all(|a| a.leaf_args().is_some())
 }
 
 /// One resolved split parameter of a function, positioned against the rendered
@@ -362,7 +362,7 @@ fn resolve_split<'a>(
     // presence flag (`null` = absent). Multi-leaf arms stay selector-only.
     let optional = plan.produces_option();
     let arms: Vec<(usize, Vec<(KtParam, usize)>)> = plan
-        .core
+        .tree
         .arms()
         .into_iter()
         .enumerate()
@@ -453,7 +453,7 @@ pub(crate) fn render_param_overloads(
                 .iter()
                 .zip(combo)
                 .flat_map(|(s, &ai)| {
-                    let ctor = s.plan.core.arms()[s.arms[ai].0].ctor();
+                    let ctor = s.plan.tree.arms()[s.arms[ai].0].ctor();
                     arm_erased_sig(ext, registry, &s.plan.target.key(), ctor)
                 })
                 .collect()
@@ -576,7 +576,7 @@ fn combo_label(splits: &[Split], combo: &[usize]) -> String {
         .iter()
         .zip(combo)
         .map(|(s, &ai)| {
-            let v = match s.plan.core.arms()[s.arms[ai].0].ctor() {
+            let v = match s.plan.tree.arms()[s.arms[ai].0].ctor() {
                 Some(c) => c.to_string(),
                 None => "variant_self()".to_string(),
             };
@@ -590,7 +590,7 @@ fn combo_label(splits: &[Split], combo: &[usize]) -> String {
 mod tests {
     use prebindgen::SourceLocation;
     use prebindgen_registry::{
-        expand::{InChild, InLeaf, InLink, InProduct},
+        expand::{InChild, InLeaf, InLink, InProduct, InSlot},
         transform::TransformKind,
     };
 
@@ -629,9 +629,12 @@ mod tests {
                         link: InLink { by_ref: false },
                         node: InNode {
                             ty: p.ty.clone(),
-                            kind: TransformKind::Leaf(InLeaf {
-                                slot: i,
-                                name: p.name.clone(),
+                            kind: TransformKind::Leaf(InLeaf::Slot {
+                                slot: InSlot {
+                                    slot: i,
+                                    name: p.name.clone(),
+                                    ty: p.ty.clone(),
+                                },
                                 wrapped: false,
                             }),
                         },

--- a/prebindgen-jni/src/jni/render.rs
+++ b/prebindgen-jni/src/jni/render.rs
@@ -1450,7 +1450,7 @@ fn classify_output(
         // `Vec<data_class>` fold, a `List<Class>` composed on the Kotlin side.
         // The concrete element/return Kotlin type. For a decomposed `data_class`
         // builder/fold it is the data class (`plan.source`'s registered FQN); for
-        // a **whole-element leaf** fold (`plan.element` set — String / handle)
+        // a **whole-element leaf** fold (`plan.element()` set — String / handle)
         // `plan.source` (e.g. `String`) has no class FQN, so take the
         // element's typed view from the folder interface's element param instead.
         // Full-FQN class type: the render-time `ImportSet` shortens it (and
@@ -1784,7 +1784,7 @@ fn error_sink_parts(
                 (p.raw.clone(), p.wrap.clone())
             })
             .collect();
-        debug_assert_eq!(ze_info.len(), error_plan.leaves.len());
+        debug_assert_eq!(ze_info.len(), error_plan.leaves().len());
         imports.insert(domain_spec.capture_fqn());
         // The domain redispatch args — the decomposed leaves only (no `je`).
         // The native side always fills the raw ze on `Err`, so non-null slots
@@ -2408,7 +2408,7 @@ fn shape_notes(
             })
             .collect();
         let leaf_names: Vec<String> = plan
-            .leaves
+            .leaves()
             .iter()
             .map(|l| snake_to_camel(&l.name.to_string()))
             .collect();
@@ -2436,7 +2436,7 @@ fn shape_notes(
 
     if let Some(plan) = registry.unfold_plans().get(fn_ident) {
         let source = plan.source.to_string();
-        let leaves: Vec<&str> = plan.leaves.iter().map(|l| l.name.as_str()).collect();
+        let leaves: Vec<&str> = plan.leaves().iter().map(|l| l.name.as_str()).collect();
         match plan.delivery {
             prebindgen_registry::unfold::Delivery::Callback if !leaves.is_empty() => {
                 notes.push(format!(
@@ -2456,7 +2456,7 @@ fn shape_notes(
 
     if let Some(plan) = registry.error_plans().get(fn_ident) {
         let source = plan.source.to_string();
-        let leaves: Vec<&str> = plan.leaves.iter().map(|l| l.name.as_str()).collect();
+        let leaves: Vec<&str> = plan.leaves().iter().map(|l| l.name.as_str()).collect();
         notes.push(format!(
             "On a domain error `onError` receives the decomposed Rust `{source}` error \
              (`{}`); a binding/system failure goes to `onBindingError` instead.",

--- a/prebindgen-jni/src/jni/render.rs
+++ b/prebindgen-jni/src/jni/render.rs
@@ -2399,9 +2399,10 @@ fn shape_notes(
     for (param, plan) in plans {
         let target = plan.target.to_string();
         let arms: Vec<String> = plan
-            .variants
-            .iter()
-            .map(|v| match &v.ctor {
+            .core
+            .arms()
+            .into_iter()
+            .map(|a| match a.ctor() {
                 Some(c) => format!("its `{c}` inputs"),
                 None => format!("an existing `{target}`"),
             })
@@ -2411,7 +2412,7 @@ fn shape_notes(
             .iter()
             .map(|l| snake_to_camel(&l.name.to_string()))
             .collect();
-        let how = if plan.selector.is_some() {
+        let how = if plan.selector().is_some() {
             if plan.produces_option() {
                 format!(
                     "pass EITHER {} — the selector chooses the arm, `-1` = absent",

--- a/prebindgen-jni/src/jni/render.rs
+++ b/prebindgen-jni/src/jni/render.rs
@@ -2399,7 +2399,7 @@ fn shape_notes(
     for (param, plan) in plans {
         let target = plan.target.to_string();
         let arms: Vec<String> = plan
-            .core
+            .tree
             .arms()
             .into_iter()
             .map(|a| match a.ctor() {

--- a/prebindgen-jni/src/jni/report.rs
+++ b/prebindgen-jni/src/jni/report.rs
@@ -217,9 +217,10 @@ impl super::JniGen {
         plans.sort_by_key(|(p, _)| p.to_string());
         for (param, plan) in plans {
             let variants: Vec<String> = plan
-                .variants
-                .iter()
-                .map(|v| match &v.ctor {
+                .core
+                .arms()
+                .into_iter()
+                .map(|a| match a.ctor() {
                     Some(c) => c.to_string(),
                     None => "self".to_string(),
                 })

--- a/prebindgen-jni/src/jni/report.rs
+++ b/prebindgen-jni/src/jni/report.rs
@@ -232,7 +232,7 @@ impl super::JniGen {
             ));
         }
         if let Some(plan) = registry.unfold_plans().get(rust_ident) {
-            let leaves: Vec<&str> = plan.leaves.iter().map(|l| l.name.as_str()).collect();
+            let leaves: Vec<&str> = plan.leaves().iter().map(|l| l.name.as_str()).collect();
             shaped.push(format!(
                 "return `{}` decomposed → [{}] ({:?} delivery)",
                 plan.source,
@@ -241,7 +241,7 @@ impl super::JniGen {
             ));
         }
         if let Some(plan) = registry.error_plans().get(rust_ident) {
-            let leaves: Vec<&str> = plan.leaves.iter().map(|l| l.name.as_str()).collect();
+            let leaves: Vec<&str> = plan.leaves().iter().map(|l| l.name.as_str()).collect();
             shaped.push(format!(
                 "domain error `{}` decomposed → onError [{}] (binding failures → onBindingError)",
                 plan.source,

--- a/prebindgen-jni/src/jni/report.rs
+++ b/prebindgen-jni/src/jni/report.rs
@@ -217,7 +217,7 @@ impl super::JniGen {
         plans.sort_by_key(|(p, _)| p.to_string());
         for (param, plan) in plans {
             let variants: Vec<String> = plan
-                .core
+                .tree
                 .arms()
                 .into_iter()
                 .map(|a| match a.ctor() {

--- a/prebindgen-jni/src/jni/tests/value_form.rs
+++ b/prebindgen-jni/src/jni/tests/value_form.rs
@@ -251,7 +251,7 @@ fn deriving_matches_the_equivalent_hand_written_list() {
         let gen = jni.build_with(registry).expect("resolve");
         gen.registry()
             .callback_arg_plans_for_test()
-            .flat_map(|p| p.leaves.iter())
+            .flat_map(|p| p.leaves().iter())
             .map(|l| (l.name.clone(), l.out_ty.to_string()))
             .collect()
     };

--- a/prebindgen-registry/src/expand.rs
+++ b/prebindgen-registry/src/expand.rs
@@ -42,7 +42,7 @@ mod tree;
 pub use self::{
     error::{ExpandDeclError, ExpandError},
     plan::{FoldLeaf, FoldPlan, FoldShape},
-    tree::{InChild, InChoice, InLeaf, InLink, InNode, InProduct, IntoRust},
+    tree::{wire_leaves, InChild, InChoice, InLeaf, InLink, InNode, InProduct, IntoRust},
 };
 
 use crate::transform::{Lowered, TransformKind, TransformLowerer};
@@ -414,7 +414,9 @@ fn build_plan<M>(
     visited: &mut HashSet<TypeKey>,
 ) -> Result<FoldPlan, ExpandError> {
     let param = &ed.param;
-    let mut leaves: Vec<FoldLeaf> = Vec::new();
+    // Wire slots are handed out as the construction is built; the flat
+    // signature is collected from the tree once it stands.
+    let mut next = 0usize;
 
     // Optional (`Option<T>`/`Option<&T>`) param. No recursion under `Optional`.
     //  * single single-arg ctor → one nullable leaf (`Option<arg>`) decides
@@ -432,22 +434,14 @@ fn build_plan<M>(
             visited.insert(target.key());
             let prefix = param.to_string();
             let core = build_core(
-                exp,
-                registry,
-                ed,
-                target,
-                variants,
-                by_ref,
-                &prefix,
-                &mut leaves,
-                visited,
+                exp, registry, ed, target, variants, by_ref, &prefix, &mut next, visited,
             )?;
             visited.remove(&target.key());
             return Ok(FoldPlan {
                 target: target.clone(),
                 by_ref,
                 shape: FoldShape::Optional((), Box::new(FoldShape::Base)),
-                leaves,
+                leaves: wire_leaves(&core, Vec::new()),
                 present: None,
                 core,
             });
@@ -455,47 +449,38 @@ fn build_plan<M>(
         let sig = ctor_signature(registry, func, &target.key())?;
         if sig.params.len() == 1 {
             let (_pn, pty) = &sig.params[0];
-            let leaf_ty = pty.optional();
-            leaves.push(FoldLeaf {
-                name: param.clone(),
-                ty: leaf_ty.clone(),
-            });
+            // The sole slot's `Option` is WHOLE-PARAM presence, unwrapped by
+            // the enclosing shape — not selector presence, so the constructor
+            // argument is not `wrapped`.
+            let arg = leaf_child(pty.optional(), next_slot(&mut next), param.clone(), false);
+            let core = ctor_node(target, func, sig.fallible, vec![arg]);
             return Ok(FoldPlan {
                 target: target.clone(),
                 by_ref,
                 shape: FoldShape::Optional((), Box::new(FoldShape::Base)),
-                leaves,
+                leaves: wire_leaves(&core, Vec::new()),
                 present: None,
-                // The sole leaf's `Option` is WHOLE-PARAM presence, unwrapped
-                // by the enclosing shape — not selector presence, so the
-                // constructor argument is not `wrapped`.
-                core: ctor_node(
-                    target,
-                    func,
-                    sig.fallible,
-                    vec![leaf_child(leaf_ty, 0, false)],
-                ),
+                core,
             });
         }
-        // Multi-arg: presence flag (leaf 0) + one flat leaf per ctor arg.
-        leaves.push(FoldLeaf {
-            name: ident(&format!("{}_present", param)),
-            // A presence flag no source wrote — placeless by construction.
-            ty: prebindgen_flat::flat::TypeRef::scalar(prebindgen_flat::flat::ScalarKind::Bool),
-        });
+        // Multi-arg: presence flag (slot 0) + one flat slot per ctor arg. The
+        // flag belongs to the PARAMETER, not to the construction — the
+        // `Optional` shape reads it and the constructor never sees it — so it
+        // is contributed to the signature beside the tree rather than by it.
+        let present = (
+            next_slot(&mut next),
+            FoldLeaf {
+                name: ident(&format!("{}_present", param)),
+                // A presence flag no source wrote — placeless by construction.
+                ty: prebindgen_flat::flat::TypeRef::scalar(prebindgen_flat::flat::ScalarKind::Bool),
+            },
+        );
         let prefix = param.to_string();
         let mut args = Vec::new();
         for (pname, pty) in &sig.params {
             let name = ident(&format!("{}_{}", prefix, pname));
             let arg = build_arg(
-                exp,
-                registry,
-                ed,
-                pty,
-                name,
-                /*dispatched=*/ false,
-                &mut leaves,
-                visited,
+                exp, registry, ed, pty, name, /*dispatched=*/ false, &mut next, visited,
             )?;
             if !matches!(arg.node.kind, TransformKind::Leaf(_)) {
                 return Err(ExpandError::UnsupportedOptional {
@@ -506,13 +491,15 @@ fn build_plan<M>(
             }
             args.push(arg);
         }
+        let present_slot = present.0;
+        let core = ctor_node(target, func, sig.fallible, args);
         return Ok(FoldPlan {
             target: target.clone(),
             by_ref,
             shape: FoldShape::Optional((), Box::new(FoldShape::Base)),
-            leaves,
-            present: Some(0),
-            core: ctor_node(target, func, sig.fallible, args),
+            leaves: wire_leaves(&core, vec![present]),
+            present: Some(present_slot),
+            core,
         });
     }
 
@@ -521,22 +508,14 @@ fn build_plan<M>(
     visited.insert(target.key());
     let prefix = param.to_string();
     let core = build_core(
-        exp,
-        registry,
-        ed,
-        target,
-        variants,
-        by_ref,
-        &prefix,
-        &mut leaves,
-        visited,
+        exp, registry, ed, target, variants, by_ref, &prefix, &mut next, visited,
     )?;
     visited.remove(&target.key());
     Ok(FoldPlan {
         target: target.clone(),
         by_ref,
         shape: FoldShape::Base,
-        leaves,
+        leaves: wire_leaves(&core, Vec::new()),
         present: None,
         core,
     })
@@ -561,24 +540,44 @@ fn ctor_node(
     }
 }
 
-/// One wire leaf used as an argument: decoded from slot `leaf`, `wrapped` when
-/// selector presence put an `Option` around it.
-fn leaf_child(ty: prebindgen_flat::flat::TypeRef, leaf: usize, wrapped: bool) -> InChild {
+/// One wire slot used as an argument: `wrapped` when selector presence put an
+/// `Option` around it.
+fn leaf_child(
+    ty: prebindgen_flat::flat::TypeRef,
+    slot: usize,
+    name: syn::Ident,
+    wrapped: bool,
+) -> InChild {
     InChild {
         link: InLink { by_ref: false },
         node: InNode {
             ty,
-            kind: TransformKind::Leaf(InLeaf { leaf, wrapped }),
+            kind: TransformKind::Leaf(InLeaf {
+                slot,
+                name,
+                wrapped,
+            }),
         },
     }
 }
 
-/// Build a construct core for `target` from its `variants`, appending wire
-/// leaves to `leaves`: a single constructor is one product, anything else is a
-/// selector choice over one product per arm. Recursive: a constructor parameter
-/// whose type has its OWN default constructor becomes a nested core in place of
-/// a leaf. Used by both the top-level [`build_plan`] and each nested build.
-/// `prefix` disambiguates leaf names across the tree.
+/// Hand out the next wire slot. Slots are numbered as the walk meets them,
+/// which is the order the foreign signature takes them in.
+fn next_slot(next: &mut usize) -> usize {
+    let slot = *next;
+    *next += 1;
+    slot
+}
+
+/// Build a construct core for `target` from its `variants`: a single
+/// constructor is one product, anything else is a selector choice over one
+/// product per arm. Recursive: a constructor parameter whose type has its OWN
+/// default constructor becomes a nested core in place of a leaf. Used by both
+/// the top-level [`build_plan`] and each nested build.
+///
+/// `next` hands out wire slots — a node names the slot it uses and the
+/// signature is [collected](wire_leaves) from the finished tree. `prefix`
+/// disambiguates slot names across the tree.
 #[allow(clippy::too_many_arguments)]
 fn build_core<M>(
     exp: &Expansions,
@@ -588,7 +587,7 @@ fn build_core<M>(
     variants: &[Variant],
     by_ref: bool,
     prefix: &str,
-    leaves: &mut Vec<FoldLeaf>,
+    next: &mut usize,
     visited: &mut HashSet<TypeKey>,
 ) -> Result<InNode, ExpandError> {
     if let [Variant::Ctor(func)] = variants {
@@ -603,18 +602,13 @@ fn build_core<M>(
                 ident(&format!("{}_{}", prefix, pname))
             };
             args.push(build_arg(
-                exp, registry, ed, pty, name, false, leaves, visited,
+                exp, registry, ed, pty, name, false, next, visited,
             )?);
         }
         return Ok(ctor_node(target, func, sig.fallible, args));
     }
-    // Combined — selector leaf, then `Option`-wrapped per-arm inputs.
-    let sel_idx = leaves.len();
-    leaves.push(FoldLeaf {
-        name: ident(&format!("{}_sel", prefix)),
-        // The selector, likewise composed and placeless.
-        ty: prebindgen_flat::flat::TypeRef::scalar(prebindgen_flat::flat::ScalarKind::I32),
-    });
+    // Combined — selector slot, then `Option`-wrapped per-arm inputs.
+    let sel_idx = next_slot(next);
     let mut arms: Vec<InChild> = Vec::new();
     for (vi, v) in variants.iter().enumerate() {
         let node = match v {
@@ -632,27 +626,28 @@ fn build_core<M>(
                     // `Option`-wrapped (selector presence). Recursive nesting
                     // under a combined arm is rejected by `build_arg`.
                     args.push(build_arg(
-                        exp, registry, ed, pty, name, true, leaves, visited,
+                        exp, registry, ed, pty, name, true, next, visited,
                     )?);
                 }
                 ctor_node(target, func, sig.fallible, args)
             }
             Variant::Identity => {
-                let idx = leaves.len();
                 let leaf_ty = if by_ref {
                     target.borrowed().optional()
                 } else {
                     target.optional()
                 };
-                leaves.push(FoldLeaf {
-                    name: ident(&format!("{}_{}", prefix, vi)),
-                    ty: leaf_ty.clone(),
-                });
+                let slot = next_slot(next);
                 InNode {
                     ty: target.clone(),
                     kind: TransformKind::Product {
                         op: InProduct::Identity { clone: by_ref },
-                        children: vec![leaf_child(leaf_ty, idx, true)],
+                        children: vec![leaf_child(
+                            leaf_ty,
+                            slot,
+                            ident(&format!("{}_{}", prefix, vi)),
+                            true,
+                        )],
                     },
                 }
             }
@@ -665,7 +660,10 @@ fn build_core<M>(
     Ok(InNode {
         ty: target.clone(),
         kind: TransformKind::Choice {
-            op: InChoice { selector: sel_idx },
+            op: InChoice {
+                selector: sel_idx,
+                name: ident(&format!("{}_sel", prefix)),
+            },
             variants: arms,
         },
     })
@@ -682,7 +680,7 @@ fn build_arg<M>(
     pty: &prebindgen_flat::flat::TypeRef,
     name: syn::Ident,
     dispatched: bool,
-    leaves: &mut Vec<FoldLeaf>,
+    next: &mut usize,
     visited: &mut HashSet<TypeKey>,
 ) -> Result<InChild, ExpandError> {
     // The boundary layers down to the parameter's core type.
@@ -720,7 +718,7 @@ fn build_arg<M>(
             &variants,
             pby_ref,
             &name.to_string(),
-            leaves,
+            next,
             visited,
         )?;
         visited.remove(&key);
@@ -729,19 +727,14 @@ fn build_arg<M>(
             node,
         })
     } else {
-        let idx = leaves.len();
-        // A dispatched (selector-presence) arm `Option`-wraps its leaves — but
+        // A dispatched (selector-presence) arm `Option`-wraps its slots — but
         // an argument that is itself `Option<…>` passes through with its own
         // type: `None` is a legitimate value for the taken arm, and the wire
         // cannot represent the double `Option` anyway. Such an argument is not
         // `wrapped`, so the emit side skips the selector-presence unwrap.
         let wrapped = dispatched && !popt;
         let leaf_ty = if wrapped { pty.optional() } else { pty.clone() };
-        leaves.push(FoldLeaf {
-            name,
-            ty: leaf_ty.clone(),
-        });
-        Ok(leaf_child(leaf_ty, idx, wrapped))
+        Ok(leaf_child(leaf_ty, next_slot(next), name, wrapped))
     }
 }
 
@@ -919,7 +912,7 @@ impl TransformLowerer<IntoRust> for ConstructEmitter<'_> {
     type Error = std::convert::Infallible;
 
     fn leaf(&mut self, _node: &InNode, op: &InLeaf) -> Result<syn::Expr, Self::Error> {
-        let local = &self.leaf_locals[op.leaf];
+        let local = &self.leaf_locals[op.slot];
         Ok(syn::parse_quote!(#local))
     }
 

--- a/prebindgen-registry/src/expand.rs
+++ b/prebindgen-registry/src/expand.rs
@@ -476,13 +476,21 @@ fn build_plan<M>(
                     for (pname, pty) in &sig.params {
                         let name = ident(&format!("{}_{}", prefix, pname));
                         let arg = build_arg(
-                            exp, registry, ed, pty, name, /*dispatched=*/ false, &mut next,
+                            exp,
+                            registry,
+                            ed,
+                            pty,
+                            name,
+                            &format!("{}.{}", param, pname),
+                            /*dispatched=*/ false,
+                            &mut next,
                             visited,
                         )?;
                         if !matches!(arg.node.kind, TransformKind::Leaf(_)) {
                             return Err(ExpandError::UnsupportedOptional {
                                 func: ed.func.clone(),
                                 param: ed.param.clone(),
+                                at: format!("{}.{}", prefix, pname),
                                 reason: "nested-buildable constructor arguments cannot be optional",
                             });
                         }
@@ -499,7 +507,8 @@ fn build_plan<M>(
                 visited.insert(target.key());
                 let prefix = param.to_string();
                 let core = build_core(
-                    exp, registry, ed, target, variants, by_ref, &prefix, &mut next, visited,
+                    exp, registry, ed, target, variants, by_ref, &prefix, &prefix, &mut next,
+                    visited,
                 )?;
                 visited.remove(&target.key());
                 (InPresence::Selector, core)
@@ -526,7 +535,7 @@ fn build_plan<M>(
     visited.insert(target.key());
     let prefix = param.to_string();
     let tree = build_core(
-        exp, registry, ed, target, variants, by_ref, &prefix, &mut next, visited,
+        exp, registry, ed, target, variants, by_ref, &prefix, &prefix, &mut next, visited,
     )?;
     visited.remove(&target.key());
     Ok(FoldPlan {
@@ -592,7 +601,11 @@ fn next_slot(next: &mut usize) -> usize {
 ///
 /// `next` hands out wire slots — a node names the slot it uses and the
 /// signature is [collected](wire_leaves) from the finished tree. `prefix`
-/// disambiguates slot names across the tree.
+/// disambiguates slot names across the tree, and `at` is the chain of
+/// constructor parameter names a diagnostic reports the failing node by. The
+/// two differ: a single-argument constructor keeps its parent's slot prefix
+/// (the slot is named after the parameter), so `prefix` alone cannot say how
+/// deep a chain of them a failure sits at.
 #[allow(clippy::too_many_arguments)]
 fn build_core<M>(
     exp: &Expansions,
@@ -602,6 +615,7 @@ fn build_core<M>(
     variants: &[Variant],
     by_ref: bool,
     prefix: &str,
+    at: &str,
     next: &mut usize,
     visited: &mut HashSet<TypeKey>,
 ) -> Result<InNode, ExpandError> {
@@ -617,7 +631,15 @@ fn build_core<M>(
                 ident(&format!("{}_{}", prefix, pname))
             };
             args.push(build_arg(
-                exp, registry, ed, pty, name, false, next, visited,
+                exp,
+                registry,
+                ed,
+                pty,
+                name,
+                &format!("{at}.{pname}"),
+                false,
+                next,
+                visited,
             )?);
         }
         return Ok(ctor_node(target, func, sig.fallible, args));
@@ -636,7 +658,7 @@ fn build_core<M>(
                 let sig = ctor_signature(registry, func, &target.key())?;
                 let np = sig.params.len();
                 let mut args = Vec::new();
-                for (pi, (_pname, pty)) in sig.params.iter().enumerate() {
+                for (pi, (pname, pty)) in sig.params.iter().enumerate() {
                     let name = if np == 1 {
                         ident(&format!("{}_{}", prefix, vi))
                     } else {
@@ -646,7 +668,15 @@ fn build_core<M>(
                     // `Option`-wrapped (selector presence). Recursive nesting
                     // under a combined arm is rejected by `build_arg`.
                     args.push(build_arg(
-                        exp, registry, ed, pty, name, true, next, visited,
+                        exp,
+                        registry,
+                        ed,
+                        pty,
+                        name,
+                        &format!("{at}.{pname}"),
+                        true,
+                        next,
+                        visited,
                     )?);
                 }
                 ctor_node(target, func, sig.fallible, args)
@@ -696,6 +726,7 @@ fn build_arg<M>(
     ed: &ExpandDecl,
     pty: &prebindgen_flat::flat::TypeRef,
     name: syn::Ident,
+    at: &str,
     dispatched: bool,
     next: &mut usize,
     visited: &mut HashSet<TypeKey>,
@@ -712,18 +743,21 @@ fn build_arg<M>(
         if dispatched {
             return Err(ExpandError::UnsupportedRecursive {
                 func: ed.func.clone(),
+                at: at.to_string(),
                 reason: "recursive input under a selector-dispatched constructor variant",
             });
         }
         if popt {
             return Err(ExpandError::UnsupportedRecursive {
                 func: ed.func.clone(),
+                at: at.to_string(),
                 reason: "recursive input on an Option<…> parameter",
             });
         }
         if !visited.insert(key.clone()) {
             return Err(ExpandError::InputCycle {
                 ty: key.to_string(),
+                at: at.to_string(),
             });
         }
         let variants = c.variants.clone();
@@ -735,6 +769,7 @@ fn build_arg<M>(
             &variants,
             pby_ref,
             &name.to_string(),
+            at,
             next,
             visited,
         )?;

--- a/prebindgen-registry/src/expand.rs
+++ b/prebindgen-registry/src/expand.rs
@@ -37,11 +37,15 @@ use crate::{
 
 mod error;
 mod plan;
+mod tree;
 
 pub use self::{
     error::{ExpandDeclError, ExpandError},
-    plan::{FoldArg, FoldBuild, FoldLeaf, FoldPlan, FoldShape, FoldVariant},
+    plan::{FoldLeaf, FoldPlan, FoldShape},
+    tree::{InChild, InChoice, InLeaf, InLink, InNode, InProduct, IntoRust},
 };
+
+use crate::transform::{Lowered, TransformKind, TransformLowerer};
 
 // ──────────────────────────────────────────────────────────────────────
 // Declarations (populated by the language builder)
@@ -427,7 +431,7 @@ fn build_plan<M>(
             // Combined-selector dispatch under `Optional`.
             visited.insert(target.key());
             let prefix = param.to_string();
-            let (selector, fold_variants) = build_core(
+            let core = build_core(
                 exp,
                 registry,
                 ed,
@@ -444,31 +448,33 @@ fn build_plan<M>(
                 by_ref,
                 shape: FoldShape::Optional((), Box::new(FoldShape::Base)),
                 leaves,
-                selector,
                 present: None,
-                variants: fold_variants,
+                core,
             });
         };
         let sig = ctor_signature(registry, func, &target.key())?;
         if sig.params.len() == 1 {
             let (_pn, pty) = &sig.params[0];
+            let leaf_ty = pty.optional();
             leaves.push(FoldLeaf {
                 name: param.clone(),
-                ty: pty.optional(),
+                ty: leaf_ty.clone(),
             });
             return Ok(FoldPlan {
                 target: target.clone(),
                 by_ref,
                 shape: FoldShape::Optional((), Box::new(FoldShape::Base)),
                 leaves,
-                selector: None,
                 present: None,
-                variants: vec![FoldVariant {
-                    ctor: Some(func.clone()),
-                    fallible: sig.fallible,
-                    clone: false,
-                    inputs: vec![FoldArg::Leaf(0, false)],
-                }],
+                // The sole leaf's `Option` is WHOLE-PARAM presence, unwrapped
+                // by the enclosing shape — not selector presence, so the
+                // constructor argument is not `wrapped`.
+                core: ctor_node(
+                    target,
+                    func,
+                    sig.fallible,
+                    vec![leaf_child(leaf_ty, 0, false)],
+                ),
             });
         }
         // Multi-arg: presence flag (leaf 0) + one flat leaf per ctor arg.
@@ -478,7 +484,7 @@ fn build_plan<M>(
             ty: prebindgen_flat::flat::TypeRef::scalar(prebindgen_flat::flat::ScalarKind::Bool),
         });
         let prefix = param.to_string();
-        let mut inputs = Vec::new();
+        let mut args = Vec::new();
         for (pname, pty) in &sig.params {
             let name = ident(&format!("{}_{}", prefix, pname));
             let arg = build_arg(
@@ -491,28 +497,22 @@ fn build_plan<M>(
                 &mut leaves,
                 visited,
             )?;
-            if matches!(arg, FoldArg::Build(_)) {
+            if !matches!(arg.node.kind, TransformKind::Leaf(_)) {
                 return Err(ExpandError::UnsupportedOptional {
                     func: ed.func.clone(),
                     param: ed.param.clone(),
                     reason: "nested-buildable constructor arguments cannot be optional",
                 });
             }
-            inputs.push(arg);
+            args.push(arg);
         }
         return Ok(FoldPlan {
             target: target.clone(),
             by_ref,
             shape: FoldShape::Optional((), Box::new(FoldShape::Base)),
             leaves,
-            selector: None,
             present: Some(0),
-            variants: vec![FoldVariant {
-                ctor: Some(func.clone()),
-                fallible: sig.fallible,
-                clone: false,
-                inputs,
-            }],
+            core: ctor_node(target, func, sig.fallible, args),
         });
     }
 
@@ -520,7 +520,7 @@ fn build_plan<M>(
     // on the cycle chain so a constructor parameter of the same type is rejected.
     visited.insert(target.key());
     let prefix = param.to_string();
-    let (selector, fold_variants) = build_core(
+    let core = build_core(
         exp,
         registry,
         ed,
@@ -537,17 +537,48 @@ fn build_plan<M>(
         by_ref,
         shape: FoldShape::Base,
         leaves,
-        selector,
         present: None,
-        variants: fold_variants,
+        core,
     })
 }
 
-/// Build a construct core (selector + dispatch arms) for `target` from its
-/// `variants`, appending wire leaves to `leaves`. Recursive: a constructor
-/// parameter whose type has its OWN default constructor is built as a nested
-/// [`FoldArg::Build`] (recursive input). Used by both the top-level [`build_plan`]
-/// and each nested build. `prefix` disambiguates leaf names across the tree.
+/// A constructor call over `args`, producing `target`.
+fn ctor_node(
+    target: &prebindgen_flat::flat::TypeRef,
+    func: &syn::Ident,
+    fallible: bool,
+    args: Vec<InChild>,
+) -> InNode {
+    InNode {
+        ty: target.clone(),
+        kind: TransformKind::Product {
+            op: InProduct::Ctor {
+                func: func.clone(),
+                fallible,
+            },
+            children: args,
+        },
+    }
+}
+
+/// One wire leaf used as an argument: decoded from slot `leaf`, `wrapped` when
+/// selector presence put an `Option` around it.
+fn leaf_child(ty: prebindgen_flat::flat::TypeRef, leaf: usize, wrapped: bool) -> InChild {
+    InChild {
+        link: InLink { by_ref: false },
+        node: InNode {
+            ty,
+            kind: TransformKind::Leaf(InLeaf { leaf, wrapped }),
+        },
+    }
+}
+
+/// Build a construct core for `target` from its `variants`, appending wire
+/// leaves to `leaves`: a single constructor is one product, anything else is a
+/// selector choice over one product per arm. Recursive: a constructor parameter
+/// whose type has its OWN default constructor becomes a nested core in place of
+/// a leaf. Used by both the top-level [`build_plan`] and each nested build.
+/// `prefix` disambiguates leaf names across the tree.
 #[allow(clippy::too_many_arguments)]
 fn build_core<M>(
     exp: &Expansions,
@@ -559,7 +590,7 @@ fn build_core<M>(
     prefix: &str,
     leaves: &mut Vec<FoldLeaf>,
     visited: &mut HashSet<TypeKey>,
-) -> Result<(Option<usize>, Vec<FoldVariant>), ExpandError> {
+) -> Result<InNode, ExpandError> {
     if let [Variant::Ctor(func)] = variants {
         // Single constructor — no selector; args passed directly (not Option-wrapped).
         let sig = ctor_signature(registry, func, &target.key())?;
@@ -575,77 +606,74 @@ fn build_core<M>(
                 exp, registry, ed, pty, name, false, leaves, visited,
             )?);
         }
-        Ok((
-            None,
-            vec![FoldVariant {
-                ctor: Some(func.clone()),
-                fallible: sig.fallible,
-                clone: false,
-                inputs: args,
-            }],
-        ))
-    } else {
-        // Combined — selector leaf, then `Option`-wrapped per-arm inputs.
-        let sel_idx = leaves.len();
-        leaves.push(FoldLeaf {
-            name: ident(&format!("{}_sel", prefix)),
-            // The selector, likewise composed and placeless.
-            ty: prebindgen_flat::flat::TypeRef::scalar(prebindgen_flat::flat::ScalarKind::I32),
-        });
-        let mut fold_variants: Vec<FoldVariant> = Vec::new();
-        for (vi, v) in variants.iter().enumerate() {
-            match v {
-                Variant::Ctor(func) => {
-                    let sig = ctor_signature(registry, func, &target.key())?;
-                    let np = sig.params.len();
-                    let mut args = Vec::new();
-                    for (pi, (_pname, pty)) in sig.params.iter().enumerate() {
-                        let name = if np == 1 {
-                            ident(&format!("{}_{}", prefix, vi))
-                        } else {
-                            ident(&format!("{}_{}_{}", prefix, vi, pi))
-                        };
-                        // `dispatched = true`: a combined arm's leaves are
-                        // `Option`-wrapped (selector presence). Recursive nesting
-                        // under a combined arm is rejected by `build_arg`.
-                        args.push(build_arg(
-                            exp, registry, ed, pty, name, true, leaves, visited,
-                        )?);
-                    }
-                    fold_variants.push(FoldVariant {
-                        ctor: Some(func.clone()),
-                        fallible: sig.fallible,
-                        clone: false,
-                        inputs: args,
-                    });
-                }
-                Variant::Identity => {
-                    let idx = leaves.len();
-                    let leaf_ty = if by_ref {
-                        target.borrowed().optional()
+        return Ok(ctor_node(target, func, sig.fallible, args));
+    }
+    // Combined — selector leaf, then `Option`-wrapped per-arm inputs.
+    let sel_idx = leaves.len();
+    leaves.push(FoldLeaf {
+        name: ident(&format!("{}_sel", prefix)),
+        // The selector, likewise composed and placeless.
+        ty: prebindgen_flat::flat::TypeRef::scalar(prebindgen_flat::flat::ScalarKind::I32),
+    });
+    let mut arms: Vec<InChild> = Vec::new();
+    for (vi, v) in variants.iter().enumerate() {
+        let node = match v {
+            Variant::Ctor(func) => {
+                let sig = ctor_signature(registry, func, &target.key())?;
+                let np = sig.params.len();
+                let mut args = Vec::new();
+                for (pi, (_pname, pty)) in sig.params.iter().enumerate() {
+                    let name = if np == 1 {
+                        ident(&format!("{}_{}", prefix, vi))
                     } else {
-                        target.optional()
+                        ident(&format!("{}_{}_{}", prefix, vi, pi))
                     };
-                    leaves.push(FoldLeaf {
-                        name: ident(&format!("{}_{}", prefix, vi)),
-                        ty: leaf_ty,
-                    });
-                    fold_variants.push(FoldVariant {
-                        ctor: None,
-                        fallible: false,
-                        clone: by_ref,
-                        inputs: vec![FoldArg::Leaf(idx, false)],
-                    });
+                    // `dispatched = true`: a combined arm's leaves are
+                    // `Option`-wrapped (selector presence). Recursive nesting
+                    // under a combined arm is rejected by `build_arg`.
+                    args.push(build_arg(
+                        exp, registry, ed, pty, name, true, leaves, visited,
+                    )?);
+                }
+                ctor_node(target, func, sig.fallible, args)
+            }
+            Variant::Identity => {
+                let idx = leaves.len();
+                let leaf_ty = if by_ref {
+                    target.borrowed().optional()
+                } else {
+                    target.optional()
+                };
+                leaves.push(FoldLeaf {
+                    name: ident(&format!("{}_{}", prefix, vi)),
+                    ty: leaf_ty.clone(),
+                });
+                InNode {
+                    ty: target.clone(),
+                    kind: TransformKind::Product {
+                        op: InProduct::Identity { clone: by_ref },
+                        children: vec![leaf_child(leaf_ty, idx, true)],
+                    },
                 }
             }
-        }
-        Ok((Some(sel_idx), fold_variants))
+        };
+        arms.push(InChild {
+            link: InLink { by_ref: false },
+            node,
+        });
     }
+    Ok(InNode {
+        ty: target.clone(),
+        kind: TransformKind::Choice {
+            op: InChoice { selector: sel_idx },
+            variants: arms,
+        },
+    })
 }
 
 /// Build one constructor-parameter input. If the parameter's (peeled) type has
-/// its own default constructor, recurse into a nested [`FoldArg::Build`]
-/// (recursive input); otherwise it is a flat wire [`FoldArg::Leaf`].
+/// its own default constructor, recurse into a nested core (a recursive input);
+/// otherwise it is a flat wire leaf.
 #[allow(clippy::too_many_arguments)]
 fn build_arg<M>(
     exp: &Expansions,
@@ -656,7 +684,7 @@ fn build_arg<M>(
     dispatched: bool,
     leaves: &mut Vec<FoldLeaf>,
     visited: &mut HashSet<TypeKey>,
-) -> Result<FoldArg, ExpandError> {
+) -> Result<InChild, ExpandError> {
     // The boundary layers down to the parameter's core type.
     let (popt, pby_ref, bare) = constructed_value_layers(pty);
     let key = bare.key();
@@ -684,7 +712,7 @@ fn build_arg<M>(
             });
         }
         let variants = c.variants.clone();
-        let (selector, vars) = build_core(
+        let node = build_core(
             exp,
             registry,
             ed,
@@ -696,29 +724,24 @@ fn build_arg<M>(
             visited,
         )?;
         visited.remove(&key);
-        Ok(FoldArg::Build(Box::new(FoldBuild {
-            target: bare.clone(),
-            by_ref: pby_ref,
-            selector,
-            variants: vars,
-        })))
+        Ok(InChild {
+            link: InLink { by_ref: pby_ref },
+            node,
+        })
     } else {
         let idx = leaves.len();
         // A dispatched (selector-presence) arm `Option`-wraps its leaves — but
         // an argument that is itself `Option<…>` passes through with its own
         // type: `None` is a legitimate value for the taken arm, and the wire
-        // cannot represent the double `Option` anyway. Marked `passthrough` so
-        // the emit side skips the selector-presence unwrap.
-        let passthrough = dispatched && popt;
+        // cannot represent the double `Option` anyway. Such an argument is not
+        // `wrapped`, so the emit side skips the selector-presence unwrap.
+        let wrapped = dispatched && !popt;
+        let leaf_ty = if wrapped { pty.optional() } else { pty.clone() };
         leaves.push(FoldLeaf {
             name,
-            ty: if dispatched && !passthrough {
-                pty.optional()
-            } else {
-                pty.clone()
-            },
+            ty: leaf_ty.clone(),
         });
-        Ok(FoldArg::Leaf(idx, passthrough))
+        Ok(leaf_child(leaf_ty, idx, wrapped))
     }
 }
 
@@ -769,7 +792,7 @@ fn fold_shape(
     match shape {
         FoldShape::Base => emit_core_construct(plan, leaf_locals, bound, qualify),
         FoldShape::Optional((), inner) => {
-            if let Some(sidx) = plan.selector {
+            if let Some(sidx) = plan.selector() {
                 // Combined-selector dispatch under `Optional`: the selector
                 // ALSO encodes absence — `-1` = `None`, `0..n-1` = the taken
                 // arm (dispatched by the shared construct core; an out-of-range
@@ -825,8 +848,8 @@ fn fold_shape(
 
 /// Emit the innermost construct → `Result<Target, String>`. With `bound =
 /// Some(v)` (under an `Optional`/`Iterable` layer ⇒ single, single-arg ctor)
-/// the ctor is applied to `v`; with `bound = None` (top level) it reads the
-/// leaves — a single constructor (any arity) or a combined-selector dispatch.
+/// the ctor is applied to `v`; with `bound = None` (top level) the whole
+/// construct core is lowered, reading the decoded leaves.
 fn emit_core_construct(
     plan: &FoldPlan,
     leaf_locals: &[syn::Ident],
@@ -837,217 +860,221 @@ fn emit_core_construct(
         // Shaped construct: a single, single-arg constructor applied to the
         // unwrapped element. (`apply` guarantees this shape — never identity,
         // never combined, never multi-arg under a shape layer.)
-        let var = &plan.variants[0];
-        let func = var
-            .ctor
-            .as_ref()
-            .expect("shaped expansion is single-constructor (never identity)");
-        return ctor_call_result(&qualify(func), std::slice::from_ref(v), var.fallible);
+        let TransformKind::Product {
+            op: InProduct::Ctor { func, fallible },
+            ..
+        } = &plan.core.kind
+        else {
+            unreachable!(
+                "shaped expansion is a single constructor (never identity, never combined)"
+            )
+        };
+        return ctor_call_result(&qualify(func), std::slice::from_ref(v), *fallible);
     }
-    emit_dispatch(plan.selector, &plan.variants, leaf_locals, qualify)
+    lower_core(&plan.core, leaf_locals, qualify)
 }
 
-/// Emit a construct dispatch → `Result<Target, String>`: a single variant
-/// applied directly (no selector), or a `match` over the selector leaf. Shared
-/// by the top-level [`emit_core_construct`] and each nested [`emit_build`].
-fn emit_dispatch(
-    selector: Option<usize>,
-    variants: &[FoldVariant],
+/// Lower one construct core to a `Result<Target, String>` expression, through
+/// the shared traversal — the registry writes node policy here and no recursion
+/// of its own.
+fn lower_core(
+    core: &InNode,
     leaf_locals: &[syn::Ident],
     qualify: &dyn Fn(&syn::Ident) -> syn::Path,
 ) -> syn::Expr {
-    match selector {
-        None => variant_result_expr(
-            &variants[0],
-            leaf_locals,
-            qualify,
-            /*dispatched=*/ false,
-        ),
-        Some(si) => {
-            let sel = &leaf_locals[si];
-            let arms: Vec<TokenStream> = variants
-                .iter()
-                .enumerate()
-                .map(|(vi, v)| {
-                    let lit = vi as i32;
-                    let body =
-                        variant_result_expr(v, leaf_locals, qualify, /*dispatched=*/ true);
-                    quote!(#lit => #body,)
-                })
-                .collect();
-            syn::parse_quote!({
-                match #sel {
-                    #(#arms)*
-                    __sel => ::core::result::Result::Err(::std::format!(
-                        "invalid constructor selector: {}",
-                        __sel
-                    )),
-                }
-            })
+    core.lower(&mut ConstructEmitter {
+        leaf_locals,
+        qualify,
+    })
+    .expect("emitting a built construct cannot fail")
+}
+
+/// Lowers an into-Rust construct into the Rust expression that performs it.
+///
+/// Two kinds of value flow through it, told apart by the child's node kind
+/// exactly as the constructor call must anyway: a **leaf** lowers to its
+/// decoded local, while a **product or choice** lowers to an expression of type
+/// `Result<_, String>`.
+struct ConstructEmitter<'a> {
+    /// The already-decoded Rust locals, 1:1 with `FoldPlan::leaves`.
+    leaf_locals: &'a [syn::Ident],
+    /// Maps a constructor ident to its call path (e.g. prefixing the source
+    /// module).
+    qualify: &'a dyn Fn(&syn::Ident) -> syn::Path,
+}
+
+impl ConstructEmitter<'_> {
+    /// The `Option`-wrapped-by-selector-presence flag of a child that is a
+    /// leaf; `None` for a child that is a nested construct.
+    fn wrapped(child: &InChild) -> Option<bool> {
+        match &child.node.kind {
+            TransformKind::Leaf(op) => Some(op.wrapped),
+            _ => None,
         }
     }
 }
 
-/// Emit a nested recursive-input build → `Result<SubTarget, String>` (the dual
-/// of [`emit_core_construct`] for a [`FoldArg::Build`] parameter).
-fn emit_build(
-    b: &FoldBuild,
-    leaf_locals: &[syn::Ident],
-    qualify: &dyn Fn(&syn::Ident) -> syn::Path,
-) -> syn::Expr {
-    emit_dispatch(b.selector, &b.variants, leaf_locals, qualify)
-}
+impl TransformLowerer<IntoRust> for ConstructEmitter<'_> {
+    type Value = syn::Expr;
+    type Error = std::convert::Infallible;
 
-/// Build a `Result<Target, String>` expression for one core variant. When
-/// `dispatched` (a combined-selector arm), the variant's input leaves are
-/// `Option<_>` — only the selected arm's inputs are present — so they are
-/// unwrapped (a missing input yields `Err`); otherwise they are passed
-/// directly. (This `Option`-ness is *selector presence*, distinct from
-/// [`FoldShape::Optional`], which is whole-param presence handled by the
-/// enclosing fold.)
-fn variant_result_expr(
-    v: &FoldVariant,
-    leaf_locals: &[syn::Ident],
-    qualify: &dyn Fn(&syn::Ident) -> syn::Path,
-    dispatched: bool,
-) -> syn::Expr {
-    // A Leaf arg's decoded local. Identity arms and combined-dispatched arms are
-    // Leaf-only (recursive `Build` args appear only in a non-dispatched single
-    // constructor — `build_arg` rejects nesting under a dispatched variant).
-    let leaf = |a: &FoldArg| -> &syn::Ident {
-        match a {
-            FoldArg::Leaf(i, _) => &leaf_locals[*i],
-            FoldArg::Build(_) => {
-                unreachable!("recursive Build arg only in a non-dispatched single constructor")
-            }
-        }
-    };
+    fn leaf(&mut self, _node: &InNode, op: &InLeaf) -> Result<syn::Expr, Self::Error> {
+        let local = &self.leaf_locals[op.leaf];
+        Ok(syn::parse_quote!(#local))
+    }
 
-    match &v.ctor {
-        None => {
-            // Identity: the sole input is the target value (or a borrow of it
-            // that we clone, for `&T` consumers — preserving the caller's handle).
-            let loc = leaf(&v.inputs[0]);
-            // `&*__v` derefs through whatever the borrow leaf decoded to (a
-            // plain `&T`, or an adapter smart-pointer like jnigen's
-            // `OwnedObject<T>`) down to `T`, then clones — keeping the caller's
-            // handle alive without the core knowing the adapter's borrow type.
-            let some_val: syn::Expr = if v.clone {
-                syn::parse_quote!(::core::result::Result::Ok(::core::clone::Clone::clone(
-                    &*__v
-                )))
-            } else {
-                syn::parse_quote!(::core::result::Result::Ok(__v))
-            };
-            if dispatched {
-                syn::parse_quote!(match #loc {
-                    ::core::option::Option::Some(__v) => #some_val,
-                    ::core::option::Option::None => ::core::result::Result::Err(
-                        ::std::string::String::from("identity variant value missing")
-                    ),
-                })
-            } else if v.clone {
-                syn::parse_quote!(::core::result::Result::Ok(::core::clone::Clone::clone(&*#loc)))
-            } else {
-                syn::parse_quote!(::core::result::Result::Ok(#loc))
-            }
-        }
-        Some(func) => {
-            let path = qualify(func);
-            if dispatched {
-                // Combined arm — Leaf-only inputs. Selector-presence-wrapped
-                // inputs are unwrapped (missing ⇒ `Err`); **passthrough**
-                // inputs (constructor args that are themselves `Option<…>`)
-                // pass their decoded local directly — `None` is a legitimate
-                // value for the taken arm.
-                let mut wrapped_locals: Vec<&syn::Ident> = Vec::new();
-                let mut wrapped_binds: Vec<syn::Ident> = Vec::new();
-                let mut call_args: Vec<syn::Expr> = Vec::new();
-                for (i, a) in v.inputs.iter().enumerate() {
-                    let loc = leaf(a);
-                    if matches!(a, FoldArg::Leaf(_, true)) {
-                        call_args.push(syn::parse_quote!(#loc));
+    fn product(
+        &mut self,
+        _node: &InNode,
+        op: &InProduct,
+        children: Lowered<'_, IntoRust, syn::Expr>,
+    ) -> Result<syn::Expr, Self::Error> {
+        let missing = quote!(::core::result::Result::Err(::std::string::String::from(
+            "constructor variant input missing"
+        )));
+        match op {
+            InProduct::Identity { clone } => {
+                // The sole input is the target value (or a borrow of it that we
+                // clone, for `&T` consumers — preserving the caller's handle).
+                let (child, value) = &children[0];
+                // `&*__v` derefs through whatever the borrow leaf decoded to (a
+                // plain `&T`, or an adapter smart-pointer like jnigen's
+                // `OwnedObject<T>`) down to `T`, then clones — keeping the
+                // caller's handle alive without the core knowing the adapter's
+                // borrow type.
+                if Self::wrapped(child) == Some(true) {
+                    let some_val: syn::Expr = if *clone {
+                        syn::parse_quote!(::core::result::Result::Ok(::core::clone::Clone::clone(
+                            &*__v
+                        )))
                     } else {
-                        let b = ident(&format!("__p{}", i));
-                        wrapped_locals.push(loc);
-                        wrapped_binds.push(b.clone());
-                        call_args.push(syn::parse_quote!(#b));
-                    }
+                        syn::parse_quote!(::core::result::Result::Ok(__v))
+                    };
+                    return Ok(syn::parse_quote!(match #value {
+                        ::core::option::Option::Some(__v) => #some_val,
+                        ::core::option::Option::None => ::core::result::Result::Err(
+                            ::std::string::String::from("identity variant value missing")
+                        ),
+                    }));
                 }
-                let call = ctor_call_result(&path, &call_args, v.fallible);
-                let missing = quote!(::core::result::Result::Err(::std::string::String::from(
-                    "constructor variant input missing"
-                )));
-                match wrapped_locals.len() {
-                    // All-passthrough arm: the selector alone decides; call directly.
-                    0 => call,
-                    1 => {
-                        // `match a { Some(p0) => <call>, None => Err }`
-                        let loc = wrapped_locals[0];
-                        let p0 = &wrapped_binds[0];
-                        syn::parse_quote!(match #loc {
-                            ::core::option::Option::Some(#p0) => #call,
-                            ::core::option::Option::None => #missing,
-                        })
+                Ok(if *clone {
+                    syn::parse_quote!(::core::result::Result::Ok(::core::clone::Clone::clone(
+                        &*#value
+                    )))
+                } else {
+                    syn::parse_quote!(::core::result::Result::Ok(#value))
+                })
+            }
+            InProduct::Ctor { func, fallible } => {
+                let path = (self.qualify)(func);
+                if children.iter().all(|(c, _)| Self::wrapped(c).is_some()) {
+                    // Flat arguments only. Those `Option`-wrapped by selector
+                    // presence are unwrapped (missing ⇒ `Err`); the rest — a
+                    // non-dispatched constructor's arguments, and *passthrough*
+                    // ones the constructor itself declares `Option<…>` — are
+                    // passed as decoded.
+                    let mut wrapped_values: Vec<&syn::Expr> = Vec::new();
+                    let mut wrapped_binds: Vec<syn::Ident> = Vec::new();
+                    let mut call_args: Vec<syn::Expr> = Vec::new();
+                    for (i, (child, value)) in children.iter().enumerate() {
+                        if Self::wrapped(child) == Some(true) {
+                            let b = ident(&format!("__p{}", i));
+                            wrapped_values.push(value);
+                            wrapped_binds.push(b.clone());
+                            call_args.push(syn::parse_quote!(#b));
+                        } else {
+                            call_args.push(value.clone());
+                        }
                     }
-                    _ => {
-                        // `match (a, b, …) { (Some(p0), Some(p1), …) => <call>, _ => Err }`
-                        let some_pats: Vec<TokenStream> = wrapped_binds
-                            .iter()
-                            .map(|b| quote!(::core::option::Option::Some(#b)))
-                            .collect();
-                        syn::parse_quote!(match ( #(#wrapped_locals),* ) {
-                            ( #(#some_pats),* ) => #call,
-                            _ => #missing,
-                        })
-                    }
+                    let call = ctor_call_result(&path, &call_args, *fallible);
+                    return Ok(match wrapped_values.len() {
+                        // Nothing to unwrap: call directly.
+                        0 => call,
+                        1 => {
+                            // `match a { Some(p0) => <call>, None => Err }`
+                            let value = wrapped_values[0];
+                            let p0 = &wrapped_binds[0];
+                            syn::parse_quote!(match #value {
+                                ::core::option::Option::Some(#p0) => #call,
+                                ::core::option::Option::None => #missing,
+                            })
+                        }
+                        _ => {
+                            // `match (a, b, …) { (Some(p0), Some(p1), …) => <call>, _ => Err }`
+                            let some_pats: Vec<TokenStream> = wrapped_binds
+                                .iter()
+                                .map(|b| quote!(::core::option::Option::Some(#b)))
+                                .collect();
+                            syn::parse_quote!(match ( #(#wrapped_values),* ) {
+                                ( #(#some_pats),* ) => #call,
+                                _ => #missing,
+                            })
+                        }
+                    });
                 }
-            } else if v.inputs.iter().all(|a| matches!(a, FoldArg::Leaf(..))) {
-                // Non-dispatched, flat (no recursion): call directly — identical
-                // to the pre-recursion form.
-                let args: Vec<&syn::Ident> = v.inputs.iter().map(&leaf).collect();
-                ctor_call_result(&path, &args, v.fallible)
-            } else {
-                // Non-dispatched with ≥1 recursive `Build` arg: bind each arg
-                // (Leaf = the decoded value; Build = the nested construct,
+                // At least one argument is itself built. Bind every argument
+                // (a leaf to its decoded value; a nested construct
                 // `?`-unwrapped) in an IIFE that provides the `Result` context.
+                // Selector-presence unwrapping never meets this case —
+                // `build_arg` rejects a nested build under a dispatched arm.
                 let mut stmts: Vec<TokenStream> = Vec::new();
                 let mut args: Vec<TokenStream> = Vec::new();
-                for (i, a) in v.inputs.iter().enumerate() {
+                for (i, (child, value)) in children.iter().enumerate() {
                     let ai = ident(&format!("__a{}", i));
-                    match a {
-                        FoldArg::Leaf(li, _) => {
-                            let loc = &leaf_locals[*li];
-                            stmts.push(quote!(let #ai = #loc;));
+                    if Self::wrapped(child).is_some() {
+                        stmts.push(quote!(let #ai = #value;));
+                        args.push(quote!(#ai));
+                    } else {
+                        // Pin the nested build's error type to `String` so a
+                        // non-fallible inner ctor's bare `Ok(..)` infers `E`.
+                        stmts.push(quote!(
+                            let #ai = {
+                                let __r: ::core::result::Result<_, ::std::string::String> = #value;
+                                __r?
+                            };
+                        ));
+                        if child.link.by_ref {
+                            args.push(quote!(&#ai));
+                        } else {
                             args.push(quote!(#ai));
-                        }
-                        FoldArg::Build(b) => {
-                            // Pin the nested build's error type to `String` so a
-                            // non-fallible inner ctor's bare `Ok(..)` infers `E`.
-                            let be = emit_build(b, leaf_locals, qualify);
-                            stmts.push(quote!(
-                                let #ai = {
-                                    let __r: ::core::result::Result<_, ::std::string::String> = #be;
-                                    __r?
-                                };
-                            ));
-                            if b.by_ref {
-                                args.push(quote!(&#ai));
-                            } else {
-                                args.push(quote!(#ai));
-                            }
                         }
                     }
                 }
-                let call = ctor_call_result(&path, &args, v.fallible);
-                syn::parse_quote!({
+                let call = ctor_call_result(&path, &args, *fallible);
+                Ok(syn::parse_quote!({
                     (|| -> ::core::result::Result<_, ::std::string::String> {
                         #(#stmts)*
                         #call
                     })()
-                })
+                }))
             }
         }
+    }
+
+    fn choice(
+        &mut self,
+        _node: &InNode,
+        op: &InChoice,
+        variants: Lowered<'_, IntoRust, syn::Expr>,
+    ) -> Result<syn::Expr, Self::Error> {
+        let sel = &self.leaf_locals[op.selector];
+        let arms: Vec<TokenStream> = variants
+            .iter()
+            .enumerate()
+            .map(|(vi, (_, body))| {
+                let lit = vi as i32;
+                quote!(#lit => #body,)
+            })
+            .collect();
+        Ok(syn::parse_quote!({
+            match #sel {
+                #(#arms)*
+                __sel => ::core::result::Result::Err(::std::format!(
+                    "invalid constructor selector: {}",
+                    __sel
+                )),
+            }
+        }))
     }
 }
 

--- a/prebindgen-registry/src/expand.rs
+++ b/prebindgen-registry/src/expand.rs
@@ -47,7 +47,6 @@ pub use self::{
         IntoRust,
     },
 };
-
 use crate::transform::{Lowered, TransformKind, TransformLowerer};
 
 // ──────────────────────────────────────────────────────────────────────

--- a/prebindgen-registry/src/expand.rs
+++ b/prebindgen-registry/src/expand.rs
@@ -42,7 +42,10 @@ mod tree;
 pub use self::{
     error::{ExpandDeclError, ExpandError},
     plan::{FoldLeaf, FoldPlan, FoldShape},
-    tree::{wire_leaves, InChild, InChoice, InLeaf, InLink, InNode, InProduct, IntoRust},
+    tree::{
+        wire_leaves, InChild, InChoice, InLeaf, InLink, InNode, InPresence, InProduct, InSlot,
+        IntoRust,
+    },
 };
 
 use crate::transform::{Lowered, TransformKind, TransformLowerer};
@@ -311,6 +314,7 @@ fn process_expand<M>(
         exp,
         registry,
         ed,
+        &param_ty,
         optional,
         by_ref,
         &target,
@@ -407,6 +411,7 @@ fn build_plan<M>(
     exp: &Expansions,
     registry: &Registry<M>,
     ed: &ExpandDecl,
+    param_ty: &prebindgen_flat::flat::TypeRef,
     optional: bool,
     by_ref: bool,
     target: &prebindgen_flat::flat::TypeRef,
@@ -418,88 +423,101 @@ fn build_plan<M>(
     // signature is collected from the tree once it stands.
     let mut next = 0usize;
 
-    // Optional (`Option<T>`/`Option<&T>`) param. No recursion under `Optional`.
-    //  * single single-arg ctor → one nullable leaf (`Option<arg>`) decides
-    //    presence.
+    // Optional (`Option<T>`/`Option<&T>`) param. No recursion under the layer.
+    // The three ways the layer decides presence — see `InPresence`:
+    //  * single single-arg ctor → the layer decodes its own `Option<arg>` slot
+    //    and hands the payload to the constructor.
     //  * single multi-arg ctor  → an explicit leading `present: bool` flag +
-    //    one plain (non-`Option`) leaf per arg. The flag keeps nullable
+    //    one plain (non-`Option`) slot per arg. The flag keeps nullable
     //    primitive args (e.g. an `Option<i32>` id) from boxing on the wire.
     //  * combined (≥2 variants) → the same selector dispatch as a non-optional
     //    param, with the selector ALSO encoding absence: `-1` = `None`,
     //    `0..n-1` = the taken arm (no separate present flag — not-taken arms'
-    //    leaves are null exactly as in the non-optional selector case).
+    //    slots are null exactly as in the non-optional selector case).
     if optional {
-        let [Variant::Ctor(func)] = variants else {
-            // Combined-selector dispatch under `Optional`.
-            visited.insert(target.key());
-            let prefix = param.to_string();
-            let core = build_core(
-                exp, registry, ed, target, variants, by_ref, &prefix, &mut next, visited,
-            )?;
-            visited.remove(&target.key());
-            return Ok(FoldPlan {
-                target: target.clone(),
-                by_ref,
-                shape: FoldShape::Optional((), Box::new(FoldShape::Base)),
-                leaves: wire_leaves(&core, Vec::new()),
-                present: None,
-                core,
-            });
-        };
-        let sig = ctor_signature(registry, func, &target.key())?;
-        if sig.params.len() == 1 {
-            let (_pn, pty) = &sig.params[0];
-            // The sole slot's `Option` is WHOLE-PARAM presence, unwrapped by
-            // the enclosing shape — not selector presence, so the constructor
-            // argument is not `wrapped`.
-            let arg = leaf_child(pty.optional(), next_slot(&mut next), param.clone(), false);
-            let core = ctor_node(target, func, sig.fallible, vec![arg]);
-            return Ok(FoldPlan {
-                target: target.clone(),
-                by_ref,
-                shape: FoldShape::Optional((), Box::new(FoldShape::Base)),
-                leaves: wire_leaves(&core, Vec::new()),
-                present: None,
-                core,
-            });
-        }
-        // Multi-arg: presence flag (slot 0) + one flat slot per ctor arg. The
-        // flag belongs to the PARAMETER, not to the construction — the
-        // `Optional` shape reads it and the constructor never sees it — so it
-        // is contributed to the signature beside the tree rather than by it.
-        let present = (
-            next_slot(&mut next),
-            FoldLeaf {
-                name: ident(&format!("{}_present", param)),
-                // A presence flag no source wrote — placeless by construction.
-                ty: prebindgen_flat::flat::TypeRef::scalar(prebindgen_flat::flat::ScalarKind::Bool),
-            },
-        );
-        let prefix = param.to_string();
-        let mut args = Vec::new();
-        for (pname, pty) in &sig.params {
-            let name = ident(&format!("{}_{}", prefix, pname));
-            let arg = build_arg(
-                exp, registry, ed, pty, name, /*dispatched=*/ false, &mut next, visited,
-            )?;
-            if !matches!(arg.node.kind, TransformKind::Leaf(_)) {
-                return Err(ExpandError::UnsupportedOptional {
-                    func: ed.func.clone(),
-                    param: ed.param.clone(),
-                    reason: "nested-buildable constructor arguments cannot be optional",
-                });
+        let presence_and_core = match variants {
+            [Variant::Ctor(func)] => {
+                let sig = ctor_signature(registry, func, &target.key())?;
+                if sig.params.len() == 1 {
+                    let (_pn, pty) = &sig.params[0];
+                    // The layer's slot holds the ARGUMENT, optionally: its
+                    // `Option` is whole-parameter presence, and what the
+                    // constructor gets is the payload the layer unwrapped.
+                    let payload = InSlot {
+                        slot: next_slot(&mut next),
+                        name: param.clone(),
+                        ty: pty.optional(),
+                    };
+                    let arg = InChild {
+                        link: InLink { by_ref: false },
+                        node: InNode {
+                            ty: pty.clone(),
+                            kind: TransformKind::Leaf(InLeaf::Bound),
+                        },
+                    };
+                    (
+                        InPresence::Payload(payload),
+                        ctor_node(target, func, sig.fallible, vec![arg]),
+                    )
+                } else {
+                    // Multi-arg: presence flag first, then one plain slot per
+                    // constructor argument.
+                    let flag = InSlot {
+                        slot: next_slot(&mut next),
+                        name: ident(&format!("{}_present", param)),
+                        // A presence flag no source wrote — placeless by
+                        // construction.
+                        ty: prebindgen_flat::flat::TypeRef::scalar(
+                            prebindgen_flat::flat::ScalarKind::Bool,
+                        ),
+                    };
+                    let prefix = param.to_string();
+                    let mut args = Vec::new();
+                    for (pname, pty) in &sig.params {
+                        let name = ident(&format!("{}_{}", prefix, pname));
+                        let arg = build_arg(
+                            exp, registry, ed, pty, name, /*dispatched=*/ false, &mut next,
+                            visited,
+                        )?;
+                        if !matches!(arg.node.kind, TransformKind::Leaf(_)) {
+                            return Err(ExpandError::UnsupportedOptional {
+                                func: ed.func.clone(),
+                                param: ed.param.clone(),
+                                reason: "nested-buildable constructor arguments cannot be optional",
+                            });
+                        }
+                        args.push(arg);
+                    }
+                    (
+                        InPresence::Flag(flag),
+                        ctor_node(target, func, sig.fallible, args),
+                    )
+                }
             }
-            args.push(arg);
-        }
-        let present_slot = present.0;
-        let core = ctor_node(target, func, sig.fallible, args);
+            _ => {
+                // Combined-selector dispatch under the layer.
+                visited.insert(target.key());
+                let prefix = param.to_string();
+                let core = build_core(
+                    exp, registry, ed, target, variants, by_ref, &prefix, &mut next, visited,
+                )?;
+                visited.remove(&target.key());
+                (InPresence::Selector, core)
+            }
+        };
+        let (presence, core) = presence_and_core;
+        let tree = InNode {
+            ty: param_ty.clone(),
+            kind: TransformKind::Optional {
+                op: presence,
+                inner: Box::new(core),
+            },
+        };
         return Ok(FoldPlan {
             target: target.clone(),
             by_ref,
-            shape: FoldShape::Optional((), Box::new(FoldShape::Base)),
-            leaves: wire_leaves(&core, vec![present]),
-            present: Some(present_slot),
-            core,
+            leaves: wire_leaves(&tree),
+            tree,
         });
     }
 
@@ -507,17 +525,15 @@ fn build_plan<M>(
     // on the cycle chain so a constructor parameter of the same type is rejected.
     visited.insert(target.key());
     let prefix = param.to_string();
-    let core = build_core(
+    let tree = build_core(
         exp, registry, ed, target, variants, by_ref, &prefix, &mut next, visited,
     )?;
     visited.remove(&target.key());
     Ok(FoldPlan {
         target: target.clone(),
         by_ref,
-        shape: FoldShape::Base,
-        leaves: wire_leaves(&core, Vec::new()),
-        present: None,
-        core,
+        leaves: wire_leaves(&tree),
+        tree,
     })
 }
 
@@ -551,10 +567,9 @@ fn leaf_child(
     InChild {
         link: InLink { by_ref: false },
         node: InNode {
-            ty,
-            kind: TransformKind::Leaf(InLeaf {
-                slot,
-                name,
+            ty: ty.clone(),
+            kind: TransformKind::Leaf(InLeaf::Slot {
+                slot: InSlot { slot, name, ty },
                 wrapped,
             }),
         },
@@ -608,7 +623,12 @@ fn build_core<M>(
         return Ok(ctor_node(target, func, sig.fallible, args));
     }
     // Combined — selector slot, then `Option`-wrapped per-arm inputs.
-    let sel_idx = next_slot(next);
+    let selector = InSlot {
+        slot: next_slot(next),
+        name: ident(&format!("{}_sel", prefix)),
+        // The selector, likewise composed and placeless.
+        ty: prebindgen_flat::flat::TypeRef::scalar(prebindgen_flat::flat::ScalarKind::I32),
+    };
     let mut arms: Vec<InChild> = Vec::new();
     for (vi, v) in variants.iter().enumerate() {
         let node = match v {
@@ -660,10 +680,7 @@ fn build_core<M>(
     Ok(InNode {
         ty: target.clone(),
         kind: TransformKind::Choice {
-            op: InChoice {
-                selector: sel_idx,
-                name: ident(&format!("{}_sel", prefix)),
-            },
+            op: InChoice { selector },
             variants: arms,
         },
     })
@@ -760,134 +777,36 @@ impl From<crate::declared_target::TargetMismatch> for ExpandError {
 ///
 /// The returned expression has type `Result<<shaped> plan.target, String>`
 /// (`Result<Target>`, `Result<Option<Target>>`, …). The adapter routes its
-/// `Err(String)` through its own error channel. Folds the [`FoldShape`] layers
-/// top-down over one shared core construct — the value
-/// analog of how `Option<_>`/`Vec<_>` wrappers compose at the wire.
+/// `Err(String)` through its own error channel. One pass over the plan's tree:
+/// the arity layers are nodes like the construction under them, so nothing here
+/// walks a second structure.
 pub fn emit_fold(
     plan: &FoldPlan,
     leaf_locals: &[syn::Ident],
     qualify: &dyn Fn(&syn::Ident) -> syn::Path,
 ) -> syn::Expr {
-    fold_shape(&plan.shape, plan, leaf_locals, None, qualify)
+    plan.tree
+        .lower(&mut ConstructEmitter {
+            leaf_locals,
+            qualify,
+        })
+        .expect("emitting a built construct cannot fail")
 }
 
-/// Recurse over one [`FoldShape`] layer. `bound` is `Some(var)` when an
-/// enclosing `Optional`/`Iterable` layer has unwrapped the structured leaf and
-/// bound its element to `var` — the inner construct then builds from `var`
-/// instead of reading `leaf_locals`.
-fn fold_shape(
-    shape: &FoldShape,
-    plan: &FoldPlan,
-    leaf_locals: &[syn::Ident],
-    bound: Option<&syn::Ident>,
-    qualify: &dyn Fn(&syn::Ident) -> syn::Path,
-) -> syn::Expr {
-    match shape {
-        FoldShape::Base => emit_core_construct(plan, leaf_locals, bound, qualify),
-        FoldShape::Optional((), inner) => {
-            if let Some(sidx) = plan.selector() {
-                // Combined-selector dispatch under `Optional`: the selector
-                // ALSO encodes absence — `-1` = `None`, `0..n-1` = the taken
-                // arm (dispatched by the shared construct core; an out-of-range
-                // selector still hits its `Err` default arm).
-                let sel_local = &leaf_locals[sidx];
-                let inner_expr = emit_core_construct(plan, leaf_locals, None, qualify);
-                syn::parse_quote!(if #sel_local < 0 {
-                    ::core::result::Result::Ok(::core::option::Option::None)
-                } else {
-                    (#inner_expr).map(::core::option::Option::Some)
-                })
-            } else if let Some(pidx) = plan.present {
-                // Multi-arg: an explicit `present: bool` flag decides presence;
-                // the construct reads its plain arg leaves directly (`bound =
-                // None`), the flag leaf is consumed only by this `if`.
-                let present_local = &leaf_locals[pidx];
-                let inner_expr = emit_core_construct(plan, leaf_locals, None, qualify);
-                syn::parse_quote!(if #present_local {
-                    (#inner_expr).map(::core::option::Option::Some)
-                } else {
-                    ::core::result::Result::Ok(::core::option::Option::None)
-                })
-            } else {
-                // Single-arg: presence rides the sole shaped leaf's `Option`.
-                // The structured value is the enclosing bound var, or — at the
-                // top — that leaf's decoded local (`leaf_locals[0]`).
-                let value = bound.unwrap_or(&leaf_locals[0]);
-                let inner_ident = ident("__inner");
-                let inner_expr = fold_shape(inner, plan, leaf_locals, Some(&inner_ident), qualify);
-                syn::parse_quote!(match #value {
-                    ::core::option::Option::Some(#inner_ident) => {
-                        (#inner_expr).map(::core::option::Option::Some)
-                    }
-                    ::core::option::Option::None => {
-                        ::core::result::Result::Ok(::core::option::Option::None)
-                    }
-                })
-            }
-        }
-        FoldShape::Iterable(inner) => {
-            let value = bound.unwrap_or(&leaf_locals[0]);
-            let elem_ident = ident("__elem");
-            let inner_expr = fold_shape(inner, plan, leaf_locals, Some(&elem_ident), qualify);
-            syn::parse_quote!(
-                #value
-                    .into_iter()
-                    .map(|#elem_ident| #inner_expr)
-                    .collect::<::core::result::Result<::std::vec::Vec<_>, _>>()
-            )
-        }
-    }
+/// The local an arity layer binds its unwrapped value to, and the local an
+/// [`InLeaf::Bound`] argument reads. One name for both layers: a nested layer
+/// shadows its parent's binding, which is what reaching the innermost value
+/// means.
+fn bound_local() -> syn::Ident {
+    ident("__inner")
 }
 
-/// Emit the innermost construct → `Result<Target, String>`. With `bound =
-/// Some(v)` (under an `Optional`/`Iterable` layer ⇒ single, single-arg ctor)
-/// the ctor is applied to `v`; with `bound = None` (top level) the whole
-/// construct core is lowered, reading the decoded leaves.
-fn emit_core_construct(
-    plan: &FoldPlan,
-    leaf_locals: &[syn::Ident],
-    bound: Option<&syn::Ident>,
-    qualify: &dyn Fn(&syn::Ident) -> syn::Path,
-) -> syn::Expr {
-    if let Some(v) = bound {
-        // Shaped construct: a single, single-arg constructor applied to the
-        // unwrapped element. (`apply` guarantees this shape — never identity,
-        // never combined, never multi-arg under a shape layer.)
-        let TransformKind::Product {
-            op: InProduct::Ctor { func, fallible },
-            ..
-        } = &plan.core.kind
-        else {
-            unreachable!(
-                "shaped expansion is a single constructor (never identity, never combined)"
-            )
-        };
-        return ctor_call_result(&qualify(func), std::slice::from_ref(v), *fallible);
-    }
-    lower_core(&plan.core, leaf_locals, qualify)
-}
-
-/// Lower one construct core to a `Result<Target, String>` expression, through
-/// the shared traversal — the registry writes node policy here and no recursion
-/// of its own.
-fn lower_core(
-    core: &InNode,
-    leaf_locals: &[syn::Ident],
-    qualify: &dyn Fn(&syn::Ident) -> syn::Path,
-) -> syn::Expr {
-    core.lower(&mut ConstructEmitter {
-        leaf_locals,
-        qualify,
-    })
-    .expect("emitting a built construct cannot fail")
-}
-
-/// Lowers an into-Rust construct into the Rust expression that performs it.
+/// Lowers an into-Rust plan into the Rust expression that performs it.
 ///
 /// Two kinds of value flow through it, told apart by the child's node kind
-/// exactly as the constructor call must anyway: a **leaf** lowers to its
-/// decoded local, while a **product or choice** lowers to an expression of type
-/// `Result<_, String>`.
+/// exactly as the constructor call must anyway: a **leaf** lowers to the local
+/// holding its decoded value, while every other node lowers to an expression of
+/// type `Result<_, String>`.
 struct ConstructEmitter<'a> {
     /// The already-decoded Rust locals, 1:1 with `FoldPlan::leaves`.
     leaf_locals: &'a [syn::Ident],
@@ -901,7 +820,8 @@ impl ConstructEmitter<'_> {
     /// leaf; `None` for a child that is a nested construct.
     fn wrapped(child: &InChild) -> Option<bool> {
         match &child.node.kind {
-            TransformKind::Leaf(op) => Some(op.wrapped),
+            TransformKind::Leaf(InLeaf::Slot { wrapped, .. }) => Some(*wrapped),
+            TransformKind::Leaf(InLeaf::Bound) => Some(false),
             _ => None,
         }
     }
@@ -912,7 +832,10 @@ impl TransformLowerer<IntoRust> for ConstructEmitter<'_> {
     type Error = std::convert::Infallible;
 
     fn leaf(&mut self, _node: &InNode, op: &InLeaf) -> Result<syn::Expr, Self::Error> {
-        let local = &self.leaf_locals[op.slot];
+        let local = match op {
+            InLeaf::Slot { slot, .. } => self.leaf_locals[slot.slot].clone(),
+            InLeaf::Bound => bound_local(),
+        };
         Ok(syn::parse_quote!(#local))
     }
 
@@ -963,9 +886,9 @@ impl TransformLowerer<IntoRust> for ConstructEmitter<'_> {
                 if children.iter().all(|(c, _)| Self::wrapped(c).is_some()) {
                     // Flat arguments only. Those `Option`-wrapped by selector
                     // presence are unwrapped (missing ⇒ `Err`); the rest — a
-                    // non-dispatched constructor's arguments, and *passthrough*
-                    // ones the constructor itself declares `Option<…>` — are
-                    // passed as decoded.
+                    // non-dispatched constructor's arguments, *passthrough* ones
+                    // the constructor itself declares `Option<…>`, and the value
+                    // an enclosing layer bound — are passed as decoded.
                     let mut wrapped_values: Vec<&syn::Expr> = Vec::new();
                     let mut wrapped_binds: Vec<syn::Ident> = Vec::new();
                     let mut call_args: Vec<syn::Expr> = Vec::new();
@@ -1050,7 +973,7 @@ impl TransformLowerer<IntoRust> for ConstructEmitter<'_> {
         op: &InChoice,
         variants: Lowered<'_, IntoRust, syn::Expr>,
     ) -> Result<syn::Expr, Self::Error> {
-        let sel = &self.leaf_locals[op.selector];
+        let sel = &self.leaf_locals[op.selector.slot];
         let arms: Vec<TokenStream> = variants
             .iter()
             .enumerate()
@@ -1073,21 +996,65 @@ impl TransformLowerer<IntoRust> for ConstructEmitter<'_> {
     fn optional(
         &mut self,
         _node: &InNode,
-        op: &std::convert::Infallible,
+        op: &InPresence,
         _inner: &InNode,
-        _value: syn::Expr,
+        value: syn::Expr,
     ) -> Result<syn::Expr, Self::Error> {
-        match *op {}
+        Ok(match op {
+            // The dispatch's selector ALSO encodes absence — `-1` = `None`,
+            // `0..n-1` = the taken arm (dispatched by the construction below;
+            // an out-of-range selector still hits its `Err` default arm).
+            InPresence::Selector => {
+                let sel = &self.leaf_locals[_inner.selector().expect("a selector-decided layer")];
+                syn::parse_quote!(if #sel < 0 {
+                    ::core::result::Result::Ok(::core::option::Option::None)
+                } else {
+                    (#value).map(::core::option::Option::Some)
+                })
+            }
+            // An explicit flag decides; the construction reads its plain
+            // argument slots directly, and the flag slot is consumed only here.
+            InPresence::Flag(flag) => {
+                let present = &self.leaf_locals[flag.slot];
+                syn::parse_quote!(if #present {
+                    (#value).map(::core::option::Option::Some)
+                } else {
+                    ::core::result::Result::Ok(::core::option::Option::None)
+                })
+            }
+            // Presence rides the layer's own `Option` slot: unwrap it, bind the
+            // payload, and the single-argument construction below reads that
+            // binding.
+            InPresence::Payload(payload) => {
+                let slot = &self.leaf_locals[payload.slot];
+                let bound = bound_local();
+                syn::parse_quote!(match #slot {
+                    ::core::option::Option::Some(#bound) => {
+                        (#value).map(::core::option::Option::Some)
+                    }
+                    ::core::option::Option::None => {
+                        ::core::result::Result::Ok(::core::option::Option::None)
+                    }
+                })
+            }
+        })
     }
 
     fn sequence(
         &mut self,
         _node: &InNode,
-        op: &std::convert::Infallible,
+        op: &InSlot,
         _inner: &InNode,
-        _value: syn::Expr,
+        value: syn::Expr,
     ) -> Result<syn::Expr, Self::Error> {
-        match *op {}
+        let slot = &self.leaf_locals[op.slot];
+        let bound = bound_local();
+        Ok(syn::parse_quote!(
+            #slot
+                .into_iter()
+                .map(|#bound| #value)
+                .collect::<::core::result::Result<::std::vec::Vec<_>, _>>()
+        ))
     }
 }
 

--- a/prebindgen-registry/src/expand.rs
+++ b/prebindgen-registry/src/expand.rs
@@ -1069,6 +1069,26 @@ impl TransformLowerer<IntoRust> for ConstructEmitter<'_> {
             }
         }))
     }
+
+    fn optional(
+        &mut self,
+        _node: &InNode,
+        op: &std::convert::Infallible,
+        _inner: &InNode,
+        _value: syn::Expr,
+    ) -> Result<syn::Expr, Self::Error> {
+        match *op {}
+    }
+
+    fn sequence(
+        &mut self,
+        _node: &InNode,
+        op: &std::convert::Infallible,
+        _inner: &InNode,
+        _value: syn::Expr,
+    ) -> Result<syn::Expr, Self::Error> {
+        match *op {}
+    }
 }
 
 /// `path(args…)` lifted to `Result<Target, String>` (mapping a fallible

--- a/prebindgen-registry/src/expand/error.rs
+++ b/prebindgen-registry/src/expand/error.rs
@@ -20,6 +20,9 @@ pub enum ExpandError {
         func: syn::Ident,
         param: syn::Ident,
         reason: &'static str,
+        /// Where in the construction — see
+        /// [`ExpandError::UnsupportedRecursive::at`].
+        at: String,
     },
     /// An explicit per-fn input flatten targeted a read accessor — accessors
     /// are never parameter-composed.
@@ -37,12 +40,22 @@ pub enum ExpandError {
     /// Recursive input reached a type already on the build chain (`A → … → A`).
     InputCycle {
         ty: String,
+        /// Where in the construction — see
+        /// [`ExpandError::UnsupportedRecursive::at`].
+        at: String,
     },
     /// A recursive-input shape that is declared-but-not-yet-supported (recursion
     /// under a selector-dispatched variant, or on an `Option<…>` parameter).
     UnsupportedRecursive {
         func: syn::Ident,
         reason: &'static str,
+        /// Where in the construction the transformation failed: the chain of
+        /// parameter names from the expanded parameter down to the argument
+        /// that could not be built, which is also the prefix its wire slots are
+        /// named with. A constructor argument may itself be constructed, so
+        /// naming only the function leaves the reader to work out which nesting
+        /// of it is the one that failed.
+        at: String,
     },
     /// Structurally invalid declaration records — empty variant lists or
     /// duplicate targets. All offenders are collected before failing
@@ -99,16 +112,16 @@ impl std::fmt::Display for ExpandError {
                  parameter-composed (remove the override, or declare it as `.fun`)",
                 func
             ),
-            ExpandError::InputCycle { ty } => write!(
+            ExpandError::InputCycle { ty, at } => write!(
                 f,
-                "expand: recursive input forms a cycle through `{}` — a constructor \
+                "expand at `{}`: recursive input forms a cycle through `{}` — a constructor \
                  parameter's type transitively constructs itself",
-                ty
+                at, ty
             ),
-            ExpandError::UnsupportedRecursive { func, reason } => write!(
+            ExpandError::UnsupportedRecursive { func, reason, at } => write!(
                 f,
-                "expand: `{}`: recursive input not supported here: {}",
-                func, reason
+                "expand: `{}` at `{}`: recursive input not supported here: {}",
+                func, at, reason
             ),
             ExpandError::UnknownParam(func, param) => write!(
                 f,
@@ -154,10 +167,11 @@ impl std::fmt::Display for ExpandError {
                 func,
                 param,
                 reason,
+                at,
             } => write!(
                 f,
-                "expand: optional parameter `{}` of `{}` is not supported: {}",
-                param, func, reason
+                "expand: optional parameter `{}` of `{}` is not supported at `{}`: {}",
+                param, func, at, reason
             ),
             ExpandError::InvalidDeclarations { entries } => {
                 writeln!(f, "expand: invalid declarations:")?;

--- a/prebindgen-registry/src/expand/plan.rs
+++ b/prebindgen-registry/src/expand/plan.rs
@@ -14,6 +14,12 @@
 pub use prebindgen_flat::shape::Shape as FoldShape;
 
 /// A resolved expansion for one `(function, parameter)`.
+///
+/// [`leaves`](Self::leaves) is readable but not settable from outside the
+/// crate, and neither is a plan constructible there: it is collected from
+/// [`Self::tree`] where the plan is built, and a caller that could set it could
+/// make a tree-reading adapter and a signature-reading one see different
+/// expansions.
 pub struct FoldPlan {
     /// Owned type the core construct produces — what the underlying call needs
     /// (before any [`Self::shape`] wrapping). A **reading**: `emit.spell(&target)` in an emission callback
@@ -29,7 +35,7 @@ pub struct FoldPlan {
     /// A derived view of [`Self::tree`]: every slot is described by the node
     /// that uses it, and [`wire_leaves`](crate::expand::wire_leaves) collects
     /// them.
-    pub leaves: Vec<FoldLeaf>,
+    pub(crate) leaves: Vec<FoldLeaf>,
     /// The plan itself: the `Option` / `Vec` layers the parameter is written
     /// with, and the construction under them (#442). Everything recursive about
     /// an expansion lives here — a constructor argument that is itself built
@@ -38,6 +44,12 @@ pub struct FoldPlan {
 }
 
 impl FoldPlan {
+    /// Flattened wire leaves, in foreign-signature order — see the field's own
+    /// note.
+    pub fn leaves(&self) -> &[FoldLeaf] {
+        &self.leaves
+    }
+
     /// Outer shape over the core construct (`Construct` for a plain `T`/`&T`
     /// param; `Optional(Construct)` for `Option<T>`/`Option<&T>`).
     ///

--- a/prebindgen-registry/src/expand/plan.rs
+++ b/prebindgen-registry/src/expand/plan.rs
@@ -14,7 +14,6 @@
 pub use prebindgen_flat::shape::Shape as FoldShape;
 
 /// A resolved expansion for one `(function, parameter)`.
-#[derive(Clone)]
 pub struct FoldPlan {
     /// Owned type the core construct produces — what the underlying call needs
     /// (before any [`Self::shape`] wrapping). A **reading**: `emit.spell(&target)` in an emission callback
@@ -30,11 +29,6 @@ pub struct FoldPlan {
     pub shape: FoldShape,
     /// Flattened wire leaves, in foreign-signature order.
     pub leaves: Vec<FoldLeaf>,
-    /// Index into [`Self::leaves`] of the selector leaf; `None` for a single
-    /// constructor (the sole variant is applied unconditionally). Under an
-    /// [`Optional`](FoldShape::Optional) shape the selector also encodes
-    /// **absence**: `-1` = `None`, `0..n-1` = the taken arm.
-    pub selector: Option<usize>,
     /// Index into [`Self::leaves`] of the explicit presence-flag (`bool`) leaf
     /// for a **multi-argument** `Optional` shape (`Option<T>` built from a
     /// constructor taking ≥2 args): the flag decides `Some`/`None`, the arg
@@ -43,9 +37,11 @@ pub struct FoldPlan {
     /// `Option`-ness). A separate flag avoids boxing a nullable primitive arg
     /// (e.g. `Option<i32>` → `Integer?`) on the wire.
     pub present: Option<usize>,
-    /// Dispatch arms — one for a single constructor, selector order for a
-    /// combined one.
-    pub variants: Vec<FoldVariant>,
+    /// The construction itself: a constructor product over its arguments, or a
+    /// selector choice over such products (#442). Everything recursive about an
+    /// expansion lives here — a constructor argument that is itself built has
+    /// the same node kinds as the top level.
+    pub core: crate::expand::InNode,
 }
 
 impl FoldPlan {
@@ -53,6 +49,18 @@ impl FoldPlan {
     /// `Optional`) — drives the by-ref call-site form (`folded.as_ref()`).
     pub fn produces_option(&self) -> bool {
         matches!(self.shape, FoldShape::Optional((), _))
+    }
+
+    /// Index into [`Self::leaves`] of the selector leaf; `None` for a single
+    /// constructor (the sole variant is applied unconditionally). Under an
+    /// [`Optional`](FoldShape::Optional) shape the selector also encodes
+    /// **absence**: `-1` = `None`, `0..n-1` = the taken arm.
+    ///
+    /// Read off [`Self::core`] rather than stored beside it: the dispatch is
+    /// the node, and a second copy of which slot selects it could disagree
+    /// with the node the emitter actually walks.
+    pub fn selector(&self) -> Option<usize> {
+        self.core.selector()
     }
 }
 
@@ -73,58 +81,4 @@ pub struct FoldLeaf {
     /// [`TypeRef::scalar`](prebindgen_flat::flat::TypeRef::scalar), which
     /// pairs the kind with its own spelling and is placeless by construction.
     pub ty: prebindgen_flat::flat::TypeRef,
-}
-
-/// One dispatch arm of a [`FoldPlan`].
-#[derive(Clone)]
-pub struct FoldVariant {
-    /// `None` => identity (pass the decoded target value through). `Some` =>
-    /// call this constructor function.
-    pub ctor: Option<syn::Ident>,
-    /// Whether the constructor returns `Result` (its `Err` is routed through
-    /// the adapter's error channel). Always `false` for identity.
-    pub fallible: bool,
-    /// `true` for a borrowed identity arm (`&T` parameter): the input leaf is
-    /// `Option<&T>` and the fold clones it (`T: Clone`) so the caller's handle
-    /// is preserved rather than consumed. `false` otherwise.
-    pub clone: bool,
-    /// This variant's constructor inputs, in parameter order. Each is either a
-    /// flat wire leaf or a recursively-built sub-value (a parameter that is
-    /// itself a type with a default constructor — recursive input).
-    pub inputs: Vec<FoldArg>,
-}
-
-/// One constructor-parameter input of a [`FoldVariant`].
-#[derive(Clone)]
-pub enum FoldArg {
-    /// Decode the flat wire leaf at this index into [`FoldPlan::leaves`].
-    ///
-    /// The `bool` is the **passthrough** marker for selector-dispatched arms:
-    /// `false` = the leaf is `Option`-wrapped by selector presence and is
-    /// unwrapped before the constructor call (a missing input is an error);
-    /// `true` = the constructor argument is itself an `Option<…>`, so the leaf
-    /// keeps the argument's own type and passes through unwrapped (`None` is a
-    /// legitimate value for the taken arm — arm-taken-ness is decided by the
-    /// selector alone). Always `false` outside dispatched arms.
-    Leaf(usize, bool),
-    /// Build this parameter by recursively folding its own default
-    /// constructor (the parameter's type is itself a ptr_class with a default
-    /// input). Its leaves live in the shared flat [`FoldPlan::leaves`].
-    Build(Box<FoldBuild>),
-}
-
-/// A recursively-nested construction for one [`FoldArg::Build`] parameter — the
-/// same dispatch shape as a top-level [`FoldPlan`]'s core, minus the outer
-/// `Option`/`Vec` wrapping (a nested param is built by value).
-#[derive(Clone)]
-pub struct FoldBuild {
-    /// Owned type this nested build produces (the constructor parameter type).
-    pub target: prebindgen_flat::flat::TypeRef,
-    /// `true` when the consuming parameter is `&T` (the built value is borrowed
-    /// at the call site).
-    pub by_ref: bool,
-    /// Selector leaf index for a combined nested build; `None` for a single one.
-    pub selector: Option<usize>,
-    /// Dispatch arms (recursive).
-    pub variants: Vec<FoldVariant>,
 }

--- a/prebindgen-registry/src/expand/plan.rs
+++ b/prebindgen-registry/src/expand/plan.rs
@@ -24,43 +24,57 @@ pub struct FoldPlan {
     /// call-site concern (the resolver's `&_` handler shares the inner
     /// converter the same way), not part of the fold.
     pub by_ref: bool,
-    /// Outer shape over the core construct (`Construct` for a plain `T`/`&T`
-    /// param; `Optional(Construct)` for `Option<T>`/`Option<&T>`).
-    pub shape: FoldShape,
     /// Flattened wire leaves, in foreign-signature order.
+    ///
+    /// A derived view of [`Self::tree`]: every slot is described by the node
+    /// that uses it, and [`wire_leaves`](crate::expand::wire_leaves) collects
+    /// them.
     pub leaves: Vec<FoldLeaf>,
-    /// Index into [`Self::leaves`] of the explicit presence-flag (`bool`) leaf
-    /// for a **multi-argument** `Optional` shape (`Option<T>` built from a
-    /// constructor taking ≥2 args): the flag decides `Some`/`None`, the arg
-    /// leaves are plain (non-`Option`). `None` for a non-optional fold or the
-    /// legacy single-arg `Optional` (where presence rides the sole leaf's own
-    /// `Option`-ness). A separate flag avoids boxing a nullable primitive arg
-    /// (e.g. `Option<i32>` → `Integer?`) on the wire.
-    pub present: Option<usize>,
-    /// The construction itself: a constructor product over its arguments, or a
-    /// selector choice over such products (#442). Everything recursive about an
-    /// expansion lives here — a constructor argument that is itself built has
-    /// the same node kinds as the top level.
-    pub core: crate::expand::InNode,
+    /// The plan itself: the `Option` / `Vec` layers the parameter is written
+    /// with, and the construction under them (#442). Everything recursive about
+    /// an expansion lives here — a constructor argument that is itself built
+    /// has the same node kinds as the top level.
+    pub tree: crate::expand::InNode,
 }
 
 impl FoldPlan {
+    /// Outer shape over the core construct (`Construct` for a plain `T`/`&T`
+    /// param; `Optional(Construct)` for `Option<T>`/`Option<&T>`).
+    ///
+    /// A derived view of [`Self::tree`]: each layer is a node wrapping the
+    /// construction, and [`InNode::shape`](crate::expand::InNode::shape) reads
+    /// the stack back off them.
+    pub fn shape(&self) -> FoldShape {
+        self.tree.shape()
+    }
+
     /// True when the fold produces an `Option<_>` (outermost shape layer is
     /// `Optional`) — drives the by-ref call-site form (`folded.as_ref()`).
     pub fn produces_option(&self) -> bool {
-        matches!(self.shape, FoldShape::Optional((), _))
+        matches!(self.shape(), FoldShape::Optional((), _))
+    }
+
+    /// Index into [`Self::leaves`] of the explicit presence-flag (`bool`) leaf
+    /// for a **multi-argument** `Optional` shape (`Option<T>` built from a
+    /// constructor taking ≥2 args): the flag decides `Some`/`None`, the arg
+    /// leaves are plain (non-`Option`). `None` for a non-optional fold or a
+    /// single-argument `Optional` (where presence rides the layer's own
+    /// `Option` slot). A separate flag avoids boxing a nullable primitive arg
+    /// (e.g. `Option<i32>` → `Integer?`) on the wire.
+    pub fn present(&self) -> Option<usize> {
+        self.tree.present()
     }
 
     /// Index into [`Self::leaves`] of the selector leaf; `None` for a single
     /// constructor (the sole variant is applied unconditionally). Under an
-    /// [`Optional`](FoldShape::Optional) shape the selector also encodes
+    /// [`Optional`](FoldShape::Optional) layer the selector also encodes
     /// **absence**: `-1` = `None`, `0..n-1` = the taken arm.
     ///
-    /// Read off [`Self::core`] rather than stored beside it: the dispatch is
+    /// Read off [`Self::tree`] rather than stored beside it: the dispatch is
     /// the node, and a second copy of which slot selects it could disagree
     /// with the node the emitter actually walks.
     pub fn selector(&self) -> Option<usize> {
-        self.core.selector()
+        self.tree.selector()
     }
 }
 

--- a/prebindgen-registry/src/expand/tests.rs
+++ b/prebindgen-registry/src/expand/tests.rs
@@ -126,7 +126,7 @@ fn constructor_plan_and_fold() {
         plan.leaves[2].ty.spell().to_string(),
         "Option < & ZKeyExpr >"
     );
-    let arms = plan.core.arms();
+    let arms = plan.tree.arms();
     assert_eq!(arms.len(), 2);
     assert!(arms[0].ctor().is_some());
     assert!(arms[1].ctor().is_none(), "identity arm");
@@ -183,7 +183,7 @@ fn optional_byvalue_single_ctor() {
         .expansion_plans
         .get(&(ident("z_session_delete"), ident("attachment")))
         .unwrap();
-    assert!(matches!(plan.shape, FoldShape::Optional((), _)));
+    assert!(matches!(plan.shape(), FoldShape::Optional((), _)));
     assert!(plan.produces_option());
     assert!(!plan.by_ref);
     assert_eq!(plan.leaves.len(), 1);
@@ -191,6 +191,14 @@ fn optional_byvalue_single_ctor() {
     assert_eq!(
         plan.leaves[0].ty.spell().to_string(),
         "Option < Vec < u8 > >"
+    );
+    // The layer owns that one slot and binds its payload (`^`); the
+    // constructor under it takes the binding, having no slot of its own.
+    assert_eq!(
+        plan.tree
+            .lower(&mut RenderIn)
+            .expect("lowering cannot fail"),
+        "z_zbytes_from_vec(^)?^#0"
     );
 
     let locals = vec![ident("att")];
@@ -236,7 +244,7 @@ fn optional_byref_single_ctor() {
         .expansion_plans
         .get(&(ident("z_session_put"), ident("encoding")))
         .unwrap();
-    assert!(matches!(plan.shape, FoldShape::Optional((), _)));
+    assert!(matches!(plan.shape(), FoldShape::Optional((), _)));
     assert!(plan.produces_option());
     assert!(plan.by_ref, "Option<&T> ⇒ by_ref");
     assert_eq!(plan.leaves[0].ty.spell().to_string(), "Option < String >");
@@ -283,10 +291,10 @@ fn optional_byref_multi_arg_ctor() {
         .expansion_plans
         .get(&(ident("z_session_put"), ident("encoding")))
         .unwrap();
-    assert!(matches!(plan.shape, FoldShape::Optional((), _)));
+    assert!(matches!(plan.shape(), FoldShape::Optional((), _)));
     assert!(plan.produces_option());
     assert!(plan.by_ref, "Option<&T> ⇒ by_ref");
-    assert_eq!(plan.present, Some(0), "explicit presence flag at leaf 0");
+    assert_eq!(plan.present(), Some(0), "explicit presence flag at leaf 0");
     // leaf 0 = present:bool, leaf 1 = id:i32, leaf 2 = schema:Option<String>
     assert_eq!(plan.leaves.len(), 3);
     assert_eq!(plan.leaves[0].name.to_string(), "encoding_present");
@@ -356,11 +364,11 @@ fn optional_combined_selector_encodes_absence() {
         .expansion_plans
         .get(&(ident("z_session_put"), ident("encoding")))
         .unwrap();
-    assert!(matches!(plan.shape, FoldShape::Optional((), _)));
+    assert!(matches!(plan.shape(), FoldShape::Optional((), _)));
     assert!(plan.produces_option());
     assert!(plan.by_ref, "Option<&T> ⇒ by_ref");
     assert_eq!(plan.selector(), Some(0), "selector at leaf 0");
-    assert_eq!(plan.present, None, "absence rides the selector, no flag");
+    assert_eq!(plan.present(), None, "absence rides the selector, no flag");
     // leaves: sel:i32, id:Option<i32> (wrapped), schema:Option<String>
     // (passthrough), identity:Option<&ZEncoding>.
     assert_eq!(plan.leaves.len(), 4);
@@ -376,14 +384,13 @@ fn optional_combined_selector_encodes_absence() {
         plan.leaves[3].ty.spell().to_string(),
         "Option < & ZEncoding >"
     );
-    let arms = plan.core.arms();
+    let arms = plan.tree.arms();
     assert!(
         matches!(
             &args(arms[0])[1].node.kind,
-            TransformKind::Leaf(InLeaf {
-                slot: 2,
-                wrapped: false,
-                ..
+            TransformKind::Leaf(InLeaf::Slot {
+                slot: InSlot { slot: 2, .. },
+                wrapped: false
             })
         ),
         "an already-Option ctor arg passes through unwrapped"
@@ -427,35 +434,40 @@ fn iterable_emit_shape() {
     // param expansion is declared), but the fold is emit-ready: a hand-built
     // plan must produce the `into_iter().map(...).collect::<Result<Vec<_>,_>>()`
     // form, with the inner single-arg ctor applied per element.
+    // The run owns the wire slot; the constructor under it takes the element
+    // the layer bound.
+    let core = InNode {
+        ty: tref(syn::parse_quote!(ZKeyExpr)),
+        kind: TransformKind::Product {
+            op: InProduct::Ctor {
+                func: ident("z_keyexpr_try_from"),
+                fallible: true,
+            },
+            children: vec![InChild {
+                link: InLink { by_ref: false },
+                node: InNode {
+                    ty: tref(syn::parse_quote!(String)),
+                    kind: TransformKind::Leaf(InLeaf::Bound),
+                },
+            }],
+        },
+    };
+    let tree = InNode {
+        ty: tref(syn::parse_quote!(Vec<ZKeyExpr>)),
+        kind: TransformKind::Sequence {
+            op: InSlot {
+                slot: 0,
+                name: ident("kes"),
+                ty: tref(syn::parse_quote!(Vec<String>)),
+            },
+            inner: Box::new(core),
+        },
+    };
     let plan = FoldPlan {
         target: tref(syn::parse_quote!(ZKeyExpr)),
         by_ref: false,
-        shape: FoldShape::Iterable(Box::new(FoldShape::Base)),
-        leaves: vec![FoldLeaf {
-            name: ident("kes"),
-            ty: tref(syn::parse_quote!(Vec<String>)),
-        }],
-        present: None,
-        core: InNode {
-            ty: tref(syn::parse_quote!(ZKeyExpr)),
-            kind: TransformKind::Product {
-                op: InProduct::Ctor {
-                    func: ident("z_keyexpr_try_from"),
-                    fallible: true,
-                },
-                children: vec![InChild {
-                    link: InLink { by_ref: false },
-                    node: InNode {
-                        ty: tref(syn::parse_quote!(String)),
-                        kind: TransformKind::Leaf(InLeaf {
-                            slot: 0,
-                            name: ident("kes"),
-                            wrapped: false,
-                        }),
-                    },
-                }],
-            },
-        },
+        leaves: wire_leaves(&tree),
+        tree,
     };
     let locals = vec![ident("kes")];
     let s = emit_fold(&plan, &locals, &src_qualify)
@@ -619,8 +631,8 @@ fn recursive_input_nests_param_constructors() {
         .expect("sample plan");
     // Top: single z_sample_new ctor, 2 args, both recursive Build.
     assert_eq!(plan.selector(), None);
-    assert_eq!(plan.core.arms().len(), 1);
-    let args = args(&plan.core);
+    assert_eq!(plan.tree.arms().len(), 1);
+    let args = args(plan.tree.core());
     assert_eq!(args.len(), 2);
     assert!(is_build(&args[0]), "key_expr is a nested build");
     assert!(is_build(&args[1]), "payload is a nested build");
@@ -870,7 +882,12 @@ impl crate::transform::TransformLowerer<IntoRust> for RenderIn {
     type Error = std::convert::Infallible;
 
     fn leaf(&mut self, _node: &InNode, op: &InLeaf) -> Result<String, Self::Error> {
-        Ok(format!("#{}{}", op.slot, if op.wrapped { "?" } else { "" }))
+        Ok(match op {
+            InLeaf::Slot { slot, wrapped } => {
+                format!("#{}{}", slot.slot, if *wrapped { "?" } else { "" })
+            }
+            InLeaf::Bound => "^".to_string(),
+        })
     }
 
     fn product(
@@ -906,27 +923,31 @@ impl crate::transform::TransformLowerer<IntoRust> for RenderIn {
         variants: crate::transform::Lowered<'_, IntoRust, String>,
     ) -> Result<String, Self::Error> {
         let arms: Vec<String> = variants.into_iter().map(|(_, v)| v).collect();
-        Ok(format!("#{} ? {}", op.selector, arms.join(" | ")))
+        Ok(format!("#{} ? {}", op.selector.slot, arms.join(" | ")))
     }
 
     fn optional(
         &mut self,
         _node: &InNode,
-        op: &std::convert::Infallible,
+        op: &InPresence,
         _inner: &InNode,
-        _value: String,
+        value: String,
     ) -> Result<String, Self::Error> {
-        match *op {}
+        Ok(match op {
+            InPresence::Selector => format!("{value}?sel"),
+            InPresence::Flag(s) => format!("{value}?#{}", s.slot),
+            InPresence::Payload(s) => format!("{value}?^#{}", s.slot),
+        })
     }
 
     fn sequence(
         &mut self,
         _node: &InNode,
-        op: &std::convert::Infallible,
+        op: &InSlot,
         _inner: &InNode,
-        _value: String,
+        value: String,
     ) -> Result<String, Self::Error> {
-        match *op {}
+        Ok(format!("[{value}]*#{}", op.slot))
     }
 }
 
@@ -986,7 +1007,7 @@ fn core_lowers_through_the_shared_visitor() {
     // is a dispatch behind a by-ref link, the payload a single constructor, and
     // every wire slot names its index in `plan.leaves`.
     let rendered = plan
-        .core
+        .tree
         .lower(&mut RenderIn)
         .expect("lowering cannot fail");
     assert_eq!(

--- a/prebindgen-registry/src/expand/tests.rs
+++ b/prebindgen-registry/src/expand/tests.rs
@@ -697,6 +697,12 @@ fn recursive_input_cycle_errors() {
     )
     .unwrap_err();
     assert!(matches!(err, ExpandError::InputCycle { .. }), "got {err:?}");
+    // Mutual recursion terminates with a typed error that says WHERE: the
+    // argument chain `a → b → a`, not just the function it started from.
+    assert!(
+        err.to_string().contains("expand at `a.b.a`:"),
+        "the cycle names its argument chain: {err}"
+    );
 }
 
 /// C5 validation map: a variant ctor ident that names no `#[prebindgen]`

--- a/prebindgen-registry/src/expand/tests.rs
+++ b/prebindgen-registry/src/expand/tests.rs
@@ -9,6 +9,21 @@ fn key(s: &str) -> crate::registry::TypeKey {
     crate::registry::TypeKey::parse(s).expect("a fixture type")
 }
 
+/// The children of a product node — a constructor's arguments, in parameter
+/// order.
+fn args(node: &InNode) -> &[InChild] {
+    match &node.kind {
+        TransformKind::Product { children, .. } => children,
+        _ => panic!("a constructor product, not a dispatch"),
+    }
+}
+
+/// Whether a constructor argument is itself built, rather than decoded from one
+/// wire slot.
+fn is_build(child: &InChild) -> bool {
+    !matches!(child.node.kind, TransformKind::Leaf(_))
+}
+
 /// A reading for a fixture type — see the twin in `core/unfold/tests.rs`.
 /// Plan leaves carry `TypeRef`s, and a fixture naming a type inline needs one.
 fn tref(ty: syn::Type) -> prebindgen_flat::flat::TypeRef {
@@ -54,7 +69,7 @@ fn single_constructor_plan_and_fold() {
         .get(&(ident("z_keyexpr_intersects"), ident("a")))
         .expect("plan for a");
     assert!(plan.by_ref, "param was &ZKeyExpr");
-    assert_eq!(plan.selector, None);
+    assert_eq!(plan.selector(), None);
     assert_eq!(plan.leaves.len(), 1);
     assert_eq!(plan.leaves[0].name.to_string(), "a");
     assert_eq!(plan.leaves[0].ty.spell().to_string(), "String");
@@ -101,7 +116,7 @@ fn constructor_plan_and_fold() {
         .expansion_plans
         .get(&(ident("z_keyexpr_intersects"), ident("a")))
         .unwrap();
-    assert_eq!(plan.selector, Some(0));
+    assert_eq!(plan.selector(), Some(0));
     // selector + try_from(String) + identity(ZKeyExpr) = 3 leaves
     assert_eq!(plan.leaves.len(), 3);
     assert_eq!(plan.leaves[0].ty.spell().to_string(), "i32");
@@ -111,10 +126,20 @@ fn constructor_plan_and_fold() {
         plan.leaves[2].ty.spell().to_string(),
         "Option < & ZKeyExpr >"
     );
-    assert_eq!(plan.variants.len(), 2);
-    assert!(plan.variants[0].ctor.is_some());
-    assert!(plan.variants[1].ctor.is_none(), "identity arm");
-    assert!(plan.variants[1].clone, "by-ref identity clones");
+    let arms = plan.core.arms();
+    assert_eq!(arms.len(), 2);
+    assert!(arms[0].ctor().is_some());
+    assert!(arms[1].ctor().is_none(), "identity arm");
+    assert!(
+        matches!(
+            &arms[1].kind,
+            TransformKind::Product {
+                op: InProduct::Identity { clone: true },
+                ..
+            }
+        ),
+        "by-ref identity clones"
+    );
 
     // Leaf types registered as required inputs (so the resolver builds
     // their converters).
@@ -334,7 +359,7 @@ fn optional_combined_selector_encodes_absence() {
     assert!(matches!(plan.shape, FoldShape::Optional((), _)));
     assert!(plan.produces_option());
     assert!(plan.by_ref, "Option<&T> ⇒ by_ref");
-    assert_eq!(plan.selector, Some(0), "selector at leaf 0");
+    assert_eq!(plan.selector(), Some(0), "selector at leaf 0");
     assert_eq!(plan.present, None, "absence rides the selector, no flag");
     // leaves: sel:i32, id:Option<i32> (wrapped), schema:Option<String>
     // (passthrough), identity:Option<&ZEncoding>.
@@ -351,11 +376,27 @@ fn optional_combined_selector_encodes_absence() {
         plan.leaves[3].ty.spell().to_string(),
         "Option < & ZEncoding >"
     );
+    let arms = plan.core.arms();
     assert!(
-        matches!(plan.variants[0].inputs[1], FoldArg::Leaf(2, true)),
-        "schema input marked passthrough"
+        matches!(
+            &args(arms[0])[1].node.kind,
+            TransformKind::Leaf(InLeaf {
+                leaf: 2,
+                wrapped: false
+            })
+        ),
+        "an already-Option ctor arg passes through unwrapped"
     );
-    assert!(plan.variants[1].clone, "borrowed identity arm clones");
+    assert!(
+        matches!(
+            &arms[1].kind,
+            TransformKind::Product {
+                op: InProduct::Identity { clone: true },
+                ..
+            }
+        ),
+        "borrowed identity arm clones"
+    );
 
     let locals = vec![ident("sel"), ident("id"), ident("schema"), ident("enc")];
     let s = emit_fold(plan, &locals, &src_qualify)
@@ -393,14 +434,26 @@ fn iterable_emit_shape() {
             name: ident("kes"),
             ty: tref(syn::parse_quote!(Vec<String>)),
         }],
-        selector: None,
         present: None,
-        variants: vec![FoldVariant {
-            ctor: Some(ident("z_keyexpr_try_from")),
-            fallible: true,
-            clone: false,
-            inputs: vec![FoldArg::Leaf(0, false)],
-        }],
+        core: InNode {
+            ty: tref(syn::parse_quote!(ZKeyExpr)),
+            kind: TransformKind::Product {
+                op: InProduct::Ctor {
+                    func: ident("z_keyexpr_try_from"),
+                    fallible: true,
+                },
+                children: vec![InChild {
+                    link: InLink { by_ref: false },
+                    node: InNode {
+                        ty: tref(syn::parse_quote!(String)),
+                        kind: TransformKind::Leaf(InLeaf {
+                            leaf: 0,
+                            wrapped: false,
+                        }),
+                    },
+                }],
+            },
+        },
     };
     let locals = vec![ident("kes")];
     let s = emit_fold(&plan, &locals, &src_qualify)
@@ -563,27 +616,23 @@ fn recursive_input_nests_param_constructors() {
         .get(&(ident("z_reply_sample"), ident("sample")))
         .expect("sample plan");
     // Top: single z_sample_new ctor, 2 args, both recursive Build.
-    assert_eq!(plan.selector, None);
-    assert_eq!(plan.variants.len(), 1);
-    let args = &plan.variants[0].inputs;
+    assert_eq!(plan.selector(), None);
+    assert_eq!(plan.core.arms().len(), 1);
+    let args = args(&plan.core);
     assert_eq!(args.len(), 2);
-    assert!(
-        matches!(args[0], FoldArg::Build(_)),
-        "key_expr is a nested build"
-    );
-    assert!(
-        matches!(args[1], FoldArg::Build(_)),
-        "payload is a nested build"
-    );
+    assert!(is_build(&args[0]), "key_expr is a nested build");
+    assert!(is_build(&args[1]), "payload is a nested build");
     // key_expr's nested build is COMBINED (try_from | identity ⇒ selector).
-    if let FoldArg::Build(b) = &args[0] {
-        assert!(b.selector.is_some(), "ZKeyExpr default input is combined");
-        assert_eq!(b.variants.len(), 2);
-    }
+    assert!(
+        args[0].node.selector().is_some(),
+        "ZKeyExpr default input is combined"
+    );
+    assert_eq!(args[0].node.arms().len(), 2);
     // payload's nested build is SINGLE (no selector).
-    if let FoldArg::Build(b) = &args[1] {
-        assert!(b.selector.is_none(), "ZZBytes default input is single");
-    }
+    assert!(
+        args[1].node.selector().is_none(),
+        "ZZBytes default input is single"
+    );
     // Wire leaves: key-expr selector + try_from String + identity ZKeyExpr +
     // zbytes Vec<u8> — all flattened into the one signature.
     let leaf_tys: Vec<String> = plan
@@ -804,5 +853,138 @@ fn a_vec_param_does_not_match_its_elements_constructor() {
         "a Vec<ZKeyExpr> parameter must not be expanded as one ZKeyExpr; \
          plans: {:?}",
         reg.expansion_plans.keys().collect::<Vec<_>>()
+    );
+}
+
+/// A stand-in language adapter (#442), the input-direction twin of
+/// `unfold::tests::Render`: it says what a leaf, a constructor and a dispatch
+/// *render as* and nothing else. No recursion, no `TypeRef` walk, no leaf-index
+/// arithmetic — the registry supplies the descent, the child order and the
+/// links.
+struct RenderIn;
+
+impl crate::transform::TransformLowerer<IntoRust> for RenderIn {
+    type Value = String;
+    type Error = std::convert::Infallible;
+
+    fn leaf(&mut self, _node: &InNode, op: &InLeaf) -> Result<String, Self::Error> {
+        Ok(format!("#{}{}", op.leaf, if op.wrapped { "?" } else { "" }))
+    }
+
+    fn product(
+        &mut self,
+        _node: &InNode,
+        op: &InProduct,
+        children: crate::transform::Lowered<'_, IntoRust, String>,
+    ) -> Result<String, Self::Error> {
+        let args: Vec<String> = children
+            .iter()
+            .map(|(child, value)| format!("{}{value}", if child.link.by_ref { "&" } else { "" }))
+            .collect();
+        Ok(match op {
+            InProduct::Ctor { func, fallible } => format!(
+                "{func}{}({})",
+                if *fallible { "!" } else { "" },
+                args.join(", ")
+            ),
+            InProduct::Identity { clone } => {
+                format!(
+                    "self{}({})",
+                    if *clone { ".clone" } else { "" },
+                    args.join(", ")
+                )
+            }
+        })
+    }
+
+    fn choice(
+        &mut self,
+        _node: &InNode,
+        op: &InChoice,
+        variants: crate::transform::Lowered<'_, IntoRust, String>,
+    ) -> Result<String, Self::Error> {
+        let arms: Vec<String> = variants.into_iter().map(|(_, v)| v).collect();
+        Ok(format!("#{} ? {}", op.selector, arms.join(" | ")))
+    }
+}
+
+#[test]
+fn core_lowers_through_the_shared_visitor() {
+    // `z_sample_new(&ZKeyExpr, ZZBytes)` where BOTH arguments have their own
+    // default constructor: a product whose children are themselves built, one
+    // of them a dispatch. That is every into-Rust node kind in one tree, with
+    // a by-ref link over the nested one.
+    let mut reg: Registry<()> = reg_with(&[
+        "fn z_sample_new(ke: &ZKeyExpr, payload: ZZBytes) -> ZSample { todo!() }",
+        "fn z_keyexpr_try_from(s: String) -> Result<ZKeyExpr, Error> { todo!() }",
+        "fn z_zbytes_from_vec(v: Vec<u8>) -> ZZBytes { todo!() }",
+        "fn z_reply_sample(sample: ZSample) -> bool { todo!() }",
+    ]);
+    let mut exp = Expansions::default();
+    exp.constructors.push(ConstructorDecl {
+        target: key("ZSample"),
+        variants: vec![Variant::Ctor(ident("z_sample_new"))],
+        default: true,
+    });
+    exp.constructors.push(ConstructorDecl {
+        target: key("ZKeyExpr"),
+        variants: vec![
+            Variant::Ctor(ident("z_keyexpr_try_from")),
+            Variant::Identity,
+        ],
+        default: true,
+    });
+    exp.constructors.push(ConstructorDecl {
+        target: key("ZZBytes"),
+        variants: vec![Variant::Ctor(ident("z_zbytes_from_vec"))],
+        default: true,
+    });
+    exp.expands.push(ExpandDecl {
+        func: ident("z_reply_sample"),
+        param: ident("sample"),
+        declared_target: Some(key("ZSample")),
+        sel: ExpandSel::TopLevel,
+    });
+
+    apply(
+        &mut reg,
+        &exp,
+        &Default::default(),
+        &Default::default(),
+        &Default::default(),
+    )
+    .expect("apply");
+
+    let plan = reg
+        .expansion_plans
+        .get(&(ident("z_reply_sample"), ident("sample")))
+        .expect("plan");
+
+    // The whole construction, read through the hooks alone: the key expression
+    // is a dispatch behind a by-ref link, the payload a single constructor, and
+    // every wire slot names its index in `plan.leaves`.
+    let rendered = plan
+        .core
+        .lower(&mut RenderIn)
+        .expect("lowering cannot fail");
+    assert_eq!(
+        rendered,
+        "z_sample_new(&#0 ? z_keyexpr_try_from!(#1?) | self.clone(#2?), z_zbytes_from_vec(#3))"
+    );
+
+    // The slots that rendering named, in wire order.
+    let leaves: Vec<String> = plan
+        .leaves
+        .iter()
+        .map(|l| l.ty.spell().to_string())
+        .collect();
+    assert_eq!(
+        leaves,
+        vec![
+            "i32",
+            "Option < String >",
+            "Option < & ZKeyExpr >",
+            "Vec < u8 >"
+        ]
     );
 }

--- a/prebindgen-registry/src/expand/tests.rs
+++ b/prebindgen-registry/src/expand/tests.rs
@@ -908,6 +908,26 @@ impl crate::transform::TransformLowerer<IntoRust> for RenderIn {
         let arms: Vec<String> = variants.into_iter().map(|(_, v)| v).collect();
         Ok(format!("#{} ? {}", op.selector, arms.join(" | ")))
     }
+
+    fn optional(
+        &mut self,
+        _node: &InNode,
+        op: &std::convert::Infallible,
+        _inner: &InNode,
+        _value: String,
+    ) -> Result<String, Self::Error> {
+        match *op {}
+    }
+
+    fn sequence(
+        &mut self,
+        _node: &InNode,
+        op: &std::convert::Infallible,
+        _inner: &InNode,
+        _value: String,
+    ) -> Result<String, Self::Error> {
+        match *op {}
+    }
 }
 
 #[test]

--- a/prebindgen-registry/src/expand/tests.rs
+++ b/prebindgen-registry/src/expand/tests.rs
@@ -381,8 +381,9 @@ fn optional_combined_selector_encodes_absence() {
         matches!(
             &args(arms[0])[1].node.kind,
             TransformKind::Leaf(InLeaf {
-                leaf: 2,
-                wrapped: false
+                slot: 2,
+                wrapped: false,
+                ..
             })
         ),
         "an already-Option ctor arg passes through unwrapped"
@@ -447,7 +448,8 @@ fn iterable_emit_shape() {
                     node: InNode {
                         ty: tref(syn::parse_quote!(String)),
                         kind: TransformKind::Leaf(InLeaf {
-                            leaf: 0,
+                            slot: 0,
+                            name: ident("kes"),
                             wrapped: false,
                         }),
                     },
@@ -868,7 +870,7 @@ impl crate::transform::TransformLowerer<IntoRust> for RenderIn {
     type Error = std::convert::Infallible;
 
     fn leaf(&mut self, _node: &InNode, op: &InLeaf) -> Result<String, Self::Error> {
-        Ok(format!("#{}{}", op.leaf, if op.wrapped { "?" } else { "" }))
+        Ok(format!("#{}{}", op.slot, if op.wrapped { "?" } else { "" }))
     }
 
     fn product(
@@ -972,19 +974,23 @@ fn core_lowers_through_the_shared_visitor() {
         "z_sample_new(&#0 ? z_keyexpr_try_from!(#1?) | self.clone(#2?), z_zbytes_from_vec(#3))"
     );
 
-    // The slots that rendering named, in wire order.
-    let leaves: Vec<String> = plan
+    // The signature is COLLECTED from those same nodes: each slot's name and
+    // type come from the node that uses it, in slot order.
+    let leaves: Vec<(String, String)> = plan
         .leaves
         .iter()
-        .map(|l| l.ty.spell().to_string())
+        .map(|l| (l.name.to_string(), l.ty.spell().to_string()))
         .collect();
     assert_eq!(
         leaves,
         vec![
-            "i32",
-            "Option < String >",
-            "Option < & ZKeyExpr >",
-            "Vec < u8 >"
+            ("sample_ke_sel".to_string(), "i32".to_string()),
+            ("sample_ke_0".to_string(), "Option < String >".to_string()),
+            (
+                "sample_ke_1".to_string(),
+                "Option < & ZKeyExpr >".to_string()
+            ),
+            ("sample_payload".to_string(), "Vec < u8 >".to_string()),
         ]
     );
 }

--- a/prebindgen-registry/src/expand/tree.rs
+++ b/prebindgen-registry/src/expand/tree.rs
@@ -8,14 +8,19 @@
 //! tree's, so a nested build is the same node kind as the top-level one rather
 //! than a second type spelling the same thing.
 //!
-//! What is NOT here yet: the flat [`FoldPlan::leaves`] vector and the selector
-//! and presence slots that ride in it are still built by the walk rather than
-//! derived from the tree. Separating constructor semantics from those synthetic
-//! wire slots is the next step of #442.
+//! Every wire slot is described exactly once, by the node that uses it: its
+//! type is that node's [`ty`](TransformNode::ty) and its foreign-side name is
+//! on the node's payload. [`FoldPlan::leaves`] is [collected](wire_leaves) from
+//! them — a derived view of the tree, in slot order, not a second list the
+//! builder keeps in step by hand.
 //!
 //! [`FoldPlan::leaves`]: super::FoldPlan::leaves
 
-use crate::transform::{TransformChild, TransformDirection, TransformKind, TransformNode};
+use crate::transform::{
+    Lowered, TransformChild, TransformDirection, TransformKind, TransformLowerer, TransformNode,
+};
+
+use super::FoldLeaf;
 
 /// Direction marker: crossing values assembled into a Rust value.
 pub enum IntoRust {}
@@ -32,12 +37,15 @@ pub type InNode = TransformNode<IntoRust>;
 /// One argument of an into-Rust product, or one arm of a choice.
 pub type InChild = TransformChild<IntoRust>;
 
-/// One decoded wire value, used as it stands.
+/// One decoded wire value, used as it stands. The slot's type is the node's
+/// [`ty`](TransformNode::ty).
 pub struct InLeaf {
     /// Which slot of [`FoldPlan::leaves`](super::FoldPlan::leaves) this decodes
     /// — the wire signature's own order, and the index of the caller's decoded
     /// local.
-    pub leaf: usize,
+    pub slot: usize,
+    /// The slot's foreign-side parameter name.
+    pub name: syn::Ident,
     /// The slot is `Option`-wrapped by **selector presence** (it belongs to a
     /// dispatched arm and only the taken arm's slots are filled), so a consumer
     /// unwraps it before use and treats a missing value as an error.
@@ -67,13 +75,16 @@ pub enum InProduct {
     },
 }
 
-/// How a choice node picks the arm that runs.
+/// How a choice node picks the arm that runs. The selector is a slot of its
+/// own — a wire value no source wrote, contributed by this node.
 pub struct InChoice {
     /// Which slot of [`FoldPlan::leaves`](super::FoldPlan::leaves) carries the
     /// `i32` selector. Arm `i` is taken when the selector reads `i`; under an
     /// [`Optional`](super::FoldShape::Optional) shape `-1` additionally means
     /// absent.
     pub selector: usize,
+    /// The selector slot's foreign-side parameter name.
+    pub name: syn::Ident,
 }
 
 /// How one child hangs off its parent.
@@ -130,9 +141,81 @@ impl InNode {
         children
             .iter()
             .map(|c| match &c.node.kind {
-                TransformKind::Leaf(op) => Some(op.leaf),
+                TransformKind::Leaf(op) => Some(op.slot),
                 _ => None,
             })
             .collect()
+    }
+}
+
+/// Collect the wire slots a construction uses, in slot order — the flat
+/// signature [`FoldPlan::leaves`](super::FoldPlan::leaves) exposes.
+///
+/// `extra` carries slots that belong to the parameter rather than to the
+/// construction: today only the whole-parameter presence flag of a multi-argument
+/// `Option<T>`, which the [`Optional`](super::FoldShape::Optional) shape reads
+/// and the construction never sees. Every slot is named exactly once — a gap or
+/// a collision here means the builder handed out an id twice.
+pub fn wire_leaves(core: &InNode, extra: Vec<(usize, FoldLeaf)>) -> Vec<FoldLeaf> {
+    let mut slots = extra;
+    core.lower(&mut CollectSlots(&mut slots))
+        .expect("collecting wire slots cannot fail");
+    let mut out: Vec<Option<FoldLeaf>> = (0..slots.len()).map(|_| None).collect();
+    for (slot, leaf) in slots {
+        let cell = out
+            .get_mut(slot)
+            .expect("a wire slot outside the construction's own count");
+        assert!(cell.is_none(), "two wire values claim slot {slot}");
+        *cell = Some(leaf);
+    }
+    out.into_iter()
+        .enumerate()
+        .map(|(slot, leaf)| leaf.unwrap_or_else(|| panic!("wire slot {slot} is unclaimed")))
+        .collect()
+}
+
+/// The lowerer behind [`wire_leaves`]: each node contributes the slots it uses
+/// and nothing else.
+struct CollectSlots<'a>(&'a mut Vec<(usize, FoldLeaf)>);
+
+impl TransformLowerer<IntoRust> for CollectSlots<'_> {
+    type Value = ();
+    type Error = std::convert::Infallible;
+
+    fn leaf(&mut self, node: &InNode, op: &InLeaf) -> Result<(), Self::Error> {
+        self.0.push((
+            op.slot,
+            FoldLeaf {
+                name: op.name.clone(),
+                ty: node.ty.clone(),
+            },
+        ));
+        Ok(())
+    }
+
+    fn product(
+        &mut self,
+        _node: &InNode,
+        _op: &InProduct,
+        _children: Lowered<'_, IntoRust, ()>,
+    ) -> Result<(), Self::Error> {
+        Ok(())
+    }
+
+    fn choice(
+        &mut self,
+        _node: &InNode,
+        op: &InChoice,
+        _variants: Lowered<'_, IntoRust, ()>,
+    ) -> Result<(), Self::Error> {
+        self.0.push((
+            op.selector,
+            FoldLeaf {
+                name: op.name.clone(),
+                // The selector: composed, and placeless by construction.
+                ty: prebindgen_flat::flat::TypeRef::scalar(prebindgen_flat::flat::ScalarKind::I32),
+            },
+        ));
+        Ok(())
     }
 }

--- a/prebindgen-registry/src/expand/tree.rs
+++ b/prebindgen-registry/src/expand/tree.rs
@@ -1,26 +1,27 @@
 //! The into-Rust direction of the shared transformation tree (#442): how the
 //! values that cross in are put back together into one Rust value.
 //!
-//! The tree replaces the former `FoldVariant` / `FoldArg` / `FoldBuild` triple.
-//! A constructor call is a [product](InProduct) over its arguments, a
-//! selector dispatch is a [choice](InChoice) over its arms, and a wire value is
-//! a [leaf](InLeaf) naming its slot in [`FoldPlan::leaves`]. Recursion is the
-//! tree's, so a nested build is the same node kind as the top-level one rather
-//! than a second type spelling the same thing.
+//! The tree is the plan. A constructor call is a [product](InProduct) over its
+//! arguments, a selector dispatch is a [choice](InChoice) over its arms, the
+//! `Option<…>` and `Vec<…>` a parameter is written with are the layers over
+//! that ([`InPresence`], [`InSlot`]), and a wire value is a [leaf](InLeaf).
+//! Recursion is the tree's, so a nested build is the same node kinds as the
+//! top-level one rather than a second type spelling the same thing.
 //!
-//! Every wire slot is described exactly once, by the node that uses it: its
-//! type is that node's [`ty`](TransformNode::ty) and its foreign-side name is
-//! on the node's payload. [`FoldPlan::leaves`] is [collected](wire_leaves) from
-//! them — a derived view of the tree, in slot order, not a second list the
-//! builder keeps in step by hand.
+//! Every wire slot is described exactly once, by the node that uses it — a
+//! constructor argument, a dispatch's selector, a layer's presence flag, the
+//! payload an `Option` layer unwraps. [`FoldPlan::leaves`] is
+//! [collected](wire_leaves) from them, and [`FoldPlan::shape`] is read back off
+//! the layer nodes.
 //!
 //! [`FoldPlan::leaves`]: super::FoldPlan::leaves
+//! [`FoldPlan::shape`]: super::FoldPlan::shape
 
 use crate::transform::{
     Lowered, TransformChild, TransformDirection, TransformKind, TransformLowerer, TransformNode,
 };
 
-use super::FoldLeaf;
+use super::{FoldLeaf, FoldShape};
 
 /// Direction marker: crossing values assembled into a Rust value.
 pub enum IntoRust {}
@@ -29,13 +30,10 @@ impl TransformDirection for IntoRust {
     type Leaf = InLeaf;
     type Product = InProduct;
     type Choice = InChoice;
-    /// The `Option<T>` parameter layer and the `Vec<T>` one still live on
-    /// [`FoldPlan::shape`](super::FoldPlan::shape): moving them in means the
-    /// emitter reading a *bound* value the layer unwrapped, which the
-    /// children-first traversal has no hook for yet (#442). Uninhabited until
-    /// then, so neither node kind can be built in this direction.
-    type Optional = std::convert::Infallible;
-    type Sequence = std::convert::Infallible;
+    type Optional = InPresence;
+    /// The run's own wire slot: one value carrying the whole collection, which
+    /// the layer iterates.
+    type Sequence = InSlot;
     type Link = InLink;
 }
 
@@ -44,24 +42,49 @@ pub type InNode = TransformNode<IntoRust>;
 /// One argument of an into-Rust product, or one arm of a choice.
 pub type InChild = TransformChild<IntoRust>;
 
-/// One decoded wire value, used as it stands. The slot's type is the node's
-/// [`ty`](TransformNode::ty).
-pub struct InLeaf {
-    /// Which slot of [`FoldPlan::leaves`](super::FoldPlan::leaves) this decodes
-    /// — the wire signature's own order, and the index of the caller's decoded
-    /// local.
+/// One wire slot: where it sits in the foreign signature, what it is called
+/// there, and what it carries.
+///
+/// The single description of a slot. [`wire_leaves`] turns the slots a tree
+/// names into [`FoldPlan::leaves`](super::FoldPlan::leaves), so a slot exists
+/// exactly where the node that uses it says so.
+#[derive(Clone)]
+pub struct InSlot {
+    /// Position in the foreign signature, and the index of the caller's
+    /// decoded local.
     pub slot: usize,
     /// The slot's foreign-side parameter name.
     pub name: syn::Ident,
-    /// The slot is `Option`-wrapped by **selector presence** (it belongs to a
-    /// dispatched arm and only the taken arm's slots are filled), so a consumer
-    /// unwraps it before use and treats a missing value as an error.
-    ///
-    /// `false` both outside a dispatch and for a *passthrough* argument — one
-    /// the constructor itself declares `Option<…>`, which keeps its own type on
-    /// the wire because `None` is a legitimate value for the taken arm and the
-    /// wire cannot carry the double `Option` anyway.
-    pub wrapped: bool,
+    /// What the slot carries. A **reading**: spell it with `emit.spell(&ty)`
+    /// in an emission callback.
+    pub ty: prebindgen_flat::flat::TypeRef,
+}
+
+/// Where one decoded value comes from.
+// large_enum_variant: a plan has a handful of leaves, and boxing `InSlot` to
+// even the arms out would only put an indirection between a node and the slot
+// it names (same trade-off as `DeconRecord`).
+#[allow(clippy::large_enum_variant)]
+pub enum InLeaf {
+    /// A wire slot of its own.
+    Slot {
+        slot: InSlot,
+        /// The slot is `Option`-wrapped by **selector presence** (it belongs to
+        /// a dispatched arm and only the taken arm's slots are filled), so a
+        /// consumer unwraps it before use and treats a missing value as an
+        /// error.
+        ///
+        /// `false` both outside a dispatch and for a *passthrough* argument —
+        /// one the constructor itself declares `Option<…>`, which keeps its own
+        /// type on the wire because `None` is a legitimate value for the taken
+        /// arm and the wire cannot carry the double `Option` anyway.
+        wrapped: bool,
+    },
+    /// The value the enclosing layer unwrapped and bound: a single-argument
+    /// construction under an [`Option`](InPresence::Payload) layer or a run
+    /// takes what that layer produced, and the slot belongs to the layer rather
+    /// than to this argument.
+    Bound,
 }
 
 /// How a product node's children combine into its value.
@@ -85,13 +108,26 @@ pub enum InProduct {
 /// How a choice node picks the arm that runs. The selector is a slot of its
 /// own — a wire value no source wrote, contributed by this node.
 pub struct InChoice {
-    /// Which slot of [`FoldPlan::leaves`](super::FoldPlan::leaves) carries the
-    /// `i32` selector. Arm `i` is taken when the selector reads `i`; under an
-    /// [`Optional`](super::FoldShape::Optional) shape `-1` additionally means
-    /// absent.
-    pub selector: usize,
-    /// The selector slot's foreign-side parameter name.
-    pub name: syn::Ident,
+    /// The `i32` slot. Arm `i` is taken when it reads `i`; under an
+    /// [`Optional`](InPresence) layer `-1` additionally means absent.
+    pub selector: InSlot,
+}
+
+/// How an `Option<…>` layer decides whether its value is present. The three
+/// forms differ in what crosses, which is why the layer names its own slot
+/// rather than inheriting one.
+pub enum InPresence {
+    /// The dispatch under the layer also encodes absence: its selector reads
+    /// `-1`. No slot of the layer's own.
+    Selector,
+    /// An explicit `bool` slot decides, and the construction's arguments cross
+    /// plain. Used for a constructor of two or more arguments, where riding the
+    /// arguments' own `Option`s would box a nullable primitive on the wire.
+    Flag(InSlot),
+    /// The layer decodes its own `Option<…>` slot and hands the payload to the
+    /// single-argument construction under it — which reads it as
+    /// [`InLeaf::Bound`], having no slot of its own.
+    Payload(InSlot),
 }
 
 /// How one child hangs off its parent.
@@ -104,11 +140,47 @@ pub struct InLink {
 }
 
 impl InNode {
-    /// The selector slot when this node dispatches, `None` when it is a single
-    /// unconditional construction.
-    pub fn selector(&self) -> Option<usize> {
+    /// The construction under any arity layers — what the `Option` / `Vec` a
+    /// parameter is written with wraps.
+    pub fn core(&self) -> &InNode {
         match &self.kind {
-            crate::transform::TransformKind::Choice { op, .. } => Some(op.selector),
+            TransformKind::Optional { inner, .. } | TransformKind::Sequence { inner, .. } => {
+                inner.core()
+            }
+            _ => self,
+        }
+    }
+
+    /// The arity layers this node wraps its construction in — the plan's
+    /// [`shape`](super::FoldPlan::shape), read back off the nodes that carry it.
+    pub fn shape(&self) -> FoldShape {
+        match &self.kind {
+            TransformKind::Optional { inner, .. } => FoldShape::optional((), inner.shape()),
+            TransformKind::Sequence { inner, .. } => FoldShape::iterable(inner.shape()),
+            _ => FoldShape::Base,
+        }
+    }
+
+    /// The slot of the explicit presence flag, when an `Option` layer decides
+    /// presence with one — see [`InPresence::Flag`].
+    pub fn present(&self) -> Option<usize> {
+        match &self.kind {
+            TransformKind::Optional {
+                op: InPresence::Flag(s),
+                ..
+            } => Some(s.slot),
+            TransformKind::Optional { inner, .. } | TransformKind::Sequence { inner, .. } => {
+                inner.present()
+            }
+            _ => None,
+        }
+    }
+
+    /// The selector slot when the construction dispatches, `None` when it is a
+    /// single unconditional one.
+    pub fn selector(&self) -> Option<usize> {
+        match &self.core().kind {
+            TransformKind::Choice { op, .. } => Some(op.selector.slot),
             _ => None,
         }
     }
@@ -117,9 +189,10 @@ impl InNode {
     /// reading a consumer wants when it asks what this parameter can be built
     /// from. In selector order: arm `i` is taken when the selector reads `i`.
     pub fn arms(&self) -> Vec<&InNode> {
-        match &self.kind {
+        let core = self.core();
+        match &core.kind {
             TransformKind::Choice { variants, .. } => variants.iter().map(|v| &v.node).collect(),
-            _ => vec![self],
+            _ => vec![core],
         }
     }
 
@@ -138,9 +211,10 @@ impl InNode {
     /// Which slots of [`FoldPlan::leaves`](super::FoldPlan::leaves) an
     /// [arm](Self::arms)'s arguments decode, in parameter order.
     ///
-    /// `None` when any argument is itself built from further slots: the arm
-    /// then has no flat signature, which is what makes it unsplittable into a
-    /// destination-language overload.
+    /// `None` when any argument is itself built from further slots, or reads a
+    /// layer's payload instead of a slot: the arm then has no flat signature,
+    /// which is what makes it unsplittable into a destination-language
+    /// overload.
     pub fn leaf_args(&self) -> Option<Vec<usize>> {
         let TransformKind::Product { children, .. } = &self.kind else {
             return None;
@@ -148,30 +222,27 @@ impl InNode {
         children
             .iter()
             .map(|c| match &c.node.kind {
-                TransformKind::Leaf(op) => Some(op.slot),
+                TransformKind::Leaf(InLeaf::Slot { slot, .. }) => Some(slot.slot),
                 _ => None,
             })
             .collect()
     }
 }
 
-/// Collect the wire slots a construction uses, in slot order — the flat
-/// signature [`FoldPlan::leaves`](super::FoldPlan::leaves) exposes.
+/// Collect the wire slots a plan uses, in slot order — the flat signature
+/// [`FoldPlan::leaves`](super::FoldPlan::leaves) exposes.
 ///
-/// `extra` carries slots that belong to the parameter rather than to the
-/// construction: today only the whole-parameter presence flag of a multi-argument
-/// `Option<T>`, which the [`Optional`](super::FoldShape::Optional) shape reads
-/// and the construction never sees. Every slot is named exactly once — a gap or
-/// a collision here means the builder handed out an id twice.
-pub fn wire_leaves(core: &InNode, extra: Vec<(usize, FoldLeaf)>) -> Vec<FoldLeaf> {
-    let mut slots = extra;
-    core.lower(&mut CollectSlots(&mut slots))
+/// Every slot is named exactly once — a gap or a collision here means the
+/// builder handed out a position twice.
+pub fn wire_leaves(tree: &InNode) -> Vec<FoldLeaf> {
+    let mut slots: Vec<(usize, FoldLeaf)> = Vec::new();
+    tree.lower(&mut CollectSlots(&mut slots))
         .expect("collecting wire slots cannot fail");
     let mut out: Vec<Option<FoldLeaf>> = (0..slots.len()).map(|_| None).collect();
     for (slot, leaf) in slots {
         let cell = out
             .get_mut(slot)
-            .expect("a wire slot outside the construction's own count");
+            .expect("a wire slot outside the plan's own count");
         assert!(cell.is_none(), "two wire values claim slot {slot}");
         *cell = Some(leaf);
     }
@@ -185,18 +256,28 @@ pub fn wire_leaves(core: &InNode, extra: Vec<(usize, FoldLeaf)>) -> Vec<FoldLeaf
 /// and nothing else.
 struct CollectSlots<'a>(&'a mut Vec<(usize, FoldLeaf)>);
 
+impl CollectSlots<'_> {
+    fn take(&mut self, s: &InSlot) {
+        self.0.push((
+            s.slot,
+            FoldLeaf {
+                name: s.name.clone(),
+                ty: s.ty.clone(),
+            },
+        ));
+    }
+}
+
 impl TransformLowerer<IntoRust> for CollectSlots<'_> {
     type Value = ();
     type Error = std::convert::Infallible;
 
-    fn leaf(&mut self, node: &InNode, op: &InLeaf) -> Result<(), Self::Error> {
-        self.0.push((
-            op.slot,
-            FoldLeaf {
-                name: op.name.clone(),
-                ty: node.ty.clone(),
-            },
-        ));
+    fn leaf(&mut self, _node: &InNode, op: &InLeaf) -> Result<(), Self::Error> {
+        // A bound argument reads what its layer unwrapped; that slot is the
+        // layer's, contributed there.
+        if let InLeaf::Slot { slot, .. } = op {
+            self.take(slot);
+        }
         Ok(())
     }
 
@@ -215,34 +296,32 @@ impl TransformLowerer<IntoRust> for CollectSlots<'_> {
         op: &InChoice,
         _variants: Lowered<'_, IntoRust, ()>,
     ) -> Result<(), Self::Error> {
-        self.0.push((
-            op.selector,
-            FoldLeaf {
-                name: op.name.clone(),
-                // The selector: composed, and placeless by construction.
-                ty: prebindgen_flat::flat::TypeRef::scalar(prebindgen_flat::flat::ScalarKind::I32),
-            },
-        ));
+        self.take(&op.selector);
         Ok(())
     }
 
     fn optional(
         &mut self,
         _node: &InNode,
-        op: &std::convert::Infallible,
+        op: &InPresence,
         _inner: &InNode,
         _value: (),
     ) -> Result<(), Self::Error> {
-        match *op {}
+        match op {
+            InPresence::Selector => {}
+            InPresence::Flag(s) | InPresence::Payload(s) => self.take(s),
+        }
+        Ok(())
     }
 
     fn sequence(
         &mut self,
         _node: &InNode,
-        op: &std::convert::Infallible,
+        op: &InSlot,
         _inner: &InNode,
         _value: (),
     ) -> Result<(), Self::Error> {
-        match *op {}
+        self.take(op);
+        Ok(())
     }
 }

--- a/prebindgen-registry/src/expand/tree.rs
+++ b/prebindgen-registry/src/expand/tree.rs
@@ -29,6 +29,13 @@ impl TransformDirection for IntoRust {
     type Leaf = InLeaf;
     type Product = InProduct;
     type Choice = InChoice;
+    /// The `Option<T>` parameter layer and the `Vec<T>` one still live on
+    /// [`FoldPlan::shape`](super::FoldPlan::shape): moving them in means the
+    /// emitter reading a *bound* value the layer unwrapped, which the
+    /// children-first traversal has no hook for yet (#442). Uninhabited until
+    /// then, so neither node kind can be built in this direction.
+    type Optional = std::convert::Infallible;
+    type Sequence = std::convert::Infallible;
     type Link = InLink;
 }
 
@@ -217,5 +224,25 @@ impl TransformLowerer<IntoRust> for CollectSlots<'_> {
             },
         ));
         Ok(())
+    }
+
+    fn optional(
+        &mut self,
+        _node: &InNode,
+        op: &std::convert::Infallible,
+        _inner: &InNode,
+        _value: (),
+    ) -> Result<(), Self::Error> {
+        match *op {}
+    }
+
+    fn sequence(
+        &mut self,
+        _node: &InNode,
+        op: &std::convert::Infallible,
+        _inner: &InNode,
+        _value: (),
+    ) -> Result<(), Self::Error> {
+        match *op {}
     }
 }

--- a/prebindgen-registry/src/expand/tree.rs
+++ b/prebindgen-registry/src/expand/tree.rs
@@ -17,11 +17,10 @@
 //! [`FoldPlan::leaves`]: super::FoldPlan::leaves
 //! [`FoldPlan::shape`]: super::FoldPlan::shape
 
+use super::{FoldLeaf, FoldShape};
 use crate::transform::{
     Lowered, TransformChild, TransformDirection, TransformKind, TransformLowerer, TransformNode,
 };
-
-use super::{FoldLeaf, FoldShape};
 
 /// Direction marker: crossing values assembled into a Rust value.
 pub enum IntoRust {}

--- a/prebindgen-registry/src/expand/tree.rs
+++ b/prebindgen-registry/src/expand/tree.rs
@@ -1,0 +1,138 @@
+//! The into-Rust direction of the shared transformation tree (#442): how the
+//! values that cross in are put back together into one Rust value.
+//!
+//! The tree replaces the former `FoldVariant` / `FoldArg` / `FoldBuild` triple.
+//! A constructor call is a [product](InProduct) over its arguments, a
+//! selector dispatch is a [choice](InChoice) over its arms, and a wire value is
+//! a [leaf](InLeaf) naming its slot in [`FoldPlan::leaves`]. Recursion is the
+//! tree's, so a nested build is the same node kind as the top-level one rather
+//! than a second type spelling the same thing.
+//!
+//! What is NOT here yet: the flat [`FoldPlan::leaves`] vector and the selector
+//! and presence slots that ride in it are still built by the walk rather than
+//! derived from the tree. Separating constructor semantics from those synthetic
+//! wire slots is the next step of #442.
+//!
+//! [`FoldPlan::leaves`]: super::FoldPlan::leaves
+
+use crate::transform::{TransformChild, TransformDirection, TransformKind, TransformNode};
+
+/// Direction marker: crossing values assembled into a Rust value.
+pub enum IntoRust {}
+
+impl TransformDirection for IntoRust {
+    type Leaf = InLeaf;
+    type Product = InProduct;
+    type Choice = InChoice;
+    type Link = InLink;
+}
+
+/// One node of an into-Rust construction.
+pub type InNode = TransformNode<IntoRust>;
+/// One argument of an into-Rust product, or one arm of a choice.
+pub type InChild = TransformChild<IntoRust>;
+
+/// One decoded wire value, used as it stands.
+pub struct InLeaf {
+    /// Which slot of [`FoldPlan::leaves`](super::FoldPlan::leaves) this decodes
+    /// — the wire signature's own order, and the index of the caller's decoded
+    /// local.
+    pub leaf: usize,
+    /// The slot is `Option`-wrapped by **selector presence** (it belongs to a
+    /// dispatched arm and only the taken arm's slots are filled), so a consumer
+    /// unwraps it before use and treats a missing value as an error.
+    ///
+    /// `false` both outside a dispatch and for a *passthrough* argument — one
+    /// the constructor itself declares `Option<…>`, which keeps its own type on
+    /// the wire because `None` is a legitimate value for the taken arm and the
+    /// wire cannot carry the double `Option` anyway.
+    pub wrapped: bool,
+}
+
+/// How a product node's children combine into its value.
+pub enum InProduct {
+    /// Call this constructor on the children, in parameter order.
+    Ctor {
+        func: syn::Ident,
+        /// The constructor returns `Result`; its `Err` is routed through the
+        /// adapter's error channel.
+        fallible: bool,
+    },
+    /// The value itself, decoded from the node's single child.
+    Identity {
+        /// A borrowed identity arm (`&T` parameter): the decoded value is a
+        /// borrow, and the fold clones it (`T: Clone`) so the caller's handle
+        /// is preserved rather than consumed.
+        clone: bool,
+    },
+}
+
+/// How a choice node picks the arm that runs.
+pub struct InChoice {
+    /// Which slot of [`FoldPlan::leaves`](super::FoldPlan::leaves) carries the
+    /// `i32` selector. Arm `i` is taken when the selector reads `i`; under an
+    /// [`Optional`](super::FoldShape::Optional) shape `-1` additionally means
+    /// absent.
+    pub selector: usize,
+}
+
+/// How one child hangs off its parent.
+pub struct InLink {
+    /// The consuming constructor parameter is `&T`, so the child's value is
+    /// borrowed at the call site. Always `false` for a leaf child, whose
+    /// decoded local already has the parameter's type, and for a choice arm,
+    /// which is not consumed by anything.
+    pub by_ref: bool,
+}
+
+impl InNode {
+    /// The selector slot when this node dispatches, `None` when it is a single
+    /// unconditional construction.
+    pub fn selector(&self) -> Option<usize> {
+        match &self.kind {
+            crate::transform::TransformKind::Choice { op, .. } => Some(op.selector),
+            _ => None,
+        }
+    }
+
+    /// The arms of a dispatch, or the single construction on its own — the
+    /// reading a consumer wants when it asks what this parameter can be built
+    /// from. In selector order: arm `i` is taken when the selector reads `i`.
+    pub fn arms(&self) -> Vec<&InNode> {
+        match &self.kind {
+            TransformKind::Choice { variants, .. } => variants.iter().map(|v| &v.node).collect(),
+            _ => vec![self],
+        }
+    }
+
+    /// The constructor an [arm](Self::arms) calls; `None` for the identity arm,
+    /// which passes an existing value through rather than building one.
+    pub fn ctor(&self) -> Option<&syn::Ident> {
+        match &self.kind {
+            TransformKind::Product {
+                op: InProduct::Ctor { func, .. },
+                ..
+            } => Some(func),
+            _ => None,
+        }
+    }
+
+    /// Which slots of [`FoldPlan::leaves`](super::FoldPlan::leaves) an
+    /// [arm](Self::arms)'s arguments decode, in parameter order.
+    ///
+    /// `None` when any argument is itself built from further slots: the arm
+    /// then has no flat signature, which is what makes it unsplittable into a
+    /// destination-language overload.
+    pub fn leaf_args(&self) -> Option<Vec<usize>> {
+        let TransformKind::Product { children, .. } = &self.kind else {
+            return None;
+        };
+        children
+            .iter()
+            .map(|c| match &c.node.kind {
+                TransformKind::Leaf(op) => Some(op.leaf),
+                _ => None,
+            })
+            .collect()
+    }
+}

--- a/prebindgen-registry/src/lib.rs
+++ b/prebindgen-registry/src/lib.rs
@@ -109,6 +109,7 @@ pub mod registry;
 pub(crate) mod resolve;
 #[cfg(test)]
 pub(crate) mod test_util;
+pub mod transform;
 pub mod unfold;
 pub mod write;
 

--- a/prebindgen-registry/src/transform.rs
+++ b/prebindgen-registry/src/transform.rs
@@ -1,0 +1,114 @@
+//! The one recursive mechanism both boundary directions share.
+//!
+//! A **transformation tree** describes what happens at ONE boundary use: how a
+//! Rust value is taken apart into the values that cross ([`OutOfRust`](crate::unfold::OutOfRust)), or how
+//! the values that cross are put back together into a Rust one (`IntoRust`, not
+//! migrated yet — see #442). It is not a second type model: every node names
+//! its [`TypeRef`](prebindgen_flat::flat::TypeRef), which stays the authoritative reading.
+//!
+//! The tree is generic over its **direction** so the recursion, the child
+//! ordering and the traversal are written once. Only the payloads differ:
+//! [`TransformDirection::Leaf`] says what one crossing value is, `Product` says
+//! how a node's children are obtained, and `Link` says how one child hangs off
+//! its parent. A language adapter supplies node-level policy through
+//! [`TransformLowerer`] and never writes the walk itself.
+//!
+//! The flat views the plans still expose — a leaf vector, a hoist list — are
+//! **derived** by lowering the tree ([`crate::unfold::UnfoldPlan::leaves`] is
+//! built this way), not carried beside it.
+
+/// The direction a transformation runs in, and the payloads its nodes carry.
+///
+/// Implemented by an uninhabited marker per direction, so a tree cannot mix the
+/// two: every node of a [`TransformNode<D>`] is that one direction's.
+pub trait TransformDirection {
+    /// A terminal: one value as it crosses the boundary.
+    type Leaf;
+    /// A node whose children **all** contribute — a deterministic product
+    /// (a deconstructor's records, a constructor's arguments).
+    type Product;
+    /// How one child is reached from its parent's value.
+    type Link;
+}
+
+/// One node of a transformation tree.
+pub struct TransformNode<D: TransformDirection> {
+    /// The Rust type this node transforms — a leaf's crossing type, a
+    /// product's decomposed/constructed type. The single source-type model:
+    /// nothing below re-spells it.
+    pub ty: prebindgen_flat::flat::TypeRef,
+    /// What happens at this node.
+    pub kind: TransformKind<D>,
+}
+
+/// What a [`TransformNode`] does.
+///
+/// `Optional` / `Sequence` / `Choice` nodes are the remaining structural kinds
+/// (#442): today the outer `Option` / `Vec` layers live on the plans' own
+/// [`Shape`](prebindgen_flat::shape::Shape) and the choice payloads belong to
+/// the not-yet-migrated input direction, so adding those variants here would
+/// add arms nothing produces.
+pub enum TransformKind<D: TransformDirection> {
+    /// A value that crosses as it is.
+    Leaf(D::Leaf),
+    /// Every child contributes, in order.
+    Product {
+        op: D::Product,
+        children: Vec<TransformChild<D>>,
+    },
+}
+
+/// One child of a [`TransformKind::Product`], with the link that reaches it.
+pub struct TransformChild<D: TransformDirection> {
+    /// How this child hangs off its parent's value.
+    pub link: D::Link,
+    /// The child itself.
+    pub node: TransformNode<D>,
+}
+
+/// Node-level policy for one traversal of a tree: the caller says what a leaf
+/// and a product *mean*, the tree supplies the recursion and the order.
+///
+/// Bottom-up by construction — a product is handed its children's already
+/// lowered values, each with the link it came through, so a lowerer that needs
+/// to prefix something (an access path, a name chain) does it once per level
+/// rather than threading state down a walk it wrote itself.
+pub trait TransformLowerer<D: TransformDirection> {
+    /// What lowering one node yields.
+    type Value;
+    /// Why lowering a node can fail.
+    type Error;
+
+    /// Lower a terminal. `node.ty` is the crossing type.
+    fn leaf(&mut self, node: &TransformNode<D>, op: &D::Leaf) -> Result<Self::Value, Self::Error>;
+
+    /// Combine the already lowered children of a product, in child order.
+    ///
+    /// Each child arrives with the [`TransformChild`] it came from, so a
+    /// lowerer can read the link it hangs on and what kind of node it is — the
+    /// two questions a per-level rule asks — without descending itself.
+    fn product(
+        &mut self,
+        node: &TransformNode<D>,
+        op: &D::Product,
+        children: Vec<(&TransformChild<D>, Self::Value)>,
+    ) -> Result<Self::Value, Self::Error>;
+}
+
+impl<D: TransformDirection> TransformNode<D> {
+    /// Run `lowerer` over this node and everything below it, children before
+    /// parents and in declaration order.
+    pub fn lower<L: TransformLowerer<D>>(&self, lowerer: &mut L) -> Result<L::Value, L::Error> {
+        match &self.kind {
+            TransformKind::Leaf(op) => lowerer.leaf(self, op),
+            TransformKind::Product { op, children } => {
+                let mut lowered = Vec::with_capacity(children.len());
+                for child in children {
+                    let value = child.node.lower(lowerer)?;
+                    lowered.push((child, value));
+                }
+                lowerer.product(self, op, lowered)
+            }
+        }
+    }
+}

--- a/prebindgen-registry/src/transform.rs
+++ b/prebindgen-registry/src/transform.rs
@@ -1,17 +1,25 @@
 //! The one recursive mechanism both boundary directions share.
 //!
 //! A **transformation tree** describes what happens at ONE boundary use: how a
-//! Rust value is taken apart into the values that cross ([`OutOfRust`](crate::unfold::OutOfRust)), or how
-//! the values that cross are put back together into a Rust one (`IntoRust`, not
-//! migrated yet — see #442). It is not a second type model: every node names
-//! its [`TypeRef`](prebindgen_flat::flat::TypeRef), which stays the authoritative reading.
+//! Rust value is taken apart into the values that cross
+//! ([`OutOfRust`](crate::unfold::OutOfRust)), or how the values that cross are
+//! put back together into a Rust one
+//! ([`IntoRust`](crate::expand::IntoRust)). It is not a second type model:
+//! every node names its [`TypeRef`](prebindgen_flat::flat::TypeRef), which
+//! stays the authoritative reading.
 //!
 //! The tree is generic over its **direction** so the recursion, the child
 //! ordering and the traversal are written once. Only the payloads differ:
 //! [`TransformDirection::Leaf`] says what one crossing value is, `Product` says
-//! how a node's children are obtained, and `Link` says how one child hangs off
-//! its parent. A language adapter supplies node-level policy through
-//! [`TransformLowerer`] and never writes the walk itself.
+//! how a node's children combine, `Choice` says how one of them is selected,
+//! and `Link` says how one child hangs off its parent. A language adapter
+//! supplies node-level policy through [`TransformLowerer`] and never writes the
+//! walk itself.
+//!
+//! A direction that has no use for a kind gives its payload an uninhabited
+//! type, and the kind is then unconstructible for that direction: decomposition
+//! has no `Choice`, so `OutOfRust::Choice` is
+//! [`Infallible`](std::convert::Infallible).
 //!
 //! The flat views the plans still expose — a leaf vector, a hoist list — are
 //! **derived** by lowering the tree ([`crate::unfold::UnfoldPlan::leaves`] is
@@ -27,7 +35,9 @@ pub trait TransformDirection {
     /// A node whose children **all** contribute — a deterministic product
     /// (a deconstructor's records, a constructor's arguments).
     type Product;
-    /// How one child is reached from its parent's value.
+    /// A node where **exactly one** child runs — a constructor dispatch.
+    type Choice;
+    /// How one child hangs off its parent.
     type Link;
 }
 
@@ -43,11 +53,10 @@ pub struct TransformNode<D: TransformDirection> {
 
 /// What a [`TransformNode`] does.
 ///
-/// `Optional` / `Sequence` / `Choice` nodes are the remaining structural kinds
-/// (#442): today the outer `Option` / `Vec` layers live on the plans' own
-/// [`Shape`](prebindgen_flat::shape::Shape) and the choice payloads belong to
-/// the not-yet-migrated input direction, so adding those variants here would
-/// add arms nothing produces.
+/// `Optional` and `Sequence` are the remaining structural kinds (#442): the
+/// outer `Option` / `Vec` layers still live on the plans' own
+/// [`Shape`](prebindgen_flat::shape::Shape), so adding those variants here
+/// would add arms nothing produces.
 pub enum TransformKind<D: TransformDirection> {
     /// A value that crosses as it is.
     Leaf(D::Leaf),
@@ -55,6 +64,13 @@ pub enum TransformKind<D: TransformDirection> {
     Product {
         op: D::Product,
         children: Vec<TransformChild<D>>,
+    },
+    /// Exactly one child runs — which one is `op`'s business. The children's
+    /// [links](TransformChild::link) carry nothing: an alternative is named by
+    /// its position, not by how it hangs off the choice.
+    Choice {
+        op: D::Choice,
+        variants: Vec<TransformChild<D>>,
     },
 }
 
@@ -65,6 +81,10 @@ pub struct TransformChild<D: TransformDirection> {
     /// The child itself.
     pub node: TransformNode<D>,
 }
+
+/// One node's already lowered children, each paired with the
+/// [`TransformChild`] it came from.
+pub type Lowered<'a, D, V> = Vec<(&'a TransformChild<D>, V)>;
 
 /// Node-level policy for one traversal of a tree: the caller says what a leaf
 /// and a product *mean*, the tree supplies the recursion and the order.
@@ -91,7 +111,19 @@ pub trait TransformLowerer<D: TransformDirection> {
         &mut self,
         node: &TransformNode<D>,
         op: &D::Product,
-        children: Vec<(&TransformChild<D>, Self::Value)>,
+        children: Lowered<'_, D, Self::Value>,
+    ) -> Result<Self::Value, Self::Error>;
+
+    /// Select between the already lowered alternatives of a choice, in
+    /// declaration order — which is also selector order.
+    ///
+    /// A direction whose `Choice` payload is uninhabited discharges this with
+    /// `match *op {}`: the kind cannot occur, so there is nothing to write.
+    fn choice(
+        &mut self,
+        node: &TransformNode<D>,
+        op: &D::Choice,
+        variants: Lowered<'_, D, Self::Value>,
     ) -> Result<Self::Value, Self::Error>;
 }
 
@@ -102,13 +134,26 @@ impl<D: TransformDirection> TransformNode<D> {
         match &self.kind {
             TransformKind::Leaf(op) => lowerer.leaf(self, op),
             TransformKind::Product { op, children } => {
-                let mut lowered = Vec::with_capacity(children.len());
-                for child in children {
-                    let value = child.node.lower(lowerer)?;
-                    lowered.push((child, value));
-                }
+                let lowered = lower_all(children, lowerer)?;
                 lowerer.product(self, op, lowered)
+            }
+            TransformKind::Choice { op, variants } => {
+                let lowered = lower_all(variants, lowerer)?;
+                lowerer.choice(self, op, lowered)
             }
         }
     }
+}
+
+/// Lower each child in order, keeping it paired with the child it came from.
+fn lower_all<'a, D: TransformDirection, L: TransformLowerer<D>>(
+    children: &'a [TransformChild<D>],
+    lowerer: &mut L,
+) -> Result<Lowered<'a, D, L::Value>, L::Error> {
+    let mut lowered = Vec::with_capacity(children.len());
+    for child in children {
+        let value = child.node.lower(lowerer)?;
+        lowered.push((child, value));
+    }
+    Ok(lowered)
 }

--- a/prebindgen-registry/src/transform.rs
+++ b/prebindgen-registry/src/transform.rs
@@ -37,6 +37,10 @@ pub trait TransformDirection {
     type Product;
     /// A node where **exactly one** child runs — a constructor dispatch.
     type Choice;
+    /// An `Option<…>` layer over one inner node.
+    type Optional;
+    /// A run of one inner node.
+    type Sequence;
     /// How one child hangs off its parent.
     type Link;
 }
@@ -52,11 +56,6 @@ pub struct TransformNode<D: TransformDirection> {
 }
 
 /// What a [`TransformNode`] does.
-///
-/// `Optional` and `Sequence` are the remaining structural kinds (#442): the
-/// outer `Option` / `Vec` layers still live on the plans' own
-/// [`Shape`](prebindgen_flat::shape::Shape), so adding those variants here
-/// would add arms nothing produces.
 pub enum TransformKind<D: TransformDirection> {
     /// A value that crosses as it is.
     Leaf(D::Leaf),
@@ -71,6 +70,16 @@ pub enum TransformKind<D: TransformDirection> {
     Choice {
         op: D::Choice,
         variants: Vec<TransformChild<D>>,
+    },
+    /// `Option<…>` over `inner`: absent, or `inner`.
+    Optional {
+        op: D::Optional,
+        inner: Box<TransformNode<D>>,
+    },
+    /// A run of `inner`s.
+    Sequence {
+        op: D::Sequence,
+        inner: Box<TransformNode<D>>,
     },
 }
 
@@ -125,6 +134,26 @@ pub trait TransformLowerer<D: TransformDirection> {
         op: &D::Choice,
         variants: Lowered<'_, D, Self::Value>,
     ) -> Result<Self::Value, Self::Error>;
+
+    /// Lift the already lowered `inner` over an `Option<…>` layer. `inner` is
+    /// handed over as well as its value, for a rule that turns on what kind of
+    /// node sits under the layer.
+    fn optional(
+        &mut self,
+        node: &TransformNode<D>,
+        op: &D::Optional,
+        inner: &TransformNode<D>,
+        value: Self::Value,
+    ) -> Result<Self::Value, Self::Error>;
+
+    /// Lift the already lowered `inner` over a run of it.
+    fn sequence(
+        &mut self,
+        node: &TransformNode<D>,
+        op: &D::Sequence,
+        inner: &TransformNode<D>,
+        value: Self::Value,
+    ) -> Result<Self::Value, Self::Error>;
 }
 
 impl<D: TransformDirection> TransformNode<D> {
@@ -140,6 +169,14 @@ impl<D: TransformDirection> TransformNode<D> {
             TransformKind::Choice { op, variants } => {
                 let lowered = lower_all(variants, lowerer)?;
                 lowerer.choice(self, op, lowered)
+            }
+            TransformKind::Optional { op, inner } => {
+                let value = inner.lower(lowerer)?;
+                lowerer.optional(self, op, inner, value)
+            }
+            TransformKind::Sequence { op, inner } => {
+                let value = inner.lower(lowerer)?;
+                lowerer.sequence(self, op, inner, value)
             }
         }
     }

--- a/prebindgen-registry/src/unfold.rs
+++ b/prebindgen-registry/src/unfold.rs
@@ -1047,6 +1047,7 @@ fn process_decl<M>(
                     .map(|(_, e)| e.clone())
                     .ok_or_else(|| UnfoldError::Unsupported {
                         func: ed.func.clone(),
+                        at: node_path(&[]),
                         reason: "convert_error/deconstruct_error on a non-Result return",
                     })?
             }
@@ -1077,6 +1078,7 @@ fn process_decl<M>(
             if inner.optional_inner().is_some() {
                 return Err(UnfoldError::Unsupported {
                     func: ed.func.clone(),
+                    at: node_path(&[]),
                     reason: "Vec<Option<…>> returns",
                 });
             }
@@ -1397,6 +1399,7 @@ fn flatten<M>(
                 if seen_identity {
                     return Err(UnfoldError::MultipleIdentity {
                         target: source_key.to_string(),
+                        at: node_path(path_prefix),
                     });
                 }
                 seen_identity = true;
@@ -1449,6 +1452,7 @@ fn flatten<M>(
                 if consuming != accessor_consumes(registry, func) {
                     return Err(UnfoldError::Unsupported {
                         func: func.clone(),
+                        at: node_path(path_prefix),
                         reason: if consuming {
                             "declared as a CONSUMING value form (`.fields_self_into(..)`) but the \
                              accessor borrows its receiver — declare it with `.fields(..)`, or \
@@ -1482,6 +1486,7 @@ fn flatten<M>(
                 {
                     return Err(UnfoldError::Unsupported {
                         func: func.clone(),
+                        at: node_path(&root_path),
                         reason: "a value form nested under another one that is reached through \
                                  `Option` — conditional hoists do not nest",
                     });
@@ -1498,6 +1503,7 @@ fn flatten<M>(
                 if consuming && records.len() > 1 {
                     return Err(UnfoldError::Unsupported {
                         func: func.clone(),
+                        at: node_path(&root_path),
                         reason: "a consuming value form must be the only record of its \
                                  declaration — it moves the value, so `.field_self()` or \
                                  a sibling `.field()` would read a moved value",
@@ -1540,6 +1546,7 @@ fn flatten<M>(
                             Some(_) => {
                                 return Err(UnfoldError::Cycle {
                                     target: child_key.to_string(),
+                                    at: node_path(&root_path),
                                 });
                             }
                             None => None,
@@ -1684,6 +1691,7 @@ fn flatten<M>(
                     Some(_) => {
                         return Err(UnfoldError::Cycle {
                             target: child_key.to_string(),
+                            at: node_path(path_prefix),
                         });
                     }
                     None => None,
@@ -1738,6 +1746,7 @@ fn flatten<M>(
                         if seen_identity {
                             return Err(UnfoldError::MultipleIdentity {
                                 target: source_key.to_string(),
+                                at: node_path(path_prefix),
                             });
                         }
                         seen_identity = true;
@@ -1810,6 +1819,25 @@ fn build_tree<M>(
             children,
         },
     })
+}
+
+/// Where a node sits in a decomposition, for a diagnostic: the access chain
+/// from the returned value, `value` at the root. An accessor call reads `f()`
+/// and an `Option`-returning step keeps its `?`, so the reader sees the same
+/// reach the generated code takes.
+fn node_path(steps: &[PathStep]) -> String {
+    let mut out = String::from("value");
+    for step in steps {
+        out.push('.');
+        out.push_str(&step.ident().to_string());
+        if !step.is_field() {
+            out.push_str("()");
+        }
+        if step.is_optional() {
+            out.push('?');
+        }
+    }
+    out
 }
 
 /// Error if two leaves of one flattened deconstructor share a name. Author leaf

--- a/prebindgen-registry/src/unfold.rs
+++ b/prebindgen-registry/src/unfold.rs
@@ -47,7 +47,6 @@ pub use self::{
         OutOfRust, OutProduct,
     },
 };
-
 use crate::transform::TransformKind;
 
 // ──────────────────────────────────────────────────────────────────────

--- a/prebindgen-registry/src/unfold.rs
+++ b/prebindgen-registry/src/unfold.rs
@@ -42,7 +42,10 @@ pub use self::{
         steps_are_movable, DeconId, DeconSpec, Hoist, LeafSource, PathStep, UnfoldLeaf, UnfoldPlan,
         UnfoldShape,
     },
-    tree::{flat_tree, flat_view, OutChild, OutLeaf, OutLink, OutNode, OutOfRust, OutProduct},
+    tree::{
+        element_of, flat_tree, flat_view, shape_of, shaped, OutChild, OutLeaf, OutLink, OutNode,
+        OutOfRust, OutProduct,
+    },
 };
 
 use crate::transform::TransformKind;
@@ -461,6 +464,7 @@ pub(crate) fn apply<M>(
                     by_ref,
                     core_ty,
                     UnfoldShape::Base,
+                    &[],
                     &records,
                     decon,
                 )?;
@@ -678,14 +682,18 @@ fn wire_fixed_returns<M>(
             }
         }
         register_leaves(registry, &vd.leaves);
+        // `layer_types` ends at the core the shape stops on, so the layers are
+        // everything before it.
+        let layer_tys = &layers.layer_types[..layers.layer_types.len() - 1];
+        let tree = shaped(&shape, layer_tys, flat_tree(&vd.source, &vd.leaves));
         let plan = UnfoldPlan {
             source: vd.source.clone(),
             decon: Some(decon.clone()),
             by_ref,
-            shape,
-            tree: std::rc::Rc::new(flat_tree(&vd.source, &vd.leaves)),
+            shape: shape_of(&tree),
+            element: element_of(&tree).cloned(),
+            tree: std::rc::Rc::new(tree),
             leaves: vd.leaves.clone(),
-            element: None,
             delivery: Delivery::Callback,
             convert_out_ty: None,
             fixed_builder: true,
@@ -729,12 +737,15 @@ fn wire_fixed_callbacks<M>(
                 // A run of `T` is an Iterable fold over the element; anything else
                 // is a Base fold over the value itself. `Sequence` is the one
                 // question, and it covers `[T]` and `Vec<T>` alike.
-                let (shape, matches_key) = match after_ref.sequence_elem() {
+                let (shape, layer_tys, matches_key) = match after_ref.sequence_elem() {
                     Some(elem) => (
                         UnfoldShape::Iterable(Box::new(UnfoldShape::Base)),
+                        // The run itself, past the borrow the shape was read
+                        // through.
+                        vec![after_ref.clone()],
                         elem.key() == vd.key,
                     ),
-                    None => (UnfoldShape::Base, after_ref.key() == vd.key),
+                    None => (UnfoldShape::Base, Vec::new(), after_ref.key() == vd.key),
                 };
                 if !matches_key {
                     continue;
@@ -744,14 +755,15 @@ fn wire_fixed_callbacks<M>(
                     continue;
                 }
                 register_leaves(registry, &vd.leaves);
+                let tree = shaped(&shape, &layer_tys, flat_tree(&vd.source, &vd.leaves));
                 let plan = UnfoldPlan {
                     source: vd.source.clone(),
                     decon: Some(decon.clone()),
                     by_ref,
-                    shape,
-                    tree: std::rc::Rc::new(flat_tree(&vd.source, &vd.leaves)),
+                    shape: shape_of(&tree),
+                    element: element_of(&tree).cloned(),
+                    tree: std::rc::Rc::new(tree),
                     leaves: vd.leaves.clone(),
-                    element: None,
                     delivery: Delivery::Callback,
                     convert_out_ty: None,
                     fixed_builder: true,
@@ -807,10 +819,15 @@ pub(crate) fn apply_leaf_vec_folds<M>(
                 let bare = peel_borrow(vec_elem).1;
                 if is_nominated(bare) {
                     let inner_shape = UnfoldShape::Iterable(Box::new(UnfoldShape::Base));
-                    let shape = if optional {
-                        UnfoldShape::Optional((), Box::new(inner_shape))
+                    // The types the layers wrap, outermost first: the declared
+                    // return, and under an `Option` the `Vec` inside it.
+                    let (shape, layer_tys) = if optional {
+                        (
+                            UnfoldShape::Optional((), Box::new(inner_shape)),
+                            vec![ret.clone(), after_opt.clone()],
+                        )
                     } else {
-                        inner_shape
+                        (inner_shape, vec![ret.clone()])
                     };
                     registry.require_output(vec_elem);
                     // The fold delivers the return element-by-element, so the
@@ -821,9 +838,10 @@ pub(crate) fn apply_leaf_vec_folds<M>(
                     // JObject-shaped), and de-requiring keeps that `None` from
                     // being flagged as an unresolved-required error.
                     registry.unrequire_output(&ret);
-                    registry
-                        .unfold_plans
-                        .insert(func.clone(), whole_leaf_fold_plan(vec_elem, shape));
+                    registry.unfold_plans.insert(
+                        func.clone(),
+                        whole_leaf_fold_plan(vec_elem, shape, &layer_tys),
+                    );
                 }
             }
         }
@@ -848,8 +866,13 @@ pub(crate) fn apply_leaf_vec_folds<M>(
                     continue;
                 }
                 registry.require_output(elem);
-                let plan =
-                    whole_leaf_fold_plan(elem, UnfoldShape::Iterable(Box::new(UnfoldShape::Base)));
+                let plan = whole_leaf_fold_plan(
+                    elem,
+                    UnfoldShape::Iterable(Box::new(UnfoldShape::Base)),
+                    // The run itself, past the borrow the shape was read
+                    // through.
+                    std::slice::from_ref(after_ref),
+                );
                 registry.callback_arg_plans.insert(key, plan);
             }
         }
@@ -863,17 +886,31 @@ pub(crate) fn apply_leaf_vec_folds<M>(
 fn whole_leaf_fold_plan(
     vec_elem: &prebindgen_flat::flat::TypeRef,
     shape: UnfoldShape,
+    layer_tys: &[prebindgen_flat::flat::TypeRef],
 ) -> UnfoldPlan {
+    // Nothing is taken apart: a bare leaf under the run IS the whole element,
+    // crossing through its own output converter.
+    let tree = shaped(
+        &shape,
+        layer_tys,
+        OutNode {
+            ty: vec_elem.clone(),
+            kind: TransformKind::Leaf(OutLeaf {
+                nullable: false,
+                identity: false,
+                source: LeafSource::Accessor,
+                group: None,
+            }),
+        },
+    );
     UnfoldPlan {
         source: vec_elem.clone(),
         decon: None,
         by_ref: peel_borrow(vec_elem).0,
-        shape,
-        // Nothing is taken apart: the element crosses whole through its own
-        // converter (see `element`), so the tree is an empty decomposition.
-        tree: std::rc::Rc::new(flat_tree(vec_elem, &[])),
+        shape: shape_of(&tree),
+        element: element_of(&tree).cloned(),
+        tree: std::rc::Rc::new(tree),
         leaves: vec![],
-        element: Some(vec_elem.clone()),
         delivery: Delivery::Callback,
         convert_out_ty: None,
         fixed_builder: true,
@@ -1044,10 +1081,15 @@ fn process_decl<M>(
                 });
             }
             let iterable = UnfoldShape::Iterable(Box::new(UnfoldShape::Base));
-            let shape = if optional {
-                UnfoldShape::Optional((), Box::new(iterable))
+            // The types the layers wrap, outermost first: the declared return,
+            // and under an `Option` the `Vec` inside it.
+            let (shape, layer_tys) = if optional {
+                (
+                    UnfoldShape::Optional((), Box::new(iterable)),
+                    vec![ret_ty.clone(), after_opt.clone()],
+                )
             } else {
-                iterable
+                (iterable, vec![ret_ty.clone()])
             };
             // The fold delivers the return element-by-element, so the
             // whole-collection converter is not needed — and for an
@@ -1070,7 +1112,9 @@ fn process_decl<M>(
                 let records = d.records.clone();
                 let decon = decl_id(&ekey, d);
                 register_decon_spec(registry, acc, &decon, &records, element)?;
-                let plan = build_plan(acc, registry, ed, by_ref, element, shape, &records, decon)?;
+                let plan = build_plan(
+                    acc, registry, ed, by_ref, element, shape, &layer_tys, &records, decon,
+                )?;
                 for leaf in &plan.leaves {
                     registry.require_output(&leaf.out_ty);
                 }
@@ -1082,42 +1126,43 @@ fn process_decl<M>(
                 // crosses whole through its own converter.
                 let by_ref = peel_borrow(inner).0;
                 registry.require_output(inner);
-                UnfoldPlan {
-                    source: inner.clone(),
-                    decon: None,
-                    by_ref,
-                    shape,
-                    tree: std::rc::Rc::new(flat_tree(inner, &[])),
-                    leaves: vec![],
-                    element: Some(inner.clone()),
-                    delivery: ed.delivery,
-                    convert_out_ty: None,
-                    fixed_builder: false,
-                    hoists: Vec::new(),
-                }
+                let mut plan = whole_leaf_fold_plan(inner, shape, &layer_tys);
+                plan.by_ref = by_ref;
+                plan.delivery = ed.delivery;
+                plan.fixed_builder = false;
+                plan
             }
         } else {
             // Scalar/decomposed arm. The `Option` peel already happened above
             // for `Output` (exactly one layer — `Option<Option<…>>` is NOT
             // re-peeled and fails as "no deconstructor" for the inner
             // `Option`); for `Error` it happens here, unchanged.
-            let (optional, core_ty) = match ed.target {
-                DeconTarget::Output => (optional, after_opt),
+            // `opt_ty` is the type the `Option` layer wraps — the declared
+            // return for an output, the error type for an error target.
+            let (optional, core_ty, opt_ty) = match ed.target {
+                DeconTarget::Output => (optional, after_opt, &ret_ty),
                 DeconTarget::Error => match after_opt.optional_inner() {
-                    Some(inner) => (true, inner),
-                    None => (false, after_opt),
+                    Some(inner) => (true, inner, after_opt),
+                    None => (false, after_opt, after_opt),
                 },
             };
             let (by_ref, source) = peel_borrow(core_ty);
             let source_key = source.key();
-            let shape = if optional {
-                UnfoldShape::Optional((), Box::new(UnfoldShape::Base))
+            // The `Option` layer wraps the type it was peeled from, which for
+            // an error target may be the inner one rather than the return.
+            let (shape, layer_tys) = if optional {
+                (
+                    UnfoldShape::Optional((), Box::new(UnfoldShape::Base)),
+                    vec![opt_ty.clone()],
+                )
             } else {
-                UnfoldShape::Base
+                (UnfoldShape::Base, Vec::new())
             };
             let (records, decon) = resolve_deconstructor(acc, &source_key, ed)?;
             register_decon_spec(registry, acc, &decon, &records, source)?;
-            let plan = build_plan(acc, registry, ed, by_ref, source, shape, &records, decon)?;
+            let plan = build_plan(
+                acc, registry, ed, by_ref, source, shape, &layer_tys, &records, decon,
+            )?;
             for leaf in &plan.leaves {
                 registry.require_output(&leaf.out_ty);
             }
@@ -1253,10 +1298,12 @@ fn build_plan<M>(
     by_ref: bool,
     source: &prebindgen_flat::flat::TypeRef,
     shape: UnfoldShape,
+    layer_tys: &[prebindgen_flat::flat::TypeRef],
     records: &[DeconRecord],
     decon: DeconId,
 ) -> Result<UnfoldPlan, UnfoldError> {
-    let tree = build_tree(acc, registry, records, source, by_ref)?;
+    let core = build_tree(acc, registry, records, source, by_ref)?;
+    let tree = shaped(&shape, layer_tys, core);
     let (leaves, hoists) = flat_view(&tree);
     require_unique_leaf_names(source, &leaves)?;
     require_root_identity_last(by_ref, source, &leaves)?;
@@ -1265,10 +1312,10 @@ fn build_plan<M>(
         source: source.clone(),
         decon: Some(decon),
         by_ref,
-        shape,
+        shape: shape_of(&tree),
+        element: element_of(&tree).cloned(),
         tree: std::rc::Rc::new(tree),
         leaves,
-        element: None,
         delivery: ed.delivery,
         convert_out_ty: None,
         fixed_builder: false,

--- a/prebindgen-registry/src/unfold.rs
+++ b/prebindgen-registry/src/unfold.rs
@@ -34,6 +34,7 @@ use crate::{
 
 mod error;
 mod plan;
+mod tree;
 
 pub use self::{
     error::{UnfoldDeclError, UnfoldError},
@@ -41,7 +42,10 @@ pub use self::{
         steps_are_movable, DeconId, DeconSpec, Hoist, LeafSource, PathStep, UnfoldLeaf, UnfoldPlan,
         UnfoldShape,
     },
+    tree::{flat_tree, flat_view, OutChild, OutLeaf, OutLink, OutNode, OutOfRust, OutProduct},
 };
+
+use crate::transform::TransformKind;
 
 // ──────────────────────────────────────────────────────────────────────
 // Declarations (populated by the language builder)
@@ -679,6 +683,7 @@ fn wire_fixed_returns<M>(
             decon: Some(decon.clone()),
             by_ref,
             shape,
+            tree: std::rc::Rc::new(flat_tree(&vd.source, &vd.leaves)),
             leaves: vd.leaves.clone(),
             element: None,
             delivery: Delivery::Callback,
@@ -744,6 +749,7 @@ fn wire_fixed_callbacks<M>(
                     decon: Some(decon.clone()),
                     by_ref,
                     shape,
+                    tree: std::rc::Rc::new(flat_tree(&vd.source, &vd.leaves)),
                     leaves: vd.leaves.clone(),
                     element: None,
                     delivery: Delivery::Callback,
@@ -863,6 +869,9 @@ fn whole_leaf_fold_plan(
         decon: None,
         by_ref: peel_borrow(vec_elem).0,
         shape,
+        // Nothing is taken apart: the element crosses whole through its own
+        // converter (see `element`), so the tree is an empty decomposition.
+        tree: std::rc::Rc::new(flat_tree(vec_elem, &[])),
         leaves: vec![],
         element: Some(vec_elem.clone()),
         delivery: Delivery::Callback,
@@ -1078,6 +1087,7 @@ fn process_decl<M>(
                     decon: None,
                     by_ref,
                     shape,
+                    tree: std::rc::Rc::new(flat_tree(inner, &[])),
                     leaves: vec![],
                     element: Some(inner.clone()),
                     delivery: ed.delivery,
@@ -1185,24 +1195,9 @@ fn register_decon_spec<M>(
     if registry.decon_plans.contains_key(decon) {
         return Ok(());
     }
-    let mut leaves: Vec<UnfoldLeaf> = Vec::new();
-    let mut visited: HashSet<TypeKey> = HashSet::new();
-    visited.insert(source.key());
-    flatten(
-        acc,
-        registry,
-        records,
-        source,
-        &[],
-        &[],
-        true,
-        false,
-        &mut visited,
-        &mut leaves,
-        // A `DeconSpec` describes the leaf list only — signature artifacts are
-        // derived from it, never emitted code — so its hoists are discarded.
-        &mut Vec::new(),
-    )?;
+    // A `DeconSpec` describes the leaf list only — signature artifacts are
+    // derived from it, never emitted code — so the tree's hoists are dropped.
+    let (leaves, _) = flat_view(&build_tree(acc, registry, records, source, true)?);
     require_unique_leaf_names(source, &leaves)?;
     registry.decon_plans.insert(
         decon.clone(),
@@ -1261,23 +1256,8 @@ fn build_plan<M>(
     records: &[DeconRecord],
     decon: DeconId,
 ) -> Result<UnfoldPlan, UnfoldError> {
-    let mut leaves: Vec<UnfoldLeaf> = Vec::new();
-    let mut visited: HashSet<TypeKey> = HashSet::new();
-    visited.insert(source.key());
-    let mut hoists: Vec<Hoist> = Vec::new();
-    flatten(
-        acc,
-        registry,
-        records,
-        source,
-        &[],
-        &[],
-        by_ref,
-        false,
-        &mut visited,
-        &mut leaves,
-        &mut hoists,
-    )?;
+    let tree = build_tree(acc, registry, records, source, by_ref)?;
+    let (leaves, hoists) = flat_view(&tree);
     require_unique_leaf_names(source, &leaves)?;
     require_root_identity_last(by_ref, source, &leaves)?;
 
@@ -1286,6 +1266,7 @@ fn build_plan<M>(
         decon: Some(decon),
         by_ref,
         shape,
+        tree: std::rc::Rc::new(tree),
         leaves,
         element: None,
         delivery: ed.delivery,
@@ -1324,21 +1305,28 @@ fn require_root_identity_last(
     Ok(())
 }
 
-/// Recursively flatten an accessor's records into [`UnfoldLeaf`]s.
+/// Recursively read an accessor's records into the children of one
+/// [out-of-Rust product node](OutProduct::Records).
+///
+/// The leaf list the plans expose is [derived](flat_view) from what this
+/// builds — names, access paths and nullability all live on the links, so this
+/// walk states each level once instead of carrying an accumulated copy of
+/// everything above it.
 ///
 /// * `source` — the type whose accessor `records` belong to (the root
 ///   on the first call, a nested child type on recursion).
 /// * `path_prefix` — accessor chain from the root value to `source` (empty at
 ///   the root; `[…, nesting_accessor]` when recursing into a nested child).
+///   Only [`place_is_owned`] reads it; the emitted paths come from the links.
 /// * `by_ref` — the top-level return/element borrow-ness. The identity leaf is
 ///   **owned** (`source`) only at the root of an owned value (`path_prefix`
 ///   empty && `!by_ref`) — a `Copy` value delivers itself by copy and an
 ///   opaque handle moves; everywhere else it is **borrowed** (`&source`,
 ///   cloned).
-/// * `nullable` — `true` once any nesting accessor on the path returned
-///   `Option` (the reached value may be absent ⇒ the leaf is `null`).
 /// * `visited` — type keys on the current nesting chain (cycle guard; entries
 ///   are removed after each nested recursion so sibling records may reuse a type).
+/// * `hoists` — the value forms bound so far, the input to [`place_is_owned`].
+///   The plan's own hoist list is derived from the tree, not from this.
 #[allow(clippy::too_many_arguments)]
 fn flatten<M>(
     acc: &Deconstructors,
@@ -1346,21 +1334,12 @@ fn flatten<M>(
     records: &[DeconRecord],
     source: &prebindgen_flat::flat::TypeRef,
     path_prefix: &[PathStep],
-    name_prefix: &[String],
     by_ref: bool,
-    nullable: bool,
     visited: &mut HashSet<TypeKey>,
-    leaves: &mut Vec<UnfoldLeaf>,
     hoists: &mut Vec<Hoist>,
-) -> Result<(), UnfoldError> {
+) -> Result<Vec<OutChild>, UnfoldError> {
     let source_key = source.key();
-    // The author-supplied (literal) leaf-name segment at this level, appended
-    // to the inherited chain prefix. Segments are joined with `"__"`.
-    let seg_name = |name: &str| -> Vec<String> {
-        let mut v = name_prefix.to_vec();
-        v.push(name.to_string());
-        v
-    };
+    let mut children: Vec<OutChild> = Vec::new();
     // Identity uniqueness is per accessor (one move/clone of the value
     // at this level); nested levels each get their own identity budget.
     let mut seen_identity = false;
@@ -1382,9 +1361,6 @@ fn flatten<M>(
                 // + projection come from this `out_ty`'s output converter, so
                 // this is what decides whether the leaf is boxed by move or
                 // cloned through the borrowed-opaque one.
-                // A plan field: the drop to spelling happens here, where the value
-                // is stored for emission, and the borrowed form is composed rather
-                // than looked up because no source wrote it.
                 // The borrowed form is COMPOSED — no source wrote it — and the
                 // composition pairs the kind with its own spelling, so nothing
                 // downstream has to look either up.
@@ -1393,19 +1369,20 @@ fn flatten<M>(
                 } else {
                     source.borrowed()
                 };
-                leaves.push(UnfoldLeaf {
-                    name: if path_prefix.is_empty() {
-                        "handle".to_string()
-                    } else {
-                        name_prefix.join("__")
-                    },
-                    path: path_prefix.to_vec(),
+                // The identity names nothing of its own: it IS the value at the
+                // level it sits on, so it takes that level's name chain (and
+                // `"handle"` at the root, where there is none).
+                children.push(leaf_child(
+                    Vec::new(),
+                    Vec::new(),
                     out_ty,
-                    identity: true,
-                    nullable,
-                    source: LeafSource::Accessor,
-                    group: None,
-                });
+                    OutLeaf {
+                        nullable: false,
+                        identity: true,
+                        source: LeafSource::Accessor,
+                        group: None,
+                    },
+                ));
             }
             DeconRecord::Fields {
                 func,
@@ -1416,7 +1393,7 @@ fn flatten<M>(
                 // The value form is called once; every field hangs off that one
                 // call, so the whole record shares a single `Call` step and the
                 // emitter can hoist it.
-                accessor_signature(registry, func, &source.key())?;
+                let form_ty = accessor_signature(registry, func, &source.key())?;
                 // The declarator states whether the value is given away; the
                 // signature has to agree, or the emitted call would not compile
                 // in the consumer's crate. Checked rather than inferred so that
@@ -1436,17 +1413,18 @@ fn flatten<M>(
                         },
                     });
                 }
+                let form_step = PathStep::call(func.clone(), false, false);
                 let mut root_path = path_prefix.to_vec();
-                root_path.push(PathStep::call(func.clone(), false, false));
+                root_path.push(form_step.clone());
                 // A hoist below an optional step is CONDITIONAL: it binds an
                 // `Option<TStruct>` local (built only in the `Some` arm) and
                 // every leaf under it is null when the value is absent — which
-                // is the nullability `flatten` already propagates down here.
-                // What it cannot do is nest: composing a second hoist off a
-                // conditional one would have to reach through the outer
-                // `Option`, and the binder has no arm to put that in. One level
-                // is the shape real bindings need (`Option<&Sample>` delivering
-                // a sample's value form), so implement that and name the rest.
+                // is the nullability the links already carry. What it cannot do
+                // is nest: composing a second hoist off a conditional one would
+                // have to reach through the outer `Option`, and the binder has
+                // no arm to put that in. One level is the shape real bindings
+                // need (`Option<&Sample>` delivering a sample's value form), so
+                // implement that and name the rest.
                 //
                 // A top-level `Option<T>` is represented by
                 // `UnfoldShape::Optional`, not by a path step, and is unaffected.
@@ -1478,17 +1456,16 @@ fn flatten<M>(
                                  a sibling `.field()` would read a moved value",
                     });
                 }
-                // Evaluate this value form ONCE. Recorded at the prefix it sits
-                // at rather than as a lone accessor, so a nested value form
-                // (this record reached through another one's field) gets its own
-                // hoist instead of being rebuilt per child leaf. `path_prefix`
-                // grows as `flatten` descends, so the list comes out
-                // outermost-first.
+                // Evaluate this value form ONCE. The node is what says so — the
+                // derived view turns it into the [`Hoist`] at its own path — and
+                // this local copy is what [`place_is_owned`] consults while the
+                // walk is still running.
                 hoists.push(Hoist {
                     prefix: root_path.clone(),
                     consuming,
                 });
 
+                let mut form_children: Vec<OutChild> = Vec::new();
                 for fr in fields {
                     // The declaration carries the field's reading, so nothing is
                     // looked up and nothing is re-classified.
@@ -1529,68 +1506,103 @@ fn flatten<M>(
                     // the whole `Option<F>` is what the converter takes — the
                     // same rule that makes a terminal accessor's `Option` ride
                     // its converter instead of being unwrapped.
-                    let mut field_path = root_path.clone();
                     let (last, lead) = fr
                         .members
                         .split_last()
                         .expect("a field record addresses at least one member");
                     // Only the LAST member can be optional — an inlined nested
                     // class is reached directly, never through an `Option`.
-                    field_path.extend(lead.iter().map(|m| PathStep::field(m.clone(), false)));
-                    field_path.push(PathStep::field(last.clone(), opt && decomposed));
+                    let mut field_steps: Vec<PathStep> = lead
+                        .iter()
+                        .map(|m| PathStep::field(m.clone(), false))
+                        .collect();
+                    field_steps.push(PathStep::field(last.clone(), opt && decomposed));
 
-                    // Adapter-built leaves: rebase each onto this field's path
-                    // and name. Their internal structure (a selector plus its
-                    // groups) is opaque here and passes through untouched.
+                    // Adapter-built leaves: hang each off this field's link and
+                    // name. Their internal structure (a selector plus its
+                    // groups) is opaque here and passes through untouched — the
+                    // field's own `Option` rides each leaf, since the leaves are
+                    // where this level ends.
                     if let FieldDecon::Leaves(built) = &fr.decon {
                         for l in built {
-                            let mut path = field_path.clone();
-                            path.extend(l.path.iter().cloned());
-                            let mut name = seg_name(&fr.name);
-                            name.push(l.name.clone());
-                            leaves.push(UnfoldLeaf {
-                                name: name.join("__"),
-                                path,
-                                nullable: l.nullable || nullable || opt,
-                                ..l.clone()
-                            });
+                            let mut steps = field_steps.clone();
+                            steps.extend(l.path.iter().cloned());
+                            form_children.push(leaf_child(
+                                steps,
+                                vec![fr.name.clone(), l.name.clone()],
+                                l.out_ty.clone(),
+                                OutLeaf {
+                                    nullable: l.nullable || opt,
+                                    identity: l.identity,
+                                    source: l.source.clone(),
+                                    group: l.group,
+                                },
+                            ));
                         }
                         continue;
                     }
 
                     if let Some(child_records) = child_records {
+                        let mut field_path = root_path.clone();
+                        field_path.extend(field_steps.iter().cloned());
                         visited.insert(child_key.clone());
-                        flatten(
+                        let grandchildren = flatten(
                             acc,
                             registry,
                             &child_records,
                             // The declaration's reading, peeled — not a new one.
                             child_ty,
                             &field_path,
-                            &seg_name(&fr.name),
                             by_ref,
-                            nullable || opt,
                             visited,
-                            leaves,
                             hoists,
                         )?;
                         visited.remove(&child_key);
+                        form_children.push(OutChild {
+                            link: OutLink {
+                                steps: field_steps,
+                                name: vec![fr.name.clone()],
+                            },
+                            node: OutNode {
+                                ty: child_ty.clone(),
+                                kind: TransformKind::Product {
+                                    op: OutProduct::Records,
+                                    children: grandchildren,
+                                },
+                            },
+                        });
                     } else {
                         // A plain field leaf: the value is CLONED out of the
                         // struct, so its converter takes the owned field type as
                         // written — `Option` and all, which is why a terminal
                         // `Option` step is not a nesting step for it.
-                        leaves.push(UnfoldLeaf {
-                            name: seg_name(&fr.name).join("__"),
-                            path: field_path,
-                            out_ty: fr.ty.clone(),
-                            identity: false,
-                            nullable,
-                            source: LeafSource::Field,
-                            group: None,
-                        });
+                        form_children.push(leaf_child(
+                            field_steps,
+                            vec![fr.name.clone()],
+                            fr.ty.clone(),
+                            OutLeaf {
+                                nullable: false,
+                                identity: false,
+                                source: LeafSource::Field,
+                                group: None,
+                            },
+                        ));
                     }
                 }
+                children.push(OutChild {
+                    link: OutLink {
+                        steps: vec![form_step],
+                        // The value form names nothing: its fields do.
+                        name: Vec::new(),
+                    },
+                    node: OutNode {
+                        ty: form_ty,
+                        kind: TransformKind::Product {
+                            op: OutProduct::ValueForm { consuming },
+                            children: form_children,
+                        },
+                    },
+                });
             }
             DeconRecord::Acc { name, .. } | DeconRecord::LocalAcc { name, .. } => {
                 // A binding-local record resolves through its synthesized
@@ -1629,25 +1641,36 @@ fn flatten<M>(
                     }
                     None => None,
                 };
+                let step = PathStep::call(func.clone(), opt, !core_by_ref);
                 if let Some(child_decl) = splice {
                     visited.insert(child_key.clone());
                     let child_records = child_decl.records.clone();
                     let mut child_path = path_prefix.to_vec();
-                    child_path.push(PathStep::call(func.clone(), opt, !core_by_ref));
-                    flatten(
+                    child_path.push(step.clone());
+                    let grandchildren = flatten(
                         acc,
                         registry,
                         &child_records,
                         child_ty,
                         &child_path,
-                        &seg_name(name),
                         by_ref,
-                        nullable || opt,
                         visited,
-                        leaves,
                         hoists,
                     )?;
                     visited.remove(&child_key);
+                    children.push(OutChild {
+                        link: OutLink {
+                            steps: vec![step],
+                            name: vec![name.clone()],
+                        },
+                        node: OutNode {
+                            ty: child_ty.clone(),
+                            kind: TransformKind::Product {
+                                op: OutProduct::Records,
+                                children: grandchildren,
+                            },
+                        },
+                    });
                 } else {
                     // Leaf: the return value as written (`&str`, enum, `i64`, …).
                     // One exception: a binding-local field returning an
@@ -1672,30 +1695,74 @@ fn flatten<M>(
                         }
                         seen_identity = true;
                     }
-                    // A plan field: the spelling is taken here, once, where the
-                    // leaf is stored for emission.
-                    let (out_ty, nullable, identity) = if cond_handle {
-                        (core.clone(), true, true)
+                    let out_ty = if cond_handle {
+                        core.clone()
                     } else {
-                        (ret.clone(), nullable, false)
+                        ret.clone()
                     };
-                    let mut path = path_prefix.to_vec();
-                    path.push(PathStep::call(func.clone(), opt, !core_by_ref));
-                    leaves.push(UnfoldLeaf {
-                        name: seg_name(name).join("__"),
-                        path,
+                    children.push(leaf_child(
+                        vec![step],
+                        vec![name.clone()],
                         out_ty,
-                        identity,
-                        nullable,
-                        source: LeafSource::Accessor,
-                        group: None,
-                    });
+                        OutLeaf {
+                            nullable: cond_handle,
+                            identity: cond_handle,
+                            source: LeafSource::Accessor,
+                            group: None,
+                        },
+                    ));
                 }
             }
         }
     }
 
-    Ok(())
+    Ok(children)
+}
+
+/// One leaf hanging off its parent by `steps`, naming `name` at this level.
+fn leaf_child(
+    steps: Vec<PathStep>,
+    name: Vec<String>,
+    ty: prebindgen_flat::flat::TypeRef,
+    op: OutLeaf,
+) -> OutChild {
+    OutChild {
+        link: OutLink { steps, name },
+        node: OutNode {
+            ty,
+            kind: TransformKind::Leaf(op),
+        },
+    }
+}
+
+/// The whole out-of-Rust tree of one deconstructor's records: the product at
+/// `source`, everything below it reached by [`flatten`].
+fn build_tree<M>(
+    acc: &Deconstructors,
+    registry: &Registry<M>,
+    records: &[DeconRecord],
+    source: &prebindgen_flat::flat::TypeRef,
+    by_ref: bool,
+) -> Result<OutNode, UnfoldError> {
+    let mut visited: HashSet<TypeKey> = HashSet::new();
+    visited.insert(source.key());
+    let children = flatten(
+        acc,
+        registry,
+        records,
+        source,
+        &[],
+        by_ref,
+        &mut visited,
+        &mut Vec::new(),
+    )?;
+    Ok(OutNode {
+        ty: source.clone(),
+        kind: TransformKind::Product {
+            op: OutProduct::Records,
+            children,
+        },
+    })
 }
 
 /// Error if two leaves of one flattened deconstructor share a name. Author leaf

--- a/prebindgen-registry/src/unfold/error.rs
+++ b/prebindgen-registry/src/unfold/error.rs
@@ -17,11 +17,15 @@ pub enum UnfoldError {
     },
     MultipleIdentity {
         target: String,
+        /// Where in the decomposition — see [`UnfoldError::Unsupported::at`].
+        at: String,
     },
     /// A nested deconstructor recurses back into a type already on the nesting
     /// chain (`A → … → A`).
     Cycle {
         target: String,
+        /// Where in the decomposition — see [`UnfoldError::Unsupported::at`].
+        at: String,
     },
     /// A single-value (`Return`) delivery on a decomposition that does not
     /// flatten to exactly one leaf, or whose shape is `Iterable`.
@@ -38,6 +42,12 @@ pub enum UnfoldError {
     Unsupported {
         func: syn::Ident,
         reason: &'static str,
+        /// Where in the decomposition the transformation failed: the access
+        /// path from the returned value to the node that could not be built,
+        /// `value` at the root. A deconstructor splices nested ones, so naming
+        /// only the accessor leaves the reader to work out which nesting of it
+        /// is the one that failed.
+        at: String,
     },
     /// Two leaves of one deconstructor resolved to the same (literal) name.
     /// Author leaf names are explicit and emitted verbatim, so a collision is a
@@ -139,15 +149,15 @@ impl std::fmt::Display for UnfoldError {
                 "output expansion: accessor `{}` takes `{}` but the deconstructor decomposes `{}`",
                 accessor, takes, expected
             ),
-            UnfoldError::MultipleIdentity { target } => write!(
+            UnfoldError::MultipleIdentity { target, at } => write!(
                 f,
-                "output expansion: deconstructor for `{}` has more than one identity record",
-                target
+                "output expansion at `{}`: deconstructor for `{}` has more than one identity record",
+                at, target
             ),
-            UnfoldError::Cycle { target } => write!(
+            UnfoldError::Cycle { target, at } => write!(
                 f,
-                "output expansion: nested deconstructors form a cycle through `{}`",
-                target
+                "output expansion at `{}`: nested deconstructors form a cycle through `{}`",
+                at, target
             ),
             UnfoldError::ConvertNotSingle { func, reason } => write!(
                 f,
@@ -160,10 +170,10 @@ impl std::fmt::Display for UnfoldError {
                  reference functions declared via `.fun_accessor(...)`",
                 func
             ),
-            UnfoldError::Unsupported { func, reason } => write!(
+            UnfoldError::Unsupported { func, reason, at } => write!(
                 f,
-                "output expansion: `{}` not yet supported: {}",
-                func, reason
+                "output expansion of `{}` at `{}` not yet supported: {}",
+                func, at, reason
             ),
             UnfoldError::DuplicateLeafName { target, name } => write!(
                 f,

--- a/prebindgen-registry/src/unfold/plan.rs
+++ b/prebindgen-registry/src/unfold/plan.rs
@@ -237,6 +237,18 @@ pub struct UnfoldPlan {
     /// Outer shape over the core decomposition (`Decompose` for a plain
     /// `T`/`&T` return).
     pub shape: UnfoldShape,
+    /// The decomposition itself: what is taken out of the value, and how
+    /// (#442). [`Self::leaves`] and [`Self::hoists`] are **derived views** of
+    /// this tree — [`flat_view`](crate::unfold::flat_view) produces them, and a
+    /// language adapter reads either the tree (through
+    /// [`TransformLowerer`](crate::transform::TransformLowerer)) or a view,
+    /// never a walk of its own.
+    ///
+    /// Shared rather than cloned: a plan is copied to be re-delivered
+    /// (`..plan` with a different [`Self::delivery`]), and the decomposition
+    /// underneath is the same one. `Rc` because the model it names is
+    /// `syn`-backed and so single-threaded already.
+    pub tree: std::rc::Rc<crate::unfold::OutNode>,
     /// Flattened output leaves, in builder-argument order. Populated for
     /// `Decompose`/`Optional` (accessor decomposition) and for a **decomposed**
     /// `Iterable` fold (per-element leaves — explicit-accessor or a synthesized

--- a/prebindgen-registry/src/unfold/plan.rs
+++ b/prebindgen-registry/src/unfold/plan.rs
@@ -222,6 +222,13 @@ pub enum LeafSource {
 }
 
 /// A resolved output expansion for one function.
+///
+/// The views derived from [`Self::tree`] — [`shape`](Self::shape),
+/// [`leaves`](Self::leaves), [`element`](Self::element) and
+/// [`hoists`](Self::hoists) — are readable but not settable from outside the
+/// crate, and neither is a plan constructible there: they are computed from the
+/// tree where the plan is built, and a caller that could set one could make a
+/// tree-reading adapter and a view-reading one see different decompositions.
 #[derive(Clone)]
 pub struct UnfoldPlan {
     /// Owned core type the records decompose — the function's return after
@@ -242,7 +249,7 @@ pub struct UnfoldPlan {
     /// [`Sequence`](crate::transform::TransformKind::Sequence) node wrapping
     /// the decomposition, and [`shape_of`](crate::unfold::shape_of) reads the
     /// stack back off them.
-    pub shape: UnfoldShape,
+    pub(crate) shape: UnfoldShape,
     /// The plan itself: the `Option` / `Vec` layers the value crosses in, and
     /// what is taken out of it under them (#442). [`Self::shape`],
     /// [`Self::element`], [`Self::leaves`] and [`Self::hoists`] are **derived
@@ -261,7 +268,7 @@ pub struct UnfoldPlan {
     /// `data_class` [`Self::fixed_builder`]); **empty** only for a
     /// **whole-element** `Iterable`, which delivers each element via
     /// [`Self::element`].
-    pub leaves: Vec<UnfoldLeaf>,
+    pub(crate) leaves: Vec<UnfoldLeaf>,
     /// For a **whole-element** `Iterable` plan: the owned/ref element type,
     /// delivered to the fold via its own output converter + projection (not
     /// decomposed). `None` for `Decompose`/`Optional` and for a **decomposed**
@@ -271,7 +278,7 @@ pub struct UnfoldPlan {
     /// [`Sequence`](crate::transform::TransformKind::Sequence) node crosses
     /// whole, where a decomposed run has a product there instead. See
     /// [`element_of`](crate::unfold::element_of).
-    pub element: Option<prebindgen_flat::flat::TypeRef>,
+    pub(crate) element: Option<prebindgen_flat::flat::TypeRef>,
     /// Callback (`deconstruct_output`) vs return-value (`convert_output`)
     /// delivery.
     pub delivery: Delivery,
@@ -296,7 +303,31 @@ pub struct UnfoldPlan {
     /// value form, and that child call is a second hoist nested under the
     /// first. Ordered outermost-first, so a hoist can be composed from the
     /// longest already-bound prefix of itself.
-    pub hoists: Vec<Hoist>,
+    pub(crate) hoists: Vec<Hoist>,
+}
+
+impl UnfoldPlan {
+    /// Outer shape over the core decomposition — see the field's own note.
+    pub fn shape(&self) -> &UnfoldShape {
+        &self.shape
+    }
+
+    /// Flattened output leaves, in builder-argument order — see the field's
+    /// own note.
+    pub fn leaves(&self) -> &[UnfoldLeaf] {
+        &self.leaves
+    }
+
+    /// The whole-element type of an `Iterable` plan that delivers its elements
+    /// whole — see the field's own note.
+    pub fn element(&self) -> Option<&prebindgen_flat::flat::TypeRef> {
+        self.element.as_ref()
+    }
+
+    /// Value forms to evaluate once and bind — see the field's own note.
+    pub fn hoists(&self) -> &[Hoist] {
+        &self.hoists
+    }
 }
 
 /// One hoisted value form: where it sits, and whether it **consumes** the value

--- a/prebindgen-registry/src/unfold/plan.rs
+++ b/prebindgen-registry/src/unfold/plan.rs
@@ -236,13 +236,19 @@ pub struct UnfoldPlan {
     pub by_ref: bool,
     /// Outer shape over the core decomposition (`Decompose` for a plain
     /// `T`/`&T` return).
+    ///
+    /// A derived view of [`Self::tree`]: each layer is an
+    /// [`Optional`](crate::transform::TransformKind::Optional) or
+    /// [`Sequence`](crate::transform::TransformKind::Sequence) node wrapping
+    /// the decomposition, and [`shape_of`](crate::unfold::shape_of) reads the
+    /// stack back off them.
     pub shape: UnfoldShape,
-    /// The decomposition itself: what is taken out of the value, and how
-    /// (#442). [`Self::leaves`] and [`Self::hoists`] are **derived views** of
-    /// this tree — [`flat_view`](crate::unfold::flat_view) produces them, and a
-    /// language adapter reads either the tree (through
-    /// [`TransformLowerer`](crate::transform::TransformLowerer)) or a view,
-    /// never a walk of its own.
+    /// The plan itself: the `Option` / `Vec` layers the value crosses in, and
+    /// what is taken out of it under them (#442). [`Self::shape`],
+    /// [`Self::element`], [`Self::leaves`] and [`Self::hoists`] are **derived
+    /// views** of this tree, and a language adapter reads either the tree
+    /// (through [`TransformLowerer`](crate::transform::TransformLowerer)) or a
+    /// view, never a walk of its own.
     ///
     /// Shared rather than cloned: a plan is copied to be re-delivered
     /// (`..plan` with a different [`Self::delivery`]), and the decomposition
@@ -260,6 +266,11 @@ pub struct UnfoldPlan {
     /// delivered to the fold via its own output converter + projection (not
     /// decomposed). `None` for `Decompose`/`Optional` and for a **decomposed**
     /// `Iterable` fold (which uses [`Self::leaves`]).
+    ///
+    /// A derived view of [`Self::tree`]: a leaf directly under the
+    /// [`Sequence`](crate::transform::TransformKind::Sequence) node crosses
+    /// whole, where a decomposed run has a product there instead. See
+    /// [`element_of`](crate::unfold::element_of).
     pub element: Option<prebindgen_flat::flat::TypeRef>,
     /// Callback (`deconstruct_output`) vs return-value (`convert_output`)
     /// delivery.

--- a/prebindgen-registry/src/unfold/tests.rs
+++ b/prebindgen-registry/src/unfold/tests.rs
@@ -1947,6 +1947,26 @@ impl crate::transform::TransformLowerer<OutOfRust> for Render {
     ) -> Result<String, Self::Error> {
         match *op {}
     }
+
+    fn optional(
+        &mut self,
+        _node: &OutNode,
+        _op: &(),
+        _inner: &OutNode,
+        value: String,
+    ) -> Result<String, Self::Error> {
+        Ok(format!("{value}?"))
+    }
+
+    fn sequence(
+        &mut self,
+        _node: &OutNode,
+        _op: &(),
+        _inner: &OutNode,
+        value: String,
+    ) -> Result<String, Self::Error> {
+        Ok(format!("[{value}]*"))
+    }
 }
 
 #[test]
@@ -2010,12 +2030,22 @@ fn tree_lowers_through_the_shared_visitor() {
         .get(&ident("z_reply_sample"))
         .expect("plan");
 
-    // The whole decomposition, read through the hooks alone.
+    // The whole plan, read through the hooks alone — the `Option<&ZSample>`
+    // return is the trailing `?`, so the arity layer is a node like any other.
     let rendered = plan.tree.lower(&mut Render).expect("lowering cannot fail");
     assert_eq!(
         rendered,
         "[ke<-z_sample_key_expr: [<-: & ZKeyExpr (identity), str<-z_keyexpr_as_str: & str], \
-         ts<-z_sample_timestamp?: [ntp64<-z_timestamp_ntp64: i64]]"
+         ts<-z_sample_timestamp?: [ntp64<-z_timestamp_ntp64: i64]]?"
+    );
+    // …and the shape the plan exposes is read back off those same nodes.
+    assert!(
+        matches!(&plan.shape, UnfoldShape::Optional((), inner) if matches!(**inner, UnfoldShape::Base)),
+        "the layer node IS the plan's shape"
+    );
+    assert!(
+        plan.element.is_none(),
+        "the value is taken apart, not delivered whole"
     );
 
     // …and the derived view of the same tree, which is what the plan exposes:

--- a/prebindgen-registry/src/unfold/tests.rs
+++ b/prebindgen-registry/src/unfold/tests.rs
@@ -728,6 +728,12 @@ fn nested_cycle_errors() {
     )
     .unwrap_err();
     assert!(matches!(err, UnfoldError::Cycle { .. }));
+    // The message says WHERE: `ZB` is reached through `a_to_b`, and it is the
+    // deconstructor spliced there that closes the loop.
+    assert_eq!(
+        err.to_string(),
+        "output expansion at `value.a_to_b()`: nested deconstructors form a cycle through `ZA`"
+    );
 }
 
 #[test]

--- a/prebindgen-registry/src/unfold/tests.rs
+++ b/prebindgen-registry/src/unfold/tests.rs
@@ -1918,7 +1918,7 @@ impl crate::transform::TransformLowerer<OutOfRust> for Render {
         &mut self,
         _node: &OutNode,
         _op: &OutProduct,
-        children: Vec<(&OutChild, String)>,
+        children: crate::transform::Lowered<'_, OutOfRust, String>,
     ) -> Result<String, Self::Error> {
         let rendered: Vec<String> = children
             .into_iter()
@@ -1937,6 +1937,15 @@ impl crate::transform::TransformLowerer<OutOfRust> for Render {
             })
             .collect();
         Ok(format!("[{}]", rendered.join(", ")))
+    }
+
+    fn choice(
+        &mut self,
+        _node: &OutNode,
+        op: &std::convert::Infallible,
+        _variants: crate::transform::Lowered<'_, OutOfRust, String>,
+    ) -> Result<String, Self::Error> {
+        match *op {}
     }
 }
 

--- a/prebindgen-registry/src/unfold/tests.rs
+++ b/prebindgen-registry/src/unfold/tests.rs
@@ -1555,11 +1555,13 @@ fn leaf_vec_fold_skips_unnominated_and_preexisting() {
     let declared: std::collections::HashSet<syn::Ident> =
         ["other", "strings"].iter().map(|s| ident(s)).collect();
     // Pre-seed `strings` with a sentinel plan to prove it is preserved.
+    let source = tref(syn::parse_quote!(String));
     let sentinel = UnfoldPlan {
-        source: tref(syn::parse_quote!(String)),
+        source: source.clone(),
         decon: None,
         by_ref: false,
         shape: UnfoldShape::Base,
+        tree: std::rc::Rc::new(crate::unfold::flat_tree(&source, &[])),
         leaves: vec![],
         element: None,
         delivery: Delivery::Return,
@@ -1891,5 +1893,132 @@ fn a_vec_of_optionals_installs_no_fixed_fold() {
     assert!(
         !reg.unfold_plans.contains_key(&ident("storage_get_vec")),
         "a Vec<Option<Payload>> return must not fold as a Payload decomposition"
+    );
+}
+
+/// A stand-in language adapter (#442): it says what a leaf and a product
+/// *render as* and nothing else. There is no recursion here, no `TypeRef`
+/// walk and no path arithmetic — the registry supplies the order, the links
+/// and the descent, which is the whole claim the shared tree makes.
+struct Render;
+
+impl crate::transform::TransformLowerer<OutOfRust> for Render {
+    type Value = String;
+    type Error = std::convert::Infallible;
+
+    fn leaf(&mut self, node: &OutNode, op: &OutLeaf) -> Result<String, Self::Error> {
+        Ok(format!(
+            "{}{}",
+            node.ty.spell(),
+            if op.identity { " (identity)" } else { "" }
+        ))
+    }
+
+    fn product(
+        &mut self,
+        _node: &OutNode,
+        _op: &OutProduct,
+        children: Vec<(&OutChild, String)>,
+    ) -> Result<String, Self::Error> {
+        let rendered: Vec<String> = children
+            .into_iter()
+            .map(|(child, value)| {
+                let steps: Vec<String> = child
+                    .link
+                    .steps
+                    .iter()
+                    .map(|s| format!("{}{}", s.ident(), if s.is_optional() { "?" } else { "" }))
+                    .collect();
+                format!(
+                    "{}<-{}: {value}",
+                    child.link.name.join("__"),
+                    steps.join(".")
+                )
+            })
+            .collect();
+        Ok(format!("[{}]", rendered.join(", ")))
+    }
+}
+
+#[test]
+fn tree_lowers_through_the_shared_visitor() {
+    // `z_reply_sample -> Option<&ZSample>` whose ZSample splices ZKeyExpr
+    // (identity + string) and a nullable ZTimestamp. The tree is what the
+    // decomposition IS; the leaf list below is a derived view of it, so both
+    // readings of the same plan must agree on names, order and nullability.
+    let mut reg: Registry<()> = reg_with(&[
+        "fn z_reply_sample(r: &ZReply) -> Option<&ZSample> { todo!() }",
+        "fn z_sample_key_expr(s: &ZSample) -> &ZKeyExpr { todo!() }",
+        "fn z_sample_timestamp(s: &ZSample) -> Option<&ZTimestamp> { todo!() }",
+        "fn z_keyexpr_as_str(ke: &ZKeyExpr) -> &str { todo!() }",
+        "fn z_timestamp_ntp64(t: &ZTimestamp) -> i64 { todo!() }",
+    ]);
+    let mut acc = Deconstructors::default();
+    acc.deconstructors.push(DeconstructorDecl {
+        target: key("ZKeyExpr"),
+        records: vec![
+            DeconRecord::Identity,
+            DeconRecord::Acc {
+                func: ident("z_keyexpr_as_str"),
+                name: "str".into(),
+            },
+        ],
+        default: Some((DeconTarget::Output, Delivery::Callback)),
+    });
+    acc.deconstructors.push(DeconstructorDecl {
+        target: key("ZTimestamp"),
+        records: vec![DeconRecord::Acc {
+            func: ident("z_timestamp_ntp64"),
+            name: "ntp64".into(),
+        }],
+        default: Some((DeconTarget::Output, Delivery::Callback)),
+    });
+    acc.deconstructors.push(DeconstructorDecl {
+        target: key("ZSample"),
+        records: vec![
+            DeconRecord::Acc {
+                func: ident("z_sample_key_expr"),
+                name: "ke".into(),
+            },
+            DeconRecord::Acc {
+                func: ident("z_sample_timestamp"),
+                name: "ts".into(),
+            },
+        ],
+        default: Some((DeconTarget::Output, Delivery::Callback)),
+    });
+
+    apply(
+        &mut reg,
+        &acc,
+        &[ident("z_reply_sample")].into_iter().collect(),
+        &acc_set_without("z_reply_sample"),
+    )
+    .expect("apply");
+
+    let plan = reg
+        .unfold_plans
+        .get(&ident("z_reply_sample"))
+        .expect("plan");
+
+    // The whole decomposition, read through the hooks alone.
+    let rendered = plan.tree.lower(&mut Render).expect("lowering cannot fail");
+    assert_eq!(
+        rendered,
+        "[ke<-z_sample_key_expr: [<-: & ZKeyExpr (identity), str<-z_keyexpr_as_str: & str], \
+         ts<-z_sample_timestamp?: [ntp64<-z_timestamp_ntp64: i64]]"
+    );
+
+    // …and the derived view of the same tree, which is what the plan exposes:
+    // the identity takes the chain it sits at, the `Option` nesting step makes
+    // everything under it nullable, and nothing else is.
+    let names: Vec<(&str, bool)> = plan
+        .leaves
+        .iter()
+        .map(|l| (l.name.as_str(), l.nullable))
+        .collect();
+    assert_eq!(
+        names,
+        vec![("ke", false), ("ke__str", false), ("ts__ntp64", true)]
     );
 }

--- a/prebindgen-registry/src/unfold/tree.rs
+++ b/prebindgen-registry/src/unfold/tree.rs
@@ -1,0 +1,221 @@
+//! The out-of-Rust direction of the shared transformation tree (#442): how a
+//! returned Rust value is taken apart into the values that cross.
+//!
+//! The tree is what the decomposition IS; [`UnfoldPlan::leaves`] and
+//! [`UnfoldPlan::hoists`] are **derived views** of it, produced by
+//! [`flat_view`] through the same [`TransformLowerer`] a language adapter
+//! implements. Nothing is stored twice: a leaf's crossing type is its node's
+//! [`ty`](TransformNode::ty), its access path is the links above it, and its
+//! nullability is which of those links pass through an `Option`.
+//!
+//! [`UnfoldPlan::leaves`]: super::UnfoldPlan::leaves
+//! [`UnfoldPlan::hoists`]: super::UnfoldPlan::hoists
+
+use crate::transform::{
+    TransformChild, TransformDirection, TransformKind, TransformLowerer, TransformNode,
+};
+
+use super::{Hoist, LeafSource, PathStep, UnfoldLeaf};
+
+/// Direction marker: a Rust value taken apart into crossing values.
+pub enum OutOfRust {}
+
+impl TransformDirection for OutOfRust {
+    type Leaf = OutLeaf;
+    type Product = OutProduct;
+    type Link = OutLink;
+}
+
+/// One node of an out-of-Rust decomposition.
+pub type OutNode = TransformNode<OutOfRust>;
+/// One child of an out-of-Rust product, with the link reaching it.
+pub type OutChild = TransformChild<OutOfRust>;
+
+/// A value that crosses out as one leaf. Its type is the node's
+/// [`ty`](TransformNode::ty) and its access path is the links above it — this
+/// carries only what neither of those says.
+pub struct OutLeaf {
+    /// `true` when the leaf is null **of itself**, independently of the path
+    /// reaching it: a conditional handle delivery (`Option<&T>`), or a
+    /// pre-built leaf whose own field was optional. Absence coming from a
+    /// nesting link is derived, not stored.
+    pub nullable: bool,
+    /// The move/clone-the-value handle leaf — see [`UnfoldLeaf::identity`].
+    pub identity: bool,
+    /// How the leaf is reached — see [`LeafSource`].
+    pub source: LeafSource,
+    /// Sum-alternative membership — see [`UnfoldLeaf::group`].
+    pub group: Option<i32>,
+}
+
+/// How a product node's children are obtained from its value.
+pub enum OutProduct {
+    /// Read the records off the value directly: the root of a decomposition,
+    /// or a spliced child deconstructor reached through its link.
+    Records,
+    /// Call a **value form** once and bind the result, then read fields off
+    /// that binding — the [`Hoist`] the derived view emits for this node.
+    ValueForm {
+        /// The accessor takes its receiver by value, so its fields move out
+        /// instead of being cloned — see [`Hoist::consuming`].
+        consuming: bool,
+    },
+}
+
+/// How one child is reached from its parent's value.
+pub struct OutLink {
+    /// Access steps from the parent's value to the child's.
+    pub steps: Vec<PathStep>,
+    /// Leaf-name segments this level contributes, joined with `"__"` into the
+    /// final name. Empty where a level names nothing (a value form; the
+    /// identity leaf, which takes the chain it sits at).
+    pub name: Vec<String>,
+}
+
+/// The flat views the plans expose: leaves in decomposition order, and the
+/// value forms to bind once. Derived — never stored beside the tree.
+pub fn flat_view(root: &OutNode) -> (Vec<UnfoldLeaf>, Vec<Hoist>) {
+    let derived = root
+        .lower(&mut FlatView)
+        .expect("deriving a flat view of a built tree cannot fail");
+    let leaves = derived
+        .leaves
+        .into_iter()
+        .map(|(segs, mut leaf)| {
+            // A leaf that names nothing at any level is the root identity —
+            // the only one, since every nesting level contributes a segment.
+            leaf.name = if segs.is_empty() {
+                "handle".to_string()
+            } else {
+                segs.join("__")
+            };
+            leaf
+        })
+        .collect();
+    (leaves, derived.hoists)
+}
+
+/// Everything below one node, with paths and names still **relative** to it —
+/// each level prefixes its own link on the way up.
+#[derive(Default)]
+struct Partial {
+    /// Leaves with their name segments carried alongside: the segments are
+    /// joined only at the root, so a level that names nothing (a value form)
+    /// prefixes nothing rather than an empty string.
+    leaves: Vec<(Vec<String>, UnfoldLeaf)>,
+    hoists: Vec<Hoist>,
+}
+
+/// The lowerer behind [`flat_view`].
+struct FlatView;
+
+impl TransformLowerer<OutOfRust> for FlatView {
+    type Value = Partial;
+    type Error = std::convert::Infallible;
+
+    fn leaf(&mut self, node: &OutNode, op: &OutLeaf) -> Result<Partial, Self::Error> {
+        Ok(Partial {
+            leaves: vec![(
+                Vec::new(),
+                UnfoldLeaf {
+                    name: String::new(),
+                    path: Vec::new(),
+                    out_ty: node.ty.clone(),
+                    identity: op.identity,
+                    nullable: op.nullable,
+                    source: op.source.clone(),
+                    group: op.group,
+                },
+            )],
+            hoists: Vec::new(),
+        })
+    }
+
+    fn product(
+        &mut self,
+        _node: &OutNode,
+        op: &OutProduct,
+        children: Vec<(&OutChild, Partial)>,
+    ) -> Result<Partial, Self::Error> {
+        let mut out = Partial::default();
+        // Outermost-first: this node's own binding precedes everything reached
+        // through it.
+        if let OutProduct::ValueForm { consuming } = op {
+            out.hoists.push(Hoist {
+                prefix: Vec::new(),
+                consuming: *consuming,
+            });
+        }
+        for (child, mut part) in children {
+            // An `Option` on the way to a child is a nullable **nesting** step
+            // only when something is decomposed below it. A leaf's own final
+            // `Option` is what its converter takes, so it rides the leaf
+            // instead — the leaf says so itself where that is not true.
+            let nullable = !matches!(child.node.kind, TransformKind::Leaf(_))
+                && child.link.steps.iter().any(PathStep::is_optional);
+            for (segs, leaf) in &mut part.leaves {
+                *segs = child
+                    .link
+                    .name
+                    .iter()
+                    .cloned()
+                    .chain(segs.drain(..))
+                    .collect();
+                leaf.path = child
+                    .link
+                    .steps
+                    .iter()
+                    .cloned()
+                    .chain(leaf.path.drain(..))
+                    .collect();
+                leaf.nullable |= nullable;
+            }
+            for hoist in &mut part.hoists {
+                hoist.prefix = child
+                    .link
+                    .steps
+                    .iter()
+                    .cloned()
+                    .chain(hoist.prefix.drain(..))
+                    .collect();
+            }
+            out.leaves.append(&mut part.leaves);
+            out.hoists.append(&mut part.hoists);
+        }
+        Ok(out)
+    }
+}
+
+/// The tree of a decomposition whose leaves an **adapter** computed (a
+/// by-value `data_class`, a sum): one product over the list it handed over,
+/// each leaf reached by its own whole path.
+///
+/// Shallow rather than wrong — [`flat_view`] gives the list back unchanged.
+/// Those declaration families describe a leaf list and not yet a tree, which is
+/// the next thing #442 moves.
+pub fn flat_tree(source: &prebindgen_flat::flat::TypeRef, leaves: &[UnfoldLeaf]) -> OutNode {
+    OutNode {
+        ty: source.clone(),
+        kind: TransformKind::Product {
+            op: OutProduct::Records,
+            children: leaves
+                .iter()
+                .map(|leaf| OutChild {
+                    link: OutLink {
+                        steps: leaf.path.clone(),
+                        name: vec![leaf.name.clone()],
+                    },
+                    node: OutNode {
+                        ty: leaf.out_ty.clone(),
+                        kind: TransformKind::Leaf(OutLeaf {
+                            nullable: leaf.nullable,
+                            identity: leaf.identity,
+                            source: leaf.source.clone(),
+                            group: leaf.group,
+                        }),
+                    },
+                })
+                .collect(),
+        },
+    }
+}

--- a/prebindgen-registry/src/unfold/tree.rs
+++ b/prebindgen-registry/src/unfold/tree.rs
@@ -15,11 +15,10 @@
 //! [`UnfoldPlan::leaves`]: super::UnfoldPlan::leaves
 //! [`UnfoldPlan::hoists`]: super::UnfoldPlan::hoists
 
+use super::{Hoist, LeafSource, PathStep, UnfoldLeaf, UnfoldShape};
 use crate::transform::{
     Lowered, TransformChild, TransformDirection, TransformKind, TransformLowerer, TransformNode,
 };
-
-use super::{Hoist, LeafSource, PathStep, UnfoldLeaf, UnfoldShape};
 
 /// Direction marker: a Rust value taken apart into crossing values.
 pub enum OutOfRust {}

--- a/prebindgen-registry/src/unfold/tree.rs
+++ b/prebindgen-registry/src/unfold/tree.rs
@@ -1,13 +1,17 @@
 //! The out-of-Rust direction of the shared transformation tree (#442): how a
 //! returned Rust value is taken apart into the values that cross.
 //!
-//! The tree is what the decomposition IS; [`UnfoldPlan::leaves`] and
-//! [`UnfoldPlan::hoists`] are **derived views** of it, produced by
-//! [`flat_view`] through the same [`TransformLowerer`] a language adapter
-//! implements. Nothing is stored twice: a leaf's crossing type is its node's
-//! [`ty`](TransformNode::ty), its access path is the links above it, and its
-//! nullability is which of those links pass through an `Option`.
+//! The tree is what the plan IS — the `Option` / `Vec` layers the value
+//! crosses in ([`shaped`]) and the decomposition under them. [`UnfoldPlan::shape`],
+//! [`UnfoldPlan::element`], [`UnfoldPlan::leaves`] and [`UnfoldPlan::hoists`]
+//! are **derived views** of it, produced through the same [`TransformLowerer`]
+//! a language adapter implements. Nothing is stored twice: a leaf's crossing
+//! type is its node's [`ty`](TransformNode::ty), its access path is the links
+//! above it, and its nullability is which of those links pass through an
+//! `Option`.
 //!
+//! [`UnfoldPlan::shape`]: super::UnfoldPlan::shape
+//! [`UnfoldPlan::element`]: super::UnfoldPlan::element
 //! [`UnfoldPlan::leaves`]: super::UnfoldPlan::leaves
 //! [`UnfoldPlan::hoists`]: super::UnfoldPlan::hoists
 
@@ -15,7 +19,7 @@ use crate::transform::{
     Lowered, TransformChild, TransformDirection, TransformKind, TransformLowerer, TransformNode,
 };
 
-use super::{Hoist, LeafSource, PathStep, UnfoldLeaf};
+use super::{Hoist, LeafSource, PathStep, UnfoldLeaf, UnfoldShape};
 
 /// Direction marker: a Rust value taken apart into crossing values.
 pub enum OutOfRust {}
@@ -27,6 +31,12 @@ impl TransformDirection for OutOfRust {
     /// contributes. Uninhabited, so a [`TransformKind::Choice`] node cannot be
     /// built in this direction at all.
     type Choice = std::convert::Infallible;
+    /// The `Option<T>` / `Option<&T>` return layer carries nothing of its own:
+    /// absent delivers a null result and the builder is skipped.
+    type Optional = ();
+    /// The `Vec<T>` / `&[T]` return layer carries nothing of its own — how its
+    /// elements are delivered is what sits under it (see [`element_of`]).
+    type Sequence = ();
     type Link = OutLink;
 }
 
@@ -196,6 +206,105 @@ impl TransformLowerer<OutOfRust> for FlatView {
         _variants: Lowered<'_, OutOfRust, Partial>,
     ) -> Result<Partial, Self::Error> {
         match *op {}
+    }
+
+    fn optional(
+        &mut self,
+        _node: &OutNode,
+        _op: &(),
+        _inner: &OutNode,
+        value: Partial,
+    ) -> Result<Partial, Self::Error> {
+        // Whole-value presence, decided once for the delivery — not a step on
+        // any leaf's path, and not what makes a leaf nullable.
+        Ok(value)
+    }
+
+    fn sequence(
+        &mut self,
+        _node: &OutNode,
+        _op: &(),
+        inner: &OutNode,
+        value: Partial,
+    ) -> Result<Partial, Self::Error> {
+        // A leaf directly under the run is the WHOLE element: it crosses
+        // through its own output converter as the fold's element, not as a
+        // named slot of the call. Decomposed elements — a product under the
+        // run — contribute their leaves as usual.
+        if matches!(inner.kind, TransformKind::Leaf(_)) {
+            return Ok(Partial::default());
+        }
+        Ok(value)
+    }
+}
+
+/// The arity layers of `ty`, as nodes wrapping `core`.
+///
+/// `shape` is the layer stack already read off `ty`, and `layer_tys` are the
+/// types those layers wrap, outermost first — the caller holds both, and
+/// passing them beats re-reading a stack that was decided where the boundary
+/// was classified.
+pub fn shaped(
+    shape: &UnfoldShape,
+    layer_tys: &[prebindgen_flat::flat::TypeRef],
+    core: OutNode,
+) -> OutNode {
+    fn wrap(shape: &UnfoldShape, tys: &[prebindgen_flat::flat::TypeRef], core: OutNode) -> OutNode {
+        match shape {
+            UnfoldShape::Base => core,
+            UnfoldShape::Optional((), rest) => OutNode {
+                ty: tys[0].clone(),
+                kind: TransformKind::Optional {
+                    op: (),
+                    inner: Box::new(wrap(rest, &tys[1..], core)),
+                },
+            },
+            UnfoldShape::Iterable(rest) => OutNode {
+                ty: tys[0].clone(),
+                kind: TransformKind::Sequence {
+                    op: (),
+                    inner: Box::new(wrap(rest, &tys[1..], core)),
+                },
+            },
+        }
+    }
+    assert_eq!(
+        layer_count(shape),
+        layer_tys.len(),
+        "each arity layer names the type it wraps"
+    );
+    wrap(shape, layer_tys, core)
+}
+
+/// How many `Option` / `Vec` layers a shape stacks.
+fn layer_count(shape: &UnfoldShape) -> usize {
+    match shape {
+        UnfoldShape::Base => 0,
+        UnfoldShape::Optional((), rest) | UnfoldShape::Iterable(rest) => 1 + layer_count(rest),
+    }
+}
+
+/// The arity layers a tree wraps its decomposition in — the plan's
+/// [`shape`](super::UnfoldPlan::shape), read back off the nodes that carry it.
+pub fn shape_of(node: &OutNode) -> UnfoldShape {
+    match &node.kind {
+        TransformKind::Optional { inner, .. } => UnfoldShape::optional((), shape_of(inner)),
+        TransformKind::Sequence { inner, .. } => UnfoldShape::iterable(shape_of(inner)),
+        _ => UnfoldShape::Base,
+    }
+}
+
+/// The element type of a **whole-element** run: a leaf directly under a
+/// [`Sequence`](TransformKind::Sequence) crosses through its own output
+/// converter instead of being taken apart. `None` for every other tree,
+/// including a run whose elements ARE taken apart.
+pub fn element_of(node: &OutNode) -> Option<&prebindgen_flat::flat::TypeRef> {
+    match &node.kind {
+        TransformKind::Optional { inner, .. } => element_of(inner),
+        TransformKind::Sequence { inner, .. } => {
+            matches!(inner.kind, TransformKind::Leaf(_)).then(|| &inner.ty)
+        }
+        _ => None,
     }
 }
 

--- a/prebindgen-registry/src/unfold/tree.rs
+++ b/prebindgen-registry/src/unfold/tree.rs
@@ -12,7 +12,7 @@
 //! [`UnfoldPlan::hoists`]: super::UnfoldPlan::hoists
 
 use crate::transform::{
-    TransformChild, TransformDirection, TransformKind, TransformLowerer, TransformNode,
+    Lowered, TransformChild, TransformDirection, TransformKind, TransformLowerer, TransformNode,
 };
 
 use super::{Hoist, LeafSource, PathStep, UnfoldLeaf};
@@ -23,6 +23,10 @@ pub enum OutOfRust {}
 impl TransformDirection for OutOfRust {
     type Leaf = OutLeaf;
     type Product = OutProduct;
+    /// Decomposition has no alternatives: every record of a deconstructor
+    /// contributes. Uninhabited, so a [`TransformKind::Choice`] node cannot be
+    /// built in this direction at all.
+    type Choice = std::convert::Infallible;
     type Link = OutLink;
 }
 
@@ -135,7 +139,7 @@ impl TransformLowerer<OutOfRust> for FlatView {
         &mut self,
         _node: &OutNode,
         op: &OutProduct,
-        children: Vec<(&OutChild, Partial)>,
+        children: Lowered<'_, OutOfRust, Partial>,
     ) -> Result<Partial, Self::Error> {
         let mut out = Partial::default();
         // Outermost-first: this node's own binding precedes everything reached
@@ -183,6 +187,15 @@ impl TransformLowerer<OutOfRust> for FlatView {
             out.hoists.append(&mut part.hoists);
         }
         Ok(out)
+    }
+
+    fn choice(
+        &mut self,
+        _node: &OutNode,
+        op: &std::convert::Infallible,
+        _variants: Lowered<'_, OutOfRust, Partial>,
+    ) -> Result<Partial, Self::Error> {
+        match *op {}
     }
 }
 


### PR DESCRIPTION
The first two steps of #442: give `prebindgen-registry` one shared recursive
mechanism for boundary transformations, so a language adapter describes what a
node *means* rather than writing its own walk. Both directions are on it after
this PR; the flat leaf vectors are not fully derived yet (see *Not in this PR*).

Six commits, reviewable in order: the mechanism plus the output direction, then
the input direction, then the input direction's wire signature, then each
direction's arity layers, then the diagnostics.

## The shared mechanism

`prebindgen_registry::transform` is direction-generic:

* `TransformNode<D>` — a tree of `Leaf`, `Product` (every child contributes),
  `Choice` (exactly one child runs), `Optional` and `Sequence` nodes. Each node
  names the `TypeRef` it transforms, so the flat model stays the only
  source-type model.
* `TransformChild<D>` — one child plus the link reaching it.
* `TransformLowerer<D>` — the visitor. `TransformNode::lower` drives it
  children-first, in declaration order, handing each product or choice its
  children's lowered values together with the children they came from.
* `TransformDirection` — the marker trait naming a direction's payload types:
  what a leaf is, what a product does, how a choice selects, and how one child
  hangs off its parent. A direction with no use for a kind gives that payload an
  uninhabited type, which makes the kind unconstructible for it.

## The output direction (`unfold::OutOfRust`)

A returned Rust value taken apart into the values that cross out.
`unfold::flatten` reads a deconstructor's records into that tree instead of
pushing into a flat `Vec<UnfoldLeaf>`, and `unfold::flat_view` derives the leaf
list and the hoist list (the value forms an emitter binds once) back out of the
tree by lowering it.

`UnfoldPlan::leaves` and `UnfoldPlan::hoists` are therefore derived views of the
new `UnfoldPlan::tree`, not a second copy of the same information:

* a leaf's crossing type is its node's `ty`,
* its access path is the links above it,
* its name is the name segments those links contribute,
* its nullability is which of those links pass through an `Option`.

The walk states each level once: `flatten` no longer threads an accumulated name
prefix and an accumulated nullable flag down the recursion.

`unfold::shaped` then wraps that decomposition in the `Option` / `Vec` layers
the value crosses in, so the tree is the whole plan. `UnfoldPlan::shape` and
`UnfoldPlan::element` are read back off those layer nodes (`unfold::shape_of`,
`unfold::element_of`). How a run delivers its elements is the kind of node under
the `Sequence`, not a sibling field: a leaf there is the whole element, crossing
through its own output converter, and a product there is a decomposed element
contributing its leaves.

`ValueDecon` and `SumDecon` — the two decomposition families whose leaves a
language adapter computes, rather than declaring records the registry walks —
get a depth-1 tree over the leaf list they hand over, so `UnfoldPlan::tree` is
always present. `flat_view` gives their list back unchanged.

Decomposition has no alternatives, so `OutOfRust::Choice` is `Infallible`.

## The input direction (`expand::IntoRust`)

The values that cross in, assembled into one Rust value. `FoldVariant`,
`FoldArg` and `FoldBuild` are **gone**, replaced by `FoldPlan::core`, a
`TransformNode<IntoRust>`:

* a constructor call is a product over its arguments (`InProduct::Ctor`), and
  the identity arm is a product over the one value it passes through
  (`InProduct::Identity`);
* a selector dispatch is a choice over those products (`InChoice`);
* a wire value is a leaf naming its slot in `FoldPlan::leaves` (`InLeaf`);
* whether the consuming constructor parameter is `&T` is the link to the child
  (`InLink`) — what a nested build needed `FoldBuild::by_ref` for.

A constructor argument that is itself built is now the same node kinds as the
top level, rather than a second type spelling the same shape.

The `Option<…>` / `Vec<…>` a parameter is written with are layer nodes over
that, and the layer says how presence is decided — which is what the three
optional forms actually differ by (`InPresence`): the dispatch's selector also
encoding absence, an explicit `bool` flag with the arguments crossing plain, or
the layer decoding its own `Option<…>` slot and handing the payload to the
single-argument construction under it. A construction under a layer reads what
the layer unwrapped rather than a slot of its own — `InLeaf::Bound`, with the
slot belonging to the layer.

`emit_fold` is therefore one pass over the tree: the mutually recursive
`fold_shape` / `emit_core_construct` walk over `FoldPlan::shape` is gone, and
`FoldPlan::shape` and `FoldPlan::present` are read back off the layer nodes.

`FoldPlan::selector` becomes a method reading the tree, so which slot selects
the arm has one source rather than a field that could disagree with the node
the emitter walks. `FoldPlan` ends up carrying only `target`, `by_ref`, the
derived `leaves` and the tree.

`FoldPlan::leaves` is derived too: the builder hands out wire slots as it meets
them, each node names the slots it uses, and `expand::wire_leaves` collects the
signature from the finished tree. A slot is described uniformly by `InSlot` —
position, foreign-side name, carried type — and a constructor argument, a
dispatch's selector, a presence flag, an unwrapped payload and a run all name
one. `wire_leaves` places each slot by its own number, so a slot handed out
twice or never claimed is a panic naming the slot rather than a signature that
silently shifts.

## Consumers moved onto the traversal

* The registry's own Rust emitter is a `TransformLowerer<IntoRust>`
  (`ConstructEmitter`), replacing the mutually recursive `emit_dispatch` /
  `variant_result_expr` / `emit_build` walk.
* `prebindgen-jni`'s overload splitting and its two report sites read
  `InNode::arms`, `InNode::ctor` and `InNode::leaf_args` instead of the deleted
  plan types.

## Diagnostics

Both directions splice nested transformations, so an error naming only the
accessor or the function left the reader to work out which nesting of it was the
one that failed. `UnfoldError`'s `Unsupported`, `Cycle` and `MultipleIdentity`
now carry the access chain from the returned value (`value.a_to_b()`, with an
`Option`-returning step keeping its `?`), and `ExpandError`'s
`UnsupportedRecursive`, `InputCycle` and `UnsupportedOptional` carry the chain of
constructor parameter names — so a mutual cycle reports `a.b.a` rather than the
one parameter it started from.

That chain is deliberately not the slot-name prefix the builder already had: a
single-argument constructor keeps its parent's prefix, because the slot is named
after the parameter, so the prefix alone cannot say how deep a chain of them a
failure sits at.

## Verification

* The whole workspace test suite passes, including the JNI and C adapters'
  snapshot tests.
* The generated bindings committed under `examples/` are byte-identical, so no
  ABI, no generated Rust and no generated Kotlin moves.
* Two new tests, one per direction, lower a plan's tree with a stand-in adapter
  that implements only the lowering hooks — no recursion, no `TypeRef` walk, no
  path or slot arithmetic — and check its rendering against what the plan
  exposes: `unfold::tests::tree_lowers_through_the_shared_visitor` and
  `expand::tests::core_lowers_through_the_shared_visitor`. The latter also
  checks the collected wire signature, name by name, and the same stand-in
  pins the layer nodes in `expand::tests::optional_byvalue_single_ctor`.
* The two cycle tests — one per direction — assert the rendered message, so a
  self-recursive or mutually recursive input is shown terminating with a typed
  error that says where, rather than only that it terminated.

## Not in this PR

Named here because #442 asks for them and this is deliberately incremental:

* Migrating the **adapters** off `plan.shape` and onto the `optional` /
  `sequence` hooks. `prebindgen-jni` still matches on an `UnfoldPlan`'s shape in
  its delivery and wrapper emitters; the node kinds those hooks need now exist,
  but moving them is its own change.
* Turning the adapter-computed `ValueDecon` / `SumDecon` declarations into real
  trees, which means changing the adapter-facing declaration surface.
* Stable node and leaf identifiers, and dependency traversal over the tree.

#442 stays open for those.




