### PR TITLE
Which row a site takes, and which declaration decides (#450)

### DIFF
--- a/prebindgen-registry/src/recipe.rs
+++ b/prebindgen-registry/src/recipe.rs
@@ -44,8 +44,11 @@ use std::{
 
 use crate::flat::{Field, Flat, Function, Type, TypeKey, TypeKind, TypeRef};
 
+mod site;
 #[cfg(test)]
 mod tests;
+
+pub use self::site::{Ask, Bindings, BindingsBuilder, Bound, Origin, Role, Site};
 
 // ── The two jobs ──────────────────────────────────────────────────────────
 
@@ -998,6 +1001,22 @@ pub enum RecipeError {
         /// Which of the crossing's rows was declared.
         recipe: RecipeId,
     },
+    /// A site asked for a row that was never declared.
+    UnknownRow {
+        /// Where the value crosses.
+        site: Site,
+        /// The crossing that has no such row.
+        crossing: CrossingKey,
+        /// The name the site asked for.
+        recipe: RecipeId,
+    },
+    /// Two declarations of equal precedence bound one site to different rows.
+    Rebound {
+        /// The site both named.
+        site: Site,
+        /// The precedence they share.
+        origin: Origin,
+    },
     /// A row was declared for a callback, which has no decision to record.
     CallbackDeclared {
         /// The callback crossing.
@@ -1053,6 +1072,19 @@ impl fmt::Display for RecipeError {
             RecipeError::NotAProduct { row, recipe } => write!(
                 f,
                 "row `{recipe}` takes {row} apart, and the model gives that type no parts"
+            ),
+            RecipeError::UnknownRow {
+                site,
+                crossing,
+                recipe,
+            } => write!(
+                f,
+                "{site} asks for row `{recipe}`, which {crossing} does not have"
+            ),
+            RecipeError::Rebound { site, origin } => write!(
+                f,
+                "{site} is bound to two different rows by {origin}; one of them has to \
+                 be written at a higher precedence"
             ),
             RecipeError::CallbackDeclared { row, recipe } => write!(
                 f,

--- a/prebindgen-registry/src/recipe/site.rs
+++ b/prebindgen-registry/src/recipe/site.rs
@@ -9,7 +9,10 @@
 //! A site nobody binds uses its crossing's default row, so the common case is
 //! declared nowhere.
 
-use std::{collections::HashMap, fmt};
+use std::{
+    collections::{BTreeMap, HashMap},
+    fmt,
+};
 
 use super::{Crossing, CrossingKey, RecipeError, RecipeId, Recipes};
 
@@ -33,11 +36,13 @@ impl fmt::Display for Site {
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub enum Role {
     /// One parameter of an exported function.
+    ///
+    /// Identified by position and not by name: a `Site` is a map key, so
+    /// anything on it has to be something two callers cannot spell differently.
+    /// The parameter's name is the model's, reached through `owner`.
     Param {
         /// Position in the parameter list.
         index: usize,
-        /// The parameter's name, for diagnostics.
-        name: String,
     },
     /// The value a method is called on.
     Receiver,
@@ -71,7 +76,7 @@ pub enum Role {
 impl fmt::Display for Role {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Role::Param { index, name } => write!(f, "parameter {index} (`{name}`)"),
+            Role::Param { index } => write!(f, "parameter {index}"),
             Role::Receiver => f.write_str("receiver"),
             Role::Return => f.write_str("return value"),
             Role::Error => f.write_str("error arm"),
@@ -152,8 +157,9 @@ struct Binding {
 pub struct BindingsBuilder {
     asks: HashMap<Site, Binding>,
     /// Two declarations of equal precedence that disagree, reported by
-    /// [`Self::build`] rather than resolved by declaration order.
-    conflicts: Vec<(Site, Origin)>,
+    /// [`Self::build`] rather than resolved by declaration order. One entry per
+    /// site, so a site declared three ways is reported once.
+    conflicts: BTreeMap<String, (Site, Origin)>,
 }
 
 impl BindingsBuilder {
@@ -173,8 +179,11 @@ impl BindingsBuilder {
             // A weaker declaration never displaces a stronger one.
             Some(held) if held.origin < binding.origin => {}
             Some(held) if held.origin == binding.origin => {
-                if held.ask != binding.ask {
-                    self.conflicts.push((site, origin));
+                // The whole answer has to match, not only the ask: two
+                // declarations naming different crossings disagree just as much
+                // as two naming different rows.
+                if held.ask != binding.ask || held.crossing.key() != binding.crossing.key() {
+                    self.conflicts.insert(site.to_string(), (site, origin));
                 }
             }
             _ => {
@@ -192,7 +201,7 @@ impl BindingsBuilder {
     pub fn build(self, recipes: &Recipes) -> Result<Bindings, Vec<RecipeError>> {
         let mut errors: Vec<RecipeError> = self
             .conflicts
-            .into_iter()
+            .into_values()
             .map(|(site, origin)| RecipeError::Rebound { site, origin })
             .collect();
         let mut bound = HashMap::new();
@@ -257,7 +266,23 @@ impl Bindings {
     /// checking first whether one was declared.
     pub fn resolve(&self, site: &Site, crossing: &Crossing, recipes: &Recipes) -> Option<Bound> {
         match self.bound.get(site) {
-            Some(bound) => bound.clone(),
+            Some(bound) => {
+                // A site is one place, so the crossing a caller asks with must
+                // be the one the declaration bound. Getting a plausible answer
+                // back for the wrong type would hide the caller's bug.
+                debug_assert!(
+                    bound
+                        .as_ref()
+                        .is_none_or(|b| b.crossing.key() == crossing.key()),
+                    "{site} was bound as {} and is being resolved as {}",
+                    bound
+                        .as_ref()
+                        .map(|b| b.crossing.key().to_string())
+                        .unwrap_or_default(),
+                    crossing.key(),
+                );
+                bound.clone()
+            }
             None => Some(Bound {
                 site: site.clone(),
                 recipe: recipes.row(crossing).0,

--- a/prebindgen-registry/src/recipe/site.rs
+++ b/prebindgen-registry/src/recipe/site.rs
@@ -1,0 +1,274 @@
+//! Which row a given place in the generated API uses.
+//!
+//! [`Recipes`] says what rows a crossing has; this says which of them the
+//! second parameter of `z_put`, or the `Err` arm of a return, or one part of
+//! another row actually takes. A declaration states that through
+//! [`BindingsBuilder::bind`], and [`Bindings::resolve`] answers it for one
+//! site.
+//!
+//! A site nobody binds uses its crossing's default row, so the common case is
+//! declared nowhere.
+
+use std::{collections::HashMap, fmt};
+
+use super::{Crossing, CrossingKey, RecipeError, RecipeId, Recipes};
+
+/// One place in the generated API where a value crosses.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct Site {
+    /// The item the site belongs to: the exported function for a parameter or
+    /// a return, the crossed type for a part.
+    pub owner: syn::Ident,
+    /// Which place within that item.
+    pub role: Role,
+}
+
+impl fmt::Display for Site {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}'s {}", self.owner, self.role)
+    }
+}
+
+/// Which place within an item a site is.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub enum Role {
+    /// One parameter of an exported function.
+    Param {
+        /// Position in the parameter list.
+        index: usize,
+        /// The parameter's name, for diagnostics.
+        name: String,
+    },
+    /// The value a method is called on.
+    Receiver,
+    /// What the function returns.
+    Return,
+    /// The `Err` arm of a `Result`.
+    Error,
+    /// One argument the Rust side passes out through a callback.
+    ///
+    /// Swaps jobs: Rust holds the value and pushes it out, so the argument is
+    /// deconstructed even though it sits in a parameter list.
+    CallbackArg {
+        /// Which parameter of the exported function is the callback.
+        param: usize,
+        /// Which argument of that callback.
+        arg: usize,
+    },
+    /// One part of another crossing's recipe.
+    Part {
+        /// The crossing whose row names this part.
+        of: CrossingKey,
+        /// Which of that crossing's rows.
+        recipe: RecipeId,
+        /// The part's position within the row.
+        index: usize,
+    },
+    /// A `#[prebindgen]` constant's value.
+    Const,
+}
+
+impl fmt::Display for Role {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Role::Param { index, name } => write!(f, "parameter {index} (`{name}`)"),
+            Role::Receiver => f.write_str("receiver"),
+            Role::Return => f.write_str("return value"),
+            Role::Error => f.write_str("error arm"),
+            Role::CallbackArg { param, arg } => {
+                write!(f, "argument {arg} of the callback in parameter {param}")
+            }
+            Role::Part { of, recipe, index } => {
+                write!(f, "part {index} of row `{recipe}` of {of}")
+            }
+            Role::Const => f.write_str("value"),
+        }
+    }
+}
+
+/// What a declaration asks for at one site.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum Ask {
+    /// The crossing's default row.
+    Default,
+    /// This named row of the crossing.
+    Recipe(RecipeId),
+    /// This site contributes nothing.
+    Omit,
+}
+
+/// Which declaration made the ask.
+///
+/// Ordered highest precedence first, so the winner of two asks for one site is
+/// the smaller of the two.
+///
+/// Not to be confused with [`flat::Origin`](crate::flat::Origin), which is a
+/// captured item's own syntax.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum Origin {
+    /// A per-function override, written against one exported function.
+    Function,
+    /// A per-part declaration, written against one part of one row.
+    Part,
+    /// The type's own default, written against the type.
+    Type,
+    /// What the adapter would otherwise have picked.
+    Adapter,
+}
+
+impl fmt::Display for Origin {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(match self {
+            Origin::Function => "a per-function declaration",
+            Origin::Part => "a per-part declaration",
+            Origin::Type => "the type's own declaration",
+            Origin::Adapter => "the adapter",
+        })
+    }
+}
+
+/// What the table hands an adapter for one site. Immutable.
+#[derive(Clone, Debug)]
+pub struct Bound {
+    /// Where the value crosses.
+    pub site: Site,
+    /// What crosses, and which way.
+    pub crossing: Crossing,
+    /// Which of the crossing's rows this site takes.
+    pub recipe: RecipeId,
+    /// Which declaration won, so a diagnostic can say why this row applies.
+    pub origin: Origin,
+}
+
+#[derive(Clone, Debug)]
+struct Binding {
+    crossing: Crossing,
+    ask: Ask,
+    origin: Origin,
+}
+
+/// Describes the [`Bindings`] of one binding crate.
+#[derive(Default)]
+pub struct BindingsBuilder {
+    asks: HashMap<Site, Binding>,
+    /// Two declarations of equal precedence that disagree, reported by
+    /// [`Self::build`] rather than resolved by declaration order.
+    conflicts: Vec<(Site, Origin)>,
+}
+
+impl BindingsBuilder {
+    /// State which row one site takes.
+    ///
+    /// Where two declarations bind one site, the higher-precedence `origin`
+    /// wins — with its `crossing` and its `ask` together, since the two are one
+    /// declaration's answer. Two declarations of equal precedence asking for
+    /// different rows is an error, and two asking for the same row is not.
+    pub fn bind(&mut self, site: Site, crossing: Crossing, ask: Ask, origin: Origin) -> &mut Self {
+        let binding = Binding {
+            crossing,
+            ask,
+            origin,
+        };
+        match self.asks.get(&site) {
+            // A weaker declaration never displaces a stronger one.
+            Some(held) if held.origin < binding.origin => {}
+            Some(held) if held.origin == binding.origin => {
+                if held.ask != binding.ask {
+                    self.conflicts.push((site, origin));
+                }
+            }
+            _ => {
+                self.asks.insert(site, binding);
+            }
+        }
+        self
+    }
+
+    /// Check every ask against the table and freeze the result.
+    ///
+    /// The one check here is that a site naming a row asks for one the crossing
+    /// has. Whether a crossing with several rows says which of them is the
+    /// default is [`RecipesBuilder::build`](super::RecipesBuilder::build)'s.
+    pub fn build(self, recipes: &Recipes) -> Result<Bindings, Vec<RecipeError>> {
+        let mut errors: Vec<RecipeError> = self
+            .conflicts
+            .into_iter()
+            .map(|(site, origin)| RecipeError::Rebound { site, origin })
+            .collect();
+        let mut bound = HashMap::new();
+        for (site, binding) in self.asks {
+            let key = binding.crossing.key();
+            let recipe = match &binding.ask {
+                Ask::Omit => {
+                    bound.insert(site, None);
+                    continue;
+                }
+                Ask::Default => recipes.row(&binding.crossing).0,
+                Ask::Recipe(id) => {
+                    if recipes.get(&key, id).is_none() {
+                        errors.push(RecipeError::UnknownRow {
+                            site,
+                            crossing: key,
+                            recipe: id.clone(),
+                        });
+                        continue;
+                    }
+                    id.clone()
+                }
+            };
+            bound.insert(
+                site.clone(),
+                Some(Bound {
+                    site,
+                    crossing: binding.crossing,
+                    recipe,
+                    origin: binding.origin,
+                }),
+            );
+        }
+        if errors.is_empty() {
+            Ok(Bindings { bound })
+        } else {
+            Err(errors)
+        }
+    }
+}
+
+/// Which row every declared site takes. Built by [`BindingsBuilder`], checked
+/// once, then immutable.
+#[derive(Debug, Default)]
+pub struct Bindings {
+    /// `None` for a site a declaration omitted, which is a different answer
+    /// from a site nobody bound.
+    bound: HashMap<Site, Option<Bound>>,
+}
+
+impl Bindings {
+    /// Start describing the sites of one binding crate.
+    pub fn builder() -> BindingsBuilder {
+        BindingsBuilder::default()
+    }
+
+    /// The row this site takes.
+    ///
+    /// `None` when a declaration bound the site to [`Ask::Omit`]. A site nobody
+    /// bound takes its crossing's default row, attributed to
+    /// [`Origin::Adapter`], so an adapter asks here for every site rather than
+    /// checking first whether one was declared.
+    pub fn resolve(&self, site: &Site, crossing: &Crossing, recipes: &Recipes) -> Option<Bound> {
+        match self.bound.get(site) {
+            Some(bound) => bound.clone(),
+            None => Some(Bound {
+                site: site.clone(),
+                recipe: recipes.row(crossing).0,
+                crossing: crossing.clone(),
+                origin: Origin::Adapter,
+            }),
+        }
+    }
+
+    /// Whether any declaration named this site.
+    pub fn is_declared(&self, site: &Site) -> bool {
+        self.bound.contains_key(site)
+    }
+}

--- a/prebindgen-registry/src/recipe/tests.rs
+++ b/prebindgen-registry/src/recipe/tests.rs
@@ -533,10 +533,7 @@ fn a_part_is_accepted_where_the_edge_can_consume_it() {
 fn site(owner: &str, index: usize) -> Site {
     Site {
         owner: ident(owner),
-        role: Role::Param {
-            index,
-            name: format!("p{index}"),
-        },
+        role: Role::Param { index },
     }
 }
 
@@ -676,6 +673,39 @@ fn two_declarations_of_equal_precedence_may_agree_and_may_not_disagree() {
     let errors = disagreeing.build(&recipes).expect_err("two answers");
     assert!(
         matches!(errors.as_slice(), [RecipeError::Rebound { origin, .. }] if *origin == Origin::Function),
+        "{errors:?}"
+    );
+}
+
+#[test]
+fn two_declarations_of_equal_precedence_naming_different_crossings_disagree() {
+    let model = model(&[SAMPLE]);
+    let recipes = two_rows(&model);
+    let mut builder = Bindings::builder();
+    builder
+        .bind(
+            site("z_put", 0),
+            Crossing::new(ty(&model, "Sample"), Assembly::Deconstruct),
+            Ask::Default,
+            Origin::Function,
+        )
+        // Same ask, different type: still two answers for one place.
+        .bind(
+            site("z_put", 0),
+            Crossing::new(ty(&model, "u32"), Assembly::Deconstruct),
+            Ask::Default,
+            Origin::Function,
+        )
+        // A third disagreement over the same site is still one report.
+        .bind(
+            site("z_put", 0),
+            Crossing::new(ty(&model, "u64"), Assembly::Deconstruct),
+            Ask::Default,
+            Origin::Function,
+        );
+    let errors = builder.build(&recipes).expect_err("two crossings");
+    assert!(
+        matches!(errors.as_slice(), [RecipeError::Rebound { .. }]),
         "{errors:?}"
     );
 }

--- a/prebindgen-registry/src/recipe/tests.rs
+++ b/prebindgen-registry/src/recipe/tests.rs
@@ -527,3 +527,242 @@ fn a_part_is_accepted_where_the_edge_can_consume_it() {
     assert!(Mode::Exclusive.satisfies(Mode::Exclusive));
     assert!(!Mode::Exclusive.satisfies(Mode::Shared));
 }
+
+// ── Sites and row selection ───────────────────────────────────────────────
+
+fn site(owner: &str, index: usize) -> Site {
+    Site {
+        owner: ident(owner),
+        role: Role::Param {
+            index,
+            name: format!("p{index}"),
+        },
+    }
+}
+
+/// A table where `Sample` has two deconstructing rows, `whole` being the
+/// default — the shape every selection test below needs.
+fn two_rows(model: &Flat) -> Recipes {
+    let mut builder = Recipes::builder();
+    builder
+        .declare_default(ty(model, "Sample"), id("whole"), Deconstructing::Atomic)
+        .declare(
+            ty(model, "Sample"),
+            id("fields"),
+            Deconstructing::Product(Deconstruct::Fields(vec![Reach::Field(0), Reach::Field(1)])),
+        );
+    builder.build(model).expect("table")
+}
+
+#[test]
+fn a_site_nobody_bound_takes_the_default_row() {
+    let model = model(&[SAMPLE]);
+    let recipes = two_rows(&model);
+    let bindings = Bindings::default();
+    let crossing = Crossing::new(ty(&model, "Sample"), Assembly::Deconstruct);
+
+    let bound = bindings
+        .resolve(&site("z_put", 0), &crossing, &recipes)
+        .expect("a site nobody bound still crosses");
+    assert_eq!(bound.recipe, id("whole"));
+    assert_eq!(bound.origin, Origin::Adapter);
+    assert!(!bindings.is_declared(&site("z_put", 0)));
+}
+
+#[test]
+fn an_undeclared_crossing_resolves_to_its_derived_row() {
+    let model = model(&[SAMPLE]);
+    let recipes = Recipes::default();
+    let bindings = Bindings::default();
+    let crossing = Crossing::new(ty(&model, "Vec<Sample>"), Assembly::Deconstruct);
+
+    let bound = bindings
+        .resolve(&site("z_put", 0), &crossing, &recipes)
+        .expect("the derived row");
+    assert_eq!(bound.recipe, RecipeId::derived());
+}
+
+#[test]
+fn a_site_takes_the_row_it_names() {
+    let model = model(&[SAMPLE]);
+    let recipes = two_rows(&model);
+    let crossing = Crossing::new(ty(&model, "Sample"), Assembly::Deconstruct);
+    let mut builder = Bindings::builder();
+    builder.bind(
+        site("z_put", 0),
+        crossing.clone(),
+        Ask::Recipe(id("fields")),
+        Origin::Function,
+    );
+    let bindings = builder.build(&recipes).expect("bindings");
+
+    let bound = bindings
+        .resolve(&site("z_put", 0), &crossing, &recipes)
+        .expect("bound");
+    assert_eq!(bound.recipe, id("fields"));
+    assert_eq!(bound.origin, Origin::Function);
+    // Every other site of the same crossing still takes the default.
+    let other = bindings
+        .resolve(&site("z_get", 0), &crossing, &recipes)
+        .expect("bound");
+    assert_eq!(other.recipe, id("whole"));
+}
+
+#[test]
+fn the_higher_precedence_declaration_wins_whichever_was_written_first() {
+    let model = model(&[SAMPLE]);
+    let recipes = two_rows(&model);
+    let crossing = Crossing::new(ty(&model, "Sample"), Assembly::Deconstruct);
+
+    for order in [
+        [Origin::Type, Origin::Function],
+        [Origin::Function, Origin::Type],
+    ] {
+        let mut builder = Bindings::builder();
+        for origin in order {
+            let ask = match origin {
+                Origin::Function => Ask::Recipe(id("fields")),
+                _ => Ask::Recipe(id("whole")),
+            };
+            builder.bind(site("z_put", 0), crossing.clone(), ask, origin);
+        }
+        let bindings = builder.build(&recipes).expect("bindings");
+        let bound = bindings
+            .resolve(&site("z_put", 0), &crossing, &recipes)
+            .expect("bound");
+        assert_eq!(bound.recipe, id("fields"), "written {order:?}");
+        assert_eq!(bound.origin, Origin::Function, "written {order:?}");
+    }
+}
+
+#[test]
+fn two_declarations_of_equal_precedence_may_agree_and_may_not_disagree() {
+    let model = model(&[SAMPLE]);
+    let recipes = two_rows(&model);
+    let crossing = Crossing::new(ty(&model, "Sample"), Assembly::Deconstruct);
+
+    let mut agreeing = Bindings::builder();
+    agreeing
+        .bind(
+            site("z_put", 0),
+            crossing.clone(),
+            Ask::Recipe(id("fields")),
+            Origin::Function,
+        )
+        .bind(
+            site("z_put", 0),
+            crossing.clone(),
+            Ask::Recipe(id("fields")),
+            Origin::Function,
+        );
+    agreeing
+        .build(&recipes)
+        .expect("saying it twice is not a conflict");
+
+    let mut disagreeing = Bindings::builder();
+    disagreeing
+        .bind(
+            site("z_put", 0),
+            crossing.clone(),
+            Ask::Recipe(id("fields")),
+            Origin::Function,
+        )
+        .bind(
+            site("z_put", 0),
+            crossing,
+            Ask::Recipe(id("whole")),
+            Origin::Function,
+        );
+    let errors = disagreeing.build(&recipes).expect_err("two answers");
+    assert!(
+        matches!(errors.as_slice(), [RecipeError::Rebound { origin, .. }] if *origin == Origin::Function),
+        "{errors:?}"
+    );
+}
+
+#[test]
+fn a_site_naming_a_row_the_crossing_lacks_is_refused() {
+    let model = model(&[SAMPLE]);
+    let recipes = two_rows(&model);
+    let crossing = Crossing::new(ty(&model, "Sample"), Assembly::Deconstruct);
+    let mut builder = Bindings::builder();
+    builder.bind(
+        site("z_put", 0),
+        crossing,
+        Ask::Recipe(id("jobject")),
+        Origin::Function,
+    );
+    let errors = builder.build(&recipes).expect_err("no such row");
+    assert!(
+        matches!(errors.as_slice(), [RecipeError::UnknownRow { recipe, .. }] if recipe == &id("jobject")),
+        "{errors:?}"
+    );
+}
+
+#[test]
+fn an_omitted_site_contributes_nothing() {
+    let model = model(&[SAMPLE]);
+    let recipes = two_rows(&model);
+    let crossing = Crossing::new(ty(&model, "Sample"), Assembly::Deconstruct);
+    let mut builder = Bindings::builder();
+    builder.bind(site("z_put", 0), crossing.clone(), Ask::Omit, Origin::Part);
+    let bindings = builder.build(&recipes).expect("bindings");
+
+    assert!(bindings.is_declared(&site("z_put", 0)));
+    assert!(bindings
+        .resolve(&site("z_put", 0), &crossing, &recipes)
+        .is_none());
+}
+
+#[test]
+fn asking_for_the_default_records_which_row_that_was() {
+    let model = model(&[SAMPLE]);
+    let recipes = two_rows(&model);
+    let crossing = Crossing::new(ty(&model, "Sample"), Assembly::Deconstruct);
+    let mut builder = Bindings::builder();
+    builder.bind(
+        site("z_put", 0),
+        crossing.clone(),
+        Ask::Default,
+        Origin::Type,
+    );
+    let bindings = builder.build(&recipes).expect("bindings");
+
+    let bound = bindings
+        .resolve(&site("z_put", 0), &crossing, &recipes)
+        .expect("bound");
+    assert_eq!(bound.recipe, id("whole"));
+    assert_eq!(bound.origin, Origin::Type);
+}
+
+#[test]
+fn one_site_is_one_role_of_one_owner() {
+    let model = model(&[SAMPLE]);
+    let recipes = two_rows(&model);
+    let crossing = Crossing::new(ty(&model, "Sample"), Assembly::Deconstruct);
+    let ret = Site {
+        owner: ident("z_put"),
+        role: Role::Return,
+    };
+    let mut builder = Bindings::builder();
+    builder.bind(
+        ret.clone(),
+        crossing.clone(),
+        Ask::Recipe(id("fields")),
+        Origin::Function,
+    );
+    let bindings = builder.build(&recipes).expect("bindings");
+
+    assert_eq!(
+        bindings.resolve(&ret, &crossing, &recipes).unwrap().recipe,
+        id("fields")
+    );
+    // The same function's parameter 0 is a different site.
+    assert_eq!(
+        bindings
+            .resolve(&site("z_put", 0), &crossing, &recipes)
+            .unwrap()
+            .recipe,
+        id("whole")
+    );
+}


### PR DESCRIPTION
Stage 2 of [#451](https://github.com/milyin/prebindgen/pull/451), the umbrella for [#450](https://github.com/milyin/prebindgen/issues/450). Targets `recipe-table`, not `main`.

Stage 1 added `Recipes`, the table that says which rows a crossing has — a crossing being one Rust type plus one of two jobs, *construct* a Rust value from what arrived or *deconstruct* one into what leaves. This stage says which of those rows a given place in the generated API takes. Still nothing consumes it: `prebindgen-c` and `prebindgen-jni` are untouched.

## A site is a place, not a type

`Site` is one place where a value crosses — parameter 2 of `z_put`, the return value of `z_session_open`, the `Err` arm of a `Result`, argument 1 of a callback, one part of another row's recipe, a constant's value. One Rust type usually crosses at many sites and need not cross the same way at every one of them, which is the whole reason this layer exists.

A declaration states the exception through `BindingsBuilder::bind`, naming the site, its crossing, what it asks for, and which declaration is asking:

```rust
bindings.bind(site, crossing, Ask::Recipe(RecipeId::new("jobject")), Origin::Function);
```

`Ask` has three forms: `Default` for the crossing's default row, `Recipe(id)` for a named one, and `Omit` for a site that contributes nothing.

## The common case is declared nowhere

`Bindings::resolve` answers for **every** site, bound or not. A site nobody bound takes its crossing's default row, attributed to `Origin::Adapter`, so an adapter asks the same question at every position rather than checking first whether a declaration exists. An omitted site is the one case that resolves to nothing, and that is a different answer from an unbound one — `Bindings::is_declared` tells the two apart.

## Which declaration wins

`Origin` names who is asking, and is ordered highest precedence first: a per-function override beats a per-part one, which beats the type's own default, which beats what the adapter would otherwise have picked. Where two declarations bind one site, the higher-precedence one wins **whole** — its `crossing` and its `ask` together, since the two are one declaration's answer — and the order they were written in does not matter.

Two declarations of *equal* precedence asking for the same row is not a conflict. Asking for different rows is `RecipeError::Rebound`, rather than a silent win for whichever ran last.

## Two new checks

`BindingsBuilder::build` takes the finished table and reports, together, every problem across every site:

- `UnknownRow` — a site named a row its crossing does not have. This is the check #450 lists as needing the site, and it is why binding happens against a built `Recipes` rather than alongside it.
- `Rebound` — the equal-precedence conflict above.

## Two deviations from #450

`Origin` is also the name of `prebindgen_flat::flat::Origin`, which is a captured item's own syntax and an unrelated thing. #450 names this one `Origin`, so it keeps that name and its doc comment points at the other; an adapter importing both aliases one.

`Role::Param` carries only the position, where #450 also gives it the parameter's name. A `Site` is a map key, so anything on it has to be something two callers cannot spell differently — a name written one way at binding and another at lookup would silently lose the binding. The name is the model's anyway, reachable through `Site::owner` and the index.

## Checks

Ten unit tests added to `prebindgen-registry/src/recipe/tests.rs`, alongside stage 1's: an unbound site taking the default, an undeclared crossing resolving to its derived row, a bound site taking the row it names while its siblings do not, precedence winning in both writing orders, equal precedence agreeing, disagreeing about the row, and disagreeing about the crossing while agreeing about the row, an omitted site resolving to nothing, `Ask::Default` recording which row that turned out to be, and a return value and a parameter of one function being separate sites.

Local gate clean: clippy and rustfmt on 1.85.0 and stable, `cargo doc` with warnings denied, `cargo test --all`, and `examples/regen-check.sh` reporting no drift.
