### PR TITLE
Bind and compile every function's sites (#450)

### DIFF
--- a/prebindgen-c/src/compile.rs
+++ b/prebindgen-c/src/compile.rs
@@ -12,7 +12,7 @@
 
 use prebindgen_registry::{
     flat::{Alternative, Function},
-    recipe::{At, Carrier, Compile, Cx, Frag, Mode, Parts, Validity, Yield},
+    recipe::{At, Carrier, Compile, Cx, Frag, Mode, Parts, Role, Validity, Yield},
 };
 
 use super::*;
@@ -687,6 +687,18 @@ impl<R: Conversions<()>> Compile for CCompile<'_, R> {
         };
         let conv = self.gen.dispatch_fn_input(args, self.registry);
         self.wrap(at, "undeclared callback signature", conv)
+    }
+
+    /// C hands out borrows deliberately, so a returned one is not an error.
+    ///
+    /// A zero-copy accessor — `fn(&Sample) -> &ZBytes` — crosses as
+    /// `*const zbytes_t`, and C's own contract is that a `const` pointer is
+    /// non-owning: the caller neither frees it nor outlives the value it points
+    /// into. That is the target's ownership model rather than a weaker check,
+    /// and it is why the default strict reading belongs to the JVM and not
+    /// here.
+    fn tolerates(&self, _role: &Role) -> Validity {
+        Validity::Borrowed
     }
 
     fn plan(&mut self, _cx: &mut Cx<'_>, _bound: &Bound, _root: &CFrag) -> Result<(), String> {

--- a/prebindgen-c/src/trait_impl.rs
+++ b/prebindgen-c/src/trait_impl.rs
@@ -346,6 +346,75 @@ impl CbindgenBuilder {
         })
     }
 
+    /// Compile every site of every exported function.
+    ///
+    /// The second half of #450 reaching real positions. A **row** is what a
+    /// type's conversion is, and both adapters have compiled those since
+    /// #455/#457; a **site** is one position in the generated API, and this is
+    /// where they start being asked about.
+    ///
+    /// What it buys today is the validity contract: `Compiler::site` refuses a
+    /// site whose role outlives the call — a return, an error arm, a constant —
+    /// when the fragment it resolves to only borrows. Inside a product that has
+    /// been checked since #462; at a function's own boundary it has not.
+    ///
+    /// The plans are discarded. C's per-item emitter still builds each wrapper
+    /// from the converter table, and moving that is a change of its own.
+    fn check_sites<'v>(
+        &'v self,
+        compiler: &mut prebindgen_registry::recipe::Compiler<
+            '_,
+            crate::compile::CCompile<'v, Registry<()>>,
+        >,
+        registry: &'v Registry<()>,
+    ) -> Result<(), String> {
+        use prebindgen_registry::recipe::{Assembly, Crossing, Role, Site};
+
+        let mut adapter = crate::compile::CCompile {
+            gen: self,
+            registry,
+        };
+        let declared = self.declared_functions();
+        let mut names: Vec<&syn::Ident> = declared.iter().collect();
+        names.sort_by_key(|i| i.to_string());
+        for name in names {
+            let Some(f) = registry.flat().function(name) else {
+                continue;
+            };
+            for (index, param) in f.params.iter().enumerate() {
+                let site = Site {
+                    owner: name.clone(),
+                    role: Role::Param { index },
+                };
+                let crossing = Crossing::new(param.ty.clone(), Assembly::Construct);
+                compiler
+                    .site(&mut adapter, site, crossing)
+                    .map_err(|e| e.to_string())?;
+            }
+            // A `Result`'s arms are their own sites; the whole `Result` is not
+            // a value C ever holds, so it is not one.
+            let returns: Vec<(Role, &prebindgen_registry::flat::TypeRef)> =
+                match f.ret.fallible_parts() {
+                    Some((ok, err)) => vec![(Role::Return, ok), (Role::Error, err)],
+                    None => vec![(Role::Return, &f.ret)],
+                };
+            for (role, ty) in returns {
+                if matches!(ty.kind(), prebindgen_registry::flat::TypeKind::Unit) {
+                    continue;
+                }
+                let site = Site {
+                    owner: name.clone(),
+                    role,
+                };
+                let crossing = Crossing::new(ty.clone(), Assembly::Deconstruct);
+                compiler
+                    .site(&mut adapter, site, crossing)
+                    .map_err(|e| e.to_string())?;
+            }
+        }
+        Ok(())
+    }
+
     /// Which alternative of `key` these parts came from, by matching their
     /// field types against the model's.
     ///
