### PR TITLE
Compose both layers when a part is reached through a container (#450)

### DIFF
--- a/prebindgen-registry/src/recipe.rs
+++ b/prebindgen-registry/src/recipe.rs
@@ -192,6 +192,33 @@ pub enum Mode {
 }
 
 impl Mode {
+    /// How a value of mode `self` is held when it is reached **through** a
+    /// container held as `outer`.
+    ///
+    /// Both layers decide it, and neither alone: reading through a shared
+    /// `&Option<T>` can only ever lend its value, however the value is spelled,
+    /// and a `Vec<&T>` hands its elements over while what it hands over is a
+    /// borrow. Composing them is what a nested reading needs and what asking
+    /// either layer on its own gets wrong in both directions — refusing the one
+    /// correct fragment, or accepting one the hook cannot be fed.
+    ///
+    /// | held through | this mode | reached as |
+    /// |---|---|---|
+    /// | owned | any | itself — the container gives its contents up |
+    /// | `&` | any | `&` — a shared view yields nothing stronger |
+    /// | `&mut` | `&` | `&` — an exclusive view of a shared reference is still shared |
+    /// | `&mut` | owned or `&mut` | `&mut` |
+    pub fn through(self, outer: Mode) -> Mode {
+        match outer {
+            Mode::Owned => self,
+            Mode::Shared => Mode::Shared,
+            Mode::Exclusive => match self {
+                Mode::Shared => Mode::Shared,
+                Mode::Owned | Mode::Exclusive => Mode::Exclusive,
+            },
+        }
+    }
+
     /// Whether a part yielded in this mode can be consumed where `wanted` is
     /// required. An edge declared `&T` accepts a borrow or an owned value; one
     /// declared `T` accepts only an owned value.

--- a/prebindgen-registry/src/recipe/compile.rs
+++ b/prebindgen-registry/src/recipe/compile.rs
@@ -634,8 +634,12 @@ impl<'a, C: Compile> Compiler<'a, C> {
         at: At<'_>,
         inner: &TypeRef,
     ) -> Result<C::Fragment, CompileError<C::Error>> {
-        // An optional holds its value the way the value itself is spelled.
-        let wanted = mode_of(inner);
+        // Both layers: an `Option<&T>` holds a borrow, and a `&Option<T>` can
+        // only lend whatever it holds. Reading either alone is wrong in a
+        // different direction — `&Option<T>` would demand an owned `T` that
+        // reading through the shared optional cannot produce, and
+        // `&mut Option<T>` would demand an owned one where it lends `&mut T`.
+        let wanted = mode_of(inner).through(at.crossing.mode());
         let inner = self.part(adapter, at, at.crossing.assembly(), 0, inner, wanted)?;
         let mut cx = self.cx();
         adapter
@@ -975,17 +979,20 @@ fn mode_of(ty: &TypeRef) -> Mode {
 /// borrow however the collection hands it over, and reading only the collection
 /// would call that element owned.
 fn element_mode(crossing: &Crossing, elem: &TypeRef) -> Mode {
-    match mode_of(elem) {
-        // The element is a reference: handing it over hands over a borrow.
+    // How the collection hands an element over, before the element's own
+    // spelling is considered: a run reached through a borrow lends the same way
+    // it was reached, and a bare `[T]` is only ever reached through one.
+    let lent_as = match crossing.mode() {
         borrowed @ (Mode::Shared | Mode::Exclusive) => borrowed,
-        Mode::Owned => match crossing.mode() {
-            borrowed @ (Mode::Shared | Mode::Exclusive) => borrowed,
-            Mode::Owned => match crossing.value().unwrapped().kind() {
-                TypeKind::Slice(_) => Mode::Shared,
-                _ => Mode::Owned,
-            },
+        Mode::Owned => match crossing.value().unwrapped().kind() {
+            TypeKind::Slice(_) => Mode::Shared,
+            _ => Mode::Owned,
         },
-    }
+    };
+    // Then the element's own, held through that. A `Vec<&T>` gives its elements
+    // up and what it gives up is a borrow; a `&[&mut T]` yields `&&mut T` and
+    // so cannot hand over the `&mut T` its element is spelled as.
+    mode_of(elem).through(lent_as)
 }
 
 /// The weakest validity a role accepts.

--- a/prebindgen-registry/src/recipe/tests.rs
+++ b/prebindgen-registry/src/recipe/tests.rs
@@ -823,7 +823,9 @@ impl Carrier for Note {
 struct Recorder {
     /// One line per hook call, in call order.
     calls: Vec<String>,
-    /// Crossings whose fragment is reached through a borrow.
+    /// Crossings whose fragment claims to be reached through a shared borrow
+    /// where the crossing itself is not — an adapter that lends where the
+    /// spelling hands over.
     shared: HashSet<String>,
     /// Crossings whose fragment is valid only while its source is alive.
     borrowed: HashSet<String>,
@@ -845,10 +847,13 @@ impl Recorder {
                     .get(&name)
                     .cloned()
                     .unwrap_or_else(|| at.crossing.value().stripped_key()),
+                // The crossing's own mode, as both real adapters report it;
+                // `shared` is an override for the tests that need a fragment to
+                // disagree with its spelling.
                 mode: if self.shared.contains(&name) {
                     Mode::Shared
                 } else {
-                    Mode::Owned
+                    at.crossing.mode()
                 },
                 validity: if self.borrowed.contains(&name) {
                     Validity::Borrowed
@@ -1253,6 +1258,146 @@ fn a_sequence_reads_its_element_mode_off_the_collection() {
     assert!(modes("&[u32]").contains("elements &"));
     assert!(modes("&Vec<u32>").contains("elements &"));
     assert!(modes("[u32; 4]").contains("elements owned"));
+}
+
+#[test]
+fn a_mode_reached_through_a_container_composes_both_layers() {
+    use Mode::{Exclusive, Owned, Shared};
+    // An owned container gives its contents up, so the value's own mode stands.
+    assert_eq!(Owned.through(Owned), Owned);
+    assert_eq!(Shared.through(Owned), Shared);
+    assert_eq!(Exclusive.through(Owned), Exclusive);
+    // A shared view yields nothing stronger, whatever it holds.
+    assert_eq!(Owned.through(Shared), Shared);
+    assert_eq!(Shared.through(Shared), Shared);
+    assert_eq!(Exclusive.through(Shared), Shared);
+    // An exclusive view of a shared reference is still shared; of anything
+    // else it is exclusive.
+    assert_eq!(Shared.through(Exclusive), Shared);
+    assert_eq!(Owned.through(Exclusive), Exclusive);
+    assert_eq!(Exclusive.through(Exclusive), Exclusive);
+}
+
+#[test]
+fn an_optionals_value_is_held_through_the_optional() {
+    // Reading through a shared `&Option<T>` can only lend its value, so the
+    // shared fragment is the correct one and demanding an owned `T` refuses it.
+    let model = model(&[SAMPLE]);
+    let recipes = Recipes::default();
+    let bindings = Bindings::default();
+
+    let mut adapter = Recorder::default();
+    adapter.shared.insert("Sample".to_owned());
+    let mut compiler = Compiler::new(&model, &recipes, &bindings);
+    compiler
+        .site(
+            &mut adapter,
+            site("z_put", 0),
+            Crossing::new(ty(&model, "&Option<Sample>"), Assembly::Construct),
+        )
+        .expect("a shared optional lends its value");
+
+    // The same fragment cannot serve an owned `Option<T>`, which hands it over.
+    let mut adapter = Recorder::default();
+    adapter.shared.insert("Sample".to_owned());
+    let mut compiler = Compiler::new(&model, &recipes, &bindings);
+    let error = compiler
+        .site(
+            &mut adapter,
+            site("z_put", 0),
+            Crossing::new(ty(&model, "Option<Sample>"), Assembly::Construct),
+        )
+        .expect_err("an owned optional hands its value over");
+    assert!(
+        matches!(
+            recipe_error(&error),
+            RecipeError::Composition {
+                wanted: Mode::Owned,
+                got: Mode::Shared,
+                ..
+            }
+        ),
+        "{error:?}"
+    );
+}
+
+#[test]
+fn an_exclusive_optional_lends_its_value_exclusively() {
+    // `&mut Option<T>` lends `&mut T`, so an owned fragment satisfies it and a
+    // merely shared one does not — the opposite direction from `&Option<T>`.
+    let model = model(&[SAMPLE]);
+    let recipes = Recipes::default();
+    let bindings = Bindings::default();
+
+    let mut adapter = Recorder::default();
+    adapter.shared.insert("Sample".to_owned());
+    let mut compiler = Compiler::new(&model, &recipes, &bindings);
+    let error = compiler
+        .site(
+            &mut adapter,
+            site("z_put", 0),
+            Crossing::new(ty(&model, "&mut Option<Sample>"), Assembly::Construct),
+        )
+        .expect_err("a shared fragment cannot serve an exclusive optional");
+    assert!(
+        matches!(
+            recipe_error(&error),
+            RecipeError::Composition {
+                wanted: Mode::Exclusive,
+                got: Mode::Shared,
+                ..
+            }
+        ),
+        "{error:?}"
+    );
+}
+
+#[test]
+fn a_shared_run_of_exclusive_references_caps_at_shared() {
+    // `&[&mut T]` yields `&&mut T`, so it cannot hand over the `&mut T` its
+    // element is spelled as. Reading the element alone asks `Exclusive` and
+    // accepts the exclusive fragment, which the sequence hook could not
+    // legally be fed; composing caps the ask at `Shared` and refuses it.
+    let model = model(&[SAMPLE]);
+    let recipes = Recipes::default();
+    let bindings = Bindings::default();
+    let mut adapter = Recorder::default();
+    let mut compiler = Compiler::new(&model, &recipes, &bindings);
+
+    let error = compiler
+        .site(
+            &mut adapter,
+            site("z_put", 0),
+            Crossing::new(ty(&model, "&[&mut Sample]"), Assembly::Construct),
+        )
+        .expect_err("a shared slice cannot lend its elements exclusively");
+    assert!(
+        matches!(
+            recipe_error(&error),
+            RecipeError::Composition {
+                wanted: Mode::Shared,
+                got: Mode::Exclusive,
+                ..
+            }
+        ),
+        "{error:?}"
+    );
+
+    // An exclusive run of exclusive references does hand them over.
+    let mut adapter = Recorder::default();
+    let mut compiler = Compiler::new(&model, &recipes, &bindings);
+    compiler
+        .site(
+            &mut adapter,
+            site("z_put", 0),
+            Crossing::new(ty(&model, "&mut [&mut Sample]"), Assembly::Construct),
+        )
+        .expect("an exclusive slice lends its elements exclusively");
+    assert!(
+        adapter.calls.iter().any(|c| c.contains("elements &mut")),
+        "{:?}",
+        adapter.calls
+    );
 }
 
 #[test]


### PR DESCRIPTION
Addresses the blocker from Codex's [third review](https://github.com/milyin/prebindgen/pull/451#issuecomment-5360960652) of umbrella [#451](https://github.com/milyin/prebindgen/pull/451). Targets `recipe-table`, not `main`.

## The gap

A part reached through a container is held by **two** facts: how the container itself is held, and how the value is spelled. [#462](https://github.com/milyin/prebindgen/pull/462) made every edge state the mode it needs, and two of those edges each read only one of the two.

`optional` read only the inner spelling. So `&Option<T>` demanded an owned `T` — which reading through a shared optional cannot produce — and refused the shared fragment that is the correct one. `&mut Option<T>` failed in the other direction: it lends `&mut T` and asked for owned.

`element_mode` read the element's own mode *before* consulting the collection, which was the shape of the fix in #462 and only half of it. So `&[&mut T]` asked `Exclusive` and **accepted** a fragment the sequence hook could not legally be fed: a shared slice yields `&&mut T` and cannot hand over the `&mut T`.

The two failure modes are worth separating. The optional cases refuse correct code; the slice case admits incorrect code. Only the first would ever be noticed by someone using the branch.

## The fix

`Mode::through` states the composition once:

| held through | this mode | reached as |
|---|---|---|
| owned | any | itself — the container gives its contents up |
| `&` | any | `&` — a shared view yields nothing stronger |
| `&mut` | `&` | `&` — an exclusive view of a shared reference is still shared |
| `&mut` | owned or `&mut` | `&mut` |

`optional` composes the inner spelling through the crossing's mode. `element_mode` computes how the collection lends first — a run reached through a borrow lends the way it was reached, a bare `[T]` only ever through one — and then holds the element's own mode through that, which keeps #462's `Vec<&T>` reading and adds the cap #462 missed.

## The recorder was flattering the tests

Writing the `&mut` regressions surfaced that the test recorder reported `Mode::Owned` for every fragment regardless of its crossing, where both real adapters report `at.crossing.mode()`. That made it unable to express the exclusive cases at all. It now reports the crossing's own mode, and the `shared` set stays as the override for the tests that need a fragment to deliberately disagree with its spelling.

## Checks

Four tests:

- the composition table itself, all nine combinations;
- `&Option<T>` accepting the shared fragment, and the same fragment still refused for an owned `Option<T>`;
- `&mut Option<T>` refusing a merely shared fragment;
- `&[&mut T]` refused, and `&mut [&mut T]` accepted with `elements &mut`.

The three regressions were verified to **fail** with the composition reverted and the tests kept.

Local gate clean: clippy and rustfmt on 1.85.0 and stable, `cargo doc` with warnings denied, `cargo test --all`, and `examples/regen-check.sh` byte-identical.
