### PR TITLE
Key a callback argument's site to the row that names it (#450)

### DIFF
--- a/prebindgen-registry/src/recipe/compile.rs
+++ b/prebindgen-registry/src/recipe/compile.rs
@@ -497,15 +497,26 @@ impl<'a, C: Compile> Compiler<'a, C> {
     /// that signature shares; an adapter that wants a per-function answer
     /// compiles that position as its own root site through [`Self::site`].
     fn part(&mut self, adapter: &mut C, at: At<'_>, index: usize, ty: &TypeRef) -> Built<C> {
-        let crossing = Crossing::new(ty.clone(), at.crossing.assembly());
-        let site = Site {
-            owner: owner_of(at.crossing),
-            role: Role::Part {
-                of: at.crossing.key(),
-                recipe: at.recipe.clone(),
-                index,
-            },
-        };
+        self.part_doing(adapter, at, at.crossing.assembly(), index, ty)
+    }
+
+    /// [`Self::part`] where the part does a different job from the row.
+    ///
+    /// Only a callback: it is constructed, and the values passing through it
+    /// are deconstructed. The **site** is still the row's own — a part is
+    /// identified by the row that names it and its index, and a binding written
+    /// against that row has to match here — so only the part's `Crossing`
+    /// carries the swap.
+    fn part_doing(
+        &mut self,
+        adapter: &mut C,
+        at: At<'_>,
+        assembly: Assembly,
+        index: usize,
+        ty: &TypeRef,
+    ) -> Built<C> {
+        let crossing = Crossing::new(ty.clone(), assembly);
+        let site = Site::part(at.crossing, at.recipe, index);
         match self.bindings.resolve(&site, &crossing, self.recipes) {
             Some(bound) => self.row(adapter, &bound.crossing, &bound.recipe),
             None => Err(RecipeError::UnknownRow {
@@ -622,15 +633,11 @@ impl<'a, C: Compile> Compiler<'a, C> {
             .unwrap_or_default()
             .to_vec();
         // The one place the two jobs swap: Rust holds these values and pushes
-        // them out through the call.
-        let swapped = Crossing::new(at.crossing.spelled().clone(), assembly.swap());
-        let inner = At {
-            crossing: &swapped,
-            recipe: at.recipe,
-        };
+        // them out through the call. The swap is the argument's, not the site's
+        // — the parts still belong to the callback row that names them.
         let mut built = Vec::new();
         for (index, arg) in args.iter().enumerate() {
-            built.push(self.part(adapter, inner, index, arg)?);
+            built.push(self.part_doing(adapter, at, assembly.swap(), index, arg)?);
         }
         let refs: Vec<&C::Fragment> = built.iter().map(|f| &**f).collect();
         let mut cx = self.cx();
@@ -653,14 +660,7 @@ impl<'a, C: Compile> Compiler<'a, C> {
             let got = fragment.yields().mode;
             if !got.satisfies(part.mode) {
                 return Err(RecipeError::Composition {
-                    site: Site {
-                        owner: owner_of(at.crossing),
-                        role: Role::Part {
-                            of: at.crossing.key(),
-                            recipe: at.recipe.clone(),
-                            index,
-                        },
-                    },
+                    site: Site::part(at.crossing, at.recipe, index),
                     part: index,
                     wanted: part.mode,
                     got,
@@ -940,13 +940,4 @@ fn tolerated(role: &Role) -> Validity {
             Validity::Borrowed
         }
     }
-}
-
-/// The name a part's site is filed under: the crossed type.
-fn owner_of(crossing: &Crossing) -> syn::Ident {
-    crossing
-        .value()
-        .stripped_key()
-        .ident()
-        .unwrap_or_else(|| syn::Ident::new("_", proc_macro2::Span::call_site()))
 }

--- a/prebindgen-registry/src/recipe/site.rs
+++ b/prebindgen-registry/src/recipe/site.rs
@@ -26,6 +26,30 @@ pub struct Site {
     pub role: Role,
 }
 
+impl Site {
+    /// The site of one part of `of`'s row `recipe`.
+    ///
+    /// The one `Site` an adapter must be able to build **exactly**, because the
+    /// driver builds it too and the two have to meet: a per-part binding is
+    /// found by this key or not at all. Its `owner` is derived from the crossed
+    /// type rather than chosen, so composing one by hand is a guess — this is
+    /// the answer instead.
+    pub fn part(of: &Crossing, recipe: &RecipeId, index: usize) -> Self {
+        Self {
+            owner: of
+                .value()
+                .stripped_key()
+                .ident()
+                .unwrap_or_else(|| syn::Ident::new("_", proc_macro2::Span::call_site())),
+            role: Role::Part {
+                of: of.key(),
+                recipe: recipe.clone(),
+                index,
+            },
+        }
+    }
+}
+
 impl fmt::Display for Site {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}'s {}", self.owner, self.role)

--- a/prebindgen-registry/src/recipe/tests.rs
+++ b/prebindgen-registry/src/recipe/tests.rs
@@ -1355,6 +1355,58 @@ fn a_callbacks_arguments_do_the_other_job() {
 }
 
 #[test]
+fn a_callback_argument_is_a_part_of_the_callback_row_that_names_it() {
+    // The argument does the *other* job — Rust holds the value and pushes it
+    // out — but the part still belongs to the callback row, so a binding
+    // written against that row applies. Keying the site by the swapped
+    // crossing instead made every such binding silently miss.
+    let model = model(&[
+        SAMPLE,
+        "pub fn listen(on: impl Fn(Sample) + Send + Sync + 'static) {}",
+    ]);
+    let listen = model.function("listen").expect("listen");
+    let callback = listen.params[0].ty.clone();
+    let mut builder = Recipes::builder();
+    builder
+        .declare_default(ty(&model, "Sample"), id("whole"), Deconstructing::Atomic)
+        .declare(
+            ty(&model, "Sample"),
+            id("fields"),
+            Deconstructing::Product(Deconstruct::Fields(vec![Reach::Field(0)])),
+        );
+    let recipes = builder.build(&model).expect("table");
+
+    // The row this part belongs to: the callback, constructed.
+    let row = Crossing::new(callback.clone(), Assembly::Construct);
+    // Built the same way the driver builds it, which is the point of the
+    // helper: a per-part binding is found by this exact key or not at all.
+    let part = Site::part(&row, &RecipeId::derived(), 0);
+    let mut bound = Bindings::builder();
+    bound.bind(
+        part,
+        // The part's own crossing carries the swap; the site does not.
+        Crossing::new(ty(&model, "Sample"), Assembly::Deconstruct),
+        Ask::Recipe(id("fields")),
+        Origin::Part,
+    );
+    let bindings = bound.build(&recipes).expect("bindings");
+    let mut adapter = Recorder::default();
+    let mut compiler = Compiler::new(&model, &recipes, &bindings);
+
+    compiler
+        .site(&mut adapter, site("listen", 0), row)
+        .expect("compile");
+    assert!(
+        adapter
+            .calls
+            .iter()
+            .any(|c| c.starts_with("fields Sample deconstruct")),
+        "the per-part binding did not reach the callback argument: {:?}",
+        adapter.calls
+    );
+}
+
+#[test]
 fn a_callback_argument_is_overridden_by_compiling_it_as_its_own_site() {
     // A callback row is shared by every function whose callback has the same
     // signature, so a per-function answer cannot apply to it. `Role::CallbackArg`


### PR DESCRIPTION
Fixes a defect Copilot found reviewing umbrella [#451](https://github.com/milyin/prebindgen/pull/451) as a whole, which none of the five stage reviews caught. Targets `recipe-table`, not `main`.

## The bug

A callback is the one place the two jobs swap: the callback itself is **constructed** — Rust builds a callable out of what the foreign side sent — while the values passing through it are **deconstructed**, because Rust holds them and pushes them out through the call.

The driver expressed that by building a `Crossing` for the callback with the opposite `Assembly` and compiling each argument as a part *of that*. So the part's own crossing came out right, and its **site** did not:

```rust
Role::Part { of: <the callback, deconstructing>, .. }   // wrong
Role::Part { of: <the callback, constructing>,   .. }   // the row being compiled
```

A row is keyed by crossing **and** job, so the `of` key named a row that does not exist. Two consequences: a per-part binding written against the callback row could never match, silently, and a `RecipeError::Composition` from a callback argument pointed at the wrong crossing.

Nothing in tree hit it — neither adapter binds a callback argument per part today, and `prebindgen-jni` still compiles callbacks whole — which is why five stage reviews and the full suite missed it. It would have hit the first adapter to use the mechanism.

## The fix

The swap belongs to the argument, not to the site. `Compiler::part_doing` takes the part's `Assembly` explicitly and leaves `At` — and therefore the site — as the row being compiled; `Compiler::part` is it with the row's own job.

## `Site::part`, and why this needed one

Writing the regression test surfaced the reason the bug was easy to introduce and hard to notice: a `Site` for a part is not something a caller can reliably compose. Its `owner` is *derived* from the crossed type — and for a callback, whose `TypeKey` is `impl Fn (Sample) + Send + Sync + 'static`, there is no identifier to derive, so it falls back to `_`. An adapter binding a part had to guess that, and a wrong guess is a binding that is silently never found.

`Site::part(of, recipe, index)` is the answer instead. The driver builds part sites through it, the composition diagnostic builds its site through it, and an adapter writing a per-part binding builds the same key by construction rather than by matching an undocumented derivation.

## Checks

One regression test: it binds a callback argument at `Role::Part`, keyed by the callback row through `Site::part`, and asserts the bound row reaches the argument. Verified to **fail** against the old keying — reverting just the driver change and keeping the test reproduces the original defect, with the argument taking the default row instead of the bound one.

Local gate clean: clippy and rustfmt on 1.85.0 and stable, `cargo doc` with warnings denied, `cargo test --all`, and `examples/regen-check.sh` — no drift, since nothing in tree exercised the broken path.
