### PR TITLE
cbindgen: a tagged union is its arms (closes #458)

### DIFF
--- a/examples/example-cbindgen/generated/example_flat_x86_64.rs
+++ b/examples/example-cbindgen/generated/example_flat_x86_64.rs
@@ -337,11 +337,7 @@ pub(crate) unsafe fn __cbg_in_Note(
             note_t::Silent => example_flat::Note::Silent,
             note_t::Titled(__f0) => example_flat::Note::Titled(__cbg_in_Caption(__f0)),
             note_t::After(__f0) => example_flat::Note::After(__cbg_in_Millis(__f0)),
-            note_t::Flagged(__f0) => {
-                example_flat::Note::Flagged(
-                    ::core::ptr::read(__f0.as_ptr() as *const u8) != 0,
-                )
-            }
+            note_t::Flagged(__f0) => example_flat::Note::Flagged(__cbg_in_bool(__f0)),
             note_t::Sketched(__f0) => {
                 example_flat::Note::Sketched(__cbg_in_Drawing(__f0)?)
             }
@@ -406,20 +402,16 @@ pub(crate) unsafe fn __cbg_in_Shape(
     ::core::result::Result::Ok(
         match v {
             shape_t::Empty => example_flat::Shape::Empty,
-            shape_t::Circle(__f0) => example_flat::Shape::Circle(__f0),
+            shape_t::Circle(__f0) => example_flat::Shape::Circle(__cbg_in_f64(__f0)),
             shape_t::Rect { width: __f0, height: __f1 } => {
                 example_flat::Shape::Rect {
-                    width: __f0,
-                    height: __f1,
+                    width: __cbg_in_f64(__f0),
+                    height: __cbg_in_f64(__f1),
                 }
             }
             shape_t::Labeled(__f0, __f1) => {
                 example_flat::Shape::Labeled(
-                    if __f0.is_null() {
-                        ::std::string::String::new()
-                    } else {
-                        ::std::ffi::CStr::from_ptr(__f0).to_string_lossy().into_owned()
-                    },
+                    __cbg_in_String_field(__f0),
                     __cbg_in_Operation(__f1)?,
                 )
             }
@@ -709,7 +701,7 @@ pub(crate) fn __cbg_out_Note(v: example_flat::Note) -> ::core::mem::MaybeUninit<
             example_flat::Note::Titled(__f0) => note_t::Titled(__cbg_out_Caption(__f0)),
             example_flat::Note::After(__f0) => note_t::After(__cbg_out_Millis(__f0)),
             example_flat::Note::Flagged(__f0) => {
-                note_t::Flagged(::core::mem::MaybeUninit::new(__f0))
+                note_t::Flagged(__cbg_out_bool_field(__f0))
             }
             example_flat::Note::Sketched(__f0) => {
                 note_t::Sketched(__cbg_out_Drawing(__f0))
@@ -733,16 +725,16 @@ pub(crate) fn __cbg_out_Shape(
     ::core::mem::MaybeUninit::new(
         match v {
             example_flat::Shape::Empty => shape_t::Empty,
-            example_flat::Shape::Circle(__f0) => shape_t::Circle(__f0),
+            example_flat::Shape::Circle(__f0) => shape_t::Circle(__cbg_out_f64(__f0)),
             example_flat::Shape::Rect { width: __f0, height: __f1 } => {
                 shape_t::Rect {
-                    width: __f0,
-                    height: __f1,
+                    width: __cbg_out_f64(__f0),
+                    height: __cbg_out_f64(__f1),
                 }
             }
             example_flat::Shape::Labeled(__f0, __f1) => {
                 shape_t::Labeled(
-                    __cbg_alloc_cstr(__f0),
+                    __cbg_out_String(__f0),
                     ::core::mem::MaybeUninit::new(__cbg_out_Operation(__f1)),
                 )
             }

--- a/examples/example-cbindgen/generated/example_flat_x86_64_internal_unstable.rs
+++ b/examples/example-cbindgen/generated/example_flat_x86_64_internal_unstable.rs
@@ -337,11 +337,7 @@ pub(crate) unsafe fn __cbg_in_Note(
             note_t::Silent => example_flat::Note::Silent,
             note_t::Titled(__f0) => example_flat::Note::Titled(__cbg_in_Caption(__f0)),
             note_t::After(__f0) => example_flat::Note::After(__cbg_in_Millis(__f0)),
-            note_t::Flagged(__f0) => {
-                example_flat::Note::Flagged(
-                    ::core::ptr::read(__f0.as_ptr() as *const u8) != 0,
-                )
-            }
+            note_t::Flagged(__f0) => example_flat::Note::Flagged(__cbg_in_bool(__f0)),
             note_t::Sketched(__f0) => {
                 example_flat::Note::Sketched(__cbg_in_Drawing(__f0)?)
             }
@@ -406,20 +402,16 @@ pub(crate) unsafe fn __cbg_in_Shape(
     ::core::result::Result::Ok(
         match v {
             shape_t::Empty => example_flat::Shape::Empty,
-            shape_t::Circle(__f0) => example_flat::Shape::Circle(__f0),
+            shape_t::Circle(__f0) => example_flat::Shape::Circle(__cbg_in_f64(__f0)),
             shape_t::Rect { width: __f0, height: __f1 } => {
                 example_flat::Shape::Rect {
-                    width: __f0,
-                    height: __f1,
+                    width: __cbg_in_f64(__f0),
+                    height: __cbg_in_f64(__f1),
                 }
             }
             shape_t::Labeled(__f0, __f1) => {
                 example_flat::Shape::Labeled(
-                    if __f0.is_null() {
-                        ::std::string::String::new()
-                    } else {
-                        ::std::ffi::CStr::from_ptr(__f0).to_string_lossy().into_owned()
-                    },
+                    __cbg_in_String_field(__f0),
                     __cbg_in_Operation(__f1)?,
                 )
             }
@@ -709,7 +701,7 @@ pub(crate) fn __cbg_out_Note(v: example_flat::Note) -> ::core::mem::MaybeUninit<
             example_flat::Note::Titled(__f0) => note_t::Titled(__cbg_out_Caption(__f0)),
             example_flat::Note::After(__f0) => note_t::After(__cbg_out_Millis(__f0)),
             example_flat::Note::Flagged(__f0) => {
-                note_t::Flagged(::core::mem::MaybeUninit::new(__f0))
+                note_t::Flagged(__cbg_out_bool_field(__f0))
             }
             example_flat::Note::Sketched(__f0) => {
                 note_t::Sketched(__cbg_out_Drawing(__f0))
@@ -733,16 +725,16 @@ pub(crate) fn __cbg_out_Shape(
     ::core::mem::MaybeUninit::new(
         match v {
             example_flat::Shape::Empty => shape_t::Empty,
-            example_flat::Shape::Circle(__f0) => shape_t::Circle(__f0),
+            example_flat::Shape::Circle(__f0) => shape_t::Circle(__cbg_out_f64(__f0)),
             example_flat::Shape::Rect { width: __f0, height: __f1 } => {
                 shape_t::Rect {
-                    width: __f0,
-                    height: __f1,
+                    width: __cbg_out_f64(__f0),
+                    height: __cbg_out_f64(__f1),
                 }
             }
             example_flat::Shape::Labeled(__f0, __f1) => {
                 shape_t::Labeled(
-                    __cbg_alloc_cstr(__f0),
+                    __cbg_out_String(__f0),
                     ::core::mem::MaybeUninit::new(__cbg_out_Operation(__f1)),
                 )
             }

--- a/prebindgen-c/src/compile.rs
+++ b/prebindgen-c/src/compile.rs
@@ -29,8 +29,33 @@ pub(crate) struct CFrag {
     /// Inner types this fragment composed from, which is what marks them
     /// reachable in the registry that still emits them.
     pub(crate) subs: Vec<TypeKey>,
+    /// One arm's payload, converted, for a fragment on its way from
+    /// [`Compile::fields`] to [`Compile::choice`].
+    ///
+    /// A union's arm is a product whose parts do not assemble into a value of
+    /// their own — they are bound in a `match` and rebuilt on the other side —
+    /// so the arm's fragment carries the converted expressions rather than a
+    /// function. `None` for every other fragment, which is what a struct's is.
+    pub(crate) arm: Option<Arm>,
     /// What the fragment produces, which is all the registry reads of it.
     pub(crate) yields: Yield,
+}
+
+/// One alternative's payload, converted in both directions.
+///
+/// What [`Compile::fields`] hands [`Compile::choice`] for a tagged union: the
+/// per-field expressions, keyed by nothing because their order is the
+/// alternative's own.
+#[derive(Clone)]
+pub(crate) struct Arm {
+    /// Converted payload expressions, in field order, over the bindings
+    /// `__f0..__fN` a `match` arm introduces.
+    pub(crate) exprs: Vec<TokenStream>,
+    /// Whether any of them can fail, so the union's own converter knows
+    /// whether it needs a `Result`.
+    pub(crate) fallible: bool,
+    /// Inner types the payloads composed from.
+    pub(crate) subs: Vec<TypeKey>,
 }
 
 impl Carrier for CFrag {
@@ -48,6 +73,7 @@ impl CFrag {
             function: conv.function,
             niches: conv.niches,
             subs: conv.subs,
+            arm: None,
             yields: Yield {
                 ty: at.crossing.value().stripped_key(),
                 mode: at.crossing.mode(),
@@ -135,6 +161,29 @@ fn same_wire(declared: &syn::Type, produced: &syn::Type) -> bool {
     TypeKey::from_type(&strip(declared)) == TypeKey::from_type(&strip(produced))
 }
 
+/// Whether the mirror holds this field as `MaybeUninit<T>` where the
+/// conversion produces a bare `T`.
+///
+/// One field, two readings again: the decode needs somewhere a C caller's
+/// arbitrary bytes can legally sit until they are checked, and the encode
+/// writes a value that is already valid.
+fn held_uninit(declared: &syn::Type, produced: &syn::Type) -> bool {
+    let syn::Type::Path(p) = declared else {
+        return false;
+    };
+    let Some(last) = p.path.segments.last() else {
+        return false;
+    };
+    if last.ident != "MaybeUninit" {
+        return false;
+    }
+    let syn::PathArguments::AngleBracketed(args) = &last.arguments else {
+        return false;
+    };
+    matches!(args.args.first(), Some(syn::GenericArgument::Type(inner))
+        if TypeKey::from_type(inner) == TypeKey::from_type(produced))
+}
+
 /// Whether a generated converter can fail, read off its own return type.
 fn fallible(function: &syn::ItemFn) -> bool {
     matches!(&function.sig.output, syn::ReturnType::Type(_, t) if is_result(t))
@@ -166,6 +215,21 @@ impl<R: Conversions<()>> Compile for CCompile<'_, R> {
         // `bool`, whose field shares a mirror with the decode that normalises
         // it, and `String`, whose field decodes a null pointer leniently so one
         // field cannot make a whole struct's decode fallible.
+        // A `Box`-over-handle rides in a union arm as a bare pointer the C side
+        // owns, and that is the only place C crosses one — a handle parameter
+        // is spelled `Blob` and reclaimed from its own pointer.
+        //
+        // Keyed by the **spelling** rather than by a row of its own: a row is
+        // filed under `Crossing::key`, which strips `Box`, so `Box<Blob>` and
+        // `Blob` share one row and could not be told apart there. A fragment is
+        // keyed by the spelling, which is exactly the distinction needed.
+        if *at.recipe == crate::rows::payload() {
+            let conv = match at.crossing.assembly() {
+                Assembly::Construct => self.gen.in_boxed_payload(ty),
+                Assembly::Deconstruct => self.gen.out_boxed_payload(ty),
+            };
+            return self.wrap(at, "no payload reading for this handle", conv);
+        }
         if *at.recipe == crate::rows::in_field() {
             let conv = match at.crossing.assembly() {
                 Assembly::Construct => self
@@ -185,7 +249,6 @@ impl<R: Conversions<()>> Compile for CCompile<'_, R> {
                 .or_else(|| self.gen.in_opaque_handle(ty))
                 .or_else(|| self.gen.in_value_opaque(ty, self.registry))
                 .or_else(|| self.gen.in_enum(ty, self.registry))
-                .or_else(|| self.gen.in_tagged_union(ty, self.registry, cx.emit()))
                 .or_else(|| self.gen.in_string(ty))
                 .or_else(|| self.gen.in_str(ty))
                 .or_else(|| self.gen.in_bool(ty))
@@ -270,6 +333,112 @@ impl<R: Conversions<()>> Compile for CCompile<'_, R> {
     fn fields(&mut self, _cx: &mut Cx<'_>, at: At<'_>, parts: Parts<'_, Self>) -> Frag<Self> {
         let ty = at.crossing.spelled();
         let key = ty.key();
+        // A tagged union's arm is a product whose parts do not assemble into a
+        // value of their own: they are bound by a `match` and rebuilt on the
+        // other side. So this hands `choice` the converted payloads and builds
+        // no function — which is what "compose a product's fragment from its
+        // parts' fragments" means when the product is one arm of a sum.
+        if self.gen.tagged_unions.contains_key(&key) {
+            // Which alternative these parts belong to, for a refusal that names
+            // the arm the way the declaration writes it.
+            let arm_name = self
+                .gen
+                .union_arm_name(&key, self.registry, parts)
+                .unwrap_or_default();
+            // Acceptance is decided here, before a part is asked to convert:
+            // `payload_field_wire` is where a union says what one of its fields
+            // can carry, and its refusals name the shape rather than the
+            // missing converter — a `Vec` needs two C wires and a union field
+            // has one, which is a fact about the union and not about the
+            // sequence. Asking the registry for a `Vec<u8>` conversion first
+            // would report an unresolved crossing instead.
+            //
+            // A refusal here is a **declaration** error, not a missing
+            // conversion, so it aborts with the reason rather than leaving the
+            // crossing unresolved — the same contract the walk this replaces
+            // had, and the same one `prereq_data_structs` uses for a field it
+            // cannot mirror.
+            //
+            // Only the shapes that can **never** cross. "This payload has no
+            // converter yet" was the other half of the old check and is not a
+            // question any more: the part in hand *is* the conversion, so a
+            // payload that reached here has one by construction.
+            for (part, _) in parts {
+                if let Err(why) = self.gen.payload_shape_refusal(&part.ty) {
+                    panic!(
+                        "Cbindgen::tagged_union: payload `{}::{}{}` of type `{}` cannot cross: {}",
+                        type_short(&key),
+                        arm_name,
+                        match &part.name.parse::<usize>() {
+                            Ok(_) => String::new(),
+                            Err(_) => format!(".{}", part.name),
+                        },
+                        part.ty,
+                        why
+                    );
+                }
+            }
+            let exprs = parts
+                .iter()
+                .enumerate()
+                .map(|(i, (part, frag))| {
+                    let bind = format_ident!("__f{}", i);
+                    let conv = &frag.function.sig.ident;
+                    let call = if fallible(&frag.function) {
+                        quote!(#conv(#bind)?)
+                    } else {
+                        quote!(#conv(#bind))
+                    };
+                    // The union holds a payload whose bytes C may write —
+                    // a nested enum or a `bool` — as `MaybeUninit`, so the
+                    // decode can check them before assuming them valid. Same
+                    // holding form a struct's mirror field takes, and the same
+                    // reason: the wrap belongs to whatever holds the value, not
+                    // to the value's own conversion.
+                    match (
+                        at.crossing.assembly(),
+                        self.gen.payload_field_wire(&part.ty, self.registry),
+                    ) {
+                        (Assembly::Deconstruct, Ok(w)) if held_uninit(&w, &frag.destination) => {
+                            quote!(::core::mem::MaybeUninit::new(#call))
+                        }
+                        _ => call,
+                    }
+                })
+                .collect();
+            // A payload built inline from the handle's own C name is not a
+            // crossing the registry has to resolve — the old walk did not make
+            // one either. Marking it reachable would demand a whole-value
+            // conversion for `Box<Blob>`, which C has none of: a handle
+            // parameter is spelled `Blob`.
+            let subs: Vec<TypeKey> = parts
+                .iter()
+                .filter(|(p, _)| {
+                    self.gen.declared_opaque_payload_inner(&p.ty).is_none()
+                        && r_boxed_inner(&p.ty).is_none()
+                })
+                .map(|(p, _)| p.ty.key())
+                .collect();
+            return Ok(CFrag {
+                destination: syn::parse_quote!(()),
+                function: syn::parse_quote!(
+                    #[allow(dead_code)]
+                    fn __cbg_arm() {}
+                ),
+                niches: Niches::empty(),
+                subs: subs.clone(),
+                arm: Some(Arm {
+                    fallible: parts.iter().any(|(_, f)| fallible(&f.function)),
+                    subs,
+                    exprs,
+                }),
+                yields: Yield {
+                    ty: at.crossing.value().stripped_key(),
+                    mode: at.crossing.mode(),
+                    validity: Validity::SelfSufficient,
+                },
+            });
+        }
         let c_struct = self.gen.c_type_ident(&key);
         let src = self.gen.src_ty_of(&key);
         // Each part converts itself. The three statements of a field's wire —
@@ -278,10 +447,9 @@ impl<R: Conversions<()>> Compile for CCompile<'_, R> {
         // `data_field_wire` is checked against it rather than re-deriving it.
         for (part, frag) in parts {
             let declared = self.gen.data_field_wire(&part.ty);
-            if declared
-                .as_ref()
-                .is_some_and(|w| !same_wire(w, &frag.destination))
-            {
+            if declared.as_ref().is_some_and(|w| {
+                !same_wire(w, &frag.destination) && !held_uninit(w, &frag.destination)
+            }) {
                 return Err(refuse(
                     at,
                     &format!(
@@ -300,13 +468,25 @@ impl<R: Conversions<()>> Compile for CCompile<'_, R> {
         let calls: Vec<TokenStream> = parts
             .iter()
             .zip(&names)
-            .map(|((_, frag), fname)| {
+            .map(|((part, frag), fname)| {
                 let conv = &frag.function.sig.ident;
                 let call = quote!(#conv(v.#fname));
-                if fallible(&frag.function) {
+                let call = if fallible(&frag.function) {
                     quote!(#call?)
                 } else {
                     call
+                };
+                // The mirror holds a tagged-union field as `MaybeUninit`, so a
+                // C caller can hand over any discriminant and the decode can
+                // check it before assuming it initialised. That is the
+                // struct's holding form rather than the union's wire, so the
+                // wrap belongs here and the union's own conversion stays the
+                // one both directions use.
+                match (at.crossing.assembly(), self.gen.data_field_wire(&part.ty)) {
+                    (Assembly::Deconstruct, Some(w)) if held_uninit(&w, &frag.destination) => {
+                        quote!(::core::mem::MaybeUninit::new(#call))
+                    }
+                    _ => call,
                 }
             })
             .collect();
@@ -381,11 +561,118 @@ impl<R: Conversions<()>> Compile for CCompile<'_, R> {
 
     fn choice(
         &mut self,
-        _cx: &mut Cx<'_>,
+        cx: &mut Cx<'_>,
         at: At<'_>,
-        _arms: &[(&Alternative, &CFrag)],
+        arms: &[(&Alternative, &CFrag)],
     ) -> Frag<Self> {
-        Err(refuse(at, "Cbindgen states no choice rows yet"))
+        let ty = at.crossing.spelled();
+        let key = ty.key();
+        let cname = self.gen.c_type_ident(&key);
+        let src = self.gen.src_ty_of(&key);
+        let emit = cx.emit();
+        let construct = at.crossing.assembly() == Assembly::Construct;
+
+        let mut subs: Vec<TypeKey> = Vec::new();
+        let mut fallible_any = false;
+        let mut match_arms: Vec<TokenStream> = Vec::new();
+        for (alternative, frag) in arms {
+            let Some(arm) = frag.arm.as_ref() else {
+                return Err(refuse(at, "an arm that composed no payload"));
+            };
+            subs.extend(arm.subs.iter().cloned());
+            fallible_any |= arm.fallible;
+            let vident = &alternative.name;
+            let binds: Vec<syn::Ident> = (0..alternative.fields.len())
+                .map(|i| format_ident!("__f{}", i))
+                .collect();
+            let bound: Vec<TokenStream> = alternative
+                .fields
+                .iter()
+                .zip(&binds)
+                .map(|(f, b)| f.bind(b))
+                .collect();
+            let built: Vec<TokenStream> = alternative
+                .fields
+                .iter()
+                .zip(&arm.exprs)
+                .map(|(f, e)| f.bind(e))
+                .collect();
+            // The alternative's own delimiters on both sides, so a tuple arm
+            // and a braced one each spell themselves.
+            let (from_head, to_head) = if construct {
+                (quote!(#cname::#vident), quote!(#src::#vident))
+            } else {
+                (quote!(#src::#vident), quote!(#cname::#vident))
+            };
+            let from = emit.shape_alternative(alternative, from_head, &bound);
+            let to = emit.shape_alternative(alternative, to_head, &built);
+            match_arms.push(quote!(#from => #to,));
+        }
+
+        let conv = if construct {
+            let name = CbindgenBuilder::in_name_of(&key);
+            let bad = format!(
+                "invalid tag {{}} for `{cname}` (expected 0..{})",
+                arms.len()
+            );
+            // A C-supplied mirror may hold any discriminant, so the tag is
+            // checked before the value is assumed initialised. Neither the tag
+            // nor the check is a crossing — the adapter invents both, which is
+            // why no row mentions them.
+            let guard = self.gen.tag_guard(
+                &cname,
+                arms.len(),
+                quote!(v),
+                quote!(return ::core::result::Result::Err(::std::format!(#bad, __tag));),
+            );
+            let function: syn::ItemFn = syn::parse_quote!(
+                #[allow(non_snake_case, unused_variables, dead_code)]
+                pub(crate) unsafe fn #name(
+                    v: ::core::mem::MaybeUninit<#cname>,
+                ) -> ::core::result::Result<#src, ::std::string::String> {
+                    #guard
+                    let v = v.assume_init();
+                    ::core::result::Result::Ok(match v { #(#match_arms)* })
+                }
+            );
+            ConverterImpl {
+                subs,
+                destination: syn::parse_quote!(::core::mem::MaybeUninit<#cname>),
+                function,
+                pre_stages: vec![],
+                niches: Niches::empty(),
+                metadata: (),
+            }
+        } else {
+            if fallible_any {
+                return Err(refuse(
+                    at,
+                    "a payload whose encode can fail, which a union has no way to report",
+                ));
+            }
+            let name = CbindgenBuilder::out_name_of(&key);
+            // `MaybeUninit`, matching the wire the decode takes: one C type for
+            // both directions, so a union returned by one function can be
+            // handed straight to another that takes one. The value written is
+            // always initialised — only the *type* has room for a discriminant
+            // C might not have written.
+            let function: syn::ItemFn = syn::parse_quote!(
+                #[allow(non_snake_case, unused_variables, dead_code)]
+                pub(crate) fn #name(v: #src) -> ::core::mem::MaybeUninit<#cname> {
+                    ::core::mem::MaybeUninit::new(match v { #(#match_arms)* })
+                }
+            );
+            ConverterImpl {
+                subs,
+                destination: syn::parse_quote!(::core::mem::MaybeUninit<#cname>),
+                function,
+                pre_stages: vec![],
+                niches: Niches::empty(),
+                metadata: (),
+            }
+        };
+        let _ = fallible_any;
+        Ok(CFrag::from_converter(at, conv))
     }
 
     fn callback(

--- a/prebindgen-c/src/emit.rs
+++ b/prebindgen-c/src/emit.rs
@@ -116,10 +116,29 @@ impl CbindgenBuilder {
     /// A `bool` reached through a nested `data_struct` payload is covered by
     /// the same [`bool_wire`] policy, which [`c_field_wire`] and the plain
     /// `bool` parameter now share (#170).
+    /// Why this type can **never** be a union payload, whatever converts it.
+    ///
+    /// The half of [`Self::payload_field_wire`] that is a fact about the union
+    /// rather than about the conversion: one union field carries one C wire, so
+    /// a shape needing two cannot ride in one however well it converts. The
+    /// other half — "no resolved converter" — stops being a question once the
+    /// payload is composed from its own part, which is a conversion in hand.
+    pub(super) fn payload_shape_refusal(&self, fty: &TypeRef) -> Result<(), String> {
+        if r_is_vec(fty) {
+            return Err(
+                "a `Vec` needs TWO C wires (pointer + length) and one union field carries only \
+                 one, so its length would be silently dropped — hand the sequence over through \
+                 a separate function, or wrap it in a declared `opaque_ptr` handle"
+                    .to_string(),
+            );
+        }
+        Ok(())
+    }
+
     pub(super) fn payload_field_wire(
         &self,
         fty: &TypeRef,
-        registry: &Registry<()>,
+        registry: &impl Conversions<()>,
     ) -> Result<syn::Type, String> {
         // `String` is the one type whose two directions disagree on the wire
         // (`*const c_char` in, `*mut c_char` out), so the union field fixes the
@@ -275,26 +294,6 @@ impl CbindgenBuilder {
             return true;
         }
         !self.owning_data_struct_fields(fty, registry).is_empty()
-    }
-
-    /// Whether a tagged-union payload crosses through a converter of its own,
-    /// rather than being its own wire. Everything except a scalar and the
-    /// hand-written `String` / opaque-pointer shapes does — a declared
-    /// `enum_type`, a nested `data_struct`, a bare `opaque_ptr` handle, a
-    /// converted leaf. Such a payload must be registered as a resolver
-    /// dependency so its converter exists by the time the union's own is
-    /// emitted; without that it silently degrades to a passthrough and the
-    /// generated code does not compile.
-    pub(super) fn payload_needs_converter(&self, fty: &TypeRef) -> bool {
-        if r_is_string(fty) || r_is_scalar(fty) || r_is_vec(fty) {
-            return false;
-        }
-        if self.enums.contains_key(&fty.key()) {
-            return true;
-        }
-        // `Box<T>` / `Option<Box<T>>` opaque pointers are built inline from the
-        // handle's C ident, not through a converter call.
-        !matches!(self.mirror_field_wire(fty), Some(syn::Type::Ptr(_)))
     }
 
     /// The `(name, type)` of every field of a declared `data_struct` whose own

--- a/prebindgen-c/src/rows.rs
+++ b/prebindgen-c/src/rows.rs
@@ -13,9 +13,10 @@
 //! whatever the build script said rather than whichever guess fired first.
 
 use prebindgen_registry::{
-    flat::{Flat, Type},
+    flat::{Flat, Type, TypeRef},
     recipe::{
-        Construct, Constructing, Deconstruct, Deconstructing, Reach, RecipeError, RecipeId, Recipes,
+        Arm, Assembly, Construct, Constructing, Deconstruct, Deconstructing, Reach, RecipeError,
+        RecipeId, Recipes,
     },
 };
 
@@ -29,6 +30,22 @@ fn whole() -> RecipeId {
 /// The row a type crossing field by field takes.
 pub(crate) fn parts() -> RecipeId {
     RecipeId::new("parts")
+}
+
+/// The row a value takes as a **tagged union's payload**, where it rides
+/// differently from both of the readings below.
+///
+/// A `Box<T>` or `Option<Box<T>>` over a declared `opaque_ptr` rides in the
+/// union as a bare `*mut t_t` the C side owns. That is neither the whole-value
+/// reading — a handle parameter is spelled `T` and reclaimed from its own
+/// pointer — nor a struct field's.
+///
+/// The row is filed on the **stripped** crossing, because `Crossing::key` peels
+/// `Box`: `Box<Blob>` and `Blob` share one crossing and are told apart by the
+/// site that picks between their rows, and by the fragment, which is keyed by
+/// the spelling.
+pub(crate) fn payload() -> RecipeId {
+    RecipeId::new("payload")
 }
 
 /// The row a value takes **inside a `data_struct`'s mirror**, where its wire
@@ -56,6 +73,15 @@ impl CbindgenBuilder {
     /// different words helps nobody.
     pub(crate) fn recipes(&self, model: &Flat) -> Result<Recipes, Vec<RecipeError>> {
         let mut rows = Recipes::builder();
+        // The crossings a payload row will also land on. `Crossing::key` peels
+        // `Box`, so a `Box<Blob>` payload shares `Blob`'s crossing — which is
+        // right for lookup, and means the handle's own row has to say it is
+        // what a site gets when it names neither.
+        let shared: std::collections::HashSet<TypeKey> = self
+            .boxed_payloads(model)
+            .iter()
+            .map(|t| t.borrow_target().unwrap_or(t).stripped_key())
+            .collect();
         // Every per-type policy, and every `convert!`-declared conversion. The
         // second matters as much as the first: a conversion may be declared on
         // a type the registry would otherwise read as an arity layer, and
@@ -85,14 +111,39 @@ impl CbindgenBuilder {
             let Ok(ty) = model.classify(&spelled) else {
                 continue;
             };
+            // A tagged union is a tag plus a union, rebuilt one arm at a time.
+            // Neither the tag nor the selector is a crossing, so neither is
+            // declared: how the C side is told which arm is live is the
+            // adapter's business.
+            if self.tagged_unions.contains_key(&_key) {
+                let Some(alternatives) = alternative_field_counts(model, &_key) else {
+                    continue;
+                };
+                let out: Vec<Arm<Deconstruct>> = alternatives
+                    .iter()
+                    .enumerate()
+                    .map(|(alternative, count)| Arm {
+                        alternative,
+                        op: Deconstruct::Fields((0..*count).map(Reach::Field).collect()),
+                    })
+                    .collect();
+                let into: Vec<Arm<Construct>> = alternatives
+                    .iter()
+                    .enumerate()
+                    .map(|(alternative, _)| Arm {
+                        alternative,
+                        op: Construct::Fields,
+                    })
+                    .collect();
+                rows.declare(ty.clone(), parts(), Deconstructing::Choice { arms: out })
+                    .declare(ty, parts(), Constructing::Choice { arms: into });
+                continue;
+            }
             // A `data_struct` converts each field and reassembles the
             // converted fields into one C struct — many parts, one wire value,
             // which is the pair #450 keeps apart. Everything else declared here
             // is one wire value with nothing inside it that crosses on its own:
-            // an opaque handle, a value-opaque mirror, a C enum. A tagged union
-            // plainly has arms and is still `Atomic`, because `in_tagged_union`
-            // walks an arm's payload inside one generated function; stating
-            // those arms is the next stage.
+            // an opaque handle, a value-opaque mirror, a C enum.
             if let Some(count) = self
                 .data
                 .contains_key(&_key)
@@ -108,9 +159,24 @@ impl CbindgenBuilder {
                 .declare(ty, parts(), Constructing::Product(Construct::Fields));
                 continue;
             }
-            rows.declare(ty.clone(), whole(), Deconstructing::Atomic)
-                .declare(ty, whole(), Constructing::Atomic);
+            if shared.contains(&ty.borrow_target().unwrap_or(&ty).stripped_key()) {
+                rows.declare_default(ty.clone(), whole(), Deconstructing::Atomic)
+                    .declare_default(ty, whole(), Constructing::Atomic);
+            } else {
+                rows.declare(ty.clone(), whole(), Deconstructing::Atomic)
+                    .declare(ty, whole(), Constructing::Atomic);
+            }
         }
+        // The payload rows, on the stripped crossing each `Box`-over-handle
+        // shares with its own handle type. Only the types a union arm actually
+        // carries.
+        for ty in self.boxed_payloads(model) {
+            // The handle's own row is already filed on this crossing, so one of
+            // the two has to say which a site gets when it names neither.
+            rows.declare(ty.clone(), payload(), Deconstructing::Atomic)
+                .declare(ty, payload(), Constructing::Atomic);
+        }
+
         // `bool`'s second row. Declared for every binding rather than only
         // where a struct has such a field: a row for a crossing nobody uses is
         // inert, and the alternative is walking every declared struct twice to
@@ -137,6 +203,44 @@ impl CbindgenBuilder {
         rows.build(model)
     }
 
+    /// Which row a union payload of this type takes, and in which directions,
+    /// where it is not the type's own default.
+    ///
+    /// Every `Box`-over-handle a union arm carries, keyed once.
+    fn boxed_payloads(&self, model: &Flat) -> Vec<TypeRef> {
+        let mut payloads: Vec<TypeRef> = Vec::new();
+        for (key, _) in sorted_by_key(&self.tagged_unions) {
+            for fields in alternatives_of(model, key).unwrap_or_default() {
+                for field in fields {
+                    if self.declared_opaque_payload_inner(&field.ty).is_some()
+                        || r_boxed_inner(&field.ty).is_some()
+                    {
+                        payloads.push(field.ty.clone());
+                    }
+                }
+            }
+        }
+        payloads.sort_by_key(|t| t.key().as_str().to_owned());
+        payloads.dedup_by_key(|t| t.key().as_str().to_owned());
+        payloads
+    }
+
+    /// `bool` and `String` read as they do inside a struct; a `Box`-over-handle
+    /// needs [`payload`], the one reading neither of the other two covers.
+    fn payload_reading(&self, fty: &TypeRef) -> Option<(RecipeId, &'static [Assembly])> {
+        use prebindgen_registry::flat::{ScalarKind, TypeKind};
+        if self.declared_opaque_payload_inner(fty).is_some() || r_boxed_inner(fty).is_some() {
+            return Some((payload(), &[Assembly::Construct, Assembly::Deconstruct]));
+        }
+        match fty.unwrapped().kind() {
+            TypeKind::Scalar(ScalarKind::Bool) => {
+                Some((in_field(), &[Assembly::Construct, Assembly::Deconstruct]))
+            }
+            TypeKind::String => Some((in_field(), &[Assembly::Construct])),
+            _ => None,
+        }
+    }
+
     /// Which row each part of a declared product takes, where it is not the
     /// part type's own default.
     ///
@@ -154,6 +258,39 @@ impl CbindgenBuilder {
         };
 
         let mut bound = Bindings::builder();
+        // A union's payload reads like a struct's field for `bool` and
+        // `String`, and needs a reading of its own where it is a `Box` over a
+        // declared handle — see [`payload`].
+        for (key, cfg) in sorted_by_key(&self.tagged_unions) {
+            let Ok(spelled) = syn::parse2::<syn::Type>(cfg.rust_type.declared_spelling()) else {
+                continue;
+            };
+            let Ok(ty) = model.classify(&spelled) else {
+                continue;
+            };
+            let Some(alternatives) = alternatives_of(model, key) else {
+                continue;
+            };
+            // Every arm numbers its parts from zero, so a payload is addressed
+            // by its alternative as well as its index — `part 0` alone names
+            // one part per arm.
+            for (arm, fields) in alternatives.iter().enumerate() {
+                for (index, field) in fields.iter().enumerate() {
+                    let Some((row, directions)) = self.payload_reading(&field.ty) else {
+                        continue;
+                    };
+                    for &assembly in directions {
+                        let of = Crossing::new(ty.clone(), assembly);
+                        bound.bind(
+                            Site::arm_part(&of, &parts(), Some(arm), index),
+                            Crossing::new(field.ty.clone(), assembly),
+                            Ask::Recipe(row.clone()),
+                            Asked::Part,
+                        );
+                    }
+                }
+            }
+        }
         let mut declared: Vec<(TypeKey, Origin<syn::Type>)> = self
             .data
             .iter()
@@ -207,6 +344,25 @@ impl CbindgenBuilder {
 fn struct_fields(model: &Flat, key: &TypeKey) -> Option<Vec<prebindgen_registry::flat::Field>> {
     match model.declared_type(&key.ident()?)? {
         Type::Struct(s) => Some(s.fields.clone()),
+        _ => None,
+    }
+}
+
+/// The alternatives of this declared sum, with their payload fields.
+fn alternatives_of(
+    model: &Flat,
+    key: &TypeKey,
+) -> Option<Vec<Vec<prebindgen_registry::flat::Field>>> {
+    match model.declared_type(&key.ident()?)? {
+        Type::Variant(v) => Some(v.alternatives.iter().map(|a| a.fields.clone()).collect()),
+        _ => None,
+    }
+}
+
+/// How many fields each alternative of this declared sum carries.
+fn alternative_field_counts(model: &Flat, key: &TypeKey) -> Option<Vec<usize>> {
+    match model.declared_type(&key.ident()?)? {
+        Type::Variant(v) => Some(v.alternatives.iter().map(|a| a.fields.len()).collect()),
         _ => None,
     }
 }

--- a/prebindgen-c/src/tests/rows.rs
+++ b/prebindgen-c/src/tests/rows.rs
@@ -102,15 +102,15 @@ fn a_data_struct_is_its_fields() {
 }
 
 #[test]
-fn a_tagged_union_still_crosses_whole() {
-    // It plainly has arms, and is still one row with no parts: `in_tagged_union`
-    // walks an arm's payload inside one generated function, which is exactly
-    // what `Atomic` says. Stating those arms is the next stage.
+fn a_tagged_union_is_its_arms() {
+    // One arm per alternative, each a product of that alternative's payload.
+    // Neither the tag nor the selector appears: how the C side is told which
+    // arm is live is the adapter's business, so no row mentions it.
     let model = model();
     let gen = Cbindgen::builder().tagged_union(syn::parse_quote!(Reply));
     assert_eq!(
         rows_of(&gen, &model, "Reply"),
-        "construct whole:atomic, deconstruct whole:atomic"
+        "construct parts:choice(2), deconstruct parts:choice(2)"
     );
 }
 

--- a/prebindgen-c/src/tests/tagged_unions.rs
+++ b/prebindgen-c/src/tests/tagged_unions.rs
@@ -80,11 +80,17 @@ fn tagged_union_mirror_and_converters() {
         "{src}"
     );
     assert!(
-        compact.contains("example_flat::Shape::Circle(__f0)=>shape_t::Circle(__f0),"),
+        // The payload converts through its own scalar conversion rather than
+        // passing through inline — same value, named once.
+        compact
+            .contains("example_flat::Shape::Circle(__f0)=>shape_t::Circle(__cbg_out_f64(__f0)),"),
         "{src}"
     );
     assert!(
-        compact.contains("shape_t::Labeled(__cbg_alloc_cstr(__f0),"),
+        // The `String` payload allocates through `String`'s own conversion,
+        // which is where `__cbg_alloc_cstr` lives — one statement of it rather
+        // than one per payload position.
+        compact.contains("shape_t::Labeled(__cbg_out_String(__f0),"),
         "{src}"
     );
     assert!(
@@ -258,6 +264,8 @@ fn tagged_union_as_data_struct_field() {
         compact.contains("fn__cbg_in_Drawing(v:drawing_t,)->::core::result::Result<"),
         "{src}"
     );
+    // The union's own conversion already produces the `MaybeUninit` the
+    // mirror field holds, so the struct passes it through.
     assert!(compact.contains("shape:__cbg_out_Shape(v.shape),"), "{src}");
 }
 
@@ -553,15 +561,21 @@ fn null_opaque_payload_is_reported_not_materialised() {
     let src = write(cbindgen, registry, "tagged_union_null_payload");
     let compact: String = src.split_whitespace().collect();
 
-    // The bare `Box` arm checks before boxing, and names why.
+    // The bare `Box` arm checks before boxing, and names why. The check lives
+    // in the payload's own conversion now rather than inline in the arm, so the
+    // guard reads `v` — the converter's parameter — and the arm calls it.
     assert!(
-        compact.contains("if__f0.is_null(){return::core::result::Result::Err("),
+        compact.contains("ifv.is_null(){return::core::result::Result::Err("),
         "{src}"
     );
     assert!(compact.contains("nullpayloadfor`Blob`"), "{src}");
+    assert!(
+        compact.contains("Slot::Filled(__cbg_in_Box___Blob___payload(__f0)?)"),
+        "{src}"
+    );
     // The `Option` arm keeps NULL as a legitimate value.
     assert!(
-        compact.contains("if__f0.is_null(){::core::option::Option::None}"),
+        compact.contains("ifv.is_null(){::core::option::Option::None}"),
         "{src}"
     );
 }
@@ -747,12 +761,19 @@ fn bool_payload_is_normalised_not_materialised() {
         compact.contains("On(::core::mem::MaybeUninit<bool>),"),
         "{src}"
     );
+    // The payload converts through `bool`'s own field reading rather than
+    // inline: same normalisation, named once.
     assert!(
-        compact.contains("example_flat::Flagged::On(::core::ptr::read(__f0.as_ptr()as*constu8)!=0"),
+        compact.contains("example_flat::Flagged::On(__cbg_in_bool(__f0))"),
         "{src}"
     );
     assert!(
-        compact.contains("flagged_t::On(::core::mem::MaybeUninit::new(__f0))"),
+        compact.contains("__cbg_in_bool(v:::core::mem::MaybeUninit<bool>)->bool"),
+        "{src}"
+    );
+    assert!(
+        compact
+            .contains("example_flat::Flagged::On(__f0)=>flagged_t::On(__cbg_out_bool_field(__f0))"),
         "{src}"
     );
     // A bool owns nothing, so the union still gets no typed drop.
@@ -830,7 +851,11 @@ fn one_kind_presents_one_c_type_however_it_is_spelled() {
     // the C type follows `kind`, the conversion follows the syntax. The `Box`
     // spelling hands its box over; the bare ones are boxed here.
     assert!(
-        compact.contains("::std::boxed::Box::into_raw(__b)as*muthandle_t"),
+        // `Option<Box<Handle>>` — the box is handed over, not made. The
+        // payload conversion binds the `Some` arm as `__v`; what distinguishes
+        // the two spellings is `into_raw(__v)` against `into_raw(Box::new(__v))`
+        // below.
+        compact.contains("::std::boxed::Box::into_raw(__v)as*muthandle_t"),
         "the `Box` spelling hands over the box it already has:\n{src}"
     );
     assert!(

--- a/prebindgen-c/src/trait_impl.rs
+++ b/prebindgen-c/src/trait_impl.rs
@@ -346,6 +346,165 @@ impl CbindgenBuilder {
         })
     }
 
+    /// Which alternative of `key` these parts came from, by matching their
+    /// field types against the model's.
+    ///
+    /// Only for a refusal message. `Compile::fields` is handed one arm's parts
+    /// without being told which arm — the driver numbers parts per alternative
+    /// and `choice` is where the `Alternative` arrives — so naming the arm the
+    /// way the declaration writes it means finding it again. A refusal that
+    /// says `Odd::Many` points at the line to change; one that says only the
+    /// type does not.
+    pub(crate) fn union_arm_name(
+        &self,
+        key: &TypeKey,
+        registry: &impl Conversions<()>,
+        parts: &[(
+            prebindgen_registry::recipe::Part<'_>,
+            &crate::compile::CFrag,
+        )],
+    ) -> Option<String> {
+        let variant = match registry.flat().declared_type(&key.ident()?)? {
+            prebindgen_registry::flat::Type::Variant(v) => v,
+            _ => return None,
+        };
+        variant
+            .alternatives
+            .iter()
+            .find(|a| {
+                a.fields.len() == parts.len()
+                    && a.fields
+                        .iter()
+                        .zip(parts)
+                        .all(|(f, (p, _))| f.ty.key() == p.ty.key())
+            })
+            .map(|a| a.name.to_string())
+    }
+
+    /// A `Box`-over-handle **payload of a tagged union**, C to Rust.
+    ///
+    /// The payload rides as a bare `*mut t_t` the C caller gave up ownership
+    /// of, so the pointer is reclaimed. A NULL one is reachable rather than
+    /// hypothetical — the typed drop nulls the arm it frees, so a union passed
+    /// back after being dropped arrives here NULL — and is reported, never
+    /// materialised. An `Option<Box<T>>` reads NULL as `None` instead, which is
+    /// the representation it has room for.
+    pub(crate) fn in_boxed_payload(&self, fty: &TypeRef) -> Option<ConverterImpl<()>> {
+        let name = format_ident!("{}_payload", Self::in_name_of(&fty.key()));
+        let optional = fty.optional_inner().is_some();
+        let (wire, src_inner, owned, short) =
+            if let Some(inner) = self.declared_opaque_payload_inner(fty) {
+                let c = self.c_type_ident(&inner);
+                let src_inner = self.src_ty_of(&inner);
+                let short = type_short(&inner);
+                // The value is moved out of the box the C side owned.
+                (
+                    quote!(*mut #c),
+                    src_inner.clone(),
+                    quote!(*::std::boxed::Box::from_raw(v as *mut #src_inner)),
+                    short,
+                )
+            } else {
+                let inner = r_boxed_inner(fty)?;
+                let c = self.c_type_ident(&inner.key());
+                let src_inner = self.src_ty_of(&inner.key());
+                let short = type_short(&inner.key());
+                (
+                    quote!(*mut #c),
+                    src_inner.clone(),
+                    quote!(::std::boxed::Box::from_raw(v as *mut #src_inner)),
+                    short,
+                )
+            };
+        let _ = src_inner;
+        let produced = self.src_ty_of(&fty.key());
+        let function: syn::ItemFn = if optional {
+            syn::parse_quote!(
+                #[allow(non_snake_case, unused_variables, dead_code)]
+                pub(crate) unsafe fn #name(v: #wire) -> #produced {
+                    if v.is_null() {
+                        ::core::option::Option::None
+                    } else {
+                        ::core::option::Option::Some(#owned)
+                    }
+                }
+            )
+        } else {
+            let null_msg = format!(
+                "null payload for `{short}` (a non-optional payload cannot be NULL — the \
+                 union may already have been dropped)"
+            );
+            syn::parse_quote!(
+                #[allow(non_snake_case, unused_variables, dead_code)]
+                pub(crate) unsafe fn #name(
+                    v: #wire,
+                ) -> ::core::result::Result<#produced, ::std::string::String> {
+                    if v.is_null() {
+                        return ::core::result::Result::Err(
+                            ::std::string::String::from(#null_msg),
+                        );
+                    }
+                    ::core::result::Result::Ok(#owned)
+                }
+            )
+        };
+        Some(ConverterImpl {
+            subs: vec![],
+            destination: syn::parse_quote!(#wire),
+            function,
+            pre_stages: vec![],
+            niches: Niches::empty(),
+            metadata: (),
+        })
+    }
+
+    /// The peer of [`Self::in_boxed_payload`]: an owned value the C side must
+    /// later release, boxed here rather than having arrived boxed.
+    pub(crate) fn out_boxed_payload(&self, fty: &TypeRef) -> Option<ConverterImpl<()>> {
+        let name = format_ident!("{}_payload", Self::out_name_of(&fty.key()));
+        let optional = fty.optional_inner().is_some();
+        let src = self.src_ty_of(&fty.key());
+        let (wire, some_expr, bare_expr) =
+            if let Some(inner) = self.declared_opaque_payload_inner(fty) {
+                let c = self.c_type_ident(&inner);
+                (
+                    quote!(*mut #c),
+                    quote!(::std::boxed::Box::into_raw(::std::boxed::Box::new(__v)) as *mut #c),
+                    quote!(::std::boxed::Box::into_raw(::std::boxed::Box::new(v)) as *mut #c),
+                )
+            } else {
+                let inner = r_boxed_inner(fty)?;
+                let c = self.c_type_ident(&inner.key());
+                (
+                    quote!(*mut #c),
+                    quote!(::std::boxed::Box::into_raw(__v) as *mut #c),
+                    quote!(::std::boxed::Box::into_raw(v) as *mut #c),
+                )
+            };
+        let body: TokenStream = if optional {
+            quote!(match v {
+                ::core::option::Option::Some(__v) => #some_expr,
+                ::core::option::Option::None => ::core::ptr::null_mut(),
+            })
+        } else {
+            bare_expr
+        };
+        let function: syn::ItemFn = syn::parse_quote!(
+            #[allow(non_snake_case, unused_variables, dead_code)]
+            pub(crate) fn #name(v: #src) -> #wire {
+                #body
+            }
+        );
+        Some(ConverterImpl {
+            subs: vec![],
+            destination: syn::parse_quote!(#wire),
+            function,
+            pre_stages: vec![],
+            niches: Niches::empty(),
+            metadata: (),
+        })
+    }
+
     /// `String` **input from a `data_struct`'s mirror**: a null `char *`
     /// decodes to an empty string rather than refusing.
     ///
@@ -1076,123 +1235,6 @@ impl CbindgenBuilder {
         )
     }
 
-    /// Tagged-union **input**: **validate the tag**, then `match` the C union
-    /// back to the source enum, converting each arm's payload through the
-    /// per-field policy. The generalization of [`Self::in_enum`] from "match
-    /// idents" to "match idents and convert each arm's fields" — fallible for
-    /// the same reason, and by the same rule (#158): a Rust `enum` must never
-    /// be *materialised* from C-supplied bytes without checking first, because
-    /// an undeclared discriminant is UB at the boundary, before any `match`.
-    ///
-    /// So the wire is [`::core::mem::MaybeUninit`] over the mirror. A
-    /// `#[repr(C)]` enum with payload variants is laid out as a leading
-    /// discriminant of a C `int` followed by the variant union, so the tag is
-    /// read from the front as a plain `c_int` and range-checked against the
-    /// variants (the mirror carries no explicit discriminants, so its tags are
-    /// declaration order `0..N`). Only then is the value `assume_init`ed —
-    /// which is sound because [`CbindgenBuilder::payload_field_wire`] makes every
-    /// payload wire bit-pattern-agnostic, leaving the tag as the sole
-    /// obligation.
-    pub(crate) fn in_tagged_union(
-        &self,
-        ty: &TypeRef,
-        r: &impl Conversions<()>,
-        emit: &prebindgen_registry::Emit,
-    ) -> Option<ConverterImpl<()>> {
-        let key = ty.key();
-        if !self.tagged_unions.contains_key(&key) {
-            return None;
-        }
-        let e = payload_enum(r, &key)?;
-        let name = Self::in_name_of(&ty.key());
-        let cname = self.c_type_ident(&ty.key());
-        let src = self.src_ty_of(&ty.key());
-        // A payload that crosses through its own converter needs that converter
-        // to exist before this one can call it. `subs` only drives the
-        // post-resolution propagation pass, so it cannot order the build —
-        // returning `None` here is the resolver's DEFERRAL protocol, and it
-        // retries at the next fixed point. Without this the payload silently
-        // degrades to a passthrough and the generated code does not compile.
-        for a in &e.alternatives {
-            for f in &a.fields {
-                if self.payload_needs_converter(&f.ty) && r.input_entry(&f.ty).is_none() {
-                    return None;
-                }
-            }
-        }
-        let mut subs: Vec<TypeKey> = Vec::new();
-        let arms: Vec<TokenStream> = e
-            .alternatives
-            .iter()
-            .map(|a| {
-                let vident = &a.name;
-                let binds: Vec<syn::Ident> = (0..a.fields.len())
-                    .map(|i| format_ident!("__f{}", i))
-                    .collect();
-                let parts: Vec<TokenStream> = a
-                    .fields
-                    .iter()
-                    .zip(&binds)
-                    .map(|(f, b)| f.bind(b))
-                    .collect();
-                let from = emit.shape_alternative(a, quote!(#cname::#vident), &parts);
-                let exprs: Vec<TokenStream> = a
-                    .fields
-                    .iter()
-                    .zip(&binds)
-                    .map(|(f, b)| {
-                        // Every payload that crosses through a converter of its
-                        // own — a declared `enum_type`, a nested `data_struct`,
-                        // an opaque handle, a converted leaf — is a resolver
-                        // dependency, so its converter exists before this one is
-                        // emitted. Without it the payload silently falls back to
-                        // a passthrough and the generated code does not compile.
-                        if self.payload_needs_converter(&f.ty) {
-                            subs.push(f.ty.key());
-                        }
-                        self.payload_in_expr(&f.ty, b, r)
-                    })
-                    .collect();
-                let inits: Vec<TokenStream> = a
-                    .fields
-                    .iter()
-                    .zip(&exprs)
-                    .map(|(f, e)| f.bind(e))
-                    .collect();
-                let to = emit.shape_alternative(a, quote!(#src::#vident), &inits);
-                quote!(#from => #to,)
-            })
-            .collect();
-        let bad_msg = format!(
-            "invalid tag {{}} for `{cname}` (expected 0..{})",
-            e.alternatives.len()
-        );
-        let tag_guard = self.tag_guard(
-            &cname,
-            e.alternatives.len(),
-            quote!(v),
-            quote!(return ::core::result::Result::Err(::std::format!(#bad_msg, __tag));),
-        );
-        let function: syn::ItemFn = syn::parse_quote!(
-            #[allow(non_snake_case, unused_variables, dead_code)]
-            pub(crate) unsafe fn #name(
-                v: ::core::mem::MaybeUninit<#cname>,
-            ) -> ::core::result::Result<#src, ::std::string::String> {
-                #tag_guard
-                let v = v.assume_init();
-                ::core::result::Result::Ok(match v { #(#arms)* })
-            }
-        );
-        Some(ConverterImpl {
-            subs,
-            destination: syn::parse_quote!(::core::mem::MaybeUninit<#cname>),
-            function,
-            pre_stages: vec![],
-            niches: Niches::empty(),
-            metadata: (),
-        })
-    }
-
     /// The statements that make a C-supplied `MaybeUninit<mirror>` safe to
     /// `assume_init`: read the leading discriminant as a plain `c_int` and
     /// reject anything outside `0..variants`.
@@ -1203,7 +1245,7 @@ impl CbindgenBuilder {
     /// the typed drop returns `()` and so just bails). Passing that difference
     /// in, rather than letting the drop repeat the check inline, is what keeps
     /// the two from drifting apart.
-    fn tag_guard(
+    pub(crate) fn tag_guard(
         &self,
         cname: &syn::Ident,
         variants: usize,
@@ -1229,261 +1271,6 @@ impl CbindgenBuilder {
                 #on_bad
             }
         )
-    }
-
-    /// Tagged-union **output**: `match` the source enum to the C union,
-    /// converting each arm's payload. The counterpart of
-    /// [`Self::in_tagged_union`]; a `String` payload is allocated here and
-    /// released by the union's typed drop.
-    pub(crate) fn out_tagged_union(
-        &self,
-        ty: &TypeRef,
-        r: &impl Conversions<()>,
-        emit: &prebindgen_registry::Emit,
-    ) -> Option<ConverterImpl<()>> {
-        let key = ty.key();
-        if !self.tagged_unions.contains_key(&key) {
-            return None;
-        }
-        let e = payload_enum(r, &key)?;
-        let name = Self::out_name_of(&ty.key());
-        let cname = self.c_type_ident(&ty.key());
-        let src = self.src_ty_of(&ty.key());
-        // Deferral, as in `in_tagged_union` — the output counterpart.
-        for a in &e.alternatives {
-            for f in &a.fields {
-                if self.payload_needs_converter(&f.ty) && r.output_entry(&f.ty).is_none() {
-                    return None;
-                }
-            }
-        }
-        let mut subs: Vec<TypeKey> = Vec::new();
-        let arms: Vec<TokenStream> = e
-            .alternatives
-            .iter()
-            .map(|a| {
-                let vident = &a.name;
-                let binds: Vec<syn::Ident> = (0..a.fields.len())
-                    .map(|i| format_ident!("__f{}", i))
-                    .collect();
-                let parts: Vec<TokenStream> = a
-                    .fields
-                    .iter()
-                    .zip(&binds)
-                    .map(|(f, b)| f.bind(b))
-                    .collect();
-                let from = emit.shape_alternative(a, quote!(#src::#vident), &parts);
-                let exprs: Vec<TokenStream> = a
-                    .fields
-                    .iter()
-                    .zip(&binds)
-                    .map(|(f, b)| {
-                        if self.payload_needs_converter(&f.ty) {
-                            subs.push(f.ty.key());
-                        }
-                        self.payload_out_expr(&f.ty, b, r)
-                    })
-                    .collect();
-                let inits: Vec<TokenStream> = a
-                    .fields
-                    .iter()
-                    .zip(&exprs)
-                    .map(|(f, e)| f.bind(e))
-                    .collect();
-                let to = emit.shape_alternative(a, quote!(#cname::#vident), &inits);
-                quote!(#from => #to,)
-            })
-            .collect();
-        // Same wire as the input direction — one mirror type serves both, and a
-        // union carried through a `data_struct` field has only one field type
-        // to be. Rust always writes a live arm, so nothing is validated here.
-        let function: syn::ItemFn = syn::parse_quote!(
-            #[allow(non_snake_case, unused_variables, dead_code)]
-            pub(crate) fn #name(v: #src) -> ::core::mem::MaybeUninit<#cname> {
-                ::core::mem::MaybeUninit::new(match v { #(#arms)* })
-            }
-        );
-        Some(ConverterImpl {
-            subs,
-            destination: syn::parse_quote!(::core::mem::MaybeUninit<#cname>),
-            function,
-            pre_stages: vec![],
-            niches: Niches::empty(),
-            metadata: (),
-        })
-    }
-
-    /// One payload field, C wire → Rust value. Mirrors the `data_struct`
-    /// input policy, plus the opaque-pointer and declared-enum cases the
-    /// mirror wire allows.
-    fn payload_in_expr(
-        &self,
-        fty: &TypeRef,
-        b: &syn::Ident,
-        registry: &impl Conversions<()>,
-    ) -> TokenStream {
-        if r_is_string(fty) {
-            return quote!(if #b.is_null() {
-                ::std::string::String::new()
-            } else {
-                ::std::ffi::CStr::from_ptr(#b).to_string_lossy().into_owned()
-            });
-        }
-        if self.enums.contains_key(&fty.key()) {
-            // The payload rides as `MaybeUninit<enum mirror>` and goes through
-            // the same validating decode a top-level enum parameter does; an
-            // out-of-range one propagates out of the union's own converter.
-            let conv = Self::in_name_of(&fty.key());
-            return quote!(#conv(#b)?);
-        }
-        // The same opaque-pointer arm the wire took, for a spelling with no
-        // `Box` in it: the C caller still hands over a `*mut handle_t` it gave
-        // up ownership of, so the pointer is reclaimed the same way — the value
-        // is just moved out of the box instead of kept in one. Conversion
-        // follows the SYNTAX; the C type followed `kind` + the declaration.
-        if let Some(inner) = self.declared_opaque_payload_inner(fty) {
-            let src_inner = self.src_ty_of(&inner);
-            let owned = quote!(*::std::boxed::Box::from_raw(#b as *mut #src_inner));
-            let null_msg = format!(
-                "null payload for `{}` (a non-optional handle payload cannot be NULL — the \
-                 union may already have been dropped)",
-                type_short(&inner)
-            );
-            return if fty.optional_inner().is_some() {
-                quote!(if #b.is_null() {
-                    ::core::option::Option::None
-                } else {
-                    ::core::option::Option::Some(#owned)
-                })
-            } else {
-                quote!({
-                    if #b.is_null() {
-                        return ::core::result::Result::Err(
-                            ::std::string::String::from(#null_msg),
-                        );
-                    }
-                    #owned
-                })
-            };
-        }
-        if let Some(inner) = r_boxed_inner(fty) {
-            let src_inner = self.src_ty_of(&inner.key());
-            let boxed = quote!(::std::boxed::Box::from_raw(#b as *mut #src_inner));
-            return if fty.optional_inner().is_some() {
-                quote!(if #b.is_null() {
-                    ::core::option::Option::None
-                } else {
-                    ::core::option::Option::Some(#boxed)
-                })
-            } else {
-                // A bare `Box<T>` has no null representation, so a NULL slot
-                // cannot be decoded — and it is reachable, not hypothetical:
-                // the typed drop nulls the arm it frees, so a union passed back
-                // in after being dropped arrives here NULL. Same rule as the
-                // tag: report it, never materialise it.
-                let null_msg = format!(
-                    "null payload for `{}` (a non-optional `Box` payload cannot be NULL — the \
-                     union may already have been dropped)",
-                    type_short(&inner.key())
-                );
-                quote!({
-                    if #b.is_null() {
-                        return ::core::result::Result::Err(
-                            ::std::string::String::from(#null_msg),
-                        );
-                    }
-                    #boxed
-                })
-            };
-        }
-        // A `bool` payload rides as `MaybeUninit<bool>` (see `bool_wire`), so
-        // the byte C wrote is normalised rather than materialised.
-        if r_is_bool(fty) {
-            return bool_in_expr(quote!(#b));
-        }
-        // A scalar is its own wire and needs no call.
-        if r_is_scalar(fty) {
-            return quote!(#b);
-        }
-        // Everything else rides its own resolved input converter — the wire
-        // came from that converter's destination, so the two cannot disagree.
-        // A fallible one propagates with `?`, which the union's own `Result`
-        // already provides.
-        match registry.input_entry(fty) {
-            Some(entry) => {
-                let conv = &entry.function.sig.ident;
-                if returns_result(&entry.function.sig.output) {
-                    quote!(#conv(#b)?)
-                } else {
-                    quote!(#conv(#b))
-                }
-            }
-            None => quote!(#b),
-        }
-    }
-
-    /// One payload field, Rust value → C wire. The `String` arm allocates the
-    /// `char *` block the union's typed drop later frees.
-    fn payload_out_expr(
-        &self,
-        fty: &TypeRef,
-        b: &syn::Ident,
-        registry: &impl Conversions<()>,
-    ) -> TokenStream {
-        if r_is_string(fty) {
-            return quote!(__cbg_alloc_cstr(#b));
-        }
-        if self.enums.contains_key(&fty.key()) {
-            let conv = Self::out_name_of(&fty.key());
-            return quote!(::core::mem::MaybeUninit::new(#conv(#b)));
-        }
-        // The peer of the input arm above: an owned value the C side must later
-        // release, so it is boxed HERE rather than having arrived boxed.
-        if let Some(inner) = self.declared_opaque_payload_inner(fty) {
-            let c = self.c_type_ident(&inner);
-            return if fty.optional_inner().is_some() {
-                quote!(match #b {
-                    ::core::option::Option::Some(__v) => {
-                        ::std::boxed::Box::into_raw(::std::boxed::Box::new(__v)) as *mut #c
-                    }
-                    ::core::option::Option::None => ::core::ptr::null_mut(),
-                })
-            } else {
-                quote!(::std::boxed::Box::into_raw(::std::boxed::Box::new(#b)) as *mut #c)
-            };
-        }
-        if let Some(inner) = r_boxed_inner(fty) {
-            let c = self.c_type_ident(&inner.key());
-            return if fty.optional_inner().is_some() {
-                quote!(match #b {
-                    ::core::option::Option::Some(__b) => {
-                        ::std::boxed::Box::into_raw(__b) as *mut #c
-                    }
-                    ::core::option::Option::None => ::core::ptr::null_mut(),
-                })
-            } else {
-                quote!(::std::boxed::Box::into_raw(#b) as *mut #c)
-            };
-        }
-        // The counterpart of the normalising read above: Rust always writes a
-        // valid `0`/`1`, so this only wraps.
-        if r_is_bool(fty) {
-            return bool_out_expr(quote!(#b));
-        }
-        if r_is_scalar(fty) {
-            return quote!(#b);
-        }
-        // The output counterpart of the input dispatch above. Acceptance —
-        // including the refusal of a FALLIBLE output converter, which a union
-        // cannot report through — is decided once in `payload_field_wire`, so
-        // this site only emits the call.
-        match registry.output_entry(fty) {
-            Some(entry) => {
-                let conv = entry.function.sig.ident.clone();
-                quote!(#conv(#b))
-            }
-            None => quote!(#b),
-        }
     }
 
     /// Callback closure structs: one `#[repr(C)]` `{ context, call, drop }`
@@ -2054,14 +1841,14 @@ impl Prebindgen for CbindgenBuilder {
     }
 }
 
-/// Output-direction terminal categories — the rank-0 chain, now an inherent
-/// helper called by [`CbindgenBuilder::select_output_type`].
+/// Output-direction terminal categories: the shapes that cross whole, reached
+/// from the `atomic` hook.
 impl CbindgenBuilder {
     pub(crate) fn out_terminal(
         &self,
         ty: &TypeRef,
         _r: &impl Conversions<()>,
-        emit: &prebindgen_registry::Emit,
+        _emit: &prebindgen_registry::Emit,
     ) -> Option<ConverterImpl<()>> {
         // Unit return: trivial converter so `()` (and `Result<(), _>`) resolves.
         // Never actually called — void-returning wrappers ignore it, and
@@ -2218,12 +2005,6 @@ impl CbindgenBuilder {
                 niches: Niches::empty(),
                 metadata: (),
             });
-        }
-
-        // Tagged-union output: `match` the source enum to the C union,
-        // converting each arm's payload.
-        if let Some(c) = self.out_tagged_union(ty, _r, emit) {
-            return Some(c);
         }
 
         None

--- a/prebindgen-registry/src/recipe/compile.rs
+++ b/prebindgen-registry/src/recipe/compile.rs
@@ -546,8 +546,24 @@ impl<'a, C: Compile> Compiler<'a, C> {
         ty: &TypeRef,
         wanted: Mode,
     ) -> Built<C> {
+        self.part_of(adapter, at, assembly, None, index, ty, wanted)
+    }
+
+    /// [`Self::part`] for a part inside a [`Shape::Choice`] arm, which numbers
+    /// its parts from zero like every other arm.
+    #[allow(clippy::too_many_arguments)]
+    fn part_of(
+        &mut self,
+        adapter: &mut C,
+        at: At<'_>,
+        assembly: Assembly,
+        arm: Option<usize>,
+        index: usize,
+        ty: &TypeRef,
+        wanted: Mode,
+    ) -> Built<C> {
         let crossing = Crossing::new(ty.clone(), assembly);
-        let site = Site::part(at.crossing, at.recipe, index);
+        let site = Site::arm_part(at.crossing, at.recipe, arm, index);
         let Some(bound) = self.bindings.resolve(&site, &crossing, self.recipes) else {
             return Err(RecipeError::UnknownRow {
                 site,
@@ -596,7 +612,7 @@ impl<'a, C: Compile> Compiler<'a, C> {
             Shape::Sequence { inner } => self.sequence(adapter, at, inner),
             Shape::Product(op) => {
                 let (kind, parts) = self.construct_parts(at, op, None)?;
-                self.product(adapter, at, kind, parts)
+                self.product(adapter, at, None, kind, parts)
             }
             Shape::Choice { arms } => {
                 let mut built = Vec::new();
@@ -604,7 +620,8 @@ impl<'a, C: Compile> Compiler<'a, C> {
                     let alternative = self.alternative(at, arm.alternative)?;
                     let (kind, parts) =
                         self.construct_parts(at, &arm.op, Some(&alternative.fields))?;
-                    built.push((alternative, self.product(adapter, at, kind, parts)?));
+                    let at_arm = Some(arm.alternative);
+                    built.push((alternative, self.product(adapter, at, at_arm, kind, parts)?));
                 }
                 self.choice(adapter, at, built)
             }
@@ -623,7 +640,7 @@ impl<'a, C: Compile> Compiler<'a, C> {
             Shape::Sequence { inner } => self.sequence(adapter, at, inner),
             Shape::Product(op) => {
                 let (kind, parts) = self.deconstruct_parts(at, op, None)?;
-                self.product(adapter, at, kind, parts)
+                self.product(adapter, at, None, kind, parts)
             }
             Shape::Choice { arms } => {
                 let mut built = Vec::new();
@@ -631,7 +648,8 @@ impl<'a, C: Compile> Compiler<'a, C> {
                     let alternative = self.alternative(at, arm.alternative)?;
                     let (kind, parts) =
                         self.deconstruct_parts(at, &arm.op, Some(&alternative.fields))?;
-                    built.push((alternative, self.product(adapter, at, kind, parts)?));
+                    let at_arm = Some(arm.alternative);
+                    built.push((alternative, self.product(adapter, at, at_arm, kind, parts)?));
                 }
                 self.choice(adapter, at, built)
             }
@@ -716,6 +734,7 @@ impl<'a, C: Compile> Compiler<'a, C> {
         &mut self,
         adapter: &mut C,
         at: At<'_>,
+        arm: Option<usize>,
         kind: ProductKind<'p>,
         parts: Vec<Part<'p>>,
     ) -> Result<C::Fragment, CompileError<C::Error>> {
@@ -724,10 +743,11 @@ impl<'a, C: Compile> Compiler<'a, C> {
             // `part.mode` rather than the type's own spelling: a product edge
             // states what it needs — a constructor parameter, a field, an
             // accessor's receiver — and `part` checks against that.
-            built.push(self.part(
+            built.push(self.part_of(
                 adapter,
                 at,
                 at.crossing.assembly(),
+                arm,
                 index,
                 &part.ty,
                 part.mode,

--- a/prebindgen-registry/src/recipe/site.rs
+++ b/prebindgen-registry/src/recipe/site.rs
@@ -35,6 +35,15 @@ impl Site {
     /// type rather than chosen, so composing one by hand is a guess — this is
     /// the answer instead.
     pub fn part(of: &Crossing, recipe: &RecipeId, index: usize) -> Self {
+        Self::arm_part(of, recipe, None, index)
+    }
+
+    /// The site of one part of `of`'s row `recipe`, inside alternative `arm`.
+    ///
+    /// [`Self::part`] with the alternative stated. A part of a
+    /// [`Shape::Choice`](super::Shape::Choice) row needs it, because every arm
+    /// numbers its parts from zero.
+    pub fn arm_part(of: &Crossing, recipe: &RecipeId, arm: Option<usize>, index: usize) -> Self {
         Self {
             owner: of
                 .value()
@@ -44,6 +53,7 @@ impl Site {
             role: Role::Part {
                 of: of.key(),
                 recipe: recipe.clone(),
+                arm,
                 index,
             },
         }
@@ -99,7 +109,16 @@ pub enum Role {
         of: CrossingKey,
         /// Which of that crossing's rows.
         recipe: RecipeId,
-        /// The part's position within the row.
+        /// Which alternative, for a part inside a [`Shape::Choice`](super::Shape::Choice)
+        /// arm; `None` for a product's own part.
+        ///
+        /// Load-bearing rather than decorative: **every arm numbers its parts
+        /// from zero**, so `part 0` of a two-armed sum names two different
+        /// parts of two different types. Without the alternative there is no
+        /// key that tells them apart, and a binding written for one silently
+        /// collides with the other.
+        arm: Option<usize>,
+        /// The part's position within the row — or within its arm.
         index: usize,
     },
     /// A `#[prebindgen]` constant's value.
@@ -116,9 +135,15 @@ impl fmt::Display for Role {
             Role::CallbackArg { param, arg } => {
                 write!(f, "argument {arg} of the callback in parameter {param}")
             }
-            Role::Part { of, recipe, index } => {
-                write!(f, "part {index} of row `{recipe}` of {of}")
-            }
+            Role::Part {
+                of,
+                recipe,
+                arm,
+                index,
+            } => match arm {
+                Some(arm) => write!(f, "part {index} of arm {arm} of row `{recipe}` of {of}"),
+                None => write!(f, "part {index} of row `{recipe}` of {of}"),
+            },
             Role::Const => f.write_str("value"),
         }
     }


### PR DESCRIPTION
Stage 3 of [#465](https://github.com/milyin/prebindgen/pull/465), **closing [#458](https://github.com/milyin/prebindgen/issues/458)**. Targets `recipe-finish`. Stacked on [#467](https://github.com/milyin/prebindgen/pull/467).

All four hand-written walks named in #458 are deleted: `in_tagged_union`, `out_tagged_union`, and — once nothing called them — `payload_in_expr`, `payload_out_expr` and `payload_needs_converter`. Each arm's payload converts itself, and `Compile::choice` assembles the match, the tag guard and the mirror.

The generated **C ABI is unchanged**, `examples/smoke-asan.sh` is clean under ASan/LSan/UBSan, and the example's own compiled boundary tests pass.

## The three readings a payload has

A payload does not cross the way the same type crosses on its own, and the walks encoded that as branches. All three are now rows or holding forms.

**A `Box`-over-handle** rides in the union as a bare `*mut t_t` the C side owns — neither the whole-value reading (a handle parameter is spelled `Blob` and reclaimed from its own pointer) nor a struct field's. It shares a crossing with `Blob`'s own row, because `Crossing::key` peels `Box`; the two are told apart by the **site** that picks between their rows, and by the **fragment**, which is keyed by the spelling. That is the pair working exactly as #451 designed it.

**A `bool` and a `String`** read as they do inside a `data_struct`'s mirror — the row [#467](https://github.com/milyin/prebindgen/pull/467) added, reused here.

**A nested enum or `bool` is held as `MaybeUninit`** by whatever contains it, so a C caller's bytes have somewhere legal to sit until the tag is checked. That wrap belongs to the **container**, not to the value's own conversion. The existing `bool_payload_is_normalised_not_materialised` test caught it when it was briefly missing.

## Acceptance narrows to what can never cross

`payload_field_wire` mixed two refusals. One is a fact about the union: **a `Vec` needs two C wires and one union field carries one**, so its length would be silently dropped. That is still a panic, still names the arm (`Odd::Many`), and is now `payload_shape_refusal`.

The other — "no resolved OUTPUT converter" — **stops being a question**. It was the deferral protocol: a payload whose converter had not been built yet. Under composition the part in hand *is* the conversion, so a payload that reaches the hook has one by construction.

## Two things the existing tests caught

Worth naming, because both were mine and both were caught by tests that already existed rather than by ones I added:

- **The union's output wire briefly lost its `MaybeUninit`.** `__cbg_out_Note` returned a bare `note_t`, so a union returned by one function could not be handed to another that takes one. The example's compiled `boundary_tests.rs` failed to typecheck, which is exactly what that file is for.
- **A nested enum payload lost its `MaybeUninit` wrap** inside an arm. `tagged_union_mirror_and_converters` caught it.

## Registry changes this needed

**`Role::Part` gained the alternative.** Every arm numbers its parts from zero, so `part 0` of a two-armed sum named two different parts of two different types, and a binding written for one silently collided with the other. The table's own `Rebound` check caught it the first time a union's arms were stated — a gap in the site vocabulary from [#453](https://github.com/milyin/prebindgen/pull/453), invisible until something used it.

**`CFrag` carries an arm's converted payloads** from `fields` to `choice`. A union's arm is a product whose parts do not assemble into a value of their own — they are bound by a `match` and rebuilt on the other side — so the arm's fragment holds expressions rather than a function. That is "the adapter builds a product's fragment from its parts' fragments" when the product is one arm of a sum.

## Checks

93 `prebindgen-c` tests pass. The regen diff is the review surface, as the umbrella says from stage 2 on: the union converters keep their structure and their per-payload logic becomes calls to each payload's own conversion.

Local gate clean: clippy and rustfmt on 1.85.0 and stable, `cargo doc` with warnings denied, `cargo test --all`, `examples/regen-check.sh`, `examples/smoke-asan.sh`.
