### PR TITLE
Enforce the two contracts a recipe cannot state itself (#450)

### DIFF
--- a/prebindgen-c/src/compile.rs
+++ b/prebindgen-c/src/compile.rs
@@ -42,22 +42,16 @@ impl Carrier for CFrag {
 impl CFrag {
     /// One of the adapter's existing converter builders, as a fragment.
     fn from_converter(at: At<'_>, conv: ConverterImpl<()>) -> Self {
-        let crossing = at.crossing;
-        let mode = crossing.mode();
+        let validity = validity_of(&conv, at.crossing.assembly());
         Self {
             destination: conv.destination,
             function: conv.function,
             niches: conv.niches,
             subs: conv.subs,
             yields: Yield {
-                ty: crossing.value().stripped_key(),
-                mode,
-                // A borrow is only usable while what it was reached through is
-                // alive; anything else the C side may keep.
-                validity: match mode {
-                    Mode::Owned => Validity::SelfSufficient,
-                    Mode::Shared | Mode::Exclusive => Validity::Borrowed,
-                },
+                ty: at.crossing.value().stripped_key(),
+                mode: at.crossing.mode(),
+                validity,
             },
         }
     }
@@ -72,6 +66,42 @@ impl CFrag {
             pre_stages: vec![],
             metadata: (),
         }
+    }
+}
+
+/// How long what this conversion produces stays usable.
+///
+/// A property of the **conversion**, not of how the crossing was spelled.
+/// Reading the spelling is wrong in both directions: a conversion may clone or
+/// allocate out of a borrow, and — the case C actually has — a conversion may
+/// hand C a pointer *into* a Rust value from a crossing that looks owned.
+fn validity_of(conv: &ConverterImpl<()>, assembly: Assembly) -> Validity {
+    match assembly {
+        // Rust to C. A `*const T` is the zero-copy borrow: `out_borrow_or_result`
+        // casts the Rust value's own address, and `repr_c_struct`'s reinterpret
+        // does the same, so the pointer dies with the value it points into. A
+        // `*mut` is a handle C now owns (`Box::into_raw`) or a block C must free
+        // (`__cbg_alloc_cstr`), and every by-value wire is a copy.
+        Assembly::Deconstruct => match &conv.destination {
+            syn::Type::Ptr(p) if p.mutability.is_none() => Validity::Borrowed,
+            _ => Validity::SelfSufficient,
+        },
+        // C to Rust: what the converter's own function hands back. A decode
+        // yielding `&'a T` borrows the caller's memory, which is right at a
+        // parameter and refused at a return.
+        Assembly::Construct => match &conv.function.sig.output {
+            syn::ReturnType::Type(_, ty) if produces_borrow(ty) => Validity::Borrowed,
+            _ => Validity::SelfSufficient,
+        },
+    }
+}
+
+/// Whether a converter's return type hands back a borrow — `&T`, or a
+/// `Result<&T, E>` whose success arm is one.
+fn produces_borrow(ty: &syn::Type) -> bool {
+    match ty {
+        syn::Type::Reference(_) => true,
+        _ => result_parts(ty).is_some_and(|(ok, _)| matches!(ok, syn::Type::Reference(_))),
     }
 }
 

--- a/prebindgen-jni/src/jni/compile.rs
+++ b/prebindgen-jni/src/jni/compile.rs
@@ -34,20 +34,48 @@ impl Carrier for JFrag {
 
 impl JFrag {
     fn new(at: At<'_>, conv: ConverterImpl<KotlinMeta>) -> Self {
-        let mode = at.crossing.mode();
+        let validity = validity_of(&conv, at.crossing.assembly());
         Self {
             conv,
             yields: Yield {
                 ty: at.crossing.value().stripped_key(),
-                mode,
-                // A borrow is only usable while what it was reached through is
-                // alive; anything else the JVM may keep.
-                validity: match mode {
-                    Mode::Owned => Validity::SelfSufficient,
-                    Mode::Shared | Mode::Exclusive => Validity::Borrowed,
-                },
+                mode: at.crossing.mode(),
+                validity,
             },
         }
+    }
+}
+
+/// How long what this conversion produces stays usable.
+///
+/// A property of the **conversion**, not of how the crossing was spelled. The
+/// two disagree and the spelling is the wrong one to read: a `&T` output over a
+/// declared opaque handle clones its referent into a fresh `Box`-handle, and a
+/// `&str` output copies into a JVM string, so both are self-sufficient although
+/// the crossing is a borrow.
+fn validity_of(conv: &ConverterImpl<KotlinMeta>, assembly: Assembly) -> Validity {
+    match assembly {
+        // Rust to the JVM. Every JNI wire value is a `jlong` the Rust side
+        // handed over or a JVM object the JVM now owns; nothing on this wire
+        // points into the Rust value it came from.
+        Assembly::Deconstruct => Validity::SelfSufficient,
+        // The JVM to Rust: what the converter's own function hands back. A
+        // decode that yields a borrow is valid only for the call, which is
+        // exactly right at a parameter and refused at a return.
+        Assembly::Construct => match &conv.function.sig.output {
+            syn::ReturnType::Type(_, ty) if produces_borrow(ty) => Validity::Borrowed,
+            _ => Validity::SelfSufficient,
+        },
+    }
+}
+
+/// Whether a converter's return type hands back a borrow — `&T`, or a
+/// `Result<&T, E>` whose success arm is one.
+fn produces_borrow(ty: &syn::Type) -> bool {
+    match ty {
+        syn::Type::Reference(_) => true,
+        _ => prebindgen_registry::types_util::result_parts(ty)
+            .is_some_and(|(ok, _)| matches!(ok, syn::Type::Reference(_))),
     }
 }
 

--- a/prebindgen-registry/src/recipe.rs
+++ b/prebindgen-registry/src/recipe.rs
@@ -1200,7 +1200,7 @@ impl fmt::Display for RecipeError {
                 got,
             } => write!(
                 f,
-                "part {part} of {site} needs a `{wanted}` and its recipe yields a `{got}`"
+                "part {part} of {site} needs a `{wanted}` and its fragment produces a `{got}`"
             ),
             RecipeError::Composition {
                 site,
@@ -1209,11 +1209,11 @@ impl fmt::Display for RecipeError {
                 got,
             } => write!(
                 f,
-                "part {part} of {site} needs `{wanted}` and its recipe yields `{got}`"
+                "part {part} of {site} needs `{wanted}` and its fragment produces `{got}`"
             ),
             RecipeError::Validity { site, needed, got } => write!(
                 f,
-                "{site} needs a {needed} value and its recipe yields a {got} one"
+                "{site} needs a {needed} value and its fragment produces a {got} one"
             ),
             RecipeError::CallbackDeclared { row, recipe } => write!(
                 f,

--- a/prebindgen-registry/src/recipe.rs
+++ b/prebindgen-registry/src/recipe.rs
@@ -735,7 +735,17 @@ impl<'a> Check<'a, '_> {
         match op {
             Construct::Identity(inner) => vec![(**inner).clone()],
             Construct::Call(func) => match self.function(func) {
-                Some(f) => f.params.iter().map(|p| p.ty.clone()).collect(),
+                Some(f) => {
+                    let parts = f.params.iter().map(|p| p.ty.clone()).collect();
+                    if !constructor_of(f, ty) {
+                        self.push(RecipeError::NotAConstructor {
+                            row: self.row.clone(),
+                            recipe: self.recipe.clone(),
+                            func: func.clone(),
+                        });
+                    }
+                    parts
+                }
                 None => Vec::new(),
             },
             Construct::Fields => match self.fields(ty) {
@@ -848,6 +858,22 @@ fn accessor_of(f: &Function, ty: &TypeRef) -> bool {
         return false;
     };
     value_key(&first.ty) == value_key(ty)
+}
+
+/// Whether `f` builds a value of `ty` — `fn(..) -> T`, or `fn(..) -> Result<T, E>`
+/// for a construction that can fail.
+///
+/// The constructing twin of [`accessor_of`]. A recipe names the function and the
+/// model supplies everything else, so the one thing left to check is that the
+/// function it names produces the type the row is filed under.
+fn constructor_of(f: &Function, ty: &TypeRef) -> bool {
+    // A fallible constructor is recognised by its return type, which is the same
+    // place the parts' fallibility is read from — the recipe never states it.
+    let built = match f.ret.fallible_parts() {
+        Some((ok, _err)) => ok,
+        None => &f.ret,
+    };
+    value_key(built) == value_key(ty)
 }
 
 /// The type's identity with a borrow and any transparent wrapper gone — what
@@ -1000,6 +1026,19 @@ pub enum RecipeError {
         /// The name that resolved to nothing.
         func: syn::Ident,
     },
+    /// A constructor was named where what it returns is not the row's type.
+    ///
+    /// The constructing twin of [`NotAnAccessor`](Self::NotAnAccessor). A
+    /// `Result<T, E>` return counts as building a `T`, because that is where a
+    /// construction's fallibility is read from.
+    NotAConstructor {
+        /// The crossing the recipe answers.
+        row: CrossingKey,
+        /// Which of the crossing's rows named it.
+        recipe: RecipeId,
+        /// The function whose return type does not match.
+        func: syn::Ident,
+    },
     /// An accessor was named where its first parameter is not the row's type.
     NotAnAccessor {
         /// The crossing the recipe answers.
@@ -1044,6 +1083,21 @@ pub enum RecipeError {
         site: Site,
         /// The precedence they share.
         origin: Origin,
+    },
+    /// A part yields a different Rust type from the one its edge needs.
+    ///
+    /// The type half of the composition contract; [`Composition`](Self::Composition)
+    /// is the ownership half. Both are checked at every part, this one first: a
+    /// part producing the wrong value is wrong however it is held.
+    ComposedType {
+        /// The part's own site.
+        site: Site,
+        /// Which part of the row.
+        part: usize,
+        /// What the constructor's parameter, field or accessor requires.
+        wanted: TypeKey,
+        /// What the part's fragment says it produces.
+        got: TypeKey,
     },
     /// A part yields something the edge it feeds cannot consume.
     Composition {
@@ -1103,6 +1157,11 @@ impl fmt::Display for RecipeError {
                 "row `{recipe}` of {row} names `{func}`, which no #[prebindgen] \
                  source declares"
             ),
+            RecipeError::NotAConstructor { row, recipe, func } => write!(
+                f,
+                "row `{recipe}` of {row} builds the value with `{func}`, which does \
+                 not return that type"
+            ),
             RecipeError::NotAnAccessor { row, recipe, func } => write!(
                 f,
                 "row `{recipe}` of {row} reaches a part through `{func}`, whose \
@@ -1133,6 +1192,15 @@ impl fmt::Display for RecipeError {
                 f,
                 "{site} is bound to two different rows by {origin}; one of them has to \
                  be written at a higher precedence"
+            ),
+            RecipeError::ComposedType {
+                site,
+                part,
+                wanted,
+                got,
+            } => write!(
+                f,
+                "part {part} of {site} needs a `{wanted}` and its recipe yields a `{got}`"
             ),
             RecipeError::Composition {
                 site,

--- a/prebindgen-registry/src/recipe/compile.rs
+++ b/prebindgen-registry/src/recipe/compile.rs
@@ -69,6 +69,16 @@ pub enum Validity {
     Borrowed,
 }
 
+impl Validity {
+    /// Whether a value of this validity can be used where `needed` is required.
+    ///
+    /// Only one direction fails: something the foreign side will keep cannot be
+    /// borrowed from a value the call is about to drop.
+    pub fn satisfies(self, needed: Validity) -> bool {
+        needed == Validity::Borrowed || self == Validity::SelfSufficient
+    }
+}
+
 impl fmt::Display for Validity {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(match self {
@@ -428,7 +438,7 @@ impl<'a, C: Compile> Compiler<'a, C> {
         let root = self.row(adapter, &bound.crossing, &bound.recipe)?;
         let needed = tolerated(&bound.site.role);
         let got = root.yields().validity;
-        if needed == Validity::SelfSufficient && got == Validity::Borrowed {
+        if !got.satisfies(needed) {
             return Err(RecipeError::Validity {
                 site: bound.site,
                 needed,
@@ -657,13 +667,28 @@ impl<'a, C: Compile> Compiler<'a, C> {
         let mut built = Vec::new();
         for (index, part) in parts.iter().enumerate() {
             let fragment = self.part(adapter, at, index, &part.ty)?;
-            let got = fragment.yields().mode;
-            if !got.satisfies(part.mode) {
+            let site = || Site::part(at.crossing, at.recipe, index);
+            let produced = fragment.yields();
+            // The type first: a part yielding the wrong Rust value is wrong
+            // however it is held. Normalized the way a crossing is keyed, so a
+            // fragment answering for `&T` or `Box<T>` satisfies a `T` part —
+            // holding it is the mode's question, immediately below.
+            let wanted = part_key(&part.ty);
+            if produced.ty != wanted {
+                return Err(RecipeError::ComposedType {
+                    site: site(),
+                    part: index,
+                    wanted,
+                    got: produced.ty,
+                }
+                .into());
+            }
+            if !produced.mode.satisfies(part.mode) {
                 return Err(RecipeError::Composition {
-                    site: Site::part(at.crossing, at.recipe, index),
+                    site: site(),
                     part: index,
                     wanted: part.mode,
-                    got,
+                    got: produced.mode,
                 }
                 .into());
             }
@@ -884,6 +909,16 @@ impl<'a, C: Compile> Compiler<'a, C> {
             _ => None,
         }
     }
+}
+
+/// A part's type as a fragment must answer for it.
+///
+/// The same normalization [`Crossing::key`] uses, so the two cannot disagree
+/// about what a fragment for a given part is called: a part spelled `&T` or
+/// `Box<T>` is answered by a fragment yielding `T`, and whether that fragment
+/// may be *held* the way the part needs is [`Mode`]'s question.
+fn part_key(ty: &TypeRef) -> TypeKey {
+    ty.borrow_target().unwrap_or(ty).stripped_key()
 }
 
 /// A field's name, or its position when the struct is positional.

--- a/prebindgen-registry/src/recipe/compile.rs
+++ b/prebindgen-registry/src/recipe/compile.rs
@@ -669,10 +669,10 @@ impl<'a, C: Compile> Compiler<'a, C> {
             let fragment = self.part(adapter, at, index, &part.ty)?;
             let site = || Site::part(at.crossing, at.recipe, index);
             let produced = fragment.yields();
-            // The type first: a part yielding the wrong Rust value is wrong
-            // however it is held. Normalized the way a crossing is keyed, so a
-            // fragment answering for `&T` or `Box<T>` satisfies a `T` part —
-            // holding it is the mode's question, immediately below.
+            // The type first: a part producing the wrong Rust value is wrong
+            // however it is held. Both sides are normalized the way a crossing
+            // is keyed, so a fragment answering for `&T` or `Box<T>` satisfies a
+            // `T` part — holding it is the mode's question, immediately below.
             let wanted = part_key(&part.ty);
             if produced.ty != wanted {
                 return Err(RecipeError::ComposedType {

--- a/prebindgen-registry/src/recipe/tests.rs
+++ b/prebindgen-registry/src/recipe/tests.rs
@@ -799,7 +799,7 @@ fn one_site_is_one_role_of_one_owner() {
 
 // ── Compiling rows into fragments ─────────────────────────────────────────
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 
 use crate::flat::Alternative;
 
@@ -827,6 +827,10 @@ struct Recorder {
     shared: HashSet<String>,
     /// Crossings whose fragment is valid only while its source is alive.
     borrowed: HashSet<String>,
+    /// Crossings whose fragment claims to produce a different Rust type — an
+    /// adapter answering for the wrong value, which nothing in the shape of a
+    /// recipe can prevent.
+    mistyped: HashMap<String, TypeKey>,
 }
 
 impl Recorder {
@@ -836,7 +840,11 @@ impl Recorder {
         Note {
             text,
             yields: Yield {
-                ty: at.crossing.value().stripped_key(),
+                ty: self
+                    .mistyped
+                    .get(&name)
+                    .cloned()
+                    .unwrap_or_else(|| at.crossing.value().stripped_key()),
                 mode: if self.shared.contains(&name) {
                     Mode::Shared
                 } else {
@@ -1488,6 +1496,144 @@ fn a_part_that_only_lends_cannot_feed_an_edge_that_consumes() {
         ),
         "{error:?}"
     );
+}
+
+#[test]
+fn a_part_producing_the_wrong_rust_type_is_refused() {
+    let model = model(&[
+        SAMPLE,
+        "pub fn sample_new(key: u32, payload: u64) -> Sample {}",
+    ]);
+    let mut builder = Recipes::builder();
+    builder.declare(
+        ty(&model, "Sample"),
+        id("fields"),
+        Constructing::Product(Construct::Call(ident("sample_new"))),
+    );
+    let recipes = builder.build(&model).expect("table");
+    let bindings = Bindings::default();
+    let mut adapter = Recorder::default();
+    // `payload` is a `u64`, and the adapter's fragment answers with a `u32`.
+    // Nothing about the recipe's shape can catch that: the recipe names the
+    // constructor and the model supplies the part types, so the only place the
+    // two can disagree is what the adapter says it produces.
+    adapter
+        .mistyped
+        .insert("u64".to_owned(), ty(&model, "u32").stripped_key());
+    let mut compiler = Compiler::new(&model, &recipes, &bindings);
+
+    let error = compiler
+        .site(
+            &mut adapter,
+            site("z_put", 0),
+            Crossing::new(ty(&model, "Sample"), Assembly::Construct),
+        )
+        .expect_err("the part produces the wrong type");
+    assert!(
+        matches!(
+            recipe_error(&error),
+            RecipeError::ComposedType { part: 1, wanted, got, .. }
+                if wanted.as_str() == "u64" && got.as_str() == "u32"
+        ),
+        "{error:?}"
+    );
+}
+
+#[test]
+fn a_part_answering_through_a_borrow_or_a_box_still_matches_its_type() {
+    // The type check normalizes the way a crossing is keyed, so a fragment
+    // yielding `T` answers a part spelled `&T` — whether it may be *held* that
+    // way is the mode check, which is separate and runs second.
+    let model = model(&[
+        SAMPLE,
+        "pub fn sample_of(key: &u32, payload: Box<u64>) -> Sample {}",
+    ]);
+    let mut builder = Recipes::builder();
+    builder.declare(
+        ty(&model, "Sample"),
+        id("fields"),
+        Constructing::Product(Construct::Call(ident("sample_of"))),
+    );
+    let recipes = builder.build(&model).expect("table");
+    let bindings = Bindings::default();
+    let mut adapter = Recorder::default();
+    let mut compiler = Compiler::new(&model, &recipes, &bindings);
+
+    compiler
+        .site(
+            &mut adapter,
+            site("z_put", 0),
+            Crossing::new(ty(&model, "Sample"), Assembly::Construct),
+        )
+        .expect("a borrow and a Box are answered by the bare type's fragment");
+}
+
+#[test]
+fn a_constructor_that_builds_another_type_is_refused() {
+    let model = model(&[
+        SAMPLE,
+        "pub struct Other { pub n: u32 }",
+        "pub fn make_other(key: u32) -> Other {}",
+    ]);
+    let mut builder = Recipes::builder();
+    builder.declare(
+        ty(&model, "Sample"),
+        id("fields"),
+        Constructing::Product(Construct::Call(ident("make_other"))),
+    );
+    let errors = builder
+        .build(&model)
+        .expect_err("make_other builds an Other");
+    assert!(
+        matches!(errors.as_slice(), [RecipeError::NotAConstructor { func, .. }] if func == "make_other"),
+        "{errors:?}"
+    );
+}
+
+#[test]
+fn a_fallible_constructor_builds_its_success_arm() {
+    // Where a construction's fallibility is read from is the return type, so
+    // `Result<Sample, E>` builds a `Sample` and nothing states it twice.
+    let model = model(&[
+        SAMPLE,
+        "pub struct Error { pub code: u32 }",
+        "pub fn sample_try(key: u32) -> Result<Sample, Error> {}",
+        "pub fn other_try(key: u32) -> Result<u32, Error> {}",
+    ]);
+    let mut good = Recipes::builder();
+    good.declare(
+        ty(&model, "Sample"),
+        id("fields"),
+        Constructing::Product(Construct::Call(ident("sample_try"))),
+    );
+    good.build(&model)
+        .expect("Result<Sample, _> builds a Sample");
+
+    let mut bad = Recipes::builder();
+    bad.declare(
+        ty(&model, "Sample"),
+        id("fields"),
+        Constructing::Product(Construct::Call(ident("other_try"))),
+    );
+    let errors = bad.build(&model).expect_err("Result<u32, _> does not");
+    assert!(
+        matches!(errors.as_slice(), [RecipeError::NotAConstructor { .. }]),
+        "{errors:?}"
+    );
+}
+
+#[test]
+fn a_constructor_reached_through_a_borrow_or_a_box_is_accepted() {
+    let model = model(&[SAMPLE, "pub fn sample_boxed(key: u32) -> Box<Sample> {}"]);
+    let mut builder = Recipes::builder();
+    builder.declare(
+        ty(&model, "Sample"),
+        id("fields"),
+        Constructing::Product(Construct::Call(ident("sample_boxed"))),
+    );
+    builder
+        .build(&model)
+        .expect("a Box<Sample> builds a Sample");
 }
 
 #[test]


### PR DESCRIPTION
Addresses the four findings Codex raised on umbrella [#451](https://github.com/milyin/prebindgen/pull/451). Targets `recipe-table`, not `main`.

Codex's framing is the right one and worth repeating: every declared row in both adapters is `Atomic` today, so none of these paths is reachable in tree. The green suite and the byte-identical output say nothing about them — which is exactly why they needed finding by reading rather than by running.

**Finding 1 was already fixed.** Codex reviewed at `c7eabe0`; [#460](https://github.com/milyin/prebindgen/pull/460) landed the same fix it describes — keep the parent row's identity for the `Role::Part` site, swap only the child crossing's assembly — and added `Site::part` so the driver and an adapter build that key the same way. The three below are new here.

## A constructor must build the row's type

`Construct::Call` verified that the named function exists and then took all of its parameters as parts. Nothing checked what it *returns*, so a row for `Sample` could name `fn make_other(..) -> Other` and `RecipesBuilder::build` accepted a recipe contradicting the model — against the table's own stated invariant that structural facts come from the model.

`RecipeError::NotAConstructor` is the constructing twin of `NotAnAccessor`, using the same `value_key` normalization, so a constructor returning `Box<Sample>` still builds a `Sample`. A `Result<T, E>` return counts as building a `T`: that is the same place a construction's fallibility is read from, and a recipe states neither.

## Validity is the conversion's fact, not the spelling's

Both adapters derived `Validity` centrally from `Crossing::mode` — a borrow is `Borrowed`, anything else `SelfSufficient`. Codex is right that those are different questions, and the counterexample is in tree: JniGen's borrowed opaque-handle output clones its referent into a fresh `Box` handle (`trait_impl.rs`), and its `&str` output copies into a JVM string. Both are self-sufficient although the crossing is `Shared`, and once `Compiler::site` owns return planning the central rule would have rejected both sound returns.

Each adapter now answers from what its own conversion emits, which is what #450 asks for:

- **JniGen**, Rust to the JVM: always self-sufficient. Every JNI wire value is a `jlong` the Rust side handed over or a JVM object the JVM now owns; nothing on that wire points into the Rust value it came from.
- **Cbindgen**, Rust to C: `*const T` is borrowed and everything else is not. That is the zero-copy case #450 cites — `out_borrow_or_result` casts the Rust value's own address, and `repr_c_struct`'s reinterpret does the same — while a `*mut` is a handle C owns or a block C must free.
- **Both**, foreign side to Rust: read off the converter function's own return type, including through a `Result`. A decode yielding `&'a T` borrows the caller's memory, which is right at a parameter and refused at a return.

`Validity::satisfies` replaces the open-coded comparison at the site check, so the one direction that fails is named once.

## The type half of the composition contract

`Yield::ty` was exposed and read nowhere. `Compiler::product` checked only `.mode`, so a fragment could claim or produce the wrong Rust value for a constructor argument or a field and still compose.

It is compared against the model-derived part type now, under the same normalization a crossing is keyed by — so a fragment yielding `T` still answers a part spelled `&T` or `Box<T>`, and whether it may be *held* that way remains the mode check, which runs second. `RecipeError::ComposedType` is the type half; `Composition` keeps the ownership half.

## Checks

Five new tests, and Codex is right that the recorder needed changing first: it always reported the crossing's expected type, so it could not express the failure at all. It now takes a `mistyped` map, which is the only way an adapter's fragment can lie about what it produces.

- a part producing the wrong Rust type is refused, naming both types;
- a part answering through a borrow or a `Box` still matches, so the normalization is pinned;
- a constructor returning another type is refused;
- a fallible constructor builds its success arm, and `Result<u32, E>` does not build a `Sample`;
- a constructor returning `Box<Sample>` is accepted.

Each was verified to **fail** with its fix reverted and the test kept.

Local gate clean: clippy and rustfmt on 1.85.0 and stable, `cargo doc` with warnings denied, `cargo test --all`, and `examples/regen-check.sh` — no drift, since nothing in tree reaches the changed paths.
