### PR TITLE
Move the emission seam off the adapter trait (#450)

### DIFF
--- a/prebindgen-c/src/lib.rs
+++ b/prebindgen-c/src/lib.rs
@@ -359,6 +359,7 @@ impl Cbindgen {
         Ok(prebindgen_registry::write::write_rust(
             &self.registry,
             &self.gen,
+            prebindgen_registry::write::Conversions::Compiled(&self.gen.compiled_fns),
             out_path,
         )?)
     }
@@ -445,8 +446,8 @@ pub struct CbindgenBuilder {
     pub(crate) sources: prebindgen_registry::flat::FlatBuilder,
     /// Every conversion this binding compiled.
     ///
-    /// Filled once by [`Self::build_with`] and read by
-    /// [`Prebindgen::converter_items`]. It is what reaches the generated file,
+    /// Filled once by [`Self::build_with`] and handed to `write_rust` as
+    /// `Conversions::Compiled`. It is what reaches the generated file,
     /// so a fragment no longer has to be expressible as one `ConverterImpl` to
     /// be emitted — only to be looked up. The writer sorts and de-duplicates by
     /// function name, so the order here decides which of two same-named

--- a/prebindgen-c/src/trait_impl.rs
+++ b/prebindgen-c/src/trait_impl.rs
@@ -1971,10 +1971,6 @@ impl Prebindgen for CbindgenBuilder {
     // with non-portable initializers valid in the generated file. (cbindgen
     // cannot evaluate a path initializer, so aliased consts don't surface
     // as `#define`s in the C header.)
-    fn converter_items(&self, _registry: &Registry<()>) -> Option<Vec<syn::ItemFn>> {
-        Some(self.compiled_fns.clone())
-    }
-
     fn source_module(&self) -> Option<&syn::Path> {
         self.source_module.as_ref()
     }

--- a/prebindgen-jni/src/jni/mod.rs
+++ b/prebindgen-jni/src/jni/mod.rs
@@ -478,6 +478,7 @@ impl JniGen {
         Ok(prebindgen_registry::write::write_rust(
             &self.registry,
             &self.decls,
+            prebindgen_registry::write::Conversions::Compiled(&self.decls.compiled_fns),
             out_path,
         )?)
     }
@@ -571,8 +572,8 @@ pub struct Declarations {
     pub(crate) convert_decls: Vec<ConvertDecl>,
     /// Every conversion this binding compiled.
     ///
-    /// Filled once by `JniGenBuilder::build_with` and read by
-    /// `Prebindgen::converter_items`. It is what reaches the generated file, so
+    /// Filled once by `JniGenBuilder::build_with` and handed to `write_rust` as
+    /// `Conversions::Compiled`. It is what reaches the generated file, so
     /// a fragment no longer has to be expressible as one `ConverterImpl` to be
     /// emitted — only to be looked up. The writer sorts and de-duplicates by
     /// function name, so the order here decides which of two same-named

--- a/prebindgen-jni/src/jni/trait_impl.rs
+++ b/prebindgen-jni/src/jni/trait_impl.rs
@@ -1822,13 +1822,6 @@ impl Prebindgen for Declarations {
     /// typed-handle / `JNIWrappers` signature.
     type Metadata = KotlinMeta;
 
-    fn converter_items(
-        &self,
-        _registry: &prebindgen_registry::Registry<KotlinMeta>,
-    ) -> Option<Vec<syn::ItemFn>> {
-        Some(self.compiled_fns.clone())
-    }
-
     // ── Structural type resolution ──────────────────────────────────────
     // Try the terminal categories, then the `Result` peel, then the built-in
     // wrapper shapes — peel

--- a/prebindgen-registry/src/prebindgen.rs
+++ b/prebindgen-registry/src/prebindgen.rs
@@ -260,22 +260,6 @@ pub trait Prebindgen {
     /// [`Self::on_const`]: with a source module available, a named const
     /// re-emits as a path-alias to the source item instead of copying its
     /// initializer tokens. Default: `None`.
-    /// The converter functions this binding emits, if the adapter tracks them
-    /// itself.
-    ///
-    /// `None` — the default — means "read them off the converter table", which
-    /// is where they lived when a conversion could only ever be one
-    /// [`ConverterImpl`] per crossing. An adapter that compiles its own
-    /// fragments answers here instead, and is then free to emit a conversion
-    /// the table cannot hold: several functions for one crossing, or one that
-    /// occupies more than a single wire value.
-    ///
-    /// The table stays the **lookup** index either way. This says only who
-    /// decides what reaches the file.
-    fn converter_items(&self, _registry: &Registry<Self::Metadata>) -> Option<Vec<syn::ItemFn>> {
-        None
-    }
-
     fn source_module(&self) -> Option<&syn::Path> {
         None
     }

--- a/prebindgen-registry/src/recipe/compile.rs
+++ b/prebindgen-registry/src/recipe/compile.rs
@@ -382,8 +382,9 @@ impl<F> Compiled<F> {
     /// Every fragment this compilation built, in a deterministic order.
     ///
     /// What an adapter emits from once it stops routing its conversions back
-    /// through the converter table — see
-    /// [`Prebindgen::converter_items`](crate::Prebindgen::converter_items). The
+    /// through the converter table — handed to
+    /// [`write_rust`](crate::write::write_rust) as
+    /// [`Conversions::Compiled`](crate::write::Conversions::Compiled). The
     /// order is by crossing key and then by row name, so a file written from
     /// this is stable across runs.
     pub fn fragments(&self) -> Vec<&F> {

--- a/prebindgen-registry/src/write.rs
+++ b/prebindgen-registry/src/write.rs
@@ -25,6 +25,24 @@ use crate::{
     registry::{Registry, TypeEntry, TypeKey},
 };
 
+/// Where the generated conversions come from.
+///
+/// The converter table is the **lookup** index either way; this says only what
+/// reaches the file. An adapter that compiles its own fragments hands them over
+/// directly, and is then free to emit a conversion the table cannot hold —
+/// several functions for one crossing, or one occupying more than a single wire
+/// value, which is what a `ConverterImpl`'s single `destination` cannot name.
+pub enum Conversions<'a> {
+    /// What the adapter's compilation produced, in the order it produced it.
+    ///
+    /// Sorted and de-duplicated by function name here, so the order decides
+    /// which of two same-named functions wins and not where any of them lands.
+    Compiled(&'a [syn::ItemFn]),
+    /// Read them off the converter table, where they lived when a conversion
+    /// could only ever be one `ConverterImpl` per crossing.
+    Table,
+}
+
 /// Errors surfaced by the file-emission phase.
 ///
 /// Binding validation is NOT here — it runs once in
@@ -64,6 +82,7 @@ impl std::error::Error for WriteError {}
 pub fn write_rust<P: AsRef<Path>, E: Prebindgen>(
     registry: &Registry<E::Metadata>,
     ext: &E,
+    conversions: Conversions<'_>,
     out_path: P,
 ) -> Result<PathBuf, WriteError> {
     // Validation already ran ONCE in the generator's `build` — a built generator
@@ -81,14 +100,11 @@ pub fn write_rust<P: AsRef<Path>, E: Prebindgen>(
     //    everything below can reference them.
     items.extend(ext.prerequisites(registry, &emit));
 
-    // 1. Auto-generated converter wrappers (sorted by ident, deduped). From
-    //    the adapter when it tracks its own, else off the converter table —
-    //    see `Prebindgen::converter_items` for why that seam exists.
-    let converters = match ext.converter_items(registry) {
-        Some(from_adapter) => dedup_by_name(from_adapter),
-        None => collect_converter_items(registry),
-    };
-    for (_, item_fn) in converters {
+    // 1. Auto-generated converter wrappers (sorted by ident, deduped).
+    for (_, item_fn) in match conversions {
+        Conversions::Compiled(functions) => dedup_by_name(functions.to_vec()),
+        Conversions::Table => collect_converter_items(registry),
+    } {
         items.push(syn::Item::Fn(item_fn));
     }
 

--- a/prebindgen-registry/src/write/tests.rs
+++ b/prebindgen-registry/src/write/tests.rs
@@ -182,7 +182,8 @@ fn write_rust_sorts_declared_items_by_ident() {
         .expect("clock drift")
         .as_nanos();
     let path = std::env::temp_dir().join(format!("prebindgen-write-rust-{unique}.rs"));
-    let written = write_rust(&reg, &IdentityExt, &path).expect("write_rust");
+    let written = write_rust(&reg, &IdentityExt, crate::write::Conversions::Table, &path)
+        .expect("write_rust");
     let content = std::fs::read_to_string(&written).expect("read generated file");
     let _ = std::fs::remove_file(&written);
 
@@ -305,8 +306,13 @@ fn guards_emit_ungated_and_in_stream_order() {
     let dir = crate::test_util::unique_test_dir("write_guards");
     std::fs::create_dir_all(&dir).unwrap();
     let registry = registry.resolve_gating(ConstGatingExt).expect("resolve");
-    let path = crate::write::write_rust(&registry, &ConstGatingExt, dir.join("gen.rs"))
-        .expect("write_rust");
+    let path = crate::write::write_rust(
+        &registry,
+        &ConstGatingExt,
+        crate::write::Conversions::Table,
+        dir.join("gen.rs"),
+    )
+    .expect("write_rust");
     let src = std::fs::read_to_string(&path).unwrap();
 
     // The named const is gated out; both guards emit regardless.


### PR DESCRIPTION
Acts on the [architecture review](https://github.com/milyin/prebindgen/pull/465#issuecomment-5361741324) of [#466](https://github.com/milyin/prebindgen/pull/466). Targets `recipe-finish`.

## The point, and it is right

#466 put the emission seam on `Prebindgen::converter_items` — the trait **every language adapter implements**, and the first thing someone writing a new one reads. It did not need to be there. `write_rust` is called by each adapter's own `write_rust`, so the adapter can hand its conversions over as an argument.

```rust
pub enum Conversions<'a> {
    Compiled(&'a [syn::ItemFn]),
    Table,
}
```

Same two paths. One fewer place to publish them. The adapter-facing trait gains nothing, so stage 6 has nothing extra to take away — which was the reviewer's actual objection: a seam cut where a later stage has to undo it.

Net **eight lines shorter** than #466, and byte-identical either way.

## What I checked before acting

Both load-bearing claims in the review, because they are the ones the conclusion rests on:

- **`Compile::plan` is dead code.** Confirmed — its only call is inside `Compiler::site`, and no adapter calls `Compiler::site`. Both use `Compiler::crossing`, whose own doc says it is "the per-row half of `Self::site`, for an adapter that composes the per-site wrapping itself."
- **Both adapters build empty `Bindings`.** True of `prebindgen-jni` on this branch. **No longer true of `prebindgen-c`**: [#467](https://github.com/milyin/prebindgen/pull/467) gives it real bindings, because a `bool` or `String` field reads differently inside a `data_struct`'s mirror than on its own, and that is `Ask::Recipe` at a `Role::Part` site. So the site layer stops being inert one stage from now — for row selection, though not yet for `plan`.

## What this does not do

The review's larger question — should sites → plans be wired before the composition stages, and is `Compile::plan` speculative surface until then — is **not** settled here, deliberately. It is a change to who owns per-site emission, currently `Prebindgen::on_function`, and that is a stage of its own rather than a rider on a seam fix.

My reading: stages 2 and 3 do not need `plan`. They need a fragment to reach the file without being squeezed through one `ConverterImpl`, which is what this gives them. But the reviewer is right that `Compile::plan` and `Compiler::site` are shipping unused in the shared crate, and right that every emission question will keep needing a side channel until something calls them. I have added it to the umbrella as its own stage rather than leaving it implicit.

## Checks

Byte-identical output, `cargo test --all`, `examples/regen-check.sh`, clippy and rustfmt on 1.85.0 and stable, `cargo doc` with warnings denied.
