### PR TITLE
jnigen: choose a conversion from the table, not from a chain of guesses (#450)

### DIFF
--- a/prebindgen-jni/src/jni/compile.rs
+++ b/prebindgen-jni/src/jni/compile.rs
@@ -1,0 +1,270 @@
+//! What one crossing costs on the JNI wire.
+//!
+//! [`super::rows`] states which parts a value gets across in; this says what
+//! each of those parts looks like across the Java Native Interface. The
+//! registry drives the walk over the table and hands every hook the fragment
+//! its inner crossing already produced, so nothing here decides which arity
+//! layer it is looking at and nothing here recurses.
+
+use prebindgen_registry::{
+    flat::{Alternative, Function, TypeKind, TypeRef},
+    recipe::{Assembly, At, Bound, Carrier, Compile, Cx, Frag, Mode, Parts, Validity, Yield},
+    Conversions,
+};
+
+use super::{
+    trait_impl::{Produced, WrapperShape},
+    *,
+};
+
+/// The JNI adapter's answer for one crossing.
+///
+/// What a `ConverterImpl` was, minus the bookkeeping the table now does.
+#[derive(Clone)]
+pub(crate) struct JFrag {
+    pub(crate) conv: ConverterImpl<KotlinMeta>,
+    pub(crate) yields: Yield,
+}
+
+impl Carrier for JFrag {
+    fn yields(&self) -> Yield {
+        self.yields.clone()
+    }
+}
+
+impl JFrag {
+    fn new(at: At<'_>, conv: ConverterImpl<KotlinMeta>) -> Self {
+        let mode = at.crossing.mode();
+        Self {
+            conv,
+            yields: Yield {
+                ty: at.crossing.value().stripped_key(),
+                mode,
+                // A borrow is only usable while what it was reached through is
+                // alive; anything else the JVM may keep.
+                validity: match mode {
+                    Mode::Owned => Validity::SelfSufficient,
+                    Mode::Shared | Mode::Exclusive => Validity::Borrowed,
+                },
+            },
+        }
+    }
+}
+
+/// The adapter, for the length of one crossing's compilation.
+pub(crate) struct JCompile<'a, R> {
+    pub(crate) decls: &'a Declarations,
+    pub(crate) registry: &'a R,
+}
+
+fn refuse(at: At<'_>, why: &str) -> String {
+    format!("JniGen: {} ({why})", at.crossing.key())
+}
+
+impl<R: Conversions<KotlinMeta>> JCompile<'_, R> {
+    fn wrap(&self, at: At<'_>, why: &str, conv: Option<ConverterImpl<KotlinMeta>>) -> Frag<Self> {
+        conv.map(|c| JFrag::new(at, c))
+            .ok_or_else(|| refuse(at, why))
+    }
+
+    /// The borrow arms, which are neither a terminal nor an arity layer.
+    fn borrow(
+        &self,
+        ty: &TypeRef,
+        emit: &prebindgen_registry::Emit,
+        into_rust: bool,
+    ) -> Option<ConverterImpl<KotlinMeta>> {
+        let TypeKind::Ref {
+            mutable,
+            inner: borrowed,
+            ..
+        } = ty.unwrapped().kind()
+        else {
+            return None;
+        };
+        let mutable = *mutable;
+        // The target through the accessor: an out-parameter's `MaybeUninit` is
+        // the slot a `T` goes in, and it is the `T` that converts.
+        let inner = ty.borrow_target().expect("a borrow");
+        let produced = Produced::Reading(ty);
+        if into_rust {
+            // An exclusive borrow crosses only when the borrowed value lives on
+            // the Rust side — see `input_borrow`'s own note. `mutable` is read
+            // off the `Ref` kind rather than through `is_exclusive_borrow`,
+            // which answers `false` for a `&mut MaybeUninit<T>` out-parameter.
+            let writes_reach_the_caller = !mutable
+                || self
+                    .decls
+                    .types
+                    .get(&borrowed.key())
+                    .is_some_and(|cfg| cfg.is_opaque());
+            if !writes_reach_the_caller {
+                return None;
+            }
+            let mutable = ty.is_exclusive_borrow();
+            let mut c = self.decls.input_wrapper_shape(
+                WrapperShape::Borrow { mutable },
+                &produced,
+                inner,
+                self.registry,
+                emit,
+            )?;
+            c.subs = vec![inner.key()];
+            Some(c)
+        } else {
+            let mutable = ty.is_exclusive_borrow();
+            let mut c = self.decls.output_wrapper_shape(
+                WrapperShape::Borrow { mutable },
+                &produced,
+                inner,
+                self.registry,
+                emit,
+            )?;
+            c.subs = vec![inner.key()];
+            Some(c)
+        }
+    }
+}
+
+impl<R: Conversions<KotlinMeta>> Compile for JCompile<'_, R> {
+    type Fragment = JFrag;
+    /// JniGen keeps its own per-site emission for now: the exported signature,
+    /// the call and the cleanup are built from the resolved registry.
+    type Plan = ();
+    type Error = String;
+
+    fn atomic(&mut self, cx: &mut Cx<'_>, at: At<'_>) -> Frag<Self> {
+        let ty = at.crossing.spelled();
+        let emit = cx.emit();
+        let conv = match at.crossing.assembly() {
+            Assembly::Construct => self
+                .decls
+                .input_terminal(ty, self.registry, emit)
+                .or_else(|| self.borrow(ty, emit, true))
+                .or_else(|| self.decls.input_transparent_bridge(ty, self.registry, emit))
+                .or_else(|| {
+                    // `impl Fn(args)` that nothing else claimed. Callback args
+                    // cross in the opposite direction, which is why their
+                    // required-ness rides `immediate_edges` rather than `subs`.
+                    let TypeKind::Callback { args } = ty.unwrapped().kind() else {
+                        return None;
+                    };
+                    self.decls.dispatch_fn_input(args, self.registry, emit)
+                }),
+            Assembly::Deconstruct => self
+                .decls
+                .output_terminal(ty, self.registry, emit)
+                .or_else(|| self.decls.result_shape(ty, self.registry, emit))
+                .or_else(|| self.borrow(ty, emit, false))
+                .or_else(|| {
+                    self.decls
+                        .output_transparent_bridge(ty, self.registry, emit)
+                }),
+        };
+        self.wrap(at, "no JNI representation for this type", conv)
+    }
+
+    fn optional(&mut self, cx: &mut Cx<'_>, at: At<'_>, _inner: &JFrag) -> Frag<Self> {
+        let ty = at.crossing.spelled();
+        let emit = cx.emit();
+        // A declared terminal outranks the arity the registry derived, exactly
+        // as it did when one chain answered both: `input_terminal` claims a
+        // `Cow<'_, [u8]>` blob, and a `convert!` may name an optional.
+        let conv = match at.crossing.assembly() {
+            Assembly::Construct => self
+                .decls
+                .input_terminal(ty, self.registry, emit)
+                .or_else(|| self.decls.input_optional(ty, self.registry, emit)),
+            Assembly::Deconstruct => self
+                .decls
+                .output_terminal(ty, self.registry, emit)
+                .or_else(|| self.decls.output_optional(ty, self.registry, emit)),
+        };
+        self.wrap(at, "no JNI representation for this optional", conv)
+    }
+
+    fn sequence(
+        &mut self,
+        cx: &mut Cx<'_>,
+        at: At<'_>,
+        _elements: Mode,
+        _inner: &JFrag,
+    ) -> Frag<Self> {
+        let ty = at.crossing.spelled();
+        let emit = cx.emit();
+        let conv = match at.crossing.assembly() {
+            Assembly::Construct => self
+                .decls
+                .input_terminal(ty, self.registry, emit)
+                .or_else(|| self.decls.input_run(ty, self.registry, emit))
+                .or_else(|| self.borrow(ty, emit, true))
+                .or_else(|| self.decls.input_transparent_bridge(ty, self.registry, emit)),
+            Assembly::Deconstruct => self
+                .decls
+                .output_terminal(ty, self.registry, emit)
+                .or_else(|| self.decls.output_run(ty, self.registry, emit))
+                .or_else(|| self.borrow(ty, emit, false))
+                .or_else(|| {
+                    self.decls
+                        .output_transparent_bridge(ty, self.registry, emit)
+                }),
+        };
+        self.wrap(at, "no JNI representation for this run", conv)
+    }
+
+    fn identity(&mut self, _cx: &mut Cx<'_>, at: At<'_>, _inner: &JFrag) -> Frag<Self> {
+        Err(refuse(at, "JniGen declares no identity rows"))
+    }
+
+    fn construct(
+        &mut self,
+        _cx: &mut Cx<'_>,
+        at: At<'_>,
+        _func: &Function,
+        _args: Parts<'_, Self>,
+    ) -> Frag<Self> {
+        Err(refuse(at, "JniGen declares no constructor rows"))
+    }
+
+    fn value_form(
+        &mut self,
+        _cx: &mut Cx<'_>,
+        at: At<'_>,
+        _func: &Function,
+        _parts: Parts<'_, Self>,
+    ) -> Frag<Self> {
+        Err(refuse(at, "JniGen states no value-form rows yet"))
+    }
+
+    fn fields(&mut self, _cx: &mut Cx<'_>, at: At<'_>, _parts: Parts<'_, Self>) -> Frag<Self> {
+        Err(refuse(at, "JniGen states no product rows yet"))
+    }
+
+    fn choice(
+        &mut self,
+        _cx: &mut Cx<'_>,
+        at: At<'_>,
+        _arms: &[(&Alternative, &JFrag)],
+    ) -> Frag<Self> {
+        Err(refuse(at, "JniGen states no choice rows yet"))
+    }
+
+    fn callback(
+        &mut self,
+        cx: &mut Cx<'_>,
+        at: At<'_>,
+        _args: &[&JFrag],
+        _result: Option<&JFrag>,
+    ) -> Frag<Self> {
+        let ty = at.crossing.spelled();
+        let TypeKind::Callback { args } = ty.unwrapped().kind() else {
+            return Err(refuse(at, "a callback row over a type that is not one"));
+        };
+        let conv = self.decls.dispatch_fn_input(args, self.registry, cx.emit());
+        self.wrap(at, "undeclared callback signature", conv)
+    }
+
+    fn plan(&mut self, _cx: &mut Cx<'_>, _bound: &Bound, _root: &JFrag) -> Result<(), String> {
+        Ok(())
+    }
+}

