### PR TITLE
Stored callback plan and plan-authoritative emission, for #447

### DIFF
--- a/prebindgen-c/src/lib.rs
+++ b/prebindgen-c/src/lib.rs
@@ -404,6 +404,11 @@ pub struct CbindgenBuilder {
     /// keyed by their argument-type list. Each emits one `#[repr(C)]` closure
     /// struct.
     callbacks: HashMap<CallbackKey, CbCfg>,
+    /// Resolved callback plans, memoized so the closure struct's declaration and
+    /// the Rust trampoline read one plan rather than two agreeing walks
+    /// (#447 §3). Keyed by the same identity `callbacks` is.
+    callback_plans:
+        std::cell::RefCell<HashMap<CallbackKey, std::rc::Rc<crate::plan::CCallbackPlan>>>,
     /// Types intentionally not exported by this adapter.
     ignored_types: HashSet<TypeKey>,
     /// Data structs additionally marked as error types (allowlist for the

--- a/prebindgen-c/src/plan.rs
+++ b/prebindgen-c/src/plan.rs
@@ -354,3 +354,221 @@ impl<R: Conversions<()>> TransformLowerer<OutOfRust> for PlanFromTree<'_, R> {
         )
     }
 }
+
+// ──────────────────────────────────────────────────────────────────────
+// The callback plan (#447 §3)
+// ──────────────────────────────────────────────────────────────────────
+
+/// One declared callback's resolved boundary: how each argument crosses, what
+/// `extern "C" fn` parameters that costs, and what the trampoline does with it.
+///
+/// The C closure struct's `call` pointer and the Rust trampoline that fires it
+/// are two renderings of one boundary. They used to classify every argument
+/// separately — the declaration to list its wire parameters, the dispatch to
+/// fill them — agreeing because both walked the same declaration deterministically
+/// rather than because they read one resolution. This is that resolution, built
+/// once per callback and handed to both.
+pub(crate) struct CCallbackPlan {
+    /// One entry per declared argument, in signature order.
+    pub(crate) args: Vec<CCallbackArg>,
+}
+
+impl CCallbackPlan {
+    /// The `extern "C" fn` parameter types, in order — the `call` pointer's
+    /// signature minus its trailing context pointer.
+    pub(crate) fn wires(&self) -> impl Iterator<Item = &syn::Type> {
+        self.args.iter().flat_map(|a| a.wires.iter())
+    }
+
+    /// Whether any argument's encoder calls `__cbg_alloc_array`, so the crate
+    /// must carry that helper — a requirement of the plan, like every other
+    /// consequence of the encoders it selected.
+    pub(crate) fn needs_array_alloc(&self) -> bool {
+        self.args.iter().any(|a| match &a.kind {
+            CCallbackArgKind::Composite(plan) => plan.needs_array_alloc,
+            _ => false,
+        })
+    }
+}
+
+/// One callback argument, resolved.
+pub(crate) struct CCallbackArg {
+    /// The Rust type the closure parameter is written with.
+    pub(crate) src: syn::Type,
+    /// The `extern "C" fn` parameters this argument contributes. A slice costs
+    /// two, a decomposed composite one per wire field, everything else one.
+    pub(crate) wires: Vec<syn::Type>,
+    /// How it crosses, and what the trampoline needs to do it.
+    pub(crate) kind: CCallbackArgKind,
+}
+
+/// How one callback argument reaches C.
+pub(crate) enum CCallbackArgKind {
+    /// A shared slice, delivered by reference as `(*const elem_wire, usize)` —
+    /// zero-copy, so there is nothing to encode and nothing to drop.
+    Slice { elem_wire: syn::Type },
+    /// An owned handle the C side may take, delivered as `*mut wire`. Dropped
+    /// after the call, which is a no-op if C took it.
+    Takeable {
+        conv: syn::Ident,
+        opaque: syn::Type,
+        fallible: bool,
+    },
+    /// A value with no wire of its own, decomposed into its shape's fields.
+    Composite(CValuePlan),
+    /// One value through its own converter.
+    Single { conv: syn::Ident, fallible: bool },
+}
+
+impl CbindgenBuilder {
+    /// The resolved plan for one declared callback, built once and shared.
+    ///
+    /// Stored rather than recomputed, because "both sides call the same
+    /// function" only makes them agree while the function stays deterministic —
+    /// which is a property of today's implementation, not of the boundary. One
+    /// stored plan makes the declaration and the trampoline the same resolution
+    /// by construction (#447 §3).
+    ///
+    /// Built from the declaration and the registry alone, so it does not depend
+    /// on which emitter asks first. Entries only ever gain in the registry, so
+    /// a plan built once its arguments resolved stays the answer.
+    pub(crate) fn callback_plan(
+        &self,
+        key: &CallbackKey,
+        registry: &impl Conversions<()>,
+    ) -> std::rc::Rc<CCallbackPlan> {
+        if let Some(hit) = self.callback_plans.borrow().get(key) {
+            return hit.clone();
+        }
+        let plan = std::rc::Rc::new(self.build_callback_plan(key, registry));
+        self.callback_plans
+            .borrow_mut()
+            .insert(key.clone(), plan.clone());
+        plan
+    }
+
+    fn build_callback_plan(
+        &self,
+        key: &CallbackKey,
+        registry: &impl Conversions<()>,
+    ) -> CCallbackPlan {
+        let cfg = self
+            .callbacks
+            .get(key)
+            .expect("a callback plan is asked for by one of its own emitters");
+        let mut args = Vec::new();
+        for (i, declared) in cfg.args.iter().enumerate() {
+            // The slice test reads the DECLARED spelling: a `.callback(...)`
+            // argument is written by the build script, and a slice one may
+            // never have been interned, so there is no reading to ask.
+            if let Some((src_elem, elem_wire)) = self.callback_slice_elem_wire(declared) {
+                args.push(CCallbackArg {
+                    src: syn::parse_quote!(&[#src_elem]),
+                    wires: vec![
+                        syn::parse_quote!(*const #elem_wire),
+                        syn::parse_quote!(usize),
+                    ],
+                    kind: CCallbackArgKind::Slice { elem_wire },
+                });
+                continue;
+            }
+            let reading = registry.reading_of(declared).unwrap_or_else(|| {
+                panic!(
+                    "Cbindgen: callback arg `{}` was never classified",
+                    declared.to_token_stream()
+                )
+            });
+            let entry = registry.output_entry(&reading).unwrap_or_else(|| {
+                panic!(
+                    "Cbindgen: callback arg `{}` has no output converter (declare it \
+                     as a opaque_ptr/data_struct/enum_type)",
+                    declared.to_token_stream()
+                )
+            });
+            let src = self.src_ty_deep_of(&reading);
+            let wire = entry.destination.clone();
+            let conv = entry.function.sig.ident.clone();
+            let fallible = returns_result(&entry.function.sig.output);
+            let is_takeable = cfg.takeable.contains(&i);
+
+            if is_takeable {
+                args.push(CCallbackArg {
+                    src,
+                    wires: vec![syn::parse_quote!(*mut #wire)],
+                    kind: CCallbackArgKind::Takeable {
+                        conv,
+                        opaque: wire,
+                        fallible,
+                    },
+                });
+                continue;
+            }
+            if self.callback_arg_is_composite(&reading, is_takeable, registry) {
+                // Decomposed: the C params are the fields its shape lowers to,
+                // each `MaybeUninit` so an absent value can leave its slot
+                // unwritten without the wrapper materialising something to fill
+                // it — and without leaving it indeterminate for a callee that
+                // reads it anyway.
+                let plan = self.c_value_plan(&reading, registry);
+                let wires = plan
+                    .shape
+                    .fields
+                    .iter()
+                    .map(|f| {
+                        let w = &f.wire;
+                        syn::parse_quote!(::core::mem::MaybeUninit<#w>)
+                    })
+                    .collect();
+                args.push(CCallbackArg {
+                    src,
+                    wires,
+                    kind: CCallbackArgKind::Composite(plan),
+                });
+                continue;
+            }
+            // A marker converter with no structural lowering has no C ABI at
+            // all — the one shape neither branch above can carry.
+            assert!(
+                !marker_destination(&entry.destination),
+                "Cbindgen: callback argument `{}` has no C ABI — it resolves to a marker \
+                 converter and is not one of the shapes lowered structurally (`Option<T>`, \
+                 `Vec<T>`, `Cow<'_, [T]>`). Deliver its parts as separate callback \
+                 arguments instead.",
+                declared.to_token_stream(),
+            );
+            args.push(CCallbackArg {
+                src,
+                wires: vec![wire],
+                kind: CCallbackArgKind::Single { conv, fallible },
+            });
+        }
+        CCallbackPlan { args }
+    }
+}
+
+/// The statement binding one callback argument's converted wire value.
+///
+/// A firing callback has no error channel, so a fallible converter aborts —
+/// stated once here because both the takeable and the single-value arms need
+/// exactly this and differ only in whether the binding is mutable.
+pub(crate) fn convert_or_abort(
+    conv: &syn::Ident,
+    arg: &syn::Ident,
+    wire: &syn::Ident,
+    fallible: bool,
+    mutable: bool,
+) -> TokenStream {
+    let mut_kw = if mutable { quote!(mut) } else { quote!() };
+    if fallible {
+        quote!(
+            let #mut_kw #wire = match #conv(#arg) {
+                ::core::result::Result::Ok(__v) => __v,
+                ::core::result::Result::Err(__e) => {
+                    ::core::panic!("cbindgen: callback argument conversion failed: {}", __e)
+                }
+            };
+        )
+    } else {
+        quote!(let #mut_kw #wire = #conv(#arg);)
+    }
+}

--- a/prebindgen-c/src/tests/callbacks.rs
+++ b/prebindgen-c/src/tests/callbacks.rs
@@ -758,3 +758,39 @@ fn a_callback_plan_is_stored_not_rebuilt() {
         "the encoder it selected calls the array helper"
     );
 }
+
+/// A declared-but-unused callback signature emits no closure struct, and must
+/// not be planned either: its arguments were never classified, so there is no
+/// converter for a plan to resolve against.
+#[test]
+fn an_unused_callback_declaration_is_not_planned() {
+    let loc = SourceLocation::default();
+    let func: syn::ItemFn = syn::parse_quote!(
+        pub fn z_plain(v: i64) -> Result<(), Error> {
+            unimplemented!()
+        }
+    );
+    let registry = crate::test_util::reg_from_items(declare_referenced([
+        (syn::Item::Fn(func), loc.clone()),
+        (syn::Item::Struct(error_struct()), loc.clone()),
+    ]))
+    .expect("index items");
+
+    // Declared, and used by nothing.
+    let cbindgen = CbindgenBuilder::new()
+        .source_module(syn::parse_quote!(zenoh_flat))
+        .free_memory_function("z_free")
+        .data_struct(syn::parse_quote!(Error))
+        .base_name("z_error")
+        .error()
+        .callback(syn::parse_quote!(impl Fn(Vec<i64>) + Send + Sync + 'static))
+        .base_name("z_closure_unused_t")
+        .function(syn::parse_quote!(z_plain));
+
+    let src = write(cbindgen, registry, "cb_unused");
+    let compact: String = src.split_whitespace().collect();
+    assert!(
+        !compact.contains("z_closure_unused_t"),
+        "an unused callback declaration emits nothing: {src}"
+    );
+}

--- a/prebindgen-c/src/tests/callbacks.rs
+++ b/prebindgen-c/src/tests/callbacks.rs
@@ -701,3 +701,60 @@ fn callback_only_run_emits_the_array_helper() {
         "…so its definition must be emitted too: {src}"
     );
 }
+
+/// #447 §3: the closure struct's `call` signature and the Rust trampoline that
+/// fires it read **one stored plan**, not two walks that agree.
+///
+/// Agreement by determinism is a property of today's implementation rather than
+/// of the boundary: the two emitters used to classify every argument
+/// separately, so a change to one classification could silently mis-declare a
+/// signature the other still filled. Storing the plan makes them the same
+/// resolution by construction, and this checks the storage rather than the
+/// coincidence — a second ask returns the same instance.
+#[test]
+fn a_callback_plan_is_stored_not_rebuilt() {
+    let loc = SourceLocation::default();
+    let func: syn::ItemFn = syn::parse_quote!(
+        pub fn z_on_batch(
+            callback: impl Fn(Vec<i64>) + Send + Sync + 'static,
+        ) -> Result<(), Error> {
+            unimplemented!()
+        }
+    );
+    let registry = crate::test_util::reg_from_items(declare_referenced([
+        (syn::Item::Fn(func), loc.clone()),
+        (syn::Item::Struct(error_struct()), loc.clone()),
+    ]))
+    .expect("index items");
+
+    let cbindgen = CbindgenBuilder::new()
+        .source_module(syn::parse_quote!(zenoh_flat))
+        .free_memory_function("z_free")
+        .data_struct(syn::parse_quote!(Error))
+        .base_name("z_error")
+        .error()
+        .callback(syn::parse_quote!(impl Fn(Vec<i64>) + Send + Sync + 'static))
+        .base_name("z_closure_batch_t")
+        .function(syn::parse_quote!(z_on_batch));
+
+    let gen = cbindgen.build_with(registry).expect("resolve");
+    let key: CallbackKey = vec![TypeKey::from_type(&syn::parse_quote!(Vec<i64>))];
+
+    let first = gen.gen.callback_plan(&key, &gen.registry);
+    let second = gen.gen.callback_plan(&key, &gen.registry);
+    assert!(
+        std::rc::Rc::ptr_eq(&first, &second),
+        "the plan is stored, so both emitters read one instance"
+    );
+    // …and it is the whole boundary: the argument's wire slots and the
+    // requirement its encoder creates come off the same plan.
+    assert_eq!(
+        first.wires().count(),
+        2,
+        "a run crosses as a pointer and a length"
+    );
+    assert!(
+        first.needs_array_alloc(),
+        "the encoder it selected calls the array helper"
+    );
+}

--- a/prebindgen-c/src/trait_impl.rs
+++ b/prebindgen-c/src/trait_impl.rs
@@ -1498,17 +1498,12 @@ impl CbindgenBuilder {
         // identities — what the map is keyed by — and the arguments it was
         // declared with are beside it, so neither is rebuilt from the other
         // (#291).
-        let mut cb_keys: Vec<(&CallbackKey, &CbCfg)> = self.callbacks.iter().collect();
-        cb_keys.sort_by_key(|(k, _)| self.callback_c_name(k));
-        for (key, cfg) in cb_keys {
-            let args: Vec<syn::Type> = cfg.args.clone();
-            // Emit only if the callback is required (its input resolved); skip a
-            // declared-but-unused signature.
-            if registry
-                .reading_of(&callback_fn_type(&args))
-                .and_then(|tr| registry.input_entry(&tr))
-                .is_none()
-            {
+        let mut cb_keys: Vec<&CallbackKey> = self.callbacks.keys().collect();
+        cb_keys.sort_by_key(|k| self.callback_c_name(k));
+        for key in cb_keys {
+            // Emit only if the callback is required; skip a declared-but-unused
+            // signature.
+            if !self.callback_is_required(key, registry) {
                 continue;
             }
             // The declaration renders the plan's wire parameters. It does not
@@ -1643,6 +1638,23 @@ impl CbindgenBuilder {
 }
 
 impl CbindgenBuilder {
+    /// Whether a declared callback signature is actually **required** — its
+    /// `impl Fn(..)` input resolved, because some exported function takes one.
+    ///
+    /// A declared-but-unused signature emits no closure struct and must not be
+    /// planned either: its argument types were never classified, so there is no
+    /// converter for a plan to resolve against. Asked by the emission that
+    /// skips it and by the requirement fold that would otherwise plan it, so
+    /// the two cannot disagree about which callbacks exist.
+    fn callback_is_required(&self, key: &CallbackKey, registry: &Registry<()>) -> bool {
+        self.callbacks.get(key).is_some_and(|cfg| {
+            registry
+                .reading_of(&callback_fn_type(&cfg.args))
+                .and_then(|tr| registry.input_entry(&tr))
+                .is_some()
+        })
+    }
+
     /// Whether a callback argument crosses as a **decomposed composite** — the
     /// one delivery lowered from a [`CValuePlan`] rather than handed to the
     /// argument's own converter.
@@ -1687,6 +1699,7 @@ impl CbindgenBuilder {
             || self
                 .callbacks
                 .keys()
+                .filter(|key| self.callback_is_required(key, registry))
                 .any(|key| self.callback_plan(key, registry).needs_array_alloc())
     }
 

--- a/prebindgen-c/src/trait_impl.rs
+++ b/prebindgen-c/src/trait_impl.rs
@@ -1,6 +1,7 @@
 use prebindgen_registry::{Building, Conversions, Crossing, RegistryBuilder};
 
 use super::{builder::callback_fn_type, *};
+use crate::plan::{convert_or_abort, CCallbackArgKind};
 
 /// Per-category **input** terminal converter builders. Each returns
 /// `Some(ConverterImpl)` only for the type category it claims (and `None`
@@ -1510,53 +1511,11 @@ impl CbindgenBuilder {
             {
                 continue;
             }
-            let takeable = &self.callbacks.get(key).expect("callback cfg").takeable;
-            let mut arg_wires: Vec<syn::Type> = Vec::new();
-            for (i, a) in args.iter().enumerate() {
-                // `&[E]` slice arg → TWO C `call` params: `const E_wire *` + `size_t`
-                // (the slice delivered by reference, zero-copy).
-                if let Some((_src, elem_wire)) = self.callback_slice_elem_wire(a) {
-                    arg_wires.push(syn::parse_quote!(*const #elem_wire));
-                    arg_wires.push(syn::parse_quote!(usize));
-                    continue;
-                }
-                let reading = registry.reading_of(a).unwrap_or_else(|| {
-                    panic!(
-                        "Cbindgen: callback arg `{}` was never classified",
-                        a.to_token_stream()
-                    )
-                });
-                let wire = registry
-                    .output_entry(&reading)
-                    .unwrap_or_else(|| {
-                        panic!(
-                            "Cbindgen: callback arg `{}` has no output converter (declare it \
-                             as a opaque_ptr/data_struct/enum_type)",
-                            a.to_token_stream()
-                        )
-                    })
-                    .destination
-                    .clone();
-                // Takeable params are delivered as an owned pointer.
-                if takeable.contains(&i) {
-                    arg_wires.push(syn::parse_quote!(*mut #wire));
-                    continue;
-                }
-                // A composite has no wire of its own, so its C params are the
-                // fields its shape lowers to — exactly as `dispatch_fn_input`
-                // fills them (#428). Each is `MaybeUninit`: an absent value
-                // leaves its slot unwritten, and the wrapper must not build a
-                // Rust value to fill it with. `#[repr(transparent)]` keeps both
-                // the C ABI and the header spelling.
-                if self.callback_arg_is_composite(&reading, takeable.contains(&i), registry) {
-                    for field in self.c_value_plan(&reading, registry).shape.fields {
-                        let w = field.wire;
-                        arg_wires.push(syn::parse_quote!(::core::mem::MaybeUninit<#w>));
-                    }
-                    continue;
-                }
-                arg_wires.push(wire);
-            }
+            // The declaration renders the plan's wire parameters. It does not
+            // classify the arguments again: the trampoline that fills these
+            // slots reads the same plan (#447 §3).
+            let plan = self.callback_plan(key, registry);
+            let arg_wires: Vec<&syn::Type> = plan.wires().collect();
             let c_struct = self.callback_c_ident(key);
             items.push(syn::parse_quote!(
                 #[repr(C)]
@@ -1691,7 +1650,7 @@ impl CbindgenBuilder {
     /// Asked by the lowering that builds the plan and by the prerequisite scan
     /// that collects what those plans need, so "is there a plan here" has one
     /// answer. A slice argument crosses by reference and never builds one.
-    fn callback_arg_is_composite(
+    pub(crate) fn callback_arg_is_composite(
         &self,
         arg: &TypeRef,
         is_takeable: bool,
@@ -1725,14 +1684,10 @@ impl CbindgenBuilder {
             })
         });
         from_returns
-            || self.callbacks.iter().any(|(key, cfg)| {
-                key.iter().enumerate().any(|(i, k)| {
-                    registry.reading(k).is_some_and(|arg| {
-                        self.callback_arg_is_composite(&arg, cfg.takeable.contains(&i), registry)
-                            && self.c_value_plan(&arg, registry).needs_array_alloc
-                    })
-                })
-            })
+            || self
+                .callbacks
+                .keys()
+                .any(|key| self.callback_plan(key, registry).needs_array_alloc())
     }
 
     fn dispatch_fn_input(
@@ -1748,146 +1703,96 @@ impl CbindgenBuilder {
         }
         let c_struct = self.callback_c_ident(&key);
 
-        // Per-arg: closure parameter (`__aN: <src>`) + encode statement
-        // (`let __wN = <output_conv>(__aN);`, panicking if the converter is
-        // fallible — a firing callback has no error channel). A non-takeable arg
-        // is passed to the C `call` by value (the C side owns + drops it); a
-        // **takeable** arg is passed as `&mut __wN` (`*mut z_x_t`) and dropped here
-        // after the call (no-op if the C side took it, leaving a gravestone).
-        let takeable = &self.callbacks.get(&key).expect("callback cfg").takeable;
+        // Not resolvable yet ⇒ leave it for a later rank rather than planning
+        // against a half-filled table. Asked in the plan's own terms, so the
+        // guard and the plan agree about which arguments even need a converter.
+        let cfg = self.callbacks.get(&key).expect("declared, checked above");
+        for declared in &cfg.args {
+            if self.callback_slice_elem_wire(declared).is_some() {
+                continue;
+            }
+            let reading = registry.reading_of(declared)?;
+            registry.output_entry(&reading)?;
+        }
+
+        // One stored plan, rendered here as the trampoline and in
+        // `prereq_callback_structs` as the `call` pointer's signature. A
+        // non-takeable arg is passed to the C `call` by value (the C side owns
+        // and drops it); a **takeable** arg is passed as `&mut __wN`
+        // (`*mut z_x_t`) and dropped here after the call — a no-op if the C
+        // side took it, leaving a gravestone.
+        let plan = self.callback_plan(&key, registry);
         let mut closure_params: Vec<TokenStream> = Vec::new();
         let mut encode_stmts: Vec<TokenStream> = Vec::new();
         let mut call_args: Vec<TokenStream> = Vec::new();
         let mut post_drops: Vec<TokenStream> = Vec::new();
-        for (i, arg) in args.iter().enumerate() {
-            // `&[E]` slice arg: deliver the slice to the C `call` **by reference** —
-            // `(*const E_wire, size_t)`, zero-copy (the closure borrows the slice for
-            // the call). The element wire is layout-identical to `E`, so the pointer
-            // cast is sound; no per-element encode and no post-call drop.
-            if let Some((src_elem, elem_wire)) = self.callback_slice_elem_wire_of(arg) {
-                let ai = format_ident!("__a{}", i);
-                closure_params.push(quote!(#ai: &[#src_elem]));
-                call_args.push(quote!(#ai.as_ptr() as *const #elem_wire));
-                call_args.push(quote!(#ai.len()));
-                continue;
-            }
-            let entry = registry.output_entry(arg)?;
-            let conv = entry.function.sig.ident.clone();
-            let opaque = entry.destination.clone();
-            let fallible = matches!(
-                &entry.function.sig.output,
-                syn::ReturnType::Type(_, ty) if is_result(ty)
-            );
-            let src = self.src_ty_deep_of(arg);
+        for (i, arg) in plan.args.iter().enumerate() {
             let ai = format_ident!("__a{}", i);
             let wi = format_ident!("__w{}", i);
-            let is_takeable = takeable.contains(&i);
-            // A COMPOSITE argument — `Option<T>`, `Vec<T>`, `Cow<'_, [T]>` — has
-            // no converter of its own: `out_wrappers` gives it a marker with a
-            // `()` destination, which exists to resolve the entry and make the
-            // inner required while the real ABI is structural. The return path
-            // lowers those in `lower_shape` / `encode_value`; this one used to
-            // call the marker as if it were a converter, which takes no
-            // arguments (#428). Same lowering, so the two directions cannot
-            // disagree about which shapes they know.
-            //
-            // A takeable argument is a whole-value policy over an opaque handle
-            // and never a composite, so it keeps the by-reference path below.
-            //
-            // Which shapes those are is the MODEL's answer, not the marker's: a
-            // `()` destination says the type has no wire of its own, and a
-            // `Result` has one of those too while no arm lowers it. Field COUNT
-            // cannot say it either — `Option<&T>` carves the pointer's niche and
-            // lowers to a single `*const`, one field and still nothing a
-            // converter call can produce.
-            if !is_takeable
-                && marker_destination(&entry.destination)
-                && !r_is_lowered_composite(arg, registry)
-            {
-                panic!(
-                    "Cbindgen: callback argument `{}` has no C ABI — it resolves to a marker \
-                     converter and is not one of the shapes lowered structurally (`Option<T>`, \
-                     `Vec<T>`, `Cow<'_, [T]>`). Deliver its parts as separate callback \
-                     arguments instead.",
-                    arg,
-                );
-            }
-            // Both halves of the marker test, and both are load-bearing. The
-            // MODEL says which shapes `lower_shape` decomposes; the marker says
-            // this type has no wire of its own — and a `convert!`-declared
-            // `Option<T>` has one, because `out_custom` is tried before
-            // `out_wrappers`. Decomposing that from its shape alone would pass
-            // several arguments to a `call` the struct declared with one
-            // (#428 review).
-            let composite = self.callback_arg_is_composite(arg, is_takeable, registry);
-            if composite {
-                // One plan, read for both the slots and the encode: a callback
-                // argument's layout and the statements that fill it must be the
-                // same resolution, not two that happen to agree (#444 §5).
-                let plan = self.c_value_plan(arg, registry);
-                let shape = &plan.shape;
-                closure_params.push(quote!(#ai: #src));
-                let mut targets = Vec::new();
-                for (f, field) in shape.fields.iter().enumerate() {
-                    let fi = if shape.fields.len() == 1 {
-                        wi.clone()
-                    } else {
-                        format_ident!("__w{}_{}", i, f)
-                    };
-                    let wire = &field.wire;
-                    // A `MaybeUninit`, zeroed. Two things it must not be.
-                    //
-                    // Not a `wire` value: a shape with a `present` flag writes
-                    // only the flag when the value is absent, and materialising
-                    // something to fill the slot is undefined for a wire whose
-                    // all-zero pattern is not a legal value of its type — a
-                    // declared `enum_type`'s discriminants are the source's own,
-                    // so zero need not name a variant at all.
-                    //
-                    // And not left indeterminate: the slot is passed BY VALUE to
-                    // foreign code, so whatever the stack or register held is
-                    // handed to a C callback that reads it despite the flag.
-                    // Zeroing costs a store and discloses nothing, while
-                    // `MaybeUninit` keeps it from ever being a `wire` (#428
-                    // review).
-                    //
-                    // Neither assumes anything about WHICH fields the encode
-                    // writes, which is the encoder's business and not this
-                    // caller's.
-                    encode_stmts
-                        .push(quote!(let mut #fi = ::core::mem::MaybeUninit::<#wire>::zeroed();));
-                    targets.push(quote!(*#fi.as_mut_ptr()));
-                    call_args.push(quote!(#fi));
-                }
-                // A firing callback has no error channel, so a fallible
-                // converter aborts — the same answer the single-value path
-                // below gives, spelled by the route the emitters share.
-                encode_stmts.push(plan.encode(&quote!(#ai), &targets, &ErrRoute::Panic));
-                continue;
-            }
+            let src = &arg.src;
             closure_params.push(quote!(#ai: #src));
-            let mut_kw = if is_takeable { quote!(mut) } else { quote!() };
-            if fallible {
-                encode_stmts.push(quote!(
-                    let #mut_kw #wi = match #conv(#ai) {
-                        ::core::result::Result::Ok(__v) => __v,
-                        ::core::result::Result::Err(__e) => {
-                            ::core::panic!("cbindgen: callback argument conversion failed: {}", __e)
-                        }
-                    };
-                ));
-            } else {
-                encode_stmts.push(quote!(let #mut_kw #wi = #conv(#ai);));
-            }
-            if is_takeable {
-                call_args.push(quote!(&mut #wi as *mut #opaque));
-                // Always drop after the call (leak-safe): live value if untaken,
-                // gravestone (no-op) if the C side took it via `z_x_take`.
-                post_drops.push(
-                    quote!(let _ = <#opaque as ::prebindgen_c_runtime::Transmute>::into_rust(#wi);),
-                );
-            } else {
-                call_args.push(quote!(#wi));
+            match &arg.kind {
+                // Delivered by reference, zero-copy: the closure borrows the
+                // slice for the call, so there is no encode and no drop. The
+                // element wire is layout-identical to `E`, which is what makes
+                // the pointer cast sound.
+                CCallbackArgKind::Slice { elem_wire } => {
+                    call_args.push(quote!(#ai.as_ptr() as *const #elem_wire));
+                    call_args.push(quote!(#ai.len()));
+                }
+                CCallbackArgKind::Composite(value) => {
+                    let mut targets = Vec::new();
+                    for (f, field) in value.shape.fields.iter().enumerate() {
+                        let fi = if value.shape.fields.len() == 1 {
+                            wi.clone()
+                        } else {
+                            format_ident!("__w{}_{}", i, f)
+                        };
+                        let wire = &field.wire;
+                        // A `MaybeUninit`, zeroed. Two things it must not be.
+                        //
+                        // Not a `wire` value: a shape with a `present` flag
+                        // writes only the flag when the value is absent, and
+                        // materialising something to fill the slot is undefined
+                        // for a wire whose all-zero pattern is not a legal value
+                        // of its type — a declared `enum_type`'s discriminants
+                        // are the source's own, so zero need not name a variant.
+                        //
+                        // And not left indeterminate: the slot is passed BY
+                        // VALUE to foreign code, so whatever the stack or
+                        // register held would be handed to a C callback that
+                        // reads it despite the flag. Zeroing costs a store and
+                        // discloses nothing.
+                        //
+                        // Neither assumes anything about WHICH fields the encode
+                        // writes, which is the encoder's business.
+                        encode_stmts.push(
+                            quote!(let mut #fi = ::core::mem::MaybeUninit::<#wire>::zeroed();),
+                        );
+                        targets.push(quote!(*#fi.as_mut_ptr()));
+                        call_args.push(quote!(#fi));
+                    }
+                    // A firing callback has no error channel, so a fallible
+                    // converter aborts — the route the emitters share says so.
+                    encode_stmts.push(value.encode(&quote!(#ai), &targets, &ErrRoute::Panic));
+                }
+                CCallbackArgKind::Takeable {
+                    conv,
+                    opaque,
+                    fallible,
+                } => {
+                    encode_stmts.push(convert_or_abort(conv, &ai, &wi, *fallible, true));
+                    call_args.push(quote!(&mut #wi as *mut #opaque));
+                    // Always drop after the call (leak-safe): a live value if
+                    // untaken, a gravestone no-op if the C side took it.
+                    post_drops.push(quote!(
+                        let _ = <#opaque as ::prebindgen_c_runtime::Transmute>::into_rust(#wi);
+                    ));
+                }
+                CCallbackArgKind::Single { conv, fallible } => {
+                    encode_stmts.push(convert_or_abort(conv, &ai, &wi, *fallible, false));
+                    call_args.push(quote!(#wi));
+                }
             }
         }
 

--- a/prebindgen-jni/src/jni/emit/flat_input.rs
+++ b/prebindgen-jni/src/jni/emit/flat_input.rs
@@ -5,8 +5,7 @@
 // classifier (via `use super::*`), and an explicit import would shadow it.
 use prebindgen_registry::{
     flat::{self, TypeRef},
-    transform::TransformKind,
-    unfold::{OutChild, OutLeaf, OutLink, OutNode, OutProduct, OutReach, PathStep},
+    transform::{Descend, Lowered, TransformKind, TransformLowerer},
     Conversions,
 };
 
@@ -16,7 +15,7 @@ use crate::jni::trait_impl::{build_through_erased_wrappers, build_through_wrappe
 /// Takes the **element**, not the `syn::ItemStruct` it was parsed from (#289):
 /// `flat::Field::ty` is already a `TypeRef`, so every peel below is the model's
 /// answer rather than a last-path-segment test on tokens that had a reading one
-/// level up. Same move `build_flat_struct_node` made for the flatten path; this
+/// level up. Same move [`FlatLower`] made for the flatten path; this
 /// is the whole-object `.jobject_input()` decoder.
 pub(crate) fn struct_input_body(
     ext: &Declarations,
@@ -1304,12 +1303,58 @@ fn push_handle_leaf(
     index
 }
 
+/// The direction of the **flatten boundary**: a Kotlin `data_class` parameter
+/// arriving as individual JNI wire slots and being rebuilt into a Rust value.
+///
+/// Its own direction rather than a borrowed one. The boundary is into-Rust, so
+/// describing it with the out-of-Rust tree said the opposite of what happens;
+/// and its payloads are this boundary's, not another adapter's wire protocol —
+/// which is what keeps physical layout adapter-local (#447 §1, §4).
+///
+/// Two kinds are uninhabited, and that is the shape of the boundary rather than
+/// an omission. A data-carrying enum flattens into a tag plus one group per
+/// variant, but only leaf-shaped payloads flatten, so it never *recurses* — it
+/// is resolved at a leaf, where the tag and groups are layout. A run keeps its
+/// collection boundary and crosses whole, so no sequence layer is ever built.
+pub(crate) struct FlattenIn;
+
+impl prebindgen_registry::transform::TransformDirection for FlattenIn {
+    /// One field crossing through its own converter. What it is, is its type.
+    type Leaf = ();
+    /// A declared struct rebuilt from its fields, named here rather than
+    /// recovered from the node's type by the lowering.
+    type Product = syn::Ident;
+    /// No dispatch at this boundary — see the type's own note.
+    type Choice = std::convert::Infallible;
+    /// An `Option<data_class>`: a present flag decides whether the child's
+    /// slots are read at all.
+    type Optional = ();
+    /// No runs at this boundary — see the type's own note.
+    type Sequence = std::convert::Infallible;
+    /// The source field this child was reached by.
+    type Link = FlatLink;
+}
+
+/// How one flattened field hangs off its struct: the Rust field it came from
+/// and the Kotlin property that reads it.
+pub(crate) struct FlatLink {
+    /// The `flat::Field` name — the native slot prefix and the rebuild's field.
+    pub(crate) field: syn::Ident,
+    /// The Kotlin property name, mangled once where the field is first seen.
+    pub(crate) kotlin: String,
+}
+
+/// One node of the flatten tree.
+pub(crate) type FlatNode = prebindgen_registry::transform::TransformNode<FlattenIn>;
+/// One child edge of the flatten tree.
+pub(crate) type FlatChild = prebindgen_registry::transform::TransformChild<FlattenIn>;
+
 /// The field structure of a flattened `data_class`, as a registry tree (#444 §5).
 ///
 /// This is the flattening's *semantic recursion*, stated once: which fields
 /// inline a nested declared class, which of those sit behind an `Option`, the
 /// order they cross in, and the cycle and depth limits that stop the descent.
-/// [`build_flat_struct_node`] then lowers this tree into JNI wire leaves
+/// [`FlatLower`] then lowers this tree into JNI wire leaves
 /// without deciding any of it again.
 ///
 /// A field is a leaf unless it names a declared `data_class` — including a
@@ -1329,23 +1374,7 @@ fn synth_input_field_tree(
     native_prefix: &str,
     root: &TypeKey,
     stack: &mut Vec<TypeKey>,
-) -> Result<OutNode, FlatInputError> {
-    // The lowering recovers this node's struct from `ty` rather than carrying
-    // it, so the two readings of "which struct is this" must not drift: the
-    // classification `type_kind` answered for the field must name the struct
-    // `unwrapped` finds in the same type. Checked here, where both are in hand,
-    // because the corpus covers a wrapped root (`Box<Payload>`) but not yet a
-    // wrapped nested field.
-    debug_assert_eq!(
-        match ty.unwrapped().kind() {
-            flat::TypeKind::Named { id, .. } => id.ident(),
-            _ => None,
-        }
-        .as_ref(),
-        Some(&st.name),
-        "flatten tree: `{}` classifies as a struct the type does not name",
-        ty.key(),
-    );
+) -> Result<FlatNode, FlatInputError> {
     let node_key = TypeKey::from_ident(&st.name);
     if stack.contains(&node_key) {
         return Err(flat_error(
@@ -1362,7 +1391,7 @@ fn synth_input_field_tree(
         ));
     }
     stack.push(node_key);
-    let mut children: Vec<OutChild> = Vec::new();
+    let mut children: Vec<FlatChild> = Vec::new();
     for field in &st.fields {
         // A positional field has no name to derive a Kotlin property from,
         // which is what "only named-field structs can flatten" used to say one
@@ -1376,9 +1405,9 @@ fn synth_input_field_tree(
             ));
         };
         let child_native = format!("{native_prefix}_{fident}");
-        let link = OutLink {
-            steps: vec![PathStep::field(fident.clone(), false)],
-            name: vec![kotlin_property_name(&fident)],
+        let link = FlatLink {
+            kotlin: kotlin_property_name(&fident),
+            field: fident.clone(),
         };
         // The optional layer off the MODEL, asked once: it becomes the node's
         // `Optional` layer for a nested class and the leaf's `nullable`
@@ -1402,35 +1431,31 @@ fn synth_input_field_tree(
                     root,
                     stack,
                 )?;
-                children.push(OutChild { link, node });
+                children.push(FlatChild { link, node });
                 continue;
             }
         }
 
         // Everything else crosses through its own converter, however many wire
         // slots that takes.
-        children.push(OutChild {
+        children.push(FlatChild {
             link,
-            node: OutNode {
+            node: FlatNode {
                 ty: field.ty.clone(),
-                kind: TransformKind::Leaf(OutLeaf {
-                    nullable: optional,
-                    identity: false,
-                    reach: OutReach::Field,
-                }),
+                kind: TransformKind::Leaf(()),
             },
         });
     }
     stack.pop();
-    let product = OutNode {
+    let product = FlatNode {
         ty: ty.clone(),
         kind: TransformKind::Product {
-            op: OutProduct::Records,
+            op: st.name.clone(),
             children,
         },
     };
     Ok(if optional {
-        OutNode {
+        FlatNode {
             ty: ty.clone(),
             kind: TransformKind::Optional {
                 op: (),
@@ -1530,16 +1555,25 @@ pub(crate) fn build_flat_input_plan(
         &mut Vec::new(),
     )?;
     let mut leaves: Vec<FlatLeaf> = Vec::new();
-    let root = build_flat_struct_node(
+    let mut lower = FlatLower {
         ext,
         registry,
-        &tree,
-        &param_name.to_string(),
-        "",
-        optional,
-        &key,
-        &mut leaves,
-    )?;
+        root: &key,
+        leaves: &mut leaves,
+        // The parameter's own position: its native prefix, an empty access the
+        // first field appends to, and no nullability of its own — the tree's
+        // outer layer supplies that if the parameter is optional.
+        ctx: vec![FlatCtx {
+            field: None,
+            native: param_name.to_string(),
+            access: String::new(),
+            nullable: false,
+        }],
+        present: vec![None],
+    };
+    let FlatValue::Struct(root) = tree.lower(&mut lower)? else {
+        unreachable!("a flattened parameter's tree is a struct")
+    };
     let contains_nested = root
         .fields
         .iter()
@@ -1565,82 +1599,189 @@ pub(crate) fn build_flat_input_plan(
 /// takes the decoupled `(present, value)` pair like its bare twin. The emitter
 /// then has to put the `Box` back — which is why this migration could not land
 /// before the rebuild did.
-fn build_flat_struct_node(
-    ext: &Declarations,
-    registry: &Registry<KotlinMeta>,
-    node: &OutNode,
-    native_prefix: &str,
-    access_prefix: &str,
-    nullable_context: bool,
-    root: &TypeKey,
-    leaves: &mut Vec<FlatLeaf>,
-) -> Result<FlatStructNode, FlatInputError> {
-    // The tree already decided that this nests and whether an `Option` layer
-    // sits over it; reading the layer off the node is what stops the lowering
-    // from re-deciding it.
-    let (optional, product) = match &node.kind {
-        TransformKind::Optional { inner, .. } => (true, inner.as_ref()),
-        _ => (false, node),
-    };
-    let TransformKind::Product { children, .. } = &product.kind else {
-        unreachable!("a flattened data-class node is a product of its fields")
-    };
-    // The NAME off the classification, not off the last path segment, so a
-    // `Box<Payload>` node answers `Payload`. This recovers what the tree
-    // already settled on; it does not decide anything again.
-    let struct_ident = match product.ty.unwrapped().kind() {
-        flat::TypeKind::Named { id, .. } => id.ident(),
-        _ => None,
+/// Where one node sits: the source field it came from, the native slot prefix,
+/// the Kotlin expression that reaches it, and whether that expression may be
+/// null.
+///
+/// Inherited context, which a bottom-up lowering has no other way to carry:
+/// [`TransformLowerer::descend`] derives each node's from its parent's before
+/// anything below is visited, and the matching hook drops it again.
+struct FlatCtx {
+    /// The link's field, kept because `leaf` is handed a node and no edge.
+    field: Option<syn::Ident>,
+    native: String,
+    access: String,
+    nullable: bool,
+}
+
+/// What one lowered node contributes to its parent.
+enum FlatValue {
+    /// A field crossing through its own converter, however many slots that
+    /// takes.
+    Field(FlatFieldNode),
+    /// A nested declared class, rebuilt from its own fields.
+    Struct(FlatStructNode),
+}
+
+/// Lowers the flatten tree into the JNI-resolved input plan.
+///
+/// The structural recursion is the tree builder's, once. This walks that tree
+/// through the shared traversal instead of matching node kinds by hand, so the
+/// flattening and its lowering are one description rather than two that must
+/// stay in step (#447 §4).
+struct FlatLower<'a> {
+    ext: &'a Declarations,
+    registry: &'a Registry<KotlinMeta>,
+    root: &'a TypeKey,
+    leaves: &'a mut Vec<FlatLeaf>,
+    /// Innermost last; seeded with the parameter's own position.
+    ctx: Vec<FlatCtx>,
+    /// The present flag a layer wrote, waiting for its `optional` hook. The
+    /// flag gates the fields below it, so it must take the earlier slot — it is
+    /// written on the way down and claimed on the way up.
+    present: Vec<Option<syn::Ident>>,
+}
+
+impl FlatLower<'_> {
+    fn top(&self) -> &FlatCtx {
+        self.ctx
+            .last()
+            .expect("a node is lowered inside its context")
     }
-    .expect("a flattened data-class node names a declared struct");
-    let present_ident = if optional {
-        let native = format!("{native_prefix}_present");
-        push_present_leaf(leaves, &native, format!("{access_prefix} != null"), None);
-        Some(format_ident!("{native}"))
-    } else {
-        None
-    };
-    let mut fields = Vec::new();
-    for child in children {
-        // Name, Kotlin property and optionality all come off the tree: the link
-        // carries the source field and the node carries the layer, so the
-        // lowering never re-reads the struct to recover them (#273).
-        let fident = child.link.steps[0].ident().clone();
-        let fcamel = child.link.name[0].clone();
-        let child_native = format!("{native_prefix}_{}", fident);
-        let field_ref = if nullable_context {
-            format!("{access_prefix}?.{fcamel}")
-        } else {
-            format!("{access_prefix}.{fcamel}")
+
+    /// Drop the context a node was lowered in, and the flag slot beside it.
+    fn leave(&mut self) -> (FlatCtx, Option<syn::Ident>) {
+        let present = self.present.pop().expect("pushed on the way down");
+        let ctx = self.ctx.pop().expect("pushed on the way down");
+        (ctx, present)
+    }
+}
+
+impl TransformLowerer<FlattenIn> for FlatLower<'_> {
+    type Value = FlatValue;
+    type Error = FlatInputError;
+
+    fn descend(
+        &mut self,
+        node: &FlatNode,
+        link: Option<&FlatLink>,
+    ) -> Result<Descend<FlatValue>, FlatInputError> {
+        let top = self.top();
+        let optional = matches!(node.kind, TransformKind::Optional { .. });
+        // A child derives its position from its parent's; an arity layer and
+        // the root reach their node directly and inherit it unchanged.
+        let ctx = match link {
+            Some(link) => FlatCtx {
+                field: Some(link.field.clone()),
+                native: format!("{}_{}", top.native, link.field),
+                access: if top.nullable {
+                    format!("{}?.{}", top.access, link.kotlin)
+                } else {
+                    format!("{}.{}", top.access, link.kotlin)
+                },
+                // An optional child is null-reachable from here down.
+                nullable: top.nullable || optional,
+            },
+            None => FlatCtx {
+                field: top.field.clone(),
+                native: top.native.clone(),
+                access: top.access.clone(),
+                nullable: top.nullable || optional,
+            },
         };
-        // The field's reading is the node's own type, so the leaf resolution
-        // below reads it from the tree rather than from the struct.
-        let field = &child.node;
-        let field_optional = matches!(
-            &child.node.kind,
-            TransformKind::Optional { .. } | TransformKind::Leaf(OutLeaf { nullable: true, .. })
-        );
+        let present = optional.then(|| {
+            let native = format!("{}_present", ctx.native);
+            push_present_leaf(
+                self.leaves,
+                &native,
+                format!("{} != null", ctx.access),
+                None,
+            );
+            format_ident!("{native}")
+        });
+        self.ctx.push(ctx);
+        self.present.push(present);
+        Ok(Descend::Recurse)
+    }
+
+    fn optional(
+        &mut self,
+        _node: &FlatNode,
+        _op: &(),
+        _inner: &FlatNode,
+        value: FlatValue,
+    ) -> Result<FlatValue, FlatInputError> {
+        let (_, present_ident) = self.leave();
+        let FlatValue::Struct(mut node) = value else {
+            unreachable!("only a declared class nests, and it lowers to a struct")
+        };
+        node.optional = true;
+        node.present_ident = present_ident;
+        Ok(FlatValue::Struct(node))
+    }
+
+    fn choice(
+        &mut self,
+        _node: &FlatNode,
+        op: &std::convert::Infallible,
+        _variants: Lowered<'_, FlattenIn, FlatValue>,
+    ) -> Result<FlatValue, FlatInputError> {
+        match *op {}
+    }
+
+    fn sequence(
+        &mut self,
+        _node: &FlatNode,
+        op: &std::convert::Infallible,
+        _inner: &FlatNode,
+        _value: FlatValue,
+    ) -> Result<FlatValue, FlatInputError> {
+        match *op {}
+    }
+
+    fn product(
+        &mut self,
+        _node: &FlatNode,
+        struct_ident: &syn::Ident,
+        children: Lowered<'_, FlattenIn, FlatValue>,
+    ) -> Result<FlatValue, FlatInputError> {
+        let fields = children
+            .into_iter()
+            .map(|(child, value)| match value {
+                FlatValue::Field(f) => f,
+                FlatValue::Struct(node) => FlatFieldNode::Nested {
+                    field: child.link.field.clone(),
+                    node: Box::new(node),
+                },
+            })
+            .collect();
+        let (ctx, _) = self.leave();
+        Ok(FlatValue::Struct(FlatStructNode {
+            struct_module: struct_module_path(self.ext, self.registry, struct_ident),
+            struct_ident: struct_ident.clone(),
+            binding: format_ident!("__flat_{}", ctx.native),
+            // A layer above sets both; a bare product has neither.
+            optional: false,
+            present_ident: None,
+            fields,
+        }))
+    }
+
+    fn leaf(&mut self, field: &FlatNode, _op: &()) -> Result<FlatValue, FlatInputError> {
+        let (ctx, _) = self.leave();
+        let ext = self.ext;
+        let registry = self.registry;
+        let root = self.root;
+        let leaves = &mut *self.leaves;
+        let fident = ctx.field.expect("a field leaf was reached by its own link");
+        let child_native = ctx.native;
+        let field_ref = ctx.access;
+        // The context the field's ACCESS was built with — its parent's — which
+        // is what every default and coalesce below answers to.
+        let nullable_context = self.ctx.last().is_some_and(|c| c.nullable);
+        let field_optional = field.ty.optional_inner().is_some();
         let nested = field.ty.optional_inner().unwrap_or(&field.ty);
 
-        // A nested declared class: the tree said so, so descend without asking
-        // the type again.
-        if !matches!(child.node.kind, TransformKind::Leaf(_)) {
-            let node = build_flat_struct_node(
-                ext,
-                registry,
-                &child.node,
-                &child_native,
-                &field_ref,
-                nullable_context || field_optional,
-                root,
-                leaves,
-            )?;
-            fields.push(FlatFieldNode::Nested {
-                field: fident,
-                node: Box::new(node),
-            });
-            continue;
-        }
         // A data-carrying enum flattens into a tag plus one group per variant.
         // `None` means some payload is not leaf-shaped — fall through and let
         // it cross as one object through its own converter.
@@ -1657,8 +1798,7 @@ fn build_flat_struct_node(
                 &field.ty,
                 leaves,
             ) {
-                fields.push(node);
-                continue;
+                return Ok(FlatValue::Field(node));
             }
         }
         let path = child_native.clone();
@@ -1701,7 +1841,7 @@ fn build_flat_struct_node(
                                 value_access,
                                 false,
                             );
-                            fields.push(FlatFieldNode::Value {
+                            return Ok(FlatValue::Field(FlatFieldNode::Value {
                                 field: fident,
                                 value_leaf: value_index,
                                 present_leaf: Some(present_index),
@@ -1709,8 +1849,7 @@ fn build_flat_struct_node(
                                 optional_handle: false,
                                 rust_ty: Box::new(field.ty.clone()),
                                 wrappers: field.ty.erased_wrappers(),
-                            });
-                            continue;
+                            }));
                         }
                     }
                 }
@@ -1751,7 +1890,7 @@ fn build_flat_struct_node(
                             format!("{field_ref}?.toLong() ?: 0L"),
                             false,
                         );
-                        fields.push(FlatFieldNode::Value {
+                        return Ok(FlatValue::Field(FlatFieldNode::Value {
                             field: fident,
                             value_leaf: value_index,
                             present_leaf: Some(present_index),
@@ -1759,8 +1898,7 @@ fn build_flat_struct_node(
                             optional_handle: false,
                             rust_ty: Box::new(field.ty.clone()),
                             wrappers: field.ty.erased_wrappers(),
-                        });
-                        continue;
+                        }));
                     }
                 }
             }
@@ -1781,7 +1919,7 @@ fn build_flat_struct_node(
                         field_ref,
                         nullable_context || optional_handle,
                     );
-                    fields.push(FlatFieldNode::Value {
+                    return Ok(FlatValue::Field(FlatFieldNode::Value {
                         field: fident,
                         value_leaf: value_index,
                         present_leaf: None,
@@ -1789,8 +1927,7 @@ fn build_flat_struct_node(
                         optional_handle,
                         rust_ty: Box::new(field.ty.clone()),
                         wrappers: field.ty.erased_wrappers(),
-                    });
-                    continue;
+                    }));
                 }
                 ProjectionKind::Unsigned64 => {
                     let is_opt = field_optional;
@@ -1812,7 +1949,7 @@ fn build_flat_struct_node(
                         access,
                         false,
                     );
-                    fields.push(FlatFieldNode::Value {
+                    return Ok(FlatValue::Field(FlatFieldNode::Value {
                         field: fident,
                         value_leaf: value_index,
                         present_leaf: None,
@@ -1820,8 +1957,7 @@ fn build_flat_struct_node(
                         optional_handle: false,
                         rust_ty: Box::new(field.ty.clone()),
                         wrappers: field.ty.erased_wrappers(),
-                    });
-                    continue;
+                    }));
                 }
             }
         }
@@ -1859,7 +1995,7 @@ fn build_flat_struct_node(
             access,
             (field_is_option || nullable_context) && is_jobject_shaped_wire(&fentry.destination),
         );
-        fields.push(FlatFieldNode::Value {
+        Ok(FlatValue::Field(FlatFieldNode::Value {
             field: fident,
             value_leaf: value_index,
             present_leaf: None,
@@ -1867,18 +2003,9 @@ fn build_flat_struct_node(
             optional_handle: false,
             rust_ty: Box::new(field.ty.clone()),
             wrappers: field.ty.erased_wrappers(),
-        });
+        }))
     }
-    Ok(FlatStructNode {
-        struct_module: struct_module_path(ext, registry, &struct_ident),
-        struct_ident,
-        binding: format_ident!("__flat_{native_prefix}"),
-        optional,
-        present_ident,
-        fields,
-    })
 }
-
 /// Render the native reconstruct for a [`FlatInputPlan`]: decode each leaf
 /// param with its per-field converter (lazily, inside the `present` branch for
 /// an `Option<struct>`) and bind the rebuilt struct to `arg_ident`. Each decode

--- a/prebindgen-jni/src/jni/overloads.rs
+++ b/prebindgen-jni/src/jni/overloads.rs
@@ -248,6 +248,9 @@ fn non_null(mut ty: KtType) -> KtType {
 fn variant_typed_params(
     registry: &impl Conversions<KotlinMeta>,
     arm: &InNode,
+    // The positions this arm's arguments occupy, supplied by the plan's
+    // layout — the tree no longer carries positions (#447 §1).
+    arg_slots: &[usize],
     origin: &syn::Ident,
     block: &[KtParam],
     multi: bool,
@@ -277,7 +280,8 @@ fn variant_typed_params(
         None => (vec![origin_kt.clone()], vec![false]),
     };
     let mut out = Vec::new();
-    for (m, idx) in arm.leaf_args()?.into_iter().enumerate() {
+    arm.leaf_args()?;
+    for (m, idx) in arg_slots.iter().copied().enumerate() {
         let slot = block.get(idx)?;
         let base = names.get(m).cloned().unwrap_or_else(|| slot.name.clone());
         let name = if multi && ctor.is_some() {
@@ -361,6 +365,7 @@ fn resolve_split<'a>(
     // single-leaf arms only — the arm's one nullable param doubles as the
     // presence flag (`null` = absent). Multi-leaf arms stay selector-only.
     let optional = plan.produces_option();
+    let arm_slots = plan.arm_arg_slots();
     let arms: Vec<(usize, Vec<(KtParam, usize)>)> = plan
         .tree()
         .arms()
@@ -368,14 +373,16 @@ fn resolve_split<'a>(
         .enumerate()
         .filter(|(_, a)| !optional || a.leaf_args().is_some_and(|l| l.len() == 1))
         .map(|(vi, a)| {
-            let typed = variant_typed_params(registry, a, &param, block, multi, optional)
-                .unwrap_or_else(|| {
-                    panic!(
+            let arg_slots = arm_slots[vi].clone().unwrap_or_default();
+            let typed =
+                variant_typed_params(registry, a, &arg_slots, &param, block, multi, optional)
+                    .unwrap_or_else(|| {
+                        panic!(
                         "fun!({}).split_on_param(\"{param_name}\"): an arm has a non-flat input; \
                          it cannot be overloaded",
                         f.name
                     )
-                });
+                    });
             (vi, typed)
         })
         .collect();
@@ -590,7 +597,7 @@ fn combo_label(splits: &[Split], combo: &[usize]) -> String {
 mod tests {
     use prebindgen::SourceLocation;
     use prebindgen_registry::{
-        expand::{InChild, InLeaf, InLink, InProduct, InSlot},
+        expand::{InChild, InLeaf, InLink, InProduct},
         transform::TransformKind,
     };
 
@@ -624,18 +631,11 @@ mod tests {
                 children: f
                     .params
                     .iter()
-                    .enumerate()
-                    .map(|(i, p)| InChild {
+                    .map(|p| InChild {
                         link: InLink { by_ref: false },
                         node: InNode {
                             ty: p.ty.clone(),
-                            kind: TransformKind::Leaf(InLeaf::Slot {
-                                slot: InSlot {
-                                    slot: i,
-                                    name: p.name.clone(),
-                                },
-                                wrapped: false,
-                            }),
+                            kind: TransformKind::Leaf(InLeaf::Slot { wrapped: false }),
                         },
                     })
                     .collect(),
@@ -651,6 +651,7 @@ mod tests {
         let params = variant_typed_params(
             &registry,
             &arm,
+            &[0, 1],
             &syn::parse_quote!(expected),
             &block,
             false,

--- a/prebindgen-registry/src/expand.rs
+++ b/prebindgen-registry/src/expand.rs
@@ -43,8 +43,8 @@ pub use self::{
     error::{ExpandDeclError, ExpandError},
     plan::{FoldLeaf, FoldPlan, FoldShape, SlotKind, SlotLayout},
     tree::{
-        dependencies, select, wire_leaves, Claim, Dependencies, InChild, InChoice, InLeaf, InLink,
-        InNode, InPresence, InProduct, InRun, InSlot, IntoRust, Lift, SelectError,
+        dependencies, derive_layout, select, wire_leaves, Claim, Dependencies, InChild, InChoice,
+        InLeaf, InLink, InNode, InPresence, InProduct, InRun, IntoRust, Lift, SelectError,
     },
 };
 use crate::transform::{Lowered, TransformKind, TransformLowerer};
@@ -451,6 +451,10 @@ fn build_plan<M>(
     //    `0..n-1` = the taken arm (no separate present flag — not-taken arms'
     //    slots are null exactly as in the non-optional selector case).
     if optional {
+        // Claimed by whichever presence the layer uses: a combined dispatch
+        // reports its selector, a flag layer records its own position.
+        let mut root_selector = None;
+        let mut root_present = None;
         let presence_and_core = match variants {
             [Variant::Ctor(func)] => {
                 let sig = ctor_signature(registry, func, &target.key())?;
@@ -459,10 +463,7 @@ fn build_plan<M>(
                     // The layer's slot holds the ARGUMENT, optionally: its
                     // `Option` is whole-parameter presence, and what the
                     // constructor gets is the payload the layer unwrapped.
-                    let payload = InSlot {
-                        slot: next_slot(&mut next, param, SlotKind::PresencePayload),
-                        name: param.clone(),
-                    };
+                    next_slot(&mut next, param, SlotKind::PresencePayload);
                     let arg = InChild {
                         link: InLink { by_ref: false },
                         node: InNode {
@@ -471,19 +472,14 @@ fn build_plan<M>(
                         },
                     };
                     (
-                        InPresence::Payload {
-                            slot: payload,
-                            ty: pty.optional(),
-                        },
+                        InPresence::Payload { ty: pty.optional() },
                         ctor_node(target, func, sig.fallible, vec![arg]),
                     )
                 } else {
                     // Multi-arg: presence flag first, then one plain slot per
                     // constructor argument.
-                    let flag = InSlot {
-                        slot: next_slot(&mut next, param, SlotKind::PresenceFlag),
-                        name: ident(&format!("{}_present", param)),
-                    };
+                    let flag_name = ident(&format!("{}_present", param));
+                    root_present = Some(next_slot(&mut next, &flag_name, SlotKind::PresenceFlag));
                     let prefix = param.to_string();
                     let mut args = Vec::new();
                     for (pname, pty) in &sig.params {
@@ -510,7 +506,7 @@ fn build_plan<M>(
                         args.push(arg);
                     }
                     (
-                        InPresence::Flag(flag),
+                        InPresence::Flag,
                         ctor_node(target, func, sig.fallible, args),
                     )
                 }
@@ -519,11 +515,12 @@ fn build_plan<M>(
                 // Combined-selector dispatch under the layer.
                 visited.insert(target.key());
                 let prefix = param.to_string();
-                let core = build_core(
+                let (core, sel) = build_core(
                     exp, registry, ed, target, variants, by_ref, &prefix, &prefix, &mut next,
                     visited,
                 )?;
                 visited.remove(&target.key());
+                root_selector = sel;
                 (InPresence::Selector, core)
             }
         };
@@ -538,10 +535,10 @@ fn build_plan<M>(
         return Ok(FoldPlan {
             target: target.clone(),
             by_ref,
-            leaves: wire_leaves(&tree),
+            leaves: wire_leaves(&tree, &next),
             layout: next,
-            selector: tree.selector(),
-            present: tree.present(),
+            selector: root_selector,
+            present: root_present,
             tree,
         });
     }
@@ -550,17 +547,19 @@ fn build_plan<M>(
     // on the cycle chain so a constructor parameter of the same type is rejected.
     visited.insert(target.key());
     let prefix = param.to_string();
-    let tree = build_core(
+    let (tree, root_selector) = build_core(
         exp, registry, ed, target, variants, by_ref, &prefix, &prefix, &mut next, visited,
     )?;
     visited.remove(&target.key());
     Ok(FoldPlan {
         target: target.clone(),
         by_ref,
-        leaves: wire_leaves(&tree),
+        leaves: wire_leaves(&tree, &next),
         layout: next,
-        selector: tree.selector(),
-        present: tree.present(),
+        // Reported by the construction that claimed it, not searched for: a
+        // nested build has a selector of its own (#447 §1).
+        selector: root_selector,
+        present: None,
         tree,
     })
 }
@@ -586,20 +585,12 @@ fn ctor_node(
 
 /// One wire slot used as an argument: `wrapped` when selector presence put an
 /// `Option` around it.
-fn leaf_child(
-    ty: prebindgen_flat::flat::TypeRef,
-    slot: usize,
-    name: syn::Ident,
-    wrapped: bool,
-) -> InChild {
+fn leaf_child(ty: prebindgen_flat::flat::TypeRef, wrapped: bool) -> InChild {
     InChild {
         link: InLink { by_ref: false },
         node: InNode {
             ty,
-            kind: TransformKind::Leaf(InLeaf::Slot {
-                slot: InSlot { slot, name },
-                wrapped,
-            }),
+            kind: TransformKind::Leaf(InLeaf::Slot { wrapped }),
         },
     }
 }
@@ -641,7 +632,7 @@ fn build_core<M>(
     at: &str,
     next: &mut SlotLayout,
     visited: &mut HashSet<TypeKey>,
-) -> Result<InNode, ExpandError> {
+) -> Result<(InNode, Option<usize>), ExpandError> {
     if let [Variant::Ctor(func)] = variants {
         // Single constructor — no selector; args passed directly (not Option-wrapped).
         let sig = ctor_signature(registry, func, &target.key())?;
@@ -665,14 +656,12 @@ fn build_core<M>(
                 visited,
             )?);
         }
-        return Ok(ctor_node(target, func, sig.fallible, args));
+        // One unconditional constructor: nothing dispatches, so no selector.
+        return Ok((ctor_node(target, func, sig.fallible, args), None));
     }
     // Combined — selector slot, then `Option`-wrapped per-arm inputs.
     let sel_name = ident(&format!("{}_sel", prefix));
-    let selector = InSlot {
-        slot: next_slot(next, &sel_name, SlotKind::Selector),
-        name: sel_name,
-    };
+    let sel_slot = next_slot(next, &sel_name, SlotKind::Selector);
     let mut arms: Vec<InChild> = Vec::new();
     for (vi, v) in variants.iter().enumerate() {
         let node = match v {
@@ -713,7 +702,7 @@ fn build_core<M>(
                     target.clone()
                 };
                 let arm_name = ident(&format!("{}_{}", prefix, vi));
-                let slot = next_slot(next, &arm_name, SlotKind::Value);
+                next_slot(next, &arm_name, SlotKind::Value);
                 InNode {
                     ty: target.clone(),
                     kind: TransformKind::Product {
@@ -726,7 +715,7 @@ fn build_core<M>(
                                 Lift::Direct
                             },
                         },
-                        children: vec![leaf_child(leaf_ty, slot, arm_name, true)],
+                        children: vec![leaf_child(leaf_ty, true)],
                     },
                 }
             }
@@ -736,13 +725,16 @@ fn build_core<M>(
             node,
         });
     }
-    Ok(InNode {
-        ty: target.clone(),
-        kind: TransformKind::Choice {
-            op: InChoice { selector },
-            variants: arms,
+    Ok((
+        InNode {
+            ty: target.clone(),
+            kind: TransformKind::Choice {
+                op: InChoice { dispatch: () },
+                variants: arms,
+            },
         },
-    })
+        Some(sel_slot),
+    ))
 }
 
 /// Build one constructor-parameter input. If the parameter's (peeled) type has
@@ -803,6 +795,8 @@ fn build_arg<M>(
             visited,
         )?;
         visited.remove(&key);
+        // A nested build's own dispatch is not the root's.
+        let (node, _nested_selector) = node;
         Ok(InChild {
             link: InLink { by_ref: pby_ref },
             node,
@@ -817,12 +811,8 @@ fn build_arg<M>(
         // The node carries the PAYLOAD; the `Option` selector presence adds is
         // derived from `wrapped` wherever the wire is asked for, so the two
         // cannot drift apart (#447 §1).
-        Ok(leaf_child(
-            pty.clone(),
-            next_slot(next, &name, SlotKind::Value),
-            name,
-            wrapped,
-        ))
+        next_slot(next, &name, SlotKind::Value);
+        Ok(leaf_child(pty.clone(), wrapped))
     }
 }
 
@@ -875,6 +865,8 @@ pub fn emit_fold_tree(
     tree.lower(&mut ConstructEmitter {
         leaf_locals,
         qualify,
+        next: 0,
+        claimed: Vec::new(),
     })
     .expect("emitting a built construct cannot fail")
 }
@@ -899,6 +891,29 @@ struct ConstructEmitter<'a> {
     /// Maps a constructor ident to its call path (e.g. prefixing the source
     /// module).
     qualify: &'a dyn Fn(&syn::Ident) -> syn::Path,
+    /// The next position to claim.
+    ///
+    /// The tree no longer carries slot numbers, so this walk re-derives them —
+    /// and gets the same ones, because it claims in the order the layout was
+    /// built in (#447 §1). `descend` runs before anything below a node, which
+    /// is that order.
+    next: usize,
+    /// The position each node claimed, innermost last; a hook pops its own.
+    /// `None` for a node that claims nothing.
+    claimed: Vec<Option<usize>>,
+}
+
+impl ConstructEmitter<'_> {
+    fn claim(&mut self) -> usize {
+        let slot = self.next;
+        self.next += 1;
+        slot
+    }
+
+    /// The position the node whose hook is running claimed.
+    fn mine(&mut self) -> Option<usize> {
+        self.claimed.pop().expect("pushed on the way down")
+    }
 }
 
 impl ConstructEmitter<'_> {
@@ -917,9 +932,39 @@ impl TransformLowerer<IntoRust> for ConstructEmitter<'_> {
     type Value = syn::Expr;
     type Error = std::convert::Infallible;
 
+    /// Claim this node's position before anything below it, which is the order
+    /// the layout claimed them in.
+    ///
+    /// A `Selector` layer claims nothing of its own: the dispatch under it
+    /// carries absence too. That layer still needs the selector's position, and
+    /// takes the one its inner choice is about to claim — exact rather than a
+    /// guess, because the traversal visits that inner node next and a choice
+    /// claims its selector before its arms.
+    fn descend(
+        &mut self,
+        node: &InNode,
+        _link: Option<&InLink>,
+    ) -> Result<crate::transform::Descend<syn::Expr>, Self::Error> {
+        let claimed = match &node.kind {
+            TransformKind::Leaf(InLeaf::Slot { .. }) => Some(self.claim()),
+            TransformKind::Choice { .. } => Some(self.claim()),
+            TransformKind::Sequence { .. } => Some(self.claim()),
+            TransformKind::Optional { op, .. } => match op {
+                InPresence::Selector => Some(self.next),
+                InPresence::Flag | InPresence::Payload { .. } => Some(self.claim()),
+            },
+            TransformKind::Leaf(InLeaf::Bound) | TransformKind::Product { .. } => None,
+        };
+        self.claimed.push(claimed);
+        Ok(crate::transform::Descend::Recurse)
+    }
+
     fn leaf(&mut self, _node: &InNode, op: &InLeaf) -> Result<syn::Expr, Self::Error> {
+        let claimed = self.mine();
         let local = match op {
-            InLeaf::Slot { slot, .. } => self.leaf_locals[slot.slot].clone(),
+            InLeaf::Slot { .. } => {
+                self.leaf_locals[claimed.expect("a slot leaf claimed a position")].clone()
+            }
             InLeaf::Bound => bound_local(),
         };
         Ok(syn::parse_quote!(#local))
@@ -931,6 +976,8 @@ impl TransformLowerer<IntoRust> for ConstructEmitter<'_> {
         op: &InProduct,
         children: Lowered<'_, IntoRust, syn::Expr>,
     ) -> Result<syn::Expr, Self::Error> {
+        // A product claims no position of its own; its children claimed theirs.
+        let _ = self.mine();
         let missing = quote!(::core::result::Result::Err(::std::string::String::from(
             "constructor variant input missing"
         )));
@@ -1054,10 +1101,10 @@ impl TransformLowerer<IntoRust> for ConstructEmitter<'_> {
     fn choice(
         &mut self,
         _node: &InNode,
-        op: &InChoice,
+        _op: &InChoice,
         variants: Lowered<'_, IntoRust, syn::Expr>,
     ) -> Result<syn::Expr, Self::Error> {
-        let sel = &self.leaf_locals[op.selector.slot];
+        let sel = &self.leaf_locals[self.mine().expect("a dispatch claimed its selector")];
         let arms: Vec<TokenStream> = variants
             .iter()
             .enumerate()
@@ -1084,12 +1131,13 @@ impl TransformLowerer<IntoRust> for ConstructEmitter<'_> {
         _inner: &InNode,
         value: syn::Expr,
     ) -> Result<syn::Expr, Self::Error> {
+        let claimed = self.mine().expect("a layer claimed or borrowed a position");
         Ok(match op {
             // The dispatch's selector ALSO encodes absence — `-1` = `None`,
             // `0..n-1` = the taken arm (dispatched by the construction below;
             // an out-of-range selector still hits its `Err` default arm).
             InPresence::Selector => {
-                let sel = &self.leaf_locals[_inner.selector().expect("a selector-decided layer")];
+                let sel = &self.leaf_locals[claimed];
                 syn::parse_quote!(if #sel < 0 {
                     ::core::result::Result::Ok(::core::option::Option::None)
                 } else {
@@ -1098,8 +1146,8 @@ impl TransformLowerer<IntoRust> for ConstructEmitter<'_> {
             }
             // An explicit flag decides; the construction reads its plain
             // argument slots directly, and the flag slot is consumed only here.
-            InPresence::Flag(flag) => {
-                let present = &self.leaf_locals[flag.slot];
+            InPresence::Flag => {
+                let present = &self.leaf_locals[claimed];
                 syn::parse_quote!(if #present {
                     (#value).map(::core::option::Option::Some)
                 } else {
@@ -1109,8 +1157,8 @@ impl TransformLowerer<IntoRust> for ConstructEmitter<'_> {
             // Presence rides the layer's own `Option` slot: unwrap it, bind the
             // payload, and the single-argument construction below reads that
             // binding.
-            InPresence::Payload { slot: payload, .. } => {
-                let slot = &self.leaf_locals[payload.slot];
+            InPresence::Payload { .. } => {
+                let slot = &self.leaf_locals[claimed];
                 let bound = bound_local();
                 syn::parse_quote!(match #slot {
                     ::core::option::Option::Some(#bound) => {
@@ -1127,11 +1175,11 @@ impl TransformLowerer<IntoRust> for ConstructEmitter<'_> {
     fn sequence(
         &mut self,
         _node: &InNode,
-        op: &InRun,
+        _op: &InRun,
         _inner: &InNode,
         value: syn::Expr,
     ) -> Result<syn::Expr, Self::Error> {
-        let slot = &self.leaf_locals[op.slot.slot];
+        let slot = &self.leaf_locals[self.mine().expect("a run claimed its position")];
         let bound = bound_local();
         Ok(syn::parse_quote!(
             #slot

--- a/prebindgen-registry/src/expand.rs
+++ b/prebindgen-registry/src/expand.rs
@@ -41,7 +41,7 @@ mod tree;
 
 pub use self::{
     error::{ExpandDeclError, ExpandError},
-    plan::{FoldLeaf, FoldPlan, FoldShape},
+    plan::{FoldLeaf, FoldPlan, FoldShape, SlotLayout},
     tree::{
         dependencies, select, wire_leaves, Claim, Dependencies, InChild, InChoice, InLeaf, InLink,
         InNode, InPresence, InProduct, InRun, InSlot, IntoRust, Lift, SelectError,
@@ -437,7 +437,7 @@ fn build_plan<M>(
     let param = &ed.param;
     // Wire slots are handed out as the construction is built; the flat
     // signature is collected from the tree once it stands.
-    let mut next = 0usize;
+    let mut next = SlotLayout::default();
 
     // Optional (`Option<T>`/`Option<&T>`) param. No recursion under the layer.
     // The three ways the layer decides presence — see `InPresence`:
@@ -460,7 +460,7 @@ fn build_plan<M>(
                     // `Option` is whole-parameter presence, and what the
                     // constructor gets is the payload the layer unwrapped.
                     let payload = InSlot {
-                        slot: next_slot(&mut next),
+                        slot: next_slot(&mut next, param),
                         name: param.clone(),
                     };
                     let arg = InChild {
@@ -481,7 +481,7 @@ fn build_plan<M>(
                     // Multi-arg: presence flag first, then one plain slot per
                     // constructor argument.
                     let flag = InSlot {
-                        slot: next_slot(&mut next),
+                        slot: next_slot(&mut next, param),
                         name: ident(&format!("{}_present", param)),
                     };
                     let prefix = param.to_string();
@@ -539,6 +539,7 @@ fn build_plan<M>(
             target: target.clone(),
             by_ref,
             leaves: wire_leaves(&tree),
+            layout: next,
             tree,
         });
     }
@@ -555,6 +556,7 @@ fn build_plan<M>(
         target: target.clone(),
         by_ref,
         leaves: wire_leaves(&tree),
+        layout: next,
         tree,
     })
 }
@@ -600,10 +602,14 @@ fn leaf_child(
 
 /// Hand out the next wire slot. Slots are numbered as the walk meets them,
 /// which is the order the foreign signature takes them in.
-fn next_slot(next: &mut usize) -> usize {
-    let slot = *next;
-    *next += 1;
-    slot
+/// Claim the next foreign-signature position, recording what it is called.
+///
+/// The counter is a [`SlotLayout`], not a bare `usize`: allocating and naming a
+/// position are the same act, and the layout is where both live once they stop
+/// living in the tree (#447 §1). Positions are claimed in the order the wire
+/// carries them, which is the order this walk meets them.
+fn next_slot(next: &mut SlotLayout, name: &syn::Ident) -> usize {
+    next.claim(name.clone())
 }
 
 /// Build a construct core for `target` from its `variants`: a single
@@ -629,7 +635,7 @@ fn build_core<M>(
     by_ref: bool,
     prefix: &str,
     at: &str,
-    next: &mut usize,
+    next: &mut SlotLayout,
     visited: &mut HashSet<TypeKey>,
 ) -> Result<InNode, ExpandError> {
     if let [Variant::Ctor(func)] = variants {
@@ -658,9 +664,10 @@ fn build_core<M>(
         return Ok(ctor_node(target, func, sig.fallible, args));
     }
     // Combined — selector slot, then `Option`-wrapped per-arm inputs.
+    let sel_name = ident(&format!("{}_sel", prefix));
     let selector = InSlot {
-        slot: next_slot(next),
-        name: ident(&format!("{}_sel", prefix)),
+        slot: next_slot(next, &sel_name),
+        name: sel_name,
     };
     let mut arms: Vec<InChild> = Vec::new();
     for (vi, v) in variants.iter().enumerate() {
@@ -701,7 +708,8 @@ fn build_core<M>(
                 } else {
                     target.clone()
                 };
-                let slot = next_slot(next);
+                let arm_name = ident(&format!("{}_{}", prefix, vi));
+                let slot = next_slot(next, &arm_name);
                 InNode {
                     ty: target.clone(),
                     kind: TransformKind::Product {
@@ -714,12 +722,7 @@ fn build_core<M>(
                                 Lift::Direct
                             },
                         },
-                        children: vec![leaf_child(
-                            leaf_ty,
-                            slot,
-                            ident(&format!("{}_{}", prefix, vi)),
-                            true,
-                        )],
+                        children: vec![leaf_child(leaf_ty, slot, arm_name, true)],
                     },
                 }
             }
@@ -750,7 +753,7 @@ fn build_arg<M>(
     name: syn::Ident,
     at: &str,
     dispatched: bool,
-    next: &mut usize,
+    next: &mut SlotLayout,
     visited: &mut HashSet<TypeKey>,
 ) -> Result<InChild, ExpandError> {
     // The boundary layers down to the parameter's core type.
@@ -810,7 +813,12 @@ fn build_arg<M>(
         // The node carries the PAYLOAD; the `Option` selector presence adds is
         // derived from `wrapped` wherever the wire is asked for, so the two
         // cannot drift apart (#447 §1).
-        Ok(leaf_child(pty.clone(), next_slot(next), name, wrapped))
+        Ok(leaf_child(
+            pty.clone(),
+            next_slot(next, &name),
+            name,
+            wrapped,
+        ))
     }
 }
 

--- a/prebindgen-registry/src/expand.rs
+++ b/prebindgen-registry/src/expand.rs
@@ -41,7 +41,7 @@ mod tree;
 
 pub use self::{
     error::{ExpandDeclError, ExpandError},
-    plan::{FoldLeaf, FoldPlan, FoldShape, SlotLayout},
+    plan::{FoldLeaf, FoldPlan, FoldShape, SlotKind, SlotLayout},
     tree::{
         dependencies, select, wire_leaves, Claim, Dependencies, InChild, InChoice, InLeaf, InLink,
         InNode, InPresence, InProduct, InRun, InSlot, IntoRust, Lift, SelectError,
@@ -460,7 +460,7 @@ fn build_plan<M>(
                     // `Option` is whole-parameter presence, and what the
                     // constructor gets is the payload the layer unwrapped.
                     let payload = InSlot {
-                        slot: next_slot(&mut next, param),
+                        slot: next_slot(&mut next, param, SlotKind::PresencePayload),
                         name: param.clone(),
                     };
                     let arg = InChild {
@@ -481,7 +481,7 @@ fn build_plan<M>(
                     // Multi-arg: presence flag first, then one plain slot per
                     // constructor argument.
                     let flag = InSlot {
-                        slot: next_slot(&mut next, param),
+                        slot: next_slot(&mut next, param, SlotKind::PresenceFlag),
                         name: ident(&format!("{}_present", param)),
                     };
                     let prefix = param.to_string();
@@ -540,6 +540,8 @@ fn build_plan<M>(
             by_ref,
             leaves: wire_leaves(&tree),
             layout: next,
+            selector: tree.selector(),
+            present: tree.present(),
             tree,
         });
     }
@@ -557,6 +559,8 @@ fn build_plan<M>(
         by_ref,
         leaves: wire_leaves(&tree),
         layout: next,
+        selector: tree.selector(),
+        present: tree.present(),
         tree,
     })
 }
@@ -608,8 +612,8 @@ fn leaf_child(
 /// position are the same act, and the layout is where both live once they stop
 /// living in the tree (#447 §1). Positions are claimed in the order the wire
 /// carries them, which is the order this walk meets them.
-fn next_slot(next: &mut SlotLayout, name: &syn::Ident) -> usize {
-    next.claim(name.clone())
+fn next_slot(next: &mut SlotLayout, name: &syn::Ident, kind: SlotKind) -> usize {
+    next.claim(name.clone(), kind)
 }
 
 /// Build a construct core for `target` from its `variants`: a single
@@ -666,7 +670,7 @@ fn build_core<M>(
     // Combined — selector slot, then `Option`-wrapped per-arm inputs.
     let sel_name = ident(&format!("{}_sel", prefix));
     let selector = InSlot {
-        slot: next_slot(next, &sel_name),
+        slot: next_slot(next, &sel_name, SlotKind::Selector),
         name: sel_name,
     };
     let mut arms: Vec<InChild> = Vec::new();
@@ -709,7 +713,7 @@ fn build_core<M>(
                     target.clone()
                 };
                 let arm_name = ident(&format!("{}_{}", prefix, vi));
-                let slot = next_slot(next, &arm_name);
+                let slot = next_slot(next, &arm_name, SlotKind::Value);
                 InNode {
                     ty: target.clone(),
                     kind: TransformKind::Product {
@@ -815,7 +819,7 @@ fn build_arg<M>(
         // cannot drift apart (#447 §1).
         Ok(leaf_child(
             pty.clone(),
-            next_slot(next, &name),
+            next_slot(next, &name, SlotKind::Value),
             name,
             wrapped,
         ))

--- a/prebindgen-registry/src/expand.rs
+++ b/prebindgen-registry/src/expand.rs
@@ -693,10 +693,13 @@ fn build_core<M>(
                 ctor_node(target, func, sig.fallible, args)
             }
             Variant::Identity => {
+                // The PAYLOAD: an identity arm's own value, borrowed when the
+                // parameter is. Selector presence is derived from the leaf's
+                // `wrapped` wherever the wire is asked for (#447 §1).
                 let leaf_ty = if by_ref {
-                    target.borrowed().optional()
+                    target.borrowed()
                 } else {
-                    target.optional()
+                    target.clone()
                 };
                 let slot = next_slot(next);
                 InNode {
@@ -804,8 +807,10 @@ fn build_arg<M>(
         // cannot represent the double `Option` anyway. Such an argument is not
         // `wrapped`, so the emit side skips the selector-presence unwrap.
         let wrapped = dispatched && !popt;
-        let leaf_ty = if wrapped { pty.optional() } else { pty.clone() };
-        Ok(leaf_child(leaf_ty, next_slot(next), name, wrapped))
+        // The node carries the PAYLOAD; the `Option` selector presence adds is
+        // derived from `wrapped` wherever the wire is asked for, so the two
+        // cannot drift apart (#447 §1).
+        Ok(leaf_child(pty.clone(), next_slot(next), name, wrapped))
     }
 }
 

--- a/prebindgen-registry/src/expand/plan.rs
+++ b/prebindgen-registry/src/expand/plan.rs
@@ -115,6 +115,31 @@ impl FoldPlan {
     /// Read off [`Self::tree`] rather than stored beside it: the dispatch is
     /// the node, and a second copy of which slot selects it could disagree
     /// with the node the emitter actually walks.
+    /// The positions each dispatch arm's arguments occupy.
+    ///
+    /// `None` for an arm that builds one of its arguments from further
+    /// positions: such an arm has no flat signature, which is what makes it
+    /// unsplittable into a destination-language overload.
+    ///
+    /// Derived, because positions are the layout's and not the tree's: they are
+    /// claimed in walk order, so the selector comes first and each arm's
+    /// arguments follow in turn (#447 §1).
+    pub fn arm_arg_slots(&self) -> Vec<Option<Vec<usize>>> {
+        let mut next = self.selector.map_or(0, |s| s + 1);
+        self.tree
+            .arms()
+            .iter()
+            .map(|arm| {
+                let claimed = crate::expand::derive_layout(arm).len();
+                let slots = arm
+                    .leaf_args()
+                    .map(|flat| (next..next + flat.len()).collect::<Vec<_>>());
+                next += claimed;
+                slots
+            })
+            .collect()
+    }
+
     pub fn selector(&self) -> Option<usize> {
         self.selector
     }

--- a/prebindgen-registry/src/expand/plan.rs
+++ b/prebindgen-registry/src/expand/plan.rs
@@ -41,6 +41,9 @@ pub struct FoldPlan {
     /// an expansion lives here — a constructor argument that is itself built
     /// has the same node kinds as the top level.
     pub(crate) tree: crate::expand::InNode,
+    /// Where each value sits on the foreign signature — the compatibility
+    /// projection the tree stops carrying (#447 §1).
+    pub(crate) layout: SlotLayout,
 }
 
 impl FoldPlan {
@@ -49,6 +52,16 @@ impl FoldPlan {
     /// Handed out by reference and never by value, for the reason
     /// [`UnfoldPlan::tree`](crate::unfold::UnfoldPlan::tree) gives: the
     /// signature beside it is collected from this tree when the plan is built.
+    /// Where each value sits on the foreign signature.
+    ///
+    /// Slot numbers and names are one flat layout's facts, not the semantic
+    /// act of folding, so they live beside the tree rather than in it. An
+    /// adapter wanting a different physical shape builds its own from
+    /// [`Self::tree`].
+    pub fn layout(&self) -> &SlotLayout {
+        &self.layout
+    }
+
     pub fn tree(&self) -> &crate::expand::InNode {
         &self.tree
     }
@@ -116,4 +129,41 @@ pub struct FoldLeaf {
     /// [`TypeRef::scalar`](prebindgen_flat::flat::TypeRef::scalar), which
     /// pairs the kind with its own spelling and is placeless by construction.
     pub ty: prebindgen_flat::flat::TypeRef,
+}
+
+/// Where every value sits on the foreign signature: one entry per position, in
+/// the order the wire carries them.
+///
+/// The **compatibility projection** of #447 §1. Slot numbers and names are
+/// properties of one flat wire layout rather than of the semantic act of
+/// folding values into Rust, so they live here and not on the tree's nodes. A
+/// future adapter that wants an object parameter, a tagged union, overloads or
+/// another presence representation builds its own from the same tree instead of
+/// inheriting this one.
+#[derive(Debug, Default, Clone)]
+pub struct SlotLayout {
+    names: Vec<syn::Ident>,
+}
+
+impl SlotLayout {
+    /// Claim the next position for `name`, returning its index.
+    pub(crate) fn claim(&mut self, name: syn::Ident) -> usize {
+        self.names.push(name);
+        self.names.len() - 1
+    }
+
+    /// What the position at `slot` is called on the foreign signature.
+    pub fn name(&self, slot: usize) -> &syn::Ident {
+        &self.names[slot]
+    }
+
+    /// How many positions the signature has.
+    pub fn len(&self) -> usize {
+        self.names.len()
+    }
+
+    /// Whether the signature has no positions at all.
+    pub fn is_empty(&self) -> bool {
+        self.names.is_empty()
+    }
 }

--- a/prebindgen-registry/src/expand/plan.rs
+++ b/prebindgen-registry/src/expand/plan.rs
@@ -44,6 +44,14 @@ pub struct FoldPlan {
     /// Where each value sits on the foreign signature — the compatibility
     /// projection the tree stops carrying (#447 §1).
     pub(crate) layout: SlotLayout,
+    /// The **root** construction's dispatch position, when it has one.
+    ///
+    /// Recorded rather than searched for: a nested build has a selector of its
+    /// own, so "the first selector in the layout" is a different question and
+    /// answers the inner one.
+    pub(crate) selector: Option<usize>,
+    /// The root layer's presence flag, when presence is carried by one.
+    pub(crate) present: Option<usize>,
 }
 
 impl FoldPlan {
@@ -96,7 +104,7 @@ impl FoldPlan {
     /// `Option` slot). A separate flag avoids boxing a nullable primitive arg
     /// (e.g. `Option<i32>` → `Integer?`) on the wire.
     pub fn present(&self) -> Option<usize> {
-        self.tree.present()
+        self.present
     }
 
     /// Index into [`Self::leaves`] of the selector leaf; `None` for a single
@@ -108,7 +116,7 @@ impl FoldPlan {
     /// the node, and a second copy of which slot selects it could disagree
     /// with the node the emitter actually walks.
     pub fn selector(&self) -> Option<usize> {
-        self.tree.selector()
+        self.selector
     }
 }
 
@@ -142,28 +150,60 @@ pub struct FoldLeaf {
 /// inheriting this one.
 #[derive(Debug, Default, Clone)]
 pub struct SlotLayout {
-    names: Vec<syn::Ident>,
+    positions: Vec<(syn::Ident, SlotKind)>,
+}
+
+/// What one foreign-signature position carries.
+///
+/// The encoding of a dispatch and of presence — an `i32` tag, a `bool` flag, an
+/// `Option`-wrapped argument — is this layout's choice and not the tree's. A
+/// different adapter picks differently from the same semantic nodes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SlotKind {
+    /// A value: a constructor argument, an identity arm's own value, or the
+    /// collection a run is built from.
+    Value,
+    /// Which arm of a dispatch runs, and `-1` when a `Selector` layer above it
+    /// means absent.
+    Selector,
+    /// An explicit presence flag, for a construction whose arguments cannot
+    /// carry absence themselves.
+    PresenceFlag,
+    /// Presence riding the layer's own argument: absent is that argument's
+    /// `None`.
+    PresencePayload,
 }
 
 impl SlotLayout {
-    /// Claim the next position for `name`, returning its index.
-    pub(crate) fn claim(&mut self, name: syn::Ident) -> usize {
-        self.names.push(name);
-        self.names.len() - 1
+    /// Claim the next position, returning its index.
+    pub(crate) fn claim(&mut self, name: syn::Ident, kind: SlotKind) -> usize {
+        self.positions.push((name, kind));
+        self.positions.len() - 1
     }
 
     /// What the position at `slot` is called on the foreign signature.
     pub fn name(&self, slot: usize) -> &syn::Ident {
-        &self.names[slot]
+        &self.positions[slot].0
+    }
+
+    /// What the position at `slot` carries.
+    pub fn kind(&self, slot: usize) -> SlotKind {
+        self.positions[slot].1
+    }
+
+    /// The first position of `kind`, which for a dispatch or a presence flag is
+    /// the outermost one — positions are claimed outside in.
+    pub fn first_of(&self, kind: SlotKind) -> Option<usize> {
+        self.positions.iter().position(|(_, k)| *k == kind)
     }
 
     /// How many positions the signature has.
     pub fn len(&self) -> usize {
-        self.names.len()
+        self.positions.len()
     }
 
     /// Whether the signature has no positions at all.
     pub fn is_empty(&self) -> bool {
-        self.names.is_empty()
+        self.positions.is_empty()
     }
 }

--- a/prebindgen-registry/src/expand/tests.rs
+++ b/prebindgen-registry/src/expand/tests.rs
@@ -200,7 +200,7 @@ fn optional_byvalue_single_ctor() {
         plan.tree
             .lower(&mut RenderIn)
             .expect("lowering cannot fail"),
-        "z_zbytes_from_vec(^)?^#0"
+        "z_zbytes_from_vec(^)?^payload"
     );
 
     let locals = vec![ident("att")];
@@ -390,10 +390,7 @@ fn optional_combined_selector_encodes_absence() {
     assert!(
         matches!(
             &args(arms[0])[1].node.kind,
-            TransformKind::Leaf(InLeaf::Slot {
-                slot: InSlot { slot: 2, .. },
-                wrapped: false
-            })
+            TransformKind::Leaf(InLeaf::Slot { wrapped: false })
         ),
         "an already-Option ctor arg passes through unwrapped"
     );
@@ -460,10 +457,6 @@ fn iterable_emit_shape() {
         ty: tref(syn::parse_quote!(Vec<ZKeyExpr>)),
         kind: TransformKind::Sequence {
             op: InRun {
-                slot: InSlot {
-                    slot: 0,
-                    name: ident("kes"),
-                },
                 ty: tref(syn::parse_quote!(Vec<String>)),
             },
             inner: Box::new(core),
@@ -474,10 +467,10 @@ fn iterable_emit_shape() {
     let plan = FoldPlan {
         target: tref(syn::parse_quote!(ZKeyExpr)),
         by_ref: false,
-        leaves: wire_leaves(&tree),
+        leaves: wire_leaves(&tree, &layout),
         layout,
-        selector: tree.selector(),
-        present: tree.present(),
+        selector: None,
+        present: None,
         tree,
     };
     let locals = vec![ident("kes")];
@@ -649,13 +642,13 @@ fn recursive_input_nests_param_constructors() {
     assert!(is_build(&args[1]), "payload is a nested build");
     // key_expr's nested build is COMBINED (try_from | identity ⇒ selector).
     assert!(
-        args[0].node.selector().is_some(),
+        matches!(args[0].node.core().kind, TransformKind::Choice { .. }),
         "ZKeyExpr default input is combined"
     );
     assert_eq!(args[0].node.arms().len(), 2);
     // payload's nested build is SINGLE (no selector).
     assert!(
-        args[1].node.selector().is_none(),
+        !matches!(args[1].node.core().kind, TransformKind::Choice { .. }),
         "ZZBytes default input is single"
     );
     // Wire leaves: key-expr selector + try_from String + identity ZKeyExpr +
@@ -900,9 +893,7 @@ impl crate::transform::TransformLowerer<IntoRust> for RenderIn {
 
     fn leaf(&mut self, _node: &InNode, op: &InLeaf) -> Result<String, Self::Error> {
         Ok(match op {
-            InLeaf::Slot { slot, wrapped } => {
-                format!("#{}{}", slot.slot, if *wrapped { "?" } else { "" })
-            }
+            InLeaf::Slot { wrapped } => format!("#{}", if *wrapped { "?" } else { "" }),
             InLeaf::Bound => "^".to_string(),
         })
     }
@@ -940,11 +931,11 @@ impl crate::transform::TransformLowerer<IntoRust> for RenderIn {
     fn choice(
         &mut self,
         _node: &InNode,
-        op: &InChoice,
+        _op: &InChoice,
         variants: crate::transform::Lowered<'_, IntoRust, String>,
     ) -> Result<String, Self::Error> {
         let arms: Vec<String> = variants.into_iter().map(|(_, v)| v).collect();
-        Ok(format!("#{} ? {}", op.selector.slot, arms.join(" | ")))
+        Ok(format!("#sel ? {}", arms.join(" | ")))
     }
 
     fn optional(
@@ -956,19 +947,19 @@ impl crate::transform::TransformLowerer<IntoRust> for RenderIn {
     ) -> Result<String, Self::Error> {
         Ok(match op {
             InPresence::Selector => format!("{value}?sel"),
-            InPresence::Flag(s) => format!("{value}?#{}", s.slot),
-            InPresence::Payload { slot, .. } => format!("{value}?^#{}", slot.slot),
+            InPresence::Flag => format!("{value}?#flag"),
+            InPresence::Payload { .. } => format!("{value}?^payload"),
         })
     }
 
     fn sequence(
         &mut self,
         _node: &InNode,
-        op: &InRun,
+        _op: &InRun,
         _inner: &InNode,
         value: String,
     ) -> Result<String, Self::Error> {
-        Ok(format!("[{value}]*#{}", op.slot.slot))
+        Ok(format!("[{value}]*#run"))
     }
 }
 
@@ -1033,7 +1024,7 @@ fn core_lowers_through_the_shared_visitor() {
         .expect("lowering cannot fail");
     assert_eq!(
         rendered,
-        "z_sample_new(&#0 ? z_keyexpr_try_from!(#1?) | self.clone(#2?), z_zbytes_from_vec(#3))"
+        "z_sample_new(&#sel ? z_keyexpr_try_from!(#?) | self.clone(#?), z_zbytes_from_vec(#))"
     );
 
     // The signature is COLLECTED from those same nodes: each slot's name and
@@ -1099,7 +1090,7 @@ fn selecting_a_construction_replaces_its_slots() {
         (node.ty.spell().to_string() == "ZKeyExpr").then(|| Claim::direct(node.ty.clone()))
     })
     .unwrap();
-    let leaves = crate::expand::wire_leaves(&selected);
+    let leaves = crate::expand::wire_leaves(&selected, &crate::expand::derive_layout(&selected));
     assert_eq!(
         leaves.len(),
         1,
@@ -1186,16 +1177,26 @@ fn selecting_renumbers_the_surviving_slots() {
     assert_eq!(plan.leaves().len(), 4);
     assert_eq!(plan.leaves()[3].name.to_string(), "sample_payload");
 
-    // Claiming the key expression drops slots 0..2 and the payload closes up
-    // into position 0 — keeping its name, because it is the same value.
+    // Claiming the key expression drops the three positions that built it, and
+    // the payload closes up behind the one value that replaces them.
+    //
+    // The claimed subtree takes the earliest position it replaced because the
+    // walk meets it there — not because a renumbering pass moved it. A foreign
+    // signature is a sequence, so what a caller passed fourth must still be
+    // what the wrapper reads last.
     let selected = crate::expand::select(plan.tree(), &mut |node, _link| {
         (node.ty.spell().to_string() == "ZKeyExpr").then(|| Claim::clone_deref(node.ty.borrowed()))
     })
     .unwrap();
-    let leaves = crate::expand::wire_leaves(&selected);
-    assert_eq!(leaves.len(), 2);
-    assert_eq!(leaves[0].ty.spell().to_string(), "& ZKeyExpr");
-    assert_eq!(leaves[1].name.to_string(), "sample_payload");
+    let leaves = crate::expand::wire_leaves(&selected, &crate::expand::derive_layout(&selected));
+    assert_eq!(
+        leaves
+            .iter()
+            .map(|l| l.ty.spell().to_string())
+            .collect::<Vec<_>>(),
+        vec!["& ZKeyExpr", "Vec < u8 >"],
+        "the claimed reading first, then the value that survived it"
+    );
 
     // The signature is only half the contract: the claimed node's own type says
     // it produces an owned `ZKeyExpr`, so a borrowed reading has to be cloned
@@ -1328,7 +1329,7 @@ fn a_claim_inside_a_live_choice_stays_wrapped() {
     .unwrap();
 
     assert_eq!(
-        crate::expand::wire_leaves(&selected).len(),
+        crate::expand::wire_leaves(&selected, &crate::expand::derive_layout(&selected)).len(),
         3,
         "the dispatch survives, so the selector and both arms keep their slots"
     );
@@ -1338,9 +1339,9 @@ fn a_claim_inside_a_live_choice_stays_wrapped() {
     // reaches the constructor — so the claimed leaf itself is what to check.
     fn claimed_wrapped(node: &crate::expand::InNode) -> Option<bool> {
         match &node.kind {
-            TransformKind::Leaf(crate::expand::InLeaf::Slot { slot, wrapped }) => {
-                (slot.name == "a_0").then_some(*wrapped)
-            }
+            // The FIRST arm's argument: the tree no longer names positions, so
+            // the arm is reached structurally instead.
+            TransformKind::Leaf(crate::expand::InLeaf::Slot { wrapped }) => Some(*wrapped),
             TransformKind::Leaf(_) => None,
             TransformKind::Product { children, .. } => {
                 children.iter().find_map(|c| claimed_wrapped(&c.node))
@@ -1406,7 +1407,7 @@ fn claiming_an_arm_product_keeps_the_position_optional() {
     })
     .unwrap();
 
-    let leaves = crate::expand::wire_leaves(&selected);
+    let leaves = crate::expand::wire_leaves(&selected, &crate::expand::derive_layout(&selected));
     assert_eq!(
         leaves.len(),
         3,
@@ -1486,7 +1487,7 @@ fn claiming_an_arity_layer_keeps_its_mapping() {
     })
     .unwrap();
 
-    let leaves = crate::expand::wire_leaves(&selected);
+    let leaves = crate::expand::wire_leaves(&selected, &crate::expand::derive_layout(&selected));
     assert_eq!(
         leaves.len(),
         1,
@@ -1556,10 +1557,6 @@ fn claiming_a_run_binds_one_borrowed_element() {
         ty: tref(syn::parse_quote!(Vec<ZKeyExpr>)),
         kind: TransformKind::Sequence {
             op: InRun {
-                slot: InSlot {
-                    slot: 0,
-                    name: ident("kes"),
-                },
                 ty: tref(syn::parse_quote!(Vec<String>)),
             },
             inner: Box::new(InNode {
@@ -1589,7 +1586,7 @@ fn claiming_a_run_binds_one_borrowed_element() {
     .unwrap();
 
     // The layer survives, carrying the claimed reading on its slot.
-    let leaves = crate::expand::wire_leaves(&selected);
+    let leaves = crate::expand::wire_leaves(&selected, &crate::expand::derive_layout(&selected));
     assert_eq!(leaves.len(), 1);
     assert_eq!(leaves[0].ty.spell().to_string(), "& [ZKeyExpr]");
 
@@ -1637,10 +1634,6 @@ fn claiming_a_layer_with_the_wrong_shape_is_an_error() {
         ty: tref(syn::parse_quote!(Vec<ZKeyExpr>)),
         kind: TransformKind::Sequence {
             op: InRun {
-                slot: InSlot {
-                    slot: 0,
-                    name: ident("kes"),
-                },
                 ty: tref(syn::parse_quote!(Vec<String>)),
             },
             inner: Box::new(InNode {
@@ -1684,10 +1677,6 @@ fn claiming_a_cow_run_binds_a_borrowed_element() {
         ty: tref(syn::parse_quote!(Vec<ZKeyExpr>)),
         kind: TransformKind::Sequence {
             op: InRun {
-                slot: InSlot {
-                    slot: 0,
-                    name: ident("kes"),
-                },
                 ty: tref(syn::parse_quote!(Vec<String>)),
             },
             inner: Box::new(InNode {
@@ -1736,10 +1725,6 @@ fn claiming_an_optional_behind_a_wrapper_is_an_error() {
         ty: tref(syn::parse_quote!(Option<ZEncoding>)),
         kind: TransformKind::Optional {
             op: InPresence::Payload {
-                slot: InSlot {
-                    slot: 0,
-                    name: ident("enc"),
-                },
                 ty: tref(syn::parse_quote!(Option<String>)),
             },
             inner: Box::new(InNode {
@@ -1785,13 +1770,7 @@ fn a_claim_states_how_its_reading_is_lifted() {
                 link: InLink { by_ref: false },
                 node: InNode {
                     ty: tref(syn::parse_quote!(String)),
-                    kind: TransformKind::Leaf(InLeaf::Slot {
-                        slot: InSlot {
-                            slot: 0,
-                            name: ident("s"),
-                        },
-                        wrapped: false,
-                    }),
+                    kind: TransformKind::Leaf(InLeaf::Slot { wrapped: false }),
                 },
             }],
         },
@@ -1841,10 +1820,6 @@ fn a_cow_of_vec_run_is_refused() {
         ty: tref(syn::parse_quote!(Vec<ZKeyExpr>)),
         kind: TransformKind::Sequence {
             op: InRun {
-                slot: InSlot {
-                    slot: 0,
-                    name: ident("kes"),
-                },
                 ty: tref(syn::parse_quote!(Vec<String>)),
             },
             inner: Box::new(InNode {
@@ -1903,13 +1878,7 @@ fn a_leaf_claim_lifts_before_its_constructor_reads_it() {
                 link: InLink { by_ref: false },
                 node: InNode {
                     ty: tref(target),
-                    kind: TransformKind::Leaf(InLeaf::Slot {
-                        slot: InSlot {
-                            slot: 0,
-                            name: ident("k"),
-                        },
-                        wrapped: false,
-                    }),
+                    kind: TransformKind::Leaf(InLeaf::Slot { wrapped: false }),
                 },
             }],
         },
@@ -1978,13 +1947,7 @@ fn a_non_direct_lift_onto_a_borrowed_leaf_is_an_error() {
                 link: InLink { by_ref: false },
                 node: InNode {
                     ty: tref(syn::parse_quote!(&ZKeyExpr)),
-                    kind: TransformKind::Leaf(InLeaf::Slot {
-                        slot: InSlot {
-                            slot: 0,
-                            name: ident("k"),
-                        },
-                        wrapped: false,
-                    }),
+                    kind: TransformKind::Leaf(InLeaf::Slot { wrapped: false }),
                 },
             }],
         },
@@ -2026,12 +1989,7 @@ fn a_lift_on_a_wrapped_leaf_sees_through_the_presence() {
     let tree = |arg: syn::Type| InNode {
         ty: tref(syn::parse_quote!(ZKeyExpr)),
         kind: TransformKind::Choice {
-            op: InChoice {
-                selector: InSlot {
-                    slot: 0,
-                    name: ident("sel"),
-                },
-            },
+            op: InChoice { dispatch: () },
             variants: vec![InChild {
                 link: InLink { by_ref: false },
                 node: InNode {
@@ -2047,13 +2005,7 @@ fn a_lift_on_a_wrapped_leaf_sees_through_the_presence() {
                                 // Stored WITH the selector's `Option`, which is
                                 // what a live arm's argument looks like.
                                 ty: tref(arg),
-                                kind: TransformKind::Leaf(InLeaf::Slot {
-                                    slot: InSlot {
-                                        slot: 1,
-                                        name: ident("a_0"),
-                                    },
-                                    wrapped: true,
-                                }),
+                                kind: TransformKind::Leaf(InLeaf::Slot { wrapped: true }),
                             },
                         }],
                     },
@@ -2149,7 +2101,7 @@ fn a_lift_on_a_wrapped_leaf_sees_through_the_presence() {
     )
     .unwrap();
     assert_eq!(
-        crate::expand::wire_leaves(&selected)[1]
+        crate::expand::wire_leaves(&selected, &crate::expand::derive_layout(&selected))[1]
             .ty
             .spell()
             .to_string(),
@@ -2179,10 +2131,6 @@ fn a_direct_claim_that_is_not_the_value_is_an_error() {
         ty: tref(syn::parse_quote!(Vec<ZKeyExpr>)),
         kind: TransformKind::Sequence {
             op: InRun {
-                slot: InSlot {
-                    slot: 0,
-                    name: ident("kes"),
-                },
                 ty: tref(syn::parse_quote!(Vec<String>)),
             },
             inner: Box::new(InNode {
@@ -2278,7 +2226,7 @@ fn a_gated_slots_wire_type_is_derived_from_its_payload() {
 
     // …and every reading of the wire derives the same type from them, rather
     // than carrying a second copy that could drift.
-    let leaves = crate::expand::wire_leaves(plan.tree());
+    let leaves = crate::expand::wire_leaves(plan.tree(), plan.layout());
     assert_eq!(
         leaves
             .iter()
@@ -2298,75 +2246,19 @@ fn a_gated_slots_wire_type_is_derived_from_its_payload() {
     );
 }
 
-/// #447 §1: the slot numbers in the tree are **derivable** — a walk in
-/// allocation order reproduces every one of them.
+/// #447 §1: the foreign signature lives in the layout, and only there.
 ///
-/// The check that has to hold before slot allocation can move out of the
-/// canonical tree and into adapter-local planning. If a projection walking the
-/// semantic structure yields today's numbering, the numbering is not a fact the
-/// tree has to carry; if it does not, something about the layout is not
-/// positional and the relocation would change generated signatures.
+/// The canonical tree carries constructor identity, argument order, borrowing,
+/// optionality and dispatch — and no position, name or presence encoding. Those
+/// are one flat protocol's choices; another adapter picks an object, overloads,
+/// a tagged union or a niche from the same nodes.
 ///
-/// Allocation is pre-order: a layer takes its own slot before the construction
-/// under it, and a dispatch its selector before its arms.
+/// Positions are claimed outside in, so a layer takes its own before the
+/// construction under it and a dispatch its selector before its arms. Both the
+/// leaf list and the fold emitter re-derive them by walking in that order,
+/// which is why nothing has to be stored on a node.
 #[test]
-fn slot_numbers_are_derivable_from_the_tree_walk() {
-    /// The slot names the tree carries, in the same walk order.
-    fn stored_names(node: &InNode, out: &mut Vec<String>) {
-        match &node.kind {
-            TransformKind::Leaf(InLeaf::Slot { slot, .. }) => out.push(slot.name.to_string()),
-            TransformKind::Leaf(InLeaf::Bound) => {}
-            TransformKind::Product { children, .. } => {
-                children.iter().for_each(|c| stored_names(&c.node, out))
-            }
-            TransformKind::Choice { op, variants } => {
-                out.push(op.selector.name.to_string());
-                variants.iter().for_each(|v| stored_names(&v.node, out));
-            }
-            TransformKind::Optional { op, inner } => {
-                match op {
-                    InPresence::Selector => {}
-                    InPresence::Flag(s) => out.push(s.name.to_string()),
-                    InPresence::Payload { slot, .. } => out.push(slot.name.to_string()),
-                }
-                stored_names(inner, out);
-            }
-            TransformKind::Sequence { op, inner } => {
-                out.push(op.slot.name.to_string());
-                stored_names(inner, out);
-            }
-        }
-    }
-
-    fn stored(node: &InNode, out: &mut Vec<usize>) {
-        match &node.kind {
-            TransformKind::Leaf(InLeaf::Slot { slot, .. }) => out.push(slot.slot),
-            TransformKind::Leaf(InLeaf::Bound) => {}
-            TransformKind::Product { children, .. } => {
-                children.iter().for_each(|c| stored(&c.node, out))
-            }
-            TransformKind::Choice { op, variants } => {
-                out.push(op.selector.slot);
-                variants.iter().for_each(|v| stored(&v.node, out));
-            }
-            TransformKind::Optional { op, inner } => {
-                match op {
-                    InPresence::Selector => {}
-                    InPresence::Flag(s) => out.push(s.slot),
-                    InPresence::Payload { slot, .. } => out.push(slot.slot),
-                }
-                stored(inner, out);
-            }
-            TransformKind::Sequence { op, inner } => {
-                out.push(op.slot.slot);
-                stored(inner, out);
-            }
-        }
-    }
-
-    // Three shapes that allocate differently: a dispatch (selector then arms),
-    // a single-constructor optional (the layer's own payload slot), and a
-    // multi-argument optional (an explicit flag, then one slot per argument).
+fn the_signature_lives_in_the_layout() {
     /// One shape to check: what to call it, the source it needs, the expanded
     /// parameter, and the variants it expands through.
     struct Case {
@@ -2375,6 +2267,8 @@ fn slot_numbers_are_derivable_from_the_tree_walk() {
         func: &'static str,
         param: &'static str,
         variants: Vec<Variant>,
+        /// The signature this shape should produce, in order.
+        names: Vec<&'static str>,
     }
 
     let cases = vec![
@@ -2390,6 +2284,7 @@ fn slot_numbers_are_derivable_from_the_tree_walk() {
                 Variant::Ctor(ident("z_keyexpr_try_from")),
                 Variant::Identity,
             ],
+            names: vec!["a_sel", "a_0", "a_1"],
         },
         Case {
             label: "optional payload",
@@ -2400,6 +2295,7 @@ fn slot_numbers_are_derivable_from_the_tree_walk() {
             func: "z_session_put",
             param: "encoding",
             variants: vec![Variant::Ctor(ident("z_encoding_from_string"))],
+            names: vec!["encoding"],
         },
     ];
 
@@ -2409,6 +2305,7 @@ fn slot_numbers_are_derivable_from_the_tree_walk() {
         func,
         param,
         variants,
+        names,
     } in cases
     {
         let mut reg: Registry<()> = reg_with(&items);
@@ -2432,35 +2329,44 @@ fn slot_numbers_are_derivable_from_the_tree_walk() {
             .get(&(ident(func), ident(param)))
             .unwrap_or_else(|| panic!("{label}: plan"));
 
-        let mut order = Vec::new();
-        stored(plan.tree(), &mut order);
+        // The layout names every position, in wire order.
         assert_eq!(
-            order,
-            (0..order.len()).collect::<Vec<_>>(),
-            "{label}: a pre-order walk meets the slots in numbering order, so the numbers \
-             are the walk's and need not be stored"
-        );
-        assert_eq!(
-            order.len(),
-            plan.leaves().len(),
-            "{label}: and it meets every slot the wire has"
-        );
-
-        // …and the layout beside the tree says the same thing the tree does,
-        // which is what licenses the tree to stop saying it.
-        assert_eq!(
-            plan.layout().len(),
-            plan.leaves().len(),
-            "{label}: the layout has a position per wire value"
-        );
-        let mut names = Vec::new();
-        stored_names(plan.tree(), &mut names);
-        assert_eq!(
-            names,
             (0..plan.layout().len())
                 .map(|i| plan.layout().name(i).to_string())
                 .collect::<Vec<_>>(),
-            "{label}: and calls each position what the tree calls it"
+            names,
+            "{label}: the layout is the signature"
+        );
+        // The leaf list is derived from it, so the two cannot drift.
+        assert_eq!(
+            plan.leaves()
+                .iter()
+                .map(|l| l.name.to_string())
+                .collect::<Vec<_>>(),
+            names,
+            "{label}: and the leaf list reads it"
+        );
+        // …and the tree says nothing about any of it. `InLeaf::Slot` carries
+        // only whether the position is gated; there is no number and no name to
+        // disagree with the layout.
+        fn positions_in_tree(node: &InNode) -> usize {
+            match &node.kind {
+                TransformKind::Leaf(_) => 0,
+                TransformKind::Product { children, .. } => {
+                    children.iter().map(|c| positions_in_tree(&c.node)).sum()
+                }
+                TransformKind::Choice { variants, .. } => {
+                    variants.iter().map(|v| positions_in_tree(&v.node)).sum()
+                }
+                TransformKind::Optional { inner, .. } | TransformKind::Sequence { inner, .. } => {
+                    positions_in_tree(inner)
+                }
+            }
+        }
+        assert_eq!(
+            positions_in_tree(plan.tree()),
+            0,
+            "{label}: the tree carries no wire positions"
         );
     }
 }

--- a/prebindgen-registry/src/expand/tests.rs
+++ b/prebindgen-registry/src/expand/tests.rs
@@ -469,10 +469,13 @@ fn iterable_emit_shape() {
             inner: Box::new(core),
         },
     };
+    let mut layout = crate::expand::SlotLayout::default();
+    layout.claim(ident("kes"));
     let plan = FoldPlan {
         target: tref(syn::parse_quote!(ZKeyExpr)),
         by_ref: false,
         leaves: wire_leaves(&tree),
+        layout,
         tree,
     };
     let locals = vec![ident("kes")];
@@ -2306,6 +2309,33 @@ fn a_gated_slots_wire_type_is_derived_from_its_payload() {
 /// under it, and a dispatch its selector before its arms.
 #[test]
 fn slot_numbers_are_derivable_from_the_tree_walk() {
+    /// The slot names the tree carries, in the same walk order.
+    fn stored_names(node: &InNode, out: &mut Vec<String>) {
+        match &node.kind {
+            TransformKind::Leaf(InLeaf::Slot { slot, .. }) => out.push(slot.name.to_string()),
+            TransformKind::Leaf(InLeaf::Bound) => {}
+            TransformKind::Product { children, .. } => {
+                children.iter().for_each(|c| stored_names(&c.node, out))
+            }
+            TransformKind::Choice { op, variants } => {
+                out.push(op.selector.name.to_string());
+                variants.iter().for_each(|v| stored_names(&v.node, out));
+            }
+            TransformKind::Optional { op, inner } => {
+                match op {
+                    InPresence::Selector => {}
+                    InPresence::Flag(s) => out.push(s.name.to_string()),
+                    InPresence::Payload { slot, .. } => out.push(slot.name.to_string()),
+                }
+                stored_names(inner, out);
+            }
+            TransformKind::Sequence { op, inner } => {
+                out.push(op.slot.name.to_string());
+                stored_names(inner, out);
+            }
+        }
+    }
+
     fn stored(node: &InNode, out: &mut Vec<usize>) {
         match &node.kind {
             TransformKind::Leaf(InLeaf::Slot { slot, .. }) => out.push(slot.slot),
@@ -2412,6 +2442,23 @@ fn slot_numbers_are_derivable_from_the_tree_walk() {
             order.len(),
             plan.leaves().len(),
             "{label}: and it meets every slot the wire has"
+        );
+
+        // …and the layout beside the tree says the same thing the tree does,
+        // which is what licenses the tree to stop saying it.
+        assert_eq!(
+            plan.layout().len(),
+            plan.leaves().len(),
+            "{label}: the layout has a position per wire value"
+        );
+        let mut names = Vec::new();
+        stored_names(plan.tree(), &mut names);
+        assert_eq!(
+            names,
+            (0..plan.layout().len())
+                .map(|i| plan.layout().name(i).to_string())
+                .collect::<Vec<_>>(),
+            "{label}: and calls each position what the tree calls it"
         );
     }
 }

--- a/prebindgen-registry/src/expand/tests.rs
+++ b/prebindgen-registry/src/expand/tests.rs
@@ -470,12 +470,14 @@ fn iterable_emit_shape() {
         },
     };
     let mut layout = crate::expand::SlotLayout::default();
-    layout.claim(ident("kes"));
+    layout.claim(ident("kes"), crate::expand::SlotKind::Value);
     let plan = FoldPlan {
         target: tref(syn::parse_quote!(ZKeyExpr)),
         by_ref: false,
         leaves: wire_leaves(&tree),
         layout,
+        selector: tree.selector(),
+        present: tree.present(),
         tree,
     };
     let locals = vec![ident("kes")];

--- a/prebindgen-registry/src/expand/tests.rs
+++ b/prebindgen-registry/src/expand/tests.rs
@@ -2335,33 +2335,50 @@ fn slot_numbers_are_derivable_from_the_tree_walk() {
     // Three shapes that allocate differently: a dispatch (selector then arms),
     // a single-constructor optional (the layer's own payload slot), and a
     // multi-argument optional (an explicit flag, then one slot per argument).
-    let cases: Vec<(&str, Vec<&str>, &str, &str, Vec<Variant>)> = vec![
-        (
-            "dispatch",
-            vec![
+    /// One shape to check: what to call it, the source it needs, the expanded
+    /// parameter, and the variants it expands through.
+    struct Case {
+        label: &'static str,
+        items: Vec<&'static str>,
+        func: &'static str,
+        param: &'static str,
+        variants: Vec<Variant>,
+    }
+
+    let cases = vec![
+        Case {
+            label: "dispatch",
+            items: vec![
                 "fn z_keyexpr_try_from(s: String) -> Result<ZKeyExpr, Error> { todo!() }",
                 "fn z_keyexpr_intersects(a: &ZKeyExpr, b: &ZKeyExpr) -> bool { todo!() }",
             ],
-            "z_keyexpr_intersects",
-            "a",
-            vec![
+            func: "z_keyexpr_intersects",
+            param: "a",
+            variants: vec![
                 Variant::Ctor(ident("z_keyexpr_try_from")),
                 Variant::Identity,
             ],
-        ),
-        (
-            "optional payload",
-            vec![
+        },
+        Case {
+            label: "optional payload",
+            items: vec![
                 "fn z_encoding_from_string(s: String) -> ZEncoding { todo!() }",
                 "fn z_session_put(s: &ZSession, encoding: Option<&ZEncoding>) -> bool { todo!() }",
             ],
-            "z_session_put",
-            "encoding",
-            vec![Variant::Ctor(ident("z_encoding_from_string"))],
-        ),
+            func: "z_session_put",
+            param: "encoding",
+            variants: vec![Variant::Ctor(ident("z_encoding_from_string"))],
+        },
     ];
 
-    for (label, items, func, param, variants) in cases {
+    for Case {
+        label,
+        items,
+        func,
+        param,
+        variants,
+    } in cases
+    {
         let mut reg: Registry<()> = reg_with(&items);
         let mut exp = Expansions::default();
         exp.expands.push(ExpandDecl {

--- a/prebindgen-registry/src/expand/tests.rs
+++ b/prebindgen-registry/src/expand/tests.rs
@@ -1318,7 +1318,7 @@ fn a_claim_inside_a_live_choice_stays_wrapped() {
     // The arm's argument is offered WITH its selector-presence `Option` on, so
     // the adapter answers about the wrapped position.
     let selected = crate::expand::select(plan.tree(), &mut |node, _link| {
-        (node.ty.spell().to_string() == "Option < String >").then(|| Claim::direct(node.ty.clone()))
+        (node.ty.spell().to_string() == "String").then(|| Claim::direct(node.ty.clone()))
     })
     .unwrap();
 
@@ -2056,6 +2056,8 @@ fn a_lift_on_a_wrapped_leaf_sees_through_the_presence() {
             }],
         },
     };
+    // Stored as the PAYLOAD; the selector's `Option` is the position's, added
+    // wherever the wire is asked for.
     let select = |arg: syn::Type, claim: Claim| {
         crate::expand::select(&tree(arg), &mut |node, _l| {
             matches!(node.kind, TransformKind::Leaf(_)).then(|| claim.clone())
@@ -2065,8 +2067,8 @@ fn a_lift_on_a_wrapped_leaf_sees_through_the_presence() {
     // An OWNED argument: the lift is honoured, and the node it lands on
     // advertises the unwrapped target rather than the position's `Option`.
     let selected = select(
-        syn::parse_quote!(Option<ZKeyExpr>),
-        Claim::clone_deref(tref(syn::parse_quote!(Option<OwnedObject<ZKeyExpr>>))),
+        syn::parse_quote!(ZKeyExpr),
+        Claim::clone_deref(tref(syn::parse_quote!(OwnedObject<ZKeyExpr>))),
     )
     .unwrap();
     let TransformKind::Choice { variants, .. } = &selected.kind else {
@@ -2096,8 +2098,8 @@ fn a_lift_on_a_wrapped_leaf_sees_through_the_presence() {
     // A BORROWED argument: the same claim now has an owned-producing lift onto
     // a borrowed target, which the presence used to hide.
     let err = match select(
-        syn::parse_quote!(Option<&ZKeyExpr>),
-        Claim::clone_deref(tref(syn::parse_quote!(Option<OwnedObject<ZKeyExpr>>))),
+        syn::parse_quote!(&ZKeyExpr),
+        Claim::clone_deref(tref(syn::parse_quote!(OwnedObject<ZKeyExpr>))),
     ) {
         Ok(_) => panic!("an owned lift onto a borrowed argument must be refused"),
         Err(e) => e,
@@ -2119,7 +2121,7 @@ fn a_lift_on_a_wrapped_leaf_sees_through_the_presence() {
     // blocks. Presence is added around such a reading instead — and here the
     // claim is then contradictory, so it is refused rather than lowered.
     let err = match select(
-        syn::parse_quote!(Option<String>),
+        syn::parse_quote!(String),
         Claim::direct(tref(syn::parse_quote!(Box<Option<String>>))),
     ) {
         Ok(_) => panic!("a boxed optional reading is not selector presence"),
@@ -2137,7 +2139,7 @@ fn a_lift_on_a_wrapped_leaf_sees_through_the_presence() {
     // …and a reading that needs presence added gets it explicitly, so the
     // emitted match is on an `Option` the slot really has.
     let selected = select(
-        syn::parse_quote!(Option<String>),
+        syn::parse_quote!(String),
         Claim::clone_deref(tref(syn::parse_quote!(OwnedObject<String>))),
     )
     .unwrap();
@@ -2200,5 +2202,93 @@ fn a_direct_claim_that_is_not_the_value_is_an_error() {
                 if bound == "& ZKeyExpr" && target == "ZKeyExpr"
         ),
         "got {err}"
+    );
+}
+
+/// #447 §1: presence and the crossing type are one fact.
+///
+/// A slot leaf's `ty` is the value the position holds; whether that position is
+/// gated by a live choice is `wrapped`; and the wire type is *derived* from the
+/// pair. So the state this used to be able to hold — a plain `T` beside
+/// `wrapped = true`, where the signature declares `T` while the emitter matches
+/// `Some` — is no longer a state: there is nowhere to write the second, and
+/// disagreeing answers cannot be given because only one is stored.
+#[test]
+fn a_gated_slots_wire_type_is_derived_from_its_payload() {
+    let mut reg: Registry<()> = reg_with(&[
+        "fn z_keyexpr_try_from(s: String) -> Result<ZKeyExpr, Error> { todo!() }",
+        "fn z_keyexpr_intersects(a: &ZKeyExpr, b: &ZKeyExpr) -> bool { todo!() }",
+    ]);
+    let mut exp = Expansions::default();
+    exp.expands.push(ExpandDecl {
+        func: ident("z_keyexpr_intersects"),
+        param: ident("a"),
+        declared_target: Some(key("ZKeyExpr")),
+        sel: ExpandSel::Subset(vec![
+            Variant::Ctor(ident("z_keyexpr_try_from")),
+            Variant::Identity,
+        ]),
+    });
+    apply(
+        &mut reg,
+        &exp,
+        &Default::default(),
+        &Default::default(),
+        &Default::default(),
+    )
+    .expect("apply");
+    let plan = reg
+        .expansion_plans
+        .get(&(ident("z_keyexpr_intersects"), ident("a")))
+        .expect("plan");
+
+    // The tree stores the payloads…
+    fn payloads(node: &InNode, out: &mut Vec<(String, bool)>) {
+        match &node.kind {
+            TransformKind::Leaf(InLeaf::Slot { wrapped, .. }) => {
+                out.push((node.ty.spell().to_string(), *wrapped))
+            }
+            TransformKind::Leaf(_) => {}
+            TransformKind::Product { children, .. } => {
+                children.iter().for_each(|c| payloads(&c.node, out))
+            }
+            TransformKind::Choice { variants, .. } => {
+                variants.iter().for_each(|v| payloads(&v.node, out))
+            }
+            TransformKind::Optional { inner, .. } | TransformKind::Sequence { inner, .. } => {
+                payloads(inner, out)
+            }
+        }
+    }
+    let mut stored = Vec::new();
+    payloads(plan.tree(), &mut stored);
+    assert_eq!(
+        stored,
+        vec![
+            ("String".to_string(), true),
+            ("& ZKeyExpr".to_string(), true)
+        ],
+        "each arm's argument is stored as its payload, gated by the dispatch"
+    );
+
+    // …and every reading of the wire derives the same type from them, rather
+    // than carrying a second copy that could drift.
+    let leaves = crate::expand::wire_leaves(plan.tree());
+    assert_eq!(
+        leaves
+            .iter()
+            .map(|l| l.ty.spell().to_string())
+            .collect::<Vec<_>>(),
+        vec!["i32", "Option < String >", "Option < & ZKeyExpr >"],
+        "the selector, then each arm's gated slot"
+    );
+    assert_eq!(
+        crate::expand::dependencies(plan.tree())
+            .required
+            .iter()
+            .map(|t| t.spell().to_string())
+            .collect::<Vec<_>>(),
+        vec!["Option < String >", "Option < & ZKeyExpr >"],
+        "and the crossings demanded are those same wire types"
     );
 }

--- a/prebindgen-registry/src/expand/tests.rs
+++ b/prebindgen-registry/src/expand/tests.rs
@@ -2292,3 +2292,109 @@ fn a_gated_slots_wire_type_is_derived_from_its_payload() {
         "and the crossings demanded are those same wire types"
     );
 }
+
+/// #447 §1: the slot numbers in the tree are **derivable** — a walk in
+/// allocation order reproduces every one of them.
+///
+/// The check that has to hold before slot allocation can move out of the
+/// canonical tree and into adapter-local planning. If a projection walking the
+/// semantic structure yields today's numbering, the numbering is not a fact the
+/// tree has to carry; if it does not, something about the layout is not
+/// positional and the relocation would change generated signatures.
+///
+/// Allocation is pre-order: a layer takes its own slot before the construction
+/// under it, and a dispatch its selector before its arms.
+#[test]
+fn slot_numbers_are_derivable_from_the_tree_walk() {
+    fn stored(node: &InNode, out: &mut Vec<usize>) {
+        match &node.kind {
+            TransformKind::Leaf(InLeaf::Slot { slot, .. }) => out.push(slot.slot),
+            TransformKind::Leaf(InLeaf::Bound) => {}
+            TransformKind::Product { children, .. } => {
+                children.iter().for_each(|c| stored(&c.node, out))
+            }
+            TransformKind::Choice { op, variants } => {
+                out.push(op.selector.slot);
+                variants.iter().for_each(|v| stored(&v.node, out));
+            }
+            TransformKind::Optional { op, inner } => {
+                match op {
+                    InPresence::Selector => {}
+                    InPresence::Flag(s) => out.push(s.slot),
+                    InPresence::Payload { slot, .. } => out.push(slot.slot),
+                }
+                stored(inner, out);
+            }
+            TransformKind::Sequence { op, inner } => {
+                out.push(op.slot.slot);
+                stored(inner, out);
+            }
+        }
+    }
+
+    // Three shapes that allocate differently: a dispatch (selector then arms),
+    // a single-constructor optional (the layer's own payload slot), and a
+    // multi-argument optional (an explicit flag, then one slot per argument).
+    let cases: Vec<(&str, Vec<&str>, &str, &str, Vec<Variant>)> = vec![
+        (
+            "dispatch",
+            vec![
+                "fn z_keyexpr_try_from(s: String) -> Result<ZKeyExpr, Error> { todo!() }",
+                "fn z_keyexpr_intersects(a: &ZKeyExpr, b: &ZKeyExpr) -> bool { todo!() }",
+            ],
+            "z_keyexpr_intersects",
+            "a",
+            vec![
+                Variant::Ctor(ident("z_keyexpr_try_from")),
+                Variant::Identity,
+            ],
+        ),
+        (
+            "optional payload",
+            vec![
+                "fn z_encoding_from_string(s: String) -> ZEncoding { todo!() }",
+                "fn z_session_put(s: &ZSession, encoding: Option<&ZEncoding>) -> bool { todo!() }",
+            ],
+            "z_session_put",
+            "encoding",
+            vec![Variant::Ctor(ident("z_encoding_from_string"))],
+        ),
+    ];
+
+    for (label, items, func, param, variants) in cases {
+        let mut reg: Registry<()> = reg_with(&items);
+        let mut exp = Expansions::default();
+        exp.expands.push(ExpandDecl {
+            func: ident(func),
+            param: ident(param),
+            declared_target: None,
+            sel: ExpandSel::Subset(variants),
+        });
+        apply(
+            &mut reg,
+            &exp,
+            &Default::default(),
+            &Default::default(),
+            &Default::default(),
+        )
+        .unwrap_or_else(|e| panic!("{label}: apply: {e}"));
+        let plan = reg
+            .expansion_plans
+            .get(&(ident(func), ident(param)))
+            .unwrap_or_else(|| panic!("{label}: plan"));
+
+        let mut order = Vec::new();
+        stored(plan.tree(), &mut order);
+        assert_eq!(
+            order,
+            (0..order.len()).collect::<Vec<_>>(),
+            "{label}: a pre-order walk meets the slots in numbering order, so the numbers \
+             are the walk's and need not be stored"
+        );
+        assert_eq!(
+            order.len(),
+            plan.leaves().len(),
+            "{label}: and it meets every slot the wire has"
+        );
+    }
+}

--- a/prebindgen-registry/src/expand/tree.rs
+++ b/prebindgen-registry/src/expand/tree.rs
@@ -4,7 +4,7 @@
 //! The tree is the plan. A constructor call is a [product](InProduct) over its
 //! arguments, a selector dispatch is a [choice](InChoice) over its arms, the
 //! `Option<…>` and `Vec<…>` a parameter is written with are the layers over
-//! that ([`InPresence`], [`InSlot`]), and a wire value is a [leaf](InLeaf).
+//! that ([`InPresence`], [`InRun`]), and a crossing value is a [leaf](InLeaf).
 //! Recursion is the tree's, so a nested build is the same node kinds as the
 //! top-level one rather than a second type spelling the same thing.
 //!
@@ -39,38 +39,12 @@ pub type InNode = TransformNode<IntoRust>;
 /// One argument of an into-Rust product, or one arm of a choice.
 pub type InChild = TransformChild<IntoRust>;
 
-/// One wire slot: where it sits in the foreign signature and what it is called
-/// there.
-///
-/// The single description of a slot. [`wire_leaves`] turns the slots a tree
-/// names into [`FoldPlan::leaves`](super::FoldPlan::leaves), so a slot exists
-/// exactly where the node that uses it says so.
-///
-/// What a slot **carries** is not stored here: an argument slot carries its own
-/// node's [`ty`](TransformNode::ty), a selector an `i32` and a presence flag a
-/// `bool` by definition, and the two slots that carry something else — an
-/// `Option` layer's payload and a run — say so on the layer. Storing it twice
-/// would let a node and its slot disagree about one type.
-#[derive(Clone)]
-pub struct InSlot {
-    /// Position in the foreign signature, and the index of the caller's
-    /// decoded local.
-    pub slot: usize,
-    /// The slot's foreign-side parameter name.
-    pub name: syn::Ident,
-}
-
 /// Where one decoded value comes from.
-// large_enum_variant: a plan has a handful of leaves, and boxing `InSlot` to
-// even the arms out would only put an indirection between a node and the slot
-// it names (same trade-off as `DeconRecord`).
-#[allow(clippy::large_enum_variant)]
 #[derive(Clone)]
 pub enum InLeaf {
     /// A wire slot of its own.
     Slot {
-        slot: InSlot,
-        /// The slot is `Option`-wrapped by **selector presence** (it belongs to
+        /// The position is `Option`-wrapped by **selector presence** (it belongs to
         /// a dispatched arm and only the taken arm's slots are filled), so a
         /// consumer unwraps it before use and treats a missing value as an
         /// error.
@@ -114,9 +88,11 @@ pub enum InProduct {
 /// own — a wire value no source wrote, contributed by this node.
 #[derive(Clone)]
 pub struct InChoice {
-    /// The `i32` slot. Arm `i` is taken when it reads `i`; under an
-    /// [`Optional`](InPresence) layer `-1` additionally means absent.
-    pub selector: InSlot,
+    /// A dispatch happens here. WHICH position signals it, and that the signal
+    /// is an `i32` at all, is the layout's choice rather than this node's
+    /// (#447 §1) — as is the convention that `-1` means absent under an
+    /// [`Optional`](InPresence) layer.
+    pub dispatch: (),
 }
 
 /// How an `Option<…>` layer decides whether its value is present. The three
@@ -131,16 +107,15 @@ pub enum InPresence {
     /// The dispatch under the layer also encodes absence: its selector reads
     /// `-1`. No slot of the layer's own.
     Selector,
-    /// An explicit `bool` slot decides, and the construction's arguments cross
-    /// plain. Used for a constructor of two or more arguments, where riding the
+    /// An explicit flag decides, and the construction's arguments cross plain.
+    /// Used for a constructor of two or more arguments, where riding the
     /// arguments' own `Option`s would box a nullable primitive on the wire.
-    Flag(InSlot),
+    Flag,
     /// The layer decodes its own `Option<…>` slot and hands the payload to the
     /// single-argument construction under it — which reads it as
     /// [`InLeaf::Bound`], having no slot of its own.
     Payload {
-        slot: InSlot,
-        /// The `Option<…>` the slot carries. Not the layer node's
+        /// The `Option<…>` the position carries. Not the layer node's
         /// [`ty`](TransformNode::ty): the node produces `Option<Target>` while
         /// the slot carries the constructor's own argument, optionally.
         ty: prebindgen_flat::flat::TypeRef,
@@ -151,8 +126,7 @@ pub enum InPresence {
 /// layer iterates.
 #[derive(Clone)]
 pub struct InRun {
-    pub slot: InSlot,
-    /// The collection the slot carries. Not the layer node's
+    /// The collection the position carries. Not the layer node's
     /// [`ty`](TransformNode::ty), for the reason
     /// [`InPresence::Payload`] gives.
     pub ty: prebindgen_flat::flat::TypeRef,
@@ -190,30 +164,6 @@ impl InNode {
         }
     }
 
-    /// The slot of the explicit presence flag, when an `Option` layer decides
-    /// presence with one — see [`InPresence::Flag`].
-    pub fn present(&self) -> Option<usize> {
-        match &self.kind {
-            TransformKind::Optional {
-                op: InPresence::Flag(s),
-                ..
-            } => Some(s.slot),
-            TransformKind::Optional { inner, .. } | TransformKind::Sequence { inner, .. } => {
-                inner.present()
-            }
-            _ => None,
-        }
-    }
-
-    /// The selector slot when the construction dispatches, `None` when it is a
-    /// single unconditional one.
-    pub fn selector(&self) -> Option<usize> {
-        match &self.core().kind {
-            TransformKind::Choice { op, .. } => Some(op.selector.slot),
-            _ => None,
-        }
-    }
-
     /// The arms of a dispatch, or the single construction on its own — the
     /// reading a consumer wants when it asks what this parameter can be built
     /// from. In selector order: arm `i` is taken when the selector reads `i`.
@@ -244,14 +194,14 @@ impl InNode {
     /// layer's payload instead of a slot: the arm then has no flat signature,
     /// which is what makes it unsplittable into a destination-language
     /// overload.
-    pub fn leaf_args(&self) -> Option<Vec<usize>> {
+    pub fn leaf_args(&self) -> Option<Vec<()>> {
         let TransformKind::Product { children, .. } = &self.kind else {
             return None;
         };
         children
             .iter()
             .map(|c| match &c.node.kind {
-                TransformKind::Leaf(InLeaf::Slot { slot, .. }) => Some(slot.slot),
+                TransformKind::Leaf(InLeaf::Slot { .. }) => Some(()),
                 _ => None,
             })
             .collect()
@@ -263,37 +213,118 @@ impl InNode {
 ///
 /// Every slot is named exactly once — a gap or a collision here means the
 /// builder handed out a position twice.
-pub fn wire_leaves(tree: &InNode) -> Vec<FoldLeaf> {
-    let mut slots: Vec<(usize, FoldLeaf)> = Vec::new();
-    tree.lower(&mut CollectSlots(&mut slots))
-        .expect("collecting wire slots cannot fail");
-    let mut out: Vec<Option<FoldLeaf>> = (0..slots.len()).map(|_| None).collect();
-    for (slot, leaf) in slots {
-        let cell = out
-            .get_mut(slot)
-            .expect("a wire slot outside the plan's own count");
-        assert!(cell.is_none(), "two wire values claim slot {slot}");
-        *cell = Some(leaf);
+/// Derive a flat layout for a tree that has none — the tree a
+/// [`select`] produced.
+///
+/// Selection replaces subtrees, so the signature it leaves is not the one the
+/// plan was built with. Rather than renumber a signature the tree no longer
+/// carries, an adapter claims positions over the selected tree: same walk,
+/// same order, and the surviving values close ranks because nothing was
+/// skipped. Names are positional here; an adapter that wants its own naming
+/// builds its own layout the same way (#447 §1).
+pub fn derive_layout(tree: &InNode) -> super::SlotLayout {
+    struct Derive(super::SlotLayout);
+    impl TransformLowerer<IntoRust> for Derive {
+        type Value = ();
+        type Error = std::convert::Infallible;
+
+        fn descend(
+            &mut self,
+            node: &InNode,
+            _link: Option<&InLink>,
+        ) -> Result<crate::transform::Descend<()>, Self::Error> {
+            let kind = match &node.kind {
+                TransformKind::Leaf(InLeaf::Slot { .. }) => Some(super::SlotKind::Value),
+                TransformKind::Choice { .. } => Some(super::SlotKind::Selector),
+                TransformKind::Sequence { .. } => Some(super::SlotKind::Value),
+                TransformKind::Optional { op, .. } => match op {
+                    InPresence::Selector => None,
+                    InPresence::Flag => Some(super::SlotKind::PresenceFlag),
+                    InPresence::Payload { .. } => Some(super::SlotKind::PresencePayload),
+                },
+                TransformKind::Leaf(InLeaf::Bound) | TransformKind::Product { .. } => None,
+            };
+            if let Some(kind) = kind {
+                let name = prebindgen_flat::types_util::ident(&format!("p{}", self.0.len()));
+                self.0.claim(name, kind);
+            }
+            Ok(crate::transform::Descend::Recurse)
+        }
+
+        fn leaf(&mut self, _n: &InNode, _o: &InLeaf) -> Result<(), Self::Error> {
+            Ok(())
+        }
+        fn product(
+            &mut self,
+            _n: &InNode,
+            _o: &InProduct,
+            _c: Lowered<'_, IntoRust, ()>,
+        ) -> Result<(), Self::Error> {
+            Ok(())
+        }
+        fn choice(
+            &mut self,
+            _n: &InNode,
+            _o: &InChoice,
+            _v: Lowered<'_, IntoRust, ()>,
+        ) -> Result<(), Self::Error> {
+            Ok(())
+        }
+        fn optional(
+            &mut self,
+            _n: &InNode,
+            _o: &InPresence,
+            _i: &InNode,
+            _v: (),
+        ) -> Result<(), Self::Error> {
+            Ok(())
+        }
+        fn sequence(
+            &mut self,
+            _n: &InNode,
+            _o: &InRun,
+            _i: &InNode,
+            _v: (),
+        ) -> Result<(), Self::Error> {
+            Ok(())
+        }
     }
-    out.into_iter()
+    let mut derive = Derive(super::SlotLayout::default());
+    tree.lower(&mut derive)
+        .expect("deriving a layout cannot fail");
+    derive.0
+}
+
+pub fn wire_leaves(tree: &InNode, layout: &super::SlotLayout) -> Vec<FoldLeaf> {
+    let mut types: Vec<prebindgen_flat::flat::TypeRef> = Vec::new();
+    tree.lower(&mut CollectSlots(&mut types))
+        .expect("collecting wire values cannot fail");
+    assert_eq!(
+        types.len(),
+        layout.len(),
+        "the tree carries one value per position the layout claimed"
+    );
+    types
+        .into_iter()
         .enumerate()
-        .map(|(slot, leaf)| leaf.unwrap_or_else(|| panic!("wire slot {slot} is unclaimed")))
+        .map(|(slot, ty)| FoldLeaf {
+            name: layout.name(slot).clone(),
+            ty,
+        })
         .collect()
 }
 
 /// The lowerer behind [`wire_leaves`]: each node contributes the slots it uses
 /// and nothing else.
-struct CollectSlots<'a>(&'a mut Vec<(usize, FoldLeaf)>);
+struct CollectSlots<'a>(&'a mut Vec<prebindgen_flat::flat::TypeRef>);
 
 impl CollectSlots<'_> {
-    fn take(&mut self, s: &InSlot, ty: prebindgen_flat::flat::TypeRef) {
-        self.0.push((
-            s.slot,
-            FoldLeaf {
-                name: s.name.clone(),
-                ty,
-            },
-        ));
+    /// Contribute the value at the next position. Pushed on the way DOWN, so
+    /// the order is the one positions were claimed in — a dispatch's selector
+    /// precedes the arms it selects between, which a bottom-up hook would
+    /// reverse.
+    fn take(&mut self, ty: prebindgen_flat::flat::TypeRef) {
+        self.0.push(ty);
     }
 }
 
@@ -301,12 +332,39 @@ impl TransformLowerer<IntoRust> for CollectSlots<'_> {
     type Value = ();
     type Error = std::convert::Infallible;
 
-    fn leaf(&mut self, node: &InNode, op: &InLeaf) -> Result<(), Self::Error> {
-        // A bound argument reads what its layer unwrapped; that slot is the
-        // layer's, contributed there.
-        if let InLeaf::Slot { slot, wrapped } = op {
-            self.take(slot, slot_wire_ty(&node.ty, *wrapped));
+    /// Contribute on the way DOWN, so values land in the order their positions
+    /// were claimed: a layer before its construction, a dispatch's selector
+    /// before its arms.
+    fn descend(
+        &mut self,
+        node: &InNode,
+        _link: Option<&InLink>,
+    ) -> Result<crate::transform::Descend<()>, Self::Error> {
+        match &node.kind {
+            // A bound argument reads what its layer unwrapped; that position is
+            // the layer's, contributed there.
+            TransformKind::Leaf(InLeaf::Slot { wrapped }) => {
+                self.take(slot_wire_ty(&node.ty, *wrapped))
+            }
+            TransformKind::Leaf(InLeaf::Bound) | TransformKind::Product { .. } => {}
+            // The selector: composed, and placeless by construction.
+            TransformKind::Choice { .. } => self.take(prebindgen_flat::flat::TypeRef::scalar(
+                prebindgen_flat::flat::ScalarKind::I32,
+            )),
+            TransformKind::Sequence { op, .. } => self.take(op.ty.clone()),
+            TransformKind::Optional { op, .. } => match op {
+                InPresence::Selector => {}
+                // A presence flag no source wrote — placeless by construction.
+                InPresence::Flag => self.take(prebindgen_flat::flat::TypeRef::scalar(
+                    prebindgen_flat::flat::ScalarKind::Bool,
+                )),
+                InPresence::Payload { ty, .. } => self.take(ty.clone()),
+            },
         }
+        Ok(crate::transform::Descend::Recurse)
+    }
+
+    fn leaf(&mut self, _node: &InNode, _op: &InLeaf) -> Result<(), Self::Error> {
         Ok(())
     }
 
@@ -322,44 +380,29 @@ impl TransformLowerer<IntoRust> for CollectSlots<'_> {
     fn choice(
         &mut self,
         _node: &InNode,
-        op: &InChoice,
+        _op: &InChoice,
         _variants: Lowered<'_, IntoRust, ()>,
     ) -> Result<(), Self::Error> {
-        // The selector: composed, and placeless by construction.
-        self.take(
-            &op.selector,
-            prebindgen_flat::flat::TypeRef::scalar(prebindgen_flat::flat::ScalarKind::I32),
-        );
         Ok(())
     }
 
     fn optional(
         &mut self,
         _node: &InNode,
-        op: &InPresence,
+        _op: &InPresence,
         _inner: &InNode,
         _value: (),
     ) -> Result<(), Self::Error> {
-        match op {
-            InPresence::Selector => {}
-            // A presence flag no source wrote — placeless by construction.
-            InPresence::Flag(s) => self.take(
-                s,
-                prebindgen_flat::flat::TypeRef::scalar(prebindgen_flat::flat::ScalarKind::Bool),
-            ),
-            InPresence::Payload { slot, ty } => self.take(slot, ty.clone()),
-        }
         Ok(())
     }
 
     fn sequence(
         &mut self,
         _node: &InNode,
-        op: &InRun,
+        _op: &InRun,
         _inner: &InNode,
         _value: (),
     ) -> Result<(), Self::Error> {
-        self.take(&op.slot, op.ty.clone());
         Ok(())
     }
 }
@@ -466,7 +509,7 @@ impl TransformLowerer<IntoRust> for CollectDeps {
         match op {
             // Absence rides the dispatch's own selector.
             InPresence::Selector => {}
-            InPresence::Flag(_) => out
+            InPresence::Flag => out
                 .intrinsic
                 .push(Self::scalar(prebindgen_flat::flat::ScalarKind::Bool)),
             InPresence::Payload { ty, .. } => out.required.push(ty.clone()),
@@ -618,7 +661,6 @@ pub fn select(
     claim: &mut dyn FnMut(&InNode, Option<&InLink>) -> Option<Claim>,
 ) -> Result<InNode, SelectError> {
     tree.lower(&mut Select { claim })
-        .map(|selected| renumber(&selected))
 }
 
 /// The lowerer behind [`select`]: it rebuilds the tree, replacing a claimed
@@ -809,34 +851,25 @@ impl Select<'_> {
     /// selector-wrapped arguments, so they contribute `false`; that is also the
     /// answer when the claim swallows the whole choice, which then sits under
     /// no selector at all.
-    fn first_slot(node: &InNode) -> Option<(InSlot, bool)> {
+    fn first_slot(node: &InNode) -> Option<bool> {
         match &node.kind {
-            TransformKind::Leaf(InLeaf::Slot { slot, wrapped }) => Some((slot.clone(), *wrapped)),
+            TransformKind::Leaf(InLeaf::Slot { wrapped }) => Some(*wrapped),
             TransformKind::Leaf(InLeaf::Bound) => None,
-            TransformKind::Product { children, .. } => children
-                .iter()
-                .filter_map(|c| Self::first_slot(&c.node))
-                .min_by_key(|(s, _)| s.slot),
-            TransformKind::Choice { op, variants } => variants
-                .iter()
-                .filter_map(|v| Self::first_slot(&v.node))
-                .chain(std::iter::once((op.selector.clone(), false)))
-                .min_by_key(|(s, _)| s.slot),
-            TransformKind::Optional { op, inner } => {
-                let own = match op {
-                    InPresence::Selector => None,
-                    InPresence::Flag(s) => Some((s.clone(), false)),
-                    InPresence::Payload { slot, .. } => Some((slot.clone(), false)),
-                };
-                Self::first_slot(inner)
-                    .into_iter()
-                    .chain(own)
-                    .min_by_key(|(s, _)| s.slot)
+            // The FIRST position the subtree occupies, in claim order — which
+            // is this walk's order, so the earliest is simply the first found.
+            TransformKind::Product { children, .. } => {
+                children.iter().find_map(|c| Self::first_slot(&c.node))
             }
-            TransformKind::Sequence { op, inner } => Self::first_slot(inner)
-                .into_iter()
-                .chain(std::iter::once((op.slot.clone(), false)))
-                .min_by_key(|(s, _)| s.slot),
+            // A dispatch claims its selector before its arms, and a selector is
+            // never a selector-wrapped argument.
+            TransformKind::Choice { .. } => Some(false),
+            TransformKind::Optional { op, inner } => match op {
+                // The layer claims nothing; the dispatch under it does.
+                InPresence::Selector => Self::first_slot(inner),
+                // A flag and a payload are structural, so neither is wrapped.
+                InPresence::Flag | InPresence::Payload { .. } => Some(false),
+            },
+            TransformKind::Sequence { .. } => Some(false),
         }
     }
 }
@@ -857,7 +890,7 @@ impl TransformLowerer<IntoRust> for Select<'_> {
         else {
             return Ok(crate::transform::Descend::Recurse);
         };
-        let Some((slot, wrapped)) = Self::first_slot(node) else {
+        let Some(wrapped) = Self::first_slot(node) else {
             return Err(SelectError::BoundOnlySubtree {
                 claimed: node.ty.key().to_string(),
             });
@@ -942,10 +975,7 @@ impl TransformLowerer<IntoRust> for Select<'_> {
             // is `wrapped`'s to add, and stating it here as well is the
             // disagreement the invariant removes.
             ty: selected.clone(),
-            kind: TransformKind::Leaf(InLeaf::Slot {
-                slot: slot.clone(),
-                wrapped,
-            }),
+            kind: TransformKind::Leaf(InLeaf::Slot { wrapped }),
         };
         // An identity over one value the enclosing node binds, typed with what
         // the node owes rather than what the claim reads: under a layer it
@@ -1006,7 +1036,6 @@ impl TransformLowerer<IntoRust> for Select<'_> {
                 ty: node.ty.clone(),
                 kind: TransformKind::Optional {
                     op: InPresence::Payload {
-                        slot,
                         ty: selected.clone(),
                     },
                     inner: Box::new(identity_over(bound_leaf())),
@@ -1016,7 +1045,6 @@ impl TransformLowerer<IntoRust> for Select<'_> {
                 ty: node.ty.clone(),
                 kind: TransformKind::Sequence {
                     op: InRun {
-                        slot,
                         ty: selected.clone(),
                     },
                     inner: Box::new(identity_over(bound_leaf())),
@@ -1031,10 +1059,7 @@ impl TransformLowerer<IntoRust> for Select<'_> {
         Ok(InNode {
             ty: node.ty.clone(),
             kind: TransformKind::Leaf(match op {
-                InLeaf::Slot { slot, wrapped } => InLeaf::Slot {
-                    slot: slot.clone(),
-                    wrapped: *wrapped,
-                },
+                InLeaf::Slot { wrapped } => InLeaf::Slot { wrapped: *wrapped },
                 InLeaf::Bound => InLeaf::Bound,
             }),
         })
@@ -1112,110 +1137,4 @@ fn rebuilt(children: Lowered<'_, IntoRust, InNode>) -> Vec<InChild> {
             node,
         })
         .collect()
-}
-
-/// Close the gaps a selection leaves: the surviving slots keep their order and
-/// take positions `0..n`.
-///
-/// Order rather than identity, because the foreign signature is a sequence —
-/// what a caller passes second must still be what the wrapper reads second.
-fn renumber(tree: &InNode) -> InNode {
-    let mut old: Vec<usize> = Vec::new();
-    collect_slots(tree, &mut old);
-    old.sort_unstable();
-    let dense: std::collections::HashMap<usize, usize> = old
-        .into_iter()
-        .enumerate()
-        .map(|(new, o)| (o, new))
-        .collect();
-    rewrite_slots(tree, &dense)
-}
-
-fn collect_slots(node: &InNode, out: &mut Vec<usize>) {
-    match &node.kind {
-        TransformKind::Leaf(InLeaf::Slot { slot, .. }) => out.push(slot.slot),
-        TransformKind::Leaf(InLeaf::Bound) => {}
-        TransformKind::Product { children, .. } => {
-            for c in children {
-                collect_slots(&c.node, out);
-            }
-        }
-        TransformKind::Choice { op, variants } => {
-            out.push(op.selector.slot);
-            for v in variants {
-                collect_slots(&v.node, out);
-            }
-        }
-        TransformKind::Optional { op, inner } => {
-            match op {
-                InPresence::Selector => {}
-                InPresence::Flag(s) => out.push(s.slot),
-                InPresence::Payload { slot, .. } => out.push(slot.slot),
-            }
-            collect_slots(inner, out);
-        }
-        TransformKind::Sequence { op, inner } => {
-            out.push(op.slot.slot);
-            collect_slots(inner, out);
-        }
-    }
-}
-
-fn rewrite_slots(node: &InNode, dense: &std::collections::HashMap<usize, usize>) -> InNode {
-    let at = |s: &InSlot| InSlot {
-        slot: dense[&s.slot],
-        name: s.name.clone(),
-    };
-    InNode {
-        ty: node.ty.clone(),
-        kind: match &node.kind {
-            TransformKind::Leaf(InLeaf::Slot { slot, wrapped }) => {
-                TransformKind::Leaf(InLeaf::Slot {
-                    slot: at(slot),
-                    wrapped: *wrapped,
-                })
-            }
-            TransformKind::Leaf(InLeaf::Bound) => TransformKind::Leaf(InLeaf::Bound),
-            TransformKind::Product { op, children } => TransformKind::Product {
-                op: op.clone(),
-                children: children
-                    .iter()
-                    .map(|c| InChild {
-                        link: c.link.clone(),
-                        node: rewrite_slots(&c.node, dense),
-                    })
-                    .collect(),
-            },
-            TransformKind::Choice { op, variants } => TransformKind::Choice {
-                op: InChoice {
-                    selector: at(&op.selector),
-                },
-                variants: variants
-                    .iter()
-                    .map(|v| InChild {
-                        link: v.link.clone(),
-                        node: rewrite_slots(&v.node, dense),
-                    })
-                    .collect(),
-            },
-            TransformKind::Optional { op, inner } => TransformKind::Optional {
-                op: match op {
-                    InPresence::Selector => InPresence::Selector,
-                    InPresence::Flag(s) => InPresence::Flag(at(s)),
-                    InPresence::Payload { slot, ty } => InPresence::Payload {
-                        slot: at(slot),
-                        ty: ty.clone(),
-                    },
-                },
-                inner: Box::new(rewrite_slots(inner, dense)),
-            },
-            TransformKind::Sequence { op, inner } => TransformKind::Sequence {
-                op: InRun {
-                    slot: at(&op.slot),
-                    ty: op.ty.clone(),
-                },
-                inner: Box::new(rewrite_slots(inner, dense)),
-            },
-        },
-    }
 }

--- a/prebindgen-registry/src/expand/tree.rs
+++ b/prebindgen-registry/src/expand/tree.rs
@@ -304,8 +304,8 @@ impl TransformLowerer<IntoRust> for CollectSlots<'_> {
     fn leaf(&mut self, node: &InNode, op: &InLeaf) -> Result<(), Self::Error> {
         // A bound argument reads what its layer unwrapped; that slot is the
         // layer's, contributed there.
-        if let InLeaf::Slot { slot, .. } = op {
-            self.take(slot, node.ty.clone());
+        if let InLeaf::Slot { slot, wrapped } = op {
+            self.take(slot, slot_wire_ty(&node.ty, *wrapped));
         }
         Ok(())
     }
@@ -422,8 +422,10 @@ impl TransformLowerer<IntoRust> for CollectDeps {
 
     fn leaf(&mut self, node: &InNode, op: &InLeaf) -> Result<Dependencies, Self::Error> {
         Ok(match op {
-            InLeaf::Slot { .. } => Dependencies {
-                required: vec![node.ty.clone()],
+            // The crossing a converter must exist for is what the slot
+            // carries, which is the payload plus any presence over it.
+            InLeaf::Slot { wrapped, .. } => Dependencies {
+                required: vec![slot_wire_ty(&node.ty, *wrapped)],
                 intrinsic: Vec::new(),
             },
             // A bound argument reads what its layer decoded; that crossing is
@@ -687,21 +689,22 @@ impl Claim {
     }
 }
 
-/// The payload of the `Option` **selector presence adds**, which is the one the
-/// emitter matches on.
+/// What a slot carries on the wire: its payload, plus the `Option` selector
+/// presence adds when a live choice arm gates it.
 ///
-/// Deliberately not [`optional_inner`](prebindgen_flat::flat::TypeRef::optional_inner):
-/// that looks through `Box` and `Cow`, because a destination language sees an
-/// optional either way, while `match slot { Some(..) }` does not see through
-/// either. A `Box<Option<T>>` reading carries no positional presence — its
-/// `Option` belongs to the converter — so presence has to be added around it
-/// rather than found inside it.
-fn presence_payload(
-    ty: &prebindgen_flat::flat::TypeRef,
-) -> Option<&prebindgen_flat::flat::TypeRef> {
-    match ty.kind() {
-        prebindgen_flat::flat::TypeKind::Optional(inner) => Some(inner),
-        _ => None,
+/// Presence and the crossing type are **one fact** derived here, not two fields
+/// that can disagree. A node's `ty` is always the value the position holds, and
+/// the wire type follows from whether the position is gated — so the state this
+/// used to be able to represent, a plain `T` beside `wrapped = true`, no longer
+/// exists to be constructed (#447 §1).
+pub fn slot_wire_ty(
+    payload: &prebindgen_flat::flat::TypeRef,
+    wrapped: bool,
+) -> prebindgen_flat::flat::TypeRef {
+    if wrapped {
+        payload.optional()
+    } else {
+        payload.clone()
     }
 }
 
@@ -888,33 +891,14 @@ impl TransformLowerer<IntoRust> for Select<'_> {
         // directly is what let an owned-producing lift through onto a borrowed
         // argument hidden under presence.
         //
-        // `position_ty` is idempotent in the wrapped case: a reading that is
-        // already an `Option` **at its outer kind** can only be the position
-        // type an existing leaf handed straight back, since a selector-wrapped
-        // position never carries an optional value — a parameter that is itself
-        // `Option` is built unwrapped (`wrapped = dispatched && !popt`).
-        //
-        // Asked with `presence_payload` rather than the semantic accessor: a
-        // `Box<Option<T>>` reading owns that `Option` itself, and presence has
-        // to be added around it, or the leaf would be marked `wrapped` while
-        // the emitter's `match` cannot reach through the `Box`.
-        let position_ty = if wrapped && presence_payload(&selected).is_none() {
-            selected.optional()
-        } else {
-            selected.clone()
-        };
-        // The stored position always has that outer `Option` directly —
-        // `build_arg` writes `pty.optional()` — so the same question answers
-        // for both ends.
-        let peel = |ty: &prebindgen_flat::flat::TypeRef| {
-            if wrapped {
-                presence_payload(ty).unwrap_or(ty).clone()
-            } else {
-                ty.clone()
-            }
-        };
+        // A claim answers the PAYLOAD — the value the position holds — and the
+        // wire follows from whether that position is gated. One derivation, so
+        // the two cannot be stated inconsistently; before the invariant this
+        // needed an idempotence rule to decide whether an `Option` in the
+        // reading was the position's or the value's own (#447 §1).
         let (bound_ty, target_ty) = match &node.kind {
-            TransformKind::Leaf(_) => (peel(&position_ty), peel(&node.ty)),
+            // Both ends are payloads already.
+            TransformKind::Leaf(_) => (selected.clone(), node.ty.clone()),
             TransformKind::Optional { .. } => (
                 layer_item(&selected, LayerKind::Optional, node)?,
                 node.core().ty.clone(),
@@ -954,7 +938,10 @@ impl TransformLowerer<IntoRust> for Select<'_> {
         }
 
         let leaf = InNode {
-            ty: position_ty,
+            // The payload, like every other slot leaf: the position's `Option`
+            // is `wrapped`'s to add, and stating it here as well is the
+            // disagreement the invariant removes.
+            ty: selected.clone(),
             kind: TransformKind::Leaf(InLeaf::Slot {
                 slot: slot.clone(),
                 wrapped,

--- a/prebindgen-registry/src/unfold/tests.rs
+++ b/prebindgen-registry/src/unfold/tests.rs
@@ -2899,3 +2899,298 @@ fn selecting_an_existing_leaf_keeps_its_semantics() {
         "a variant member keeps naming its member, not a generic field read"
     );
 }
+
+/// #447 §5: one semantic tree, two adapters, deliberately different wire
+/// layouts — and the same semantic child order and the same direct-converter
+/// cutoff in both.
+///
+/// The point of the shared layer is that an adapter contributes *node-level
+/// lowering* and nothing else: no second recursive walk over `TypeRef`, no
+/// struct-field walker of its own. These two stand in for the shapes C and JNI
+/// actually choose — one flat and positional, one object-shaped — and neither
+/// needs a line of recursion to produce it.
+#[test]
+fn one_semantic_tree_lowers_into_two_wire_layouts() {
+    use crate::transform::{Lowered, TransformKind, TransformLowerer};
+
+    let field = |name: &str, node: OutNode| OutChild {
+        link: OutLink {
+            steps: vec![PathStep::field(ident(name), false)],
+            name: vec![name.to_string()],
+        },
+        node,
+    };
+    let leaf = |ty: syn::Type| OutNode {
+        ty: tref(ty),
+        kind: TransformKind::Leaf(OutLeaf {
+            nullable: false,
+            identity: false,
+            reach: OutReach::Field,
+        }),
+    };
+    let arm = |name: &str, tag: i32, children: Vec<OutChild>| OutChild {
+        link: OutLink {
+            steps: Vec::new(),
+            name: Vec::new(),
+        },
+        node: OutNode {
+            ty: tref(syn::parse_quote!(Kind)),
+            kind: TransformKind::Product {
+                op: OutProduct::Variant {
+                    name: ident(name),
+                    tag,
+                },
+                children,
+            },
+        },
+    };
+
+    // All four node kinds, in one value: a record of a scalar, a run, an
+    // optional, and a dispatch.
+    let tree = OutNode {
+        ty: tref(syn::parse_quote!(Reading)),
+        kind: TransformKind::Product {
+            op: OutProduct::Records,
+            children: vec![
+                field("id", leaf(syn::parse_quote!(i64))),
+                field(
+                    "tags",
+                    OutNode {
+                        ty: tref(syn::parse_quote!(Vec<String>)),
+                        kind: TransformKind::Sequence {
+                            op: OutRun { borrowed: false },
+                            inner: Box::new(leaf(syn::parse_quote!(String))),
+                        },
+                    },
+                ),
+                field(
+                    "note",
+                    OutNode {
+                        ty: tref(syn::parse_quote!(Option<String>)),
+                        kind: TransformKind::Optional {
+                            op: (),
+                            inner: Box::new(leaf(syn::parse_quote!(String))),
+                        },
+                    },
+                ),
+                field(
+                    "kind",
+                    OutNode {
+                        ty: tref(syn::parse_quote!(Kind)),
+                        kind: TransformKind::Choice {
+                            op: OutChoice {
+                                name: "tag".to_string(),
+                            },
+                            variants: vec![
+                                arm("Exact", 0, vec![field("v", leaf(syn::parse_quote!(i64)))]),
+                                arm("Missing", 1, Vec::new()),
+                            ],
+                        },
+                    },
+                ),
+            ],
+        },
+    };
+
+    /// Records the order a lowering met its fields in, so two adapters can be
+    /// compared on the one thing they must agree about.
+    #[derive(Default)]
+    struct Order(Vec<String>);
+
+    impl Order {
+        /// Named edges only: an arity layer reaches its inner node directly and
+        /// a choice arm is not a field, so neither names a position.
+        fn record(&mut self, link: Option<&OutLink>) {
+            if let Some(name) = link.and_then(|l| l.name.first()) {
+                self.0.push(name.clone());
+            }
+        }
+    }
+
+    /// A flat, positional layout — C's shape. Every value takes its own slot,
+    /// presence is a leading flag, a run is a pointer and a length, and a
+    /// dispatch is a tag followed by its arms' slots.
+    struct FlatWire(Order);
+    impl TransformLowerer<OutOfRust> for FlatWire {
+        type Value = Vec<String>;
+        type Error = std::convert::Infallible;
+
+        fn descend(
+            &mut self,
+            _node: &OutNode,
+            link: Option<&OutLink>,
+        ) -> Result<crate::transform::Descend<Self::Value>, Self::Error> {
+            self.0.record(link);
+            Ok(crate::transform::Descend::Recurse)
+        }
+
+        fn leaf(&mut self, node: &OutNode, _op: &OutLeaf) -> Result<Self::Value, Self::Error> {
+            Ok(vec![node.ty.spell().to_string()])
+        }
+        fn product(
+            &mut self,
+            _node: &OutNode,
+            _op: &OutProduct,
+            children: Lowered<'_, OutOfRust, Self::Value>,
+        ) -> Result<Self::Value, Self::Error> {
+            let mut out = Vec::new();
+            for (child, slots) in children {
+                if let Some(name) = child.link.name.first() {
+                    out.extend(slots.into_iter().map(|s| format!("{name}:{s}")));
+                } else {
+                    out.extend(slots);
+                }
+            }
+            Ok(out)
+        }
+        fn optional(
+            &mut self,
+            _node: &OutNode,
+            _op: &(),
+            _inner: &OutNode,
+            value: Self::Value,
+        ) -> Result<Self::Value, Self::Error> {
+            let mut out = vec!["present".to_string()];
+            out.extend(value);
+            Ok(out)
+        }
+        fn sequence(
+            &mut self,
+            _node: &OutNode,
+            _op: &OutRun,
+            _inner: &OutNode,
+            _value: Self::Value,
+        ) -> Result<Self::Value, Self::Error> {
+            Ok(vec!["ptr".to_string(), "len".to_string()])
+        }
+        fn choice(
+            &mut self,
+            _node: &OutNode,
+            _op: &OutChoice,
+            variants: Lowered<'_, OutOfRust, Self::Value>,
+        ) -> Result<Self::Value, Self::Error> {
+            let mut out = vec!["tag".to_string()];
+            for (_, slots) in variants {
+                out.extend(slots);
+            }
+            Ok(out)
+        }
+    }
+
+    /// An object-shaped layout — the JVM's. One entry per field whatever its
+    /// shape, with the arity written into the entry rather than spent on slots.
+    struct ObjectWire(Order);
+    impl TransformLowerer<OutOfRust> for ObjectWire {
+        type Value = String;
+        type Error = std::convert::Infallible;
+
+        fn descend(
+            &mut self,
+            _node: &OutNode,
+            link: Option<&OutLink>,
+        ) -> Result<crate::transform::Descend<Self::Value>, Self::Error> {
+            self.0.record(link);
+            Ok(crate::transform::Descend::Recurse)
+        }
+
+        fn leaf(&mut self, node: &OutNode, _op: &OutLeaf) -> Result<Self::Value, Self::Error> {
+            Ok(node.ty.spell().to_string())
+        }
+        fn product(
+            &mut self,
+            _node: &OutNode,
+            _op: &OutProduct,
+            children: Lowered<'_, OutOfRust, Self::Value>,
+        ) -> Result<Self::Value, Self::Error> {
+            let mut parts = Vec::new();
+            for (child, value) in children {
+                if let Some(name) = child.link.name.first() {
+                    parts.push(format!("{name}: {value}"));
+                } else {
+                    parts.push(value);
+                }
+            }
+            Ok(format!("{{{}}}", parts.join(", ")))
+        }
+        fn optional(
+            &mut self,
+            _node: &OutNode,
+            _op: &(),
+            _inner: &OutNode,
+            value: Self::Value,
+        ) -> Result<Self::Value, Self::Error> {
+            Ok(format!("{value}?"))
+        }
+        fn sequence(
+            &mut self,
+            _node: &OutNode,
+            _op: &OutRun,
+            _inner: &OutNode,
+            value: Self::Value,
+        ) -> Result<Self::Value, Self::Error> {
+            Ok(format!("List<{value}>"))
+        }
+        fn choice(
+            &mut self,
+            _node: &OutNode,
+            _op: &OutChoice,
+            variants: Lowered<'_, OutOfRust, Self::Value>,
+        ) -> Result<Self::Value, Self::Error> {
+            Ok(format!(
+                "sealed({})",
+                variants
+                    .into_iter()
+                    .map(|(_, v)| v)
+                    .collect::<Vec<_>>()
+                    .join(" | ")
+            ))
+        }
+    }
+
+    let mut flat = FlatWire(Order::default());
+    let flat_slots = tree.lower(&mut flat).unwrap();
+    let mut object = ObjectWire(Order::default());
+    let object_shape = tree.lower(&mut object).unwrap();
+
+    // Deliberately different layouts: the same value, spent very differently.
+    assert_eq!(
+        flat_slots,
+        vec![
+            "id:i64",
+            "tags:ptr",
+            "tags:len",
+            "note:present",
+            "note:String",
+            "kind:tag",
+            "kind:v:i64",
+        ]
+    );
+    assert_eq!(
+        object_shape,
+        "{id: i64, tags: List<String>, note: String?, kind: sealed({v: i64} | {})}"
+    );
+
+    // …and the one thing they must agree about: the semantic order of the
+    // children, which is the tree's and not either adapter's.
+    assert_eq!(flat.0 .0, ["id", "tags", "note", "kind", "v"]);
+    assert_eq!(flat.0 .0, object.0 .0);
+
+    // A claimed subtree is atomic for BOTH: neither lowering reaches the run's
+    // element, because the cutoff is the tree's too.
+    let selected = crate::unfold::select(&tree, &mut |node, _link| {
+        (node.ty.spell().to_string() == "Vec < String >").then(|| node.ty.clone())
+    });
+    let mut flat = FlatWire(Order::default());
+    let flat_slots = selected.lower(&mut flat).unwrap();
+    let mut object = ObjectWire(Order::default());
+    let object_shape = selected.lower(&mut object).unwrap();
+    assert_eq!(
+        flat_slots.iter().filter(|s| s.starts_with("tags")).count(),
+        1,
+        "the claimed run is one crossing, not a pointer and a length: {flat_slots:?}"
+    );
+    assert!(
+        object_shape.contains("tags: Vec < String >"),
+        "and not a List of its elements either: {object_shape}"
+    );
+}


### PR DESCRIPTION
Stacked on #446 — this branch is based on `feat/444-adapter-plans`, and the base
moves down the stack as that lands. Implements #447, whose work plan finishes
the transform stack #446 built so it is a usable cross-adapter abstraction
rather than one more intermediate representation. Section numbers below are that
work plan's.

## Already satisfied by #446

Recorded so the remaining work is clear: §2's first three boxes landed there.
`CValuePlan` carries `needs_array_alloc`, prerequisite emission folds it over
the plans the emitters actually consume, and the syntactic `produces_array`
scan is deleted. That closed the acceptance criterion about a callback-only
`Vec<T>` or `Cow<[T]>` emitting every helper its encoder calls.

## §3 — a callback has one stored plan

The closure struct's `call` pointer and the Rust trampoline that fires it are
two renderings of one boundary, and each classified every argument for itself:
the declaration to list its wire parameters, the dispatch to fill them. They
agreed because both walked the declaration deterministically — which is a
property of the implementation rather than of the boundary, so a change to one
classification could mis-declare a signature the other still filled.

`CCallbackPlan` resolves a callback once: per argument its source type, the
`extern "C" fn` parameters it costs, and how it crosses — a zero-copy slice, a
takeable handle pointer, a decomposed composite carrying its `CValuePlan`, or
one value through its converter. It is memoized on the builder, so the two
emitters read **one instance**, not two equal ones. `needs_array_alloc` now
folds over those plans rather than re-deriving which arguments are composite.

The trampoline keeps its "not resolvable yet ⇒ `None`" retry, asked in the
plan's own terms so the guard and the plan agree about which arguments even need
a converter. The plan is built only once every argument has resolved, which is
what makes storing it safe: registry entries only ever gain.

## §4 — the JNI flatten tree lowers through the shared traversal

#446 gave the input flattener a tree and left two structural passes: a builder
recursing over `flat::Struct` to synthesize an `OutNode`, and a lowering
recursing over that tree by hand to reach the same shape again. The tree was an
extra shape AST rather than the authoritative plan — and it described an
into-Rust boundary with the out-of-Rust direction, which says the opposite of
what happens there.

The boundary now has its own direction. `FlattenIn` names what it does: a leaf
is a field crossing through its own converter, a product is a declared struct
rebuilt from its fields, an optional is a present flag gating a nested class.
`Choice` and `Sequence` are uninhabited, which is the boundary's shape rather
than an omission — a data-carrying enum resolves at a leaf because only
leaf-shaped payloads flatten, and a run keeps its collection boundary.

`FlatLower` implements `TransformLowerer<FlattenIn>`, so the second recursion is
gone. Inherited context — native prefix, Kotlin access expression, nullability —
rides a stack that `descend` pushes and each hook drops, which is how a
bottom-up lowering carries what flows downward; a present flag gates the fields
under it, so it is written on the way down and claimed on the way up, keeping
wire order.

This is also the first evidence for §5's claim that a new adapter needs
node-level lowering rather than another recursive walker: a direction is six
associated types, and the traversal was reused unchanged.

## §5 — one semantic tree, two wire layouts

The claim the shared layer rests on is that an adapter contributes node-level
lowering and nothing else. Nothing checked it: each adapter lowers its own tree,
so a mechanism that quietly required more of one of them would not show.

`one_semantic_tree_lowers_into_two_wire_layouts` builds one tree with all four
node kinds and lowers it twice. `FlatWire` stands in for C's shape — a slot per
value, presence as a leading flag, a run as a pointer and a length, a dispatch
as a tag then its arms. `ObjectWire` stands in for the JVM's — one entry per
field, arity written into the entry rather than spent on slots. Seven slots
against one nested description, from the same tree, and neither lowerer contains
a line of recursion.

They agree on exactly the two things that are the tree's rather than either
adapter's: the semantic child order, and the direct-converter cutoff — claiming
the run makes it one crossing for both, and neither reaches its element.

## §1 — a slot's presence and its crossing type are one fact

A slot leaf stated both: `ty` carried the wire type, `wrapped` carried whether
selector presence gated the position. Two fields, so `ty = T` beside
`wrapped = true` was a state — the signature declaring `T` while the fold
emitter matched `Some`. #446 answered it with a normalization that decided, per
case, which end an `Option` belonged to.

The leaf now stores the **payload** and nothing else, and `slot_wire_ty` derives
the wire from the payload and the gate. Every reading of the wire goes through
it — the leaf list, the dependency set, selection — so there is nowhere to write
a second answer.

What that removes is larger than what it adds. `select` loses the idempotence
rule that existed only to decide whether an `Option` in a claimed reading was
the position's or the value's own, and `presence_payload` goes with it: the
question it answered is no longer asked. The arity layer keeps its own
outer-kind check, which is a different question — whether a `match` can reach
the payload of the slot as written.

This is the acceptance criterion about a structural subtree claimed inside a
live input choice having a consistent crossing type and presence representation.
The rest of §1 — removing slot numbers and names from the canonical tree, with
the flat `FoldPlan` layout derived as a compatibility projection — is not in this
branch; see below.

## Verification

Full workspace tests, clippy `--deny warnings`, rustfmt with the repo config and
rustdoc `-D warnings`, each checked by exit code. Generated Rust, C and Kotlin
under `examples/` are byte-identical.

`a_callback_plan_is_stored_not_rebuilt` checks the storage rather than the
coincidence: two asks return the same `Rc`, and removing the memo fails it. It
also reads the argument's wire slots and its encoder's requirement off that one
plan, which is the property §3 asks for.

The flatten refactor is covered by the corpus rather than by a new fixture: 84
distinct nested bindings, `__flat_a_alternate` nesting two levels, and
`a_alternate_present` for the optional-nested path. Removing the layer's present
flag stops the generated crate compiling, which is what says the tree's layer
decision is load-bearing rather than decorative.

## Still open

### §1 — the flat layout moves off the tree

`SlotLayout` is the compatibility projection the work plan asks for: one entry
per foreign-signature position, in the order the wire carries them, reached
through `FoldPlan::layout`. Allocating and naming a position became one act —
the counter threaded through `build_plan` *is* the layout, so `next_slot` claims
a position for a name rather than handing back an index and leaving the name to
a separate field. `SlotKind` records what each position carries, which is where
the encoding of a dispatch tag or a presence flag now lives.

`FoldPlan::selector` and `present` answer from stored values rather than walking
the tree. **JNI reads no slot fact off the tree at all** — those two accessors
and `leaves()` are its whole surface.

A first cut had them answer `layout.first_of(Selector)`, which finds a *nested*
build's dispatch where the accessor means the root's; four tests caught it, and
the answers are now recorded where that distinction is known.

### The signature leaves the tree

`InSlot` is gone. The tree kept the semantics — constructor identity, argument
order, borrowing, optionality, dispatch, and whether a position is gated by
selector presence — and `SlotLayout` holds the positions and names alone.
`InChoice` says a dispatch happens, not that an `i32` signals it; `InPresence`
distinguishes flag from payload from selector without naming a slot for any.

Positions are claimed outside in, and the three consumers re-derive them by
walking in that order rather than reading them off a node:

* `wire_leaves` contributes each value on the way DOWN, so a selector precedes
  the arms it selects between — a bottom-up hook would reverse them.
* `ConstructEmitter` claims in `descend`. Its `Selector` layer takes the
  position its inner choice is about to claim, which is exact rather than
  positional guesswork: the traversal visits that node next, and a choice claims
  its selector before its arms.
* `FoldPlan::arm_arg_slots` gives JNI's overload builder each arm's positions,
  which it previously read off the arm's own leaves.

`select` no longer renumbers, because there is nothing to renumber:
`renumber`, `collect_slots` and `rewrite_slots` are deleted, and a claimed
subtree takes the earliest position it replaced because the walk meets it there.
A selected tree gets its layout from `derive_layout` — the same walk an adapter
runs to choose its own physical shape, which is what "selecting is also choosing
the layout" now means literally.

`build_core` reports the selector it claims, so the plan records the **root**
dispatch instead of searching for one.

## Verification

Full workspace tests, clippy `--deny warnings`, rustfmt with the repo config and
rustdoc `-D warnings`, each checked by exit code. Generated Rust, C and Kotlin
under `examples/` are byte-identical.

`a_callback_plan_is_stored_not_rebuilt` checks the storage rather than the
coincidence: two asks return the same `Rc`, and removing the memo fails it. It
also reads the argument's wire slots and its encoder's requirement off that one
plan, which is the property §3 asks for.

The flatten refactor is covered by the corpus rather than by a new fixture: 84
distinct nested bindings, `__flat_a_alternate` nesting two levels, and
`a_alternate_present` for the optional-nested path. Removing the layer's present
flag stops the generated crate compiling, which is what says the tree's layer
decision is load-bearing rather than decorative.

## Still open

### §1 — the flat layout moves off the tree

`SlotLayout` is the compatibility projection the work plan asks for: one entry
per foreign-signature position, in the order the wire carries them, reached
through `FoldPlan::layout`. Allocating and naming a position became one act —
the counter threaded through `build_plan` *is* the layout, so `next_slot` claims
a position for a name rather than handing back an index and leaving the name to
a separate field. `SlotKind` records what each position carries, which is where
the encoding of a dispatch tag or a presence flag now lives.

`FoldPlan::selector` and `present` answer from stored values rather than walking
the tree. **JNI reads no slot fact off the tree at all** — those two accessors
and `leaves()` are its whole surface.

A first cut had them answer `layout.first_of(Selector)`, which finds a *nested*
build's dispatch where the accessor means the root's; four tests caught it, and
the answers are now recorded where that distinction is known.

### What is still on the tree

`InSlot` — a position index and name — still sits inside `InLeaf::Slot`,
`InChoice`, `InPresence` and `InRun`, read by two registry-internal renderers:
`wire_leaves` and `ConstructEmitter`. So the acceptance criterion "physical
signature slots and selector/presence encodings are adapter-local" is **not
fully met**.

I attempted the removal and reverted it rather than leave the branch broken. It
is 47 compile errors across four rewrites, each a design change rather than a
substitution:

* `CollectSlots` must push in `descend`, because a bottom-up hook would place a
  dispatch's selector after the arms it precedes on the wire;
* `select`'s `first_slot`, `renumber`, `collect_slots` and `rewrite_slots` are
  deleted — with no slots to inherit, selection stops renumbering and an adapter
  derives its own layout, which is the better architecture but changes what
  three of #446's review-driven tests assert;
* `ConstructEmitter` needs a pre-order counter, and its `InPresence::Selector`
  arm needs its *inner* choice's index, which a bottom-up hook returning a
  `syn::Expr` cannot hand back;
* `InNode::selector`/`present` go, once `build_core` reports the selector it
  claims — the one part of the attempt that did work.

## Verification

Full workspace tests, clippy `--deny warnings`, rustfmt with the repo config and
rustdoc `-D warnings`, each checked by exit code. Generated Rust, C and Kotlin
under `examples/` are byte-identical.

`a_callback_plan_is_stored_not_rebuilt` checks the storage rather than the
coincidence: two asks return the same `Rc`, and removing the memo fails it. It
also reads the argument's wire slots and its encoder's requirement off that one
plan, which is the property §3 asks for.

The flatten refactor is covered by the corpus rather than by a new fixture: 84
distinct nested bindings, `__flat_a_alternate` nesting two levels, and
`a_alternate_present` for the optional-nested path. Removing the layer's present
flag stops the generated crate compiling, which is what says the tree's layer
decision is load-bearing rather than decorative.

## Still open

The remainder of §1: slot numbers, names and the dense renumbering still live in
the canonical `IntoRust` tree. **Not done here**, and the acceptance criterion
"physical signature slots and selector/presence encodings are adapter-local" is
not met. What is done is the groundwork, so the change is a mechanical one
rather than an open question:

* **The numbering is positional.** `slot_numbers_are_derivable_from_the_tree_walk`
  checks that a pre-order walk meets every slot in numbering order, across the
  two shapes that allocate differently. So a projection can assign the numbers
  without moving the wire.
* **The names are derivable too**, from the root parameter name, arm ordinals,
  and the constructor idents the tree already carries in `InProduct::Ctor` —
  `a_sel`, `a_1`, `sample_payload` and `p_expected_0_0` are all built from those.
* **The external surface is already insulated.** JNI reads slots only through
  `FoldPlan::{leaves, selector, present}`, never off the tree, so those three
  accessors are the whole boundary a relocation has to preserve.

What blocks it is a missing prerequisite rather than the size of the diff.
A layout has to be keyed by something, and **`TransformNode` has no identity** —
it carries `ty` and `kind` and nothing else. That is why `ConstructEmitter`'s
`optional` hook reaches its inner choice's selector *structurally*, with
`_inner.selector()`: the slot is reachable only because it lives in the tree. A
pre-order counter cannot replace that lookup, because a bottom-up hook whose
`Value` is a `syn::Expr` has no way to hand its index back to the parent that
needs it.

So the relocation wants #444 §2's still-unticked box first — "add stable node
and semantic-leaf identities" — after which the layout is a map from node id to
slot and every hook can ask for its own or its inner's. `select`'s slot
inheritance and renumbering then collapse into re-deriving the layout from the
selected tree.

Building the layout on positional reasoning instead would work today and break
on the first tree shape that visits nodes in a different order, which is the
class of bug the last several review rounds on #446 were about.







