### PR TITLE
A fragment carries its own emission (#450)

### DIFF
--- a/prebindgen-c/src/lib.rs
+++ b/prebindgen-c/src/lib.rs
@@ -443,12 +443,14 @@ pub struct CbindgenBuilder {
     /// Where the `#[prebindgen]` items come from — see
     /// `JniGenBuilder::source`.
     pub(crate) sources: prebindgen_registry::flat::FlatBuilder,
-    /// Every conversion this binding compiled, in emission order.
+    /// Every conversion this binding compiled.
     ///
     /// Filled once by [`Self::build_with`] and read by
     /// [`Prebindgen::converter_items`]. It is what reaches the generated file,
     /// so a fragment no longer has to be expressible as one `ConverterImpl` to
-    /// be emitted — only to be looked up.
+    /// be emitted — only to be looked up. The writer sorts and de-duplicates by
+    /// function name, so the order here decides which of two same-named
+    /// functions wins and not where any of them lands.
     pub(crate) compiled_fns: Vec<syn::ItemFn>,
 }
 

--- a/prebindgen-c/src/lib.rs
+++ b/prebindgen-c/src/lib.rs
@@ -443,6 +443,13 @@ pub struct CbindgenBuilder {
     /// Where the `#[prebindgen]` items come from — see
     /// `JniGenBuilder::source`.
     pub(crate) sources: prebindgen_registry::flat::FlatBuilder,
+    /// Every conversion this binding compiled, in emission order.
+    ///
+    /// Filled once by [`Self::build_with`] and read by
+    /// [`Prebindgen::converter_items`]. It is what reaches the generated file,
+    /// so a fragment no longer has to be expressible as one `ConverterImpl` to
+    /// be emitted — only to be looked up.
+    pub(crate) compiled_fns: Vec<syn::ItemFn>,
 }
 
 /// A mangler over a single name component (Rust short name, base, or fn ident).

--- a/prebindgen-c/src/trait_impl.rs
+++ b/prebindgen-c/src/trait_impl.rs
@@ -1621,7 +1621,7 @@ impl CbindgenBuilder {
 
     /// [`Self::build`] over a registry described elsewhere — the test seam.
     pub(crate) fn build_with(
-        self,
+        mut self,
         registry: prebindgen_registry::RegistryBuilder<()>,
     ) -> Result<Cbindgen, prebindgen_registry::WriteRustError> {
         let declared = self.declare_into(registry)?.validate_with(&self)?;
@@ -1657,6 +1657,13 @@ impl CbindgenBuilder {
                 conv
             })?
             .build()?;
+        // What the compilation produced, kept for emission. The converter table
+        // stays the lookup index; this is what reaches the file.
+        self.compiled_fns = compiled
+            .fragments()
+            .into_iter()
+            .map(|f| f.function.clone())
+            .collect();
         self.validate_resolved(&registry)
             .map_err(|message| prebindgen_registry::ScanError::AdapterInvariant { message })?;
         Ok(Cbindgen {
@@ -1964,6 +1971,10 @@ impl Prebindgen for CbindgenBuilder {
     // with non-portable initializers valid in the generated file. (cbindgen
     // cannot evaluate a path initializer, so aliased consts don't surface
     // as `#define`s in the C header.)
+    fn converter_items(&self, _registry: &Registry<()>) -> Option<Vec<syn::ItemFn>> {
+        Some(self.compiled_fns.clone())
+    }
+
     fn source_module(&self) -> Option<&syn::Path> {
         self.source_module.as_ref()
     }

--- a/prebindgen-jni/src/jni/builder.rs
+++ b/prebindgen-jni/src/jni/builder.rs
@@ -147,6 +147,7 @@ impl Declarations {
 impl Default for Declarations {
     fn default() -> Self {
         Self {
+            compiled_fns: Vec::new(),
             package: String::new(),
             fun_name_mangle: None,
             ptr_class_name_mangle: None,

--- a/prebindgen-jni/src/jni/mod.rs
+++ b/prebindgen-jni/src/jni/mod.rs
@@ -569,6 +569,13 @@ pub struct Declarations {
     /// ([`JniGenBuilder::convert_input_body`] / [`JniGenBuilder::convert_output_body`]),
     /// keeping declarations order-independent and origin-qualified.
     pub(crate) convert_decls: Vec<ConvertDecl>,
+    /// Every conversion this binding compiled, in emission order.
+    ///
+    /// Filled once by `JniGenBuilder::build_with` and read by
+    /// `Prebindgen::converter_items`. It is what reaches the generated file, so
+    /// a fragment no longer has to be expressible as one `ConverterImpl` to be
+    /// emitted — only to be looked up.
+    pub(crate) compiled_fns: Vec<syn::ItemFn>,
 
     /// When `true` (default), generated wrappers wrap each call that
     /// touches an opaque handle in the per-call `withSortedHandleLocks`

--- a/prebindgen-jni/src/jni/mod.rs
+++ b/prebindgen-jni/src/jni/mod.rs
@@ -569,12 +569,14 @@ pub struct Declarations {
     /// ([`JniGenBuilder::convert_input_body`] / [`JniGenBuilder::convert_output_body`]),
     /// keeping declarations order-independent and origin-qualified.
     pub(crate) convert_decls: Vec<ConvertDecl>,
-    /// Every conversion this binding compiled, in emission order.
+    /// Every conversion this binding compiled.
     ///
     /// Filled once by `JniGenBuilder::build_with` and read by
     /// `Prebindgen::converter_items`. It is what reaches the generated file, so
     /// a fragment no longer has to be expressible as one `ConverterImpl` to be
-    /// emitted — only to be looked up.
+    /// emitted — only to be looked up. The writer sorts and de-duplicates by
+    /// function name, so the order here decides which of two same-named
+    /// functions wins and not where any of them lands.
     pub(crate) compiled_fns: Vec<syn::ItemFn>,
 
     /// When `true` (default), generated wrappers wrap each call that

--- a/prebindgen-jni/src/jni/trait_impl.rs
+++ b/prebindgen-jni/src/jni/trait_impl.rs
@@ -1412,7 +1412,7 @@ impl JniGenBuilder {
         self,
         registry: prebindgen_registry::RegistryBuilder<KotlinMeta>,
     ) -> Result<JniGen, prebindgen_registry::WriteRustError> {
-        let decls = self.decls;
+        let mut decls = self.decls;
         let declared = decls.declare_into(registry)?.validate_with(&decls)?;
         // A second holding of the model: `convert_with` consumes the builder,
         // and the table outlives that call.
@@ -1434,6 +1434,12 @@ impl JniGenBuilder {
         let mut compiled = Some(prebindgen_registry::recipe::Compiled::<
             crate::jni::compile::JFrag,
         >::default());
+        // A callback is still answered without the compiler — see
+        // `compile_crossing` — so no fragment carries its conversion and the
+        // fragment list alone would not reach the file. Collected here rather
+        // than papered over: this list empties when the derived callback row
+        // takes over.
+        let mut uncompiled: Vec<syn::ItemFn> = Vec::new();
         let registry = declared
             .convert_with(|crossing, built, emit| {
                 let mut compiler = prebindgen_registry::recipe::Compiler::resume(
@@ -1444,9 +1450,31 @@ impl JniGenBuilder {
                 );
                 let conv = decls.compile_crossing(&mut compiler, crossing, built, emit);
                 compiled = Some(compiler.finish());
+                if let (Some(c), true) =
+                    (conv.as_ref(), decls.is_callback_crossing(crossing, built))
+                {
+                    uncompiled.push(c.function.clone());
+                }
                 conv
             })?
             .build()?;
+        // What the compilation produced, kept for emission. The converter table
+        // stays the lookup index; this is what reaches the file.
+        decls.compiled_fns = compiled
+            .expect("the state is put back every call")
+            .fragments()
+            .into_iter()
+            // A JNI conversion already emits more than one function: a
+            // `convert!` with a fallible or binding-local step carries it as a
+            // pre-stage, and every one of them has to reach the file. This is
+            // the case the converter table could hold only because it kept a
+            // list beside the conversion; a fragment says it directly.
+            .flat_map(|f| {
+                std::iter::once(f.conv.function.clone())
+                    .chain(f.conv.pre_stages.iter().map(|s| s.function.clone()))
+            })
+            .chain(uncompiled)
+            .collect();
         // Post-resolve invariants, run once here so the writers are pure reads
         // and a `JniGen` is valid by construction.
         decls
@@ -1462,6 +1490,23 @@ impl Declarations {
     ///
     /// `None` is *cannot*, never *not yet*: the crossings arrive inner-first,
     /// so everything this could compose from is already in `built`.
+    /// Whether this crossing is the callback shape `compile_crossing` answers
+    /// without the compiler.
+    fn is_callback_crossing<R: Conversions<KotlinMeta>>(
+        &self,
+        crossing: &Crossing,
+        built: &R,
+    ) -> bool {
+        let (dir, key) = crossing;
+        matches!(dir, Direction::Input)
+            && built.reading(key).is_some_and(|r| {
+                matches!(
+                    r.unwrapped().kind(),
+                    prebindgen_registry::flat::TypeKind::Callback { .. }
+                )
+            })
+    }
+
     fn compile_crossing<'v, R: Conversions<KotlinMeta>>(
         &'v self,
         compiler: &mut prebindgen_registry::recipe::Compiler<
@@ -1776,6 +1821,13 @@ impl Prebindgen for Declarations {
     /// the Kotlin emitter reads it back to drive every wrapper /
     /// typed-handle / `JNIWrappers` signature.
     type Metadata = KotlinMeta;
+
+    fn converter_items(
+        &self,
+        _registry: &prebindgen_registry::Registry<KotlinMeta>,
+    ) -> Option<Vec<syn::ItemFn>> {
+        Some(self.compiled_fns.clone())
+    }
 
     // ── Structural type resolution ──────────────────────────────────────
     // Try the terminal categories, then the `Result` peel, then the built-in

--- a/prebindgen-registry/src/prebindgen.rs
+++ b/prebindgen-registry/src/prebindgen.rs
@@ -260,6 +260,22 @@ pub trait Prebindgen {
     /// [`Self::on_const`]: with a source module available, a named const
     /// re-emits as a path-alias to the source item instead of copying its
     /// initializer tokens. Default: `None`.
+    /// The converter functions this binding emits, if the adapter tracks them
+    /// itself.
+    ///
+    /// `None` — the default — means "read them off the converter table", which
+    /// is where they lived when a conversion could only ever be one
+    /// [`ConverterImpl`] per crossing. An adapter that compiles its own
+    /// fragments answers here instead, and is then free to emit a conversion
+    /// the table cannot hold: several functions for one crossing, or one that
+    /// occupies more than a single wire value.
+    ///
+    /// The table stays the **lookup** index either way. This says only who
+    /// decides what reaches the file.
+    fn converter_items(&self, _registry: &Registry<Self::Metadata>) -> Option<Vec<syn::ItemFn>> {
+        None
+    }
+
     fn source_module(&self) -> Option<&syn::Path> {
         None
     }

--- a/prebindgen-registry/src/recipe/compile.rs
+++ b/prebindgen-registry/src/recipe/compile.rs
@@ -344,9 +344,14 @@ type Built<C> = Result<Rc<<C as Compile>::Fragment>, CompileError<<C as Compile>
 /// and so cannot keep one [`Compiler`], but the fragments it built borrow
 /// nothing and outlive any of them.
 pub struct Compiled<F> {
-    fragments: HashMap<(TypeKey, Assembly, RecipeId), Rc<F>>,
+    fragments: HashMap<FragmentKey, Rc<F>>,
     required: BTreeSet<RequirementId>,
 }
+
+/// What a fragment is memoised under: the type **as the site spelled it**, the
+/// job, and which row answered. See the module docs on why the spelling and not
+/// the row's own identity.
+type FragmentKey = (TypeKey, Assembly, RecipeId);
 
 impl<F> Default for Compiled<F> {
     fn default() -> Self {
@@ -372,6 +377,21 @@ impl<F> Compiled<F> {
     /// Every helper a compiled fragment asked for, de-duplicated.
     pub fn required(&self) -> impl Iterator<Item = &RequirementId> {
         self.required.iter()
+    }
+
+    /// Every fragment this compilation built, in a deterministic order.
+    ///
+    /// What an adapter emits from once it stops routing its conversions back
+    /// through the converter table — see
+    /// [`Prebindgen::converter_items`](crate::Prebindgen::converter_items). The
+    /// order is by crossing key and then by row name, so a file written from
+    /// this is stable across runs.
+    pub fn fragments(&self) -> Vec<&F> {
+        let mut keyed: Vec<(&FragmentKey, &Rc<F>)> = self.fragments.iter().collect();
+        keyed.sort_by(|a, b| {
+            (a.0 .0.as_str(), a.0 .1, &a.0 .2).cmp(&(b.0 .0.as_str(), b.0 .1, &b.0 .2))
+        });
+        keyed.into_iter().map(|(_, f)| &**f).collect()
     }
 }
 

--- a/prebindgen-registry/src/write.rs
+++ b/prebindgen-registry/src/write.rs
@@ -81,8 +81,14 @@ pub fn write_rust<P: AsRef<Path>, E: Prebindgen>(
     //    everything below can reference them.
     items.extend(ext.prerequisites(registry, &emit));
 
-    // 1. Auto-generated converter wrappers (sorted by ident, deduped).
-    for (_, item_fn) in collect_converter_items(registry) {
+    // 1. Auto-generated converter wrappers (sorted by ident, deduped). From
+    //    the adapter when it tracks its own, else off the converter table —
+    //    see `Prebindgen::converter_items` for why that seam exists.
+    let converters = match ext.converter_items(registry) {
+        Some(from_adapter) => dedup_by_name(from_adapter),
+        None => collect_converter_items(registry),
+    };
+    for (_, item_fn) in converters {
         items.push(syn::Item::Fn(item_fn));
     }
 
@@ -172,6 +178,18 @@ pub fn write_rust<P: AsRef<Path>, E: Prebindgen>(
 ///
 /// Private: an internal step of [`write_rust`], not part of the
 /// adapter-facing surface this module exposes.
+/// Sort by name and keep the first of each, which is what the converter table
+/// does for the entries it holds — one function per name reaches the file
+/// however many crossings produced it.
+fn dedup_by_name(functions: Vec<syn::ItemFn>) -> Vec<(syn::Ident, syn::ItemFn)> {
+    let mut by_name: BTreeMap<String, (syn::Ident, syn::ItemFn)> = BTreeMap::new();
+    for function in functions {
+        let name = function.sig.ident.clone();
+        by_name.entry(name.to_string()).or_insert((name, function));
+    }
+    by_name.into_values().collect()
+}
+
 fn collect_converter_items<M>(registry: &Registry<M>) -> Vec<(syn::Ident, syn::ItemFn)> {
     let mut by_name: BTreeMap<String, (syn::Ident, syn::ItemFn)> = BTreeMap::new();
     let mut collect = |entry: &TypeEntry<M>| {


### PR DESCRIPTION
Stage 1 of [#465](https://github.com/milyin/prebindgen/pull/465), the umbrella finishing [#450](https://github.com/milyin/prebindgen/issues/450). Targets `recipe-finish`, not `main`.

## What both follow-ups are blocked on

[#458](https://github.com/milyin/prebindgen/issues/458) and [#459](https://github.com/milyin/prebindgen/issues/459) both wait on the same thing, and it is not the table. Every conversion still leaves its adapter as a `ConverterImpl`, whose `destination` is a single `syn::Type`. A C tagged union carries a `Vec<u8>` payload that is a pointer **and** a length — the arity separation #450 is built on, and precisely what one `destination` cannot name.

So a product cannot be composed from its parts while every part has to be expressible as one converter on its way out.

## The seam

`Prebindgen::converter_items` decides **who** says what reaches the generated file:

- `None`, the default, means "read them off the converter table" — where they lived when a conversion could only ever be one `ConverterImpl` per crossing.
- An adapter that compiles its own fragments answers there instead, and is then free to emit a conversion the table cannot hold: several functions for one crossing, or one occupying more than a single wire value.

Both adapters now answer it, from `Compiled::fragments` — the compiler already memoised every fragment it built, ordered by crossing key and row name so the file is stable across runs.

**The converter table is unchanged and still the lookup index.** `input_entry` / `output_entry` answer exactly as before, and the wrapper emitters that read them are untouched. Only the emission path moved.

## Two things the fragment list had to account for

Both are the point rather than obstacles.

**A JNI conversion already emits more than one function.** A `convert!` with a fallible or binding-local step carries it as a `pre_stage`, and every one has to reach the file. The converter table could hold that only by keeping a list *beside* the conversion; a fragment says it directly. Seven `values::convert_*` tests caught this the moment the fragment list was the source.

**JniGen still answers a callback without the compiler.** `compile_crossing` short-circuits `TypeKind::Callback` to `dispatch_fn_input`, so no fragment carries that conversion and the fragment list alone would not reach the file. Those are collected explicitly rather than papered over — the list empties when the derived callback row takes over, which is stage 5's business.

## Checks

**Byte-identical**: same functions, same dedup, same file. `examples/regen-check.sh` is clean, and all 91 `prebindgen-c` and 264 `prebindgen-jni` tests pass unchanged — which is the whole claim, since this stage changes who emits and not what.

That property ends here. From stage 2 on, composing a value from its parts emits different code and the regen diff becomes the review surface.

Local gate clean: clippy and rustfmt on 1.85.0 and stable, `cargo doc` with warnings denied, `cargo test --all`, `examples/regen-check.sh`.
