### PR TITLE
Check every part, not only a product's (#450)

### DIFF
--- a/prebindgen-registry/src/recipe.rs
+++ b/prebindgen-registry/src/recipe.rs
@@ -1089,12 +1089,19 @@ pub enum RecipeError {
     /// The type half of the composition contract; [`Composition`](Self::Composition)
     /// is the ownership half. Both are checked at every part, this one first: a
     /// part producing the wrong value is wrong however it is held.
+    ///
+    /// **Every** part, in the full sense — a product's fields and constructor
+    /// arguments, an optional's value, a run's element, and a callback's
+    /// arguments. Each is a crossing the row reaches, and each is checked in
+    /// the one place the driver reaches one.
     ComposedType {
         /// The part's own site.
         site: Site,
         /// Which part of the row.
         part: usize,
-        /// What the constructor's parameter, field or accessor requires.
+        /// What the edge requires: a constructor's parameter, a field, an
+        /// accessor's receiver, an optional's value, a run's element, or a
+        /// callback argument.
         wanted: TypeKey,
         /// What the part's fragment says it produces.
         got: TypeKey,
@@ -1105,7 +1112,9 @@ pub enum RecipeError {
         site: Site,
         /// Which part of the row.
         part: usize,
-        /// What the constructor's parameter, field or accessor requires.
+        /// How the edge requires it held: a product's declared parameter or
+        /// field mode, an optional's value, the mode a collection lends its
+        /// elements in, or a callback argument's own.
         wanted: Mode,
         /// What the part's fragment produces.
         got: Mode,

--- a/prebindgen-registry/src/recipe/compile.rs
+++ b/prebindgen-registry/src/recipe/compile.rs
@@ -506,36 +506,61 @@ impl<'a, C: Compile> Compiler<'a, C> {
     /// exported function, so it cannot answer for a row every function with
     /// that signature shares; an adapter that wants a per-function answer
     /// compiles that position as its own root site through [`Self::site`].
-    fn part(&mut self, adapter: &mut C, at: At<'_>, index: usize, ty: &TypeRef) -> Built<C> {
-        self.part_doing(adapter, at, at.crossing.assembly(), index, ty)
-    }
-
-    /// [`Self::part`] where the part does a different job from the row.
+    /// `assembly` is the row's own except for a callback, whose arguments do
+    /// the other job — Rust holds those values and pushes them out through the
+    /// call. The **site** is still the row's either way: a part is identified
+    /// by the row that names it and its index, and a binding written against
+    /// that row has to match here, so only the part's `Crossing` carries the
+    /// swap.
     ///
-    /// Only a callback: it is constructed, and the values passing through it
-    /// are deconstructed. The **site** is still the row's own — a part is
-    /// identified by the row that names it and its index, and a binding written
-    /// against that row has to match here — so only the part's `Crossing`
-    /// carries the swap.
-    fn part_doing(
+    /// `wanted` is what the edge needs, and every edge states it: a product's
+    /// declared parameter or field mode, an optional's value, the mode a
+    /// collection lends its elements in, a callback argument's own.
+    fn part(
         &mut self,
         adapter: &mut C,
         at: At<'_>,
         assembly: Assembly,
         index: usize,
         ty: &TypeRef,
+        wanted: Mode,
     ) -> Built<C> {
         let crossing = Crossing::new(ty.clone(), assembly);
         let site = Site::part(at.crossing, at.recipe, index);
-        match self.bindings.resolve(&site, &crossing, self.recipes) {
-            Some(bound) => self.row(adapter, &bound.crossing, &bound.recipe),
-            None => Err(RecipeError::UnknownRow {
+        let Some(bound) = self.bindings.resolve(&site, &crossing, self.recipes) else {
+            return Err(RecipeError::UnknownRow {
                 site,
                 crossing: crossing.key(),
                 recipe: super::RecipeId::new("<omitted>"),
             }
-            .into()),
+            .into());
+        };
+        let fragment = self.row(adapter, &bound.crossing, &bound.recipe)?;
+        // Both contracts, here rather than at each caller: an optional's value,
+        // a run's element and a callback's argument are parts as much as a
+        // product's are, and a check written per edge is a check an edge can be
+        // added without.
+        let produced = fragment.yields();
+        let expected = part_key(ty);
+        if produced.ty != expected {
+            return Err(RecipeError::ComposedType {
+                site,
+                part: index,
+                wanted: expected,
+                got: produced.ty,
+            }
+            .into());
         }
+        if !produced.mode.satisfies(wanted) {
+            return Err(RecipeError::Composition {
+                site,
+                part: index,
+                wanted,
+                got: produced.mode,
+            }
+            .into());
+        }
+        Ok(fragment)
     }
 
     fn constructing(
@@ -609,7 +634,9 @@ impl<'a, C: Compile> Compiler<'a, C> {
         at: At<'_>,
         inner: &TypeRef,
     ) -> Result<C::Fragment, CompileError<C::Error>> {
-        let inner = self.part(adapter, at, 0, inner)?;
+        // An optional holds its value the way the value itself is spelled.
+        let wanted = mode_of(inner);
+        let inner = self.part(adapter, at, at.crossing.assembly(), 0, inner, wanted)?;
         let mut cx = self.cx();
         adapter
             .optional(&mut cx, at, &inner)
@@ -622,8 +649,10 @@ impl<'a, C: Compile> Compiler<'a, C> {
         at: At<'_>,
         inner: &TypeRef,
     ) -> Result<C::Fragment, CompileError<C::Error>> {
-        let elements = element_mode(at.crossing);
-        let inner = self.part(adapter, at, 0, inner)?;
+        // A run's element is held the way the collection lends it, which is
+        // what the adapter is told and so what its fragment must satisfy.
+        let elements = element_mode(at.crossing, inner);
+        let inner = self.part(adapter, at, at.crossing.assembly(), 0, inner, elements)?;
         let mut cx = self.cx();
         adapter
             .sequence(&mut cx, at, elements, &inner)
@@ -647,7 +676,8 @@ impl<'a, C: Compile> Compiler<'a, C> {
         // — the parts still belong to the callback row that names them.
         let mut built = Vec::new();
         for (index, arg) in args.iter().enumerate() {
-            built.push(self.part_doing(adapter, at, assembly.swap(), index, arg)?);
+            let wanted = mode_of(arg);
+            built.push(self.part(adapter, at, assembly.swap(), index, arg, wanted)?);
         }
         let refs: Vec<&C::Fragment> = built.iter().map(|f| &**f).collect();
         let mut cx = self.cx();
@@ -666,33 +696,17 @@ impl<'a, C: Compile> Compiler<'a, C> {
     ) -> Result<C::Fragment, CompileError<C::Error>> {
         let mut built = Vec::new();
         for (index, part) in parts.iter().enumerate() {
-            let fragment = self.part(adapter, at, index, &part.ty)?;
-            let site = || Site::part(at.crossing, at.recipe, index);
-            let produced = fragment.yields();
-            // The type first: a part producing the wrong Rust value is wrong
-            // however it is held. Both sides are normalized the way a crossing
-            // is keyed, so a fragment answering for `&T` or `Box<T>` satisfies a
-            // `T` part — holding it is the mode's question, immediately below.
-            let wanted = part_key(&part.ty);
-            if produced.ty != wanted {
-                return Err(RecipeError::ComposedType {
-                    site: site(),
-                    part: index,
-                    wanted,
-                    got: produced.ty,
-                }
-                .into());
-            }
-            if !produced.mode.satisfies(part.mode) {
-                return Err(RecipeError::Composition {
-                    site: site(),
-                    part: index,
-                    wanted: part.mode,
-                    got: produced.mode,
-                }
-                .into());
-            }
-            built.push(fragment);
+            // `part.mode` rather than the type's own spelling: a product edge
+            // states what it needs — a constructor parameter, a field, an
+            // accessor's receiver — and `part` checks against that.
+            built.push(self.part(
+                adapter,
+                at,
+                at.crossing.assembly(),
+                index,
+                &part.ty,
+                part.mode,
+            )?);
         }
         let paired: Vec<(Part<'p>, &C::Fragment)> =
             parts.into_iter().zip(built.iter().map(|f| &**f)).collect();
@@ -947,19 +961,29 @@ fn mode_of(ty: &TypeRef) -> Mode {
     }
 }
 
-/// Whether iterating a run yields owned values, shared borrows or exclusive
-/// ones.
+/// How an element of a run is held once you have it.
 ///
-/// The collection's business, not the recipe's: `Vec<T>` gives its elements up,
-/// `&[T]` and `Cow<'_, [T]>` lend them, and `&mut [T]` lends them exclusively.
-fn element_mode(crossing: &Crossing) -> Mode {
-    match crossing.mode() {
-        // A run reached through a borrow lends its elements the same way it was
-        // reached: `&mut Vec<T>` yields `&mut T`, not `&T`.
+/// Two facts, and both belong to the type rather than to the recipe.
+///
+/// How the collection hands an element over: `Vec<T>` gives its elements up,
+/// `&[T]` and `Cow<'_, [T]>` lend them, and `&mut [T]` lends them exclusively —
+/// a run reached through a borrow lends the same way it was reached, so
+/// `&mut Vec<T>` yields `&mut T` and not `&T`.
+///
+/// And whether the element **is** a borrow: a `Vec<&T>` gives its elements up,
+/// and what it gives up is a reference. So an element spelled `&T` is held as a
+/// borrow however the collection hands it over, and reading only the collection
+/// would call that element owned.
+fn element_mode(crossing: &Crossing, elem: &TypeRef) -> Mode {
+    match mode_of(elem) {
+        // The element is a reference: handing it over hands over a borrow.
         borrowed @ (Mode::Shared | Mode::Exclusive) => borrowed,
-        Mode::Owned => match crossing.value().unwrapped().kind() {
-            TypeKind::Slice(_) => Mode::Shared,
-            _ => Mode::Owned,
+        Mode::Owned => match crossing.mode() {
+            borrowed @ (Mode::Shared | Mode::Exclusive) => borrowed,
+            Mode::Owned => match crossing.value().unwrapped().kind() {
+                TypeKind::Slice(_) => Mode::Shared,
+                _ => Mode::Owned,
+            },
         },
     }
 }

--- a/prebindgen-registry/src/recipe/tests.rs
+++ b/prebindgen-registry/src/recipe/tests.rs
@@ -1539,6 +1539,134 @@ fn a_part_producing_the_wrong_rust_type_is_refused() {
     );
 }
 
+/// Compile one crossing with `mistyped` in force, and hand back the refusal.
+fn mistyped_refusal(
+    model: &Flat,
+    spelling: &str,
+    lie_about: &str,
+    lie: &str,
+) -> CompileError<String> {
+    let recipes = Recipes::default();
+    let bindings = Bindings::default();
+    let mut adapter = Recorder::default();
+    adapter
+        .mistyped
+        .insert(lie_about.to_owned(), ty(model, lie).stripped_key());
+    let mut compiler = Compiler::new(model, &recipes, &bindings);
+    compiler
+        .site(
+            &mut adapter,
+            site("z_put", 0),
+            Crossing::new(ty(model, spelling), Assembly::Construct),
+        )
+        .expect_err("the inner fragment produces the wrong type")
+}
+
+#[test]
+fn an_optionals_value_is_a_part_and_is_checked_like_one() {
+    let model = model(&[SAMPLE]);
+    let error = mistyped_refusal(&model, "Option<u64>", "u64", "u32");
+    assert!(
+        matches!(
+            recipe_error(&error),
+            RecipeError::ComposedType { wanted, got, .. }
+                if wanted.as_str() == "u64" && got.as_str() == "u32"
+        ),
+        "{error:?}"
+    );
+}
+
+#[test]
+fn a_runs_element_is_a_part_and_is_checked_like_one() {
+    let model = model(&[SAMPLE]);
+    for spelling in ["Vec<u64>", "&[u64]", "[u64; 4]"] {
+        let error = mistyped_refusal(&model, spelling, "u64", "u32");
+        assert!(
+            matches!(
+                recipe_error(&error),
+                RecipeError::ComposedType { wanted, got, .. }
+                    if wanted.as_str() == "u64" && got.as_str() == "u32"
+            ),
+            "{spelling}: {error:?}"
+        );
+    }
+}
+
+#[test]
+fn a_callback_argument_is_a_part_and_is_checked_like_one() {
+    let model = model(&[
+        SAMPLE,
+        "pub fn listen(on: impl Fn(u64) + Send + Sync + 'static) {}",
+    ]);
+    let listen = model.function("listen").expect("listen");
+    let recipes = Recipes::default();
+    let bindings = Bindings::default();
+    let mut adapter = Recorder::default();
+    adapter
+        .mistyped
+        .insert("u64".to_owned(), ty(&model, "u32").stripped_key());
+    let mut compiler = Compiler::new(&model, &recipes, &bindings);
+
+    let error = compiler
+        .site(
+            &mut adapter,
+            site("listen", 0),
+            Crossing::new(listen.params[0].ty.clone(), Assembly::Construct),
+        )
+        .expect_err("the argument's fragment produces the wrong type");
+    assert!(
+        matches!(
+            recipe_error(&error),
+            RecipeError::ComposedType { wanted, got, .. }
+                if wanted.as_str() == "u64" && got.as_str() == "u32"
+        ),
+        "{error:?}"
+    );
+}
+
+#[test]
+fn a_runs_element_must_be_held_the_way_the_collection_lends_it() {
+    // A `Vec<T>` gives its elements up, so an element fragment that only lends
+    // cannot serve one — the mode half of the contract, on a non-product edge.
+    let model = model(&[SAMPLE]);
+    let recipes = Recipes::default();
+    let bindings = Bindings::default();
+    let mut adapter = Recorder::default();
+    adapter.shared.insert("u64".to_owned());
+    let mut compiler = Compiler::new(&model, &recipes, &bindings);
+
+    let error = compiler
+        .site(
+            &mut adapter,
+            site("z_put", 0),
+            Crossing::new(ty(&model, "Vec<u64>"), Assembly::Construct),
+        )
+        .expect_err("a Vec hands its elements over");
+    assert!(
+        matches!(
+            recipe_error(&error),
+            RecipeError::Composition {
+                wanted: Mode::Owned,
+                got: Mode::Shared,
+                ..
+            }
+        ),
+        "{error:?}"
+    );
+
+    // `&[T]` lends them, so the same fragment is fine there.
+    let mut adapter = Recorder::default();
+    adapter.shared.insert("u64".to_owned());
+    let mut compiler = Compiler::new(&model, &recipes, &bindings);
+    compiler
+        .site(
+            &mut adapter,
+            site("z_put", 0),
+            Crossing::new(ty(&model, "&[u64]"), Assembly::Construct),
+        )
+        .expect("a slice lends its elements");
+}
+
 #[test]
 fn a_part_answering_through_a_borrow_or_a_box_still_matches_its_type() {
     // The type check normalizes the way a crossing is keyed, so a fragment


### PR DESCRIPTION
Addresses the remaining blocker from Codex's [second review](https://github.com/milyin/prebindgen/pull/451#issuecomment-5360671516) of umbrella [#451](https://github.com/milyin/prebindgen/pull/451). Targets `recipe-table`, not `main`.

## The gap

[#461](https://github.com/milyin/prebindgen/pull/461) added the type half of the composition contract — and put it, along with the ownership half that was already there, inside `Compiler::product`'s loop. Three other edges reach a part and none of them went through it: an optional's value, a run's element, and a callback's arguments each called `part` and handed the fragment straight to the adapter.

So an adapter fragment claiming a `u64` yields a `u32` was refused inside a struct and accepted inside `Option<u64>`, `Vec<u64>` and `impl Fn(u64)`. Their ownership was not checked at all. The module contract and `ComposedType`'s own documentation both said the checks run "at every part", and three quarters of the parts were exempt.

## The fix

Both checks move into `part`, which is the one place the driver reaches a part — so an edge cannot be added without them, which is the property that was actually missing. Each edge now **states** the mode it needs rather than the check inferring one:

- a product: the part's declared mode — a constructor parameter, a field, an accessor's receiver;
- an optional: how its value is spelled;
- a run: the mode the collection lends its elements in;
- a callback argument: its own.

`part_doing` folds back into `part`, since every caller now passes a mode and there is only one function left.

## Widening the check found a second bug

`element_mode` read only how the collection hands an element over. A `Vec<&T>` gives its elements up — and what it gives up is a *reference*, so calling that element owned is wrong, and the element's own fragment correctly reporting a borrow was then refused.

An element spelled `&T` is held as a borrow however the collection hands it over. Two existing `prebindgen-c` tests cover that shape — `vec_of_borrows_calls_the_unsafe_element_converter` and `a_run_of_markers_is_refused` — and both failed the moment the check reached the sequence edge, which is how the bug surfaced. Both pass again.

That is worth noting for its own sake: it is the first of these contract defects that any adapter actually reached, and it was reachable only because the check moved to where the parts are.

## Checks

Five tests, on top of the existing 91 `prebindgen-c` and 264 `prebindgen-jni` ones:

- an optional's value, a run's element (over `Vec<T>`, `&[T]` and `[T; N]`), and a callback's argument each refused when the fragment produces the wrong type;
- a run's element refused when it only lends where the `Vec` hands over, and accepted for the same fragment under `&[T]`;
- `element_mode` over `Vec<&T>` and `&[&T]`, pinning the borrowed-element reading.

The first four were verified to **fail** with the checks left in the product loop.

Local gate clean: clippy and rustfmt on 1.85.0 and stable, `cargo doc` with warnings denied, `cargo test --all`, and `examples/regen-check.sh` byte-identical.