--- a/prebindgen-jni/src/jni/mod.rs
+++ b/prebindgen-jni/src/jni/mod.rs
@@ -696,6 +696,7 @@ pub struct JniGenBuilder {
 // ── Sibling submodules (carved from the former monolithic file) ─────────
 mod builder;
 mod classify;
+mod compile;
 mod config;
 mod decl;
 mod emit;
@@ -703,6 +704,7 @@ mod equality;
 mod iface;
 mod prim;
 mod prim_array;
+mod rows;
 mod selector;
 #[cfg(test)]
 mod tests;

--- a/prebindgen-jni/src/jni/rows.rs
+++ b/prebindgen-jni/src/jni/rows.rs
@@ -13,6 +13,8 @@
 //! then a borrow, then a transparent bridge — is a lookup for the declared
 //! half, and the derived half is the registry's.
 
+use std::collections::BTreeMap;
+
 use prebindgen_registry::{
     flat::{Flat, TypeRef},
     recipe::{Constructing, Deconstructing, RecipeError, RecipeId, Recipes},
@@ -102,17 +104,22 @@ impl Declarations {
         // something says otherwise, and this is JniGen saying otherwise for
         // every array the model holds. Nothing is enumerated twice: a row for
         // a crossing nobody uses is inert.
-        let mut arrays: Vec<TypeRef> = model
+        // Keyed by identity in a `BTreeMap`, so each array type is keyed once
+        // and the declaration order is the key order — no sort, no second pass
+        // rebuilding a key it already has, and nothing cloned before the entry
+        // turns out to be new.
+        let mut arrays: BTreeMap<TypeKey, &TypeRef> = BTreeMap::new();
+        for ty in model
             .elements()
             .flat_map(element_types)
-            .flat_map(|ty| ty.walk().into_iter().cloned().collect::<Vec<_>>())
+            .flat_map(|ty| ty.walk())
             .filter(|ty| matches!(ty.kind(), prebindgen_registry::flat::TypeKind::Array { .. }))
-            .collect();
-        arrays.sort_by_key(|ty| ty.key().as_str().to_owned());
-        arrays.dedup_by_key(|ty| ty.key().as_str().to_owned());
-        for ty in arrays {
+        {
+            arrays.entry(ty.key()).or_insert(ty);
+        }
+        for ty in arrays.into_values() {
             rows.declare(ty.clone(), whole(), Deconstructing::Atomic)
-                .declare(ty, whole(), Constructing::Atomic);
+                .declare(ty.clone(), whole(), Constructing::Atomic);
         }
 
         rows.build(model)

--- a/prebindgen-jni/src/jni/rows.rs
+++ b/prebindgen-jni/src/jni/rows.rs
@@ -1,0 +1,120 @@
+//! JniGen's Kotlin class declarations, lowered into the registry's row
+//! vocabulary.
+//!
+//! A build script writes `ptr_class!`, `data_class!`, `enum_class!` or
+//! `sealed_class!`, each naming the Kotlin type one Rust type becomes, and
+//! `convert!` for a conversion the binding supplies itself. This turns those
+//! into rows in a [`Recipes`] table: the shared statement of **which parts** a
+//! value gets across in, with nothing about the JNI wire in it.
+//!
+//! One row per declared type and job, and every crossing nobody declared takes
+//! the row the registry derives from its kind. The chain of guesses this
+//! replaced — try a terminal, then a `Result`, then an optional, then a run,
+//! then a borrow, then a transparent bridge — is a lookup for the declared
+//! half, and the derived half is the registry's.
+
+use prebindgen_registry::{
+    flat::{Flat, TypeRef},
+    recipe::{Constructing, Deconstructing, RecipeError, RecipeId, Recipes},
+};
+
+use super::*;
+
+/// Every type one captured item names, so a reading nested inside it can be
+/// found without the caller knowing which kind of item it came from.
+fn element_types(element: &prebindgen_registry::Element) -> Vec<&TypeRef> {
+    use prebindgen_registry::flat::Type;
+    match element {
+        prebindgen_registry::Element::Function(f) => f
+            .params
+            .iter()
+            .map(|p| &p.ty)
+            .chain(std::iter::once(&f.ret))
+            .collect(),
+        prebindgen_registry::Element::Type(Type::Struct(s)) => {
+            s.fields.iter().map(|f| &f.ty).collect()
+        }
+        prebindgen_registry::Element::Type(Type::Variant(v)) => v
+            .alternatives
+            .iter()
+            .flat_map(|a| a.fields.iter().map(|f| &f.ty))
+            .collect(),
+        prebindgen_registry::Element::Constant(c) => vec![&c.ty],
+        _ => Vec::new(),
+    }
+}
+
+/// The row a type with no parts takes: the adapter emits the conversion itself.
+fn whole() -> RecipeId {
+    RecipeId::new("whole")
+}
+
+impl Declarations {
+    /// Every row this binding's declarations state.
+    ///
+    /// A type declared but absent from the model is skipped rather than
+    /// refused: the scan already reports it, and reporting it twice in
+    /// different words helps nobody.
+    pub(crate) fn recipes(&self, model: &Flat) -> Result<Recipes, Vec<RecipeError>> {
+        let mut rows = Recipes::builder();
+        // Every Kotlin class declaration, and every `convert!`-declared
+        // conversion. The second matters as much as the first: a conversion may
+        // be declared on a type the registry would otherwise read as an arity
+        // layer, and `convert!(Option<Duration> => ..)` means the adapter emits
+        // that optional's conversion itself rather than wrapping `Duration`'s.
+        let mut declared: Vec<(TypeKey, Origin<syn::Type>)> = self
+            .declared_types()
+            .into_iter()
+            .chain(
+                self.convert_decls
+                    .iter()
+                    .map(|d| (d.key().clone(), d.rust_type().clone())),
+            )
+            .collect();
+        declared.sort_by(|a, b| a.0.as_str().cmp(b.0.as_str()));
+        declared.dedup_by(|a, b| a.0 == b.0);
+
+        for (_key, origin) in declared {
+            // The declarator's own tokens, re-parsed: a declared type may be an
+            // alias the model holds as an `Extern`, which carries no reading of
+            // its own to borrow.
+            let Ok(spelled) = syn::parse2::<syn::Type>(origin.declared_spelling()) else {
+                continue;
+            };
+            let Ok(ty) = model.classify(&spelled) else {
+                continue;
+            };
+            // Every declared Kotlin shape is one row with no parts today,
+            // including the two that plainly have some: a `data_class` arrives
+            // as separate JNI parameters and is rebuilt inside one generated
+            // function, and a `sealed_class` is a selector plus the live arm's
+            // slots inside another. `Atomic` is what a row says about that —
+            // the adapter emits the conversion itself, and how many wire values
+            // that costs is its own business — so it describes the adapter as it
+            // stands rather than as it will be.
+            rows.declare(ty.clone(), whole(), Deconstructing::Atomic)
+                .declare(ty, whole(), Constructing::Atomic);
+        }
+
+        // A fixed-size array of JNI primitives is one Kotlin `ByteArray` or
+        // `LongArray`, bulk-copied with nothing boxed — one wire value, not a
+        // run this adapter walks. The registry reads `[T; N]` as a run unless
+        // something says otherwise, and this is JniGen saying otherwise for
+        // every array the model holds. Nothing is enumerated twice: a row for
+        // a crossing nobody uses is inert.
+        let mut arrays: Vec<TypeRef> = model
+            .elements()
+            .flat_map(element_types)
+            .flat_map(|ty| ty.walk().into_iter().cloned().collect::<Vec<_>>())
+            .filter(|ty| matches!(ty.kind(), prebindgen_registry::flat::TypeKind::Array { .. }))
+            .collect();
+        arrays.sort_by_key(|ty| ty.key().as_str().to_owned());
+        arrays.dedup_by_key(|ty| ty.key().as_str().to_owned());
+        for ty in arrays {
+            rows.declare(ty.clone(), whole(), Deconstructing::Atomic)
+                .declare(ty, whole(), Constructing::Atomic);
+        }
+
+        rows.build(model)
+    }
+}

--- a/prebindgen-jni/src/jni/selector.rs
+++ b/prebindgen-jni/src/jni/selector.rs
@@ -39,273 +39,153 @@ fn is_unsized_spelling(ty: &prebindgen_registry::flat::TypeRef) -> bool {
 }
 
 impl Declarations {
-    /// Select the input converter for `ty`: terminals, user wrappers, then
-    /// built-in structural wrappers.
-    pub(crate) fn select_input_type(
+    /// The `Option<X>` **input** shape.
+    ///
+    /// `Option<&T>` tries the deep `OptionRef` — a borrowed handle decoded to
+    /// `Option<OwnedObject<T>>` — before the shallow `Optional`; the shape that
+    /// resolves correctly wins.
+    pub(crate) fn input_optional(
         &self,
         ty: &prebindgen_registry::flat::TypeRef,
         registry: &impl Conversions<KotlinMeta>,
         emit: &prebindgen_registry::Emit,
     ) -> Option<ConverterImpl<KotlinMeta>> {
         // What the converter YIELDS: this crossing's own reading, so a
-        // `Box<Option<T>>` crossing produces a `Box<Option<T>>` — the shape it
-        // is dispatched as does not decide what it is called. The one arm that
-        // yields something else says so with `crate::jni::trait_impl::Produced::Composed`.
+        // `Box<Option<T>>` crossing produces a `Box<Option<T>>`.
         let produced = crate::jni::trait_impl::Produced::Reading(ty);
-
-        // 1. Terminal categories (incl. the terminal user-wrapper lookup).
-        if let Some(c) = self.input_terminal(ty, registry, emit) {
-            return Some(c);
-        }
-        // 3. Built-in wrapper shapes, read one layer at a time rather than as a
-        //    whole stack: each arm handles exactly one, and hands the rest back
-        //    through `subs` to be selected on its own. Peeling further here would
-        //    claim a shape this selector does not emit.
-        if let Some(inner) = ty.optional_inner() {
-            // `Option<&T>` tries the DEEP `OptionRef` (borrowed-handle →
-            // `Option<OwnedObject<T>>`) before the shallow `Optional`; the shape
-            // that resolves correctly wins.
-            if let Some(target) = inner.borrow_target() {
-                let mutable = inner.is_exclusive_borrow();
-                if let Some(mut c) = self.input_wrapper_shape(
-                    WrapperShape::OptionRef { mutable },
-                    &produced,
-                    target,
-                    registry,
-                    emit,
-                ) {
-                    c.subs = vec![target.key()];
-                    return Some(c);
-                }
-            }
-            // An optional BORROW is the deep handler's alone. It declined —
-            // either the inner is not a handle (then the shallow handler below
-            // is right, and only for the canonical spelling) or the spelling
-            // carries a wrapper it cannot bridge. The shallow handler cannot
-            // tell those apart and would decode the jlong as a `*mut &T`, so a
-            // wrapped optional borrow stops here rather than resolving wrong.
-            if inner.borrow_target().is_some() && !ty.erased_wrappers().is_empty() {
-                // "the spelling is exactly `Option<inner>`", off the model: this
-                // rebuilt that canonical form and compared token strings, where
-                // a wrapper over it is what `erased_wrappers` reports.
-                return None;
-            }
-            if let Some(mut c) =
-                self.input_wrapper_shape(WrapperShape::Optional, &produced, inner, registry, emit)
-            {
-                c.subs = vec![inner.key()];
+        let inner = ty.optional_inner()?;
+        if let Some(target) = inner.borrow_target() {
+            let mutable = inner.is_exclusive_borrow();
+            if let Some(mut c) = self.input_wrapper_shape(
+                WrapperShape::OptionRef { mutable },
+                &produced,
+                target,
+                registry,
+                emit,
+            ) {
+                c.subs = vec![target.key()];
                 return Some(c);
             }
+        }
+        // An optional BORROW is the deep handler's alone. It declined — either
+        // the inner is not a handle (then the shallow handler below is right,
+        // and only for the canonical spelling) or the spelling carries a
+        // wrapper it cannot bridge. The shallow handler cannot tell those apart
+        // and would decode the jlong as a `*mut &T`, so a wrapped optional
+        // borrow stops here rather than resolving wrong.
+        if inner.borrow_target().is_some() && !ty.erased_wrappers().is_empty() {
             return None;
         }
-        if let Some(elem) = ty.sequence_elem().filter(|_| !is_unsized_spelling(ty)) {
-            if let Some(mut c) =
-                self.input_wrapper_shape(WrapperShape::Sequence, &produced, elem, registry, emit)
-            {
-                c.subs = vec![elem.key()];
-                return Some(c);
-            }
-            return None;
-        }
-        if let prebindgen_registry::flat::TypeKind::Ref {
-            mutable,
-            inner: borrowed,
-            ..
-        } = ty.unwrapped().kind()
-        {
-            // The target through the accessor: an out-parameter's `MaybeUninit`
-            // is the slot a `T` goes in, and it is the `T` that converts.
-            let inner = ty.borrow_target().expect("a borrow");
-            // `&[T]` shared slice borrow: there is no owned `[T]` to decode, so
-            // reuse the `Vec<_>` shape — decode the Java `List<T>` into an owned
-            // `Vec<T>`; the call site borrows it (`&Vec<T>` deref-coerces to
-            // `&[T]`). Wire/Kotlin type are `List<T>`, identical to a by-value
-            // `Vec<T>` input (the writer dedupes the shared converter fn by ident,
-            // so the two can coexist). `&mut [T]` is intentionally not supported
-            // (no write-back of the decoded Vec).
-            // Two questions, and only the first is `kind`'s. That it is a run of
-            // values makes this arm a *candidate*; whether the decoded `Vec<T>`
-            // can be handed to the Rust function is a question about the
-            // **spelling**, because the generated glue is the one consumer that
-            // can tell `&Vec<T>` from `&Box<Vec<T>>` — the exact thing
-            // `TypeRef::origin` exists to carry.
-            //
-            // `&[T]` deref-coerces from `&Vec<T>` and `&Vec<T>` is already it, so
-            // both are satisfied by the decoded local. A transparent wrapper —
-            // `Box<Vec<T>>`, `Cow<'_, [T]>` — is `Sequence` all the same and is
-            // NOT: passing `&Vec<T>` there does not compile. Those fall through to
-            // the plain borrow arm below, which hands the whole spelling on as the
-            // sub, exactly as the old syntactic slice check did.
-            if !*mutable && decoded_vec_satisfies(inner) {
-                if let Some(elem) = inner.sequence_elem() {
-                    let elem_ty = emit.spell(elem);
-                    // The one place `produced` is NOT the crossing's spelling:
-                    // there is no owned `[T]` to decode into, so the converter
-                    // yields an owned `Vec<T>` and the call site borrows it.
-                    //
-                    // It is also why `produced` stays a spelling while `t1`
-                    // becomes a reading: this one is composed by the ADAPTER,
-                    // and #280 sealed minting to the model — there is no
-                    // `Vec<T>` reading for `api::lang` to make. Which is
-                    // consistent rather than awkward: `produced` is defined as
-                    // the tokens the converter yields, and every question asked
-                    // of it (`is_canonical_spelling`, the `Type::Reference`
-                    // bridgeability guards) is a spelling question.
-                    let produced = crate::jni::trait_impl::Produced::Composed(
-                        syn::parse_quote!(Vec<#elem_ty>),
-                    );
-                    if let Some(mut c) = self.input_wrapper_shape(
-                        WrapperShape::Sequence,
-                        &produced,
-                        elem,
-                        registry,
-                        emit,
-                    ) {
-                        c.subs = vec![elem.key()];
-                        return Some(c);
-                    }
-                    return None;
-                }
-            }
-            // An exclusive borrow crosses only when the borrowed value LIVES on
-            // the Rust side. A handle's input converter hands back an
-            // `OwnedObject<T>` that derefs to the object the JVM holds a
-            // pointer to, so a write through the `&mut` is still there once the
-            // wrapper returns. Every other input converter decodes a fresh
-            // value onto the Rust stack — a `data_class`'s fields, a scalar, an
-            // out-parameter's slot — and the callee's writes to that value are
-            // dropped with the wrapper's frame. Declining is what the `&mut [T]`
-            // branch above already does, for the same reason (#411).
-            //
-            // The question is asked of `borrowed` — the node written directly
-            // under the `&` — and it is asked of the DECLARATION. Two things
-            // make that the only answer that holds.
-            //
-            // `inner` is the same node with an out-parameter's `MaybeUninit`
-            // already peeled off, so asking it admits `&mut MaybeUninit<T>`,
-            // which borrows a slot rather than the object.
-            //
-            // And a converter's own metadata cannot say whether the borrowed
-            // thing is the object: `is_direct_handle` reads the projection, and
-            // a transparent bridge, a borrow, and a `convert!` composed over a
-            // handle all inherit that projection from the type underneath. Each
-            // of `&mut Box<Handle>`, `&mut &Handle` and `&mut ConvertedHandle`
-            // therefore answered yes while decoding a local the wrapper drops —
-            // the last one also loses the conversion stage `input_borrow` does
-            // not carry, so the call gets an `OwnedObject<Handle>` where the
-            // declared type was expected. `ptr_class!` is the declaration that
-            // means "the JVM holds a pointer to this object", and nothing else
-            // does.
-            //
-            // `mutable` off the `Ref` kind rather than through
-            // `is_exclusive_borrow`, which answers `false` for a
-            // `&mut MaybeUninit<T>` out-parameter — a slot whose writes are lost
-            // exactly as an exclusive borrow's are.
-            let writes_reach_the_caller = !*mutable
-                || self
-                    .types
-                    .get(&borrowed.key())
-                    .is_some_and(|cfg| cfg.is_opaque());
-            if writes_reach_the_caller {
-                let mutable = ty.is_exclusive_borrow();
-                if let Some(mut c) = self.input_wrapper_shape(
-                    WrapperShape::Borrow { mutable },
-                    &produced,
-                    inner,
-                    registry,
-                    emit,
-                ) {
-                    c.subs = vec![inner.key()];
-                    return Some(c);
-                }
-            }
-        }
-        // 4. Last resort: the spelling differs from something convertible only
-        //    by the wrappers the model erased. Nothing that resolves above
-        //    reaches here, so this adds routes rather than changing them.
-        self.input_transparent_bridge(ty, registry, emit)
+        let mut c =
+            self.input_wrapper_shape(WrapperShape::Optional, &produced, inner, registry, emit)?;
+        c.subs = vec![inner.key()];
+        Some(c)
     }
 
-    /// Select the output converter for `ty`: terminals, user wrappers, then
-    /// built-in structural wrappers.
-    pub(crate) fn select_output_type(
+    /// The `Vec<X>` / `&[X]` / `&Vec<X>` **input** shapes.
+    ///
+    /// A shared slice borrow has no owned `[T]` to decode into, so it reuses the
+    /// `Vec<_>` shape: the Java `List<T>` becomes an owned `Vec<T>` and the call
+    /// site borrows it (`&Vec<T>` deref-coerces to `&[T]`). `&mut [T]` is
+    /// deliberately not supported, because the decoded `Vec` is never written
+    /// back.
+    pub(crate) fn input_run(
         &self,
         ty: &prebindgen_registry::flat::TypeRef,
         registry: &impl Conversions<KotlinMeta>,
         emit: &prebindgen_registry::Emit,
     ) -> Option<ConverterImpl<KotlinMeta>> {
-        // What the converter YIELDS. This direction used to be handed only the
-        // spelling — `convert_crossing` fetched the reading and threw it away —
-        // so it detected its layers with `option_inner_type`/`vec_inner_type`,
-        // which read the last path segment's ident. A `Box<Option<T>>` answered
-        // "neither", and got no converter at all (#270).
         let produced = crate::jni::trait_impl::Produced::Reading(ty);
-
-        // 1. Terminal categories (incl. the terminal user-wrapper lookup).
-        if let Some(c) = self.output_terminal(ty, registry, emit) {
+        if let Some(elem) = ty.sequence_elem().filter(|_| !is_unsized_spelling(ty)) {
+            let mut c =
+                self.input_wrapper_shape(WrapperShape::Sequence, &produced, elem, registry, emit)?;
+            c.subs = vec![elem.key()];
             return Some(c);
         }
-        // 2. `Result<T, E>`: succeeds as `T`, routes `E` to the error sink.
-        //    Read off the model, which calls this shape `TypeKind::Fallible`.
-        //    `result_parts` covers a `Result` the adapter composed itself, which
-        //    the frontend never read.
-        if let Some((ok, err)) = fallible_parts(ty, emit) {
-            if let Some(c) = self.result_peel(ty, &ok, &err, registry, emit) {
-                return Some(c);
-            }
-        }
-        // 3. Built-in wrapper shapes, dispatched on what the model says the
-        //    type IS. An `Option<&Handle>` resolves via the shallow `Optional`
-        //    whose inner converter is the `&Handle` borrow entry (no deep
-        //    output handler).
-        if let Some(inner) = ty.optional_inner() {
-            if let Some(mut c) =
-                self.output_wrapper_shape(WrapperShape::Optional, &produced, inner, registry, emit)
-            {
-                c.subs = vec![inner.key()];
-                return Some(c);
-            }
+        // Two questions, and only the first is `kind`'s. That it is a run of
+        // values makes this arm a *candidate*; whether the decoded `Vec<T>` can
+        // be handed to the Rust function is a question about the **spelling**,
+        // because the generated glue is the one consumer that can tell
+        // `&Vec<T>` from `&Box<Vec<T>>`.
+        let prebindgen_registry::flat::TypeKind::Ref { mutable, .. } = ty.unwrapped().kind() else {
+            return None;
+        };
+        let inner = ty.borrow_target().expect("a borrow");
+        if *mutable || !decoded_vec_satisfies(inner) {
             return None;
         }
+        let elem = inner.sequence_elem()?;
+        let elem_ty = emit.spell(elem);
+        // The one place `produced` is NOT the crossing's spelling: there is no
+        // owned `[T]` to decode into, so the converter yields an owned `Vec<T>`
+        // and the call site borrows it.
+        let produced = crate::jni::trait_impl::Produced::Composed(syn::parse_quote!(Vec<#elem_ty>));
+        let mut c =
+            self.input_wrapper_shape(WrapperShape::Sequence, &produced, elem, registry, emit)?;
+        c.subs = vec![elem.key()];
+        Some(c)
+    }
+
+    /// `Result<T, E>` **output**: succeeds as `T`, routes `E` to the error sink.
+    ///
+    /// Read off the model, which calls this shape `TypeKind::Fallible`.
+    pub(crate) fn result_shape(
+        &self,
+        ty: &prebindgen_registry::flat::TypeRef,
+        registry: &impl Conversions<KotlinMeta>,
+        emit: &prebindgen_registry::Emit,
+    ) -> Option<ConverterImpl<KotlinMeta>> {
+        let (ok, err) = fallible_parts(ty, emit)?;
+        self.result_peel(ty, &ok, &err, registry, emit)
+    }
+
+    /// The `Option<X>` **output** shape.
+    ///
+    /// An `Option<&Handle>` resolves via the shallow `Optional` whose inner
+    /// conversion is the `&Handle` borrow's; there is no deep output handler.
+    pub(crate) fn output_optional(
+        &self,
+        ty: &prebindgen_registry::flat::TypeRef,
+        registry: &impl Conversions<KotlinMeta>,
+        emit: &prebindgen_registry::Emit,
+    ) -> Option<ConverterImpl<KotlinMeta>> {
+        let produced = crate::jni::trait_impl::Produced::Reading(ty);
+        let inner = ty.optional_inner()?;
+        let mut c =
+            self.output_wrapper_shape(WrapperShape::Optional, &produced, inner, registry, emit)?;
+        c.subs = vec![inner.key()];
+        Some(c)
+    }
+
+    /// The `Vec<X>` / `&[X]` **output** shapes.
+    ///
+    /// A shared slice borrow is a callback argument crossing native to JVM: it
+    /// builds a `List<T>` from the borrowed run. Dual of [`Self::input_run`],
+    /// and split the same way — `kind` says it is a borrow of a run of values,
+    /// and whether the generated Rust can iterate the borrow directly is a
+    /// question about the spelling.
+    pub(crate) fn output_run(
+        &self,
+        ty: &prebindgen_registry::flat::TypeRef,
+        registry: &impl Conversions<KotlinMeta>,
+        emit: &prebindgen_registry::Emit,
+    ) -> Option<ConverterImpl<KotlinMeta>> {
+        let produced = crate::jni::trait_impl::Produced::Reading(ty);
         if let Some(elem) = ty.sequence_elem().filter(|_| !is_unsized_spelling(ty)) {
-            if let Some(mut c) =
-                self.output_wrapper_shape(WrapperShape::Sequence, &produced, elem, registry, emit)
-            {
-                c.subs = vec![elem.key()];
-                return Some(c);
-            }
+            let mut c =
+                self.output_wrapper_shape(WrapperShape::Sequence, &produced, elem, registry, emit)?;
+            c.subs = vec![elem.key()];
+            return Some(c);
+        }
+        let prebindgen_registry::flat::TypeKind::Ref { mutable, .. } = ty.unwrapped().kind() else {
+            return None;
+        };
+        let inner = ty.borrow_target().expect("a borrow");
+        if *mutable || !decoded_vec_satisfies(inner) {
             return None;
         }
-        if let prebindgen_registry::flat::TypeKind::Ref { mutable, .. } = ty.unwrapped().kind() {
-            // The target through the accessor, as on the input side.
-            let inner = ty.borrow_target().expect("a borrow");
-            // `&[T]` shared slice (a callback argument crossing native→JVM):
-            // build a `List<T>` from the borrowed slice. Dual of the `&[T]`
-            // input branch, and the same split: `kind` says it is a borrow of a
-            // run of values; whether the generated Rust can iterate the borrow
-            // directly is a question about the SPELLING.
-            if !*mutable && decoded_vec_satisfies(inner) {
-                if let Some(elem) = inner.sequence_elem() {
-                    return self.output_slice(elem, registry, emit);
-                }
-            }
-            let mutable = ty.is_exclusive_borrow();
-            if let Some(mut c) = self.output_wrapper_shape(
-                WrapperShape::Borrow { mutable },
-                &produced,
-                inner,
-                registry,
-                emit,
-            ) {
-                c.subs = vec![inner.key()];
-                return Some(c);
-            }
-        }
-        // 4. Last resort: the spelling differs from something convertible only
-        //    by the wrappers the model erased. Dual of the input side's step 4,
-        //    and reached the same way — after every layer arm, so nothing that
-        //    resolves today changes route (#309).
-        self.output_transparent_bridge(ty, registry, emit)
+        let elem = inner.sequence_elem()?;
+        self.output_slice(elem, registry, emit)
     }
 }
 

--- a/prebindgen-jni/src/jni/trait_impl.rs
+++ b/prebindgen-jni/src/jni/trait_impl.rs
@@ -1413,10 +1413,39 @@ impl JniGenBuilder {
         registry: prebindgen_registry::RegistryBuilder<KotlinMeta>,
     ) -> Result<JniGen, prebindgen_registry::WriteRustError> {
         let decls = self.decls;
-        let registry = decls
-            .declare_into(registry)?
-            .validate_with(&decls)?
-            .convert_with(|crossing, built, emit| decls.convert_crossing(crossing, built, emit))?
+        let declared = decls.declare_into(registry)?.validate_with(&decls)?;
+        // A second holding of the model: `convert_with` consumes the builder,
+        // and the table outlives that call.
+        let model = declared.flat().clone();
+        let recipes = decls.recipes(&model).map_err(|errors| {
+            prebindgen_registry::ScanError::AdapterInvariant {
+                message: errors
+                    .iter()
+                    .map(|e| e.to_string())
+                    .collect::<Vec<_>>()
+                    .join("; "),
+            }
+        })?;
+        // JniGen overrides no site yet: every crossing takes its type's own row.
+        let bindings = prebindgen_registry::recipe::Bindings::default();
+        // The driver's state, carried between calls. The adapter borrows the
+        // partial registry view, which is lent per call and so is a different
+        // type each time; what it built is not, and outlives every one of them.
+        let mut compiled = Some(prebindgen_registry::recipe::Compiled::<
+            crate::jni::compile::JFrag,
+        >::default());
+        let registry = declared
+            .convert_with(|crossing, built, emit| {
+                let mut compiler = prebindgen_registry::recipe::Compiler::resume(
+                    &model,
+                    &recipes,
+                    &bindings,
+                    compiled.take().expect("the state is put back every call"),
+                );
+                let conv = decls.compile_crossing(&mut compiler, crossing, built, emit);
+                compiled = Some(compiler.finish());
+                conv
+            })?
             .build()?;
         // Post-resolve invariants, run once here so the writers are pure reads
         // and a `JniGen` is valid by construction.
@@ -1428,39 +1457,51 @@ impl JniGenBuilder {
 }
 
 impl Declarations {
-    /// Build the conversion for one crossing, against what is already built.
+    /// Build the conversion for one crossing by asking the table which row it
+    /// takes and the driver to compile that row.
     ///
-    /// `None` is *cannot*, never *not yet*: `crossings` hands them out
-    /// inner-first, so everything this could compose from is already in `built`.
-    fn convert_crossing(
-        &self,
+    /// `None` is *cannot*, never *not yet*: the crossings arrive inner-first,
+    /// so everything this could compose from is already in `built`.
+    fn compile_crossing<'v, R: Conversions<KotlinMeta>>(
+        &'v self,
+        compiler: &mut prebindgen_registry::recipe::Compiler<
+            '_,
+            crate::jni::compile::JCompile<'v, R>,
+        >,
         crossing: &Crossing,
-        built: &Building<'_, KotlinMeta>,
+        built: &'v R,
         emit: &prebindgen_registry::Emit,
     ) -> Option<ConverterImpl<KotlinMeta>> {
         let (dir, key) = crossing;
         // The reading the scan already took for this crossing, fetched by the
-        // key the crossing IS. This used to go `key -> to_type() -> reading`,
-        // and its own comment called that "the same door, one layer out" as the
-        // round trip #263 removed from `api/core`. The door is now keyed, so
-        // there is no spelling to rebuild (#284).
+        // key the crossing IS.
         let reading = built.reading(key)?;
-        match dir {
-            Direction::Input => self.select_input_type(&reading, built, emit).or_else(|| {
-                // `impl Fn(args)` that nothing else claimed. Callback args cross
-                // in the OPPOSITE direction, which is why their required-ness
-                // rides `immediate_edges` rather than this converter's `subs`.
-                // The arguments are `TypeRef`s on the classification, so nothing
-                // is re-extracted from the signature's syntax.
-                let prebindgen_registry::flat::TypeKind::Callback { args } =
-                    reading.unwrapped().kind()
-                else {
-                    return None;
-                };
-                self.dispatch_fn_input(args, built, emit)
-            }),
-            Direction::Output => self.select_output_type(&reading, built, emit),
+        // A callback is compiled whole rather than through the table. The
+        // registry derives a row that takes one apart into its arguments and
+        // compiles each of them, and a JniGen callback argument does not always
+        // have a conversion to compile: a sealed class reaches the JVM as a
+        // selector plus the live arm's slots, through a decomposition the table
+        // does not describe yet. Stating those arms as rows is what lets the
+        // derived callback row take over, and it is a later stage than this
+        // one.
+        if matches!(dir, Direction::Input) {
+            if let prebindgen_registry::flat::TypeKind::Callback { args } =
+                reading.unwrapped().kind()
+            {
+                return self.dispatch_fn_input(args, built, emit);
+            }
         }
+        let assembly = match dir {
+            Direction::Input => prebindgen_registry::recipe::Assembly::Construct,
+            Direction::Output => prebindgen_registry::recipe::Assembly::Deconstruct,
+        };
+        let mut adapter = crate::jni::compile::JCompile {
+            decls: self,
+            registry: built,
+        };
+        let crossing = prebindgen_registry::recipe::Crossing::new(reading, assembly);
+        let fragment = compiler.crossing(&mut adapter, &crossing).ok()?;
+        Some((*fragment).clone().conv)
     }
 
     pub fn declare_into(
@@ -1703,7 +1744,7 @@ fn flat_unit_enum<'r>(
 }
 
 impl Declarations {
-    fn dispatch_fn_input(
+    pub(crate) fn dispatch_fn_input(
         &self,
         args: &[prebindgen_registry::flat::TypeRef],
         registry: &impl Conversions<KotlinMeta>,


### PR DESCRIPTION
Stage 5 of [#451](https://github.com/milyin/prebindgen/pull/451), the umbrella for [#450](https://github.com/milyin/prebindgen/issues/450). Targets `recipe-table`, not `main`. [#455](https://github.com/milyin/prebindgen/pull/455) did the same thing for the C adapter and is already merged into that branch.

The second adapter moves onto the table stages 1–3 built. **Generated output is byte-identical** — `examples/regen-check.sh` is clean and all 264 `prebindgen-jni` tests pass unchanged — so what changed is where the answers come from, not what they are.

## Selection was a chain of guesses

`select_input_type` asked, in order: is there a terminal conversion for this type, else is it an optional, else a run, else a borrow, else does it differ from something convertible only by the wrappers the model erased. `select_output_type` was the same with `Result<T, E>` inserted second. A build script's `ptr_class!`, `data_class!`, `enum_class!` or `sealed_class!` reached that chain only by being a `contains_key` inside the first step.

It is a lookup now. Each Kotlin class declaration, and each `convert!`-declared conversion, becomes a **row** in a `Recipes` table built in `prebindgen-jni/src/jni/rows.rs`. A crossing takes the row its type declared, and a type nobody declared takes the row the registry derives from its kind.

## The structural recursion is the registry's now

Working out which arity layer a type is, looking the inner conversion up, and wrapping it by hand is what the two `select_*` functions spent most of their length on. The registry drives that walk and calls one hook per shape — `Compile::atomic`, `::optional`, `::sequence` in `prebindgen-jni/src/jni/compile.rs` — so what is left in `selector.rs` is four shape helpers with no dispatch in them: `input_optional`, `input_run` and their output twins, each holding the policy its own shape needs and none of them deciding which shape it is.

The subtleties survive intact and are now stated where they apply rather than in the middle of a chain: `Option<&T>` still tries the deep `OptionRef` before the shallow `Optional`, a wrapped optional borrow still stops rather than decoding a `jlong` as a `*mut &T`, `&[T]` still decodes to an owned `Vec<T>` the call site borrows, and `&mut T` still crosses only when the borrowed value lives on the Rust side.

## Two things JniGen states that the C adapter did not have to

**A fixed-size array is one wire value.** `[u8; N]` is a Kotlin `ByteArray` and `[i64; N]` a `LongArray`, bulk-copied with nothing boxed — not a run this adapter walks. The registry reads `[T; N]` as a run unless something says otherwise, and it compiles a run's element before offering the run to the adapter, so the terminal that claims the whole array would never be reached. JniGen therefore declares a row for every array type the model holds, which is #450's own answer to a disagreement about arity: it is a disagreement about the row. Declaring eagerly costs nothing, because a row for a crossing nobody uses is inert.

**A callback is still compiled whole.** The registry derives a row that takes a callback apart into its arguments and compiles each of them, and a JniGen callback argument does not always have a conversion to compile: a sealed class reaches the JVM as a selector plus the live arm's slots, through a decomposition that the table does not describe yet. Until those arms are rows, `Declarations::compile_crossing` answers a callback crossing with `dispatch_fn_input` directly, and the derived row takes over when they are.

## What the rows say, and what they will say

Every declared type states **one row with no parts**, and that is a true description of `prebindgen-jni` as it stands. `Shape::Atomic` means "the adapter emits the conversion itself, and how many wire values that costs is its business" — which is what a `data_class` does when it arrives as separate JNI parameters and is rebuilt inside one generated function, and what a `sealed_class` does when it becomes a selector plus the live arm's slots inside another.

Stating those parts is what lets `FlattenIn`, `InputKind` and the per-function plan bookkeeping be deleted, and it is a later stage: composing a product from its parts changes what is emitted, and a change whose diff is the emitted code should not also be carrying a mechanism swap.

## Checks

The 264 existing `prebindgen-jni` tests are unchanged and pass, which is the real check: they assert on emitted Rust and Kotlin, and the byte-identical regen — including the covertest and perftest bindings, which are committed — says the port did not move any of it.

Local gate clean: clippy and rustfmt on 1.85.0 and stable, `cargo doc` with warnings denied, `cargo test --all`, and `examples/regen-check.sh`.
