### PR TITLE
Owning a value is enough to serve any edge (#450)

### DIFF
--- a/prebindgen-registry/src/recipe.rs
+++ b/prebindgen-registry/src/recipe.rs
@@ -219,15 +219,22 @@ impl Mode {
         }
     }
 
-    /// Whether a part yielded in this mode can be consumed where `wanted` is
-    /// required. An edge declared `&T` accepts a borrow or an owned value; one
-    /// declared `T` accepts only an owned value.
+    /// Whether a part produced in this mode can be consumed where `wanted` is
+    /// required.
+    ///
+    /// **Owning it is enough for anything**: a value handed over can be
+    /// consumed, lent, or lent mutably, so an owned production serves every
+    /// edge. A borrow serves only its own kind — a `&T` cannot be consumed and
+    /// cannot be written through, and a `&mut T` is not what an edge asking for
+    /// `&T` was written against.
+    ///
+    /// The rule fires only where an adapter's fragment **disagrees** with how
+    /// its crossing is spelled, since both sides are otherwise read off the same
+    /// type. `prebindgen-jni`'s borrowed opaque output is the live example: it
+    /// clones its referent into a fresh handle, so it produces owned where the
+    /// crossing says `&T`.
     pub fn satisfies(self, wanted: Mode) -> bool {
-        match wanted {
-            Mode::Owned => self == Mode::Owned,
-            Mode::Shared => self != Mode::Exclusive,
-            Mode::Exclusive => self == Mode::Exclusive,
-        }
+        self == Mode::Owned || self == wanted
     }
 }
 

--- a/prebindgen-registry/src/recipe/tests.rs
+++ b/prebindgen-registry/src/recipe/tests.rs
@@ -519,13 +519,18 @@ fn the_two_jobs_swap_only_once() {
 
 #[test]
 fn a_part_is_accepted_where_the_edge_can_consume_it() {
+    // Owning it is enough for anything: a value handed over can be consumed,
+    // lent, or lent mutably.
     assert!(Mode::Owned.satisfies(Mode::Owned));
     assert!(Mode::Owned.satisfies(Mode::Shared));
+    assert!(Mode::Owned.satisfies(Mode::Exclusive));
+    // A borrow serves only its own kind.
     assert!(!Mode::Shared.satisfies(Mode::Owned));
     assert!(Mode::Shared.satisfies(Mode::Shared));
     assert!(!Mode::Shared.satisfies(Mode::Exclusive));
-    assert!(Mode::Exclusive.satisfies(Mode::Exclusive));
+    assert!(!Mode::Exclusive.satisfies(Mode::Owned));
     assert!(!Mode::Exclusive.satisfies(Mode::Shared));
+    assert!(Mode::Exclusive.satisfies(Mode::Exclusive));
 }
 
 // ── Sites and row selection ───────────────────────────────────────────────
@@ -1328,6 +1333,19 @@ fn an_exclusive_optional_lends_its_value_exclusively() {
     let model = model(&[SAMPLE]);
     let recipes = Recipes::default();
     let bindings = Bindings::default();
+
+    // The positive half, and the one that matters: the *ordinary* fragment for
+    // a bare `T` reports owned, and it has to serve this edge. Asserting only
+    // the refusal below would pass with no usable fragment at all.
+    let mut adapter = Recorder::default();
+    let mut compiler = Compiler::new(&model, &recipes, &bindings);
+    compiler
+        .site(
+            &mut adapter,
+            site("z_put", 0),
+            Crossing::new(ty(&model, "&mut Option<Sample>"), Assembly::Construct),
+        )
+        .expect("an owned fragment serves an exclusive optional");
 
     let mut adapter = Recorder::default();
     adapter.shared.insert("Sample".to_owned());


### PR DESCRIPTION
Addresses the blocker from Codex's [fourth review](https://github.com/milyin/prebindgen/pull/451#issuecomment-5361135788) of umbrella [#451](https://github.com/milyin/prebindgen/pull/451). Targets `recipe-table`, not `main`.

## The bug

`&mut Option<T>` had **no usable fragment at all**. [#463](https://github.com/milyin/prebindgen/pull/463) correctly made that edge ask for `Exclusive`, and then:

- `part` builds the child crossing from the inner spelling, a bare `T`;
- the fragment for a bare `T` reports `Owned`, as both real adapters do;
- `Mode::satisfies` accepted only `Exclusive` for an exclusive edge.

So the ordinary owned fragment was refused, and a shared one was refused too. Reproduced before fixing:

```
part 0 of `Option<Sample>` (construct) needs `&mut` and its fragment produces `owned`
```

## The fix, and why it is the smaller of the two options

Codex offered two: make `Owned` satisfy an exclusive edge, or compile the child as an exclusive crossing. The first is right, because the asymmetry was the bug rather than a deliberate restriction.

`satisfies` already let an owned production serve a **shared** edge — own it, lend it — and then refused the same reasoning one step further for an exclusive one. Owning a value is enough for anything: it can be consumed, lent, or lent mutably. A borrow serves only its own kind, because a `&T` can neither be consumed nor written through, and a `&mut T` is not what an edge written against `&T` expects.

```rust
self == Mode::Owned || self == wanted
```

The second option would have changed which fragment gets built for every optional and sequence — a change to emitted code, on paths both adapters reach today, to fix a case neither reaches. That is the wrong trade.

The `&[&mut T]` refusal from #463 is unaffected: an exclusive production still does not serve a shared edge, which is what that refusal rests on. Verified by re-running its test.

## The test was the actual failure here

The previous `&mut Option<T>` test asserted only that a deliberately shared fragment is refused. That passes just as well when **nothing** can serve the edge, which is exactly what was happening — a negative-only test that cannot distinguish "the wrong fragment is rejected" from "every fragment is rejected".

It now asserts the positive case first, with the ordinary fragment and no overrides, and the compatibility table states all nine mode combinations rather than the seven it happened to cover. Both were verified to **fail** with the old predicate restored.

Local gate clean: clippy and rustfmt on 1.85.0 and stable, `cargo doc` with warnings denied, `cargo test --all`, and `examples/regen-check.sh` byte-identical.