@@ -1452,6 +1521,19 @@ impl CbindgenBuilder {
                 conv
             })?
             .build()?;
+        // Every site of every exported function, compiled. Nothing consumes
+        // the plans yet — C's per-item emitter still builds each wrapper — but
+        // this is what makes the contracts a site owns run against real
+        // positions rather than only inside a product: a returned value the C
+        // side keeps cannot be a borrow of something the call drops.
+        {
+            let mut compiler = prebindgen_registry::recipe::Compiler::resume(
+                &model, &recipes, &bindings, compiled,
+            );
+            self.check_sites(&mut compiler, &registry)
+                .map_err(|message| prebindgen_registry::ScanError::AdapterInvariant { message })?;
+            compiled = compiler.finish();
+        }
         // What the compilation produced, kept for emission. The converter table
         // stays the lookup index; this is what reaches the file.
         self.compiled_fns = compiled

--- a/prebindgen-c/src/trait_impl.rs
+++ b/prebindgen-c/src/trait_impl.rs
@@ -353,10 +353,13 @@ impl CbindgenBuilder {
     /// #455/#457; a **site** is one position in the generated API, and this is
     /// where they start being asked about.
     ///
-    /// What it buys today is the validity contract: `Compiler::site` refuses a
-    /// site whose role outlives the call — a return, an error arm, a constant —
-    /// when the fragment it resolves to only borrows. Inside a product that has
-    /// been checked since #462; at a function's own boundary it has not.
+    /// What it buys is that the contracts a site owns are asked at all. Which
+    /// answers count as failures is the target's, through
+    /// [`Compile::tolerates`] — and Cbindgen answers `Borrowed` everywhere,
+    /// because a `*const T` is C's own non-owning pointer and its zero-copy
+    /// accessors return one. So the validity check passes here by policy
+    /// rather than by luck, and the composition contracts — a part's type and
+    /// how it is held — are what actually run.
     ///
     /// The plans are discarded. C's per-item emitter still builds each wrapper
     /// from the converter table, and moving that is a change of its own.
@@ -1523,9 +1526,10 @@ impl CbindgenBuilder {
             .build()?;
         // Every site of every exported function, compiled. Nothing consumes
         // the plans yet — C's per-item emitter still builds each wrapper — but
-        // this is what makes the contracts a site owns run against real
-        // positions rather than only inside a product: a returned value the C
-        // side keeps cannot be a borrow of something the call drops.
+        // it is what makes the contracts a site owns run against real positions
+        // rather than only inside a product. What each one demands is the
+        // target's answer: see `CCompile::tolerates` for why C accepts a
+        // borrowed return where the JVM must not.
         {
             let mut compiler = prebindgen_registry::recipe::Compiler::resume(
                 &model, &recipes, &bindings, compiled,

--- a/prebindgen-registry/src/recipe/compile.rs
+++ b/prebindgen-registry/src/recipe/compile.rs
@@ -293,6 +293,26 @@ pub trait Compile {
         result: Option<&Self::Fragment>,
     ) -> Frag<Self>;
 
+    /// The weakest validity this role accepts in **this** target.
+    ///
+    /// Not the registry's to decide, because it follows from the target's
+    /// ownership model. C hands out a `*const T` for a zero-copy accessor and
+    /// its contract says the caller neither frees nor outlives it, so a
+    /// borrowed return is correct there. The JVM keeps what it is given, so
+    /// JniGen clones instead and a borrowed return would be a use-after-free.
+    ///
+    /// The default is the strict reading: anything the foreign side may keep
+    /// past the call must be self-sufficient, and only a position that lives
+    /// for the duration of the call may borrow.
+    fn tolerates(&self, role: &Role) -> Validity {
+        match role {
+            Role::Return | Role::Error | Role::Const => Validity::SelfSufficient,
+            Role::Param { .. } | Role::Receiver | Role::CallbackArg { .. } | Role::Part { .. } => {
+                Validity::Borrowed
+            }
+        }
+    }
+
     /// Wrap the site's root fragment into a plan — the signature, the call, the
     /// cleanup.
     ///
@@ -457,7 +477,7 @@ impl<'a, C: Compile> Compiler<'a, C> {
             return Ok(None);
         };
         let root = self.row(adapter, &bound.crossing, &bound.recipe)?;
-        let needed = tolerated(&bound.site.role);
+        let needed = adapter.tolerates(&bound.site.role);
         let got = root.yields().validity;
         if !got.satisfies(needed) {
             return Err(RecipeError::Validity {
@@ -1034,17 +1054,4 @@ fn element_mode(crossing: &Crossing, elem: &TypeRef) -> Mode {
     // up and what it gives up is a borrow; a `&[&mut T]` yields `&&mut T` and
     // so cannot hand over the `&mut T` its element is spelled as.
     mode_of(elem).through(lent_as)
-}
-
-/// The weakest validity a role accepts.
-///
-/// A value the foreign side stores has to outlive the call; an argument valid
-/// only for the duration of one may be borrowed.
-fn tolerated(role: &Role) -> Validity {
-    match role {
-        Role::Return | Role::Error | Role::Const => Validity::SelfSufficient,
-        Role::Param { .. } | Role::Receiver | Role::CallbackArg { .. } | Role::Part { .. } => {
-            Validity::Borrowed
-        }
-    }
 }

--- a/prebindgen-registry/src/recipe/tests.rs
+++ b/prebindgen-registry/src/recipe/tests.rs
@@ -1963,15 +1963,13 @@ fn what_a_role_tolerates_is_the_adapters_own_answer() {
             func: &Function,
             args: Parts<'_, Self>,
         ) -> Frag<Self> {
-            let args: Vec<_> = args.iter().map(|(p, f)| (p.clone(), *f)).collect();
-            self.0.construct(cx, at, func, &args)
+            self.0.construct(cx, at, func, args)
         }
         fn identity(&mut self, cx: &mut Cx<'_>, at: At<'_>, inner: &Note) -> Frag<Self> {
             self.0.identity(cx, at, inner)
         }
         fn fields(&mut self, cx: &mut Cx<'_>, at: At<'_>, parts: Parts<'_, Self>) -> Frag<Self> {
-            let parts: Vec<_> = parts.iter().map(|(p, f)| (p.clone(), *f)).collect();
-            self.0.fields(cx, at, &parts)
+            self.0.fields(cx, at, parts)
         }
         fn value_form(
             &mut self,
@@ -1980,8 +1978,7 @@ fn what_a_role_tolerates_is_the_adapters_own_answer() {
             func: &Function,
             parts: Parts<'_, Self>,
         ) -> Frag<Self> {
-            let parts: Vec<_> = parts.iter().map(|(p, f)| (p.clone(), *f)).collect();
-            self.0.value_form(cx, at, func, &parts)
+            self.0.value_form(cx, at, func, parts)
         }
         fn choice(
             &mut self,

--- a/prebindgen-registry/src/recipe/tests.rs
+++ b/prebindgen-registry/src/recipe/tests.rs
@@ -1928,6 +1928,115 @@ fn a_constructor_reached_through_a_borrow_or_a_box_is_accepted() {
 }
 
 #[test]
+fn what_a_role_tolerates_is_the_adapters_own_answer() {
+    // The strict default refuses a borrowed return; an adapter whose target
+    // hands out non-owning pointers deliberately says so and is not refused.
+    // C is that adapter: a zero-copy accessor crosses as `*const T`, and C's
+    // contract is that the caller neither frees it nor outlives it.
+    struct Lenient(Recorder);
+    impl Compile for Lenient {
+        type Fragment = Note;
+        type Plan = String;
+        type Error = String;
+        fn tolerates(&self, _role: &Role) -> Validity {
+            Validity::Borrowed
+        }
+        fn atomic(&mut self, cx: &mut Cx<'_>, at: At<'_>) -> Frag<Self> {
+            self.0.atomic(cx, at)
+        }
+        fn optional(&mut self, cx: &mut Cx<'_>, at: At<'_>, inner: &Note) -> Frag<Self> {
+            self.0.optional(cx, at, inner)
+        }
+        fn sequence(
+            &mut self,
+            cx: &mut Cx<'_>,
+            at: At<'_>,
+            elements: Mode,
+            inner: &Note,
+        ) -> Frag<Self> {
+            self.0.sequence(cx, at, elements, inner)
+        }
+        fn construct(
+            &mut self,
+            cx: &mut Cx<'_>,
+            at: At<'_>,
+            func: &Function,
+            args: Parts<'_, Self>,
+        ) -> Frag<Self> {
+            let args: Vec<_> = args.iter().map(|(p, f)| (p.clone(), *f)).collect();
+            self.0.construct(cx, at, func, &args)
+        }
+        fn identity(&mut self, cx: &mut Cx<'_>, at: At<'_>, inner: &Note) -> Frag<Self> {
+            self.0.identity(cx, at, inner)
+        }
+        fn fields(&mut self, cx: &mut Cx<'_>, at: At<'_>, parts: Parts<'_, Self>) -> Frag<Self> {
+            let parts: Vec<_> = parts.iter().map(|(p, f)| (p.clone(), *f)).collect();
+            self.0.fields(cx, at, &parts)
+        }
+        fn value_form(
+            &mut self,
+            cx: &mut Cx<'_>,
+            at: At<'_>,
+            func: &Function,
+            parts: Parts<'_, Self>,
+        ) -> Frag<Self> {
+            let parts: Vec<_> = parts.iter().map(|(p, f)| (p.clone(), *f)).collect();
+            self.0.value_form(cx, at, func, &parts)
+        }
+        fn choice(
+            &mut self,
+            cx: &mut Cx<'_>,
+            at: At<'_>,
+            arms: &[(&Alternative, &Note)],
+        ) -> Frag<Self> {
+            self.0.choice(cx, at, arms)
+        }
+        fn callback(
+            &mut self,
+            cx: &mut Cx<'_>,
+            at: At<'_>,
+            args: &[&Note],
+            result: Option<&Note>,
+        ) -> Frag<Self> {
+            self.0.callback(cx, at, args, result)
+        }
+        fn plan(&mut self, cx: &mut Cx<'_>, bound: &Bound, root: &Note) -> Result<String, String> {
+            self.0.plan(cx, bound, root)
+        }
+    }
+
+    let model = model(&[SAMPLE]);
+    let recipes = Recipes::default();
+    let bindings = Bindings::default();
+    let ret = Site {
+        owner: ident("z_sample_payload"),
+        role: Role::Return,
+    };
+    let crossing = || Crossing::new(ty(&model, "Sample"), Assembly::Deconstruct);
+
+    // Strict: refused.
+    let mut strict = Recorder::default();
+    strict.borrowed.insert("Sample".to_owned());
+    let mut compiler = Compiler::new(&model, &recipes, &bindings);
+    let error = compiler
+        .site(&mut strict, ret.clone(), crossing())
+        .expect_err("the default refuses a borrowed return");
+    assert!(
+        matches!(recipe_error(&error), RecipeError::Validity { .. }),
+        "{error:?}"
+    );
+
+    // Lenient: the same fragment, accepted, because the target says so.
+    let mut inner = Recorder::default();
+    inner.borrowed.insert("Sample".to_owned());
+    let mut lenient = Lenient(inner);
+    let mut compiler = Compiler::new(&model, &recipes, &bindings);
+    compiler
+        .site(&mut lenient, ret, crossing())
+        .expect("an adapter that hands out non-owning pointers is not refused");
+}
+
+#[test]
 fn a_returned_value_the_foreign_side_keeps_cannot_be_borrowed() {
     let model = model(&[SAMPLE]);
     let recipes = Recipes::default();


### PR DESCRIPTION
Stage 4 of [#465](https://github.com/milyin/prebindgen/pull/465). Targets `recipe-finish`.

`Compiler::site` and `Compile::plan` have shipped unused since [#454](https://github.com/milyin/prebindgen/pull/454) — rows compiled to fragments, and nothing ever asked about a position. `prebindgen-c` now compiles every parameter, return and error arm of every exported function through `Compiler::site`.

**This is sites being *asked*, not sites *owning emission*.** The plans are discarded and C's per-item emitter still builds each wrapper from the converter table. Naming it that way rather than the other is the point: the JNI stages need the second, and this is what they build on. Output is byte-identical.

## Why the order changed

Stage 4 was "delete the stranded machinery" when this branch opened, and per-site emission was stage 6. Porting `prebindgen-c` showed why that was backwards for JNI:

`InputKind::FlattenStruct` says one Kotlin parameter arrives as **several JNI parameters**, and `render.rs:528` expands the exported signature to match. That is the signature, the call and the cleanup around one value — a plan, not a fragment, because a fragment answers per crossing and this is per site. C never asked the question; JNI asks it in its first composition stage.

That is the sequencing the [architecture review](https://github.com/milyin/prebindgen/pull/465#issuecomment-5361741324) argued for, reached from the other direction.

## Asking the question found a wrong rule

`tolerated()` was a fixed registry-side table: a return, an error arm or a constant must be self-sufficient, everything else may borrow. Turning it on refused a real function on the first run:

```
z_sample_payload's return value needs a self-sufficient value and its fragment produces a borrowed one
```

`fn z_sample_payload(s: &ZSample) -> &ZBytes` is C's zero-copy accessor idiom. It crosses as `*const zbytes_t`, and **C's own contract is that a `const` pointer is non-owning** — the caller neither frees it nor outlives the value it points into. `borrowed_ref_output_is_const_non_owning` has asserted exactly that for as long as the test has existed. #450 agrees, and says so in the same breath as introducing `Validity`:

> Zero-copy gets a legitimate home instead of being an exception — `Cbindgen::repr_c_struct` crosses a `&T` as a `*const` pointer cast, which is a `Borrowed` carrier and is correct at the sites where it is used.

So the rule was in the wrong place. **Whether a borrowed return is acceptable follows from the target's ownership model**, which is the thing #450 keeps in the adapter: the JVM keeps what it is handed, which is why JniGen *clones* a borrowed opaque output into a fresh handle; C hands out a pointer and documents that it is on loan.

`Compile::tolerates` is that policy. It defaults to the strict reading — the one the JVM needs, and the one the registry had — and `Cbindgen` overrides it with the reason written down.

## Checks

- 93 `prebindgen-c` tests pass, including `borrowed_ref_output_is_const_non_owning`, which is the one that made the finding.
- One new registry test drives two adapters over the same borrowed fragment at the same return site: the strict default refuses it, an adapter that hands out non-owning pointers does not.
- Output **byte-identical** — this stage asks questions and discards the answers.

Local gate clean: clippy and rustfmt on 1.85.0 and stable, `cargo doc` with warnings denied, `cargo test --all`, `examples/regen-check.sh`.

*(Unrelated: the box's disk hit 100%, which surfaced as linker bus errors in the doctests. 68,000 stale test-scratch directories under `/tmp` from this crate's own `write()` helper — 5.5 GB — cleared. Worth a look at whether those should be cleaned up by the tests that make them.)*
