### PR TITLE
Compile a row into whatever an adapter emits from (#450)

### DIFF
--- a/prebindgen-registry/src/recipe.rs
+++ b/prebindgen-registry/src/recipe.rs
@@ -112,6 +112,18 @@ pub enum Construct {
     /// [`Function`], so none of it is restated here, and
     /// whether the call is fallible is its return type.
     Call(syn::Ident),
+    /// Write the value's own fields. **They are the parts**, in the model's
+    /// order, and every one of them contributes.
+    ///
+    /// The adapter-synthesized case, where nothing is called: a `#[repr(C)]`
+    /// mirror of a struct with public fields is rebuilt as a struct literal,
+    /// with no constructor in the source crate to name. Unlike
+    /// [`Deconstruct::Fields`] it names no list, because a value cannot be
+    /// built with one of its fields missing, and which fields there are is the
+    /// model's answer.
+    ///
+    /// Inside a [`Shape::Choice`] arm the fields are that alternative's.
+    Fields,
     /// The single part named here already is the value.
     ///
     /// Boxed because a `TypeRef` is many times the size of the identifier
@@ -669,21 +681,23 @@ impl<'a> Check<'a, '_> {
         match shape {
             Shape::Atomic => Vec::new(),
             Shape::Optional { inner } | Shape::Sequence { inner } => vec![inner.clone()],
-            Shape::Product(op) => self.construct(op),
+            Shape::Product(op) => self.construct(ty, op),
             Shape::Choice { arms } => {
-                // An arm's constructor names the alternative it builds, so no
-                // field list has to be in scope for one.
                 let Some(alternatives) = self.alternatives(ty) else {
                     self.not_a_product();
                     return Vec::new();
                 };
                 let mut parts = Vec::new();
                 for arm in arms {
-                    if arm.alternative >= alternatives.len() {
+                    let Some(fields) = alternatives.get(arm.alternative) else {
                         self.out_of_range(arm.alternative, alternatives.len());
                         continue;
-                    }
-                    parts.extend(self.construct(&arm.op));
+                    };
+                    // The arm's payload stands in for the sum's own fields,
+                    // which the model gives a sum none of.
+                    let outer = self.arm_fields.replace(fields.clone());
+                    parts.extend(self.construct(ty, &arm.op));
+                    self.arm_fields = outer;
                 }
                 parts
             }
@@ -717,12 +731,19 @@ impl<'a> Check<'a, '_> {
         }
     }
 
-    fn construct(&mut self, op: &Construct) -> Vec<TypeRef> {
+    fn construct(&mut self, ty: &TypeRef, op: &Construct) -> Vec<TypeRef> {
         match op {
             Construct::Identity(inner) => vec![(**inner).clone()],
             Construct::Call(func) => match self.function(func) {
                 Some(f) => f.params.iter().map(|p| p.ty.clone()).collect(),
                 None => Vec::new(),
+            },
+            Construct::Fields => match self.fields(ty) {
+                Some(fields) => fields.into_iter().map(|f| f.ty).collect(),
+                None => {
+                    self.not_a_product();
+                    Vec::new()
+                }
             },
         }
     }

--- a/prebindgen-registry/src/recipe.rs
+++ b/prebindgen-registry/src/recipe.rs
@@ -44,11 +44,18 @@ use std::{
 
 use crate::flat::{Field, Flat, Function, Type, TypeKey, TypeKind, TypeRef};
 
+mod compile;
 mod site;
 #[cfg(test)]
 mod tests;
 
-pub use self::site::{Ask, Bindings, BindingsBuilder, Bound, Origin, Role, Site};
+pub use self::{
+    compile::{
+        At, Carrier, Compile, CompileError, Compiler, Cx, Frag, Part, PartSource, Parts,
+        RequirementId, Validity, Yield,
+    },
+    site::{Ask, Bindings, BindingsBuilder, Bound, Origin, Role, Site},
+};
 
 // ── The two jobs ──────────────────────────────────────────────────────────
 
@@ -1017,6 +1024,26 @@ pub enum RecipeError {
         /// The precedence they share.
         origin: Origin,
     },
+    /// A part yields something the edge it feeds cannot consume.
+    Composition {
+        /// The part's own site.
+        site: Site,
+        /// Which part of the row.
+        part: usize,
+        /// What the constructor's parameter, field or accessor requires.
+        wanted: Mode,
+        /// What the part's fragment produces.
+        got: Mode,
+    },
+    /// A site needs a value that outlives the call and got a borrowed one.
+    Validity {
+        /// Where the value crosses.
+        site: Site,
+        /// The weakest validity the site's role accepts.
+        needed: crate::recipe::Validity,
+        /// What the root fragment produces.
+        got: crate::recipe::Validity,
+    },
     /// A row was declared for a callback, which has no decision to record.
     CallbackDeclared {
         /// The callback crossing.
@@ -1085,6 +1112,19 @@ impl fmt::Display for RecipeError {
                 f,
                 "{site} is bound to two different rows by {origin}; one of them has to \
                  be written at a higher precedence"
+            ),
+            RecipeError::Composition {
+                site,
+                part,
+                wanted,
+                got,
+            } => write!(
+                f,
+                "part {part} of {site} needs `{wanted}` and its recipe yields `{got}`"
+            ),
+            RecipeError::Validity { site, needed, got } => write!(
+                f,
+                "{site} needs a {needed} value and its recipe yields a {got} one"
             ),
             RecipeError::CallbackDeclared { row, recipe } => write!(
                 f,

--- a/prebindgen-registry/src/recipe/compile.rs
+++ b/prebindgen-registry/src/recipe/compile.rs
@@ -440,7 +440,11 @@ impl<'a, C: Compile> Compiler<'a, C> {
     /// The fragment for one part of the row being compiled.
     ///
     /// Which row the part takes is the site machinery's answer, asked at
-    /// [`Role::Part`] — per row, because that is what compilation is per.
+    /// [`Role::Part`] — keyed by the row, because that is what compilation is
+    /// per. A root role such as [`Role::CallbackArg`] names a place in one
+    /// exported function, so it cannot answer for a row every function with
+    /// that signature shares; an adapter that wants a per-function answer
+    /// compiles that position as its own root site through [`Self::site`].
     fn part(&mut self, adapter: &mut C, at: At<'_>, index: usize, ty: &TypeRef) -> Built<C> {
         let crossing = Crossing::new(ty.clone(), at.crossing.assembly());
         let site = Site {
@@ -857,17 +861,20 @@ fn mode_of(ty: &TypeRef) -> Mode {
     }
 }
 
-/// Whether iterating a run yields owned values or borrows.
+/// Whether iterating a run yields owned values, shared borrows or exclusive
+/// ones.
 ///
 /// The collection's business, not the recipe's: `Vec<T>` gives its elements up,
-/// while `&[T]` and `Cow<'_, [T]>` lend them.
+/// `&[T]` and `Cow<'_, [T]>` lend them, and `&mut [T]` lends them exclusively.
 fn element_mode(crossing: &Crossing) -> Mode {
-    if crossing.mode() != Mode::Owned {
-        return Mode::Shared;
-    }
-    match crossing.value().unwrapped().kind() {
-        TypeKind::Slice(_) => Mode::Shared,
-        _ => Mode::Owned,
+    match crossing.mode() {
+        // A run reached through a borrow lends its elements the same way it was
+        // reached: `&mut Vec<T>` yields `&mut T`, not `&T`.
+        borrowed @ (Mode::Shared | Mode::Exclusive) => borrowed,
+        Mode::Owned => match crossing.value().unwrapped().kind() {
+            TypeKind::Slice(_) => Mode::Shared,
+            _ => Mode::Owned,
+        },
     }
 }
 

--- a/prebindgen-registry/src/recipe/compile.rs
+++ b/prebindgen-registry/src/recipe/compile.rs
@@ -433,14 +433,15 @@ impl<'a, C: Compile> Compiler<'a, C> {
             Shape::Optional { inner } => self.optional(adapter, at, inner),
             Shape::Sequence { inner } => self.sequence(adapter, at, inner),
             Shape::Product(op) => {
-                let (kind, parts) = self.construct_parts(at, op)?;
+                let (kind, parts) = self.construct_parts(at, op, None)?;
                 self.product(adapter, at, kind, parts)
             }
             Shape::Choice { arms } => {
                 let mut built = Vec::new();
                 for arm in arms {
                     let alternative = self.alternative(at, arm.alternative)?;
-                    let (kind, parts) = self.construct_parts(at, &arm.op)?;
+                    let (kind, parts) =
+                        self.construct_parts(at, &arm.op, Some(&alternative.fields))?;
                     built.push((alternative, self.product(adapter, at, kind, parts)?));
                 }
                 self.choice(adapter, at, built)
@@ -623,8 +624,26 @@ impl<'a, C: Compile> Compiler<'a, C> {
         &self,
         at: At<'_>,
         op: &Construct,
+        arm: Option<&'a [Field]>,
     ) -> Result<(ProductKind<'a>, Vec<Part<'a>>), CompileError<C::Error>> {
         match op {
+            Construct::Fields => {
+                let fields = match arm {
+                    Some(fields) => fields,
+                    None => self.fields_of(at.crossing.value()),
+                };
+                let parts = fields
+                    .iter()
+                    .enumerate()
+                    .map(|(index, field)| Part {
+                        from: PartSource::Field { index, field },
+                        mode: mode_of(&field.ty),
+                        ty: field.ty.clone(),
+                        name: field_name(field, index),
+                    })
+                    .collect();
+                Ok((ProductKind::Fields, parts))
+            }
             Construct::Identity(inner) => Ok((
                 ProductKind::Identity,
                 vec![Part {
@@ -703,11 +722,7 @@ impl<'a, C: Compile> Compiler<'a, C> {
                         },
                         mode: mode_of(&field.ty),
                         ty: field.ty.clone(),
-                        name: field
-                            .name
-                            .as_ref()
-                            .map(|n| n.to_string())
-                            .unwrap_or_else(|| index.to_string()),
+                        name: field_name(field, *index),
                     });
                 }
                 Reach::Accessor(name) => {
@@ -771,6 +786,15 @@ impl<'a, C: Compile> Compiler<'a, C> {
             _ => None,
         }
     }
+}
+
+/// A field's name, or its position when the struct is positional.
+fn field_name(field: &Field, index: usize) -> String {
+    field
+        .name
+        .as_ref()
+        .map(|n| n.to_string())
+        .unwrap_or_else(|| index.to_string())
 }
 
 /// Which of the four product hooks composes a set of parts.

--- a/prebindgen-registry/src/recipe/compile.rs
+++ b/prebindgen-registry/src/recipe/compile.rs
@@ -31,7 +31,10 @@ use super::{
     Assembly, Bindings, Bound, Construct, Crossing, CrossingKey, Deconstruct, Mode, Reach,
     RecipeError, RecipeId, Recipes, Role, Row, Shape, Site,
 };
-use crate::flat::{Alternative, Field, Flat, Function, Type, TypeKey, TypeKind, TypeRef};
+use crate::{
+    flat::{Alternative, Field, Flat, Function, Type, TypeKey, TypeKind, TypeRef},
+    Emit,
+};
 
 /// What a fragment produces, which is the only thing the registry reads out of
 /// one.
@@ -107,10 +110,19 @@ impl fmt::Display for RequirementId {
 pub struct Cx<'a> {
     model: &'a Flat,
     recipes: &'a Recipes,
+    emit: &'a Emit,
     required: &'a mut BTreeSet<RequirementId>,
 }
 
 impl Cx<'_> {
+    /// The Rust-emission capability.
+    ///
+    /// A fragment is generated Rust, so compiling one is an emission callback
+    /// and is handed the key exactly as `Prebindgen`'s `on_*` methods are.
+    pub fn emit(&self) -> &Emit {
+        self.emit
+    }
+
     /// The model every structural fact is read off.
     pub fn model(&self) -> &Flat {
         self.model
@@ -316,6 +328,7 @@ pub struct Compiler<'a, C: Compile> {
     bindings: &'a Bindings,
     fragments: HashMap<(CrossingKey, RecipeId), Rc<C::Fragment>>,
     required: BTreeSet<RequirementId>,
+    emit: Emit,
 }
 
 impl<'a, C: Compile> Compiler<'a, C> {
@@ -327,6 +340,7 @@ impl<'a, C: Compile> Compiler<'a, C> {
             bindings,
             fragments: HashMap::new(),
             required: BTreeSet::new(),
+            emit: Emit::new(),
         }
     }
 
@@ -368,12 +382,26 @@ impl<'a, C: Compile> Compiler<'a, C> {
         let mut cx = Cx {
             model: self.model,
             recipes: self.recipes,
+            emit: &self.emit,
             required: &mut self.required,
         };
         adapter
             .plan(&mut cx, &bound, &root)
             .map(Some)
             .map_err(CompileError::Adapter)
+    }
+
+    /// The fragment for one crossing's default row.
+    ///
+    /// The per-row half of [`Self::site`], for an adapter that composes the
+    /// per-site wrapping itself. Built once and reused, like every other row.
+    pub fn crossing(
+        &mut self,
+        adapter: &mut C,
+        crossing: &Crossing,
+    ) -> Result<Rc<C::Fragment>, CompileError<C::Error>> {
+        let recipe = self.recipes.row(crossing).0;
+        self.row(adapter, crossing, &recipe)
     }
 
     /// The fragment for one row, built once and reused.
@@ -579,6 +607,7 @@ impl<'a, C: Compile> Compiler<'a, C> {
         let mut cx = Cx {
             model: self.model,
             recipes: self.recipes,
+            emit: &self.emit,
             required: &mut self.required,
         };
         match kind {
@@ -603,6 +632,7 @@ impl<'a, C: Compile> Compiler<'a, C> {
         let mut cx = Cx {
             model: self.model,
             recipes: self.recipes,
+            emit: &self.emit,
             required: &mut self.required,
         };
         adapter
@@ -616,6 +646,7 @@ impl<'a, C: Compile> Compiler<'a, C> {
         Cx {
             model: self.model,
             recipes: self.recipes,
+            emit: &self.emit,
             required: &mut self.required,
         }
     }

--- a/prebindgen-registry/src/recipe/compile.rs
+++ b/prebindgen-registry/src/recipe/compile.rs
@@ -1,0 +1,827 @@
+//! Turning rows into whatever an adapter emits from.
+//!
+//! [`Recipes`] says how a value gets across in terms of its parts; an adapter
+//! says what that costs on the wire. Its answer for one row is a **fragment**,
+//! a type the adapter defines and this module never looks inside. A fragment is
+//! not a wire value: it may occupy none, one or several, and the count is never
+//! asked for.
+//!
+//! An adapter writes [`Compile`], one hook per row shape. [`Compiler`] drives
+//! the recursion over the table, builds each row's fragment **once**, and hands
+//! every hook the fragments its parts already produced — so an adapter says
+//! what one crossing means and never writes the walk.
+//!
+//! # Per row, not per site
+//!
+//! A fragment is built once per `(crossing, recipe)` and reused at every site
+//! that crossing appears at. That is what makes emitted code shared without a
+//! converter table, and it rests on one assumption: **a fragment is
+//! context-free**. Where an adapter appears to need site context, the site is
+//! wrapping the fragment rather than the fragment differing, and
+//! [`Compile::plan`] — the one hook called per site — is where that wrapping
+//! belongs.
+
+use std::{
+    collections::{BTreeSet, HashMap},
+    fmt,
+    rc::Rc,
+};
+
+use super::{
+    Assembly, Bindings, Bound, Construct, Crossing, CrossingKey, Deconstruct, Mode, Reach,
+    RecipeError, RecipeId, Recipes, Role, Row, Shape, Site,
+};
+use crate::flat::{Alternative, Field, Flat, Function, Type, TypeKey, TypeKind, TypeRef};
+
+/// What a fragment produces, which is the only thing the registry reads out of
+/// one.
+pub trait Carrier {
+    /// The Rust value this fragment yields.
+    fn yields(&self) -> Yield;
+}
+
+/// The Rust value a fragment produces.
+#[derive(Clone, Debug)]
+pub struct Yield {
+    /// The type produced.
+    pub ty: TypeKey,
+    /// Handed over, or reached through a borrow.
+    pub mode: Mode,
+    /// How long what the fragment produces stays usable.
+    pub validity: Validity,
+}
+
+/// How long what a fragment produces stays usable.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum Validity {
+    /// The foreign side may keep it. Destroying it needs nothing else alive.
+    SelfSufficient,
+    /// Valid only while the value it was read from is alive.
+    Borrowed,
+}
+
+impl fmt::Display for Validity {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(match self {
+            Validity::SelfSufficient => "self-sufficient",
+            Validity::Borrowed => "borrowed",
+        })
+    }
+}
+
+/// Where a hook is: which row it is compiling.
+#[derive(Copy, Clone, Debug)]
+pub struct At<'a> {
+    /// The crossing the row answers.
+    pub crossing: &'a Crossing,
+    /// Which of that crossing's rows.
+    pub recipe: &'a RecipeId,
+}
+
+/// An adapter-minted name for a helper the generated prelude must carry.
+///
+/// The registry only de-duplicates these; what one names is the adapter's.
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub struct RequirementId(String);
+
+impl RequirementId {
+    /// Name one helper.
+    pub fn new(name: impl Into<String>) -> Self {
+        Self(name.into())
+    }
+
+    /// The name as written.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Display for RequirementId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+/// What every hook receives: the read-only view of the model and the table,
+/// plus the one thing a hook may ask the registry to record.
+pub struct Cx<'a> {
+    model: &'a Flat,
+    recipes: &'a Recipes,
+    required: &'a mut BTreeSet<RequirementId>,
+}
+
+impl Cx<'_> {
+    /// The model every structural fact is read off.
+    pub fn model(&self) -> &Flat {
+        self.model
+    }
+
+    /// The table, for asking about a crossing without demanding it.
+    pub fn recipes(&self) -> &Recipes {
+        self.recipes
+    }
+
+    /// Which rows a crossing has.
+    ///
+    /// Demands nothing, so an adapter may ask about an alternative it will not
+    /// take. Empty for a crossing nobody declared, which still has a derived
+    /// row.
+    pub fn rows(&self, crossing: &Crossing) -> Vec<&RecipeId> {
+        self.recipes.rows(&crossing.key())
+    }
+
+    /// A helper the compiled fragment calls, so the generated prelude emits it.
+    pub fn require(&mut self, req: RequirementId) {
+        self.required.insert(req);
+    }
+}
+
+/// One part, as the registry resolved it.
+///
+/// Nothing here was stated by the recipe: every field was read off the model,
+/// which is why an adapter can use it without checking it against anything.
+#[derive(Clone, Debug)]
+pub struct Part<'a> {
+    /// Where the part came from, and what to call or read to get it.
+    pub from: PartSource<'a>,
+    /// The part's Rust type.
+    pub ty: TypeRef,
+    /// Handed over, or reached through a borrow.
+    pub mode: Mode,
+    /// The segment an adapter mangles into a destination-language name.
+    pub name: String,
+}
+
+/// Where one part comes from.
+#[derive(Copy, Clone, Debug)]
+pub enum PartSource<'a> {
+    /// Parameter `index` of the constructor being called.
+    Argument {
+        /// Position in the constructor's parameter list.
+        index: usize,
+    },
+    /// Field `index` of the value, read directly.
+    Field {
+        /// Position in the struct or in the arm's payload.
+        index: usize,
+        /// The field itself.
+        field: &'a Field,
+    },
+    /// This accessor call.
+    Accessor {
+        /// The function to call.
+        func: &'a Function,
+    },
+}
+
+/// A product's parts, each already compiled.
+pub type Parts<'a, C> = &'a [(Part<'a>, &'a <C as Compile>::Fragment)];
+
+/// Shorthand for what every fragment-producing hook returns.
+pub type Frag<C> = Result<<C as Compile>::Fragment, <C as Compile>::Error>;
+
+/// The adapter's half of code generation: what one crossing costs on the wire.
+///
+/// One hook per row shape, and one per operation, so an adapter never matches
+/// on [`Construct`] or [`Deconstruct`] — the registry calls only the hook that
+/// suits the row. Every hook is handed model elements rather than a copy of
+/// what the recipe said about them.
+pub trait Compile {
+    /// The adapter's answer for one row: what crosses, how it is encoded, what
+    /// it costs to clean up.
+    ///
+    /// Opaque to the registry, which only ever asks it what Rust value it
+    /// yields. Not a wire value — a fragment may occupy none, one or several.
+    type Fragment: Carrier;
+    /// The adapter's answer for one site: a root fragment plus the signature,
+    /// the call and the cleanup around it.
+    type Plan;
+    /// What the adapter reports when it cannot answer.
+    type Error;
+
+    /// No parts: the adapter emits the conversion itself.
+    fn atomic(&mut self, cx: &mut Cx<'_>, at: At<'_>) -> Frag<Self>;
+
+    /// Absent, or the inner fragment's value.
+    fn optional(&mut self, cx: &mut Cx<'_>, at: At<'_>, inner: &Self::Fragment) -> Frag<Self>;
+
+    /// A run of the inner fragment's value.
+    ///
+    /// `elements` is derived from the collection type, not declared, so an
+    /// adapter reads it rather than checking it against anything.
+    fn sequence(
+        &mut self,
+        cx: &mut Cx<'_>,
+        at: At<'_>,
+        elements: Mode,
+        inner: &Self::Fragment,
+    ) -> Frag<Self>;
+
+    /// Call `func` to assemble the value. Its parameters are `args`.
+    fn construct(
+        &mut self,
+        cx: &mut Cx<'_>,
+        at: At<'_>,
+        func: &Function,
+        args: Parts<'_, Self>,
+    ) -> Frag<Self>;
+
+    /// The single part is the value.
+    fn identity(&mut self, cx: &mut Cx<'_>, at: At<'_>, inner: &Self::Fragment) -> Frag<Self>;
+
+    /// Read the parts off the value where it stands.
+    fn fields(&mut self, cx: &mut Cx<'_>, at: At<'_>, parts: Parts<'_, Self>) -> Frag<Self>;
+
+    /// Call `func` once, then read the parts off what it returned.
+    fn value_form(
+        &mut self,
+        cx: &mut Cx<'_>,
+        at: At<'_>,
+        func: &Function,
+        parts: Parts<'_, Self>,
+    ) -> Frag<Self>;
+
+    /// Every arm, always.
+    ///
+    /// A choice is a run-time alternative, so the adapter is never offered one
+    /// of them to pick. Each arm arrives already composed by one of the four
+    /// hooks above, which is why this hook needs no job of its own.
+    fn choice(
+        &mut self,
+        cx: &mut Cx<'_>,
+        at: At<'_>,
+        arms: &[(&Alternative, &Self::Fragment)],
+    ) -> Frag<Self>;
+
+    /// A callback, taken apart into the values that pass through it.
+    ///
+    /// `result` is `None` for every callback the model can describe today; it
+    /// is the position issue #216's return value lands in.
+    fn callback(
+        &mut self,
+        cx: &mut Cx<'_>,
+        at: At<'_>,
+        args: &[&Self::Fragment],
+        result: Option<&Self::Fragment>,
+    ) -> Frag<Self>;
+
+    /// Wrap the site's root fragment into a plan — the signature, the call, the
+    /// cleanup.
+    ///
+    /// The only hook called once per site; every hook above is called once per
+    /// row, however many sites reuse it.
+    fn plan(
+        &mut self,
+        cx: &mut Cx<'_>,
+        bound: &Bound,
+        root: &Self::Fragment,
+    ) -> Result<Self::Plan, Self::Error>;
+}
+
+/// What a compilation reports when it cannot finish.
+#[derive(Debug)]
+pub enum CompileError<E> {
+    /// The adapter could not answer for a row or a site.
+    Adapter(E),
+    /// The table and the model disagree with what a site asked for.
+    ///
+    /// Boxed: a `RecipeError` names a site and a crossing, which makes it much
+    /// the larger of the two variants, and this is the rare one.
+    Recipe(Box<RecipeError>),
+}
+
+impl<E: fmt::Display> fmt::Display for CompileError<E> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            CompileError::Adapter(e) => write!(f, "{e}"),
+            CompileError::Recipe(e) => write!(f, "{e}"),
+        }
+    }
+}
+
+impl<E: fmt::Debug + fmt::Display> std::error::Error for CompileError<E> {}
+
+impl<E> From<RecipeError> for CompileError<E> {
+    fn from(e: RecipeError) -> Self {
+        CompileError::Recipe(Box::new(e))
+    }
+}
+
+type Built<C> = Result<Rc<<C as Compile>::Fragment>, CompileError<<C as Compile>::Error>>;
+
+/// Drives an adapter over the table: one fragment per row, one plan per site.
+pub struct Compiler<'a, C: Compile> {
+    model: &'a Flat,
+    recipes: &'a Recipes,
+    bindings: &'a Bindings,
+    fragments: HashMap<(CrossingKey, RecipeId), Rc<C::Fragment>>,
+    required: BTreeSet<RequirementId>,
+}
+
+impl<'a, C: Compile> Compiler<'a, C> {
+    /// Drive `adapter` over this table.
+    pub fn new(model: &'a Flat, recipes: &'a Recipes, bindings: &'a Bindings) -> Self {
+        Self {
+            model,
+            recipes,
+            bindings,
+            fragments: HashMap::new(),
+            required: BTreeSet::new(),
+        }
+    }
+
+    /// Every helper a compiled fragment asked for, de-duplicated.
+    pub fn required(&self) -> impl Iterator<Item = &RequirementId> {
+        self.required.iter()
+    }
+
+    /// How many rows have been compiled, which is what makes the per-row
+    /// promise observable.
+    pub fn compiled_rows(&self) -> usize {
+        self.fragments.len()
+    }
+
+    /// Compile one site: pick its row, build the fragment, wrap it in a plan.
+    ///
+    /// `None` when a declaration bound the site to
+    /// [`Ask::Omit`](super::Ask::Omit).
+    pub fn site(
+        &mut self,
+        adapter: &mut C,
+        site: Site,
+        crossing: Crossing,
+    ) -> Result<Option<C::Plan>, CompileError<C::Error>> {
+        let Some(bound) = self.bindings.resolve(&site, &crossing, self.recipes) else {
+            return Ok(None);
+        };
+        let root = self.row(adapter, &bound.crossing, &bound.recipe)?;
+        let needed = tolerated(&bound.site.role);
+        let got = root.yields().validity;
+        if needed == Validity::SelfSufficient && got == Validity::Borrowed {
+            return Err(RecipeError::Validity {
+                site: bound.site,
+                needed,
+                got,
+            }
+            .into());
+        }
+        let mut cx = Cx {
+            model: self.model,
+            recipes: self.recipes,
+            required: &mut self.required,
+        };
+        adapter
+            .plan(&mut cx, &bound, &root)
+            .map(Some)
+            .map_err(CompileError::Adapter)
+    }
+
+    /// The fragment for one row, built once and reused.
+    fn row(&mut self, adapter: &mut C, crossing: &Crossing, recipe: &RecipeId) -> Built<C> {
+        let key = (crossing.key(), recipe.clone());
+        if let Some(built) = self.fragments.get(&key) {
+            return Ok(built.clone());
+        }
+        let row = match self.recipes.get(&key.0, recipe) {
+            Some(row) => row.clone(),
+            None => self.recipes.row(crossing).1.into_owned(),
+        };
+        let at = At { crossing, recipe };
+        let fragment = match &row {
+            Row::Callback(assembly) => self.callback(adapter, at, *assembly)?,
+            Row::Constructing(shape) => self.constructing(adapter, at, shape)?,
+            Row::Deconstructing(shape) => self.deconstructing(adapter, at, shape)?,
+        };
+        let fragment = Rc::new(fragment);
+        self.fragments.insert(key, fragment.clone());
+        Ok(fragment)
+    }
+
+    /// The fragment for one part of the row being compiled.
+    ///
+    /// Which row the part takes is the site machinery's answer, asked at
+    /// [`Role::Part`] — per row, because that is what compilation is per.
+    fn part(&mut self, adapter: &mut C, at: At<'_>, index: usize, ty: &TypeRef) -> Built<C> {
+        let crossing = Crossing::new(ty.clone(), at.crossing.assembly());
+        let site = Site {
+            owner: owner_of(at.crossing),
+            role: Role::Part {
+                of: at.crossing.key(),
+                recipe: at.recipe.clone(),
+                index,
+            },
+        };
+        match self.bindings.resolve(&site, &crossing, self.recipes) {
+            Some(bound) => self.row(adapter, &bound.crossing, &bound.recipe),
+            None => Err(RecipeError::UnknownRow {
+                site,
+                crossing: crossing.key(),
+                recipe: super::RecipeId::new("<omitted>"),
+            }
+            .into()),
+        }
+    }
+
+    fn constructing(
+        &mut self,
+        adapter: &mut C,
+        at: At<'_>,
+        shape: &Shape<Construct>,
+    ) -> Result<C::Fragment, CompileError<C::Error>> {
+        match shape {
+            Shape::Atomic => self.atomic(adapter, at),
+            Shape::Optional { inner } => self.optional(adapter, at, inner),
+            Shape::Sequence { inner } => self.sequence(adapter, at, inner),
+            Shape::Product(op) => {
+                let (kind, parts) = self.construct_parts(at, op)?;
+                self.product(adapter, at, kind, parts)
+            }
+            Shape::Choice { arms } => {
+                let mut built = Vec::new();
+                for arm in arms {
+                    let alternative = self.alternative(at, arm.alternative)?;
+                    let (kind, parts) = self.construct_parts(at, &arm.op)?;
+                    built.push((alternative, self.product(adapter, at, kind, parts)?));
+                }
+                self.choice(adapter, at, built)
+            }
+        }
+    }
+
+    fn deconstructing(
+        &mut self,
+        adapter: &mut C,
+        at: At<'_>,
+        shape: &Shape<Deconstruct>,
+    ) -> Result<C::Fragment, CompileError<C::Error>> {
+        match shape {
+            Shape::Atomic => self.atomic(adapter, at),
+            Shape::Optional { inner } => self.optional(adapter, at, inner),
+            Shape::Sequence { inner } => self.sequence(adapter, at, inner),
+            Shape::Product(op) => {
+                let (kind, parts) = self.deconstruct_parts(at, op, None)?;
+                self.product(adapter, at, kind, parts)
+            }
+            Shape::Choice { arms } => {
+                let mut built = Vec::new();
+                for arm in arms {
+                    let alternative = self.alternative(at, arm.alternative)?;
+                    let (kind, parts) =
+                        self.deconstruct_parts(at, &arm.op, Some(&alternative.fields))?;
+                    built.push((alternative, self.product(adapter, at, kind, parts)?));
+                }
+                self.choice(adapter, at, built)
+            }
+        }
+    }
+
+    // ── The hooks ─────────────────────────────────────────────────────────
+
+    fn atomic(
+        &mut self,
+        adapter: &mut C,
+        at: At<'_>,
+    ) -> Result<C::Fragment, CompileError<C::Error>> {
+        let mut cx = self.cx();
+        adapter.atomic(&mut cx, at).map_err(CompileError::Adapter)
+    }
+
+    fn optional(
+        &mut self,
+        adapter: &mut C,
+        at: At<'_>,
+        inner: &TypeRef,
+    ) -> Result<C::Fragment, CompileError<C::Error>> {
+        let inner = self.part(adapter, at, 0, inner)?;
+        let mut cx = self.cx();
+        adapter
+            .optional(&mut cx, at, &inner)
+            .map_err(CompileError::Adapter)
+    }
+
+    fn sequence(
+        &mut self,
+        adapter: &mut C,
+        at: At<'_>,
+        inner: &TypeRef,
+    ) -> Result<C::Fragment, CompileError<C::Error>> {
+        let elements = element_mode(at.crossing);
+        let inner = self.part(adapter, at, 0, inner)?;
+        let mut cx = self.cx();
+        adapter
+            .sequence(&mut cx, at, elements, &inner)
+            .map_err(CompileError::Adapter)
+    }
+
+    fn callback(
+        &mut self,
+        adapter: &mut C,
+        at: At<'_>,
+        assembly: Assembly,
+    ) -> Result<C::Fragment, CompileError<C::Error>> {
+        let args: Vec<TypeRef> = at
+            .crossing
+            .value()
+            .callback_args()
+            .unwrap_or_default()
+            .to_vec();
+        // The one place the two jobs swap: Rust holds these values and pushes
+        // them out through the call.
+        let swapped = Crossing::new(at.crossing.spelled().clone(), assembly.swap());
+        let inner = At {
+            crossing: &swapped,
+            recipe: at.recipe,
+        };
+        let mut built = Vec::new();
+        for (index, arg) in args.iter().enumerate() {
+            built.push(self.part(adapter, inner, index, arg)?);
+        }
+        let refs: Vec<&C::Fragment> = built.iter().map(|f| &**f).collect();
+        let mut cx = self.cx();
+        adapter
+            .callback(&mut cx, at, &refs, None)
+            .map_err(CompileError::Adapter)
+    }
+
+    /// One product, whichever of the four hooks composes it.
+    fn product<'p>(
+        &mut self,
+        adapter: &mut C,
+        at: At<'_>,
+        kind: ProductKind<'p>,
+        parts: Vec<Part<'p>>,
+    ) -> Result<C::Fragment, CompileError<C::Error>> {
+        let mut built = Vec::new();
+        for (index, part) in parts.iter().enumerate() {
+            let fragment = self.part(adapter, at, index, &part.ty)?;
+            let got = fragment.yields().mode;
+            if !got.satisfies(part.mode) {
+                return Err(RecipeError::Composition {
+                    site: Site {
+                        owner: owner_of(at.crossing),
+                        role: Role::Part {
+                            of: at.crossing.key(),
+                            recipe: at.recipe.clone(),
+                            index,
+                        },
+                    },
+                    part: index,
+                    wanted: part.mode,
+                    got,
+                }
+                .into());
+            }
+            built.push(fragment);
+        }
+        let paired: Vec<(Part<'p>, &C::Fragment)> =
+            parts.into_iter().zip(built.iter().map(|f| &**f)).collect();
+        let mut cx = Cx {
+            model: self.model,
+            recipes: self.recipes,
+            required: &mut self.required,
+        };
+        match kind {
+            ProductKind::Construct(func) => adapter.construct(&mut cx, at, func, &paired),
+            ProductKind::Identity => {
+                let (_, inner) = &paired[0];
+                adapter.identity(&mut cx, at, inner)
+            }
+            ProductKind::Fields => adapter.fields(&mut cx, at, &paired),
+            ProductKind::ValueForm(func) => adapter.value_form(&mut cx, at, func, &paired),
+        }
+        .map_err(CompileError::Adapter)
+    }
+
+    fn choice(
+        &mut self,
+        adapter: &mut C,
+        at: At<'_>,
+        arms: Vec<(&'a Alternative, C::Fragment)>,
+    ) -> Result<C::Fragment, CompileError<C::Error>> {
+        let paired: Vec<(&Alternative, &C::Fragment)> = arms.iter().map(|(a, f)| (*a, f)).collect();
+        let mut cx = Cx {
+            model: self.model,
+            recipes: self.recipes,
+            required: &mut self.required,
+        };
+        adapter
+            .choice(&mut cx, at, &paired)
+            .map_err(CompileError::Adapter)
+    }
+
+    // ── Reading the parts off the model ───────────────────────────────────
+
+    fn cx(&mut self) -> Cx<'_> {
+        Cx {
+            model: self.model,
+            recipes: self.recipes,
+            required: &mut self.required,
+        }
+    }
+
+    fn construct_parts(
+        &self,
+        at: At<'_>,
+        op: &Construct,
+    ) -> Result<(ProductKind<'a>, Vec<Part<'a>>), CompileError<C::Error>> {
+        match op {
+            Construct::Identity(inner) => Ok((
+                ProductKind::Identity,
+                vec![Part {
+                    from: PartSource::Argument { index: 0 },
+                    mode: mode_of(inner),
+                    ty: (**inner).clone(),
+                    name: "value".to_owned(),
+                }],
+            )),
+            Construct::Call(name) => {
+                let func = self.function(at, name)?;
+                let parts = func
+                    .params
+                    .iter()
+                    .enumerate()
+                    .map(|(index, param)| Part {
+                        from: PartSource::Argument { index },
+                        mode: mode_of(&param.ty),
+                        ty: param.ty.clone(),
+                        name: param.name.to_string(),
+                    })
+                    .collect();
+                Ok((ProductKind::Construct(func), parts))
+            }
+        }
+    }
+
+    fn deconstruct_parts(
+        &self,
+        at: At<'_>,
+        op: &Deconstruct,
+        arm: Option<&'a [Field]>,
+    ) -> Result<(ProductKind<'a>, Vec<Part<'a>>), CompileError<C::Error>> {
+        match op {
+            Deconstruct::Fields(reaches) => {
+                let fields = match arm {
+                    Some(fields) => fields,
+                    None => self.fields_of(at.crossing.value()),
+                };
+                Ok((ProductKind::Fields, self.reaches(at, reaches, fields)?))
+            }
+            Deconstruct::ValueForm { func, parts } => {
+                let func = self.function(at, func)?;
+                let fields = self.fields_of(&func.ret);
+                Ok((
+                    ProductKind::ValueForm(func),
+                    self.reaches(at, parts, fields)?,
+                ))
+            }
+        }
+    }
+
+    fn reaches(
+        &self,
+        at: At<'_>,
+        reaches: &[Reach],
+        fields: &'a [Field],
+    ) -> Result<Vec<Part<'a>>, CompileError<C::Error>> {
+        let mut parts = Vec::new();
+        for reach in reaches {
+            match reach {
+                Reach::Omit => {}
+                Reach::Field(index) => {
+                    let field = fields.get(*index).ok_or_else(|| {
+                        CompileError::Recipe(Box::new(RecipeError::OutOfRange {
+                            row: at.crossing.key(),
+                            recipe: at.recipe.clone(),
+                            index: *index,
+                            len: fields.len(),
+                        }))
+                    })?;
+                    parts.push(Part {
+                        from: PartSource::Field {
+                            index: *index,
+                            field,
+                        },
+                        mode: mode_of(&field.ty),
+                        ty: field.ty.clone(),
+                        name: field
+                            .name
+                            .as_ref()
+                            .map(|n| n.to_string())
+                            .unwrap_or_else(|| index.to_string()),
+                    });
+                }
+                Reach::Accessor(name) => {
+                    let func = self.function(at, name)?;
+                    parts.push(Part {
+                        from: PartSource::Accessor { func },
+                        mode: mode_of(&func.ret),
+                        ty: func.ret.clone(),
+                        name: func.name.to_string(),
+                    });
+                }
+            }
+        }
+        Ok(parts)
+    }
+
+    fn function(
+        &self,
+        at: At<'_>,
+        name: &syn::Ident,
+    ) -> Result<&'a Function, CompileError<C::Error>> {
+        self.model.function(name).ok_or_else(|| {
+            CompileError::Recipe(Box::new(RecipeError::UnknownFunction {
+                row: at.crossing.key(),
+                recipe: at.recipe.clone(),
+                func: name.clone(),
+            }))
+        })
+    }
+
+    fn alternative(
+        &self,
+        at: At<'_>,
+        index: usize,
+    ) -> Result<&'a Alternative, CompileError<C::Error>> {
+        let alternatives = match self.declared(at.crossing.value()) {
+            Some(Type::Variant(v)) => v.alternatives.as_slice(),
+            _ => &[],
+        };
+        alternatives.get(index).ok_or_else(|| {
+            CompileError::Recipe(Box::new(RecipeError::OutOfRange {
+                row: at.crossing.key(),
+                recipe: at.recipe.clone(),
+                index,
+                len: alternatives.len(),
+            }))
+        })
+    }
+
+    fn fields_of(&self, ty: &TypeRef) -> &'a [Field] {
+        match self.declared(ty) {
+            Some(Type::Struct(s)) => s.fields.as_slice(),
+            _ => &[],
+        }
+    }
+
+    fn declared(&self, ty: &TypeRef) -> Option<&'a Type> {
+        let value = ty.borrow_target().unwrap_or(ty).unwrapped();
+        match value.kind() {
+            TypeKind::Named { id, .. } => self.model.resolve(id),
+            _ => None,
+        }
+    }
+}
+
+/// Which of the four product hooks composes a set of parts.
+enum ProductKind<'a> {
+    Construct(&'a Function),
+    Identity,
+    Fields,
+    ValueForm(&'a Function),
+}
+
+/// Whether a value is handed over or reached through a borrow.
+fn mode_of(ty: &TypeRef) -> Mode {
+    match ty.unwrapped().kind() {
+        TypeKind::Ref { mutable: true, .. } => Mode::Exclusive,
+        TypeKind::Ref { .. } => Mode::Shared,
+        _ => Mode::Owned,
+    }
+}
+
+/// Whether iterating a run yields owned values or borrows.
+///
+/// The collection's business, not the recipe's: `Vec<T>` gives its elements up,
+/// while `&[T]` and `Cow<'_, [T]>` lend them.
+fn element_mode(crossing: &Crossing) -> Mode {
+    if crossing.mode() != Mode::Owned {
+        return Mode::Shared;
+    }
+    match crossing.value().unwrapped().kind() {
+        TypeKind::Slice(_) => Mode::Shared,
+        _ => Mode::Owned,
+    }
+}
+
+/// The weakest validity a role accepts.
+///
+/// A value the foreign side stores has to outlive the call; an argument valid
+/// only for the duration of one may be borrowed.
+fn tolerated(role: &Role) -> Validity {
+    match role {
+        Role::Return | Role::Error | Role::Const => Validity::SelfSufficient,
+        Role::Param { .. } | Role::Receiver | Role::CallbackArg { .. } | Role::Part { .. } => {
+            Validity::Borrowed
+        }
+    }
+}
+
+/// The name a part's site is filed under: the crossed type.
+fn owner_of(crossing: &Crossing) -> syn::Ident {
+    crossing
+        .value()
+        .stripped_key()
+        .ident()
+        .unwrap_or_else(|| syn::Ident::new("_", proc_macro2::Span::call_site()))
+}

--- a/prebindgen-registry/src/recipe/compile.rs
+++ b/prebindgen-registry/src/recipe/compile.rs
@@ -11,15 +11,21 @@
 //! every hook the fragments its parts already produced — so an adapter says
 //! what one crossing means and never writes the walk.
 //!
-//! # Per row, not per site
+//! # Per crossing, not per site
 //!
-//! A fragment is built once per `(crossing, recipe)` and reused at every site
-//! that crossing appears at. That is what makes emitted code shared without a
-//! converter table, and it rests on one assumption: **a fragment is
-//! context-free**. Where an adapter appears to need site context, the site is
-//! wrapping the fragment rather than the fragment differing, and
-//! [`Compile::plan`] — the one hook called per site — is where that wrapping
-//! belongs.
+//! A fragment is built once per crossing and reused at every site that crossing
+//! appears at. That is what makes emitted code shared without a converter
+//! table, and it rests on one assumption: **a fragment is context-free**. Where
+//! an adapter appears to need site context, the site is wrapping the fragment
+//! rather than the fragment differing, and [`Compile::plan`] — the one hook
+//! called per site — is where that wrapping belongs.
+//!
+//! A crossing here is the type **as the site spelled it**, which is finer than
+//! the identity a row is declared under. `Sample`, `&Sample` and `Box<Sample>`
+//! find one row, because the same recipe assembles all three — and they get
+//! three fragments, because taking a value out of a pointer, borrowing through
+//! one, and rebuilding a `Box` are three different pieces of Rust. Sharing the
+//! row is the declaration's business; sharing the code is not.
 
 use std::{
     collections::{BTreeSet, HashMap},
@@ -28,8 +34,8 @@ use std::{
 };
 
 use super::{
-    Assembly, Bindings, Bound, Construct, Crossing, CrossingKey, Deconstruct, Mode, Reach,
-    RecipeError, RecipeId, Recipes, Role, Row, Shape, Site,
+    Assembly, Bindings, Bound, Construct, Crossing, Deconstruct, Mode, Reach, RecipeError,
+    RecipeId, Recipes, Role, Row, Shape, Site,
 };
 use crate::{
     flat::{Alternative, Field, Flat, Function, Type, TypeKey, TypeKind, TypeRef},
@@ -326,7 +332,7 @@ pub struct Compiler<'a, C: Compile> {
     model: &'a Flat,
     recipes: &'a Recipes,
     bindings: &'a Bindings,
-    fragments: HashMap<(CrossingKey, RecipeId), Rc<C::Fragment>>,
+    fragments: HashMap<(TypeKey, Assembly, RecipeId), Rc<C::Fragment>>,
     required: BTreeSet<RequirementId>,
     emit: Emit,
 }
@@ -349,9 +355,9 @@ impl<'a, C: Compile> Compiler<'a, C> {
         self.required.iter()
     }
 
-    /// How many rows have been compiled, which is what makes the per-row
-    /// promise observable.
-    pub fn compiled_rows(&self) -> usize {
+    /// How many fragments have been built, which is what makes the
+    /// per-crossing promise observable.
+    pub fn compiled_fragments(&self) -> usize {
         self.fragments.len()
     }
 
@@ -406,11 +412,17 @@ impl<'a, C: Compile> Compiler<'a, C> {
 
     /// The fragment for one row, built once and reused.
     fn row(&mut self, adapter: &mut C, crossing: &Crossing, recipe: &RecipeId) -> Built<C> {
-        let key = (crossing.key(), recipe.clone());
+        // Keyed by the spelling, not by the row's identity: one row can answer
+        // for `T`, `&T` and `Box<T>`, and each of the three needs its own Rust.
+        let key = (
+            crossing.spelled().key(),
+            crossing.assembly(),
+            recipe.clone(),
+        );
         if let Some(built) = self.fragments.get(&key) {
             return Ok(built.clone());
         }
-        let row = match self.recipes.get(&key.0, recipe) {
+        let row = match self.recipes.get(&crossing.key(), recipe) {
             Some(row) => row.clone(),
             None => self.recipes.row(crossing).1.into_owned(),
         };

--- a/prebindgen-registry/src/recipe/site.rs
+++ b/prebindgen-registry/src/recipe/site.rs
@@ -54,6 +54,15 @@ pub enum Role {
     ///
     /// Swaps jobs: Rust holds the value and pushes it out, so the argument is
     /// deconstructed even though it sits in a parameter list.
+    ///
+    /// A **root** role, like [`Return`](Self::Return) and
+    /// [`Param`](Self::Param): it names an argument of the callback in one
+    /// exported function, so it is what an adapter passes to
+    /// [`Compiler::site`](super::Compiler::site) when it compiles that argument
+    /// itself. It is deliberately not what the driver asks at while compiling a
+    /// callback row — a row is shared by every function whose callback has the
+    /// same signature, so a per-function answer could not apply to it. Inside a
+    /// row the driver asks at [`Part`](Self::Part), which is keyed by the row.
     CallbackArg {
         /// Which parameter of the exported function is the callback.
         param: usize,

--- a/prebindgen-registry/src/recipe/tests.rs
+++ b/prebindgen-registry/src/recipe/tests.rs
@@ -1355,6 +1355,51 @@ fn a_callbacks_arguments_do_the_other_job() {
 }
 
 #[test]
+fn a_callback_argument_is_overridden_by_compiling_it_as_its_own_site() {
+    // A callback row is shared by every function whose callback has the same
+    // signature, so a per-function answer cannot apply to it. `Role::CallbackArg`
+    // is a root role: an adapter compiles that position itself.
+    let model = model(&[
+        SAMPLE,
+        "pub fn listen(on: impl Fn(Sample) + Send + Sync + 'static) {}",
+    ]);
+    let mut builder = Recipes::builder();
+    builder
+        .declare_default(ty(&model, "Sample"), id("whole"), Deconstructing::Atomic)
+        .declare(
+            ty(&model, "Sample"),
+            id("fields"),
+            Deconstructing::Product(Deconstruct::Fields(vec![Reach::Field(0)])),
+        );
+    let recipes = builder.build(&model).expect("table");
+
+    let arg = Site {
+        owner: ident("listen"),
+        role: Role::CallbackArg { param: 0, arg: 0 },
+    };
+    let mut bound = Bindings::builder();
+    bound.bind(
+        arg.clone(),
+        Crossing::new(ty(&model, "Sample"), Assembly::Deconstruct),
+        Ask::Recipe(id("fields")),
+        Origin::Function,
+    );
+    let bindings = bound.build(&recipes).expect("bindings");
+    let mut adapter = Recorder::default();
+    let mut compiler = Compiler::new(&model, &recipes, &bindings);
+
+    let plan = compiler
+        .site(
+            &mut adapter,
+            arg,
+            Crossing::new(ty(&model, "Sample"), Assembly::Deconstruct),
+        )
+        .expect("compile")
+        .expect("not omitted");
+    assert!(plan.contains("fields Sample deconstruct"), "{plan}");
+}
+
+#[test]
 fn a_part_that_only_lends_cannot_feed_an_edge_that_consumes() {
     let model = model(&[
         SAMPLE,

--- a/prebindgen-registry/src/recipe/tests.rs
+++ b/prebindgen-registry/src/recipe/tests.rs
@@ -880,8 +880,11 @@ impl Compile for Recorder {
     type Plan = String;
     type Error = String;
 
-    fn atomic(&mut self, _cx: &mut Cx<'_>, at: At<'_>) -> Frag<Self> {
-        self.hook(at, "atomic", String::new())
+    fn atomic(&mut self, cx: &mut Cx<'_>, at: At<'_>) -> Frag<Self> {
+        // A fragment is generated Rust, so a hook is an emission callback and
+        // can spell a model type without naming the flat protocol itself.
+        let spelled = cx.emit().spell(at.crossing.spelled()).to_string();
+        self.hook(at, "atomic", spelled)
     }
 
     fn optional(&mut self, _cx: &mut Cx<'_>, at: At<'_>, inner: &Note) -> Frag<Self> {
@@ -1028,8 +1031,8 @@ fn a_constructors_parameters_are_the_parts() {
     assert_eq!(
         adapter.calls,
         vec![
-            "atomic u32 construct: ",
-            "atomic u64 construct: ",
+            "atomic u32 construct: u32",
+            "atomic u64 construct: u64",
             "construct Sample construct: sample_new(key=arg0/owned, payload=arg1/owned)",
         ]
     );
@@ -1128,6 +1131,31 @@ fn an_omitted_reach_contributes_no_part() {
         plan.contains("fields Sample deconstruct: key=field0/owned"),
         "{plan}"
     );
+}
+
+#[test]
+fn a_crossing_can_be_compiled_without_a_site() {
+    let model = model(&[SAMPLE]);
+    let recipes = Recipes::default();
+    let bindings = Bindings::default();
+    let mut adapter = Recorder::default();
+    let mut compiler = Compiler::new(&model, &recipes, &bindings);
+
+    let first = compiler
+        .crossing(
+            &mut adapter,
+            &Crossing::new(ty(&model, "Option<Sample>"), Assembly::Deconstruct),
+        )
+        .expect("compile");
+    assert!(first.text.starts_with("optional"), "{}", first.text);
+    // Asking twice is the same fragment, not a second compilation.
+    compiler
+        .crossing(
+            &mut adapter,
+            &Crossing::new(ty(&model, "Option<Sample>"), Assembly::Deconstruct),
+        )
+        .expect("compile");
+    assert_eq!(adapter.calls.len(), 2);
 }
 
 #[test]

--- a/prebindgen-registry/src/recipe/tests.rs
+++ b/prebindgen-registry/src/recipe/tests.rs
@@ -1134,6 +1134,35 @@ fn an_omitted_reach_contributes_no_part() {
 }
 
 #[test]
+fn one_row_answering_three_spellings_still_builds_three_fragments() {
+    let model = model(&[SAMPLE]);
+    let mut builder = Recipes::builder();
+    builder.declare(ty(&model, "Sample"), id("whole"), Deconstructing::Atomic);
+    let recipes = builder.build(&model).expect("table");
+    let bindings = Bindings::default();
+    let mut adapter = Recorder::default();
+    let mut compiler = Compiler::new(&model, &recipes, &bindings);
+
+    for spelling in ["Sample", "&Sample", "Box<Sample>"] {
+        let crossing = Crossing::new(ty(&model, spelling), Assembly::Deconstruct);
+        // All three find the one declared row …
+        assert_eq!(recipes.row(&crossing).0, id("whole"));
+        compiler.crossing(&mut adapter, &crossing).expect("compile");
+    }
+    // … and each still gets its own Rust, because taking a value out of a
+    // pointer, borrowing through one and rebuilding a Box are three things.
+    assert_eq!(compiler.compiled_fragments(), 3);
+    assert_eq!(
+        adapter.calls,
+        vec![
+            "atomic Sample deconstruct: Sample",
+            "atomic Sample deconstruct: & Sample",
+            "atomic Sample deconstruct: Box < Sample >",
+        ]
+    );
+}
+
+#[test]
 fn a_crossing_can_be_compiled_without_a_site() {
     let model = model(&[SAMPLE]);
     let recipes = Recipes::default();
@@ -1184,8 +1213,9 @@ fn a_row_is_compiled_once_however_many_sites_take_it() {
             )
             .expect("compile");
     }
-    // Three sites, three plans — and one fragment per row: Sample, u32, u64.
-    assert_eq!(compiler.compiled_rows(), 3);
+    // Three sites, three plans — and one fragment per crossing: Sample, u32,
+    // u64.
+    assert_eq!(compiler.compiled_fragments(), 3);
     assert_eq!(adapter.calls.len(), 3);
 }
 
@@ -1478,7 +1508,7 @@ fn a_site_takes_the_row_the_binding_names_and_others_take_the_default() {
     assert!(overridden.contains("fields Sample"), "{overridden}");
     assert!(plain.contains("atomic Sample"), "{plain}");
     // Two rows of one crossing, so two fragments — plus the two field types.
-    assert_eq!(compiler.compiled_rows(), 4);
+    assert_eq!(compiler.compiled_fragments(), 4);
 }
 
 #[test]

--- a/prebindgen-registry/src/recipe/tests.rs
+++ b/prebindgen-registry/src/recipe/tests.rs
@@ -1454,6 +1454,94 @@ fn a_site_takes_the_row_the_binding_names_and_others_take_the_default() {
 }
 
 #[test]
+fn a_struct_with_no_constructor_is_built_from_its_own_fields() {
+    let model = model(&[SAMPLE]);
+    let mut builder = Recipes::builder();
+    builder.declare(
+        ty(&model, "Sample"),
+        id("literal"),
+        Constructing::Product(Construct::Fields),
+    );
+    let recipes = builder.build(&model).expect("table");
+    let mut adapter = Recorder::default();
+
+    let plan = compile_one(
+        &model,
+        &recipes,
+        &mut adapter,
+        site("z_put", 0),
+        "Sample",
+        Assembly::Construct,
+    );
+    // Every field contributes, in the model's order, and the same `fields` hook
+    // serves both jobs.
+    assert!(
+        plan.contains("fields Sample construct: key=field0/owned, payload=field1/owned"),
+        "{plan}"
+    );
+}
+
+#[test]
+fn an_arm_is_built_from_its_own_payload_fields() {
+    let model = model(&["pub enum Reply { Ok(u32), Err(u64) }"]);
+    let mut builder = Recipes::builder();
+    builder.declare(
+        ty(&model, "Reply"),
+        id("variants"),
+        Constructing::Choice {
+            arms: vec![
+                Arm {
+                    alternative: 0,
+                    op: Construct::Fields,
+                },
+                Arm {
+                    alternative: 1,
+                    op: Construct::Fields,
+                },
+            ],
+        },
+    );
+    let recipes = builder.build(&model).expect("table");
+    let mut adapter = Recorder::default();
+
+    let plan = compile_one(
+        &model,
+        &recipes,
+        &mut adapter,
+        site("z_put", 0),
+        "Reply",
+        Assembly::Construct,
+    );
+    assert!(
+        plan.contains("Ok#0 [fields Reply construct: 0=field0/owned]"),
+        "{plan}"
+    );
+    assert!(
+        plan.contains("Err#1 [fields Reply construct: 0=field0/owned]"),
+        "{plan}"
+    );
+    // The two arms' payloads are different types, so they are different rows.
+    assert!(adapter.calls.iter().any(|c| c.starts_with("atomic u32")));
+    assert!(adapter.calls.iter().any(|c| c.starts_with("atomic u64")));
+}
+
+#[test]
+fn building_a_type_the_model_gives_no_fields_is_refused() {
+    let model = model(&["pub struct Handle;"]);
+    let mut builder = Recipes::builder();
+    builder.declare(
+        ty(&model, "u32"),
+        id("literal"),
+        Constructing::Product(Construct::Fields),
+    );
+    let errors = builder.build(&model).expect_err("a scalar has no fields");
+    assert!(
+        matches!(errors.as_slice(), [RecipeError::NotAProduct { .. }]),
+        "{errors:?}"
+    );
+}
+
+#[test]
 fn a_value_form_binds_the_accessors_result_and_reads_its_fields() {
     let model = model(&[
         "pub struct Handle;",

--- a/prebindgen-registry/src/recipe/tests.rs
+++ b/prebindgen-registry/src/recipe/tests.rs
@@ -796,3 +796,695 @@ fn one_site_is_one_role_of_one_owner() {
         id("whole")
     );
 }
+
+// ── Compiling rows into fragments ─────────────────────────────────────────
+
+use std::collections::HashSet;
+
+use crate::flat::Alternative;
+
+/// A fragment that records the shape it was built from, so a test can assert on
+/// the tree an adapter is handed rather than on generated code.
+#[derive(Clone, Debug)]
+struct Note {
+    text: String,
+    yields: Yield,
+}
+
+impl Carrier for Note {
+    fn yields(&self) -> Yield {
+        self.yields.clone()
+    }
+}
+
+/// The smallest adapter that exercises every hook: it emits nothing and only
+/// writes down what it was asked.
+#[derive(Default)]
+struct Recorder {
+    /// One line per hook call, in call order.
+    calls: Vec<String>,
+    /// Crossings whose fragment is reached through a borrow.
+    shared: HashSet<String>,
+    /// Crossings whose fragment is valid only while its source is alive.
+    borrowed: HashSet<String>,
+}
+
+impl Recorder {
+    fn note(&mut self, at: At<'_>, text: String) -> Note {
+        self.calls.push(text.clone());
+        let name = at.crossing.value().stripped_key().to_string();
+        Note {
+            text,
+            yields: Yield {
+                ty: at.crossing.value().stripped_key(),
+                mode: if self.shared.contains(&name) {
+                    Mode::Shared
+                } else {
+                    Mode::Owned
+                },
+                validity: if self.borrowed.contains(&name) {
+                    Validity::Borrowed
+                } else {
+                    Validity::SelfSufficient
+                },
+            },
+        }
+    }
+
+    fn hook(&mut self, at: At<'_>, hook: &str, detail: String) -> Result<Note, String> {
+        let ty = at.crossing.value().stripped_key();
+        Ok(self.note(
+            at,
+            format!("{hook} {ty} {}: {detail}", at.crossing.assembly()),
+        ))
+    }
+}
+
+fn part_names<C: Compile>(parts: Parts<'_, C>) -> String {
+    parts
+        .iter()
+        .map(|(p, _)| {
+            let source = match p.from {
+                PartSource::Argument { index } => format!("arg{index}"),
+                PartSource::Field { index, .. } => format!("field{index}"),
+                PartSource::Accessor { func } => format!("via {}", func.name),
+            };
+            format!("{}={source}/{}", p.name, p.mode)
+        })
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+impl Compile for Recorder {
+    type Fragment = Note;
+    type Plan = String;
+    type Error = String;
+
+    fn atomic(&mut self, _cx: &mut Cx<'_>, at: At<'_>) -> Frag<Self> {
+        self.hook(at, "atomic", String::new())
+    }
+
+    fn optional(&mut self, _cx: &mut Cx<'_>, at: At<'_>, inner: &Note) -> Frag<Self> {
+        let detail = inner.text.clone();
+        self.hook(at, "optional", detail)
+    }
+
+    fn sequence(
+        &mut self,
+        _cx: &mut Cx<'_>,
+        at: At<'_>,
+        elements: Mode,
+        inner: &Note,
+    ) -> Frag<Self> {
+        let detail = format!("elements {elements} of {}", inner.text);
+        self.hook(at, "sequence", detail)
+    }
+
+    fn construct(
+        &mut self,
+        _cx: &mut Cx<'_>,
+        at: At<'_>,
+        func: &Function,
+        args: Parts<'_, Self>,
+    ) -> Frag<Self> {
+        let detail = format!("{}({})", func.name, part_names::<Self>(args));
+        self.hook(at, "construct", detail)
+    }
+
+    fn identity(&mut self, _cx: &mut Cx<'_>, at: At<'_>, inner: &Note) -> Frag<Self> {
+        let detail = inner.text.clone();
+        self.hook(at, "identity", detail)
+    }
+
+    fn fields(&mut self, _cx: &mut Cx<'_>, at: At<'_>, parts: Parts<'_, Self>) -> Frag<Self> {
+        let detail = part_names::<Self>(parts);
+        self.hook(at, "fields", detail)
+    }
+
+    fn value_form(
+        &mut self,
+        _cx: &mut Cx<'_>,
+        at: At<'_>,
+        func: &Function,
+        parts: Parts<'_, Self>,
+    ) -> Frag<Self> {
+        let detail = format!("{} -> {}", func.name, part_names::<Self>(parts));
+        self.hook(at, "value_form", detail)
+    }
+
+    fn choice(
+        &mut self,
+        _cx: &mut Cx<'_>,
+        at: At<'_>,
+        arms: &[(&Alternative, &Note)],
+    ) -> Frag<Self> {
+        let detail = arms
+            .iter()
+            .map(|(a, f)| format!("{}#{} [{}]", a.name, a.index, f.text))
+            .collect::<Vec<_>>()
+            .join(" | ");
+        self.hook(at, "choice", detail)
+    }
+
+    fn callback(
+        &mut self,
+        cx: &mut Cx<'_>,
+        at: At<'_>,
+        args: &[&Note],
+        result: Option<&Note>,
+    ) -> Frag<Self> {
+        cx.require(RequirementId::new("callback-shim"));
+        let detail = format!(
+            "({}) -> {:?}",
+            args.iter()
+                .map(|a| a.text.clone())
+                .collect::<Vec<_>>()
+                .join(", "),
+            result.map(|r| r.text.clone())
+        );
+        self.hook(at, "callback", detail)
+    }
+
+    fn plan(&mut self, _cx: &mut Cx<'_>, bound: &Bound, root: &Note) -> Result<String, String> {
+        Ok(format!(
+            "{} <- {} [{}]",
+            bound.site, bound.recipe, root.text
+        ))
+    }
+}
+
+/// The registry's half of a compile failure, or a panic naming the adapter's.
+fn recipe_error(error: &CompileError<String>) -> &RecipeError {
+    match error {
+        CompileError::Recipe(e) => e,
+        CompileError::Adapter(a) => panic!("the adapter refused: {a}"),
+    }
+}
+
+fn compile_one(
+    model: &Flat,
+    recipes: &Recipes,
+    adapter: &mut Recorder,
+    site: Site,
+    spelling: &str,
+    assembly: Assembly,
+) -> String {
+    let bindings = Bindings::default();
+    let mut compiler = Compiler::new(model, recipes, &bindings);
+    compiler
+        .site(adapter, site, Crossing::new(ty(model, spelling), assembly))
+        .expect("compile")
+        .expect("not omitted")
+}
+
+#[test]
+fn a_constructors_parameters_are_the_parts() {
+    let model = model(&[
+        SAMPLE,
+        "pub fn sample_new(key: u32, payload: u64) -> Sample {}",
+    ]);
+    let mut builder = Recipes::builder();
+    builder.declare(
+        ty(&model, "Sample"),
+        id("fields"),
+        Constructing::Product(Construct::Call(ident("sample_new"))),
+    );
+    let recipes = builder.build(&model).expect("table");
+    let mut adapter = Recorder::default();
+
+    let plan = compile_one(
+        &model,
+        &recipes,
+        &mut adapter,
+        site("z_put", 0),
+        "Sample",
+        Assembly::Construct,
+    );
+    assert!(
+        plan.contains("sample_new(key=arg0/owned, payload=arg1/owned)"),
+        "{plan}"
+    );
+    // Each part is a crossing of its own, compiled before the whole.
+    assert_eq!(
+        adapter.calls,
+        vec![
+            "atomic u32 construct: ",
+            "atomic u64 construct: ",
+            "construct Sample construct: sample_new(key=arg0/owned, payload=arg1/owned)",
+        ]
+    );
+}
+
+#[test]
+fn an_accessors_return_is_the_parts_type_and_its_borrowing() {
+    let model = model(&[
+        SAMPLE,
+        "pub fn sample_key(s: &Sample) -> u32 {}",
+        "pub fn sample_payload(s: &Sample) -> &u64 {}",
+    ]);
+    let mut builder = Recipes::builder();
+    builder.declare(
+        ty(&model, "Sample"),
+        id("fields"),
+        Deconstructing::Product(Deconstruct::Fields(vec![
+            Reach::Accessor(ident("sample_key")),
+            Reach::Accessor(ident("sample_payload")),
+        ])),
+    );
+    let recipes = builder.build(&model).expect("table");
+    let mut adapter = Recorder::default();
+
+    let plan = compile_one(
+        &model,
+        &recipes,
+        &mut adapter,
+        Site {
+            owner: ident("z_get"),
+            role: Role::Return,
+        },
+        "Sample",
+        Assembly::Deconstruct,
+    );
+    assert!(
+        plan.contains("sample_key=via sample_key/owned, sample_payload=via sample_payload/&"),
+        "{plan}"
+    );
+}
+
+#[test]
+fn a_field_reach_reads_the_models_own_field() {
+    let model = model(&[SAMPLE]);
+    let mut builder = Recipes::builder();
+    builder.declare(
+        ty(&model, "Sample"),
+        id("fields"),
+        Deconstructing::Product(Deconstruct::Fields(vec![Reach::Field(1), Reach::Field(0)])),
+    );
+    let recipes = builder.build(&model).expect("table");
+    let mut adapter = Recorder::default();
+
+    let plan = compile_one(
+        &model,
+        &recipes,
+        &mut adapter,
+        Site {
+            owner: ident("z_get"),
+            role: Role::Return,
+        },
+        "Sample",
+        Assembly::Deconstruct,
+    );
+    // Declaration order is the recipe's, not the struct's.
+    assert!(
+        plan.contains("payload=field1/owned, key=field0/owned"),
+        "{plan}"
+    );
+}
+
+#[test]
+fn an_omitted_reach_contributes_no_part() {
+    let model = model(&[SAMPLE]);
+    let mut builder = Recipes::builder();
+    builder.declare(
+        ty(&model, "Sample"),
+        id("fields"),
+        Deconstructing::Product(Deconstruct::Fields(vec![Reach::Field(0), Reach::Omit])),
+    );
+    let recipes = builder.build(&model).expect("table");
+    let mut adapter = Recorder::default();
+
+    let plan = compile_one(
+        &model,
+        &recipes,
+        &mut adapter,
+        Site {
+            owner: ident("z_get"),
+            role: Role::Return,
+        },
+        "Sample",
+        Assembly::Deconstruct,
+    );
+    assert!(
+        plan.contains("fields Sample deconstruct: key=field0/owned"),
+        "{plan}"
+    );
+}
+
+#[test]
+fn a_row_is_compiled_once_however_many_sites_take_it() {
+    let model = model(&[
+        SAMPLE,
+        "pub fn sample_new(key: u32, payload: u64) -> Sample {}",
+    ]);
+    let mut builder = Recipes::builder();
+    builder.declare(
+        ty(&model, "Sample"),
+        id("fields"),
+        Constructing::Product(Construct::Call(ident("sample_new"))),
+    );
+    let recipes = builder.build(&model).expect("table");
+    let bindings = Bindings::default();
+    let mut adapter = Recorder::default();
+    let mut compiler = Compiler::new(&model, &recipes, &bindings);
+
+    for owner in ["z_put", "z_get", "z_reply"] {
+        compiler
+            .site(
+                &mut adapter,
+                site(owner, 0),
+                Crossing::new(ty(&model, "Sample"), Assembly::Construct),
+            )
+            .expect("compile");
+    }
+    // Three sites, three plans — and one fragment per row: Sample, u32, u64.
+    assert_eq!(compiler.compiled_rows(), 3);
+    assert_eq!(adapter.calls.len(), 3);
+}
+
+#[test]
+fn a_sequence_reads_its_element_mode_off_the_collection() {
+    let model = model(&[SAMPLE]);
+    let recipes = Recipes::default();
+    let modes = |spelling: &str| {
+        let mut adapter = Recorder::default();
+        compile_one(
+            &model,
+            &recipes,
+            &mut adapter,
+            Site {
+                owner: ident("z_get"),
+                role: Role::Return,
+            },
+            spelling,
+            Assembly::Deconstruct,
+        )
+    };
+    assert!(
+        modes("Vec<u32>").contains("elements owned"),
+        "{}",
+        modes("Vec<u32>")
+    );
+    assert!(modes("&[u32]").contains("elements &"));
+    assert!(modes("&Vec<u32>").contains("elements &"));
+    assert!(modes("[u32; 4]").contains("elements owned"));
+}
+
+#[test]
+fn a_nested_layer_is_a_row_of_its_own() {
+    let model = model(&[SAMPLE]);
+    let recipes = Recipes::default();
+    let mut adapter = Recorder::default();
+    compile_one(
+        &model,
+        &recipes,
+        &mut adapter,
+        Site {
+            owner: ident("z_get"),
+            role: Role::Return,
+        },
+        "Option<Vec<u32>>",
+        Assembly::Deconstruct,
+    );
+    assert_eq!(adapter.calls.len(), 3, "{:?}", adapter.calls);
+    assert!(adapter.calls[0].starts_with("atomic u32"));
+    assert!(adapter.calls[1].starts_with("sequence"));
+    assert!(adapter.calls[2].starts_with("optional"));
+}
+
+#[test]
+fn every_arm_of_a_choice_reaches_the_hook_already_composed() {
+    let model = model(&["pub enum Reply { Ok(u32), Err(u64) }"]);
+    let mut builder = Recipes::builder();
+    builder.declare(
+        ty(&model, "Reply"),
+        id("variants"),
+        Deconstructing::Choice {
+            arms: vec![
+                Arm {
+                    alternative: 0,
+                    op: Deconstruct::Fields(vec![Reach::Field(0)]),
+                },
+                Arm {
+                    alternative: 1,
+                    op: Deconstruct::Fields(vec![Reach::Field(0)]),
+                },
+            ],
+        },
+    );
+    let recipes = builder.build(&model).expect("table");
+    let mut adapter = Recorder::default();
+
+    let plan = compile_one(
+        &model,
+        &recipes,
+        &mut adapter,
+        Site {
+            owner: ident("z_get"),
+            role: Role::Return,
+        },
+        "Reply",
+        Assembly::Deconstruct,
+    );
+    assert!(plan.contains("Ok#0 ["), "{plan}");
+    assert!(plan.contains("Err#1 ["), "{plan}");
+    // Each arm's payload supplies its own field 0, so the two differ.
+    assert!(plan.contains("0=field0/owned"), "{plan}");
+    assert_eq!(
+        adapter
+            .calls
+            .iter()
+            .filter(|c| c.starts_with("choice"))
+            .count(),
+        1
+    );
+}
+
+#[test]
+fn a_callbacks_arguments_do_the_other_job() {
+    let model = model(&[
+        SAMPLE,
+        "pub fn listen(on: impl Fn(Sample) + Send + Sync + 'static) {}",
+    ]);
+    let recipes = Recipes::default();
+    let bindings = Bindings::default();
+    let mut adapter = Recorder::default();
+    let mut compiler = Compiler::new(&model, &recipes, &bindings);
+    let listen = model.function("listen").expect("listen");
+
+    compiler
+        .site(
+            &mut adapter,
+            site("listen", 0),
+            Crossing::new(listen.params[0].ty.clone(), Assembly::Construct),
+        )
+        .expect("compile");
+
+    // The callback itself is constructed; the `Sample` it carries is
+    // deconstructed, because Rust holds it and pushes it out through the call.
+    assert!(
+        adapter.calls[0].starts_with("atomic Sample deconstruct"),
+        "{:?}",
+        adapter.calls
+    );
+    assert!(adapter.calls[1].contains("callback"), "{:?}", adapter.calls);
+    assert_eq!(
+        compiler
+            .required()
+            .map(|r| r.to_string())
+            .collect::<Vec<_>>(),
+        vec!["callback-shim".to_string()]
+    );
+}
+
+#[test]
+fn a_part_that_only_lends_cannot_feed_an_edge_that_consumes() {
+    let model = model(&[
+        SAMPLE,
+        "pub fn sample_new(key: u32, payload: u64) -> Sample {}",
+    ]);
+    let mut builder = Recipes::builder();
+    builder.declare(
+        ty(&model, "Sample"),
+        id("fields"),
+        Constructing::Product(Construct::Call(ident("sample_new"))),
+    );
+    let recipes = builder.build(&model).expect("table");
+    let bindings = Bindings::default();
+    let mut adapter = Recorder::default();
+    adapter.shared.insert("u64".to_owned());
+    let mut compiler = Compiler::new(&model, &recipes, &bindings);
+
+    let error = compiler
+        .site(
+            &mut adapter,
+            site("z_put", 0),
+            Crossing::new(ty(&model, "Sample"), Assembly::Construct),
+        )
+        .expect_err("payload is taken by value");
+    assert!(
+        matches!(
+            recipe_error(&error),
+            RecipeError::Composition {
+                part: 1,
+                wanted: Mode::Owned,
+                got: Mode::Shared,
+                ..
+            }
+        ),
+        "{error:?}"
+    );
+}
+
+#[test]
+fn a_returned_value_the_foreign_side_keeps_cannot_be_borrowed() {
+    let model = model(&[SAMPLE]);
+    let recipes = Recipes::default();
+    let bindings = Bindings::default();
+    let mut adapter = Recorder::default();
+    adapter.borrowed.insert("Sample".to_owned());
+    let mut compiler = Compiler::new(&model, &recipes, &bindings);
+
+    let ret = Site {
+        owner: ident("z_get"),
+        role: Role::Return,
+    };
+    let error = compiler
+        .site(
+            &mut adapter,
+            ret,
+            Crossing::new(ty(&model, "Sample"), Assembly::Deconstruct),
+        )
+        .expect_err("a return outlives the call");
+    assert!(
+        matches!(
+            recipe_error(&error),
+            RecipeError::Validity {
+                needed: Validity::SelfSufficient,
+                got: Validity::Borrowed,
+                ..
+            }
+        ),
+        "{error:?}"
+    );
+
+    // The same borrowed fragment is fine where the value lives only for the
+    // call.
+    let mut adapter = Recorder::default();
+    adapter.borrowed.insert("Sample".to_owned());
+    let mut compiler = Compiler::new(&model, &recipes, &bindings);
+    compiler
+        .site(
+            &mut adapter,
+            site("z_put", 0),
+            Crossing::new(ty(&model, "Sample"), Assembly::Deconstruct),
+        )
+        .expect("a parameter tolerates a borrow");
+}
+
+#[test]
+fn an_omitted_site_compiles_to_no_plan() {
+    let model = model(&[SAMPLE]);
+    let recipes = Recipes::default();
+    let mut builder = Bindings::builder();
+    builder.bind(
+        site("z_put", 0),
+        Crossing::new(ty(&model, "Sample"), Assembly::Construct),
+        Ask::Omit,
+        Origin::Function,
+    );
+    let bindings = builder.build(&recipes).expect("bindings");
+    let mut adapter = Recorder::default();
+    let mut compiler = Compiler::new(&model, &recipes, &bindings);
+
+    assert!(compiler
+        .site(
+            &mut adapter,
+            site("z_put", 0),
+            Crossing::new(ty(&model, "Sample"), Assembly::Construct),
+        )
+        .expect("compile")
+        .is_none());
+    assert!(adapter.calls.is_empty());
+}
+
+#[test]
+fn a_site_takes_the_row_the_binding_names_and_others_take_the_default() {
+    let model = model(&[SAMPLE]);
+    let mut builder = Recipes::builder();
+    builder
+        .declare_default(ty(&model, "Sample"), id("whole"), Deconstructing::Atomic)
+        .declare(
+            ty(&model, "Sample"),
+            id("fields"),
+            Deconstructing::Product(Deconstruct::Fields(vec![Reach::Field(0), Reach::Field(1)])),
+        );
+    let recipes = builder.build(&model).expect("table");
+    let mut bound = Bindings::builder();
+    bound.bind(
+        site("z_put", 0),
+        Crossing::new(ty(&model, "Sample"), Assembly::Deconstruct),
+        Ask::Recipe(id("fields")),
+        Origin::Function,
+    );
+    let bindings = bound.build(&recipes).expect("bindings");
+    let mut adapter = Recorder::default();
+    let mut compiler = Compiler::new(&model, &recipes, &bindings);
+
+    let overridden = compiler
+        .site(
+            &mut adapter,
+            site("z_put", 0),
+            Crossing::new(ty(&model, "Sample"), Assembly::Deconstruct),
+        )
+        .expect("compile")
+        .expect("not omitted");
+    let plain = compiler
+        .site(
+            &mut adapter,
+            site("z_get", 0),
+            Crossing::new(ty(&model, "Sample"), Assembly::Deconstruct),
+        )
+        .expect("compile")
+        .expect("not omitted");
+
+    assert!(overridden.contains("fields Sample"), "{overridden}");
+    assert!(plain.contains("atomic Sample"), "{plain}");
+    // Two rows of one crossing, so two fragments — plus the two field types.
+    assert_eq!(compiler.compiled_rows(), 4);
+}
+
+#[test]
+fn a_value_form_binds_the_accessors_result_and_reads_its_fields() {
+    let model = model(&[
+        "pub struct Handle;",
+        SAMPLE,
+        "pub fn handle_read(h: &Handle) -> Sample {}",
+    ]);
+    let mut builder = Recipes::builder();
+    builder.declare(
+        ty(&model, "Handle"),
+        id("read"),
+        Deconstructing::Product(Deconstruct::ValueForm {
+            func: ident("handle_read"),
+            parts: vec![Reach::Field(0), Reach::Field(1)],
+        }),
+    );
+    let recipes = builder.build(&model).expect("table");
+    let mut adapter = Recorder::default();
+
+    let plan = compile_one(
+        &model,
+        &recipes,
+        &mut adapter,
+        Site {
+            owner: ident("z_get"),
+            role: Role::Return,
+        },
+        "Handle",
+        Assembly::Deconstruct,
+    );
+    assert!(
+        plan.contains("handle_read -> key=field0/owned, payload=field1/owned"),
+        "{plan}"
+    );
+}


### PR DESCRIPTION
Stage 3 of [#451](https://github.com/milyin/prebindgen/pull/451), the umbrella for [#450](https://github.com/milyin/prebindgen/issues/450). Targets `recipe-table`, not `main`.

Stages 1 and 2 built the table — which rows a crossing has, and which of them a given site takes. This stage is the half that turns a row into something an adapter can emit from. Still nothing consumes it: `prebindgen-c` and `prebindgen-jni` are untouched.

## Fragments, and what the registry can see of one

An adapter's answer for one row is a **fragment**: a type the adapter defines, holding everything it will later need in order to emit — the wire shape, whether encoding can fail, what cleanup costs, whatever else. The registry constructs none and reads nothing inside one. It asks a fragment exactly one question, through the `Carrier` trait: what Rust value does this produce, handed over or borrowed, and does it stay usable after the call.

A fragment is **not** a wire value. It may occupy none, one or several, and the count is never asked for. That separation is the point of #450: a C `data_struct` converts a struct field by field and still occupies one C parameter, while a WebAssembly `&str` has no parts at all and still needs two.

## One hook per row shape

An adapter writes `Compile`. `Compiler` drives the recursion over the table and hands each hook the fragments its parts already produced, so an adapter says what one crossing means and never writes the walk.

There is one hook per operation as well as per shape — `construct`, `identity`, `fields`, `value_form` — so an adapter never matches on `Construct` or `Deconstruct`; the registry calls only the one that suits the row. `choice` receives **every** arm, already composed by one of those four, because a choice is a run-time alternative and the adapter is never offered one of them to pick. `plan` is the only hook called per site: it wraps the root fragment in the exported signature, the call and the cleanup.

Every hook is handed model elements — a `Function`, an `Alternative`, a `Field` — rather than a copy of what the recipe said about them, and each `Part` carries the part's Rust type, its ownership and its name, all read off the model. Nothing in a `Part` was stated by a recipe, which is why an adapter can use one without checking it against anything.

## Compiled per crossing, not per site

A fragment is built once per crossing and reused at every site that crossing appears at. That is what gives shared emitted code with no converter table, makes the number of compile calls proportional to types rather than call sites, and removes every adapter's per-function plan cache.

A crossing here is the type **as the site spelled it**, which is finer than the identity a row is declared under. `Sample`, `&Sample` and `Box<Sample>` find one row, because the same recipe assembles all three — and they get three fragments, because taking a value out of a pointer, borrowing through one, and rebuilding a `Box` are three different pieces of Rust. `prebindgen-c` emits three converters for exactly that reason today. Sharing the row is the declaration's business; sharing the code is not.

It rests on the assumption #450 flags as its first open question — that a fragment is context-free. Where an adapter appears to need site context, the site is *wrapping* the fragment rather than the fragment differing, and `plan` is where that wrapping belongs. A test pins the promise: three sites over one crossing produce three plans and exactly three hook calls.

## Two contracts checked while compiling

- **Composition.** At every part, what the part's fragment yields must be consumable where the whole needs it: a constructor parameter spelled `T` accepts only an owned value, one spelled `&T` accepts either. Stated by the adapter through `Yield`, not inferred from how a type is spelled.
- **Validity.** At every site, against what the site's role can tolerate. A returned value the foreign side stores needs `SelfSufficient`; a parameter or a callback argument, valid only for the duration of the call, may be `Borrowed`. Stating it rather than inferring it is what gives zero-copy a legitimate home — a `&T` crossing as a pointer cast is a borrowed carrier, and correct at the sites where it is used.

`Cx::require` collects the helpers a fragment's generated code calls, de-duplicated, so a prelude emits each once.

## The gap the C survey found: `Construct::Fields`

#450 gives `Construct` two forms, "call this `#[prebindgen]` constructor" and "the single part is the value". Neither covers the case `prebindgen-c` lives on: a `#[repr(C)]` mirror of a struct with public fields is rebuilt as a struct literal, and there is no constructor in the source crate to name. `Cbindgen::data_struct` would have had nothing to declare.

`Construct::Fields` is that case, and it is the constructing twin of the `Reach::Field` that `Deconstruct` already had. It names no list, where `Deconstruct::Fields` does: a value cannot be built with one of its fields missing, and which fields there are is the model's answer, so every field contributes in the model's order. Inside a `Shape::Choice` arm the fields are that alternative's. No hook was added — `Compile::fields` already served both jobs by construction, and this is what makes it reachable from both.

## Two things a hook gets that #450 does not mention

**The emission key.** A fragment is generated Rust, so compiling one is an emission callback: `Cx::emit` hands a hook the same `Emit` that `Prebindgen`'s `on_*` methods and `RegistryBuilder::convert_with` receive, and the `Compiler` owns the one it lends out. Without it a hook could not spell a model type at all.

**`Compiler::crossing`.** The per-row half of `Compiler::site`, for an adapter whose own emission still owns the per-site wrapping. It is the entry point a port reaches for before its wrappers have moved onto `Compile::plan`.

## Two deviations from #450

**`Cx` has no `Metadata` type parameter, and `Compile` has no `Metadata` associated type.** #450 carries the adapter's `Prebindgen::Metadata` through `Cx` so a hook can reach the registry's type table. That table is the machinery this work replaces, so there is nothing yet for the parameter to reach; `Cx` exposes the model and the table directly. Stage 4 or 5 adds it back if porting an adapter needs it.

**A `Part` owns its `TypeRef` and its name.** #450 borrows both. A part's type may come from a row the table derived on the fly rather than from the model, so there is nothing for the borrow to point at; the model elements a `Part` names — the `Function`, the `Field` — are still borrowed.

## Checks

19 unit tests, driven through a recorder adapter that emits nothing and writes down what it was handed, so the assertions are about the tree an adapter sees rather than about generated code: a constructor's parameters becoming the parts, an accessor's return type and its borrowing, a field reach in the recipe's order rather than the struct's, an omitted reach contributing nothing, one crossing compiled once across three sites, one row answering three spellings still building three fragments, a sequence's element mode over `Vec<T>` / `&[T]` / `&Vec<T>` / `[T; N]`, `Option<Vec<u32>>` as three rows, every arm of a choice arriving composed, a callback's arguments doing the other job, a struct literal under both jobs and inside a choice arm, both contract failures, an omitted site compiling to no plan, and a bound site taking a different row from its siblings.

Local gate clean: clippy and rustfmt on 1.85.0 and stable, `cargo doc` with warnings denied, `cargo test --all`, and `examples/regen-check.sh` reporting no drift.
