### PR TITLE
cbindgen: a data struct is its fields (#458)

### DIFF
--- a/examples/example-cbindgen/generated/example_flat_x86_64.rs
+++ b/examples/example-cbindgen/generated/example_flat_x86_64.rs
@@ -228,13 +228,9 @@ pub(crate) unsafe fn __cbg_in_Calculator(
 #[allow(non_snake_case, unused_variables, dead_code)]
 pub(crate) unsafe fn __cbg_in_Caption(v: caption_t) -> example_flat::Caption {
     example_flat::Caption {
-        id: v.id,
-        text: if v.text.is_null() {
-            ::std::string::String::new()
-        } else {
-            ::std::ffi::CStr::from_ptr(v.text).to_string_lossy().into_owned()
-        },
-        emphatic: ::core::ptr::read(v.emphatic.as_ptr() as *const u8) != 0,
+        id: __cbg_in_u64(v.id),
+        text: __cbg_in_String_field(v.text),
+        emphatic: __cbg_in_bool(v.emphatic),
     }
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
@@ -242,16 +238,16 @@ pub(crate) unsafe fn __cbg_in_Drawing(
     v: drawing_t,
 ) -> ::core::result::Result<example_flat::Drawing, ::std::string::String> {
     ::core::result::Result::Ok(example_flat::Drawing {
-        id: v.id,
+        id: __cbg_in_u64(v.id),
         shape: __cbg_in_Shape(v.shape)?,
     })
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
 pub(crate) unsafe fn __cbg_in_Foo(v: foo_t) -> example_flat::Foo {
     example_flat::Foo {
-        id: v.id,
-        x86_64_field: v.x86_64_field,
-        stable_field: v.stable_field,
+        id: __cbg_in_u64(v.id),
+        x86_64_field: __cbg_in_u64(v.x86_64_field),
+        stable_field: __cbg_in_u64(v.stable_field),
     }
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
@@ -446,6 +442,16 @@ pub(crate) unsafe fn __cbg_in_String(
                 ::std::string::String::from("invalid UTF-8 in String argument"),
             )
         }
+    }
+}
+#[allow(non_snake_case, unused_variables, dead_code)]
+pub(crate) unsafe fn __cbg_in_String_field(
+    v: *const ::core::ffi::c_char,
+) -> ::std::string::String {
+    if v.is_null() {
+        ::std::string::String::new()
+    } else {
+        ::std::ffi::CStr::from_ptr(v).to_string_lossy().into_owned()
     }
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
@@ -653,15 +659,15 @@ pub(crate) fn __cbg_out_Calculator(v: example_flat::Calculator) -> *mut calculat
 #[allow(non_snake_case, unused_variables, dead_code)]
 pub(crate) fn __cbg_out_Caption(v: example_flat::Caption) -> caption_t {
     caption_t {
-        id: v.id,
-        text: __cbg_alloc_cstr(v.text),
-        emphatic: ::core::mem::MaybeUninit::new(v.emphatic),
+        id: __cbg_out_u64(v.id),
+        text: __cbg_out_String(v.text),
+        emphatic: __cbg_out_bool_field(v.emphatic),
     }
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
 pub(crate) fn __cbg_out_Drawing(v: example_flat::Drawing) -> drawing_t {
     drawing_t {
-        id: v.id,
+        id: __cbg_out_u64(v.id),
         shape: __cbg_out_Shape(v.shape),
     }
 }
@@ -672,9 +678,9 @@ pub(crate) fn __cbg_out_Error(v: example_flat::Error) -> *mut ::core::ffi::c_cha
 #[allow(non_snake_case, unused_variables, dead_code)]
 pub(crate) fn __cbg_out_Foo(v: example_flat::Foo) -> foo_t {
     foo_t {
-        id: v.id,
-        x86_64_field: v.x86_64_field,
-        stable_field: v.stable_field,
+        id: __cbg_out_u64(v.id),
+        x86_64_field: __cbg_out_u64(v.x86_64_field),
+        stable_field: __cbg_out_u64(v.stable_field),
     }
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
@@ -750,6 +756,10 @@ pub(crate) fn __cbg_out_String(v: ::std::string::String) -> *mut ::core::ffi::c_
 #[allow(non_snake_case, unused_variables, dead_code)]
 pub(crate) fn __cbg_out_bool(v: bool) -> bool {
     v
+}
+#[allow(non_snake_case, unused_variables, dead_code)]
+pub(crate) fn __cbg_out_bool_field(v: bool) -> ::core::mem::MaybeUninit<bool> {
+    ::core::mem::MaybeUninit::new(v)
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
 pub(crate) fn __cbg_out_f64(v: f64) -> f64 {

--- a/examples/example-cbindgen/generated/example_flat_x86_64_internal_unstable.rs
+++ b/examples/example-cbindgen/generated/example_flat_x86_64_internal_unstable.rs
@@ -228,13 +228,9 @@ pub(crate) unsafe fn __cbg_in_Calculator(
 #[allow(non_snake_case, unused_variables, dead_code)]
 pub(crate) unsafe fn __cbg_in_Caption(v: caption_t) -> example_flat::Caption {
     example_flat::Caption {
-        id: v.id,
-        text: if v.text.is_null() {
-            ::std::string::String::new()
-        } else {
-            ::std::ffi::CStr::from_ptr(v.text).to_string_lossy().into_owned()
-        },
-        emphatic: ::core::ptr::read(v.emphatic.as_ptr() as *const u8) != 0,
+        id: __cbg_in_u64(v.id),
+        text: __cbg_in_String_field(v.text),
+        emphatic: __cbg_in_bool(v.emphatic),
     }
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
@@ -242,16 +238,16 @@ pub(crate) unsafe fn __cbg_in_Drawing(
     v: drawing_t,
 ) -> ::core::result::Result<example_flat::Drawing, ::std::string::String> {
     ::core::result::Result::Ok(example_flat::Drawing {
-        id: v.id,
+        id: __cbg_in_u64(v.id),
         shape: __cbg_in_Shape(v.shape)?,
     })
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
 pub(crate) unsafe fn __cbg_in_Foo(v: foo_t) -> example_flat::Foo {
     example_flat::Foo {
-        id: v.id,
-        x86_64_field: v.x86_64_field,
-        unstable_field: v.unstable_field,
+        id: __cbg_in_u64(v.id),
+        x86_64_field: __cbg_in_u64(v.x86_64_field),
+        unstable_field: __cbg_in_u64(v.unstable_field),
     }
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
@@ -446,6 +442,16 @@ pub(crate) unsafe fn __cbg_in_String(
                 ::std::string::String::from("invalid UTF-8 in String argument"),
             )
         }
+    }
+}
+#[allow(non_snake_case, unused_variables, dead_code)]
+pub(crate) unsafe fn __cbg_in_String_field(
+    v: *const ::core::ffi::c_char,
+) -> ::std::string::String {
+    if v.is_null() {
+        ::std::string::String::new()
+    } else {
+        ::std::ffi::CStr::from_ptr(v).to_string_lossy().into_owned()
     }
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
@@ -653,15 +659,15 @@ pub(crate) fn __cbg_out_Calculator(v: example_flat::Calculator) -> *mut calculat
 #[allow(non_snake_case, unused_variables, dead_code)]
 pub(crate) fn __cbg_out_Caption(v: example_flat::Caption) -> caption_t {
     caption_t {
-        id: v.id,
-        text: __cbg_alloc_cstr(v.text),
-        emphatic: ::core::mem::MaybeUninit::new(v.emphatic),
+        id: __cbg_out_u64(v.id),
+        text: __cbg_out_String(v.text),
+        emphatic: __cbg_out_bool_field(v.emphatic),
     }
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
 pub(crate) fn __cbg_out_Drawing(v: example_flat::Drawing) -> drawing_t {
     drawing_t {
-        id: v.id,
+        id: __cbg_out_u64(v.id),
         shape: __cbg_out_Shape(v.shape),
     }
 }
@@ -672,9 +678,9 @@ pub(crate) fn __cbg_out_Error(v: example_flat::Error) -> *mut ::core::ffi::c_cha
 #[allow(non_snake_case, unused_variables, dead_code)]
 pub(crate) fn __cbg_out_Foo(v: example_flat::Foo) -> foo_t {
     foo_t {
-        id: v.id,
-        x86_64_field: v.x86_64_field,
-        unstable_field: v.unstable_field,
+        id: __cbg_out_u64(v.id),
+        x86_64_field: __cbg_out_u64(v.x86_64_field),
+        unstable_field: __cbg_out_u64(v.unstable_field),
     }
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
@@ -750,6 +756,10 @@ pub(crate) fn __cbg_out_String(v: ::std::string::String) -> *mut ::core::ffi::c_
 #[allow(non_snake_case, unused_variables, dead_code)]
 pub(crate) fn __cbg_out_bool(v: bool) -> bool {
     v
+}
+#[allow(non_snake_case, unused_variables, dead_code)]
+pub(crate) fn __cbg_out_bool_field(v: bool) -> ::core::mem::MaybeUninit<bool> {
+    ::core::mem::MaybeUninit::new(v)
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
 pub(crate) fn __cbg_out_f64(v: f64) -> f64 {

--- a/prebindgen-c/src/compile.rs
+++ b/prebindgen-c/src/compile.rs
@@ -114,6 +114,32 @@ pub(crate) struct CCompile<'a, R> {
     pub(crate) registry: &'a R,
 }
 
+/// Whether the mirror's declared field wire and the conversion's are the same
+/// C type.
+///
+/// Compared **modulo pointer constness**, because the mirror declares one
+/// field and the two directions read it differently: a `String` field is
+/// `*mut c_char` in the struct C owns and frees, and the decode takes the same
+/// memory as `*const`. That is one wire and two readings of it, not two wires,
+/// and C says so with a cast rather than a second field.
+fn same_wire(declared: &syn::Type, produced: &syn::Type) -> bool {
+    fn strip(t: &syn::Type) -> syn::Type {
+        match t {
+            syn::Type::Ptr(p) => {
+                let inner = strip(&p.elem);
+                syn::parse_quote!(*const #inner)
+            }
+            other => other.clone(),
+        }
+    }
+    TypeKey::from_type(&strip(declared)) == TypeKey::from_type(&strip(produced))
+}
+
+/// Whether a generated converter can fail, read off its own return type.
+fn fallible(function: &syn::ItemFn) -> bool {
+    matches!(&function.sig.output, syn::ReturnType::Type(_, t) if is_result(t))
+}
+
 /// A refusal naming the crossing that could not be answered.
 fn refuse(at: At<'_>, why: &str) -> String {
     format!("Cbindgen: {} ({why})", at.crossing.key())
@@ -135,12 +161,28 @@ impl<R: Conversions<()>> Compile for CCompile<'_, R> {
 
     fn atomic(&mut self, cx: &mut Cx<'_>, at: At<'_>) -> Frag<Self> {
         let ty = at.crossing.spelled();
+        // The field row, where a value crosses differently **inside a
+        // `data_struct`'s mirror** than it does on its own. Two types have one:
+        // `bool`, whose field shares a mirror with the decode that normalises
+        // it, and `String`, whose field decodes a null pointer leniently so one
+        // field cannot make a whole struct's decode fallible.
+        if *at.recipe == crate::rows::in_field() {
+            let conv = match at.crossing.assembly() {
+                Assembly::Construct => self
+                    .gen
+                    .in_bool(ty)
+                    .or_else(|| self.gen.in_string_field(ty)),
+                // Only `bool` reads differently on the way out; a `String`
+                // field is allocated exactly as a `String` return is.
+                Assembly::Deconstruct => self.gen.out_bool_field(ty),
+            };
+            return self.wrap(at, "no field reading for this type", conv);
+        }
         let conv = match at.crossing.assembly() {
             Assembly::Construct => self
                 .gen
                 .in_custom(ty, self.registry, cx.emit())
                 .or_else(|| self.gen.in_opaque_handle(ty))
-                .or_else(|| self.gen.in_data_struct(ty, self.registry))
                 .or_else(|| self.gen.in_value_opaque(ty, self.registry))
                 .or_else(|| self.gen.in_enum(ty, self.registry))
                 .or_else(|| self.gen.in_tagged_union(ty, self.registry, cx.emit()))
@@ -225,8 +267,116 @@ impl<R: Conversions<()>> Compile for CCompile<'_, R> {
         Err(refuse(at, "Cbindgen declares no value-form rows"))
     }
 
-    fn fields(&mut self, _cx: &mut Cx<'_>, at: At<'_>, _parts: Parts<'_, Self>) -> Frag<Self> {
-        Err(refuse(at, "Cbindgen states no product rows yet"))
+    fn fields(&mut self, _cx: &mut Cx<'_>, at: At<'_>, parts: Parts<'_, Self>) -> Frag<Self> {
+        let ty = at.crossing.spelled();
+        let key = ty.key();
+        let c_struct = self.gen.c_type_ident(&key);
+        let src = self.gen.src_ty_of(&key);
+        // Each part converts itself. The three statements of a field's wire —
+        // this conversion, its twin in the other direction, and the mirror's
+        // own field list — collapse to one: the part's fragment says it, and
+        // `data_field_wire` is checked against it rather than re-deriving it.
+        for (part, frag) in parts {
+            let declared = self.gen.data_field_wire(&part.ty);
+            if declared
+                .as_ref()
+                .is_some_and(|w| !same_wire(w, &frag.destination))
+            {
+                return Err(refuse(
+                    at,
+                    &format!(
+                        "field `{}` crosses as `{}` and its mirror declares `{}`",
+                        part.name,
+                        frag.destination.to_token_stream(),
+                        declared.to_token_stream(),
+                    ),
+                ));
+            }
+        }
+        let names: Vec<syn::Ident> = parts
+            .iter()
+            .map(|(p, _)| format_ident!("{}", p.name))
+            .collect();
+        let calls: Vec<TokenStream> = parts
+            .iter()
+            .zip(&names)
+            .map(|((_, frag), fname)| {
+                let conv = &frag.function.sig.ident;
+                let call = quote!(#conv(v.#fname));
+                if fallible(&frag.function) {
+                    quote!(#call?)
+                } else {
+                    call
+                }
+            })
+            .collect();
+        let any_fallible = parts.iter().any(|(_, f)| fallible(&f.function));
+        let subs: Vec<TypeKey> = parts.iter().map(|(p, _)| p.ty.key()).collect();
+
+        match at.crossing.assembly() {
+            Assembly::Construct => {
+                let name = CbindgenBuilder::in_name_of(&key);
+                let function: syn::ItemFn = if any_fallible {
+                    syn::parse_quote!(
+                        #[allow(non_snake_case, unused_variables, dead_code)]
+                        pub(crate) unsafe fn #name(
+                            v: #c_struct,
+                        ) -> ::core::result::Result<#src, ::std::string::String> {
+                            ::core::result::Result::Ok(#src { #(#names: #calls),* })
+                        }
+                    )
+                } else {
+                    syn::parse_quote!(
+                        #[allow(non_snake_case, unused_variables, dead_code)]
+                        pub(crate) unsafe fn #name(v: #c_struct) -> #src {
+                            #src { #(#names: #calls),* }
+                        }
+                    )
+                };
+                Ok(CFrag::from_converter(
+                    at,
+                    ConverterImpl {
+                        subs,
+                        destination: syn::parse_quote!(#c_struct),
+                        function,
+                        pre_stages: vec![],
+                        niches: Niches::empty(),
+                        metadata: (),
+                    },
+                ))
+            }
+            Assembly::Deconstruct => {
+                let name = CbindgenBuilder::out_name_of(&key);
+                let function: syn::ItemFn = if any_fallible {
+                    syn::parse_quote!(
+                        #[allow(non_snake_case, unused_variables, dead_code)]
+                        pub(crate) fn #name(
+                            v: #src,
+                        ) -> ::core::result::Result<#c_struct, ::std::string::String> {
+                            ::core::result::Result::Ok(#c_struct { #(#names: #calls),* })
+                        }
+                    )
+                } else {
+                    syn::parse_quote!(
+                        #[allow(non_snake_case, unused_variables, dead_code)]
+                        pub(crate) fn #name(v: #src) -> #c_struct {
+                            #c_struct { #(#names: #calls),* }
+                        }
+                    )
+                };
+                Ok(CFrag::from_converter(
+                    at,
+                    ConverterImpl {
+                        subs,
+                        destination: syn::parse_quote!(#c_struct),
+                        function,
+                        pre_stages: vec![],
+                        niches: Niches::empty(),
+                        metadata: (),
+                    },
+                ))
+            }
+        }
     }
 
     fn choice(

--- a/prebindgen-c/src/lib.rs
+++ b/prebindgen-c/src/lib.rs
@@ -359,6 +359,7 @@ impl Cbindgen {
         Ok(prebindgen_registry::write::write_rust(
             &self.registry,
             &self.gen,
+            prebindgen_registry::write::Conversions::Compiled(&self.gen.compiled_fns),
             out_path,
         )?)
     }
@@ -445,8 +446,8 @@ pub struct CbindgenBuilder {
     pub(crate) sources: prebindgen_registry::flat::FlatBuilder,
     /// Every conversion this binding compiled.
     ///
-    /// Filled once by [`Self::build_with`] and read by
-    /// [`Prebindgen::converter_items`]. It is what reaches the generated file,
+    /// Filled once by [`Self::build_with`] and handed to `write_rust` as
+    /// `Conversions::Compiled`. It is what reaches the generated file,
     /// so a fragment no longer has to be expressible as one `ConverterImpl` to
     /// be emitted — only to be looked up. The writer sorts and de-duplicates by
     /// function name, so the order here decides which of two same-named

--- a/prebindgen-c/src/rows.rs
+++ b/prebindgen-c/src/rows.rs
@@ -13,8 +13,10 @@
 //! whatever the build script said rather than whichever guess fired first.
 
 use prebindgen_registry::{
-    flat::Flat,
-    recipe::{Constructing, Deconstructing, RecipeError, RecipeId, Recipes},
+    flat::{Flat, Type},
+    recipe::{
+        Construct, Constructing, Deconstruct, Deconstructing, Reach, RecipeError, RecipeId, Recipes,
+    },
 };
 
 use super::*;
@@ -22,6 +24,28 @@ use super::*;
 /// The row a type with no parts takes: the adapter emits the conversion itself.
 fn whole() -> RecipeId {
     RecipeId::new("whole")
+}
+
+/// The row a type crossing field by field takes.
+pub(crate) fn parts() -> RecipeId {
+    RecipeId::new("parts")
+}
+
+/// The row a value takes **inside a `data_struct`'s mirror**, where its wire
+/// differs from the one it takes on its own.
+///
+/// One crossing read two ways is two rows, and the site picks — which is what
+/// `declare_default` and `Ask::Recipe` exist for. Two types need it.
+///
+/// `bool`: a field arrives from C by value and may hold any byte until it is
+/// normalised, so it crosses as `MaybeUninit<bool>`, while a `bool` returned
+/// from Rust is already one of two values and passes through.
+///
+/// `String`: a field decodes a null pointer to an empty string, where a
+/// `String` parameter refuses one. Both readings were in the hand-written field
+/// walk; the row is what makes the difference visible.
+pub(crate) fn in_field() -> RecipeId {
+    RecipeId::new("field")
 }
 
 impl CbindgenBuilder {
@@ -48,6 +72,8 @@ impl CbindgenBuilder {
             .collect();
         declared.sort_by(|a, b| a.0.as_str().cmp(b.0.as_str()));
         declared.dedup_by(|a, b| a.0 == b.0);
+        let declared_keys: std::collections::HashSet<TypeKey> =
+            declared.iter().map(|(k, _)| k.clone()).collect();
 
         for (_key, origin) in declared {
             // The declarator's own tokens, re-parsed: a declared type may be
@@ -59,17 +85,133 @@ impl CbindgenBuilder {
             let Ok(ty) = model.classify(&spelled) else {
                 continue;
             };
-            // Every declared C shape is one row with no parts today, including
-            // the two that plainly have some: `in_data_struct` walks a struct's
-            // fields inside one generated function, and `in_tagged_union` walks
-            // an arm's payload inside another. `Atomic` is what a row says about
-            // that — the adapter emits the conversion itself — so it describes
-            // the adapter as it stands rather than as it will be. Stating those
-            // parts is what lets the two walks be deleted, and is the next
-            // stage.
+            // A `data_struct` converts each field and reassembles the
+            // converted fields into one C struct — many parts, one wire value,
+            // which is the pair #450 keeps apart. Everything else declared here
+            // is one wire value with nothing inside it that crosses on its own:
+            // an opaque handle, a value-opaque mirror, a C enum. A tagged union
+            // plainly has arms and is still `Atomic`, because `in_tagged_union`
+            // walks an arm's payload inside one generated function; stating
+            // those arms is the next stage.
+            if let Some(count) = self
+                .data
+                .contains_key(&_key)
+                .then(|| field_count(model, &_key))
+            {
+                let Some(count) = count else { continue };
+                let reaches: Vec<Reach> = (0..count).map(Reach::Field).collect();
+                rows.declare(
+                    ty.clone(),
+                    parts(),
+                    Deconstructing::Product(Deconstruct::Fields(reaches)),
+                )
+                .declare(ty, parts(), Constructing::Product(Construct::Fields));
+                continue;
+            }
             rows.declare(ty.clone(), whole(), Deconstructing::Atomic)
                 .declare(ty, whole(), Constructing::Atomic);
         }
+        // `bool`'s second row. Declared for every binding rather than only
+        // where a struct has such a field: a row for a crossing nobody uses is
+        // inert, and the alternative is walking every declared struct twice to
+        // find out.
+        let boolean = model
+            .classify(&syn::parse_quote!(bool))
+            .expect("bool is a scalar the model always classifies");
+        rows.declare_default(boolean.clone(), whole(), Deconstructing::Atomic)
+            .declare(boolean.clone(), in_field(), Deconstructing::Atomic)
+            .declare_default(boolean.clone(), whole(), Constructing::Atomic)
+            .declare(boolean, in_field(), Constructing::Atomic);
+        // `String`'s second row, unless the binding already declared one for it
+        // — a `convert!(String => ..)` states the whole-value reading itself,
+        // and the loop above has already filed it.
+        if let Ok(string) = model.classify(&syn::parse_quote!(String)) {
+            if !declared_keys.contains(&string.key()) {
+                // Output only ever has one reading, so `String` gets a second
+                // row in the constructing direction alone.
+                rows.declare_default(string.clone(), whole(), Constructing::Atomic)
+                    .declare(string, in_field(), Constructing::Atomic);
+            }
+        }
+
         rows.build(model)
     }
+
+    /// Which row each part of a declared product takes, where it is not the
+    /// part type's own default.
+    ///
+    /// Only `bool` inside a `data_struct` today — see [`in_field`].
+    pub(crate) fn bindings(
+        &self,
+        model: &Flat,
+        recipes: &Recipes,
+    ) -> Result<prebindgen_registry::recipe::Bindings, Vec<RecipeError>> {
+        // `recipe::Origin` is which declaration asked; `flat::Origin` is a
+        // captured item's own syntax. Both are in play here, so the one that
+        // arrives by glob keeps its name.
+        use prebindgen_registry::recipe::{
+            Ask, Assembly, Bindings, Crossing, Origin as Asked, Site,
+        };
+
+        let mut bound = Bindings::builder();
+        let mut declared: Vec<(TypeKey, Origin<syn::Type>)> = self
+            .data
+            .iter()
+            .map(|(k, c)| (k.clone(), c.rust_type.clone()))
+            .collect();
+        declared.sort_by(|a, b| a.0.as_str().cmp(b.0.as_str()));
+        for (key, origin) in declared {
+            let Ok(spelled) = syn::parse2::<syn::Type>(origin.declared_spelling()) else {
+                continue;
+            };
+            let Ok(ty) = model.classify(&spelled) else {
+                continue;
+            };
+            let Some(fields) = struct_fields(model, &key) else {
+                continue;
+            };
+            for (index, field) in fields.iter().enumerate() {
+                let kind = field.ty.unwrapped().kind();
+                let is_bool = matches!(
+                    kind,
+                    prebindgen_registry::flat::TypeKind::Scalar(
+                        prebindgen_registry::flat::ScalarKind::Bool
+                    )
+                );
+                let is_string = matches!(kind, prebindgen_registry::flat::TypeKind::String);
+                if !is_bool && !is_string {
+                    continue;
+                }
+                // A `String` reads differently only on the way in.
+                let directions: &[Assembly] = if is_bool {
+                    &[Assembly::Construct, Assembly::Deconstruct]
+                } else {
+                    &[Assembly::Construct]
+                };
+                for &assembly in directions {
+                    let of = Crossing::new(ty.clone(), assembly);
+                    bound.bind(
+                        Site::part(&of, &parts(), index),
+                        Crossing::new(field.ty.clone(), assembly),
+                        Ask::Recipe(in_field()),
+                        Asked::Part,
+                    );
+                }
+            }
+        }
+        bound.build(recipes)
+    }
+}
+
+/// The fields the model gives this declared struct.
+fn struct_fields(model: &Flat, key: &TypeKey) -> Option<Vec<prebindgen_registry::flat::Field>> {
+    match model.declared_type(&key.ident()?)? {
+        Type::Struct(s) => Some(s.fields.clone()),
+        _ => None,
+    }
+}
+
+/// How many fields the model gives this declared struct.
+fn field_count(model: &Flat, key: &TypeKey) -> Option<usize> {
+    Some(struct_fields(model, key)?.len())
 }

--- a/prebindgen-c/src/tests/rows.rs
+++ b/prebindgen-c/src/tests/rows.rs
@@ -89,22 +89,54 @@ fn an_enum_has_no_parts() {
 }
 
 #[test]
-fn a_data_struct_and_a_tagged_union_still_cross_whole() {
-    // Both plainly have parts, and both are one row with none today: the field
-    // walk lives inside one generated function per direction, which is exactly
-    // what `Atomic` says. Stating the parts is what deletes those walks.
+fn a_data_struct_is_its_fields() {
+    // Many parts, one wire value: each field converts itself and the converted
+    // fields are reassembled into one C struct. That pair is what #450 keeps
+    // apart, and the struct is where C shows both halves at once.
     let model = model();
-    let gen = Cbindgen::builder()
-        .data_struct(syn::parse_quote!(Sample))
-        .tagged_union(syn::parse_quote!(Reply));
+    let gen = Cbindgen::builder().data_struct(syn::parse_quote!(Sample));
     assert_eq!(
         rows_of(&gen, &model, "Sample"),
-        "construct whole:atomic, deconstruct whole:atomic"
+        "construct parts:product, deconstruct parts:product"
     );
+}
+
+#[test]
+fn a_tagged_union_still_crosses_whole() {
+    // It plainly has arms, and is still one row with no parts: `in_tagged_union`
+    // walks an arm's payload inside one generated function, which is exactly
+    // what `Atomic` says. Stating those arms is the next stage.
+    let model = model();
+    let gen = Cbindgen::builder().tagged_union(syn::parse_quote!(Reply));
     assert_eq!(
         rows_of(&gen, &model, "Reply"),
         "construct whole:atomic, deconstruct whole:atomic"
     );
+}
+
+#[test]
+fn a_value_read_two_ways_inside_a_struct_has_two_rows() {
+    // `bool` and `String` cross differently inside a `data_struct`'s mirror
+    // than they do on their own, which is two rows of one crossing with the
+    // site picking — the table's own answer to one crossing with two wires.
+    let model = model();
+    let gen = Cbindgen::builder().data_struct(syn::parse_quote!(Sample));
+    let recipes = gen.recipes(&model).expect("rows");
+
+    for (spelling, assembly, expected) in [
+        ("bool", Assembly::Construct, 2),
+        ("bool", Assembly::Deconstruct, 2),
+        // A `String` reads differently only on the way in.
+        ("String", Assembly::Construct, 2),
+        ("String", Assembly::Deconstruct, 0),
+    ] {
+        let key = Crossing::new(ty(&model, spelling), assembly).key();
+        assert_eq!(recipes.rows(&key).len(), expected, "{spelling} {assembly}");
+    }
+    // The default is the whole-value reading in every case; the field reading
+    // is reached only by a part that asks for it.
+    let key = Crossing::new(ty(&model, "bool"), Assembly::Construct).key();
+    assert_eq!(recipes.default_of(&key).unwrap().as_str(), "whole");
 }
 
 #[test]

--- a/prebindgen-c/src/trait_impl.rs
+++ b/prebindgen-c/src/trait_impl.rs
@@ -43,77 +43,6 @@ impl CbindgenBuilder {
         })
     }
 
-    /// Data struct: decode each field from its C wire — infallible.
-    pub(crate) fn in_data_struct(
-        &self,
-        ty: &TypeRef,
-        r: &impl Conversions<()>,
-    ) -> Option<ConverterImpl<()>> {
-        let key = ty.key();
-        if !self.data.contains_key(&key) {
-            return None;
-        }
-        let fields = self.struct_fields(r, &ty.key())?;
-        let name = Self::in_name_of(&ty.key());
-        let c_struct = self.c_type_ident(&ty.key());
-        let src = self.src_ty_of(&ty.key());
-        let mut inits: Vec<TokenStream> = Vec::new();
-        let mut subs: Vec<TypeKey> = Vec::new();
-        let mut fallible = false;
-        for (fname, fty) in &fields {
-            if r_is_string(fty) {
-                inits.push(quote!(#fname: if v.#fname.is_null() {
-                    ::std::string::String::new()
-                } else {
-                    ::std::ffi::CStr::from_ptr(v.#fname).to_string_lossy().into_owned()
-                }));
-            } else if self.tagged_unions.contains_key(&fty.key()) {
-                // A sum field crosses by value as its mirror; its own converter
-                // validates the tag and rebuilds the live arm, which is what
-                // makes this whole decode fallible.
-                let conv = Self::in_name_of(&fty.key());
-                subs.push(fty.key());
-                fallible = true;
-                inits.push(quote!(#fname: #conv(v.#fname)?));
-            } else if r_is_bool(fty) {
-                // #170 instance 2: the field's wire is `MaybeUninit<bool>`, so
-                // the byte C wrote is normalised here — a Rust `bool` never
-                // holds it unchecked.
-                let read = bool_in_expr(quote!(v.#fname));
-                inits.push(quote!(#fname: #read));
-            } else {
-                inits.push(quote!(#fname: v.#fname));
-            }
-        }
-        // Only a union field can fail; a struct of strings and scalars keeps
-        // its infallible signature (and its callers keep theirs).
-        let function: syn::ItemFn = if fallible {
-            syn::parse_quote!(
-                #[allow(non_snake_case, unused_variables, dead_code)]
-                pub(crate) unsafe fn #name(
-                    v: #c_struct,
-                ) -> ::core::result::Result<#src, ::std::string::String> {
-                    ::core::result::Result::Ok(#src { #(#inits),* })
-                }
-            )
-        } else {
-            syn::parse_quote!(
-                #[allow(non_snake_case, unused_variables, dead_code)]
-                pub(crate) unsafe fn #name(v: #c_struct) -> #src {
-                    #src { #(#inits),* }
-                }
-            )
-        };
-        Some(ConverterImpl {
-            subs,
-            destination: syn::parse_quote!(#c_struct),
-            function,
-            pre_stages: vec![],
-            niches: Niches::empty(),
-            metadata: (),
-        })
-    }
-
     /// The mirror field idents to null in a by-value consume's gravestone write-back,
     /// for a `repr_c_struct` (`generate_mirror`) whose owned-pointer fields are all
     /// **nullable** (`Option<Box<T>>`). `Some(idents)` (possibly empty — a pure
@@ -405,6 +334,78 @@ impl CbindgenBuilder {
             #[allow(non_snake_case, unused_variables, dead_code)]
             pub(crate) unsafe fn #name(v: #wire) -> bool {
                 #read
+            }
+        );
+        Some(ConverterImpl {
+            subs: vec![],
+            destination: wire,
+            function,
+            pre_stages: vec![],
+            niches: Niches::empty(),
+            metadata: (),
+        })
+    }
+
+    /// `String` **input from a `data_struct`'s mirror**: a null `char *`
+    /// decodes to an empty string rather than refusing.
+    ///
+    /// The second reading a `String` has, and the reason it needs a row of its
+    /// own. A `String` **parameter** is a pointer the caller chose to pass, so
+    /// a null one is a caller error and [`Self::in_string`] says so. A `String`
+    /// **field** shares a struct with every other field, and refusing it would
+    /// make the whole struct's decode fallible — so a function taking such a
+    /// struct by value would need a `Result` return or `.panic()`, for a field
+    /// it may not even read.
+    ///
+    /// Lossy on invalid UTF-8 for the same reason. This is the reading the
+    /// hand-written field walk had; stating it as a row is what makes it
+    /// visible rather than buried.
+    pub(crate) fn in_string_field(&self, ty: &TypeRef) -> Option<ConverterImpl<()>> {
+        if !r_is_string(ty) {
+            return None;
+        }
+        let name = format_ident!("{}_field", Self::in_name_of(&ty.key()));
+        let function: syn::ItemFn = syn::parse_quote!(
+            #[allow(non_snake_case, unused_variables, dead_code)]
+            pub(crate) unsafe fn #name(
+                v: *const ::core::ffi::c_char,
+            ) -> ::std::string::String {
+                if v.is_null() {
+                    ::std::string::String::new()
+                } else {
+                    ::std::ffi::CStr::from_ptr(v).to_string_lossy().into_owned()
+                }
+            }
+        );
+        Some(ConverterImpl {
+            subs: vec![],
+            destination: syn::parse_quote!(*const ::core::ffi::c_char),
+            function,
+            pre_stages: vec![],
+            niches: Niches::empty(),
+            metadata: (),
+        })
+    }
+
+    /// `bool` **output into a `data_struct`'s mirror**: the mirror's field is
+    /// [`bool_wire`], so the plain Rust `bool` is wrapped rather than passed
+    /// through.
+    ///
+    /// The twin of [`Self::in_bool`], and the reason `bool` has a second row: a
+    /// `bool` **return** is always already one of two values and crosses as
+    /// itself, while a field shares one mirror with the decode that has to
+    /// normalise it.
+    pub(crate) fn out_bool_field(&self, ty: &TypeRef) -> Option<ConverterImpl<()>> {
+        if !r_is_bool(ty) {
+            return None;
+        }
+        let name = format_ident!("{}_field", Self::out_name_of(&ty.key()));
+        let wire = bool_wire();
+        let wrap = bool_out_expr(quote!(v));
+        let function: syn::ItemFn = syn::parse_quote!(
+            #[allow(non_snake_case, unused_variables, dead_code)]
+            pub(crate) fn #name(v: bool) -> #wire {
+                #wrap
             }
         );
         Some(ConverterImpl {
@@ -1637,8 +1638,15 @@ impl CbindgenBuilder {
                     .join("; "),
             }
         })?;
-        // Cbindgen overrides no site: every crossing takes its type's own row.
-        let bindings = prebindgen_registry::recipe::Bindings::default();
+        let bindings = self.bindings(&model, &recipes).map_err(|errors| {
+            prebindgen_registry::ScanError::AdapterInvariant {
+                message: errors
+                    .iter()
+                    .map(|e| e.to_string())
+                    .collect::<Vec<_>>()
+                    .join("; "),
+            }
+        })?;
         // The driver's state, carried between calls. The adapter borrows the
         // partial registry view, which is lent per call and so is a different
         // type each time; what it built is not, and outlives every one of them.
@@ -2156,45 +2164,6 @@ impl CbindgenBuilder {
             return Some(ConverterImpl {
                 subs: vec![],
                 destination: syn::parse_quote!(*mut ::core::ffi::c_char),
-                function,
-                pre_stages: vec![],
-                niches: Niches::empty(),
-                metadata: (),
-            });
-        }
-
-        // Data struct output: encode each field into its C wire (`String` →
-        // malloc'd `char*` raw block, freed by the `free_memory_function`).
-        if self.data.contains_key(&key) {
-            let fields = self.struct_fields(_r, &ty.key())?;
-            let name = Self::out_name_of(&ty.key());
-            let c_struct = self.c_type_ident(&ty.key());
-            let src = self.src_ty_of(&ty.key());
-            let mut inits: Vec<TokenStream> = Vec::new();
-            let mut subs: Vec<TypeKey> = Vec::new();
-            for (fname, fty) in &fields {
-                if r_is_string(fty) {
-                    inits.push(quote!(#fname: __cbg_alloc_cstr(v.#fname)));
-                } else if self.tagged_unions.contains_key(&fty.key()) {
-                    let conv = Self::out_name_of(&fty.key());
-                    subs.push(fty.key());
-                    inits.push(quote!(#fname: #conv(v.#fname)));
-                } else if r_is_bool(fty) {
-                    let wrap = bool_out_expr(quote!(v.#fname));
-                    inits.push(quote!(#fname: #wrap));
-                } else {
-                    inits.push(quote!(#fname: v.#fname));
-                }
-            }
-            let function: syn::ItemFn = syn::parse_quote!(
-                #[allow(non_snake_case, unused_variables, dead_code)]
-                pub(crate) fn #name(v: #src) -> #c_struct {
-                    #c_struct { #(#inits),* }
-                }
-            );
-            return Some(ConverterImpl {
-                subs,
-                destination: syn::parse_quote!(#c_struct),
                 function,
                 pre_stages: vec![],
                 niches: Niches::empty(),

--- a/prebindgen-c/src/trait_impl.rs
+++ b/prebindgen-c/src/trait_impl.rs
@@ -1971,10 +1971,6 @@ impl Prebindgen for CbindgenBuilder {
     // with non-portable initializers valid in the generated file. (cbindgen
     // cannot evaluate a path initializer, so aliased consts don't surface
     // as `#define`s in the C header.)
-    fn converter_items(&self, _registry: &Registry<()>) -> Option<Vec<syn::ItemFn>> {
-        Some(self.compiled_fns.clone())
-    }
-
     fn source_module(&self) -> Option<&syn::Path> {
         self.source_module.as_ref()
     }

--- a/prebindgen-jni/src/jni/mod.rs
+++ b/prebindgen-jni/src/jni/mod.rs
@@ -478,6 +478,7 @@ impl JniGen {
         Ok(prebindgen_registry::write::write_rust(
             &self.registry,
             &self.decls,
+            prebindgen_registry::write::Conversions::Compiled(&self.decls.compiled_fns),
             out_path,
         )?)
     }
@@ -571,8 +572,8 @@ pub struct Declarations {
     pub(crate) convert_decls: Vec<ConvertDecl>,
     /// Every conversion this binding compiled.
     ///
-    /// Filled once by `JniGenBuilder::build_with` and read by
-    /// `Prebindgen::converter_items`. It is what reaches the generated file, so
+    /// Filled once by `JniGenBuilder::build_with` and handed to `write_rust` as
+    /// `Conversions::Compiled`. It is what reaches the generated file, so
     /// a fragment no longer has to be expressible as one `ConverterImpl` to be
     /// emitted — only to be looked up. The writer sorts and de-duplicates by
     /// function name, so the order here decides which of two same-named

--- a/prebindgen-jni/src/jni/trait_impl.rs
+++ b/prebindgen-jni/src/jni/trait_impl.rs
@@ -1822,13 +1822,6 @@ impl Prebindgen for Declarations {
     /// typed-handle / `JNIWrappers` signature.
     type Metadata = KotlinMeta;
 
-    fn converter_items(
-        &self,
-        _registry: &prebindgen_registry::Registry<KotlinMeta>,
-    ) -> Option<Vec<syn::ItemFn>> {
-        Some(self.compiled_fns.clone())
-    }
-
     // ── Structural type resolution ──────────────────────────────────────
     // Try the terminal categories, then the `Result` peel, then the built-in
     // wrapper shapes — peel

--- a/prebindgen-registry/src/prebindgen.rs
+++ b/prebindgen-registry/src/prebindgen.rs
@@ -260,22 +260,6 @@ pub trait Prebindgen {
     /// [`Self::on_const`]: with a source module available, a named const
     /// re-emits as a path-alias to the source item instead of copying its
     /// initializer tokens. Default: `None`.
-    /// The converter functions this binding emits, if the adapter tracks them
-    /// itself.
-    ///
-    /// `None` — the default — means "read them off the converter table", which
-    /// is where they lived when a conversion could only ever be one
-    /// [`ConverterImpl`] per crossing. An adapter that compiles its own
-    /// fragments answers here instead, and is then free to emit a conversion
-    /// the table cannot hold: several functions for one crossing, or one that
-    /// occupies more than a single wire value.
-    ///
-    /// The table stays the **lookup** index either way. This says only who
-    /// decides what reaches the file.
-    fn converter_items(&self, _registry: &Registry<Self::Metadata>) -> Option<Vec<syn::ItemFn>> {
-        None
-    }
-
     fn source_module(&self) -> Option<&syn::Path> {
         None
     }

--- a/prebindgen-registry/src/recipe/compile.rs
+++ b/prebindgen-registry/src/recipe/compile.rs
@@ -382,8 +382,9 @@ impl<F> Compiled<F> {
     /// Every fragment this compilation built, in a deterministic order.
     ///
     /// What an adapter emits from once it stops routing its conversions back
-    /// through the converter table — see
-    /// [`Prebindgen::converter_items`](crate::Prebindgen::converter_items). The
+    /// through the converter table — handed to
+    /// [`write_rust`](crate::write::write_rust) as
+    /// [`Conversions::Compiled`](crate::write::Conversions::Compiled). The
     /// order is by crossing key and then by row name, so a file written from
     /// this is stable across runs.
     pub fn fragments(&self) -> Vec<&F> {

--- a/prebindgen-registry/src/write.rs
+++ b/prebindgen-registry/src/write.rs
@@ -25,6 +25,24 @@ use crate::{
     registry::{Registry, TypeEntry, TypeKey},
 };
 
+/// Where the generated conversions come from.
+///
+/// The converter table is the **lookup** index either way; this says only what
+/// reaches the file. An adapter that compiles its own fragments hands them over
+/// directly, and is then free to emit a conversion the table cannot hold —
+/// several functions for one crossing, or one occupying more than a single wire
+/// value, which is what a `ConverterImpl`'s single `destination` cannot name.
+pub enum Conversions<'a> {
+    /// What the adapter's compilation produced, in the order it produced it.
+    ///
+    /// Sorted and de-duplicated by function name here, so the order decides
+    /// which of two same-named functions wins and not where any of them lands.
+    Compiled(&'a [syn::ItemFn]),
+    /// Read them off the converter table, where they lived when a conversion
+    /// could only ever be one `ConverterImpl` per crossing.
+    Table,
+}
+
 /// Errors surfaced by the file-emission phase.
 ///
 /// Binding validation is NOT here — it runs once in
@@ -64,6 +82,7 @@ impl std::error::Error for WriteError {}
 pub fn write_rust<P: AsRef<Path>, E: Prebindgen>(
     registry: &Registry<E::Metadata>,
     ext: &E,
+    conversions: Conversions<'_>,
     out_path: P,
 ) -> Result<PathBuf, WriteError> {
     // Validation already ran ONCE in the generator's `build` — a built generator
@@ -81,14 +100,11 @@ pub fn write_rust<P: AsRef<Path>, E: Prebindgen>(
     //    everything below can reference them.
     items.extend(ext.prerequisites(registry, &emit));
 
-    // 1. Auto-generated converter wrappers (sorted by ident, deduped). From
-    //    the adapter when it tracks its own, else off the converter table —
-    //    see `Prebindgen::converter_items` for why that seam exists.
-    let converters = match ext.converter_items(registry) {
-        Some(from_adapter) => dedup_by_name(from_adapter),
-        None => collect_converter_items(registry),
-    };
-    for (_, item_fn) in converters {
+    // 1. Auto-generated converter wrappers (sorted by ident, deduped).
+    for (_, item_fn) in match conversions {
+        Conversions::Compiled(functions) => dedup_by_name(functions.to_vec()),
+        Conversions::Table => collect_converter_items(registry),
+    } {
         items.push(syn::Item::Fn(item_fn));
     }
 

--- a/prebindgen-registry/src/write/tests.rs
+++ b/prebindgen-registry/src/write/tests.rs
@@ -182,7 +182,8 @@ fn write_rust_sorts_declared_items_by_ident() {
         .expect("clock drift")
         .as_nanos();
     let path = std::env::temp_dir().join(format!("prebindgen-write-rust-{unique}.rs"));
-    let written = write_rust(&reg, &IdentityExt, &path).expect("write_rust");
+    let written = write_rust(&reg, &IdentityExt, crate::write::Conversions::Table, &path)
+        .expect("write_rust");
     let content = std::fs::read_to_string(&written).expect("read generated file");
     let _ = std::fs::remove_file(&written);
 
@@ -305,8 +306,13 @@ fn guards_emit_ungated_and_in_stream_order() {
     let dir = crate::test_util::unique_test_dir("write_guards");
     std::fs::create_dir_all(&dir).unwrap();
     let registry = registry.resolve_gating(ConstGatingExt).expect("resolve");
-    let path = crate::write::write_rust(&registry, &ConstGatingExt, dir.join("gen.rs"))
-        .expect("write_rust");
+    let path = crate::write::write_rust(
+        &registry,
+        &ConstGatingExt,
+        crate::write::Conversions::Table,
+        dir.join("gen.rs"),
+    )
+    .expect("write_rust");
     let src = std::fs::read_to_string(&path).unwrap();
 
     // The named const is gated out; both guards emit regardless.


### PR DESCRIPTION
Stage 2 of [#465](https://github.com/milyin/prebindgen/pull/465), closing half of [#458](https://github.com/milyin/prebindgen/issues/458). Targets `recipe-finish`. Stacked on [#466](https://github.com/milyin/prebindgen/pull/466).

**This is the first PR in either umbrella whose generated Rust changes.** The regen diff is the review surface. The generated **C ABI is byte-identical** — every header is unchanged — so what moved is the body of each converter, not what C sees.

## What went

`in_data_struct` and `out_terminal`'s data-struct arm: two hand-written walks over a struct's fields, each deciding per field whether it is a string, a sum, a bool, or a plain scalar, and inlining the answer. Both deleted. Each field now converts itself and `Compile::fields` reassembles the converted fields into one C struct:

```rust
 pub(crate) unsafe fn __cbg_in_Caption(v: caption_t) -> example_flat::Caption {
     example_flat::Caption {
-        id: v.id,
-        text: if v.text.is_null() {
-            ::std::string::String::new()
-        } else {
-            ::std::ffi::CStr::from_ptr(v.text).to_string_lossy().into_owned()
-        },
-        emphatic: ::core::ptr::read(v.emphatic.as_ptr() as *const u8) != 0,
+        id: __cbg_in_u64(v.id),
+        text: __cbg_in_String_field(v.text),
+        emphatic: __cbg_in_bool(v.emphatic),
     }
 }
```

A data struct is where C shows both halves of the pair #450 keeps apart: **many parts, one wire value**.

## The two readings the walks were hiding

The umbrella predicted one behaviour change here. It turned out to be two, and the table can express both rather than force either — so **nothing about the emitted semantics changes**.

A **`bool` field** arrives from C by value and may hold any byte until normalised, so it crosses as `MaybeUninit<bool>`; a `bool` *return* is already one of two values and passes through. A **`String` field** decodes a null pointer to an empty string, where a `String` *parameter* refuses one — refusing it would make a whole struct's decode fallible for a field the callee may not even read.

That is one crossing read two ways, which is **two rows with the site picking**. It is the first real use of `declare_default` plus `Ask::Recipe`, which the table has carried since [#452](https://github.com/milyin/prebindgen/pull/452) with nothing using it. `String`'s second row is skipped where the binding already declared one through `convert!`, whose reading wins.

So the umbrella's warning that a struct with a string field would become fallible does **not** happen. Better: the difference is now visible as a row instead of buried in a branch.

## A drift check that was not there before

`Compile::fields` compares each part's wire against what `data_field_wire` declares for the mirror, and refuses the crossing if they disagree. The mirror's field list and the two conversions were three independent statements of the same fact; now two of them are checked against each other.

Comparison is **modulo pointer constness**, and that is not a fudge: the mirror declares one field, and the two directions read it as `*mut` and `*const`. One wire, two readings — which C already says with a cast rather than a second field.

## Checks

- 93 `prebindgen-c` tests pass, three of them new: a data struct's row is a product, a tagged union's is still `Atomic` (stage 3's job), and the two-row shape for `bool` and `String` including which row is the default.
- The generated **C headers are byte-identical**, so no consumer sees a difference.
- `examples/smoke-asan.sh` is clean under ASan/LSan/UBSan — the ownership contract survives composition, including the data-struct field and out-of-domain bool payload cases it exercises by name.

Local gate clean: clippy and rustfmt on 1.85.0 and stable, `cargo doc` with warnings denied, `cargo test --all`.
