### PR TITLE
Umbrella: switch both adapters onto the registry API, and delete what it replaces (#450)

### DIFF
--- a/prebindgen-c/src/compile.rs
+++ b/prebindgen-c/src/compile.rs
@@ -306,10 +306,6 @@ impl<R: Conversions> Compile for CCompile<'_, R> {
         self.wrap(at, "no C representation for this run", conv)
     }
 
-    fn identity(&mut self, _cx: &mut Cx<'_>, at: At<'_>, _inner: &CFrag) -> Frag<Self> {
-        Err(refuse(at, "Cbindgen declares no identity rows"))
-    }
-
     fn construct(
         &mut self,
         _cx: &mut Cx<'_>,

--- a/prebindgen-c/src/compile.rs
+++ b/prebindgen-c/src/compile.rs
@@ -66,7 +66,7 @@ impl Carrier for CFrag {
 
 impl CFrag {
     /// One of the adapter's existing converter builders, as a fragment.
-    fn from_converter(at: At<'_>, conv: ConverterImpl<()>) -> Self {
+    fn from_converter(at: At<'_>, conv: ConverterImpl) -> Self {
         let validity = validity_of(&conv, at.crossing.assembly());
         Self {
             destination: conv.destination,
@@ -83,7 +83,7 @@ impl CFrag {
     }
 
     /// What the registry that still emits converters expects back.
-    pub(crate) fn into_converter(self) -> ConverterImpl<()> {
+    pub(crate) fn into_converter(self) -> ConverterImpl {
         ConverterImpl {
             destination: self.destination,
             function: self.function,
@@ -101,7 +101,7 @@ impl CFrag {
 /// Reading the spelling is wrong in both directions: a conversion may clone or
 /// allocate out of a borrow, and — the case C actually has — a conversion may
 /// hand C a pointer *into* a Rust value from a crossing that looks owned.
-fn validity_of(conv: &ConverterImpl<()>, assembly: Assembly) -> Validity {
+fn validity_of(conv: &ConverterImpl, assembly: Assembly) -> Validity {
     match assembly {
         // Rust to C. A `*const T` is the zero-copy borrow: `out_borrow_or_result`
         // casts the Rust value's own address, and `repr_c_struct`'s reinterpret
@@ -194,14 +194,14 @@ fn refuse(at: At<'_>, why: &str) -> String {
     format!("Cbindgen: {} ({why})", at.crossing.key())
 }
 
-impl<R: Conversions<()>> CCompile<'_, R> {
-    fn wrap(&self, at: At<'_>, why: &str, conv: Option<ConverterImpl<()>>) -> Frag<Self> {
+impl<R: Conversions> CCompile<'_, R> {
+    fn wrap(&self, at: At<'_>, why: &str, conv: Option<ConverterImpl>) -> Frag<Self> {
         conv.map(|c| CFrag::from_converter(at, c))
             .ok_or_else(|| refuse(at, why))
     }
 }
 
-impl<R: Conversions<()>> Compile for CCompile<'_, R> {
+impl<R: Conversions> Compile for CCompile<'_, R> {
     type Fragment = CFrag;
     /// C keeps its own per-site emission for now: the exported signature, the
     /// call and the cleanup are built in `emit.rs` from the resolved registry.

--- a/prebindgen-c/src/compile.rs
+++ b/prebindgen-c/src/compile.rs
@@ -397,7 +397,7 @@ impl<R: Conversions<()>> Compile for CCompile<'_, R> {
                     // to the value's own conversion.
                     match (
                         at.crossing.assembly(),
-                        self.gen.payload_field_wire(&part.ty, self.registry),
+                        self.gen.payload_field_wire(&part.ty),
                     ) {
                         (Assembly::Deconstruct, Ok(w)) if held_uninit(&w, &frag.destination) => {
                             quote!(::core::mem::MaybeUninit::new(#call))

--- a/prebindgen-c/src/convert.rs
+++ b/prebindgen-c/src/convert.rs
@@ -3,7 +3,7 @@ use prebindgen_registry::Conversions;
 use super::*;
 
 impl CbindgenBuilder {
-    pub(crate) fn prereq_domain_constants(&self, registry: &Registry<()>) -> Vec<syn::Item> {
+    pub(crate) fn prereq_domain_constants(&self, registry: &Registry) -> Vec<syn::Item> {
         let mut items = Vec::new();
         for decl in &self.convert_decls {
             let Some(domain) = decl.domain() else {
@@ -55,9 +55,9 @@ impl CbindgenBuilder {
     pub(crate) fn in_custom(
         &self,
         ty: &TypeRef,
-        registry: &impl Conversions<()>,
+        registry: &impl Conversions,
         emit: &prebindgen_registry::Emit,
-    ) -> Option<ConverterImpl<()>> {
+    ) -> Option<ConverterImpl> {
         let key = ty.key();
         let decl = self.convert_decls.iter().find(|d| *d.key() == key)?;
         let spec = decl.input_spec().as_ref()?;
@@ -123,9 +123,9 @@ impl CbindgenBuilder {
     pub(crate) fn out_custom(
         &self,
         ty: &TypeRef,
-        registry: &impl Conversions<()>,
+        registry: &impl Conversions,
         emit: &prebindgen_registry::Emit,
-    ) -> Option<ConverterImpl<()>> {
+    ) -> Option<ConverterImpl> {
         let key = ty.key();
         let decl = self.convert_decls.iter().find(|d| *d.key() == key)?;
         let spec = decl.output_spec().as_ref()?;
@@ -193,7 +193,7 @@ impl CbindgenBuilder {
         &self,
         decl: &ConvertDecl,
         spec: &ConvertSpec,
-        registry: &impl Conversions<()>,
+        registry: &impl Conversions,
         emit: &prebindgen_registry::Emit,
     ) -> (syn::Type, syn::Expr, bool) {
         let target = self.src_ty_of(&decl.rust_type().key());
@@ -240,7 +240,7 @@ impl CbindgenBuilder {
         &self,
         decl: &ConvertDecl,
         spec: &ConvertSpec,
-        registry: &impl Conversions<()>,
+        registry: &impl Conversions,
         emit: &prebindgen_registry::Emit,
     ) -> (syn::Type, syn::Expr, bool) {
         let target = self.src_ty_of(&decl.rust_type().key());
@@ -282,7 +282,7 @@ impl CbindgenBuilder {
     fn c_domain_niches(
         &self,
         decl: &ConvertDecl,
-        registry: &impl Conversions<()>,
+        registry: &impl Conversions,
         direction: Direction,
     ) -> Niches {
         let Some(domain) = decl.domain() else {
@@ -329,7 +329,7 @@ impl CbindgenBuilder {
         )
     }
 
-    fn conversion_fn_path(&self, registry: &impl Conversions<()>, ident: &syn::Ident) -> syn::Path {
+    fn conversion_fn_path(&self, registry: &impl Conversions, ident: &syn::Ident) -> syn::Path {
         let Some(mut module) = registry.origin_module(ident) else {
             return self.src_fn(ident);
         };

--- a/prebindgen-c/src/emit.rs
+++ b/prebindgen-c/src/emit.rs
@@ -493,8 +493,7 @@ impl CbindgenBuilder {
         // the `ReturnType::Default` arm this used to write.
 
         let has_fallible_input = f.params.iter().any(|p| {
-            registry
-                .input_entry(&p.ty)
+            self.in_frag(&p.ty)
                 .map(|e| returns_result(&e.function.sig.output))
                 .unwrap_or(false)
         });
@@ -508,7 +507,7 @@ impl CbindgenBuilder {
             None => (&f.ret, None),
         };
         let err_ty: Option<syn::Type> = err_reading.map(|t| spelled(t, emit));
-        let has_fallible_output = Self::output_is_fallible(value_ty, registry);
+        let has_fallible_output = self.output_is_fallible(value_ty);
 
         // Error wiring: the error type must be declared via `.error()`.
         let err_bits = err_ty.as_ref().map(|err_ty| {
@@ -716,14 +715,14 @@ impl CbindgenBuilder {
         // own; decomposing it anyway would describe a different ABI from the one
         // the converter table hands out, and the two must agree (#428 review).
         // The base case below already does this for a type with no shape arm.
-        if !r_has_own_wire(ty, registry) {
+        if !self.has_own_wire(ty) {
             // `Vec<T>` → `T_wire* + size_t`. The element must lower to a single C
             // value (one converter); a composite element is unsupported.
             // `TypeKind::Vec` and not `sequence_elem`: that reading peels the
             // erased wrappers first, so a `Cow<'_, [u8]>` would answer here and
             // take the `Vec` lowering instead of its own arm below.
             if let TypeKind::Vec(elem) = ty.kind() {
-                let entry = registry.output_entry(elem).unwrap_or_else(|| {
+                let entry = self.out_frag(elem).unwrap_or_else(|| {
                     panic!(
                         "Cbindgen: `Vec` element `{}` has no output converter",
                         elem.key()
@@ -767,7 +766,7 @@ impl CbindgenBuilder {
             // lowering, so the wrapper returned nothing and called the marker with
             // an argument it does not take (#413).
             if let Some(elem) = r_cow_slice_elem(ty).or_else(|| r_scalar_slice_elem(ty)) {
-                let entry = registry.output_entry(elem).unwrap_or_else(|| {
+                let entry = self.out_frag(elem).unwrap_or_else(|| {
                     panic!(
                         "Cbindgen: `Cow` slice element `{}` has no output converter",
                         elem.key()
@@ -813,7 +812,7 @@ impl CbindgenBuilder {
         // Base value: one wire component from its rank-0/1 converter. Custom
         // conversions may declare scalar niches; otherwise a pointer wire
         // (String, opaque handle, `&'static`) carries a free NULL niche.
-        let entry = registry.output_entry(ty).unwrap_or_else(|| {
+        let entry = self.out_frag(ty).unwrap_or_else(|| {
             panic!(
                 "Cbindgen::on_function: type `{}` has no output converter",
                 ty.key()
@@ -848,9 +847,9 @@ impl CbindgenBuilder {
         // The peer of `lower_shape`'s guard: a node with a wire of its own is
         // encoded by its own converter, whatever its shape. The two walk the
         // same value and must stop at the same places (#428 review).
-        if !r_has_own_wire(ty, registry) {
+        if !self.has_own_wire(ty) {
             if let TypeKind::Vec(elem) = ty.kind() {
-                let entry = registry.output_entry(elem).expect("Vec element converter");
+                let entry = self.out_frag(elem).expect("Vec element converter");
                 let elem_conv = entry.function.sig.ident.clone();
                 let elem_map = map_arg(&elem_conv, entry.function.sig.unsafety.is_some());
                 let elem_wire = entry.destination.clone();
@@ -878,9 +877,7 @@ impl CbindgenBuilder {
                 }
             }
             if let Some(elem) = r_cow_slice_elem(ty).or_else(|| r_scalar_slice_elem(ty)) {
-                let entry = registry
-                    .output_entry(elem)
-                    .expect("slice element converter");
+                let entry = self.out_frag(elem).expect("slice element converter");
                 let elem_conv = entry.function.sig.ident.clone();
                 let elem_map = map_arg(&elem_conv, entry.function.sig.unsafety.is_some());
                 let elem_wire = entry.destination.clone();
@@ -935,7 +932,7 @@ impl CbindgenBuilder {
             }
         }
         // Base value: run its output converter into the single target.
-        let entry = registry.output_entry(ty).expect("base value converter");
+        let entry = self.out_frag(ty).expect("base value converter");
         let conv = entry.function.sig.ident.clone();
         let t0 = &targets[0];
         if returns_result(&entry.function.sig.output) {
@@ -946,7 +943,7 @@ impl CbindgenBuilder {
         }
     }
 
-    fn output_is_fallible(ty: &TypeRef, registry: &impl Conversions<()>) -> bool {
+    fn output_is_fallible(&self, ty: &TypeRef) -> bool {
         // The third walk over the same value, and it stops where the other two
         // do: a node with a wire of its own is encoded by its own converter, so
         // whether the encode can fail is THAT converter's answer. Peeling past
@@ -954,7 +951,7 @@ impl CbindgenBuilder {
         // binding needs `.panic()`, so the two disagreeing is a wrapper that
         // aborts where nothing opted in, or an opt-in demanded for a conversion
         // that cannot fail (#428 review).
-        if !r_has_own_wire(ty, registry) {
+        if !self.has_own_wire(ty) {
             let vec_elem = match ty.kind() {
                 TypeKind::Vec(e) => Some(&**e),
                 _ => None,
@@ -965,11 +962,10 @@ impl CbindgenBuilder {
                 .or_else(|| r_cow_slice_elem(ty))
                 .or_else(|| r_scalar_slice_elem(ty))
             {
-                return Self::output_is_fallible(inner, registry);
+                return self.output_is_fallible(inner);
             }
         }
-        registry
-            .output_entry(ty)
+        self.out_frag(ty)
             .is_some_and(|entry| returns_result(&entry.function.sig.output))
     }
 

--- a/prebindgen-c/src/emit.rs
+++ b/prebindgen-c/src/emit.rs
@@ -6,7 +6,7 @@ impl CbindgenBuilder {
     /// Whether the generated layer hands `char*` data memory to C — a `String`
     /// return value, or a declared data struct that is produced as output and has
     /// a `String` field. When true, a `free_memory_function` must be declared.
-    pub(super) fn needs_free(&self, registry: &Registry<()>) -> bool {
+    pub(super) fn needs_free(&self, registry: &Registry) -> bool {
         let string_ty: syn::Type = syn::parse_quote!(String);
         // A `String` return hands out a `char*` — unless `String` is declared
         // `opaque_ptr` (then it crosses as `string_t *`, freed by `string_drop`).
@@ -65,7 +65,7 @@ impl CbindgenBuilder {
     /// path segment, and fetched the `syn::ItemEnum` to reach the same list.
     pub(super) fn enum_alternatives<'r>(
         &self,
-        registry: &'r Registry<()>,
+        registry: &'r Registry,
         key: &TypeKey,
     ) -> Option<&'r [prebindgen_registry::flat::Alternative]> {
         match registry.flat().declared_type(&key.ident()?)? {
@@ -284,7 +284,7 @@ impl CbindgenBuilder {
         &self,
         fty: &TypeRef,
         wire: &syn::Type,
-        registry: &Registry<()>,
+        registry: &Registry,
     ) -> bool {
         if matches!(wire, syn::Type::Ptr(_)) {
             return true;
@@ -297,7 +297,7 @@ impl CbindgenBuilder {
     pub(super) fn owning_data_struct_fields<'r>(
         &self,
         fty: &TypeRef,
-        registry: &'r Registry<()>,
+        registry: &'r Registry,
     ) -> Vec<(syn::Ident, &'r TypeRef)> {
         if !self.data.contains_key(&fty.key()) {
             return Vec::new();
@@ -313,7 +313,7 @@ impl CbindgenBuilder {
     /// is a pointer (`String` → `char *`), or it is a declared
     /// [`CbindgenBuilder::tagged_union`] with an owning arm — which crosses by value,
     /// so the pointer it owns is one level further down.
-    fn data_field_owns(&self, fty: &TypeRef, registry: &Registry<()>) -> bool {
+    fn data_field_owns(&self, fty: &TypeRef, registry: &Registry) -> bool {
         if matches!(self.data_field_wire(fty), Some(syn::Type::Ptr(_))) {
             return true;
         }
@@ -328,7 +328,7 @@ impl CbindgenBuilder {
     /// containing struct has to call it, so a union nested inside a payload
     /// cannot be freed through a symbol that was never emitted. `false` for
     /// anything that is not a declared tagged union.
-    pub(super) fn tagged_union_has_drop(&self, fty: &TypeRef, registry: &Registry<()>) -> bool {
+    pub(super) fn tagged_union_has_drop(&self, fty: &TypeRef, registry: &Registry) -> bool {
         if !self.tagged_unions.contains_key(&fty.key()) || self.out_frag(fty).is_none() {
             return false;
         }
@@ -352,7 +352,7 @@ impl CbindgenBuilder {
     /// it crosses as. [`sequence_elem`](prebindgen_registry::flat::TypeRef::sequence_elem)
     /// answers all three, which is why the two spellings this used to test
     /// separately need no arms of their own.
-    pub(super) fn produces_array(&self, registry: &Registry<()>) -> bool {
+    pub(super) fn produces_array(&self, registry: &Registry) -> bool {
         self.functions.keys().any(|orig| {
             registry
                 .flat()
@@ -369,7 +369,7 @@ impl CbindgenBuilder {
     /// struct.
     pub(super) fn struct_fields<'r>(
         &self,
-        registry: &'r impl Conversions<()>,
+        registry: &'r impl Conversions,
         key: &TypeKey,
     ) -> Option<Vec<(syn::Ident, &'r TypeRef)>> {
         // The element, not its item. A `Struct` holds the field list the
@@ -449,7 +449,7 @@ impl CbindgenBuilder {
     /// declaration order. Empty ⇒ the whole mirror is safe to reinterpret.
     pub(super) fn restricted_validity_fields(
         &self,
-        registry: &Registry<()>,
+        registry: &Registry,
         key: &TypeKey,
     ) -> Vec<(syn::Ident, &'static str)> {
         self.struct_fields(registry, key)
@@ -481,7 +481,7 @@ impl CbindgenBuilder {
     pub(super) fn emit_function_wrapper(
         &self,
         f: &prebindgen_registry::flat::Function,
-        registry: &Registry<()>,
+        registry: &Registry,
         emit: &prebindgen_registry::Emit,
     ) -> TokenStream {
         let orig = &f.name;
@@ -702,7 +702,7 @@ impl CbindgenBuilder {
     /// available for enclosing `Option`/`Result` layers. Mirrors the
     /// niche-stacking model in `core::niches`.
     #[allow(clippy::only_used_in_recursion)]
-    pub(super) fn lower_shape(&self, ty: &TypeRef, registry: &impl Conversions<()>) -> ValueShape {
+    pub(super) fn lower_shape(&self, ty: &TypeRef, registry: &impl Conversions) -> ValueShape {
         if matches!(ty.kind(), TypeKind::Unit) {
             return ValueShape {
                 fields: vec![],
@@ -838,7 +838,7 @@ impl CbindgenBuilder {
         ty: &TypeRef,
         val: TokenStream,
         targets: &[TokenStream],
-        registry: &impl Conversions<()>,
+        registry: &impl Conversions,
         route: &ErrRoute,
     ) -> TokenStream {
         if matches!(ty.kind(), TypeKind::Unit) {
@@ -1086,7 +1086,7 @@ impl CbindgenBuilder {
         &self,
         orig: &syn::Ident,
         f: &prebindgen_registry::flat::Function,
-        registry: &Registry<()>,
+        registry: &Registry,
         route: &ErrRoute,
         emit: &prebindgen_registry::Emit,
     ) -> (Vec<TokenStream>, Vec<TokenStream>, Vec<TokenStream>) {

--- a/prebindgen-c/src/emit.rs
+++ b/prebindgen-c/src/emit.rs
@@ -12,7 +12,7 @@ impl CbindgenBuilder {
         // `opaque_ptr` (then it crosses as `string_t *`, freed by `string_drop`).
         if registry
             .reading_of(&string_ty)
-            .and_then(|tr| registry.output_entry(&tr))
+            .and_then(|tr| self.out_frag(&tr))
             .is_some()
             && !self.opaque.contains_key(&TypeKey::from_type(&string_ty))
         {
@@ -22,7 +22,7 @@ impl CbindgenBuilder {
         if self.opaque_errors.keys().any(|key| {
             registry
                 .reading(key)
-                .and_then(|tr| registry.output_entry(&tr))
+                .and_then(|tr| self.out_frag(&tr))
                 .is_some()
         }) {
             return true;
@@ -33,7 +33,7 @@ impl CbindgenBuilder {
             let Some(reading) = registry.reading(key) else {
                 return false;
             };
-            registry.output_entry(&reading).is_some()
+            self.out_frag(&reading).is_some()
                 && self
                     .enum_alternatives(registry, key)
                     .map(|alts| {
@@ -49,7 +49,7 @@ impl CbindgenBuilder {
             let Some(reading) = registry.reading(key) else {
                 return false;
             };
-            registry.output_entry(&reading).is_some()
+            self.out_frag(&reading).is_some()
                 && self
                     .struct_fields(registry, key)
                     .map(|fields| fields.iter().any(|(_, fty)| r_is_string(fty)))
@@ -135,11 +135,7 @@ impl CbindgenBuilder {
         Ok(())
     }
 
-    pub(super) fn payload_field_wire(
-        &self,
-        fty: &TypeRef,
-        registry: &impl Conversions<()>,
-    ) -> Result<syn::Type, String> {
+    pub(super) fn payload_field_wire(&self, fty: &TypeRef) -> Result<syn::Type, String> {
         // `String` is the one type whose two directions disagree on the wire
         // (`*const c_char` in, `*mut c_char` out), so the union field fixes the
         // OWNING form and the per-arm expressions convert by hand.
@@ -214,7 +210,7 @@ impl CbindgenBuilder {
         // legitimately differ (a `String`'s const-ness above), which is why a
         // disagreement is `None` — a rejection naming the payload — rather
         // than a silent pick of one side.
-        let out_entry = registry.output_entry(fty).ok_or_else(|| {
+        let out_entry = self.out_frag(fty).ok_or_else(|| {
             "no resolved OUTPUT converter — a payload crosses as its converter's destination, so \
              it must be a scalar, a `String`, or a type this binding declares (`enum_type`, \
              `data_struct`, `opaque_ptr`, or a `convert!` conversion)"
@@ -231,7 +227,7 @@ impl CbindgenBuilder {
             );
         }
         let out = out_entry.destination.clone();
-        if let Some(inp) = registry.input_entry(fty) {
+        if let Some(inp) = self.in_frag(fty) {
             if TypeKey::from_type(&inp.destination) != TypeKey::from_type(&out) {
                 return Err(format!(
                     "its input and output converters disagree on the wire (`{}` in, `{}` out) \
@@ -333,14 +329,14 @@ impl CbindgenBuilder {
     /// cannot be freed through a symbol that was never emitted. `false` for
     /// anything that is not a declared tagged union.
     pub(super) fn tagged_union_has_drop(&self, fty: &TypeRef, registry: &Registry<()>) -> bool {
-        if !self.tagged_unions.contains_key(&fty.key()) || registry.output_entry(fty).is_none() {
+        if !self.tagged_unions.contains_key(&fty.key()) || self.out_frag(fty).is_none() {
             return false;
         }
         self.enum_alternatives(registry, &fty.key())
             .unwrap_or_default()
             .iter()
             .flat_map(|a| a.fields.iter())
-            .any(|f| match self.payload_field_wire(&f.ty, registry) {
+            .any(|f| match self.payload_field_wire(&f.ty) {
                 // A rejected payload is reported from the emission site, which
                 // panics before any of this matters.
                 Err(_) => false,
@@ -527,7 +523,7 @@ impl CbindgenBuilder {
             );
             let entry = registry
                 .reading_of(err_ty)
-                .and_then(|tr| registry.output_entry(&tr))
+                .and_then(|tr| self.out_frag(&tr))
                 .unwrap_or_else(|| {
                     panic!(
                         "Cbindgen::on_function: error type `{}` of `{}` has no output converter",
@@ -1160,7 +1156,7 @@ impl CbindgenBuilder {
 
             let entry = registry
                 .reading_of(arg_ty)
-                .and_then(|tr| registry.input_entry(&tr))
+                .and_then(|tr| self.in_frag(&tr))
                 .unwrap_or_else(|| {
                     panic!(
                         "Cbindgen::on_function: input type `{}` of `{}` has no input converter",

--- a/prebindgen-c/src/lib.rs
+++ b/prebindgen-c/src/lib.rs
@@ -334,7 +334,7 @@ impl AliasAccess {
 /// emission over a complete registry.
 pub struct Cbindgen {
     pub(crate) gen: CbindgenBuilder,
-    pub(crate) registry: prebindgen_registry::Registry<()>,
+    pub(crate) registry: prebindgen_registry::Registry,
 }
 
 // Opaque — exists so `Result<Cbindgen, _>::expect_err` works in tests.
@@ -365,7 +365,7 @@ impl Cbindgen {
     }
 
     /// The resolved registry — conversions, decompositions, and the model.
-    pub fn registry(&self) -> &prebindgen_registry::Registry<()> {
+    pub fn registry(&self) -> &prebindgen_registry::Registry {
         &self.registry
     }
 
@@ -524,7 +524,7 @@ fn type_short(key: &TypeKey) -> String {
 /// `enum_shape` over a `syn::ItemEnum` to re-derive what the first had thrown
 /// away.
 fn payload_enum<'r>(
-    registry: &'r impl Conversions<()>,
+    registry: &'r impl Conversions,
     key: &TypeKey,
 ) -> Option<&'r prebindgen_registry::flat::Variant> {
     match registry.flat().declared_type(&key.ident()?)? {
@@ -551,7 +551,7 @@ fn payload_enum<'r>(
 /// was `enum_item` + `assert_unit_enum`, the second running `enum_shape` over a
 /// `syn::ItemEnum` to re-derive what the first had already thrown away.
 fn unit_enum<'r>(
-    registry: &'r impl Conversions<()>,
+    registry: &'r impl Conversions,
     key: &TypeKey,
 ) -> Option<&'r prebindgen_registry::flat::Enum> {
     match registry.flat().declared_type(&key.ident()?)? {

--- a/prebindgen-c/src/lib.rs
+++ b/prebindgen-c/src/lib.rs
@@ -444,6 +444,13 @@ pub struct CbindgenBuilder {
     /// Where the `#[prebindgen]` items come from — see
     /// `JniGenBuilder::source`.
     pub(crate) sources: prebindgen_registry::flat::FlatBuilder,
+    /// Every conversion this binding compiled, keyed by crossing.
+    ///
+    /// What the emitters ask instead of the converter table. The table can only
+    /// name **one** wire type per crossing, so it stops being able to answer as
+    /// soon as a crossing occupies several — and the answer an emitter wants
+    /// was always the adapter's own.
+    pub(crate) compiled: Option<prebindgen_registry::recipe::Compiled<crate::compile::CFrag>>,
     /// Every conversion this binding compiled.
     ///
     /// Filled once by [`Self::build_with`] and handed to `write_rust` as

--- a/prebindgen-c/src/lib.rs
+++ b/prebindgen-c/src/lib.rs
@@ -450,7 +450,16 @@ pub struct CbindgenBuilder {
     /// name **one** wire type per crossing, so it stops being able to answer as
     /// soon as a crossing occupies several — and the answer an emitter wants
     /// was always the adapter's own.
-    pub(crate) compiled: Option<prebindgen_registry::recipe::Compiled<crate::compile::CFrag>>,
+    ///
+    /// Shared and interior-mutable because the emitters that run *during*
+    /// compilation read it too: `dispatch_fn_input` builds a callback's closure
+    /// struct out of `lower_shape` and `encode_value`, and those ask what a
+    /// type crosses as. A conversion for one type is built out of the
+    /// conversions for its inners, which the resolver compiles first, so a
+    /// fragment is there exactly when a table entry would have been.
+    pub(crate) compiled: std::rc::Rc<
+        std::cell::RefCell<prebindgen_registry::recipe::Compiled<crate::compile::CFrag>>,
+    >,
     /// Every conversion this binding compiled.
     ///
     /// Filled once by [`Self::build_with`] and handed to `write_rust` as
@@ -639,9 +648,12 @@ fn marker_destination(ty: &syn::Type) -> bool {
 /// `out_wrappers` gives that destination to a `Result` too, and no arm lowers
 /// one — so a destination test answers `yes` for a shape nothing can emit, and
 /// the caller ends up calling the marker it was trying to avoid (#428 review).
-fn r_is_lowered_composite(t: &TypeRef, registry: &impl Conversions<()>) -> bool {
-    let composite = t.optional_inner().is_some() || r_is_vec(t) || r_cow_slice_elem(t).is_some();
-    composite && r_shape_is_lowerable(t, registry)
+impl CbindgenBuilder {
+    fn is_lowered_composite(&self, t: &TypeRef) -> bool {
+        let composite =
+            t.optional_inner().is_some() || r_is_vec(t) || r_cow_slice_elem(t).is_some();
+        composite && self.shape_is_lowerable(t)
+    }
 }
 
 /// Whether this node already has a wire of its own: a real converter rather
@@ -651,10 +663,11 @@ fn r_is_lowered_composite(t: &TypeRef, registry: &impl Conversions<()>) -> bool 
 /// conversion answers here — and the shape lowering has to agree with the
 /// converter table at **every** level, not only the outermost, or the two
 /// describe different ABIs for the same argument (#428 review).
-fn r_has_own_wire(t: &TypeRef, registry: &impl Conversions<()>) -> bool {
-    registry
-        .output_entry(t)
-        .is_some_and(|e| !marker_destination(&e.destination))
+impl CbindgenBuilder {
+    fn has_own_wire(&self, t: &TypeRef) -> bool {
+        self.out_frag(t)
+            .is_some_and(|e| !marker_destination(&e.destination))
+    }
 }
 
 /// Whether [`Cbindgen::lower_shape`] decomposes `t` **all the way down**.
@@ -670,20 +683,22 @@ fn r_has_own_wire(t: &TypeRef, registry: &impl Conversions<()>) -> bool {
 /// Enumerating the wrapper kinds instead missed `Vec<&'static [u8]>`, whose
 /// element is a plain borrow by every shape test and a shared-slice marker in
 /// the table (#428 review).
-fn r_shape_is_lowerable(t: &TypeRef, registry: &impl Conversions<()>) -> bool {
-    // A node with a wire of its own IS the bottom: `lower_shape` stops there
-    // too, so the recursion must not walk past it into a shape that node no
-    // longer describes.
-    if r_has_own_wire(t, registry) {
-        return true;
+impl CbindgenBuilder {
+    fn shape_is_lowerable(&self, t: &TypeRef) -> bool {
+        // A node with a wire of its own IS the bottom: `lower_shape` stops
+        // there too, so the recursion must not walk past it into a shape that
+        // node no longer describes.
+        if self.has_own_wire(t) {
+            return true;
+        }
+        if let Some(inner) = t.optional_inner() {
+            return self.shape_is_lowerable(inner);
+        }
+        // A run's element must lower to one wire of its own — the same rule
+        // `lower_shape` asserts when it builds the `(ptr, len)` pair.
+        let leaf = r_vec_elem(t).or_else(|| r_cow_slice_elem(t)).unwrap_or(t);
+        self.has_own_wire(leaf)
     }
-    if let Some(inner) = t.optional_inner() {
-        return r_shape_is_lowerable(inner, registry);
-    }
-    // A run's element must lower to one wire of its own — the same rule
-    // `lower_shape` asserts when it builds the `(ptr, len)` pair.
-    let leaf = r_vec_elem(t).or_else(|| r_cow_slice_elem(t)).unwrap_or(t);
-    r_has_own_wire(leaf, registry)
 }
 
 /// The element of a `Vec<E>`.

--- a/prebindgen-c/src/lib.rs
+++ b/prebindgen-c/src/lib.rs
@@ -359,7 +359,7 @@ impl Cbindgen {
         Ok(prebindgen_registry::write::write_rust(
             &self.registry,
             &self.gen,
-            prebindgen_registry::write::Conversions::Compiled(&self.gen.compiled_fns),
+            &self.gen.compiled_fns,
             out_path,
         )?)
     }
@@ -462,12 +462,12 @@ pub struct CbindgenBuilder {
     >,
     /// Every conversion this binding compiled.
     ///
-    /// Filled once by [`Self::build_with`] and handed to `write_rust` as
-    /// `Conversions::Compiled`. It is what reaches the generated file,
-    /// so a fragment no longer has to be expressible as one `ConverterImpl` to
-    /// be emitted — only to be looked up. The writer sorts and de-duplicates by
-    /// function name, so the order here decides which of two same-named
-    /// functions wins and not where any of them lands.
+    /// Filled once by [`Self::build_with`] and handed to `write_rust` directly. It is what
+    /// reaches the generated file, so a fragment no longer has to be
+    /// expressible as one `ConverterImpl` to be emitted — only to be looked up.
+    /// The writer sorts and de-duplicates by function name, so the order here
+    /// decides which of two same-named functions wins and not where any of them
+    /// lands.
     pub(crate) compiled_fns: Vec<syn::ItemFn>,
 }
 

--- a/prebindgen-c/src/test_util.rs
+++ b/prebindgen-c/src/test_util.rs
@@ -15,9 +15,7 @@ use prebindgen_registry::{Registry, RegistryBuilder};
 ///
 /// Test-only sugar: the two steps are one line each in a build script, but they
 /// appear in dozens of fixtures here.
-pub(crate) fn reg_from_items<M, I>(
-    items: I,
-) -> Result<RegistryBuilder<M>, prebindgen_registry::ScanError>
+pub(crate) fn reg_from_items<I>(items: I) -> Result<RegistryBuilder, prebindgen_registry::ScanError>
 where
     I: IntoIterator<Item = (syn::Item, prebindgen::SourceLocation)>,
 {

--- a/prebindgen-c/src/tests/lowering.rs
+++ b/prebindgen-c/src/tests/lowering.rs
@@ -152,8 +152,7 @@ fn custom_conversion_without_domain_stays_infallible() {
 #[test]
 fn empty_adapter_writes_empty_file() {
     let cbindgen = CbindgenBuilder::new();
-    let registry: RegistryBuilder<()> =
-        crate::test_util::reg_from_items(Vec::new()).expect("empty");
+    let registry: RegistryBuilder = crate::test_util::reg_from_items(Vec::new()).expect("empty");
     let src = write(cbindgen, registry, "empty");
     assert!(src.trim().is_empty(), "expected empty output, got:\n{src}");
 }

--- a/prebindgen-c/src/tests/mod.rs
+++ b/prebindgen-c/src/tests/mod.rs
@@ -17,7 +17,7 @@ mod rows;
 mod structs;
 mod tagged_unions;
 
-fn write(cbindgen: CbindgenBuilder, registry: RegistryBuilder<()>, tag: &str) -> String {
+fn write(cbindgen: CbindgenBuilder, registry: RegistryBuilder, tag: &str) -> String {
     let dir = unique_test_dir(&format!("cbindgen_{tag}"));
     std::fs::create_dir_all(&dir).unwrap();
     let out = dir.join(format!("{tag}.rs"));

--- a/prebindgen-c/src/trait_impl.rs
+++ b/prebindgen-c/src/trait_impl.rs
@@ -41,7 +41,7 @@ impl CbindgenBuilder {
 impl CbindgenBuilder {
     /// Opaque handle, by-value consume: `*Box::from_raw(v)` — fallible (null
     /// handle → message). The wire is the bare handle pointer `*mut #c_struct`.
-    pub(crate) fn in_opaque_handle(&self, ty: &TypeRef) -> Option<ConverterImpl<()>> {
+    pub(crate) fn in_opaque_handle(&self, ty: &TypeRef) -> Option<ConverterImpl> {
         let key = ty.key();
         if !self.opaque.contains_key(&key) {
             return None;
@@ -82,7 +82,7 @@ impl CbindgenBuilder {
     /// invalid `Box`) forces the full `gravestone()` write.
     fn nullable_owned_ptr_fields(
         &self,
-        registry: &impl Conversions<()>,
+        registry: &impl Conversions,
         key: &TypeKey,
     ) -> Option<Vec<syn::Ident>> {
         let cfg = self.value_opaque.get(key)?;
@@ -112,7 +112,7 @@ impl CbindgenBuilder {
     /// declared `kind` (its fields are an opaque blob the generator can't introspect).
     fn value_opaque_writeback(
         &self,
-        registry: &impl Conversions<()>,
+        registry: &impl Conversions,
         key: &TypeKey,
         slot: &syn::Ident,
     ) -> Option<TokenStream> {
@@ -145,7 +145,7 @@ impl CbindgenBuilder {
     /// has a bare `Box<T>` owned-pointer field (a null `Box` is invalid). Nullable
     /// (`Option<Box<T>>`) mirrors null in place and need no `Gravestone`/`Default`;
     /// non-mirror owned types get their `Gravestone` impl from the consumer.
-    fn mirror_needs_gravestone_impl(&self, registry: &Registry<()>, key: &TypeKey) -> bool {
+    fn mirror_needs_gravestone_impl(&self, registry: &Registry, key: &TypeKey) -> bool {
         match self.value_opaque.get(key) {
             Some(cfg) if cfg.generate_mirror => {
                 self.nullable_owned_ptr_fields(registry, key).is_none()
@@ -174,8 +174,8 @@ impl CbindgenBuilder {
     pub(crate) fn in_value_opaque(
         &self,
         ty: &TypeRef,
-        registry: &impl Conversions<()>,
-    ) -> Option<ConverterImpl<()>> {
+        registry: &impl Conversions,
+    ) -> Option<ConverterImpl> {
         let opaque = self.value_opaque_ty_of(&ty.key())?.clone();
         let name = Self::in_name_of(&ty.key());
         let src = self.src_ty_of(&ty.key());
@@ -230,11 +230,7 @@ impl CbindgenBuilder {
     /// no generator-side evaluation. An unmatched value is a binding error
     /// through the wrapper's error channel; no Rust enum is ever constructed
     /// from it.
-    pub(crate) fn in_enum(
-        &self,
-        ty: &TypeRef,
-        r: &impl Conversions<()>,
-    ) -> Option<ConverterImpl<()>> {
+    pub(crate) fn in_enum(&self, ty: &TypeRef, r: &impl Conversions) -> Option<ConverterImpl> {
         let key = ty.key();
         if !self.enums.contains_key(&key) {
             return None;
@@ -290,7 +286,7 @@ impl CbindgenBuilder {
     }
 
     /// `String` input: `*const c_char` → owned `String` — fallible.
-    pub(crate) fn in_string(&self, ty: &TypeRef) -> Option<ConverterImpl<()>> {
+    pub(crate) fn in_string(&self, ty: &TypeRef) -> Option<ConverterImpl> {
         if !r_is_string(ty) {
             return None;
         }
@@ -329,7 +325,7 @@ impl CbindgenBuilder {
 
     /// Bare `str` never crosses the C ABI directly, but resolving `&str`
     /// inputs requires its inner node to have a filled rank-0 cell.
-    pub(crate) fn in_str(&self, ty: &TypeRef) -> Option<ConverterImpl<()>> {
+    pub(crate) fn in_str(&self, ty: &TypeRef) -> Option<ConverterImpl> {
         if !r_is_str(ty) {
             return None;
         }
@@ -354,7 +350,7 @@ impl CbindgenBuilder {
     /// Rust `bool` may hold, so it crosses as [`bool_wire`] and is normalised
     /// by [`bool_in_expr`] before a `bool` exists. The C prototype is
     /// unchanged — cbindgen simplifies `MaybeUninit<T>` to `T`.
-    pub(crate) fn in_bool(&self, ty: &TypeRef) -> Option<ConverterImpl<()>> {
+    pub(crate) fn in_bool(&self, ty: &TypeRef) -> Option<ConverterImpl> {
         if !r_is_bool(ty) {
             return None;
         }
@@ -398,9 +394,9 @@ impl CbindgenBuilder {
         &'v self,
         compiler: &mut prebindgen_registry::recipe::Compiler<
             '_,
-            crate::compile::CCompile<'v, Registry<()>>,
+            crate::compile::CCompile<'v, Registry>,
         >,
-        registry: &'v Registry<()>,
+        registry: &'v Registry,
     ) -> Result<(), String> {
         use prebindgen_registry::recipe::{Assembly, Crossing, Role, Site};
 
@@ -461,7 +457,7 @@ impl CbindgenBuilder {
     pub(crate) fn union_arm_name(
         &self,
         key: &TypeKey,
-        registry: &impl Conversions<()>,
+        registry: &impl Conversions,
         parts: &[(
             prebindgen_registry::recipe::Part<'_>,
             &crate::compile::CFrag,
@@ -492,7 +488,7 @@ impl CbindgenBuilder {
     /// back after being dropped arrives here NULL — and is reported, never
     /// materialised. An `Option<Box<T>>` reads NULL as `None` instead, which is
     /// the representation it has room for.
-    pub(crate) fn in_boxed_payload(&self, fty: &TypeRef) -> Option<ConverterImpl<()>> {
+    pub(crate) fn in_boxed_payload(&self, fty: &TypeRef) -> Option<ConverterImpl> {
         let name = format_ident!("{}_payload", Self::in_name_of(&fty.key()));
         let optional = fty.optional_inner().is_some();
         let (wire, src_inner, owned, short) =
@@ -563,7 +559,7 @@ impl CbindgenBuilder {
 
     /// The peer of [`Self::in_boxed_payload`]: an owned value the C side must
     /// later release, boxed here rather than having arrived boxed.
-    pub(crate) fn out_boxed_payload(&self, fty: &TypeRef) -> Option<ConverterImpl<()>> {
+    pub(crate) fn out_boxed_payload(&self, fty: &TypeRef) -> Option<ConverterImpl> {
         let name = format_ident!("{}_payload", Self::out_name_of(&fty.key()));
         let optional = fty.optional_inner().is_some();
         let src = self.src_ty_of(&fty.key());
@@ -622,7 +618,7 @@ impl CbindgenBuilder {
     /// Lossy on invalid UTF-8 for the same reason. This is the reading the
     /// hand-written field walk had; stating it as a row is what makes it
     /// visible rather than buried.
-    pub(crate) fn in_string_field(&self, ty: &TypeRef) -> Option<ConverterImpl<()>> {
+    pub(crate) fn in_string_field(&self, ty: &TypeRef) -> Option<ConverterImpl> {
         if !r_is_string(ty) {
             return None;
         }
@@ -657,7 +653,7 @@ impl CbindgenBuilder {
     /// `bool` **return** is always already one of two values and crosses as
     /// itself, while a field shares one mirror with the decode that has to
     /// normalise it.
-    pub(crate) fn out_bool_field(&self, ty: &TypeRef) -> Option<ConverterImpl<()>> {
+    pub(crate) fn out_bool_field(&self, ty: &TypeRef) -> Option<ConverterImpl> {
         if !r_is_bool(ty) {
             return None;
         }
@@ -682,7 +678,7 @@ impl CbindgenBuilder {
 
     /// FFI-safe scalar (integers, floats): identity pass-through. `bool` is
     /// claimed earlier by [`Self::in_bool`] and never reaches here.
-    pub(crate) fn in_scalar(&self, ty: &TypeRef) -> Option<ConverterImpl<()>> {
+    pub(crate) fn in_scalar(&self, ty: &TypeRef) -> Option<ConverterImpl> {
         if !r_is_scalar(ty) || r_is_bool(ty) {
             return None;
         }
@@ -713,7 +709,7 @@ impl CbindgenBuilder {
     /// C allocator extern + raw C-string allocator + the universal memory freer.
     /// Emitted when the layer hands `char*`/array memory to C. Panics if such
     /// memory is produced but no `.free_memory_function` is declared.
-    fn prereq_alloc_free(&self, registry: &Registry<()>, produces_array: bool) -> Vec<syn::Item> {
+    fn prereq_alloc_free(&self, registry: &Registry, produces_array: bool) -> Vec<syn::Item> {
         let mut items: Vec<syn::Item> = Vec::new();
         if !(self.needs_free(registry) || produces_array) {
             return items;
@@ -793,7 +789,7 @@ impl CbindgenBuilder {
 
     /// Opaque handles: bare-pointer C type (`z_*_t*` = `Box::into_raw`) + typed
     /// `_drop`. The C type is an opaque/incomplete struct.
-    fn prereq_opaque_handles(&self, registry: &Registry<()>) -> Vec<syn::Item> {
+    fn prereq_opaque_handles(&self, registry: &Registry) -> Vec<syn::Item> {
         let mut items: Vec<syn::Item> = Vec::new();
         for (key, _cfg) in sorted_by_key(&self.opaque) {
             // Keyed directly: this used to spell the key into tokens purely so
@@ -832,7 +828,7 @@ impl CbindgenBuilder {
     /// Data structs: `#[repr(C)]` mirror only. Heap (`String`) fields are
     /// `char*` raw blocks the C user releases individually via the
     /// `free_memory_function` — no per-struct destructor.
-    fn prereq_data_structs(&self, registry: &Registry<()>) -> Vec<syn::Item> {
+    fn prereq_data_structs(&self, registry: &Registry) -> Vec<syn::Item> {
         let mut items: Vec<syn::Item> = Vec::new();
         for (key, _cfg) in sorted_by_key(&self.data) {
             let Some(reading) = registry.reading(key) else {
@@ -873,7 +869,7 @@ impl CbindgenBuilder {
     /// the fail-closed size+align equality asserts and the typed `_drop` (drops
     /// the live Rust value in place; NULL/gravestone ⇒ no-op), plus a `_take`
     /// for types delivered as takeable callback params.
-    fn prereq_value_opaque(&self, registry: &Registry<()>) -> Vec<syn::Item> {
+    fn prereq_value_opaque(&self, registry: &Registry) -> Vec<syn::Item> {
         let mut items: Vec<syn::Item> = Vec::new();
         let takeable_keys = self.takeable_type_keys();
         let mut vo: Vec<(&TypeKey, &ValueOpaqueCfg)> = self.value_opaque.iter().collect();
@@ -1080,7 +1076,7 @@ impl CbindgenBuilder {
     /// need from it — a number versus a spelling.
     fn prereq_enums(
         &self,
-        registry: &Registry<()>,
+        registry: &Registry,
         emit: &prebindgen_registry::Emit,
     ) -> Vec<syn::Item> {
         let mut items: Vec<syn::Item> = Vec::new();
@@ -1130,7 +1126,7 @@ impl CbindgenBuilder {
     /// and gets no drop.
     fn prereq_tagged_unions(
         &self,
-        registry: &Registry<()>,
+        registry: &Registry,
         emit: &prebindgen_registry::Emit,
     ) -> Vec<syn::Item> {
         let mut items: Vec<syn::Item> = Vec::new();
@@ -1272,7 +1268,7 @@ impl CbindgenBuilder {
         &self,
         fty: &TypeRef,
         binding: &syn::Ident,
-        registry: &Registry<()>,
+        registry: &Registry,
     ) -> TokenStream {
         if r_is_string(fty) {
             return quote!(
@@ -1369,7 +1365,7 @@ impl CbindgenBuilder {
     /// resolved). `call` takes each arg's output wire (the owned handle the
     /// C callback must drop) plus the `void *context`; `drop` releases the
     /// context. Deterministic order by emitted name.
-    fn prereq_callback_structs(&self, registry: &Registry<()>) -> Vec<syn::Item> {
+    fn prereq_callback_structs(&self, registry: &Registry) -> Vec<syn::Item> {
         let mut items: Vec<syn::Item> = Vec::new();
         // The declaration's own argument types. `CallbackKey` is a list of
         // identities — what the map is keyed by — and the arguments it was
@@ -1501,7 +1497,7 @@ impl CbindgenBuilder {
     /// [`Self::build`] over a registry described elsewhere — the test seam.
     pub(crate) fn build_with(
         mut self,
-        registry: prebindgen_registry::RegistryBuilder<()>,
+        registry: prebindgen_registry::RegistryBuilder,
     ) -> Result<Cbindgen, prebindgen_registry::WriteRustError> {
         let declared = self.declare_into(registry)?.validate_with(&self)?;
         // A second holding of the model: `convert_with` consumes the builder,
@@ -1541,7 +1537,10 @@ impl CbindgenBuilder {
                 );
                 let conv = self.compile_crossing(&mut compiler, crossing, built);
                 *self.compiled.borrow_mut() = compiler.finish();
-                conv
+                // The conversion stays here; what the registry gets back is
+                // which other crossings this one delegates to, which is what
+                // its reachability walk needs.
+                conv.map(|c| prebindgen_registry::Answer::over(c.subs))
             })?
             .build()?;
         // Every site of every exported function, compiled. Nothing consumes
@@ -1583,12 +1582,12 @@ impl CbindgenBuilder {
     /// `None` records a gap, exactly as the chain of guesses this replaced did:
     /// whether the gap matters is the registry's call, and its report names the
     /// crossing.
-    fn compile_crossing<'v, R: Conversions<()>>(
+    fn compile_crossing<'v, R: Conversions>(
         &'v self,
         compiler: &mut prebindgen_registry::recipe::Compiler<'_, crate::compile::CCompile<'v, R>>,
         crossing: &Crossing,
         built: &'v R,
-    ) -> Option<ConverterImpl<()>> {
+    ) -> Option<ConverterImpl> {
         let (dir, key) = crossing;
         // The reading the scan already took for this crossing, fetched by the
         // key the crossing IS.
@@ -1608,8 +1607,8 @@ impl CbindgenBuilder {
 
     pub fn declare_into(
         &self,
-        mut registry: RegistryBuilder<()>,
-    ) -> Result<RegistryBuilder<()>, prebindgen_registry::ScanError> {
+        mut registry: RegistryBuilder,
+    ) -> Result<RegistryBuilder, prebindgen_registry::ScanError> {
         for (item_fn, origin) in self.collect_local_functions() {
             registry = registry.local_function(item_fn, origin)?;
         }
@@ -1630,8 +1629,8 @@ impl CbindgenBuilder {
     pub(crate) fn dispatch_fn_input(
         &self,
         args: &[TypeRef],
-        registry: &impl Conversions<()>,
-    ) -> Option<ConverterImpl<()>> {
+        registry: &impl Conversions,
+    ) -> Option<ConverterImpl> {
         let key: CallbackKey = args.iter().map(|a| a.key()).collect();
         if !self.callbacks.contains_key(&key) {
             // Undeclared callback signature: leave unresolved so the registry
@@ -1848,7 +1847,7 @@ impl Prebindgen for CbindgenBuilder {
     ///
     /// `consts: None` — cbindgen has no const declaration mechanism, so every
     /// captured const is re-emitted verbatim and none is ever a skip.
-    fn validate(&self, binding: &Building<'_, Self::Metadata>) -> Result<(), String> {
+    fn validate(&self, binding: &Building<'_>) -> Result<(), String> {
         let mut functions = self.declared_functions();
         functions.extend(self.helper_functions());
         prebindgen_registry::warn_unclaimed(
@@ -1868,8 +1867,6 @@ impl Prebindgen for CbindgenBuilder {
         Ok(())
     }
 
-    type Metadata = ();
-
     // Consts have no declaration mechanism here (`declared_consts` stays
     // `None`), so every indexed const re-emits through the default
     // `on_const` — a path-alias against this source module, keeping consts
@@ -1887,7 +1884,7 @@ impl Prebindgen for CbindgenBuilder {
 
     fn prerequisites(
         &self,
-        registry: &Registry<()>,
+        registry: &Registry,
         emit: &prebindgen_registry::Emit,
     ) -> Vec<syn::Item> {
         // C-string data memory (string returns + `String` fields of data structs)
@@ -1915,7 +1912,7 @@ impl Prebindgen for CbindgenBuilder {
     fn on_function(
         &self,
         f: &prebindgen_registry::flat::Function,
-        registry: &Registry<()>,
+        registry: &Registry,
         emit: &prebindgen_registry::Emit,
     ) -> TokenStream {
         self.emit_function_wrapper(f, registry, emit)
@@ -1924,7 +1921,7 @@ impl Prebindgen for CbindgenBuilder {
     fn on_struct(
         &self,
         _s: &prebindgen_registry::flat::Struct,
-        _registry: &Registry<()>,
+        _registry: &Registry,
         _emit: &prebindgen_registry::Emit,
     ) -> TokenStream {
         // The `#[repr(C)]` mirror + converters come from prerequisites /
@@ -1935,7 +1932,7 @@ impl Prebindgen for CbindgenBuilder {
     fn on_variant(
         &self,
         _v: &prebindgen_registry::flat::Variant,
-        _registry: &Registry<()>,
+        _registry: &Registry,
         _emit: &prebindgen_registry::Emit,
     ) -> TokenStream {
         TokenStream::new()
@@ -1944,7 +1941,7 @@ impl Prebindgen for CbindgenBuilder {
     fn on_enum(
         &self,
         _e: &prebindgen_registry::flat::Enum,
-        _registry: &Registry<()>,
+        _registry: &Registry,
         _emit: &prebindgen_registry::Emit,
     ) -> TokenStream {
         TokenStream::new()
@@ -1957,9 +1954,9 @@ impl CbindgenBuilder {
     pub(crate) fn out_terminal(
         &self,
         ty: &TypeRef,
-        _r: &impl Conversions<()>,
+        _r: &impl Conversions,
         _emit: &prebindgen_registry::Emit,
-    ) -> Option<ConverterImpl<()>> {
+    ) -> Option<ConverterImpl> {
         // Unit return: trivial converter so `()` (and `Result<(), _>`) resolves.
         // Never actually called — void-returning wrappers ignore it, and
         // `emit_fallible_wrapper` special-cases `Result<(), E>` to drop the
@@ -2134,7 +2131,7 @@ impl CbindgenBuilder {
         &self,
         inner: &TypeRef,
         entry: &crate::compile::CFrag,
-    ) -> Option<ConverterImpl<()>> {
+    ) -> Option<ConverterImpl> {
         {
             let inner_wire = entry.destination.clone();
             let inner_conv = entry.function.sig.ident.clone();
@@ -2253,7 +2250,7 @@ impl CbindgenBuilder {
 
     /// `&[E]` slice **input**: marker only — the two-param (`*const E_wire`,
     /// `usize`) lowering is done structurally in `emit_inputs`.
-    pub(crate) fn in_slice(&self, ty: &TypeRef) -> Option<ConverterImpl<()>> {
+    pub(crate) fn in_slice(&self, ty: &TypeRef) -> Option<ConverterImpl> {
         let e = r_shared_slice_elem(ty)?;
         // #170, the slice instance. The two-param lowering builds the
         // `&[E]` zero-copy from C's own block, so there is nowhere to
@@ -2294,7 +2291,7 @@ impl CbindgenBuilder {
 
     /// `&str`, `&mut T` and `&T` **input** shapes: a borrow reached through the
     /// pointer the C caller supplied.
-    pub(crate) fn in_borrow(&self, ty: &TypeRef) -> Option<ConverterImpl<()>> {
+    pub(crate) fn in_borrow(&self, ty: &TypeRef) -> Option<ConverterImpl> {
         // `mutable` off the `Ref` itself, NOT `is_exclusive_borrow`: that
         // reading deliberately answers `false` for `&mut MaybeUninit<_>` — an
         // out-param slot is not an exclusive borrow OF A VALUE — and these arms
@@ -2450,7 +2447,7 @@ impl CbindgenBuilder {
     /// Carries a `()` destination: the real lowering is structural in
     /// `emit_function_wrapper`, and this exists so the shape resolves and its
     /// inner is marked reachable.
-    pub(crate) fn out_arity_marker(&self, kind: &str, inner: &TypeRef) -> ConverterImpl<()> {
+    pub(crate) fn out_arity_marker(&self, kind: &str, inner: &TypeRef) -> ConverterImpl {
         let name = format_ident!("__cbg_outmark_{}_{}", kind, sanitize(&inner.key()));
         let function: syn::ItemFn = syn::parse_quote!(
             #[allow(non_snake_case, dead_code, unused)]
@@ -2472,7 +2469,7 @@ impl CbindgenBuilder {
     /// `call` parameter is structural in `prereq_callback_structs` /
     /// `dispatch_fn_input`; `subs: [E]` forces E's output so the closure wire
     /// element type exists.
-    pub(crate) fn out_slice_marker(&self, ty: &TypeRef) -> Option<ConverterImpl<()>> {
+    pub(crate) fn out_slice_marker(&self, ty: &TypeRef) -> Option<ConverterImpl> {
         let elem = self
             .r_value_opaque_slice_elem(ty)
             .or_else(|| r_scalar_slice_elem(ty))?;
@@ -2493,7 +2490,7 @@ impl CbindgenBuilder {
 
     /// The `&T` shared borrow and the `Result<T, E>` marker — the two **output**
     /// shapes that are neither terminal nor a run.
-    pub(crate) fn out_borrow_or_result(&self, ty: &TypeRef) -> Option<ConverterImpl<()>> {
+    pub(crate) fn out_borrow_or_result(&self, ty: &TypeRef) -> Option<ConverterImpl> {
         // `&T` shared borrow of an opaque/value-opaque type → non-owning `*const`.
         if let TypeKind::Ref { mutable, inner, .. } = ty.kind() {
             if !*mutable {

--- a/prebindgen-c/src/trait_impl.rs
+++ b/prebindgen-c/src/trait_impl.rs
@@ -9,17 +9,26 @@ use super::{builder::callback_fn_type, *};
 /// wire values; the converter table's single `destination` cannot.
 impl CbindgenBuilder {
     /// The fragment for `ty` crossing in the given direction, if one compiled.
-    pub(crate) fn frag(&self, ty: &TypeRef, assembly: Assembly) -> Option<&crate::compile::CFrag> {
-        self.compiled.as_ref()?.fragment(&ty.key(), assembly)
+    ///
+    /// Shares the fragment rather than copying it: the store is read while
+    /// compilation is still writing to it, so a borrow cannot be held across
+    /// the next write, and `shape_is_lowerable` walks a type's layers asking
+    /// this at every one.
+    pub(crate) fn frag(
+        &self,
+        ty: &TypeRef,
+        assembly: Assembly,
+    ) -> Option<std::rc::Rc<crate::compile::CFrag>> {
+        self.compiled.borrow().fragment(&ty.key(), assembly)
     }
 
     /// The fragment that builds a Rust `ty` out of C parts.
-    pub(crate) fn in_frag(&self, ty: &TypeRef) -> Option<&crate::compile::CFrag> {
+    pub(crate) fn in_frag(&self, ty: &TypeRef) -> Option<std::rc::Rc<crate::compile::CFrag>> {
         self.frag(ty, Assembly::Construct)
     }
 
     /// The fragment that takes a Rust `ty` apart into C parts.
-    pub(crate) fn out_frag(&self, ty: &TypeRef) -> Option<&crate::compile::CFrag> {
+    pub(crate) fn out_frag(&self, ty: &TypeRef) -> Option<std::rc::Rc<crate::compile::CFrag>> {
         self.frag(ty, Assembly::Deconstruct)
     }
 }
@@ -1417,7 +1426,7 @@ impl CbindgenBuilder {
                 // leaves its slot unwritten, and the wrapper must not build a
                 // Rust value to fill it with. `#[repr(transparent)]` keeps both
                 // the C ABI and the header spelling.
-                if marker_destination(&wire) && r_is_lowered_composite(&reading, registry) {
+                if marker_destination(&wire) && self.is_lowered_composite(&reading) {
                     for field in self.lower_shape(&reading, registry).fields {
                         let w = field.wire;
                         arg_wires.push(syn::parse_quote!(::core::mem::MaybeUninit<#w>));
@@ -1516,21 +1525,22 @@ impl CbindgenBuilder {
                     .join("; "),
             }
         })?;
-        // The driver's state, carried between calls. The adapter borrows the
-        // partial registry view, which is lent per call and so is a different
-        // type each time; what it built is not, and outlives every one of them.
-        let mut compiled =
-            prebindgen_registry::recipe::Compiled::<crate::compile::CFrag>::default();
+        // The driver's state lives on `self` rather than here, because the
+        // adapter reads it **while** it compiles: `dispatch_fn_input` builds a
+        // callback's closure struct out of `lower_shape` and `encode_value`,
+        // both of which ask what a type crosses as. Handing the compiler the
+        // store by `mem::take` would empty it for exactly the span of that
+        // call, so it is cloned — a map of `Rc`s.
         let registry = declared
             .convert_with(|crossing, built, _emit| {
                 let mut compiler = prebindgen_registry::recipe::Compiler::resume(
                     &model,
                     &recipes,
                     &bindings,
-                    std::mem::take(&mut compiled),
+                    self.compiled.borrow().clone(),
                 );
                 let conv = self.compile_crossing(&mut compiler, crossing, built);
-                compiled = compiler.finish();
+                *self.compiled.borrow_mut() = compiler.finish();
                 conv
             })?
             .build()?;
@@ -1542,19 +1552,23 @@ impl CbindgenBuilder {
         // borrowed return where the JVM must not.
         {
             let mut compiler = prebindgen_registry::recipe::Compiler::resume(
-                &model, &recipes, &bindings, compiled,
+                &model,
+                &recipes,
+                &bindings,
+                self.compiled.borrow().clone(),
             );
             self.check_sites(&mut compiler, &registry)
                 .map_err(|message| prebindgen_registry::ScanError::AdapterInvariant { message })?;
-            compiled = compiler.finish();
+            *self.compiled.borrow_mut() = compiler.finish();
         }
         // What the compilation produced, kept for emission and for lookup.
-        self.compiled_fns = compiled
+        self.compiled_fns = self
+            .compiled
+            .borrow()
             .fragments()
             .into_iter()
             .map(|f| f.function.clone())
             .collect();
-        self.compiled = Some(compiled);
         self.validate_resolved(&registry)
             .map_err(|message| prebindgen_registry::ScanError::AdapterInvariant { message })?;
         Ok(Cbindgen {
@@ -1649,7 +1663,7 @@ impl CbindgenBuilder {
                 call_args.push(quote!(#ai.len()));
                 continue;
             }
-            let entry = registry.output_entry(arg)?;
+            let entry = self.out_frag(arg)?;
             let conv = entry.function.sig.ident.clone();
             let opaque = entry.destination.clone();
             let fallible = matches!(
@@ -1680,7 +1694,7 @@ impl CbindgenBuilder {
             // converter call can produce.
             if !is_takeable
                 && marker_destination(&entry.destination)
-                && !r_is_lowered_composite(arg, registry)
+                && !self.is_lowered_composite(arg)
             {
                 panic!(
                     "Cbindgen: callback argument `{}` has no C ABI — it resolves to a marker \
@@ -1699,7 +1713,7 @@ impl CbindgenBuilder {
             // (#428 review).
             let composite = !is_takeable
                 && marker_destination(&entry.destination)
-                && r_is_lowered_composite(arg, registry);
+                && self.is_lowered_composite(arg);
             if composite {
                 let shape = self.lower_shape(arg, registry);
                 closure_params.push(quote!(#ai: #src));

--- a/prebindgen-c/src/trait_impl.rs
+++ b/prebindgen-c/src/trait_impl.rs
@@ -1,6 +1,28 @@
-use prebindgen_registry::{Building, Conversions, Crossing, RegistryBuilder};
+use prebindgen_registry::{recipe::Assembly, Building, Conversions, Crossing, RegistryBuilder};
 
 use super::{builder::callback_fn_type, *};
+
+/// What an emitter asks instead of the converter table.
+///
+/// [`CbindgenBuilder::compiled`] holds every fragment this binding compiled,
+/// keyed by crossing. A fragment answers for a crossing that occupies several
+/// wire values; the converter table's single `destination` cannot.
+impl CbindgenBuilder {
+    /// The fragment for `ty` crossing in the given direction, if one compiled.
+    pub(crate) fn frag(&self, ty: &TypeRef, assembly: Assembly) -> Option<&crate::compile::CFrag> {
+        self.compiled.as_ref()?.fragment(&ty.key(), assembly)
+    }
+
+    /// The fragment that builds a Rust `ty` out of C parts.
+    pub(crate) fn in_frag(&self, ty: &TypeRef) -> Option<&crate::compile::CFrag> {
+        self.frag(ty, Assembly::Construct)
+    }
+
+    /// The fragment that takes a Rust `ty` apart into C parts.
+    pub(crate) fn out_frag(&self, ty: &TypeRef) -> Option<&crate::compile::CFrag> {
+        self.frag(ty, Assembly::Deconstruct)
+    }
+}
 
 /// Per-category **input** terminal converter builders. Each returns
 /// `Some(ConverterImpl)` only for the type category it claims (and `None`
@@ -770,8 +792,7 @@ impl CbindgenBuilder {
             let Some(reading) = registry.reading(key) else {
                 continue;
             };
-            if registry.input_entry(&reading).is_none() && registry.output_entry(&reading).is_none()
-            {
+            if self.in_frag(&reading).is_none() && self.out_frag(&reading).is_none() {
                 continue;
             }
             let c_struct = self.c_type_ident(&reading.key());
@@ -808,8 +829,7 @@ impl CbindgenBuilder {
             let Some(reading) = registry.reading(key) else {
                 continue;
             };
-            if registry.input_entry(&reading).is_none() && registry.output_entry(&reading).is_none()
-            {
+            if self.in_frag(&reading).is_none() && self.out_frag(&reading).is_none() {
                 continue;
             }
             let Some(fields) = self.struct_fields(registry, &reading.key()) else {
@@ -853,8 +873,7 @@ impl CbindgenBuilder {
             let Some(reading) = registry.reading(key) else {
                 continue;
             };
-            if registry.input_entry(&reading).is_none() && registry.output_entry(&reading).is_none()
-            {
+            if self.in_frag(&reading).is_none() && self.out_frag(&reading).is_none() {
                 continue;
             }
             let src = self.src_ty_of(&reading.key());
@@ -1060,8 +1079,7 @@ impl CbindgenBuilder {
             let Some(reading) = registry.reading(key) else {
                 continue;
             };
-            if registry.input_entry(&reading).is_none() && registry.output_entry(&reading).is_none()
-            {
+            if self.in_frag(&reading).is_none() && self.out_frag(&reading).is_none() {
                 continue;
             }
             let Some(e) = unit_enum(registry, &reading.key()) else {
@@ -1111,8 +1129,7 @@ impl CbindgenBuilder {
             let Some(reading) = registry.reading(key) else {
                 continue;
             };
-            if registry.input_entry(&reading).is_none() && registry.output_entry(&reading).is_none()
-            {
+            if self.in_frag(&reading).is_none() && self.out_frag(&reading).is_none() {
                 continue;
             }
             let Some(e) = payload_enum(registry, &reading.key()) else {
@@ -1129,7 +1146,7 @@ impl CbindgenBuilder {
                 let wires: Vec<syn::Type> = a
                     .fields
                     .iter()
-                    .map(|f| self.payload_wire_of(&reading.key(), vident, f, registry))
+                    .map(|f| self.payload_wire_of(&reading.key(), vident, f))
                     .collect();
                 // `Alternative::spell` writes the delimiters the source wrote,
                 // which is what the three-armed `syn::Fields` match was doing —
@@ -1221,27 +1238,20 @@ impl CbindgenBuilder {
 
     /// The wire of one payload field, or a generation error naming the
     /// offending variant field and the supported set.
-    fn payload_wire_of(
-        &self,
-        key: &TypeKey,
-        variant: &syn::Ident,
-        field: &Field,
-        registry: &Registry<()>,
-    ) -> syn::Type {
-        self.payload_field_wire(&field.ty, registry)
-            .unwrap_or_else(|reason| {
-                panic!(
-                    "Cbindgen::tagged_union: payload `{}::{}{}` of type `{}` cannot cross: {}",
-                    type_short(key),
-                    variant,
-                    match &field.name {
-                        Some(n) => format!(".{n}"),
-                        None => String::new(),
-                    },
-                    field.ty,
-                    reason,
-                )
-            })
+    fn payload_wire_of(&self, key: &TypeKey, variant: &syn::Ident, field: &Field) -> syn::Type {
+        self.payload_field_wire(&field.ty).unwrap_or_else(|reason| {
+            panic!(
+                "Cbindgen::tagged_union: payload `{}::{}{}` of type `{}` cannot cross: {}",
+                type_short(key),
+                variant,
+                match &field.name {
+                    Some(n) => format!(".{n}"),
+                    None => String::new(),
+                },
+                field.ty,
+                reason,
+            )
+        })
     }
 
     /// Release one owning payload slot held behind `binding` (a `&mut` to the
@@ -1364,7 +1374,7 @@ impl CbindgenBuilder {
             // declared-but-unused signature.
             if registry
                 .reading_of(&callback_fn_type(&args))
-                .and_then(|tr| registry.input_entry(&tr))
+                .and_then(|tr| self.in_frag(&tr))
                 .is_none()
             {
                 continue;
@@ -1385,8 +1395,8 @@ impl CbindgenBuilder {
                         a.to_token_stream()
                     )
                 });
-                let wire = registry
-                    .output_entry(&reading)
+                let wire = self
+                    .out_frag(&reading)
                     .unwrap_or_else(|| {
                         panic!(
                             "Cbindgen: callback arg `{}` has no output converter (declare it \
@@ -1538,13 +1548,13 @@ impl CbindgenBuilder {
                 .map_err(|message| prebindgen_registry::ScanError::AdapterInvariant { message })?;
             compiled = compiler.finish();
         }
-        // What the compilation produced, kept for emission. The converter table
-        // stays the lookup index; this is what reaches the file.
+        // What the compilation produced, kept for emission and for lookup.
         self.compiled_fns = compiled
             .fragments()
             .into_iter()
             .map(|f| f.function.clone())
             .collect();
+        self.compiled = Some(compiled);
         self.validate_resolved(&registry)
             .map_err(|message| prebindgen_registry::ScanError::AdapterInvariant { message })?;
         Ok(Cbindgen {

--- a/prebindgen-jni/src/jni/builder.rs
+++ b/prebindgen-jni/src/jni/builder.rs
@@ -144,6 +144,7 @@ impl Default for Declarations {
     fn default() -> Self {
         Self {
             compiled_fns: Vec::new(),
+            tables: None,
             compiled: Default::default(),
             package: String::new(),
             fun_name_mangle: None,

--- a/prebindgen-jni/src/jni/builder.rs
+++ b/prebindgen-jni/src/jni/builder.rs
@@ -83,11 +83,7 @@ impl Declarations {
     /// stream's `SourceLocation` stamp (multi-source bindings — helper
     /// crates layered on the flat crate), else the registry's default
     /// module (first-seen stream origin), else `crate`.
-    pub(crate) fn fn_module(
-        &self,
-        registry: &impl Conversions<KotlinMeta>,
-        ident: &syn::Ident,
-    ) -> syn::Path {
+    pub(crate) fn fn_module(&self, registry: &impl Conversions, ident: &syn::Ident) -> syn::Path {
         registry
             .origin_module(ident)
             .or_else(|| registry.default_module())
@@ -97,7 +93,7 @@ impl Declarations {
     /// The module for source references with no per-item origin (declared
     /// types with no `#[prebindgen]` item, glob imports): the registry's
     /// default module (first source), `crate` for an origin-less registry.
-    pub(crate) fn default_module(&self, registry: &Registry<KotlinMeta>) -> syn::Path {
+    pub(crate) fn default_module(&self, registry: &Registry) -> syn::Path {
         registry
             .default_module()
             .unwrap_or_else(|| syn::parse_quote!(crate))
@@ -845,7 +841,7 @@ impl Declarations {
     /// once, on the member), else the camel-cased Rust name.
     fn lower_fields(
         &self,
-        registry: &impl Conversions<KotlinMeta>,
+        registry: &impl Conversions,
         key: &TypeKey,
         fields: &[LocalField],
     ) -> Vec<prebindgen_registry::unfold::DeconRecord> {
@@ -902,7 +898,7 @@ impl Declarations {
     /// a field renamed upstream must not silently lose its adjustment.
     fn lower_value_form(
         &self,
-        registry: &impl Conversions<KotlinMeta>,
+        registry: &impl Conversions,
         key: &TypeKey,
         decl: &FieldsDecl,
     ) -> Vec<prebindgen_registry::unfold::FieldRecord> {
@@ -980,7 +976,7 @@ impl Declarations {
     #[allow(clippy::too_many_arguments)]
     fn walk_value_form(
         &self,
-        registry: &impl Conversions<KotlinMeta>,
+        registry: &impl Conversions,
         key: &TypeKey,
         decl: &FieldsDecl,
         st: &flat::Struct,
@@ -1157,7 +1153,7 @@ impl Declarations {
     /// output-flattened.
     pub(crate) fn build_deconstructors(
         &self,
-        registry: &impl Conversions<KotlinMeta>,
+        registry: &impl Conversions,
     ) -> prebindgen_registry::unfold::Deconstructors {
         use prebindgen_registry::unfold::{
             DeconSel, DeconTarget, DeconstructorDecl, Deconstructors, Delivery, OutputDecl,
@@ -1496,7 +1492,7 @@ impl Declarations {
     pub(crate) fn convert_input_body(
         &self,
         key: &TypeKey,
-        registry: &impl Conversions<KotlinMeta>,
+        registry: &impl Conversions,
         emit: &prebindgen_registry::Emit,
     ) -> Option<(syn::Type, Option<syn::Type>, syn::Expr)> {
         let decl = self.convert_decls.iter().find(|d| d.key() == key)?;
@@ -1567,7 +1563,7 @@ impl Declarations {
     pub(crate) fn convert_output_body(
         &self,
         key: &TypeKey,
-        registry: &impl Conversions<KotlinMeta>,
+        registry: &impl Conversions,
         emit: &prebindgen_registry::Emit,
     ) -> Option<(syn::Type, Option<syn::Type>, syn::Expr)> {
         let decl = self.convert_decls.iter().find(|d| d.key() == key)?;
@@ -1781,7 +1777,7 @@ impl Declarations {
     fn conversion_domain_niches(
         &self,
         key: &TypeKey,
-        registry: &impl Conversions<KotlinMeta>,
+        registry: &impl Conversions,
         direction: Direction,
         wire: &syn::Type,
     ) -> (Niches, Vec<String>) {
@@ -1887,7 +1883,7 @@ impl Declarations {
     pub(crate) fn convert_target(
         &self,
         key: &TypeKey,
-        registry: &impl Conversions<KotlinMeta>,
+        registry: &impl Conversions,
         dir: Direction,
     ) -> Option<syn::Type> {
         let decl = self.convert_decls.iter().find(|d| d.key() == key)?;
@@ -1914,7 +1910,7 @@ impl Declarations {
     pub(crate) fn lookup_input(
         &self,
         outer: &prebindgen_registry::flat::TypeRef,
-        registry: &impl Conversions<KotlinMeta>,
+        registry: &impl Conversions,
         emit: &prebindgen_registry::Emit,
     ) -> Option<ConverterImpl<KotlinMeta>> {
         // A `convert!`-declared conversion is the only thing that answers here.
@@ -2025,7 +2021,7 @@ impl Declarations {
     pub(crate) fn lookup_output(
         &self,
         outer: &prebindgen_registry::flat::TypeRef,
-        registry: &impl Conversions<KotlinMeta>,
+        registry: &impl Conversions,
         emit: &prebindgen_registry::Emit,
     ) -> Option<ConverterImpl<KotlinMeta>> {
         let key = outer.key();
@@ -2045,7 +2041,7 @@ impl Declarations {
         outer: &prebindgen_registry::flat::TypeRef,
         ok: &syn::Type,
         err: &syn::Type,
-        registry: &impl Conversions<KotlinMeta>,
+        registry: &impl Conversions,
         emit: &prebindgen_registry::Emit,
     ) -> Option<ConverterImpl<KotlinMeta>> {
         self.build_output_converter(
@@ -2072,7 +2068,7 @@ impl Declarations {
         ty: syn::Type,
         exc_ty: Option<syn::Type>,
         body: syn::Expr,
-        registry: &impl Conversions<KotlinMeta>,
+        registry: &impl Conversions,
         emit: &prebindgen_registry::Emit,
     ) -> Option<ConverterImpl<KotlinMeta>> {
         let key = outer.key();

--- a/prebindgen-jni/src/jni/builder.rs
+++ b/prebindgen-jni/src/jni/builder.rs
@@ -896,7 +896,7 @@ impl Declarations {
     /// **Rust field ident**, and both are checked against the struct: naming a
     /// field the value form doesn't have is a hard error, which is the point —
     /// a field renamed upstream must not silently lose its adjustment.
-    fn lower_value_form(
+    pub(crate) fn lower_value_form(
         &self,
         registry: &impl Conversions,
         key: &TypeKey,

--- a/prebindgen-jni/src/jni/builder.rs
+++ b/prebindgen-jni/src/jni/builder.rs
@@ -1122,14 +1122,25 @@ impl Declarations {
                     else {
                         panic!("TypeKind::Sum implies a payload-carrying enum")
                     };
-                    let sum_cfg = self.types[&probe.key()]
-                        .sum()
-                        .expect("TypeKind::Sum implies a sealed-class config");
+                    // The declaration has to exist for the composition below
+                    // to name the alternatives' classes, and `TypeKind::Sum`
+                    // means it does — asserted here rather than trusted,
+                    // because the composition answers `None` for a missing one
+                    // and an empty leaf list would silently drop the field.
+                    assert!(
+                        self.types[&probe.key()].sum().is_some(),
+                        "TypeKind::Sum implies a sealed-class config",
+                    );
                     out.push(FieldRecord {
                         members: member_path,
                         name,
                         ty: field.ty.clone(),
-                        decon: FieldDecon::Leaves(crate::jni::synth_sum_leaves(self, sum_cfg, sum)),
+                        decon: FieldDecon::Leaves(crate::jni::synth_sum_leaves(
+                            self,
+                            registry,
+                            &id.ident().expect("a sum type is one identifier"),
+                            sum,
+                        )),
                     });
                     continue;
                 }

--- a/prebindgen-jni/src/jni/builder.rs
+++ b/prebindgen-jni/src/jni/builder.rs
@@ -148,6 +148,7 @@ impl Default for Declarations {
     fn default() -> Self {
         Self {
             compiled_fns: Vec::new(),
+            compiled: Default::default(),
             package: String::new(),
             fun_name_mangle: None,
             ptr_class_name_mangle: None,
@@ -1939,9 +1940,7 @@ impl Declarations {
         let inner = if is_self {
             None
         } else {
-            registry
-                .reading_of(&ty)
-                .and_then(|tr| registry.input_entry(&tr))
+            registry.reading_of(&ty).and_then(|tr| self.in_frag(&tr))
         };
         match inner {
             None if is_self || is_wire_type(&ty) => {
@@ -2085,9 +2084,7 @@ impl Declarations {
         let inner = if is_self {
             None
         } else {
-            registry
-                .reading_of(&ty)
-                .and_then(|tr| registry.output_entry(&tr))
+            registry.reading_of(&ty).and_then(|tr| self.out_frag(&tr))
         };
         match inner {
             None if is_self || is_wire_type(&ty) => {
@@ -2095,7 +2092,7 @@ impl Declarations {
                 let (kotlin_name, value_rust_type) = if let Some(a0) = arg0 {
                     registry
                         .reading_of(a0)
-                        .and_then(|tr| registry.output_entry(&tr))
+                        .and_then(|tr| self.out_frag(&tr))
                         .map(|e| {
                             (
                                 e.metadata.kotlin_name.clone(),

--- a/prebindgen-jni/src/jni/classify.rs
+++ b/prebindgen-jni/src/jni/classify.rs
@@ -54,7 +54,7 @@ impl Declarations {
     /// wrapper folding is the resolver's business, not this table's.
     pub(crate) fn type_kind<'r, 'c>(
         &'c self,
-        registry: &'r impl Conversions<KotlinMeta>,
+        registry: &'r impl Conversions,
         bare: &TypeKey,
     ) -> TypeKind<'r, 'c> {
         let cfg = self.types.get(bare);

--- a/prebindgen-jni/src/jni/compile.rs
+++ b/prebindgen-jni/src/jni/compile.rs
@@ -47,36 +47,60 @@ pub(crate) struct JFrag {
     pub(crate) composed_only: bool,
 }
 
+/// One step of the walk from the object a site names to a wire's value.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct Nav {
+    /// The Kotlin property read.
+    pub(crate) field: String,
+    /// Whether the value it is read **off** may be null, which makes the read a
+    /// safe call.
+    ///
+    /// Set by every gate above the step, not only the nearest: once a chain
+    /// passes through one `?.` every read after it is on a nullable value, so a
+    /// gate marks the whole chain below it rather than its first step.
+    pub(crate) gated: bool,
+}
+
 /// How Kotlin reaches one wire value, relative to the object the site names.
 ///
-/// Three forms rather than one string, because two of them put the base in the
-/// **middle**: a sum's tag reads `when (<base>.f) { … }` and a sum's payload
-/// slot reads `(<base>.f as? I.V)?.v0`. A suffix cannot say that, and a raw
-/// prefix/suffix pair cannot be composed — an optional layer has to know
-/// whether it is adding a `?.` navigation or a `null ->` arm, and only a named
-/// form tells it which.
+/// The walk is kept as steps rather than as one string, and that is what makes
+/// a gate composable: an optional is applied **after** the fields under it have
+/// composed, so it has to reach back and make every step below it a safe call.
+/// A string cannot say which of its dots are property reads — the `0.0` a
+/// non-nullable slot falls back to has one too.
+///
+/// Three forms, because two of them put the base in the **middle**: a sum's tag
+/// reads `when (<base>.f) { … }` and a sum's payload slot reads
+/// `(<base>.f as? I.V)?.v0`.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) enum Access {
-    /// `<base><tail>` — the ordinary read, including a presence comparison.
-    Read(String),
-    /// `when (<base><tail>) { … }` — which alternative of a sum is live, as the
+    /// `<base><walk><tail>` — the ordinary read. `tail` is whatever follows the
+    /// property chain: a presence comparison, an elvis default, a Kotlin enum's
+    /// `?.value`, or nothing.
+    Read {
+        /// The property chain from the base.
+        walk: Vec<Nav>,
+        /// What follows it.
+        tail: String,
+    },
+    /// `when (<base><walk>) { … }` — which alternative of a sum is live, as the
     /// `jint` tag the arms below are numbered by.
     Select {
-        /// What reaches the sum value from the base.
-        tail: String,
+        /// The property chain reaching the sum value.
+        walk: Vec<Nav>,
         /// One arm per alternative, in declaration order, without the `null`
-        /// one — an optional ancestor adds that by setting `nullable`.
+        /// one — a gate above adds that by setting `nullable`.
         arms: Vec<String>,
         /// Whether the value reached can be null, which is its own arm.
         nullable: bool,
     },
-    /// `(<base><tail> as? <class>)?.<read>[ ?: <zero>]` — one payload slot of
-    /// one alternative. Every alternative's slots cross on every call; the
-    /// cast yields null for the ones that are not live, and `zero` is what a
+    /// `(<base><walk> as? <class>)?.<read>[ ?: <zero>]` — one payload slot of
+    /// one alternative. Every alternative's slots cross on every call; the cast
+    /// yields null for the ones that are not live, and `zero` is what a
     /// non-nullable wire carries instead.
     Slot {
-        /// What reaches the sum value from the base.
-        tail: String,
+        /// The property chain reaching the sum value.
+        walk: Vec<Nav>,
         /// The Kotlin class of the alternative this slot belongs to. Empty
         /// until [`Compile::choice`] names it — the arm's own composition
         /// cannot, because a product hook is not told which alternative it is.
@@ -91,16 +115,29 @@ pub(crate) enum Access {
 }
 
 impl Access {
+    /// An ordinary read of the base itself, with nothing walked.
+    fn read(tail: impl Into<String>) -> Self {
+        Access::Read {
+            walk: Vec::new(),
+            tail: tail.into(),
+        }
+    }
+
     /// The Kotlin expression, rooted at the object this site destructures.
     ///
     /// Only the equivalence check calls it until the emitters take the row —
     /// the same `#[cfg(test)]` the wire's other readers carry.
     #[cfg(test)]
     pub(crate) fn render(&self, base: &str) -> String {
+        let reached = |walk: &[Nav]| {
+            walk.iter()
+                .map(|n| format!("{}{}", if n.gated { "?." } else { "." }, n.field))
+                .collect::<String>()
+        };
         match self {
-            Access::Read(tail) => format!("{base}{tail}"),
+            Access::Read { walk, tail } => format!("{base}{}{tail}", reached(walk)),
             Access::Select {
-                tail,
+                walk,
                 arms,
                 nullable,
             } => {
@@ -110,10 +147,10 @@ impl Access {
                     .chain(arms.iter().cloned())
                     .collect::<Vec<_>>()
                     .join("; ");
-                format!("when ({base}{tail}) {{ {arms} }}")
+                format!("when ({base}{}) {{ {arms} }}", reached(walk))
             }
             Access::Slot {
-                tail,
+                walk,
                 class,
                 read,
                 zero,
@@ -122,23 +159,29 @@ impl Access {
                     .as_ref()
                     .map(|z| format!(" ?: {z}"))
                     .unwrap_or_default();
-                format!("({base}{tail} as? {class})?.{read}{zero}")
+                format!("({base}{} as? {class})?.{read}{zero}", reached(walk))
             }
         }
     }
 
-    /// What reaches this value from the base — the part a container prepends
-    /// its own field to, whichever form the access takes.
-    fn tail_mut(&mut self) -> &mut String {
+    /// The property chain, whichever form the access takes.
+    fn walk_mut(&mut self) -> &mut Vec<Nav> {
         match self {
-            Access::Read(tail) | Access::Select { tail, .. } | Access::Slot { tail, .. } => tail,
+            Access::Read { walk, .. } | Access::Select { walk, .. } | Access::Slot { walk, .. } => {
+                walk
+            }
         }
     }
 
     /// This access read from one field in, rather than from the object itself.
     fn under(mut self, field: &str) -> Self {
-        let tail = self.tail_mut();
-        *tail = format!(".{field}{tail}");
+        self.walk_mut().insert(
+            0,
+            Nav {
+                field: field.to_string(),
+                gated: false,
+            },
+        );
         self
     }
 }
@@ -429,7 +472,7 @@ impl<R: Conversions> Compile for JCompile<'_, R> {
                 kt_ty: "Boolean".to_string(),
                 path: "present".to_string(),
                 // The gate reads the object itself, not through it.
-                access: Access::Read(" != null".to_string()),
+                access: Access::read(" != null"),
                 conv: None,
                 handle_target: None,
                 handle_nullable: false,
@@ -554,7 +597,7 @@ impl<R: Conversions> Compile for JCompile<'_, R> {
                     ty: syn::parse_quote!(jni::sys::jlong),
                     kt_ty: "Long".to_string(),
                     path: part.name.clone(),
-                    access: Access::Read(format!(".{}", field_kt(part))),
+                    access: Access::read("").under(&field_kt(part)),
                     conv: None,
                     handle_target: Some(format!(".{}", field_kt(part))),
                     handle_nullable: part.ty.optional_inner().is_some(),
@@ -566,7 +609,7 @@ impl<R: Conversions> Compile for JCompile<'_, R> {
                     ty: frag.conv.destination.clone(),
                     kt_ty: crate::jni::emit::wire_kotlin_type(&frag.conv),
                     path: part.name.clone(),
-                    access: Access::Read(format!(".{}", field_kt(part))),
+                    access: Access::read("").under(&field_kt(part)),
                     conv: Some(frag.conv.function.sig.ident.clone()),
                     handle_target: None,
                     handle_nullable: false,
@@ -798,7 +841,7 @@ impl<R: Conversions> JCompile<'_, R> {
             kt_ty,
             path: prop,
             access: Access::Slot {
-                tail: String::new(),
+                walk: Vec::new(),
                 // Named by `choice`, the only hook told which alternative this
                 // payload belongs to.
                 class: String::new(),
@@ -838,7 +881,7 @@ impl<R: Conversions> JCompile<'_, R> {
             kt_ty: "Int".to_string(),
             path: "_tag".to_string(),
             access: Access::Select {
-                tail: String::new(),
+                walk: Vec::new(),
                 arms: arms
                     .iter()
                     .zip(&classes)
@@ -864,7 +907,7 @@ impl<R: Conversions> JCompile<'_, R> {
                 wires.push(Wire {
                     path: crate::jni::struct_plan::sum_slot_fragment(short, &w.path),
                     access: Access::Slot {
-                        tail: String::new(),
+                        walk: Vec::new(),
                         class: class.clone(),
                         read: read.clone(),
                         zero: zero.clone(),
@@ -906,7 +949,7 @@ impl<R: Conversions> JCompile<'_, R> {
                 ty: syn::parse_quote!(jni::sys::jboolean),
                 kt_ty: "Boolean".to_string(),
                 path: "present".to_string(),
-                access: Access::Read(" != null".to_string()),
+                access: Access::read(" != null"),
                 conv: None,
                 handle_target: None,
                 handle_nullable: false,
@@ -918,7 +961,7 @@ impl<R: Conversions> JCompile<'_, R> {
                 ty: c.destination.clone(),
                 kt_ty: crate::jni::emit::wire_kotlin_type(c),
                 path: "value".to_string(),
-                access: Access::Read(value_access),
+                access: Access::read(value_access),
                 conv: Some(c.function.sig.ident.clone()),
                 handle_target: None,
                 handle_nullable: false,
@@ -994,15 +1037,18 @@ fn absent_default(w: &Wire, tail: &str) -> String {
 /// `null` arm instead, and a sum's `as?` slot needs neither — a cast over a
 /// null subject is already null.
 fn gated(access: &Access, w: &Wire) -> Access {
-    match access {
-        Access::Read(tail) => Access::Read(format!("?{tail}{}", absent_default(w, tail))),
-        Access::Select { tail, arms, .. } => Access::Select {
-            tail: tail.clone(),
-            arms: arms.clone(),
-            nullable: true,
-        },
-        slot @ Access::Slot { .. } => slot.clone(),
+    let mut gated = access.clone();
+    // Every step below the gate, not only the first: after one safe call the
+    // chain is on a nullable value and stays there.
+    for nav in gated.walk_mut() {
+        nav.gated = true;
     }
+    match &mut gated {
+        Access::Read { tail, .. } => *tail = format!("{tail}{}", absent_default(w, tail)),
+        Access::Select { nullable, .. } => *nullable = true,
+        Access::Slot { .. } => {}
+    }
+    gated
 }
 
 /// Whether this fragment states a sum taken apart into a tag and its arms'

--- a/prebindgen-jni/src/jni/compile.rs
+++ b/prebindgen-jni/src/jni/compile.rs
@@ -114,6 +114,19 @@ pub(crate) enum Access {
     },
 }
 
+/// The Kotlin property chain, rooted at the object a site destructures.
+///
+/// Only the equivalence check calls it until the emitters take the row.
+#[cfg(test)]
+pub(crate) fn reached(base: &str, walk: &[Nav]) -> String {
+    let mut out = base.to_string();
+    for nav in walk {
+        out.push_str(if nav.gated { "?." } else { "." });
+        out.push_str(&nav.field);
+    }
+    out
+}
+
 impl Access {
     /// An ordinary read of the base itself, with nothing walked.
     fn read(tail: impl Into<String>) -> Self {
@@ -129,13 +142,8 @@ impl Access {
     /// the same `#[cfg(test)]` the wire's other readers carry.
     #[cfg(test)]
     pub(crate) fn render(&self, base: &str) -> String {
-        let reached = |walk: &[Nav]| {
-            walk.iter()
-                .map(|n| format!("{}{}", if n.gated { "?." } else { "." }, n.field))
-                .collect::<String>()
-        };
         match self {
-            Access::Read { walk, tail } => format!("{base}{}{tail}", reached(walk)),
+            Access::Read { walk, tail } => format!("{}{tail}", reached(base, walk)),
             Access::Select {
                 walk,
                 arms,
@@ -147,7 +155,7 @@ impl Access {
                     .chain(arms.iter().cloned())
                     .collect::<Vec<_>>()
                     .join("; ");
-                format!("when ({base}{}) {{ {arms} }}", reached(walk))
+                format!("when ({}) {{ {arms} }}", reached(base, walk))
             }
             Access::Slot {
                 walk,
@@ -159,7 +167,7 @@ impl Access {
                     .as_ref()
                     .map(|z| format!(" ?: {z}"))
                     .unwrap_or_default();
-                format!("({base}{} as? {class})?.{read}{zero}", reached(walk))
+                format!("({} as? {class})?.{read}{zero}", reached(base, walk))
             }
         }
     }
@@ -187,7 +195,10 @@ impl Access {
 }
 
 /// One wire value of a crossing that occupies several.
-#[derive(Clone, Debug, PartialEq, Eq)]
+///
+/// `Clone` alone: a wire carries the whole conversion its value crosses
+/// through, and a `syn::ItemFn` is neither comparable nor cheap to print.
+#[derive(Clone)]
 pub(crate) struct Wire {
     /// The JNI type this value crosses as.
     pub(crate) ty: syn::Type,
@@ -208,27 +219,36 @@ pub(crate) struct Wire {
     /// next.
     pub(crate) access: Access,
     /// The conversion this value crosses through, or `None` for a presence flag
-    /// — which is read on the Rust side and converts nothing.
-    pub(crate) conv: Option<syn::Ident>,
+    /// or a tag — both of which are read on the Rust side and convert nothing.
+    ///
+    /// The whole conversion rather than its name: the Rust side that rebuilds
+    /// the value calls it through its wire-facing function **and** whatever
+    /// Rust-side stages follow, and a name says nothing about those.
+    pub(crate) entry: Option<ConverterImpl<KotlinMeta>>,
     /// For a nested owned handle: where Kotlin finds the handle **object**, as
     /// against the `Long` this wire carries.
     ///
     /// A nested handle crosses under the same lock-and-consume scaffold as a
     /// top-level one, and that scaffold needs the object, not its pointer. The
     /// wire itself is filled from a local the scaffold binds.
-    pub(crate) handle_target: Option<String>,
+    ///
+    /// A walk rather than a string, and for the reason [`Access`] is one: a gate
+    /// above has to make every read in it a safe call, and the scaffold locks
+    /// what this reaches — so a chain that ignored the gate would lock and
+    /// consume the wrong expression.
+    pub(crate) handle_target: Option<Vec<Nav>>,
     /// Whether that handle access can be null — the field is optional, or an
     /// optional ancestor gates it.
     pub(crate) handle_nullable: bool,
-    /// Whether the conversion carries Rust-side stages beyond its wire-facing
-    /// function — a `convert!` with a semantic step, say `jlong -> u64 ->
-    /// Duration`.
+    /// The Kotlin literal this wire carries while a gate above it is closed,
+    /// or `None` for one that rides a JVM `null` or already substitutes its
+    /// own.
     ///
-    /// Read where a caller may only call the wire-facing function and would
-    /// otherwise bind the representation where the value is wanted: the `Vec`
-    /// build helper declines such an element rather than emit a call that does
-    /// not compile.
-    pub(crate) staged: bool,
+    /// Stated where the wire is built rather than derived where the gate is
+    /// applied, because only the former knows what the value is: an unsigned
+    /// projection substitutes its niche sentinel, and a decoupled pair has
+    /// already put its zero in the access.
+    pub(crate) absent: Option<String>,
     /// The struct field this value fills or gates, once a product says which.
     ///
     /// `None` until then, and permanently `None` for a gate over a whole value:
@@ -454,7 +474,7 @@ impl<R: Conversions> Compile for JCompile<'_, R> {
         // value crosses through the INNER's conversion, not the optional's —
         // there is no boxed `Option` on this wire to decode.
         if at.crossing.assembly() == Assembly::Construct && inner.wires.is_none() {
-            if let Some(pair) = self.decoupled_optional(at, inner) {
+            if let Some(pair) = self.decoupled_optional(at, inner, &frag.conv) {
                 frag.wires = Some(pair);
                 return Ok(frag);
             }
@@ -473,23 +493,17 @@ impl<R: Conversions> Compile for JCompile<'_, R> {
                 path: "present".to_string(),
                 // The gate reads the object itself, not through it.
                 access: Access::read(" != null"),
-                conv: None,
+                entry: None,
                 handle_target: None,
                 handle_nullable: false,
-                staged: false,
+                absent: None,
                 field: None,
                 whole_gate: !sum,
             }];
             // Everything under the gate is reached through it, and a
             // non-nullable slot still has to hold something when the value is
             // absent — the flag is what tells Rust to ignore it.
-            wires.extend(inner_wires.iter().map(|w| Wire {
-                access: gated(&w.access, w),
-                // Anything under the gate can be absent, however the field
-                // itself was spelled.
-                handle_nullable: w.handle_target.is_some() || w.handle_nullable,
-                ..w.clone()
-            }));
+            wires.extend(inner_wires.iter().map(gated));
             frag.wires = Some(wires);
         }
         Ok(frag)
@@ -573,13 +587,17 @@ impl<R: Conversions> Compile for JCompile<'_, R> {
                         // The field this part reads, then however the part's own
                         // wire reaches on from there.
                         access: w.access.clone().under(&field_kt(part)),
-                        conv: w.conv.clone(),
-                        handle_target: w
-                            .handle_target
-                            .as_ref()
-                            .map(|t| format!(".{}{t}", field_kt(part))),
+                        entry: w.entry.clone(),
+                        handle_target: w.handle_target.as_ref().map(|t| {
+                            std::iter::once(Nav {
+                                field: field_kt(part),
+                                gated: false,
+                            })
+                            .chain(t.iter().cloned())
+                            .collect()
+                        }),
                         handle_nullable: w.handle_nullable,
-                        staged: w.staged,
+                        absent: w.absent.clone(),
                         // A part's wires name their own fields once they are
                         // inside a product; what a decoupled optional left
                         // open, the part it belongs to closes.
@@ -598,25 +616,17 @@ impl<R: Conversions> Compile for JCompile<'_, R> {
                     kt_ty: "Long".to_string(),
                     path: part.name.clone(),
                     access: Access::read("").under(&field_kt(part)),
-                    conv: None,
-                    handle_target: Some(format!(".{}", field_kt(part))),
+                    entry: None,
+                    handle_target: Some(vec![Nav {
+                        field: field_kt(part),
+                        gated: false,
+                    }]),
                     handle_nullable: part.ty.optional_inner().is_some(),
-                    staged: false,
+                    absent: None,
                     field: Some(part.name.clone()),
                     whole_gate: false,
                 }),
-                None => wires.push(Wire {
-                    ty: frag.conv.destination.clone(),
-                    kt_ty: crate::jni::emit::wire_kotlin_type(&frag.conv),
-                    path: part.name.clone(),
-                    access: Access::read("").under(&field_kt(part)),
-                    conv: Some(frag.conv.function.sig.ident.clone()),
-                    handle_target: None,
-                    handle_nullable: false,
-                    staged: !frag.conv.pre_stages.is_empty(),
-                    field: Some(part.name.clone()),
-                    whole_gate: false,
-                }),
+                None => wires.push(self.field_wire(part, frag)),
             }
         }
         // Only the wire list is composed here. The conversion that reads these
@@ -742,6 +752,30 @@ impl std::ops::Deref for Conv {
 /// the `parts` row. Only the equivalence check calls them until then.
 #[cfg(test)]
 impl Wire {
+    /// The wire-facing function this value crosses through.
+    pub(crate) fn conv(&self) -> Option<&syn::Ident> {
+        self.entry.as_ref().map(|e| &e.function.sig.ident)
+    }
+
+    /// Whether the conversion carries Rust-side stages beyond its wire-facing
+    /// function — a `convert!` with a semantic step, say `jlong -> u64 ->
+    /// Duration`.
+    ///
+    /// Read where a caller may only call the wire-facing function and would
+    /// otherwise bind the representation where the value is wanted: the `Vec`
+    /// build helper declines such an element rather than emit a call that does
+    /// not compile.
+    pub(crate) fn staged(&self) -> bool {
+        self.entry
+            .as_ref()
+            .is_some_and(|e| !e.pre_stages.is_empty())
+    }
+}
+
+/// Facts a wire states about itself, which the emitters read once they take
+/// the `parts` row. Only the equivalence check calls them until then.
+#[cfg(test)]
+impl Wire {
     /// The struct field this value fills, which the Rust-side rebuild binds by
     /// name.
     ///
@@ -812,6 +846,67 @@ impl<R: Conversions> JCompile<'_, R> {
         frag
     }
 
+    /// One field that crosses as a single value of its own conversion.
+    ///
+    /// Three reads the value itself asks for, each because the Kotlin property
+    /// holds something other than the wire: an `enum_class` property is the
+    /// enum object and the wire is its discriminant, an unsigned projection's
+    /// property is a `ULong` and the wire is the `Long` under it, and an
+    /// optional whose wire is a JVM object rides a `null` rather than a
+    /// literal.
+    fn field_wire(&self, part: &Part<'_>, frag: &JFrag) -> Wire {
+        let optional = part.ty.optional_inner().is_some();
+        let mut walk = vec![Nav {
+            field: field_kt(part),
+            gated: false,
+        }];
+        let mut kt_ty = crate::jni::emit::wire_kotlin_type(&frag.conv);
+        let projection = frag.conv.metadata.projection.as_ref();
+        let mut absent = None;
+        if projection.map(|p| &p.kind) == Some(&ProjectionKind::Unsigned64) {
+            walk.push(Nav {
+                field: "toLong()".to_string(),
+                gated: optional,
+            });
+            // An unsigned projection carves its absent value out of the
+            // representation's own range, so a closed gate substitutes that
+            // rather than the wire's zero.
+            absent = Some(
+                projection
+                    .and_then(|p| p.niche_sentinels.first().cloned())
+                    .unwrap_or_else(|| "0L".to_string()),
+            );
+        } else if self.decls.is_kotlin_enum_reading(&part.ty) {
+            walk.push(Nav {
+                field: "value".to_string(),
+                gated: optional,
+            });
+        }
+        if optional && crate::jni::emit::is_jobject_shaped_wire(&frag.conv.destination) {
+            if !kt_ty.ends_with('?') {
+                kt_ty.push('?');
+            }
+        } else if absent.is_none() {
+            absent = crate::jni::wire_access::jni_field_access(&frag.conv.destination)
+                .and_then(|(sig, _, _)| crate::jni::emit::kt_leaf_default(sig, false));
+        }
+        Wire {
+            ty: frag.conv.destination.clone(),
+            kt_ty,
+            path: part.name.clone(),
+            access: Access::Read {
+                walk,
+                tail: String::new(),
+            },
+            entry: Some(frag.conv.clone()),
+            handle_target: None,
+            handle_nullable: false,
+            absent,
+            field: Some(part.name.clone()),
+            whole_gate: false,
+        }
+    }
+
     /// One payload of one alternative, or `None` if it has no slot form.
     fn slot(&self, part: &Part<'_>, frag: &JFrag) -> Option<Wire> {
         if frag.wires.is_some() || frag.conv.metadata.projection.is_some() {
@@ -848,10 +943,10 @@ impl<R: Conversions> JCompile<'_, R> {
                 read,
                 zero: prim.map(|p| p.kotlin_zero().to_string()),
             },
-            conv: Some(frag.conv.function.sig.ident.clone()),
+            entry: Some(frag.conv.clone()),
             handle_target: None,
             handle_nullable: false,
-            staged: !frag.conv.pre_stages.is_empty(),
+            absent: None,
             field: None,
             whole_gate: false,
         })
@@ -891,10 +986,10 @@ impl<R: Conversions> JCompile<'_, R> {
                     .collect(),
                 nullable: false,
             },
-            conv: None,
+            entry: None,
             handle_target: None,
             handle_nullable: false,
-            staged: false,
+            absent: None,
             field: None,
             whole_gate: false,
         }];
@@ -925,24 +1020,57 @@ impl<R: Conversions> JCompile<'_, R> {
     /// The conditions are the ones the walk applies: the inner is not a borrow,
     /// its wire is a JNI primitive, and it has nothing that would already carry
     /// the absence — no carved niche, no projection, no Rust-side stages.
-    fn decoupled_optional(&self, at: At<'_>, inner: &JFrag) -> Option<Vec<Wire>> {
+    fn decoupled_optional(
+        &self,
+        at: At<'_>,
+        inner: &JFrag,
+        outer: &ConverterImpl<KotlinMeta>,
+    ) -> Option<Vec<Wire>> {
         let inner_reading = at.crossing.value().optional_inner()?;
         if inner_reading.borrow_target().is_some() {
             return None;
         }
         let c = &inner.conv;
         let prim = crate::jni::JniPrim::from_wire(&c.destination)?;
-        if c.niches.clone().carve().is_some()
-            || c.metadata.projection.is_some()
-            || !c.pre_stages.is_empty()
-        {
+        if c.niches.clone().carve().is_some() || !c.pre_stages.is_empty() {
             return None;
         }
-        // A Kotlin enum's slot is its `value`, reached through the same gate.
-        let value_access = if self.decls.is_kotlin_enum_reading(inner_reading) {
-            format!("?.value ?: {}", prim.kotlin_zero())
+        // An unsigned representation is the one projection that still takes the
+        // pair. Its Kotlin property is a `ULong?`, which boxes, and its wire is
+        // the `Long` under it — so the gate is worth the same here as it is over
+        // a signed primitive. Only where the optional has no primitive wire of
+        // its own: a bounded representation whose range leaves a niche already
+        // crosses as one value and keeps doing so.
+        let unsigned = match c.metadata.projection.as_ref().map(|p| &p.kind) {
+            None => false,
+            Some(ProjectionKind::Unsigned64)
+                if crate::jni::JniPrim::from_wire(&outer.destination).is_none() =>
+            {
+                true
+            }
+            Some(_) => return None,
+        };
+        // A Kotlin enum's slot is its `value`, reached through the same gate —
+        // what this pair was decoupled from is optional, so that read is a safe
+        // call however the wire above it is composed.
+        let step = if unsigned {
+            // The `ULong` property's own representation, which is the wire.
+            Some("toLong()")
+        } else if self.decls.is_kotlin_enum_reading(inner_reading) {
+            Some("value")
         } else {
-            format!(" ?: {}", prim.kotlin_zero())
+            None
+        };
+        let value_access = Access::Read {
+            walk: step
+                .map(|field| {
+                    vec![Nav {
+                        field: field.to_string(),
+                        gated: true,
+                    }]
+                })
+                .unwrap_or_default(),
+            tail: format!(" ?: {}", prim.kotlin_zero()),
         };
         Some(vec![
             Wire {
@@ -950,10 +1078,10 @@ impl<R: Conversions> JCompile<'_, R> {
                 kt_ty: "Boolean".to_string(),
                 path: "present".to_string(),
                 access: Access::read(" != null"),
-                conv: None,
+                entry: None,
                 handle_target: None,
                 handle_nullable: false,
-                staged: false,
+                absent: None,
                 field: None,
                 whole_gate: false,
             },
@@ -961,11 +1089,11 @@ impl<R: Conversions> JCompile<'_, R> {
                 ty: c.destination.clone(),
                 kt_ty: crate::jni::emit::wire_kotlin_type(c),
                 path: "value".to_string(),
-                access: Access::read(value_access),
-                conv: Some(c.function.sig.ident.clone()),
+                access: value_access,
+                entry: Some(c.clone()),
                 handle_target: None,
                 handle_nullable: false,
-                staged: false,
+                absent: None,
                 field: None,
                 whole_gate: false,
             },
@@ -1006,48 +1134,49 @@ fn is_handle(frag: &JFrag) -> bool {
         .is_some_and(|p| p.kind == crate::jni::ProjectionKind::Handle)
 }
 
-/// What a non-nullable slot holds while its gate is closed, as an elvis tail.
+/// One wire, read through a gate above it that may find nothing.
 ///
-/// Empty for the two cases that need none. A **presence flag** is a `!= null`
-/// comparison: it is already non-null, and a Kotlin elvis on a non-null operand
-/// does not compile. A wire that **already carries one** got it from a gate
-/// further in — the expression yields a value from there on, so an outer gate
-/// has nothing left to substitute for.
-fn absent_default(w: &Wire, tail: &str) -> String {
-    if w.conv.is_none() && w.handle_target.is_none() {
-        return String::new();
-    }
-    if tail.contains(" ?: ") {
-        return String::new();
-    }
-    crate::jni::emit::kt_leaf_default(
-        crate::jni::wire_access::jni_field_access(&w.ty)
-            .map(|(sig, _, _)| sig)
-            .unwrap_or(""),
-        w.kt_ty.ends_with('?'),
-    )
-    .map(|d| format!(" ?: {d}"))
-    .unwrap_or_default()
-}
-
-/// One wire's access, read through a gate that may find nothing.
+/// Every step below the gate becomes a safe call — not only the first: after
+/// one `?.` the chain is on a nullable value and stays there. What each form
+/// then needs is its own. An ordinary read carries the literal it stated for
+/// exactly this case; a sum's `when` gains the `null` arm; a sum's `as?` slot
+/// needs neither, a cast over a null subject being already null.
 ///
-/// Only an ordinary read navigates: it gains the `?` that stops at a null and
-/// the literal a non-nullable slot then carries. A sum's `when` gains the
-/// `null` arm instead, and a sum's `as?` slot needs neither — a cast over a
-/// null subject is already null.
-fn gated(access: &Access, w: &Wire) -> Access {
-    let mut gated = access.clone();
-    // Every step below the gate, not only the first: after one safe call the
-    // chain is on a nullable value and stays there.
-    for nav in gated.walk_mut() {
+/// A wire whose value is a JVM object rides that `null` instead of a literal,
+/// and its Kotlin type says so. Read **after** the literal rather than before,
+/// because a `String` slot does both: it falls back to `""` when its own field
+/// is present under a closed ancestor, and it is typed `String?`.
+fn gated(w: &Wire) -> Wire {
+    let mut gated = w.clone();
+    for nav in gated
+        .access
+        .walk_mut()
+        .iter_mut()
+        .chain(gated.handle_target.iter_mut().flatten())
+    {
         nav.gated = true;
     }
-    match &mut gated {
-        Access::Read { tail, .. } => *tail = format!("{tail}{}", absent_default(w, tail)),
+    match &mut gated.access {
+        Access::Read { tail, .. } => {
+            if let Some(absent) = gated.absent.take() {
+                if !tail.contains(" ?: ") {
+                    *tail = format!("{tail} ?: {absent}");
+                }
+            }
+        }
         Access::Select { nullable, .. } => *nullable = true,
         Access::Slot { .. } => {}
     }
+    if gated.entry.is_some()
+        && matches!(gated.access, Access::Read { .. })
+        && crate::jni::emit::is_jobject_shaped_wire(&gated.ty)
+        && !gated.kt_ty.ends_with('?')
+    {
+        gated.kt_ty.push('?');
+    }
+    // Anything under the gate can be absent, however the field itself was
+    // spelled.
+    gated.handle_nullable = gated.handle_target.is_some() || gated.handle_nullable;
     gated
 }
 

--- a/prebindgen-jni/src/jni/compile.rs
+++ b/prebindgen-jni/src/jni/compile.rs
@@ -378,10 +378,6 @@ impl<R: Conversions> Compile for JCompile<'_, R> {
         self.wrap(at, "no JNI representation for this run", conv)
     }
 
-    fn identity(&mut self, _cx: &mut Cx<'_>, at: At<'_>, _inner: &JFrag) -> Frag<Self> {
-        Err(refuse(at, "JniGen declares no identity rows"))
-    }
-
     fn construct(
         &mut self,
         _cx: &mut Cx<'_>,

--- a/prebindgen-jni/src/jni/compile.rs
+++ b/prebindgen-jni/src/jni/compile.rs
@@ -400,10 +400,57 @@ fn produces_borrow(ty: &syn::Type) -> bool {
 pub(crate) struct JCompile<'a, R> {
     pub(crate) decls: &'a Declarations,
     pub(crate) registry: &'a R,
+    /// Which site is being planned, when one is.
+    ///
+    /// `None` while compiling a row: a row answers for a crossing wherever it
+    /// appears, so nothing about a site may reach it. Set only for the one hook
+    /// the registry calls per site.
+    pub(crate) site: Option<PlanSite>,
 }
 
-fn refuse(at: At<'_>, why: &str) -> String {
-    format!("JniGen: {} ({why})", at.crossing.key())
+/// What [`Compile::plan`] needs about a site that the crossing does not say.
+pub(crate) struct PlanSite {
+    /// The parameter ident the wrapper binds this value to.
+    pub(crate) ident: syn::Ident,
+    /// Whether this leaf is one of a constructor expansion's arguments rather
+    /// than a parameter the signature names.
+    ///
+    /// The one fact a plan needs that the crossing cannot say: a `Vec`
+    /// parameter builds through a collection helper where the site is a real
+    /// parameter, and crosses as one value where it is an expansion's leaf.
+    pub(crate) expanded: bool,
+}
+
+/// What this adapter reports when it cannot answer.
+///
+/// Two kinds, because two readers act on them differently. A **refusal** names
+/// a crossing this adapter has no representation for, and the driver turns it
+/// into an adapter invariant. A **plan failure** is `fn_plan`'s own typed
+/// error, whose readers choose their diagnostic from which failure it is — so
+/// it travels whole rather than as the string it would print to.
+#[derive(Debug)]
+pub(crate) enum JErr {
+    /// No JNI representation for this crossing.
+    Refused(String),
+    /// One site could not be planned.
+    ///
+    /// Boxed for the reason `PlanError` boxes its own readings: a `Result` is
+    /// sized by its largest variant, and the success side of every hook on this
+    /// path is the one that always happens.
+    Plan(Box<crate::jni::fn_plan::PlanError>),
+}
+
+impl std::fmt::Display for JErr {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            JErr::Refused(why) => f.write_str(why),
+            JErr::Plan(e) => write!(f, "{e:?}"),
+        }
+    }
+}
+
+fn refuse(at: At<'_>, why: &str) -> JErr {
+    JErr::Refused(format!("JniGen: {} ({why})", at.crossing.key()))
 }
 
 impl<R: Conversions> JCompile<'_, R> {
@@ -471,10 +518,9 @@ impl<R: Conversions> JCompile<'_, R> {
 
 impl<R: Conversions> Compile for JCompile<'_, R> {
     type Fragment = JFrag;
-    /// JniGen keeps its own per-site emission for now: the exported signature,
-    /// the call and the cleanup are built from the resolved registry.
-    type Plan = ();
-    type Error = String;
+    /// One parameter of one exported function, classified.
+    type Plan = crate::jni::fn_plan::PlanLeaf;
+    type Error = JErr;
 
     fn atomic(&mut self, cx: &mut Cx<'_>, at: At<'_>) -> Frag<Self> {
         let ty = at.crossing.spelled();
@@ -763,8 +809,93 @@ impl<R: Conversions> Compile for JCompile<'_, R> {
         self.wrap(at, "undeclared callback signature", conv)
     }
 
-    fn plan(&mut self, _cx: &mut Cx<'_>, _bound: &Bound, _root: &JFrag) -> Result<(), String> {
-        Ok(())
+    /// One site: which of the seven wire layouts this parameter takes, and the
+    /// names the three coordinated emitters give it.
+    ///
+    /// The only hook the registry calls once per **site**; every hook above it
+    /// answers once per crossing, however many sites reuse the answer. What
+    /// makes this one per-site is not the type — that is the fragment's — but
+    /// what wraps it: a `Vec` parameter builds through a collection helper only
+    /// where the site is a real parameter and not a constructor expansion's
+    /// leaf, and the diagnostic for an unresolved leaf names the parameter that
+    /// expanded.
+    fn plan(&mut self, _cx: &mut Cx<'_>, bound: &Bound, root: &JFrag) -> Result<PlanLeaf, JErr> {
+        use crate::jni::fn_plan::{plan_error, InputKind, PlanLeaf};
+        let site = self
+            .site
+            .as_ref()
+            .ok_or_else(|| JErr::Refused("JniGen: a site compiled with no site context".into()))?;
+        let (ident, expanded) = (&site.ident, site.expanded);
+        let reading = bound.crossing.spelled();
+        let registry = self.registry;
+        let ext = self.decls;
+
+        // Every question below is the model's — the local spelling this
+        // function opened with has no users left.
+        let optional = reading.optional_inner().is_some();
+        // The enum probe off the reading: the layers it peels are the model's
+        // own (`&`, `Option`), so there is nothing to re-spell and nothing to
+        // look up.
+        let as_enum_value = ext.is_kotlin_enum_reading(reading);
+        let kt_name = crate::jni::kt_param_name(&ident.to_string());
+
+        // The site's own conversion, which the registry built before calling
+        // this. What used to be a lookup by type is the fragment it is handed.
+        let entry = &root.conv;
+
+        let flat_plan = crate::jni::emit::build_flat_input_plan(ext, registry, ident, reading)
+            .map_err(|e| plan_error(crate::jni::fn_plan::PlanError::UnflattenableDataClass(e)))?;
+        let kind = if let Some(v) = (!expanded)
+            .then(|| crate::jni::emit::vec_build_elem(ext, registry, reading))
+            .flatten()
+        {
+            InputKind::VecBuild {
+                elem: v.elem,
+                by_ref: v.by_ref,
+                elem_wrappers: v.elem_wrappers,
+            }
+        } else if let Some(sp) =
+            crate::jni::emit::build_option_scalar_input_plan(ext, ident, reading)
+        {
+            InputKind::OptionScalar(sp)
+        } else if let Some(plan) = flat_plan {
+            InputKind::FlattenStruct(plan)
+        } else {
+            match entry.metadata.projection.as_ref().map(|p| p.kind.clone()) {
+                Some(ProjectionKind::Handle) => InputKind::Handle {
+                    direct: entry.metadata.is_direct_handle(),
+                },
+                Some(ProjectionKind::Unsigned64) => InputKind::Unsigned64 {
+                    niche: entry.metadata.projection.as_ref().and_then(|p| {
+                        reading
+                            .optional_inner()
+                            .is_some()
+                            .then(|| p.niche_sentinels.first().cloned())
+                            .flatten()
+                    }),
+                },
+                None => InputKind::Plain,
+            }
+        };
+
+        // Typed surface: handle/value projections show their Kotlin class (from
+        // the projection's leaf key); everything else the conversion's resolved
+        // name.
+        let kt_meta = entry.metadata.kotlin_name.clone();
+        let kt_public = match entry.metadata.projection.as_ref() {
+            Some(p) => crate::jni::projection_leaf_kt(ext, p),
+            None => kt_meta.clone(),
+        };
+
+        Ok(PlanLeaf {
+            reading: reading.clone(),
+            kt_name,
+            kt_public,
+            kt_meta,
+            optional,
+            as_enum_value,
+            kind,
+        })
     }
 }
 

--- a/prebindgen-jni/src/jni/compile.rs
+++ b/prebindgen-jni/src/jni/compile.rs
@@ -33,6 +33,25 @@ impl Carrier for JFrag {
 }
 
 impl JFrag {
+    /// A conversion this adapter built without the compiler.
+    ///
+    /// A callback crossing is the only one: `JniGen::compile_crossing` answers
+    /// it with `dispatch_fn_input` rather than through a row, so there is no
+    /// `At` to take a crossing's own mode from. It is an owned, self-sufficient
+    /// value — a callback is delivered as a JVM object the wrapper holds — and
+    /// nothing composes a callback as an inner, so no row ever reads this
+    /// `Yield`. Goes with the derived callback row.
+    pub(crate) fn by_hand(ty: TypeKey, conv: ConverterImpl<KotlinMeta>) -> Self {
+        Self {
+            conv,
+            yields: Yield {
+                ty,
+                mode: Mode::Owned,
+                validity: Validity::SelfSufficient,
+            },
+        }
+    }
+
     fn new(at: At<'_>, conv: ConverterImpl<KotlinMeta>) -> Self {
         let validity = validity_of(&conv, at.crossing.assembly());
         Self {
@@ -294,5 +313,44 @@ impl<R: Conversions<KotlinMeta>> Compile for JCompile<'_, R> {
 
     fn plan(&mut self, _cx: &mut Cx<'_>, _bound: &Bound, _root: &JFrag) -> Result<(), String> {
         Ok(())
+    }
+}
+
+/// What an emitter asks instead of the converter table.
+///
+/// Each hands back the fragment's `ConverterImpl`, which is what a table entry
+/// was, so a call site reads the same fields it always did — from this
+/// adapter's own answer rather than from the shared index. Cloned rather than
+/// borrowed because [`Declarations::compiled`] is read while it is still being
+/// filled; a conversion is built once per crossing, so the clone is not on any
+/// hot path.
+///
+/// `None` means nothing has compiled that crossing. During compilation that is
+/// the deferral the resolver already understands — it retries — and after it,
+/// the only crossing without a fragment is a callback, which
+/// `JniGen::compile_crossing` answers without the compiler.
+impl crate::jni::Declarations {
+    /// The conversion for `ty` in the given direction, from the fragments
+    /// compiled so far.
+    pub(crate) fn frag(
+        &self,
+        ty: &TypeRef,
+        assembly: Assembly,
+    ) -> Option<ConverterImpl<KotlinMeta>> {
+        Some(
+            self.compiled
+                .borrow()
+                .fragment(&ty.key(), assembly)?
+                .conv
+                .clone(),
+        )
+    }
+
+    pub(crate) fn in_frag(&self, ty: &TypeRef) -> Option<ConverterImpl<KotlinMeta>> {
+        self.frag(ty, Assembly::Construct)
+    }
+
+    pub(crate) fn out_frag(&self, ty: &TypeRef) -> Option<ConverterImpl<KotlinMeta>> {
+        self.frag(ty, Assembly::Deconstruct)
     }
 }

--- a/prebindgen-jni/src/jni/compile.rs
+++ b/prebindgen-jni/src/jni/compile.rs
@@ -17,6 +17,37 @@ use super::{
     *,
 };
 
+/// The JNI adapter's answer for one site.
+///
+/// Both variants are boxed. A `PlanLeaf` embeds whole sub-plans and runs to
+/// ~856 bytes, a `ValueOutputPlan` to ~608, and every site pays the larger of
+/// the two — the same reason `FnOutputPlan::Value` boxes its own payload.
+pub(crate) enum JPlan {
+    /// One parameter, in the seven-way wire layout the emitters branch on.
+    Param(Box<crate::jni::fn_plan::PlanLeaf>),
+    /// A return that crosses as one value: what it converts through, and what
+    /// the Kotlin surface declares.
+    Return(Box<crate::jni::fn_plan::ValueOutputPlan>),
+}
+
+impl JPlan {
+    /// This plan as a parameter's, or `None` if it is a return's.
+    pub(crate) fn param(self) -> Option<crate::jni::fn_plan::PlanLeaf> {
+        match self {
+            JPlan::Param(leaf) => Some(*leaf),
+            JPlan::Return(_) => None,
+        }
+    }
+
+    /// This plan as a return's, or `None` if it is a parameter's.
+    pub(crate) fn returned(self) -> Option<crate::jni::fn_plan::ValueOutputPlan> {
+        match self {
+            JPlan::Return(plan) => Some(*plan),
+            JPlan::Param(_) => None,
+        }
+    }
+}
+
 /// The JNI adapter's answer for one crossing.
 ///
 /// What a `ConverterImpl` was, minus the bookkeeping the table now does.
@@ -446,6 +477,13 @@ fn produces_borrow(ty: &syn::Type) -> bool {
 pub(crate) struct JCompile<'a, R> {
     pub(crate) decls: &'a Declarations,
     pub(crate) registry: &'a R,
+    /// The return as the signature declares it, when that differs from the
+    /// crossing being compiled.
+    ///
+    /// A `Return`-delivery convert crosses the value its decomposition
+    /// produced, while the Kotlin surface is classified over what the function
+    /// says it returns. `None` when the two are the same.
+    pub(crate) declared_return: Option<TypeRef>,
     /// Which site is being planned, when one is.
     ///
     /// `None` while compiling a row: a row answers for a crossing wherever it
@@ -455,7 +493,18 @@ pub(crate) struct JCompile<'a, R> {
 }
 
 /// What [`Compile::plan`] needs about a site that the crossing does not say.
-pub(crate) struct PlanSite {
+pub(crate) enum PlanSite {
+    /// One parameter of an exported function.
+    Param(ParamSite),
+    /// What the function returns, as one value.
+    ///
+    /// A **decomposed** return is not this: it has no single crossing, which is
+    /// what decomposing it means, so it never reaches `Compiler::site` at all.
+    Return,
+}
+
+/// What planning a parameter needs beyond its crossing.
+pub(crate) struct ParamSite {
     /// The parameter ident the wrapper binds this value to.
     pub(crate) ident: syn::Ident,
     /// Whether this leaf is one of a constructor expansion's arguments rather
@@ -564,8 +613,8 @@ impl<R: Conversions> JCompile<'_, R> {
 
 impl<R: Conversions> Compile for JCompile<'_, R> {
     type Fragment = JFrag;
-    /// One parameter of one exported function, classified.
-    type Plan = crate::jni::fn_plan::PlanLeaf;
+    /// One site of one exported function, classified.
+    type Plan = JPlan;
     type Error = JErr;
 
     fn atomic(&mut self, cx: &mut Cx<'_>, at: At<'_>) -> Frag<Self> {
@@ -865,12 +914,16 @@ impl<R: Conversions> Compile for JCompile<'_, R> {
     /// where the site is a real parameter and not a constructor expansion's
     /// leaf, and the diagnostic for an unresolved leaf names the parameter that
     /// expanded.
-    fn plan(&mut self, _cx: &mut Cx<'_>, bound: &Bound, root: &JFrag) -> Result<PlanLeaf, JErr> {
+    fn plan(&mut self, _cx: &mut Cx<'_>, bound: &Bound, root: &JFrag) -> Result<JPlan, JErr> {
         use crate::jni::fn_plan::{plan_error, InputKind, PlanLeaf};
         let site = self
             .site
             .as_ref()
             .ok_or_else(|| JErr::Refused("JniGen: a site compiled with no site context".into()))?;
+        let site = match site {
+            PlanSite::Return => return Ok(JPlan::Return(Box::new(self.return_plan(bound, root)))),
+            PlanSite::Param(site) => site,
+        };
         let (ident, expanded) = (&site.ident, site.expanded);
         let reading = bound.crossing.spelled();
         let registry = self.registry;
@@ -933,7 +986,7 @@ impl<R: Conversions> Compile for JCompile<'_, R> {
             None => kt_meta.clone(),
         };
 
-        Ok(PlanLeaf {
+        Ok(JPlan::Param(Box::new(PlanLeaf {
             reading: reading.clone(),
             kt_name,
             kt_public,
@@ -941,7 +994,7 @@ impl<R: Conversions> Compile for JCompile<'_, R> {
             optional,
             as_enum_value,
             kind,
-        })
+        })))
     }
 }
 
@@ -1200,6 +1253,29 @@ impl<R: Conversions> JCompile<'_, R> {
         frag.out_wires = Some(wires);
         frag.composed_only = true;
         frag
+    }
+
+    /// A return that crosses as one value.
+    ///
+    /// The site's own fragment is the conversion — the registry built it before
+    /// calling this, which is the whole point of the hook. What the plan adds
+    /// is the Kotlin surface, which is classified over the **declared** return
+    /// rather than over the crossing: an error peel rides the conversion's
+    /// `value_rust_type`, so the full `Result<T, E>` is what the surface reads.
+    fn return_plan(&self, bound: &Bound, root: &JFrag) -> crate::jni::fn_plan::ValueOutputPlan {
+        let declared = self
+            .declared_return
+            .as_ref()
+            .unwrap_or_else(|| bound.crossing.spelled());
+        let (surface, enums) = crate::jni::fn_plan::ReturnSurface::classify(self.decls, declared);
+        crate::jni::fn_plan::ValueOutputPlan {
+            is_convert: self.declared_return.is_some(),
+            target_ty: bound.crossing.spelled().clone(),
+            wire_ty: root.conv.destination.clone(),
+            surface,
+            is_enum: enums.is_enum,
+            is_option_enum: enums.is_option_enum,
+        }
     }
 
     /// The values a `data_class` hands out, composed by

--- a/prebindgen-jni/src/jni/compile.rs
+++ b/prebindgen-jni/src/jni/compile.rs
@@ -47,6 +47,102 @@ pub(crate) struct JFrag {
     pub(crate) composed_only: bool,
 }
 
+/// How Kotlin reaches one wire value, relative to the object the site names.
+///
+/// Three forms rather than one string, because two of them put the base in the
+/// **middle**: a sum's tag reads `when (<base>.f) { … }` and a sum's payload
+/// slot reads `(<base>.f as? I.V)?.v0`. A suffix cannot say that, and a raw
+/// prefix/suffix pair cannot be composed — an optional layer has to know
+/// whether it is adding a `?.` navigation or a `null ->` arm, and only a named
+/// form tells it which.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) enum Access {
+    /// `<base><tail>` — the ordinary read, including a presence comparison.
+    Read(String),
+    /// `when (<base><tail>) { … }` — which alternative of a sum is live, as the
+    /// `jint` tag the arms below are numbered by.
+    Select {
+        /// What reaches the sum value from the base.
+        tail: String,
+        /// One arm per alternative, in declaration order, without the `null`
+        /// one — an optional ancestor adds that by setting `nullable`.
+        arms: Vec<String>,
+        /// Whether the value reached can be null, which is its own arm.
+        nullable: bool,
+    },
+    /// `(<base><tail> as? <class>)?.<read>[ ?: <zero>]` — one payload slot of
+    /// one alternative. Every alternative's slots cross on every call; the
+    /// cast yields null for the ones that are not live, and `zero` is what a
+    /// non-nullable wire carries instead.
+    Slot {
+        /// What reaches the sum value from the base.
+        tail: String,
+        /// The Kotlin class of the alternative this slot belongs to. Empty
+        /// until [`Compile::choice`] names it — the arm's own composition
+        /// cannot, because a product hook is not told which alternative it is.
+        class: String,
+        /// What reads the payload off the cast alternative — `v0`, or
+        /// `v1?.value` for a Kotlin enum payload.
+        read: String,
+        /// What an inert slot carries, or `None` for a wire that rides a JVM
+        /// `null`.
+        zero: Option<String>,
+    },
+}
+
+impl Access {
+    /// The Kotlin expression, rooted at the object this site destructures.
+    ///
+    /// Only the equivalence check calls it until the emitters take the row —
+    /// the same `#[cfg(test)]` the wire's other readers carry.
+    #[cfg(test)]
+    pub(crate) fn render(&self, base: &str) -> String {
+        match self {
+            Access::Read(tail) => format!("{base}{tail}"),
+            Access::Select {
+                tail,
+                arms,
+                nullable,
+            } => {
+                let arms = nullable
+                    .then(|| "null -> 0".to_string())
+                    .into_iter()
+                    .chain(arms.iter().cloned())
+                    .collect::<Vec<_>>()
+                    .join("; ");
+                format!("when ({base}{tail}) {{ {arms} }}")
+            }
+            Access::Slot {
+                tail,
+                class,
+                read,
+                zero,
+            } => {
+                let zero = zero
+                    .as_ref()
+                    .map(|z| format!(" ?: {z}"))
+                    .unwrap_or_default();
+                format!("({base}{tail} as? {class})?.{read}{zero}")
+            }
+        }
+    }
+
+    /// What reaches this value from the base — the part a container prepends
+    /// its own field to, whichever form the access takes.
+    fn tail_mut(&mut self) -> &mut String {
+        match self {
+            Access::Read(tail) | Access::Select { tail, .. } | Access::Slot { tail, .. } => tail,
+        }
+    }
+
+    /// This access read from one field in, rather than from the object itself.
+    fn under(mut self, field: &str) -> Self {
+        let tail = self.tail_mut();
+        *tail = format!(".{field}{tail}");
+        self
+    }
+}
+
 /// One wire value of a crossing that occupies several.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) struct Wire {
@@ -67,7 +163,7 @@ pub(crate) struct Wire {
     /// Relative for the same reason `path` is: the site supplies the base, so
     /// the same wire reads `h.flat.id` in one call and `this.flat.id` in the
     /// next.
-    pub(crate) access: String,
+    pub(crate) access: Access,
     /// The conversion this value crosses through, or `None` for a presence flag
     /// — which is read on the Rust side and converts nothing.
     pub(crate) conv: Option<syn::Ident>,
@@ -321,24 +417,31 @@ impl<R: Conversions> Compile for JCompile<'_, R> {
             }
         }
         if let (Assembly::Construct, Some(inner_wires)) = (at.crossing.assembly(), &inner.wires) {
+            // A sum reached through the gate needs no navigation added: every
+            // one of its wires already reads the value through a `when` or an
+            // `as?`, both of which take a null subject. What the gate does add
+            // is the `null` arm — and the flag it prepends gates one field
+            // rather than a whole value, because the value under it IS the
+            // field.
+            let sum = is_choice(inner);
             let mut wires = vec![Wire {
                 ty: syn::parse_quote!(jni::sys::jboolean),
                 kt_ty: "Boolean".to_string(),
                 path: "present".to_string(),
                 // The gate reads the object itself, not through it.
-                access: " != null".to_string(),
+                access: Access::Read(" != null".to_string()),
                 conv: None,
                 handle_target: None,
                 handle_nullable: false,
                 staged: false,
                 field: None,
-                whole_gate: true,
+                whole_gate: !sum,
             }];
             // Everything under the gate is reached through it, and a
             // non-nullable slot still has to hold something when the value is
             // absent — the flag is what tells Rust to ignore it.
             wires.extend(inner_wires.iter().map(|w| Wire {
-                access: format!("?{}{}", w.access, absent_default(w)),
+                access: gated(&w.access, w),
                 // Anything under the gate can be absent, however the field
                 // itself was spelled.
                 handle_nullable: w.handle_target.is_some() || w.handle_nullable,
@@ -398,12 +501,20 @@ impl<R: Conversions> Compile for JCompile<'_, R> {
         Err(refuse(at, "JniGen states no value-form rows yet"))
     }
 
-    fn fields(&mut self, _cx: &mut Cx<'_>, at: At<'_>, parts: Parts<'_, Self>) -> Frag<Self> {
+    fn fields(&mut self, cx: &mut Cx<'_>, at: At<'_>, parts: Parts<'_, Self>) -> Frag<Self> {
         if at.crossing.assembly() != Assembly::Construct {
             return Err(refuse(
                 at,
                 "JniGen states no deconstructing product rows yet",
             ));
+        }
+        // A product whose own type is a sum is one **alternative's** payload:
+        // the registry composes every arm through this hook and hands the lot
+        // to `choice`. Its parts are read off a cast rather than off the value,
+        // so they take the slot form — and which alternative to cast to is
+        // `choice`'s to fill in, being the only hook told.
+        if self.is_sum(cx, at) {
+            return Ok(self.arm(at, parts));
         }
         // A `data_class` crosses as its fields, and a field that is itself one
         // contributes its own several — which is the recursion, stated once
@@ -418,7 +529,7 @@ impl<R: Conversions> Compile for JCompile<'_, R> {
                         path: format!("{}.{}", part.name, w.path),
                         // The field this part reads, then however the part's own
                         // wire reaches on from there.
-                        access: format!(".{}{}", field_kt(part), w.access),
+                        access: w.access.clone().under(&field_kt(part)),
                         conv: w.conv.clone(),
                         handle_target: w
                             .handle_target
@@ -443,7 +554,7 @@ impl<R: Conversions> Compile for JCompile<'_, R> {
                     ty: syn::parse_quote!(jni::sys::jlong),
                     kt_ty: "Long".to_string(),
                     path: part.name.clone(),
-                    access: format!(".{}", field_kt(part)),
+                    access: Access::Read(format!(".{}", field_kt(part))),
                     conv: None,
                     handle_target: Some(format!(".{}", field_kt(part))),
                     handle_nullable: part.ty.optional_inner().is_some(),
@@ -455,7 +566,7 @@ impl<R: Conversions> Compile for JCompile<'_, R> {
                     ty: frag.conv.destination.clone(),
                     kt_ty: crate::jni::emit::wire_kotlin_type(&frag.conv),
                     path: part.name.clone(),
-                    access: format!(".{}", field_kt(part)),
+                    access: Access::Read(format!(".{}", field_kt(part))),
                     conv: Some(frag.conv.function.sig.ident.clone()),
                     handle_target: None,
                     handle_nullable: false,
@@ -474,17 +585,7 @@ impl<R: Conversions> Compile for JCompile<'_, R> {
         // their own.
         let mut frag = JFrag::new(
             at,
-            ConverterImpl {
-                destination: syn::parse_quote!(()),
-                function: syn::parse_quote!(
-                    #[allow(dead_code)]
-                    fn __jni_parts() {}
-                ),
-                pre_stages: Vec::new(),
-                niches: Niches::empty(),
-                metadata: KotlinMeta::default(),
-                subs: parts.iter().map(|(p, _)| p.ty.key()).collect(),
-            },
+            self.parts_marker(parts.iter().map(|(p, _)| p.ty.key()).collect()),
         );
         frag.wires = Some(wires);
         frag.composed_only = true;
@@ -495,9 +596,38 @@ impl<R: Conversions> Compile for JCompile<'_, R> {
         &mut self,
         _cx: &mut Cx<'_>,
         at: At<'_>,
-        _arms: &[(&Alternative, &JFrag)],
+        arms: &[(&Alternative, &JFrag)],
     ) -> Frag<Self> {
-        Err(refuse(at, "JniGen states no choice rows yet"))
+        if at.crossing.assembly() != Assembly::Construct {
+            return Err(refuse(
+                at,
+                "JniGen states no deconstructing choice rows yet",
+            ));
+        }
+        // Which alternative is live crosses as its own `jint`, and every
+        // alternative's slots cross on every call — the inert ones carrying the
+        // literal their wire takes when the cast finds nothing. The N-way form
+        // of the presence flag an optional already uses.
+        match self.selected(at, arms) {
+            Some(wires) => {
+                let mut frag = JFrag::new(at, self.parts_marker(parts_subs(arms)));
+                frag.wires = Some(wires);
+                frag.composed_only = true;
+                Ok(frag)
+            }
+            // A payload this adapter has no slot for — a nested object, a
+            // handle — leaves the whole sum object-shaped, which is the row it
+            // already had. Stated as a fragment with no wires rather than as a
+            // refusal: the site that asked composes it as one value, exactly as
+            // it did before a `parts` row existed.
+            None => {
+                let conv = self
+                    .decls
+                    .in_frag(at.crossing.spelled())
+                    .ok_or_else(|| refuse(at, "no JNI representation for this sum"))?;
+                Ok(JFrag::new(at, (*conv).clone()))
+            }
+        }
     }
 
     fn callback(
@@ -582,6 +712,170 @@ impl Wire {
 }
 
 impl<R: Conversions> JCompile<'_, R> {
+    /// The conversion a composed-only row carries: none.
+    ///
+    /// The `parts` and arm rows state what a value is made of and nothing
+    /// about how it is rebuilt, so there is no function to name. `subs` is
+    /// still real — it is what the registry walks for reachability.
+    /// `prebindgen-c` does the same for a union arm, and for the same reason.
+    fn parts_marker(&self, subs: Vec<TypeKey>) -> ConverterImpl<KotlinMeta> {
+        ConverterImpl {
+            destination: syn::parse_quote!(()),
+            function: syn::parse_quote!(
+                #[allow(dead_code)]
+                fn __jni_parts() {}
+            ),
+            pre_stages: Vec::new(),
+            niches: Niches::empty(),
+            metadata: KotlinMeta::default(),
+            subs,
+        }
+    }
+
+    /// Whether the crossing being composed is a data-carrying enum, which is
+    /// what makes a product hook an **arm** rather than a struct.
+    fn is_sum(&self, cx: &Cx<'_>, at: At<'_>) -> bool {
+        let TypeKind::Named { id, .. } = at.crossing.value().unwrapped().kind() else {
+            return false;
+        };
+        id.ident().is_some_and(|ident| {
+            matches!(
+                cx.model().declared_type(&ident),
+                Some(prebindgen_registry::flat::Type::Variant(_))
+            )
+        })
+    }
+
+    /// One alternative's payload, as the slots it crosses in.
+    ///
+    /// A fragment with **no** wires is this adapter declining: a payload it has
+    /// no slot for — one that is itself several values, an opaque handle, or a
+    /// wire that is neither a JNI primitive nor a string — keeps the whole sum
+    /// object-shaped. See [`Compile::choice`]'s `None` arm for what that costs.
+    fn arm(&self, at: At<'_>, parts: Parts<'_, Self>) -> JFrag {
+        let mut wires = Vec::new();
+        for (part, frag) in parts {
+            let Some(wire) = self.slot(part, frag) else {
+                return JFrag::new(at, self.parts_marker(Vec::new()));
+            };
+            wires.push(wire);
+        }
+        let mut frag = JFrag::new(
+            at,
+            self.parts_marker(parts.iter().map(|(p, _)| p.ty.key()).collect()),
+        );
+        frag.wires = Some(wires);
+        frag.composed_only = true;
+        frag
+    }
+
+    /// One payload of one alternative, or `None` if it has no slot form.
+    fn slot(&self, part: &Part<'_>, frag: &JFrag) -> Option<Wire> {
+        if frag.wires.is_some() || frag.conv.metadata.projection.is_some() {
+            return None;
+        }
+        let prim = crate::jni::JniPrim::from_wire(&frag.conv.destination);
+        let string_like = matches!(&frag.conv.destination, syn::Type::Path(tp)
+            if tp.path.segments.last().is_some_and(|s| s.ident == "JString"));
+        if prim.is_none() && !string_like {
+            return None;
+        }
+        let prop = crate::jni::struct_plan::sum_field_prop_name(&part_member(part)?);
+        // An `enum_class` payload is a Kotlin enum object whose wire is the
+        // `jint` discriminant, so the slot reads `.value` — without it the wire
+        // would carry a `Priority?` where it wants an `Int`.
+        let read = if self.decls.is_kotlin_enum_reading(&part.ty) {
+            format!("{prop}?.value")
+        } else {
+            prop.clone()
+        };
+        let mut kt_ty = crate::jni::emit::wire_kotlin_type(&frag.conv);
+        if prim.is_none() && !kt_ty.ends_with('?') {
+            kt_ty.push('?');
+        }
+        Some(Wire {
+            ty: frag.conv.destination.clone(),
+            kt_ty,
+            path: prop,
+            access: Access::Slot {
+                tail: String::new(),
+                // Named by `choice`, the only hook told which alternative this
+                // payload belongs to.
+                class: String::new(),
+                read,
+                zero: prim.map(|p| p.kotlin_zero().to_string()),
+            },
+            conv: Some(frag.conv.function.sig.ident.clone()),
+            handle_target: None,
+            handle_nullable: false,
+            staged: !frag.conv.pre_stages.is_empty(),
+            field: None,
+            whole_gate: false,
+        })
+    }
+
+    /// The tag, then every alternative's slots — or `None` if any alternative
+    /// declined, since a sum crosses whole or not at all.
+    fn selected(&self, at: At<'_>, arms: &[(&Alternative, &JFrag)]) -> Option<Vec<Wire>> {
+        let TypeKind::Named { id, .. } = at.crossing.value().unwrapped().kind() else {
+            return None;
+        };
+        let cfg = self.decls.types.get(&TypeKey::from_ident(&id.ident()?))?;
+        let sum_cfg = cfg.sum()?;
+        let iface = cfg.name_spec.as_ref().map(|s| self.decls.fqn_of(s))?;
+
+        let classes: Vec<String> = arms
+            .iter()
+            .map(|(alt, _)| {
+                format!(
+                    "{iface}.{}",
+                    self.decls.sum_variant_class_name(sum_cfg, &alt.name)
+                )
+            })
+            .collect();
+        let mut wires = vec![Wire {
+            ty: syn::parse_quote!(jni::sys::jint),
+            kt_ty: "Int".to_string(),
+            path: "_tag".to_string(),
+            access: Access::Select {
+                tail: String::new(),
+                arms: arms
+                    .iter()
+                    .zip(&classes)
+                    .map(|((alt, _), class)| {
+                        format!("is {class} -> {}", crate::jni::struct_plan::sum_tag(alt))
+                    })
+                    .collect(),
+                nullable: false,
+            },
+            conv: None,
+            handle_target: None,
+            handle_nullable: false,
+            staged: false,
+            field: None,
+            whole_gate: false,
+        }];
+        for ((_, frag), class) in arms.iter().zip(&classes) {
+            let short = class.rsplit('.').next().unwrap_or(class);
+            for w in frag.wires.as_ref()? {
+                let Access::Slot { read, zero, .. } = &w.access else {
+                    return None;
+                };
+                wires.push(Wire {
+                    path: crate::jni::struct_plan::sum_slot_fragment(short, &w.path),
+                    access: Access::Slot {
+                        tail: String::new(),
+                        class: class.clone(),
+                        read: read.clone(),
+                        zero: zero.clone(),
+                    },
+                    ..w.clone()
+                });
+            }
+        }
+        Some(wires)
+    }
+
     /// The `(present, value)` pair a nullable primitive or enum crosses as, or
     /// `None` if this optional boxes instead.
     ///
@@ -612,7 +906,7 @@ impl<R: Conversions> JCompile<'_, R> {
                 ty: syn::parse_quote!(jni::sys::jboolean),
                 kt_ty: "Boolean".to_string(),
                 path: "present".to_string(),
-                access: " != null".to_string(),
+                access: Access::Read(" != null".to_string()),
                 conv: None,
                 handle_target: None,
                 handle_nullable: false,
@@ -624,7 +918,7 @@ impl<R: Conversions> JCompile<'_, R> {
                 ty: c.destination.clone(),
                 kt_ty: crate::jni::emit::wire_kotlin_type(c),
                 path: "value".to_string(),
-                access: value_access,
+                access: Access::Read(value_access),
                 conv: Some(c.function.sig.ident.clone()),
                 handle_target: None,
                 handle_nullable: false,
@@ -634,6 +928,21 @@ impl<R: Conversions> JCompile<'_, R> {
             },
         ])
     }
+}
+
+/// The model field one part reads, which a sum payload names its slot after.
+fn part_member(part: &Part<'_>) -> Option<syn::Member> {
+    match part.from {
+        prebindgen_registry::recipe::PartSource::Field { field, .. } => Some(field.member()),
+        _ => None,
+    }
+}
+
+/// Every crossing a sum's arms delegate to, which is what reachability walks.
+fn parts_subs(arms: &[(&Alternative, &JFrag)]) -> Vec<TypeKey> {
+    arms.iter()
+        .flat_map(|(_, f)| f.conv.subs.iter().cloned())
+        .collect()
 }
 
 /// The Kotlin property name for one part of a product, sanitized — `object` is
@@ -661,11 +970,11 @@ fn is_handle(frag: &JFrag) -> bool {
 /// does not compile. A wire that **already carries one** got it from a gate
 /// further in — the expression yields a value from there on, so an outer gate
 /// has nothing left to substitute for.
-fn absent_default(w: &Wire) -> String {
+fn absent_default(w: &Wire, tail: &str) -> String {
     if w.conv.is_none() && w.handle_target.is_none() {
         return String::new();
     }
-    if w.access.contains(" ?: ") {
+    if tail.contains(" ?: ") {
         return String::new();
     }
     crate::jni::emit::kt_leaf_default(
@@ -676,4 +985,31 @@ fn absent_default(w: &Wire) -> String {
     )
     .map(|d| format!(" ?: {d}"))
     .unwrap_or_default()
+}
+
+/// One wire's access, read through a gate that may find nothing.
+///
+/// Only an ordinary read navigates: it gains the `?` that stops at a null and
+/// the literal a non-nullable slot then carries. A sum's `when` gains the
+/// `null` arm instead, and a sum's `as?` slot needs neither — a cast over a
+/// null subject is already null.
+fn gated(access: &Access, w: &Wire) -> Access {
+    match access {
+        Access::Read(tail) => Access::Read(format!("?{tail}{}", absent_default(w, tail))),
+        Access::Select { tail, arms, .. } => Access::Select {
+            tail: tail.clone(),
+            arms: arms.clone(),
+            nullable: true,
+        },
+        slot @ Access::Slot { .. } => slot.clone(),
+    }
+}
+
+/// Whether this fragment states a sum taken apart into a tag and its arms'
+/// slots, rather than a product taken apart into its fields.
+fn is_choice(frag: &JFrag) -> bool {
+    frag.wires
+        .as_ref()
+        .and_then(|w| w.first())
+        .is_some_and(|w| matches!(w.access, Access::Select { .. }))
 }

--- a/prebindgen-jni/src/jni/compile.rs
+++ b/prebindgen-jni/src/jni/compile.rs
@@ -8,7 +8,7 @@
 
 use prebindgen_registry::{
     flat::{Alternative, Function, TypeKind, TypeRef},
-    recipe::{Assembly, At, Bound, Carrier, Compile, Cx, Frag, Mode, Parts, Validity, Yield},
+    recipe::{Assembly, At, Bound, Carrier, Compile, Cx, Frag, Mode, Part, Parts, Validity, Yield},
     Conversions,
 };
 
@@ -61,6 +61,26 @@ pub(crate) struct Wire {
     /// `otherTag` in the next, so the parameter it hangs off is the caller's to
     /// prepend.
     pub(crate) path: String,
+    /// How Kotlin reaches this value from the object it is destructuring,
+    /// relative to that object — `.flat.id`, `.maybe?.id ?: 0L`, ` != null`.
+    ///
+    /// Relative for the same reason `path` is: the site supplies the base, so
+    /// the same wire reads `h.flat.id` in one call and `this.flat.id` in the
+    /// next.
+    pub(crate) access: String,
+    /// The conversion this value crosses through, or `None` for a presence flag
+    /// — which is read on the Rust side and converts nothing.
+    pub(crate) conv: Option<syn::Ident>,
+    /// For a nested owned handle: where Kotlin finds the handle **object**, as
+    /// against the `Long` this wire carries.
+    ///
+    /// A nested handle crosses under the same lock-and-consume scaffold as a
+    /// top-level one, and that scaffold needs the object, not its pointer. The
+    /// wire itself is filled from a local the scaffold binds.
+    pub(crate) handle_target: Option<String>,
+    /// Whether that handle access can be null — the field is optional, or an
+    /// optional ancestor gates it.
+    pub(crate) handle_nullable: bool,
 }
 
 impl Carrier for JFrag {
@@ -276,8 +296,22 @@ impl<R: Conversions> Compile for JCompile<'_, R> {
                 ty: syn::parse_quote!(jni::sys::jboolean),
                 kt_ty: "Boolean".to_string(),
                 path: "present".to_string(),
+                // The gate reads the object itself, not through it.
+                access: " != null".to_string(),
+                conv: None,
+                handle_target: None,
+                handle_nullable: false,
             }];
-            wires.extend(inner_wires.iter().cloned());
+            // Everything under the gate is reached through it, and a
+            // non-nullable slot still has to hold something when the value is
+            // absent — the flag is what tells Rust to ignore it.
+            wires.extend(inner_wires.iter().map(|w| Wire {
+                access: format!("?{}{}", w.access, absent_default(w)),
+                // Anything under the gate can be absent, however the field
+                // itself was spelled.
+                handle_nullable: w.handle_target.is_some() || w.handle_nullable,
+                ..w.clone()
+            }));
             frag.wires = Some(wires);
         }
         Ok(frag)
@@ -349,15 +383,42 @@ impl<R: Conversions> Compile for JCompile<'_, R> {
         let mut wires: Vec<Wire> = Vec::new();
         for (part, frag) in parts {
             match &frag.wires {
-                Some(inner) => wires.extend(inner.iter().map(|w| Wire {
-                    ty: w.ty.clone(),
-                    kt_ty: w.kt_ty.clone(),
-                    path: format!("{}.{}", part.name, w.path),
+                Some(inner) => wires.extend(inner.iter().map(|w| {
+                    Wire {
+                        ty: w.ty.clone(),
+                        kt_ty: w.kt_ty.clone(),
+                        path: format!("{}.{}", part.name, w.path),
+                        // The field this part reads, then however the part's own
+                        // wire reaches on from there.
+                        access: format!(".{}{}", field_kt(part), w.access),
+                        conv: w.conv.clone(),
+                        handle_target: w
+                            .handle_target
+                            .as_ref()
+                            .map(|t| format!(".{}{t}", field_kt(part))),
+                        handle_nullable: w.handle_nullable,
+                    }
                 })),
+                // A part whose conversion projects a handle crosses as that
+                // handle's `Long`, and Kotlin reaches the object it has to lock
+                // through the same access.
+                None if is_handle(frag) => wires.push(Wire {
+                    ty: syn::parse_quote!(jni::sys::jlong),
+                    kt_ty: "Long".to_string(),
+                    path: part.name.clone(),
+                    access: format!(".{}", field_kt(part)),
+                    conv: None,
+                    handle_target: Some(format!(".{}", field_kt(part))),
+                    handle_nullable: part.ty.optional_inner().is_some(),
+                }),
                 None => wires.push(Wire {
                     ty: frag.conv.destination.clone(),
                     kt_ty: crate::jni::emit::wire_kotlin_type(&frag.conv),
                     path: part.name.clone(),
+                    access: format!(".{}", field_kt(part)),
+                    conv: Some(frag.conv.function.sig.ident.clone()),
+                    handle_target: None,
+                    handle_nullable: false,
                 }),
             }
         }
@@ -459,4 +520,46 @@ impl std::ops::Deref for Conv {
     fn deref(&self) -> &Self::Target {
         &self.0.conv
     }
+}
+
+/// The Kotlin property name for one part of a product, sanitized — `object` is
+/// a keyword, and only the emitter's own mangler knows that.
+fn field_kt(part: &Part<'_>) -> String {
+    crate::jni::render::kotlin_property_name(&syn::Ident::new(
+        &part.name,
+        proc_macro2::Span::call_site(),
+    ))
+}
+
+/// Whether this conversion delivers a Kotlin typed handle rather than a value.
+fn is_handle(frag: &JFrag) -> bool {
+    frag.conv
+        .metadata
+        .projection
+        .as_ref()
+        .is_some_and(|p| p.kind == crate::jni::ProjectionKind::Handle)
+}
+
+/// What a non-nullable slot holds while its gate is closed, as an elvis tail.
+///
+/// Empty for the two cases that need none. A **presence flag** is a `!= null`
+/// comparison: it is already non-null, and a Kotlin elvis on a non-null operand
+/// does not compile. A wire that **already carries one** got it from a gate
+/// further in — the expression yields a value from there on, so an outer gate
+/// has nothing left to substitute for.
+fn absent_default(w: &Wire) -> String {
+    if w.conv.is_none() && w.handle_target.is_none() {
+        return String::new();
+    }
+    if w.access.contains(" ?: ") {
+        return String::new();
+    }
+    crate::jni::emit::kt_leaf_default(
+        crate::jni::wire_access::jni_field_access(&w.ty)
+            .map(|(sig, _, _)| sig)
+            .unwrap_or(""),
+        w.kt_ty.ends_with('?'),
+    )
+    .map(|d| format!(" ?: {d}"))
+    .unwrap_or_default()
 }

--- a/prebindgen-jni/src/jni/compile.rs
+++ b/prebindgen-jni/src/jni/compile.rs
@@ -36,6 +36,15 @@ pub(crate) struct JFrag {
     /// makes a nested `data_class` field contribute its own several rather than
     /// one.
     pub(crate) wires: Option<Vec<Wire>>,
+    /// The values this crossing hands **out**, when it hands out more than one.
+    ///
+    /// The deconstructing twin of [`Self::wires`], and a different shape rather
+    /// than the same one read backwards: an outgoing value is not filled from a
+    /// Kotlin expression, it is produced by the Rust side and named for the
+    /// builder parameter it lands in. Never set at the same time as
+    /// [`Self::wires`] — a fragment answers one crossing, and a crossing does
+    /// one job.
+    pub(crate) out_wires: Option<Vec<OutWire>>,
     /// This fragment states a wire list and nothing else — no conversion of its
     /// own, so nothing of it reaches the generated file.
     ///
@@ -187,6 +196,52 @@ impl Access {
     }
 }
 
+/// One value a crossing hands out, when it hands out several.
+///
+/// What a JVM builder call receives: a name, the Rust value behind it, and —
+/// for a sum — which alternative produces it. There is no access expression
+/// and no Kotlin type, because the foreign side does not reach for this value;
+/// the Rust side pushes it.
+#[derive(Clone)]
+pub(crate) struct OutWire {
+    /// The builder parameter this value fills, used literally.
+    pub(crate) name: String,
+    /// The reading whose output conversion encodes it.
+    ///
+    /// For the tag it is **the sum**, not the `jint` the tag crosses as: what
+    /// the tag carries is which alternative is live, and naming the sum is how
+    /// an emitter finds the enum to match over.
+    pub(crate) out_ty: TypeRef,
+    /// Which alternative produces this value, or `None` for one every call
+    /// produces — including the tag, which selects between the groups rather
+    /// than joining one.
+    ///
+    /// Composed and checked but not yet read outside the equivalence fixture:
+    /// grouping is what turns the list into a `match`, and the emitter that
+    /// writes that `match` still reads it off the leaf synthesis.
+    #[cfg_attr(not(test), allow(dead_code))]
+    pub(crate) group: Option<i32>,
+    /// How the Rust side reaches it.
+    pub(crate) from: OutFrom,
+}
+
+/// Where an outgoing value comes from.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) enum OutFrom {
+    /// The synthesized selector, which is not read off the value at all: the
+    /// emitter assigns the alternative's number in each arm of its `match`.
+    Tag,
+    /// A payload of one alternative, bound by that arm's pattern.
+    Payload {
+        /// The alternative's ident as the source enum declares it. Empty until
+        /// [`Compile::choice`] names it — an arm's own composition cannot,
+        /// because a product hook is not told which alternative it is.
+        variant: Option<syn::Ident>,
+        /// How the payload is addressed in the arm's pattern.
+        member: syn::Member,
+    },
+}
+
 /// One wire value of a crossing that occupies several.
 ///
 /// `Clone` alone: a wire carries the whole conversion its value crosses
@@ -272,6 +327,7 @@ impl JFrag {
         Self {
             conv,
             wires: None,
+            out_wires: None,
             composed_only: false,
             yields: Yield {
                 ty,
@@ -286,6 +342,7 @@ impl JFrag {
         Self {
             conv,
             wires: None,
+            out_wires: None,
             composed_only: false,
             yields: Yield {
                 ty: at.crossing.value().stripped_key(),
@@ -552,18 +609,23 @@ impl<R: Conversions> Compile for JCompile<'_, R> {
     }
 
     fn fields(&mut self, cx: &mut Cx<'_>, at: At<'_>, parts: Parts<'_, Self>) -> Frag<Self> {
-        if at.crossing.assembly() != Assembly::Construct {
-            return Err(refuse(
-                at,
-                "JniGen states no deconstructing product rows yet",
-            ));
-        }
         // A product whose own type is a sum is one **alternative's** payload:
         // the registry composes every arm through this hook and hands the lot
-        // to `choice`. Its parts are read off a cast rather than off the value,
-        // so they take the slot form — and which alternative to cast to is
-        // `choice`'s to fill in, being the only hook told.
-        if self.is_sum(cx, at) {
+        // to `choice`. Which alternative that is stays `choice`'s to fill in,
+        // being the only hook told — so both directions leave a hole here.
+        let sum = self.is_sum(cx, at);
+        if at.crossing.assembly() != Assembly::Construct {
+            return match sum {
+                true => Ok(self.out_arm(at, parts)),
+                false => Err(refuse(
+                    at,
+                    "JniGen states no deconstructing product rows yet",
+                )),
+            };
+        }
+        if sum {
+            // Its parts are read off a cast rather than off the value, so they
+            // take the slot form.
             return Ok(self.arm(at, parts));
         }
         // A `data_class` crosses as its fields, and a field that is itself one
@@ -645,10 +707,7 @@ impl<R: Conversions> Compile for JCompile<'_, R> {
         arms: &[(&Alternative, &JFrag)],
     ) -> Frag<Self> {
         if at.crossing.assembly() != Assembly::Construct {
-            return Err(refuse(
-                at,
-                "JniGen states no deconstructing choice rows yet",
-            ));
+            return self.selected_out(at, arms);
         }
         // Which alternative is live crosses as its own `jint`, and every
         // alternative's slots cross on every call — the inert ones carrying the
@@ -916,6 +975,94 @@ impl<R: Conversions> JCompile<'_, R> {
             field: Some(part.name.clone()),
             whole_gate: false,
         }
+    }
+
+    /// One alternative's payloads, as the values it hands out.
+    ///
+    /// Every payload contributes, unconditionally: a sum's alternatives are
+    /// laid side by side on the wire and the tag says which group is live, so
+    /// there is nothing for an arm to decline. That is the asymmetry with the
+    /// constructing side, where a payload with no slot form leaves the whole
+    /// sum object-shaped — going the other way the Rust side produces the
+    /// value and its own output conversion is what encodes it.
+    fn out_arm(&self, at: At<'_>, parts: Parts<'_, Self>) -> JFrag {
+        let wires = parts
+            .iter()
+            .filter_map(|(part, _)| {
+                Some(OutWire {
+                    // Named by `choice`, which knows the alternative the name
+                    // is built from.
+                    name: crate::jni::struct_plan::sum_field_prop_name(&part_member(part)?),
+                    out_ty: part.ty.clone(),
+                    group: None,
+                    from: OutFrom::Payload {
+                        variant: None,
+                        member: part_member(part)?,
+                    },
+                })
+            })
+            .collect();
+        let mut frag = JFrag::new(
+            at,
+            self.parts_marker(parts.iter().map(|(p, _)| p.ty.key()).collect()),
+        );
+        frag.out_wires = Some(wires);
+        frag.composed_only = true;
+        frag
+    }
+
+    /// The tag, then every alternative's payloads.
+    ///
+    /// The deconstructing shape of a `sealed_class`: one `jint` naming which
+    /// alternative is live, and one group of values per alternative laid
+    /// beside the others. Exactly one group is live per value and the rest
+    /// carry their wire defaults, which is what makes the whole thing one
+    /// `match` on the Rust side rather than N conditionals.
+    fn selected_out(&self, at: At<'_>, arms: &[(&Alternative, &JFrag)]) -> Frag<Self> {
+        let TypeKind::Named { id, .. } = at.crossing.value().unwrapped().kind() else {
+            return Err(refuse(at, "a choice row over a type that is not named"));
+        };
+        let sum_cfg = id
+            .ident()
+            .and_then(|ident| self.decls.types.get(&TypeKey::from_ident(&ident)))
+            .and_then(|cfg| cfg.sum())
+            .ok_or_else(|| refuse(at, "a choice row over an undeclared sum"))?;
+
+        // The selector rides ahead of the groups it chooses between, and
+        // carries **which sum** it selects over — nothing converts it, so
+        // naming the sum is the only use its type has, and it is the one an
+        // emitter needs to find the enum to match.
+        let mut wires = vec![OutWire {
+            name: crate::jni::emit::SUM_TAG_LEAF.to_string(),
+            out_ty: at.crossing.value().clone(),
+            group: None,
+            from: OutFrom::Tag,
+        }];
+        for (alt, frag) in arms {
+            let kotlin = self.decls.sum_variant_class_name(sum_cfg, &alt.name);
+            let group = Some(crate::jni::struct_plan::sum_tag(alt));
+            for w in frag.out_wires.as_ref().into_iter().flatten() {
+                let OutFrom::Payload { member, .. } = &w.from else {
+                    return Err(refuse(
+                        at,
+                        "an arm that states something other than payloads",
+                    ));
+                };
+                wires.push(OutWire {
+                    name: crate::jni::struct_plan::sum_slot_fragment(&kotlin, &w.name),
+                    out_ty: w.out_ty.clone(),
+                    group,
+                    from: OutFrom::Payload {
+                        variant: Some(alt.name.clone()),
+                        member: member.clone(),
+                    },
+                });
+            }
+        }
+        let mut frag = JFrag::new(at, self.parts_marker(parts_subs(arms)));
+        frag.out_wires = Some(wires);
+        frag.composed_only = true;
+        Ok(frag)
     }
 
     /// One payload of one alternative, or `None` if it has no slot form.

--- a/prebindgen-jni/src/jni/compile.rs
+++ b/prebindgen-jni/src/jni/compile.rs
@@ -271,6 +271,24 @@ pub(crate) struct OutWire {
     pub(crate) group: Option<i32>,
     /// How the Rust side reaches it.
     pub(crate) from: OutFrom,
+    /// The steps from the crossed value down to this one.
+    ///
+    /// **Steps** rather than a chain of idents, because the two kinds mix: a
+    /// value form calls an accessor and then reads fields off what it returned,
+    /// while a nested `data_class` reads fields all the way down. A step also
+    /// says whether it may find nothing, which is what puts every value below
+    /// it in doubt.
+    ///
+    /// Spelled in the plans' own vocabulary rather than a second one. A reach
+    /// **is** a path, and inventing a parallel spelling would leave two things
+    /// to keep in step for no gain — the mistake the constructing side avoided
+    /// by making `Access` and `handle_target` one type.
+    ///
+    /// Independent of [`Self::from`], because every kind of value has one: a
+    /// selector spliced into a value form reaches the sum it selects over, and
+    /// a payload reaches the sum whose arm binds it. Empty means the value the
+    /// site names, which is the common case.
+    pub(crate) reach: Vec<prebindgen_registry::unfold::PathStep>,
     /// Whether this value is the whole crossed object rather than a part of it
     /// — the move-or-clone handle a decomposition delivers beside its fields.
     ///
@@ -306,12 +324,10 @@ impl OutWire {
                     variant: Some(variant.clone()),
                     member: member.clone(),
                 },
-                // Every other leaf is reached off the value, and the steps say
-                // how — an accessor chain, a field chain, or the two mixed.
-                _ => OutFrom::Reach {
-                    path: leaf.path.clone(),
-                },
+                // Every other leaf is read off the place its reach names.
+                _ => OutFrom::Place,
             },
+            reach: leaf.path.clone(),
             identity: leaf.identity,
             nullable: leaf.nullable,
         }
@@ -325,10 +341,7 @@ impl OutWire {
     /// The steps from the crossed value down to this one, or empty for a value
     /// no reach describes — the selector, or a payload its arm's pattern binds.
     pub(crate) fn reach(&self) -> &[prebindgen_registry::unfold::PathStep] {
-        match &self.from {
-            OutFrom::Reach { path } => path,
-            _ => &[],
-        }
+        &self.reach
     }
 
     /// Whether this value is **read off** a place rather than produced by a
@@ -339,7 +352,7 @@ impl OutWire {
     /// what the accessor returned, and an accessor leaf ends at the call.
     pub(crate) fn is_field_read(&self) -> bool {
         matches!(
-            self.reach().last(),
+            self.reach.last(),
             Some(prebindgen_registry::unfold::PathStep::Field { .. })
         )
     }
@@ -356,22 +369,9 @@ pub(crate) enum OutFrom {
     /// The synthesized selector, which is not read off the value at all: the
     /// emitter assigns the alternative's number in each arm of its `match`.
     Tag,
-    /// Reached off the value, by field access or by calling an accessor.
-    ///
-    /// The **steps** rather than a chain of idents, because the two kinds mix:
-    /// a value form calls an accessor and then reads fields off what it
-    /// returned, and a nested `data_class` reads fields all the way down. A
-    /// step also says whether it may find nothing, which is what puts every
-    /// value below it in doubt.
-    ///
-    /// Spelled in the plans' own vocabulary rather than a second one. A reach
-    /// **is** a path, and inventing a parallel spelling for it would leave two
-    /// things to keep in step for no gain — the mistake `Access` and
-    /// `handle_target` avoided on the constructing side by being one type.
-    Reach {
-        /// The steps from the value down to this one.
-        path: Vec<prebindgen_registry::unfold::PathStep>,
-    },
+    /// Read off the place [`OutWire::reach`] names — a field access, or the
+    /// result of the accessor the reach ends in.
+    Place,
     /// A payload of one alternative, bound by that arm's pattern.
     Payload {
         /// The alternative's ident as the source enum declares it. Empty until
@@ -1307,6 +1307,7 @@ impl<R: Conversions> JCompile<'_, R> {
                     },
                     nullable: false,
                     identity: false,
+                    reach: Vec::new(),
                 })
             })
             .collect();
@@ -1403,9 +1404,8 @@ impl<R: Conversions> JCompile<'_, R> {
                 // The chain starts at the accessor's result, which the emitter
                 // binds once. The call itself is the site's to make, so what a
                 // wire states is the field read off it.
-                from: OutFrom::Reach {
-                    path: vec![field_step(&ident)],
-                },
+                from: OutFrom::Place,
+                reach: vec![field_step(&ident)],
                 nullable: false,
                 identity: false,
             });
@@ -1757,9 +1757,8 @@ impl Declarations {
                 name,
                 out_ty: field.ty.clone(),
                 group: None,
-                from: OutFrom::Reach {
-                    path: field_path.iter().map(field_step).collect(),
-                },
+                from: OutFrom::Place,
+                reach: field_path.iter().map(field_step).collect(),
                 nullable: false,
                 identity: false,
             });
@@ -1800,6 +1799,7 @@ impl Declarations {
             from: OutFrom::Tag,
             nullable: false,
             identity: false,
+            reach: Vec::new(),
         }];
         for alt in &sum.alternatives {
             let kotlin = self.sum_variant_class_name(cfg, &alt.name);
@@ -1818,6 +1818,7 @@ impl Declarations {
                     },
                     nullable: false,
                     identity: false,
+                    reach: Vec::new(),
                 });
             }
         }

--- a/prebindgen-jni/src/jni/compile.rs
+++ b/prebindgen-jni/src/jni/compile.rs
@@ -108,7 +108,7 @@ fn refuse(at: At<'_>, why: &str) -> String {
     format!("JniGen: {} ({why})", at.crossing.key())
 }
 
-impl<R: Conversions<KotlinMeta>> JCompile<'_, R> {
+impl<R: Conversions> JCompile<'_, R> {
     fn wrap(&self, at: At<'_>, why: &str, conv: Option<ConverterImpl<KotlinMeta>>) -> Frag<Self> {
         conv.map(|c| JFrag::new(at, c))
             .ok_or_else(|| refuse(at, why))
@@ -171,7 +171,7 @@ impl<R: Conversions<KotlinMeta>> JCompile<'_, R> {
     }
 }
 
-impl<R: Conversions<KotlinMeta>> Compile for JCompile<'_, R> {
+impl<R: Conversions> Compile for JCompile<'_, R> {
     type Fragment = JFrag;
     /// JniGen keeps its own per-site emission for now: the exported signature,
     /// the call and the cleanup are built from the resolved registry.

--- a/prebindgen-jni/src/jni/compile.rs
+++ b/prebindgen-jni/src/jni/compile.rs
@@ -260,6 +260,11 @@ impl OutWire {
         }
     }
 
+    /// A whole plan's leaves in the row's vocabulary.
+    pub(crate) fn from_leaves(leaves: &[prebindgen_registry::unfold::UnfoldLeaf]) -> Vec<Self> {
+        leaves.iter().map(Self::from_leaf).collect()
+    }
+
     /// Whether this value is the synthesized selector.
     pub(crate) fn is_tag(&self) -> bool {
         matches!(self.from, OutFrom::Tag)

--- a/prebindgen-jni/src/jni/compile.rs
+++ b/prebindgen-jni/src/jni/compile.rs
@@ -348,7 +348,7 @@ impl OutWire {
     /// call — so it is cloned out of the value that holds it.
     ///
     /// The last step being a field read is the whole question, and it is what
-    /// `LeafSource::Field` meant: a value form's field leaf reads a field off
+    /// `LeafSource::Reach` meant: a value form's field leaf reads a field off
     /// what the accessor returned, and an accessor leaf ends at the call.
     pub(crate) fn is_field_read(&self) -> bool {
         matches!(

--- a/prebindgen-jni/src/jni/compile.rs
+++ b/prebindgen-jni/src/jni/compile.rs
@@ -223,6 +223,47 @@ pub(crate) struct OutWire {
     pub(crate) group: Option<i32>,
     /// How the Rust side reaches it.
     pub(crate) from: OutFrom,
+    /// Whether the value may be absent, so the wire boxes rather than carrying
+    /// a raw primitive.
+    ///
+    /// Always false in a composition: a decomposition of its own is reached
+    /// unconditionally. It is a **splice** that makes one nullable — a value
+    /// form reached through an `Option` puts every value under it in doubt —
+    /// and the site that splices is what sets it.
+    pub(crate) nullable: bool,
+}
+
+impl OutWire {
+    /// One leaf of an expansion plan, in the row's vocabulary.
+    ///
+    /// The shim that lets the sum emitters speak rows before every plan is one:
+    /// what they read of a leaf is exactly what a wire states, so the switch is
+    /// per call site rather than all at once.
+    pub(crate) fn from_leaf(leaf: &prebindgen_registry::unfold::UnfoldLeaf) -> Self {
+        use prebindgen_registry::unfold::LeafSource;
+        Self {
+            name: leaf.name.clone(),
+            out_ty: leaf.out_ty.clone(),
+            group: leaf.group,
+            from: match &leaf.source {
+                LeafSource::SumTag => OutFrom::Tag,
+                LeafSource::VariantField { variant, member } => OutFrom::Payload {
+                    variant: Some(variant.clone()),
+                    member: member.clone(),
+                },
+                // An accessor chain and a field chain are one thing to a wire:
+                // where the Rust side reaches the value. Which of the two it
+                // was is the plan's, and nothing the sum emitters read.
+                _ => OutFrom::Field { path: Vec::new() },
+            },
+            nullable: leaf.nullable,
+        }
+    }
+
+    /// Whether this value is the synthesized selector.
+    pub(crate) fn is_tag(&self) -> bool {
+        matches!(self.from, OutFrom::Tag)
+    }
 }
 
 /// Where an outgoing value comes from.
@@ -1143,6 +1184,7 @@ impl<R: Conversions> JCompile<'_, R> {
                         variant: None,
                         member: part_member(part)?,
                     },
+                    nullable: false,
                 })
             })
             .collect();
@@ -1214,6 +1256,7 @@ impl<R: Conversions> JCompile<'_, R> {
                                     .chain(path.iter().cloned())
                                     .collect(),
                             },
+                            nullable: false,
                         });
                     }
                 }
@@ -1222,6 +1265,7 @@ impl<R: Conversions> JCompile<'_, R> {
                     out_ty: part.ty.clone(),
                     group: None,
                     from: OutFrom::Field { path: vec![ident] },
+                    nullable: false,
                 }),
             }
         }
@@ -1272,6 +1316,7 @@ impl<R: Conversions> JCompile<'_, R> {
                 // binds once. The call itself is the site's to make, so what a
                 // wire states is the field read off it.
                 from: OutFrom::Field { path: vec![ident] },
+                nullable: false,
             });
         }
         let mut frag = JFrag::new(
@@ -1313,6 +1358,7 @@ impl<R: Conversions> JCompile<'_, R> {
             out_ty: at.crossing.value().clone(),
             group: None,
             from: OutFrom::Tag,
+            nullable: false,
         }];
         for (alt, frag) in arms {
             let kotlin = self.decls.sum_variant_class_name(sum_cfg, &alt.name);
@@ -1332,6 +1378,7 @@ impl<R: Conversions> JCompile<'_, R> {
                         variant: Some(alt.name.clone()),
                         member: member.clone(),
                     },
+                    nullable: w.nullable,
                 });
             }
         }

--- a/prebindgen-jni/src/jni/compile.rs
+++ b/prebindgen-jni/src/jni/compile.rs
@@ -115,9 +115,6 @@ pub(crate) enum Access {
 }
 
 /// The Kotlin property chain, rooted at the object a site destructures.
-///
-/// Only the equivalence check calls it until the emitters take the row.
-#[cfg(test)]
 pub(crate) fn reached(base: &str, walk: &[Nav]) -> String {
     let mut out = base.to_string();
     for nav in walk {
@@ -137,10 +134,6 @@ impl Access {
     }
 
     /// The Kotlin expression, rooted at the object this site destructures.
-    ///
-    /// Only the equivalence check calls it until the emitters take the row —
-    /// the same `#[cfg(test)]` the wire's other readers carry.
-    #[cfg(test)]
     pub(crate) fn render(&self, base: &str) -> String {
         match self {
             Access::Read { walk, tail } => format!("{}{tail}", reached(base, walk)),
@@ -730,6 +723,22 @@ impl crate::jni::Declarations {
     pub(crate) fn out_frag(&self, ty: &TypeRef) -> Option<Conv> {
         self.frag(ty, Assembly::Deconstruct)
     }
+
+    /// Every wire the Kotlin → Rust crossing of `ty` occupies, or `None` when
+    /// it occupies the single one its conversion names.
+    ///
+    /// A declared class states its composition under the `parts` row; an
+    /// optional over one has no row of its own and composes on the row the
+    /// registry derived, which is that crossing's default.
+    pub(crate) fn wires_of(&self, ty: &TypeRef) -> Option<Vec<Wire>> {
+        let key = ty.key();
+        let compiled = self.compiled.borrow();
+        compiled
+            .row_fragment(&key, Assembly::Construct, &crate::jni::rows::parts())
+            .or_else(|| compiled.fragment(&key, Assembly::Construct))?
+            .wires
+            .clone()
+    }
 }
 
 /// A fragment's conversion, read without copying it.
@@ -748,9 +757,7 @@ impl std::ops::Deref for Conv {
     }
 }
 
-/// Facts a wire states about itself, which the emitters read once they take
-/// the `parts` row. Only the equivalence check calls them until then.
-#[cfg(test)]
+/// Facts a wire states about itself, which the emitters read off the row.
 impl Wire {
     /// The wire-facing function this value crosses through.
     pub(crate) fn conv(&self) -> Option<&syn::Ident> {
@@ -770,18 +777,18 @@ impl Wire {
             .as_ref()
             .is_some_and(|e| !e.pre_stages.is_empty())
     }
-}
 
-/// Facts a wire states about itself, which the emitters read once they take
-/// the `parts` row. Only the equivalence check calls them until then.
-#[cfg(test)]
-impl Wire {
-    /// The struct field this value fills, which the Rust-side rebuild binds by
-    /// name.
+    /// Whether this value is a gate rather than something that crosses.
     ///
-    /// The last segment of the path, because a path **is** the chain of fields
-    /// that reached the value.
-    ///
+    /// A presence flag is the one wire with neither a conversion nor a handle
+    /// behind it that is still an ordinary read. A tag has neither either, and
+    /// is told apart by being read through a `when`.
+    pub(crate) fn is_present_flag(&self) -> bool {
+        self.entry.is_none()
+            && self.handle_target.is_none()
+            && matches!(self.access, Access::Read { .. })
+    }
+
     /// The struct field this value fills or gates.
     pub(crate) fn field(&self) -> Option<&str> {
         self.field.as_deref()
@@ -863,24 +870,31 @@ impl<R: Conversions> JCompile<'_, R> {
         let mut kt_ty = crate::jni::emit::wire_kotlin_type(&frag.conv);
         let projection = frag.conv.metadata.projection.as_ref();
         let mut absent = None;
+        let mut tail = String::new();
         if projection.map(|p| &p.kind) == Some(&ProjectionKind::Unsigned64) {
             walk.push(Nav {
                 field: "toLong()".to_string(),
                 gated: optional,
             });
             // An unsigned projection carves its absent value out of the
-            // representation's own range, so a closed gate substitutes that
-            // rather than the wire's zero.
-            absent = Some(
-                projection
-                    .and_then(|p| p.niche_sentinels.first().cloned())
-                    .unwrap_or_else(|| "0L".to_string()),
-            );
+            // representation's own range, so what stands in for absence is that
+            // sentinel rather than the wire's zero. The field's own optional
+            // reaches it here; an ancestor's gate reaches it through `absent`.
+            let sentinel = projection
+                .and_then(|p| p.niche_sentinels.first().cloned())
+                .unwrap_or_else(|| "0L".to_string());
+            match optional {
+                true => tail = format!(" ?: {sentinel}"),
+                false => absent = Some(sentinel),
+            }
         } else if self.decls.is_kotlin_enum_reading(&part.ty) {
             walk.push(Nav {
                 field: "value".to_string(),
                 gated: optional,
             });
+            if optional {
+                tail = " ?: 0".to_string();
+            }
         }
         if optional && crate::jni::emit::is_jobject_shaped_wire(&frag.conv.destination) {
             if !kt_ty.ends_with('?') {
@@ -894,10 +908,7 @@ impl<R: Conversions> JCompile<'_, R> {
             ty: frag.conv.destination.clone(),
             kt_ty,
             path: part.name.clone(),
-            access: Access::Read {
-                walk,
-                tail: String::new(),
-            },
+            access: Access::Read { walk, tail },
             entry: Some(frag.conv.clone()),
             handle_target: None,
             handle_nullable: false,

--- a/prebindgen-jni/src/jni/compile.rs
+++ b/prebindgen-jni/src/jni/compile.rs
@@ -28,6 +28,14 @@ pub(crate) enum JPlan {
     /// A return that crosses as one value: what it converts through, and what
     /// the Kotlin surface declares.
     Return(Box<crate::jni::fn_plan::ValueOutputPlan>),
+    /// A return the binding takes apart: the values it hands out, in the order
+    /// the builder receives them.
+    ///
+    /// Read only by the equivalence fixture until the encode side takes it —
+    /// `reach_leaf_flat` and `encode_plan_leaves` still read the plan, because
+    /// where the Rust side reaches a value is the plan's and not the wire's.
+    #[cfg_attr(not(test), allow(dead_code))]
+    Decomposed(Vec<OutWire>),
 }
 
 impl JPlan {
@@ -35,7 +43,7 @@ impl JPlan {
     pub(crate) fn param(self) -> Option<crate::jni::fn_plan::PlanLeaf> {
         match self {
             JPlan::Param(leaf) => Some(*leaf),
-            JPlan::Return(_) => None,
+            _ => None,
         }
     }
 
@@ -43,7 +51,16 @@ impl JPlan {
     pub(crate) fn returned(self) -> Option<crate::jni::fn_plan::ValueOutputPlan> {
         match self {
             JPlan::Return(plan) => Some(*plan),
-            JPlan::Param(_) => None,
+            _ => None,
+        }
+    }
+
+    /// The values a decomposed return hands out, or `None` if it is not one.
+    #[cfg(test)]
+    pub(crate) fn decomposed(self) -> Option<Vec<OutWire>> {
+        match self {
+            JPlan::Decomposed(wires) => Some(wires),
+            _ => None,
         }
     }
 }
@@ -921,7 +938,16 @@ impl<R: Conversions> Compile for JCompile<'_, R> {
             .as_ref()
             .ok_or_else(|| JErr::Refused("JniGen: a site compiled with no site context".into()))?;
         let site = match site {
-            PlanSite::Return => return Ok(JPlan::Return(Box::new(self.return_plan(bound, root)))),
+            PlanSite::Return => {
+                // A fragment that occupies several wires IS the decomposed
+                // return: the site asked for the `parts` row and got what that
+                // row states. Nothing else distinguishes the two cases, and
+                // nothing needs to.
+                return Ok(match &root.out_wires {
+                    Some(wires) => JPlan::Decomposed(wires.clone()),
+                    None => JPlan::Return(Box::new(self.return_plan(bound, root))),
+                });
+            }
             PlanSite::Param(site) => site,
         };
         let (ident, expanded) = (&site.ident, site.expanded);

--- a/prebindgen-jni/src/jni/compile.rs
+++ b/prebindgen-jni/src/jni/compile.rs
@@ -612,10 +612,16 @@ impl<R: Conversions> Compile for JCompile<'_, R> {
         &mut self,
         _cx: &mut Cx<'_>,
         at: At<'_>,
-        _func: &Function,
-        _parts: Parts<'_, Self>,
+        func: &Function,
+        parts: Parts<'_, Self>,
     ) -> Frag<Self> {
-        Err(refuse(at, "JniGen states no value-form rows yet"))
+        if at.crossing.assembly() != Assembly::Construct {
+            return Ok(self.out_value_form(at, func, parts));
+        }
+        Err(refuse(
+            at,
+            "JniGen states no constructing value-form rows yet",
+        ))
     }
 
     fn fields(&mut self, cx: &mut Cx<'_>, at: At<'_>, parts: Parts<'_, Self>) -> Frag<Self> {
@@ -1091,6 +1097,59 @@ impl<R: Conversions> JCompile<'_, R> {
         let mut frag = JFrag::new(
             at,
             self.parts_marker(parts.iter().map(|(p, _)| p.ty.key()).collect()),
+        );
+        frag.out_wires = Some(wires);
+        frag.composed_only = true;
+        frag
+    }
+
+    /// The values a **value form** hands out: call the accessor once, then read
+    /// the fields of what it returned.
+    ///
+    /// Every field is one value here, where a by-value `data_class` inlines a
+    /// nested one — the difference is the declaration, not the type. A value
+    /// form states its own field list, and what it does not state, it does not
+    /// decompose.
+    ///
+    /// The names are the declaration's: a `.name(..)` rename carries through,
+    /// which is why the record list is asked for again rather than the Kotlin
+    /// property being derived a second time here.
+    fn out_value_form(&self, at: At<'_>, func: &Function, parts: Parts<'_, Self>) -> JFrag {
+        let declined = JFrag::new(at, self.parts_marker(Vec::new()));
+        let Some(names) = self
+            .decls
+            .value_form_names(self.registry, at.crossing.value())
+        else {
+            return declined;
+        };
+        let mut wires = Vec::new();
+        for (part, _) in parts {
+            let Some(field) = part_field(part) else {
+                return declined;
+            };
+            let Some(ident) = field.name.clone() else {
+                return declined;
+            };
+            let Some(name) = names.get(&ident.to_string()).cloned() else {
+                return declined;
+            };
+            wires.push(OutWire {
+                name,
+                out_ty: part.ty.clone(),
+                group: None,
+                // The chain starts at the accessor's result, which the emitter
+                // binds once. The call itself is the site's to make, so what a
+                // wire states is the field read off it.
+                from: OutFrom::Field { path: vec![ident] },
+            });
+        }
+        let mut frag = JFrag::new(
+            at,
+            self.parts_marker(
+                std::iter::once(TypeKey::from_ident(&func.name))
+                    .chain(parts.iter().map(|(p, _)| p.ty.key()))
+                    .collect(),
+            ),
         );
         frag.out_wires = Some(wires);
         frag.composed_only = true;

--- a/prebindgen-jni/src/jni/compile.rs
+++ b/prebindgen-jni/src/jni/compile.rs
@@ -1343,45 +1343,18 @@ impl<R: Conversions> JCompile<'_, R> {
         let TypeKind::Named { id, .. } = at.crossing.value().unwrapped().kind() else {
             return Err(refuse(at, "a choice row over a type that is not named"));
         };
-        let sum_cfg = id
+        let ident = id
             .ident()
-            .and_then(|ident| self.decls.types.get(&TypeKey::from_ident(&ident)))
-            .and_then(|cfg| cfg.sum())
+            .ok_or_else(|| refuse(at, "a choice row over a type that is not one identifier"))?;
+        // The composition is the declaration's and the model's, so the same
+        // answer serves the leaf synthesis that runs before `resolve`. The arm
+        // fragments the driver built are not read at all — a sum hands its
+        // payloads out through their own conversions, and which those are is
+        // the emitter's question rather than this row's.
+        let wires = self
+            .decls
+            .sum_out_wires(self.registry, &ident, at.crossing.value())
             .ok_or_else(|| refuse(at, "a choice row over an undeclared sum"))?;
-
-        // The selector rides ahead of the groups it chooses between, and
-        // carries **which sum** it selects over — nothing converts it, so
-        // naming the sum is the only use its type has, and it is the one an
-        // emitter needs to find the enum to match.
-        let mut wires = vec![OutWire {
-            name: crate::jni::emit::SUM_TAG_LEAF.to_string(),
-            out_ty: at.crossing.value().clone(),
-            group: None,
-            from: OutFrom::Tag,
-            nullable: false,
-        }];
-        for (alt, frag) in arms {
-            let kotlin = self.decls.sum_variant_class_name(sum_cfg, &alt.name);
-            let group = Some(crate::jni::struct_plan::sum_tag(alt));
-            for w in frag.out_wires.as_ref().into_iter().flatten() {
-                let OutFrom::Payload { member, .. } = &w.from else {
-                    return Err(refuse(
-                        at,
-                        "an arm that states something other than payloads",
-                    ));
-                };
-                wires.push(OutWire {
-                    name: crate::jni::struct_plan::sum_slot_fragment(&kotlin, &w.name),
-                    out_ty: w.out_ty.clone(),
-                    group,
-                    from: OutFrom::Payload {
-                        variant: Some(alt.name.clone()),
-                        member: member.clone(),
-                    },
-                    nullable: w.nullable,
-                });
-            }
-        }
         let mut frag = JFrag::new(at, self.parts_marker(parts_subs(arms)));
         frag.out_wires = Some(wires);
         frag.composed_only = true;
@@ -1579,6 +1552,63 @@ impl<R: Conversions> JCompile<'_, R> {
                 whole_gate: false,
             },
         ])
+    }
+}
+
+impl Declarations {
+    /// The values a `sealed_class` hands out: the selector, then one group of
+    /// slots per alternative, laid beside the others.
+    ///
+    /// Model and declaration only — no conversion is read. That is what lets
+    /// one answer serve on both sides of `resolve`: the leaf synthesis feeding
+    /// `Decompositions` runs before it, the row composes after it, and a fact
+    /// derived twice is a fact that can differ.
+    ///
+    /// `None` for a type the model does not hold as a data-carrying enum, or
+    /// one no `sealed_class!` declares — neither has a decomposition to state.
+    pub(crate) fn sum_out_wires(
+        &self,
+        registry: &impl Conversions,
+        ident: &syn::Ident,
+        sum_ty: &TypeRef,
+    ) -> Option<Vec<OutWire>> {
+        let prebindgen_registry::flat::Type::Variant(sum) = registry.flat().declared_type(ident)?
+        else {
+            return None;
+        };
+        let cfg = self.types.get(&TypeKey::from_ident(ident))?.sum()?;
+
+        // The selector rides ahead of the groups it chooses between, and
+        // carries **which sum** it selects over — nothing converts it, so
+        // naming the sum is the only use its type has, and it is the one an
+        // emitter needs: which enum to match over.
+        let mut wires = vec![OutWire {
+            name: crate::jni::emit::SUM_TAG_LEAF.to_string(),
+            out_ty: sum_ty.clone(),
+            group: None,
+            from: OutFrom::Tag,
+            nullable: false,
+        }];
+        for alt in &sum.alternatives {
+            let kotlin = self.sum_variant_class_name(cfg, &alt.name);
+            for field in &alt.fields {
+                let member = field.member();
+                wires.push(OutWire {
+                    name: crate::jni::struct_plan::sum_slot_fragment(
+                        &kotlin,
+                        &crate::jni::struct_plan::sum_field_prop_name(&member),
+                    ),
+                    out_ty: field.ty.clone(),
+                    group: Some(crate::jni::struct_plan::sum_tag(alt)),
+                    from: OutFrom::Payload {
+                        variant: Some(alt.name.clone()),
+                        member,
+                    },
+                    nullable: false,
+                });
+            }
+        }
+        Some(wires)
     }
 }
 

--- a/prebindgen-jni/src/jni/compile.rs
+++ b/prebindgen-jni/src/jni/compile.rs
@@ -153,7 +153,6 @@ impl<R: Conversions<KotlinMeta>> JCompile<'_, R> {
                 WrapperShape::Borrow { mutable },
                 &produced,
                 inner,
-                self.registry,
                 emit,
             )?;
             c.subs = vec![inner.key()];
@@ -164,7 +163,6 @@ impl<R: Conversions<KotlinMeta>> JCompile<'_, R> {
                 WrapperShape::Borrow { mutable },
                 &produced,
                 inner,
-                self.registry,
                 emit,
             )?;
             c.subs = vec![inner.key()];
@@ -221,11 +219,11 @@ impl<R: Conversions<KotlinMeta>> Compile for JCompile<'_, R> {
             Assembly::Construct => self
                 .decls
                 .input_terminal(ty, self.registry, emit)
-                .or_else(|| self.decls.input_optional(ty, self.registry, emit)),
+                .or_else(|| self.decls.input_optional(ty, emit)),
             Assembly::Deconstruct => self
                 .decls
                 .output_terminal(ty, self.registry, emit)
-                .or_else(|| self.decls.output_optional(ty, self.registry, emit)),
+                .or_else(|| self.decls.output_optional(ty, emit)),
         };
         self.wrap(at, "no JNI representation for this optional", conv)
     }
@@ -243,13 +241,13 @@ impl<R: Conversions<KotlinMeta>> Compile for JCompile<'_, R> {
             Assembly::Construct => self
                 .decls
                 .input_terminal(ty, self.registry, emit)
-                .or_else(|| self.decls.input_run(ty, self.registry, emit))
+                .or_else(|| self.decls.input_run(ty, emit))
                 .or_else(|| self.borrow(ty, emit, true))
                 .or_else(|| self.decls.input_transparent_bridge(ty, self.registry, emit)),
             Assembly::Deconstruct => self
                 .decls
                 .output_terminal(ty, self.registry, emit)
-                .or_else(|| self.decls.output_run(ty, self.registry, emit))
+                .or_else(|| self.decls.output_run(ty, emit))
                 .or_else(|| self.borrow(ty, emit, false))
                 .or_else(|| {
                     self.decls
@@ -332,25 +330,31 @@ impl<R: Conversions<KotlinMeta>> Compile for JCompile<'_, R> {
 impl crate::jni::Declarations {
     /// The conversion for `ty` in the given direction, from the fragments
     /// compiled so far.
-    pub(crate) fn frag(
-        &self,
-        ty: &TypeRef,
-        assembly: Assembly,
-    ) -> Option<ConverterImpl<KotlinMeta>> {
-        Some(
-            self.compiled
-                .borrow()
-                .fragment(&ty.key(), assembly)?
-                .conv
-                .clone(),
-        )
+    pub(crate) fn frag(&self, ty: &TypeRef, assembly: Assembly) -> Option<Conv> {
+        Some(Conv(self.compiled.borrow().fragment(&ty.key(), assembly)?))
     }
 
-    pub(crate) fn in_frag(&self, ty: &TypeRef) -> Option<ConverterImpl<KotlinMeta>> {
+    pub(crate) fn in_frag(&self, ty: &TypeRef) -> Option<Conv> {
         self.frag(ty, Assembly::Construct)
     }
 
-    pub(crate) fn out_frag(&self, ty: &TypeRef) -> Option<ConverterImpl<KotlinMeta>> {
+    pub(crate) fn out_frag(&self, ty: &TypeRef) -> Option<Conv> {
         self.frag(ty, Assembly::Deconstruct)
+    }
+}
+
+/// A fragment's conversion, read without copying it.
+///
+/// The store is read while compilation is still writing to it, so a caller
+/// cannot hold a borrow into it; sharing the fragment's `Rc` and reaching the
+/// conversion through it costs a refcount instead of a whole `syn::ItemFn` per
+/// lookup.
+pub(crate) struct Conv(std::rc::Rc<JFrag>);
+
+impl std::ops::Deref for Conv {
+    type Target = ConverterImpl<KotlinMeta>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0.conv
     }
 }

--- a/prebindgen-jni/src/jni/compile.rs
+++ b/prebindgen-jni/src/jni/compile.rs
@@ -271,6 +271,13 @@ pub(crate) struct OutWire {
     pub(crate) group: Option<i32>,
     /// How the Rust side reaches it.
     pub(crate) from: OutFrom,
+    /// Whether this value is the whole crossed object rather than a part of it
+    /// — the move-or-clone handle a decomposition delivers beside its fields.
+    ///
+    /// Never true in a composition: a row states what a value is **made of**,
+    /// and the value itself is not one of its own parts. A declaration is what
+    /// asks for one, through `.field_self()`.
+    pub(crate) identity: bool,
     /// Whether the value may be absent, so the wire boxes rather than carrying
     /// a raw primitive.
     ///
@@ -299,11 +306,13 @@ impl OutWire {
                     variant: Some(variant.clone()),
                     member: member.clone(),
                 },
-                // An accessor chain and a field chain are one thing to a wire:
-                // where the Rust side reaches the value. Which of the two it
-                // was is the plan's, and nothing the sum emitters read.
-                _ => OutFrom::Field { path: Vec::new() },
+                // Every other leaf is reached off the value, and the steps say
+                // how — an accessor chain, a field chain, or the two mixed.
+                _ => OutFrom::Reach {
+                    path: leaf.path.clone(),
+                },
             },
+            identity: leaf.identity,
             nullable: leaf.nullable,
         }
     }
@@ -311,6 +320,28 @@ impl OutWire {
     /// A whole plan's leaves in the row's vocabulary.
     pub(crate) fn from_leaves(leaves: &[prebindgen_registry::unfold::UnfoldLeaf]) -> Vec<Self> {
         leaves.iter().map(Self::from_leaf).collect()
+    }
+
+    /// The steps from the crossed value down to this one, or empty for a value
+    /// no reach describes — the selector, or a payload its arm's pattern binds.
+    pub(crate) fn reach(&self) -> &[prebindgen_registry::unfold::PathStep] {
+        match &self.from {
+            OutFrom::Reach { path } => path,
+            _ => &[],
+        }
+    }
+
+    /// Whether this value is **read off** a place rather than produced by a
+    /// call — so it is cloned out of the value that holds it.
+    ///
+    /// The last step being a field read is the whole question, and it is what
+    /// `LeafSource::Field` meant: a value form's field leaf reads a field off
+    /// what the accessor returned, and an accessor leaf ends at the call.
+    pub(crate) fn is_field_read(&self) -> bool {
+        matches!(
+            self.reach().last(),
+            Some(prebindgen_registry::unfold::PathStep::Field { .. })
+        )
     }
 
     /// Whether this value is the synthesized selector.
@@ -325,15 +356,21 @@ pub(crate) enum OutFrom {
     /// The synthesized selector, which is not read off the value at all: the
     /// emitter assigns the alternative's number in each arm of its `match`.
     Tag,
-    /// A field of the value, reached by field access and cloned — the chain of
-    /// idents from the value itself.
+    /// Reached off the value, by field access or by calling an accessor.
     ///
-    /// Nested where a `data_class` field is itself one: its fields cross as
-    /// decoupled values under the parent's chain, and the foreign side
-    /// reassembles the whole graph in one call.
-    Field {
-        /// The field idents from the value down to this one.
-        path: Vec<syn::Ident>,
+    /// The **steps** rather than a chain of idents, because the two kinds mix:
+    /// a value form calls an accessor and then reads fields off what it
+    /// returned, and a nested `data_class` reads fields all the way down. A
+    /// step also says whether it may find nothing, which is what puts every
+    /// value below it in doubt.
+    ///
+    /// Spelled in the plans' own vocabulary rather than a second one. A reach
+    /// **is** a path, and inventing a parallel spelling for it would leave two
+    /// things to keep in step for no gain — the mistake `Access` and
+    /// `handle_target` avoided on the constructing side by being one type.
+    Reach {
+        /// The steps from the value down to this one.
+        path: Vec<prebindgen_registry::unfold::PathStep>,
     },
     /// A payload of one alternative, bound by that arm's pattern.
     Payload {
@@ -1269,6 +1306,7 @@ impl<R: Conversions> JCompile<'_, R> {
                         member: part_member(part)?,
                     },
                     nullable: false,
+                    identity: false,
                 })
             })
             .collect();
@@ -1365,8 +1403,11 @@ impl<R: Conversions> JCompile<'_, R> {
                 // The chain starts at the accessor's result, which the emitter
                 // binds once. The call itself is the site's to make, so what a
                 // wire states is the field read off it.
-                from: OutFrom::Field { path: vec![ident] },
+                from: OutFrom::Reach {
+                    path: vec![field_step(&ident)],
+                },
                 nullable: false,
+                identity: false,
             });
         }
         let mut frag = JFrag::new(
@@ -1716,8 +1757,11 @@ impl Declarations {
                 name,
                 out_ty: field.ty.clone(),
                 group: None,
-                from: OutFrom::Field { path: field_path },
+                from: OutFrom::Reach {
+                    path: field_path.iter().map(field_step).collect(),
+                },
                 nullable: false,
+                identity: false,
             });
         }
         Some(wires)
@@ -1755,6 +1799,7 @@ impl Declarations {
             group: None,
             from: OutFrom::Tag,
             nullable: false,
+            identity: false,
         }];
         for alt in &sum.alternatives {
             let kotlin = self.sum_variant_class_name(cfg, &alt.name);
@@ -1772,11 +1817,21 @@ impl Declarations {
                         member,
                     },
                     nullable: false,
+                    identity: false,
                 });
             }
         }
         Some(wires)
     }
+}
+
+/// One step of a reach that reads a struct field.
+///
+/// Never optional: a composition looks through an `Option` rather than stopping
+/// at one — a terminal optional rides its own conversion, and an intermediate
+/// one is a shape the compositions decline.
+fn field_step(ident: &syn::Ident) -> prebindgen_registry::unfold::PathStep {
+    prebindgen_registry::unfold::PathStep::field(ident.clone(), false)
 }
 
 /// The model field one part reads, or `None` for a part that is not a field.

--- a/prebindgen-jni/src/jni/compile.rs
+++ b/prebindgen-jni/src/jni/compile.rs
@@ -36,6 +36,15 @@ pub(crate) struct JFrag {
     /// makes a nested `data_class` field contribute its own several rather than
     /// one.
     pub(crate) wires: Option<Vec<Wire>>,
+    /// This fragment states a wire list and nothing else — no conversion of its
+    /// own, so nothing of it reaches the generated file.
+    ///
+    /// Only the `parts` row is this. A crossing may legitimately carry **both**
+    /// a wire list and a real conversion: an `Option<data_class>` composes a
+    /// presence flag ahead of the inner's wires and still has the optional's
+    /// own conversion to emit, so "has wires" is the wrong test for what to
+    /// leave out of the file.
+    pub(crate) composed_only: bool,
 }
 
 /// One wire value of a crossing that occupies several.
@@ -43,9 +52,14 @@ pub(crate) struct JFrag {
 pub(crate) struct Wire {
     /// The JNI type this value crosses as.
     pub(crate) ty: syn::Type,
-    /// The path through the value that reached it — `tag`, `summary.count` —
-    /// which is what a JNI parameter name and a Kotlin accessor are both
-    /// mangled from.
+    /// The Kotlin type of the same value, as an `external fun` writes it.
+    pub(crate) kt_ty: String,
+    /// The path through the value that reached it — `tag`, `summary.count`.
+    ///
+    /// **Relative**, because a fragment answers for a crossing and a name
+    /// belongs to a site: the same `Holder` is `hTag` in one signature and
+    /// `otherTag` in the next, so the parameter it hangs off is the caller's to
+    /// prepend.
     pub(crate) path: String,
 }
 
@@ -68,6 +82,7 @@ impl JFrag {
         Self {
             conv,
             wires: None,
+            composed_only: false,
             yields: Yield {
                 ty,
                 mode: Mode::Owned,
@@ -81,6 +96,7 @@ impl JFrag {
         Self {
             conv,
             wires: None,
+            composed_only: false,
             yields: Yield {
                 ty: at.crossing.value().stripped_key(),
                 mode: at.crossing.mode(),
@@ -234,7 +250,7 @@ impl<R: Conversions> Compile for JCompile<'_, R> {
         self.wrap(at, "no JNI representation for this type", conv)
     }
 
-    fn optional(&mut self, cx: &mut Cx<'_>, at: At<'_>, _inner: &JFrag) -> Frag<Self> {
+    fn optional(&mut self, cx: &mut Cx<'_>, at: At<'_>, inner: &JFrag) -> Frag<Self> {
         let ty = at.crossing.spelled();
         let emit = cx.emit();
         // A declared terminal outranks the arity the registry derived, exactly
@@ -250,7 +266,21 @@ impl<R: Conversions> Compile for JCompile<'_, R> {
                 .output_terminal(ty, self.registry, emit)
                 .or_else(|| self.decls.output_optional(ty, emit)),
         };
-        self.wrap(at, "no JNI representation for this optional", conv)
+        let mut frag = self.wrap(at, "no JNI representation for this optional", conv)?;
+        // An optional over something that crosses as several values cannot ride
+        // a niche in any one of them — which of `(tag, summary)` would carry
+        // the absence? So the presence is its own wire, ahead of the rest: the
+        // `hMaybePresent` in `(hMaybePresent, hMaybeId)`.
+        if let (Assembly::Construct, Some(inner_wires)) = (at.crossing.assembly(), &inner.wires) {
+            let mut wires = vec![Wire {
+                ty: syn::parse_quote!(jni::sys::jboolean),
+                kt_ty: "Boolean".to_string(),
+                path: "present".to_string(),
+            }];
+            wires.extend(inner_wires.iter().cloned());
+            frag.wires = Some(wires);
+        }
+        Ok(frag)
     }
 
     fn sequence(
@@ -321,10 +351,12 @@ impl<R: Conversions> Compile for JCompile<'_, R> {
             match &frag.wires {
                 Some(inner) => wires.extend(inner.iter().map(|w| Wire {
                     ty: w.ty.clone(),
+                    kt_ty: w.kt_ty.clone(),
                     path: format!("{}.{}", part.name, w.path),
                 })),
                 None => wires.push(Wire {
                     ty: frag.conv.destination.clone(),
+                    kt_ty: crate::jni::emit::wire_kotlin_type(&frag.conv),
                     path: part.name.clone(),
                 }),
             }
@@ -351,6 +383,7 @@ impl<R: Conversions> Compile for JCompile<'_, R> {
             },
         );
         frag.wires = Some(wires);
+        frag.composed_only = true;
         Ok(frag)
     }
 

--- a/prebindgen-jni/src/jni/compile.rs
+++ b/prebindgen-jni/src/jni/compile.rs
@@ -231,6 +231,16 @@ pub(crate) enum OutFrom {
     /// The synthesized selector, which is not read off the value at all: the
     /// emitter assigns the alternative's number in each arm of its `match`.
     Tag,
+    /// A field of the value, reached by field access and cloned — the chain of
+    /// idents from the value itself.
+    ///
+    /// Nested where a `data_class` field is itself one: its fields cross as
+    /// decoupled values under the parent's chain, and the foreign side
+    /// reassembles the whole graph in one call.
+    Field {
+        /// The field idents from the value down to this one.
+        path: Vec<syn::Ident>,
+    },
     /// A payload of one alternative, bound by that arm's pattern.
     Payload {
         /// The alternative's ident as the source enum declares it. Empty until
@@ -617,10 +627,7 @@ impl<R: Conversions> Compile for JCompile<'_, R> {
         if at.crossing.assembly() != Assembly::Construct {
             return match sum {
                 true => Ok(self.out_arm(at, parts)),
-                false => Err(refuse(
-                    at,
-                    "JniGen states no deconstructing product rows yet",
-                )),
+                false => Ok(self.out_product(at, parts)),
             };
         }
         if sum {
@@ -1011,6 +1018,85 @@ impl<R: Conversions> JCompile<'_, R> {
         frag
     }
 
+    /// The values a `data_class` hands out: its fields, and a field that is
+    /// itself one contributes its own.
+    ///
+    /// A fragment with **no** out-wires is this adapter declining, and it
+    /// declines for the whole value rather than per field. A handle, an
+    /// `enum_class`, a sum or a `data_class` behind an `Option` or a `Vec` is
+    /// delivered with a transform the decoupled form does not carry, and one
+    /// such field sends the whole object down the whole-value `fromParts` path
+    /// — so a row that decomposed the rest of it would describe a shape nothing
+    /// emits.
+    fn out_product(&self, at: At<'_>, parts: Parts<'_, Self>) -> JFrag {
+        let declined = JFrag::new(at, self.parts_marker(Vec::new()));
+        let mut wires = Vec::new();
+        for (part, frag) in parts {
+            let Some(field) = part_field(part) else {
+                return declined;
+            };
+            let ident = match &field.name {
+                Some(name) => name.clone(),
+                None => return declined,
+            };
+            // The same name the leaf synthesis gives it: the Kotlin property,
+            // and nested names joined by the reserved `__` separator.
+            let name =
+                crate::jni::mangle_kotlin_ident(&crate::jni::kt_snake_to_camel(&ident.to_string()));
+            // The layer questions off the field's own reading — `Optional` to
+            // look through, `Vec` to decline — never a last path segment.
+            let probe = part.ty.optional_inner().unwrap_or(&part.ty);
+            if matches!(
+                self.decls.type_kind(self.registry, &probe.key()),
+                crate::jni::classify::TypeKind::Handle
+                    | crate::jni::classify::TypeKind::Enum
+                    | crate::jni::classify::TypeKind::Sum
+            ) {
+                return declined;
+            }
+            match &frag.out_wires {
+                // A nested `data_class`, which contributes its own values under
+                // this field's name and chain. Only unwrapped: behind an
+                // `Option` or a `Vec` there is no chain to reach through.
+                Some(inner) => {
+                    if part.ty.optional_inner().is_some()
+                        || matches!(part.ty.kind(), TypeKind::Vec(_))
+                    {
+                        return declined;
+                    }
+                    for w in inner {
+                        let OutFrom::Field { path } = &w.from else {
+                            return declined;
+                        };
+                        wires.push(OutWire {
+                            name: format!("{name}__{}", w.name),
+                            out_ty: w.out_ty.clone(),
+                            group: None,
+                            from: OutFrom::Field {
+                                path: std::iter::once(ident.clone())
+                                    .chain(path.iter().cloned())
+                                    .collect(),
+                            },
+                        });
+                    }
+                }
+                None => wires.push(OutWire {
+                    name,
+                    out_ty: part.ty.clone(),
+                    group: None,
+                    from: OutFrom::Field { path: vec![ident] },
+                }),
+            }
+        }
+        let mut frag = JFrag::new(
+            at,
+            self.parts_marker(parts.iter().map(|(p, _)| p.ty.key()).collect()),
+        );
+        frag.out_wires = Some(wires);
+        frag.composed_only = true;
+        frag
+    }
+
     /// The tag, then every alternative's payloads.
     ///
     /// The deconstructing shape of a `sealed_class`: one `jint` naming which
@@ -1259,12 +1345,17 @@ impl<R: Conversions> JCompile<'_, R> {
     }
 }
 
-/// The model field one part reads, which a sum payload names its slot after.
-fn part_member(part: &Part<'_>) -> Option<syn::Member> {
+/// The model field one part reads, or `None` for a part that is not a field.
+fn part_field<'a>(part: &Part<'a>) -> Option<&'a prebindgen_registry::flat::Field> {
     match part.from {
-        prebindgen_registry::recipe::PartSource::Field { field, .. } => Some(field.member()),
+        prebindgen_registry::recipe::PartSource::Field { field, .. } => Some(field),
         _ => None,
     }
+}
+
+/// The model field one part reads, which a sum payload names its slot after.
+fn part_member(part: &Part<'_>) -> Option<syn::Member> {
+    part_field(part).map(|f| f.member())
 }
 
 /// Every crossing a sum's arms delegate to, which is what reachability walks.

--- a/prebindgen-jni/src/jni/compile.rs
+++ b/prebindgen-jni/src/jni/compile.rs
@@ -24,6 +24,29 @@ use super::{
 pub(crate) struct JFrag {
     pub(crate) conv: ConverterImpl<KotlinMeta>,
     pub(crate) yields: Yield,
+    /// The wire values this crossing occupies, when it occupies more than the
+    /// one `conv.destination` names.
+    ///
+    /// A JniGen `data_class` parameter arrives as **several** JNI parameters —
+    /// `Option<Holder>` is `(hPresent, hTag, hSummary)` — so a single
+    /// destination cannot say what it costs. `None` is the ordinary case: one
+    /// wire, and `conv.destination` is it.
+    ///
+    /// Composed by [`Compile::fields`] from the parts' own wires, which is what
+    /// makes a nested `data_class` field contribute its own several rather than
+    /// one.
+    pub(crate) wires: Option<Vec<Wire>>,
+}
+
+/// One wire value of a crossing that occupies several.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct Wire {
+    /// The JNI type this value crosses as.
+    pub(crate) ty: syn::Type,
+    /// The path through the value that reached it — `tag`, `summary.count` —
+    /// which is what a JNI parameter name and a Kotlin accessor are both
+    /// mangled from.
+    pub(crate) path: String,
 }
 
 impl Carrier for JFrag {
@@ -44,6 +67,7 @@ impl JFrag {
     pub(crate) fn by_hand(ty: TypeKey, conv: ConverterImpl<KotlinMeta>) -> Self {
         Self {
             conv,
+            wires: None,
             yields: Yield {
                 ty,
                 mode: Mode::Owned,
@@ -56,6 +80,7 @@ impl JFrag {
         let validity = validity_of(&conv, at.crossing.assembly());
         Self {
             conv,
+            wires: None,
             yields: Yield {
                 ty: at.crossing.value().stripped_key(),
                 mode: at.crossing.mode(),
@@ -281,8 +306,52 @@ impl<R: Conversions> Compile for JCompile<'_, R> {
         Err(refuse(at, "JniGen states no value-form rows yet"))
     }
 
-    fn fields(&mut self, _cx: &mut Cx<'_>, at: At<'_>, _parts: Parts<'_, Self>) -> Frag<Self> {
-        Err(refuse(at, "JniGen states no product rows yet"))
+    fn fields(&mut self, _cx: &mut Cx<'_>, at: At<'_>, parts: Parts<'_, Self>) -> Frag<Self> {
+        if at.crossing.assembly() != Assembly::Construct {
+            return Err(refuse(
+                at,
+                "JniGen states no deconstructing product rows yet",
+            ));
+        }
+        // A `data_class` crosses as its fields, and a field that is itself one
+        // contributes its own several — which is the recursion, stated once
+        // here rather than walked by hand.
+        let mut wires: Vec<Wire> = Vec::new();
+        for (part, frag) in parts {
+            match &frag.wires {
+                Some(inner) => wires.extend(inner.iter().map(|w| Wire {
+                    ty: w.ty.clone(),
+                    path: format!("{}.{}", part.name, w.path),
+                })),
+                None => wires.push(Wire {
+                    ty: frag.conv.destination.clone(),
+                    path: part.name.clone(),
+                }),
+            }
+        }
+        // Only the wire list is composed here. The conversion that reads these
+        // several values and rebuilds the struct is what the emitter switch
+        // brings; until then this row is compiled but never taken, so it
+        // carries a marker rather than a conversion it would have to invent.
+        // `prebindgen-c` does the same for a union arm, and for the same
+        // reason: a product's parts do not always assemble into a function of
+        // their own.
+        let mut frag = JFrag::new(
+            at,
+            ConverterImpl {
+                destination: syn::parse_quote!(()),
+                function: syn::parse_quote!(
+                    #[allow(dead_code)]
+                    fn __jni_parts() {}
+                ),
+                pre_stages: Vec::new(),
+                niches: Niches::empty(),
+                metadata: KotlinMeta::default(),
+                subs: parts.iter().map(|(p, _)| p.ty.key()).collect(),
+            },
+        );
+        frag.wires = Some(wires);
+        Ok(frag)
     }
 
     fn choice(

--- a/prebindgen-jni/src/jni/compile.rs
+++ b/prebindgen-jni/src/jni/compile.rs
@@ -1197,85 +1197,28 @@ impl<R: Conversions> JCompile<'_, R> {
         frag
     }
 
-    /// The values a `data_class` hands out: its fields, and a field that is
-    /// itself one contributes its own.
+    /// The values a `data_class` hands out, composed by
+    /// [`Declarations::struct_out_wires`].
     ///
-    /// A fragment with **no** out-wires is this adapter declining, and it
-    /// declines for the whole value rather than per field. A handle, an
-    /// `enum_class`, a sum or a `data_class` behind an `Option` or a `Vec` is
-    /// delivered with a transform the decoupled form does not carry, and one
-    /// such field sends the whole object down the whole-value `fromParts` path
-    /// — so a row that decomposed the rest of it would describe a shape nothing
-    /// emits.
+    /// The part fragments are not read. Whether a field nests is the model's
+    /// answer and the declaration's, which is what lets the same composition
+    /// run before `resolve` — see that method for why that matters.
     fn out_product(&self, at: At<'_>, parts: Parts<'_, Self>) -> JFrag {
-        let declined = JFrag::new(at, self.parts_marker(Vec::new()));
-        let mut wires = Vec::new();
-        for (part, frag) in parts {
-            let Some(field) = part_field(part) else {
-                return declined;
-            };
-            let ident = match &field.name {
-                Some(name) => name.clone(),
-                None => return declined,
-            };
-            // The same name the leaf synthesis gives it: the Kotlin property,
-            // and nested names joined by the reserved `__` separator.
-            let name =
-                crate::jni::mangle_kotlin_ident(&crate::jni::kt_snake_to_camel(&ident.to_string()));
-            // The layer questions off the field's own reading — `Optional` to
-            // look through, `Vec` to decline — never a last path segment.
-            let probe = part.ty.optional_inner().unwrap_or(&part.ty);
-            if matches!(
-                self.decls.type_kind(self.registry, &probe.key()),
-                crate::jni::classify::TypeKind::Handle
-                    | crate::jni::classify::TypeKind::Enum
-                    | crate::jni::classify::TypeKind::Sum
-            ) {
-                return declined;
+        match self
+            .decls
+            .struct_out_wires(self.registry, at.crossing.value())
+        {
+            Some(wires) => {
+                let mut frag = JFrag::new(
+                    at,
+                    self.parts_marker(parts.iter().map(|(p, _)| p.ty.key()).collect()),
+                );
+                frag.out_wires = Some(wires);
+                frag.composed_only = true;
+                frag
             }
-            match &frag.out_wires {
-                // A nested `data_class`, which contributes its own values under
-                // this field's name and chain. Only unwrapped: behind an
-                // `Option` or a `Vec` there is no chain to reach through.
-                Some(inner) => {
-                    if part.ty.optional_inner().is_some()
-                        || matches!(part.ty.kind(), TypeKind::Vec(_))
-                    {
-                        return declined;
-                    }
-                    for w in inner {
-                        let OutFrom::Field { path } = &w.from else {
-                            return declined;
-                        };
-                        wires.push(OutWire {
-                            name: format!("{name}__{}", w.name),
-                            out_ty: w.out_ty.clone(),
-                            group: None,
-                            from: OutFrom::Field {
-                                path: std::iter::once(ident.clone())
-                                    .chain(path.iter().cloned())
-                                    .collect(),
-                            },
-                            nullable: false,
-                        });
-                    }
-                }
-                None => wires.push(OutWire {
-                    name,
-                    out_ty: part.ty.clone(),
-                    group: None,
-                    from: OutFrom::Field { path: vec![ident] },
-                    nullable: false,
-                }),
-            }
+            None => JFrag::new(at, self.parts_marker(Vec::new())),
         }
-        let mut frag = JFrag::new(
-            at,
-            self.parts_marker(parts.iter().map(|(p, _)| p.ty.key()).collect()),
-        );
-        frag.out_wires = Some(wires);
-        frag.composed_only = true;
-        frag
     }
 
     /// The values a **value form** hands out: call the accessor once, then read
@@ -1556,6 +1499,123 @@ impl<R: Conversions> JCompile<'_, R> {
 }
 
 impl Declarations {
+    /// The values a `data_class` hands out: its fields, and a field that is
+    /// itself one contributes its own under the parent's name and chain.
+    ///
+    /// Model and declaration only, like [`Self::sum_out_wires`] — so the same
+    /// answer serves the leaf synthesis that runs before `resolve` and the row
+    /// that composes after it.
+    ///
+    /// `None` is this adapter declining, and it declines for the **whole**
+    /// value rather than per field. A handle, an `enum_class`, a sum, or a
+    /// `data_class` behind an `Option` or a `Vec` is delivered with a transform
+    /// the decoupled form does not carry, and one such field sends the whole
+    /// object down the whole-value `fromParts` path — so a row that decomposed
+    /// the rest of it would describe a shape nothing emits.
+    pub(crate) fn struct_out_wires(
+        &self,
+        registry: &impl Conversions,
+        ty: &TypeRef,
+    ) -> Option<Vec<OutWire>> {
+        let TypeKind::Named { id, .. } = ty.unwrapped().kind() else {
+            return None;
+        };
+        self.struct_out_wires_at(registry, &id.ident()?, &[], "", 0)
+    }
+
+    /// One level of [`Self::struct_out_wires`]'s walk. `path` and `name_prefix`
+    /// accumulate through inlined nested classes, whose names join with the
+    /// reserved `__` separator.
+    /// [`Self::struct_out_wires`] by the struct's own name, for a caller that
+    /// has the element rather than a reading of it.
+    pub(crate) fn struct_out_wires_of(
+        &self,
+        registry: &impl Conversions,
+        ident: &syn::Ident,
+    ) -> Option<Vec<OutWire>> {
+        self.struct_out_wires_at(registry, ident, &[], "", 0)
+    }
+
+    fn struct_out_wires_at(
+        &self,
+        registry: &impl Conversions,
+        ident: &syn::Ident,
+        path: &[syn::Ident],
+        name_prefix: &str,
+        depth: usize,
+    ) -> Option<Vec<OutWire>> {
+        if depth > 16 {
+            return None;
+        }
+        let prebindgen_registry::flat::Type::Struct(st) = registry.flat().declared_type(ident)?
+        else {
+            return None;
+        };
+        let mut wires = Vec::new();
+        for field in &st.fields {
+            // Named by construction — a tuple struct is an `Extern`, not a
+            // `Struct` — so a positional field means the model and this walk
+            // disagree, and declining is the safe answer.
+            let fname = field.name.as_ref()?;
+            let name =
+                crate::jni::mangle_kotlin_ident(&crate::jni::kt_snake_to_camel(&fname.to_string()));
+            let name = match name_prefix.is_empty() {
+                true => name,
+                false => format!("{name_prefix}__{name}"),
+            };
+            let mut field_path = path.to_vec();
+            field_path.push(fname.clone());
+
+            // The layer questions off the field's own reading — `Optional` to
+            // look through, `Vec` to decline — never a last path segment.
+            let probe = field.ty.optional_inner().unwrap_or(&field.ty);
+            match self.type_kind(registry, &probe.key()) {
+                crate::jni::classify::TypeKind::Handle
+                | crate::jni::classify::TypeKind::Enum
+                | crate::jni::classify::TypeKind::Sum => return None,
+                // A nested `data_class` inlines when it is reached directly.
+                // Behind an `Option` or a `Vec` there is no chain to reach
+                // through, so the whole value stays object-shaped.
+                crate::jni::classify::TypeKind::DataStruct {
+                    st: _,
+                    cfg: Some(_),
+                } => {
+                    if field.ty.optional_inner().is_some()
+                        || matches!(field.ty.kind(), TypeKind::Vec(_))
+                    {
+                        return None;
+                    }
+                    let child = match probe.unwrapped().kind() {
+                        TypeKind::Named { id, .. } => id.ident()?,
+                        _ => return None,
+                    };
+                    wires.extend(self.struct_out_wires_at(
+                        registry,
+                        &child,
+                        &field_path,
+                        &name,
+                        depth + 1,
+                    )?);
+                    continue;
+                }
+                _ => {}
+            }
+
+            // A simple value: the field's own output conversion encodes it, and
+            // the foreign `fromParts` forwards it verbatim. Nullability rides
+            // that conversion — `Option<Box<String>>` is a `String?` — so the
+            // value itself is not path-nullable.
+            wires.push(OutWire {
+                name,
+                out_ty: field.ty.clone(),
+                group: None,
+                from: OutFrom::Field { path: field_path },
+                nullable: false,
+            });
+        }
+        Some(wires)
+    }
+
     /// The values a `sealed_class` hands out: the selector, then one group of
     /// slots per alternative, laid beside the others.
     ///

--- a/prebindgen-jni/src/jni/compile.rs
+++ b/prebindgen-jni/src/jni/compile.rs
@@ -81,6 +81,24 @@ pub(crate) struct Wire {
     /// Whether that handle access can be null — the field is optional, or an
     /// optional ancestor gates it.
     pub(crate) handle_nullable: bool,
+    /// Whether the conversion carries Rust-side stages beyond its wire-facing
+    /// function — a `convert!` with a semantic step, say `jlong -> u64 ->
+    /// Duration`.
+    ///
+    /// Read where a caller may only call the wire-facing function and would
+    /// otherwise bind the representation where the value is wanted: the `Vec`
+    /// build helper declines such an element rather than emit a call that does
+    /// not compile.
+    pub(crate) staged: bool,
+    /// The struct field this value fills or gates, once a product says which.
+    ///
+    /// `None` until then, and permanently `None` for a gate over a whole value:
+    /// such a gate says whether the fields beside it mean anything and fills
+    /// none itself. A gate over a decoupled scalar is the other case — it gates
+    /// exactly one field, and answers with it.
+    pub(crate) field: Option<String>,
+    /// Whether this wire gates a whole value rather than one field.
+    pub(crate) whole_gate: bool,
 }
 
 impl Carrier for JFrag {
@@ -291,6 +309,17 @@ impl<R: Conversions> Compile for JCompile<'_, R> {
         // a niche in any one of them — which of `(tag, summary)` would carry
         // the absence? So the presence is its own wire, ahead of the rest: the
         // `hMaybePresent` in `(hMaybePresent, hMaybeId)`.
+        // A nullable primitive or enum with no niche keeps the
+        // allocation-free `(present, value)` pair rather than boxing: the gate
+        // is read on the Rust side and the slot carries the raw value. The
+        // value crosses through the INNER's conversion, not the optional's —
+        // there is no boxed `Option` on this wire to decode.
+        if at.crossing.assembly() == Assembly::Construct && inner.wires.is_none() {
+            if let Some(pair) = self.decoupled_optional(at, inner) {
+                frag.wires = Some(pair);
+                return Ok(frag);
+            }
+        }
         if let (Assembly::Construct, Some(inner_wires)) = (at.crossing.assembly(), &inner.wires) {
             let mut wires = vec![Wire {
                 ty: syn::parse_quote!(jni::sys::jboolean),
@@ -301,6 +330,9 @@ impl<R: Conversions> Compile for JCompile<'_, R> {
                 conv: None,
                 handle_target: None,
                 handle_nullable: false,
+                staged: false,
+                field: None,
+                whole_gate: true,
             }];
             // Everything under the gate is reached through it, and a
             // non-nullable slot still has to hold something when the value is
@@ -397,6 +429,15 @@ impl<R: Conversions> Compile for JCompile<'_, R> {
                             .as_ref()
                             .map(|t| format!(".{}{t}", field_kt(part))),
                         handle_nullable: w.handle_nullable,
+                        staged: w.staged,
+                        // A part's wires name their own fields once they are
+                        // inside a product; what a decoupled optional left
+                        // open, the part it belongs to closes.
+                        field: w
+                            .field
+                            .clone()
+                            .or_else(|| (!w.whole_gate).then(|| part.name.clone())),
+                        whole_gate: w.whole_gate,
                     }
                 })),
                 // A part whose conversion projects a handle crosses as that
@@ -410,6 +451,9 @@ impl<R: Conversions> Compile for JCompile<'_, R> {
                     conv: None,
                     handle_target: Some(format!(".{}", field_kt(part))),
                     handle_nullable: part.ty.optional_inner().is_some(),
+                    staged: false,
+                    field: Some(part.name.clone()),
+                    whole_gate: false,
                 }),
                 None => wires.push(Wire {
                     ty: frag.conv.destination.clone(),
@@ -419,6 +463,9 @@ impl<R: Conversions> Compile for JCompile<'_, R> {
                     conv: Some(frag.conv.function.sig.ident.clone()),
                     handle_target: None,
                     handle_nullable: false,
+                    staged: !frag.conv.pre_stages.is_empty(),
+                    field: Some(part.name.clone()),
+                    whole_gate: false,
                 }),
             }
         }
@@ -519,6 +566,77 @@ impl std::ops::Deref for Conv {
 
     fn deref(&self) -> &Self::Target {
         &self.0.conv
+    }
+}
+
+/// Facts a wire states about itself, which the emitters read once they take
+/// the `parts` row. Only the equivalence check calls them until then.
+#[cfg(test)]
+impl Wire {
+    /// The struct field this value fills, which the Rust-side rebuild binds by
+    /// name.
+    ///
+    /// The last segment of the path, because a path **is** the chain of fields
+    /// that reached the value.
+    ///
+    /// The struct field this value fills or gates.
+    pub(crate) fn field(&self) -> Option<&str> {
+        self.field.as_deref()
+    }
+}
+
+impl<R: Conversions> JCompile<'_, R> {
+    /// The `(present, value)` pair a nullable primitive or enum crosses as, or
+    /// `None` if this optional boxes instead.
+    ///
+    /// The conditions are the ones the walk applies: the inner is not a borrow,
+    /// its wire is a JNI primitive, and it has nothing that would already carry
+    /// the absence — no carved niche, no projection, no Rust-side stages.
+    fn decoupled_optional(&self, at: At<'_>, inner: &JFrag) -> Option<Vec<Wire>> {
+        let inner_reading = at.crossing.value().optional_inner()?;
+        if inner_reading.borrow_target().is_some() {
+            return None;
+        }
+        let c = &inner.conv;
+        let prim = crate::jni::JniPrim::from_wire(&c.destination)?;
+        if c.niches.clone().carve().is_some()
+            || c.metadata.projection.is_some()
+            || !c.pre_stages.is_empty()
+        {
+            return None;
+        }
+        // A Kotlin enum's slot is its `value`, reached through the same gate.
+        let value_access = if self.decls.is_kotlin_enum_reading(inner_reading) {
+            format!("?.value ?: {}", prim.kotlin_zero())
+        } else {
+            format!(" ?: {}", prim.kotlin_zero())
+        };
+        Some(vec![
+            Wire {
+                ty: syn::parse_quote!(jni::sys::jboolean),
+                kt_ty: "Boolean".to_string(),
+                path: "present".to_string(),
+                access: " != null".to_string(),
+                conv: None,
+                handle_target: None,
+                handle_nullable: false,
+                staged: false,
+                field: None,
+                whole_gate: false,
+            },
+            Wire {
+                ty: c.destination.clone(),
+                kt_ty: crate::jni::emit::wire_kotlin_type(c),
+                path: "value".to_string(),
+                access: value_access,
+                conv: Some(c.function.sig.ident.clone()),
+                handle_target: None,
+                handle_nullable: false,
+                staged: false,
+                field: None,
+                whole_gate: false,
+            },
+        ])
     }
 }
 

--- a/prebindgen-jni/src/jni/emit/callback.rs
+++ b/prebindgen-jni/src/jni/emit/callback.rs
@@ -85,7 +85,7 @@ pub(crate) fn callback_input(
             // Every leaf converter must already be resolved (deferral safety).
             // A synthesized leaf (a sum's tag) has no converter to wait for.
             for leaf in plan.leaves.iter().filter(|l| l.has_converter()) {
-                registry.output_entry(&leaf.out_ty)?;
+                ext.out_frag(&leaf.out_ty)?;
             }
             let spec = folder_iface_for_plan(ext, registry, plan)?;
             let holder_slash =
@@ -182,7 +182,7 @@ pub(crate) fn callback_input(
             // would make the trampoline wait forever on an `i32` crossing the
             // binding may not have.
             for leaf in plan.leaves.iter().filter(|l| l.has_converter()) {
-                let e = registry.output_entry(&leaf.out_ty)?;
+                let e = ext.out_frag(&leaf.out_ty)?;
                 if leaf.identity && e.metadata.projection.is_none() {
                     return None;
                 }
@@ -212,7 +212,7 @@ pub(crate) fn callback_input(
         // converter and clone the borrow (the callback only borrows the value). The
         // `data_class` converter composes the whole object via `fromParts`, so the
         // Kotlin `run(t: T)` receives a ready-made `T`.
-        let (cb_val, arg_entry) = match registry.output_entry(arg_ty) {
+        let (cb_val, arg_entry) = match ext.out_frag(arg_ty) {
             Some(e) => (quote!(#cb_arg), e),
             // A borrow: the callback hands out a reference, and the value is
             // cloned for the JVM.
@@ -237,7 +237,7 @@ pub(crate) fn callback_input(
             // `Box<&ZThing>`, and added a classification that never fires.
             None => {
                 let core = arg_ty.borrow_target()?;
-                (quote!((#cb_arg).clone()), registry.output_entry(core)?)
+                (quote!((#cb_arg).clone()), ext.out_frag(core)?)
             }
         };
         let arg_wire = arg_entry.destination.clone();

--- a/prebindgen-jni/src/jni/emit/callback.rs
+++ b/prebindgen-jni/src/jni/emit/callback.rs
@@ -129,7 +129,7 @@ pub(crate) fn callback_input(
             let (leaf_stmts, leaf_args) = encode_plan_leaves(
                 ext,
                 registry,
-                plan,
+                crate::jni::emit::Delivered::of(plan),
                 &obj_idents,
                 &quote!(__cb_elem),
                 &fail,
@@ -193,7 +193,7 @@ pub(crate) fn callback_input(
             let (stmts, arg_exprs) = encode_plan_leaves(
                 ext,
                 registry,
-                plan,
+                crate::jni::emit::Delivered::of(plan),
                 &obj_idents,
                 &quote!(#cb_arg),
                 &fail,

--- a/prebindgen-jni/src/jni/emit/callback.rs
+++ b/prebindgen-jni/src/jni/emit/callback.rs
@@ -23,7 +23,7 @@ use super::*;
 pub(crate) fn callback_input(
     ext: &Declarations,
     args: &[prebindgen_registry::flat::TypeRef],
-    registry: &impl Conversions<KotlinMeta>,
+    registry: &impl Conversions,
     emit: &prebindgen_registry::Emit,
 ) -> Option<(syn::Type, syn::Expr)> {
     // Human-readable tag for attach/log messages.

--- a/prebindgen-jni/src/jni/emit/convert.rs
+++ b/prebindgen-jni/src/jni/emit/convert.rs
@@ -247,13 +247,13 @@ pub(crate) fn composed_inner_output(
 /// fails and the resolver falls through to other rank-1 attempts.
 pub(crate) fn option_input(
     t1: &prebindgen_registry::flat::TypeRef,
-    registry: &impl Conversions<KotlinMeta>,
+    ext: &Declarations,
     emit: &prebindgen_registry::Emit,
 ) -> Option<(syn::Type, syn::Expr, Niches)> {
-    let inner_entry = registry.input_entry(t1)?;
+    let inner_entry = ext.in_frag(t1)?;
     let t1_spelled = emit.spell(t1);
     let inner_wire = inner_entry.destination.clone();
-    let inner_decode = composed_inner_input(&inner_entry.as_converter(), quote!(v));
+    let inner_decode = composed_inner_input(&inner_entry, quote!(v));
 
     // 1. Niche path.
     if let Some((slot, rest)) = inner_entry.niches.clone().carve() {
@@ -288,7 +288,7 @@ pub(crate) fn option_input(
         let unbox_sig = jni_unbox_sig(&inner_wire);
         let getter = jni_unbox_getter(&inner_wire);
         let getter_id = format_ident!("{}", getter);
-        let inner_decode = composed_inner_input(&inner_entry.as_converter(), quote!(&__unboxed));
+        let inner_decode = composed_inner_input(&inner_entry, quote!(&__unboxed));
         let body: syn::Expr = syn::parse_quote!({
             if !v.is_null() {
                 let __unboxed: #inner_wire = env
@@ -315,11 +315,11 @@ pub(crate) fn option_input(
 /// Build `Option<T>`'s output converter — symmetric to [`option_input`].
 pub(crate) fn option_output(
     t1: &prebindgen_registry::flat::TypeRef,
-    registry: &impl Conversions<KotlinMeta>,
+    ext: &Declarations,
 ) -> Option<(syn::Type, syn::Expr, Niches)> {
-    let inner_entry = registry.output_entry(t1)?;
+    let inner_entry = ext.out_frag(t1)?;
     let inner_wire = inner_entry.destination.clone();
-    let inner_encode = composed_inner_output(&inner_entry.as_converter(), quote!(value));
+    let inner_encode = composed_inner_output(&inner_entry, quote!(value));
 
     // 1. Niche path.
     if let Some((slot, rest)) = inner_entry.niches.clone().carve() {
@@ -335,7 +335,7 @@ pub(crate) fn option_output(
 
     // 2. Boxed-primitive fallback (cached box class + `valueOf` method ID).
     if let Some(helper) = box_helper_for_wire(&inner_wire) {
-        let inner_encode = composed_inner_output(&inner_entry.as_converter(), quote!(value));
+        let inner_encode = composed_inner_output(&inner_entry, quote!(value));
         let body: syn::Expr = syn::parse_quote!({
             match v {
                 Some(value) => {
@@ -479,15 +479,12 @@ pub(crate) fn enum_output_body(
 pub(crate) fn nullable_kind_for(
     outer_wire: &syn::Type,
     inner_ty: &prebindgen_registry::flat::TypeRef,
-    registry: &impl Conversions<KotlinMeta>,
+    ext: &Declarations,
 ) -> NullableKind {
-    let inner_dest = registry
-        .input_entry(inner_ty)
-        .map(|e| e.destination.clone())
-        .expect(
-            "nullable_kind_for: Option<_> input handler reached here only after option_input \
+    let inner_dest = ext.in_frag(inner_ty).map(|e| e.destination.clone()).expect(
+        "nullable_kind_for: Option<_> input handler reached here only after option_input \
              returned Some, so the inner's input entry must exist",
-        );
+    );
     if outer_wire == &inner_dest {
         NullableKind::Niche
     } else {
@@ -498,10 +495,10 @@ pub(crate) fn nullable_kind_for(
 pub(crate) fn nullable_kind_for_output(
     outer_wire: &syn::Type,
     inner_ty: &prebindgen_registry::flat::TypeRef,
-    registry: &impl Conversions<KotlinMeta>,
+    ext: &Declarations,
 ) -> NullableKind {
-    let inner_dest = registry
-        .output_entry(inner_ty)
+    let inner_dest = ext
+        .out_frag(inner_ty)
         .map(|e| e.destination.clone())
         .expect(
             "nullable_kind_for_output: Option<_> output handler reached here only after \

--- a/prebindgen-jni/src/jni/emit/convert.rs
+++ b/prebindgen-jni/src/jni/emit/convert.rs
@@ -410,7 +410,7 @@ pub(crate) fn default_niches_for_wire(wire: &syn::Type) -> Niches {
 /// `use` statements. Pairs with output body below.
 pub(crate) fn enum_input_body(
     ext: &Declarations,
-    registry: &impl Conversions<KotlinMeta>,
+    registry: &impl Conversions,
     e: &prebindgen_registry::flat::Enum,
 ) -> (syn::Type, syn::Expr) {
     let ident = &e.name;

--- a/prebindgen-jni/src/jni/emit/convert.rs
+++ b/prebindgen-jni/src/jni/emit/convert.rs
@@ -1,6 +1,6 @@
 //! Scalar / `Option` / enum converter bodies and their wire probes.
 
-use prebindgen_registry::{Conversions, TypeEntry};
+use prebindgen_registry::Conversions;
 
 use super::*;
 
@@ -169,11 +169,14 @@ pub(crate) fn primitive_output(key: &TypeKey) -> Option<(syn::Type, syn::Expr)> 
 
 /// Invoke an inner input converter's complete `wire -> Rust` chain.
 ///
-/// Structural wrappers cannot call only [`TypeEntry::function`]: custom
+/// Structural wrappers cannot call only [`ConverterImpl::function`]: custom
 /// conversions may carry semantic steps in `pre_stages` (for example
 /// `jlong -> u64 -> Duration`). Keep those steps inside the `Some` arm so a
 /// niche discriminator is tested before any conversion runs.
-pub(crate) fn composed_inner_input(inner: &TypeEntry<KotlinMeta>, wire: TokenStream) -> syn::Expr {
+pub(crate) fn composed_inner_input(
+    inner: &ConverterImpl<KotlinMeta>,
+    wire: TokenStream,
+) -> syn::Expr {
     let converter = inner.converter_ident();
     if inner.pre_stages.is_empty() {
         return syn::parse2(quote!(#converter(env, #wire)?))
@@ -199,7 +202,7 @@ pub(crate) fn composed_inner_input(inner: &TypeEntry<KotlinMeta>, wire: TokenStr
 /// Invoke an inner output converter's complete `Rust -> wire` chain.
 /// Mirror of [`composed_inner_input`].
 pub(crate) fn composed_inner_output(
-    inner: &TypeEntry<KotlinMeta>,
+    inner: &ConverterImpl<KotlinMeta>,
     value: TokenStream,
 ) -> syn::Expr {
     let converter = inner.converter_ident();
@@ -250,7 +253,7 @@ pub(crate) fn option_input(
     let inner_entry = registry.input_entry(t1)?;
     let t1_spelled = emit.spell(t1);
     let inner_wire = inner_entry.destination.clone();
-    let inner_decode = composed_inner_input(inner_entry, quote!(v));
+    let inner_decode = composed_inner_input(&inner_entry.as_converter(), quote!(v));
 
     // 1. Niche path.
     if let Some((slot, rest)) = inner_entry.niches.clone().carve() {
@@ -285,7 +288,7 @@ pub(crate) fn option_input(
         let unbox_sig = jni_unbox_sig(&inner_wire);
         let getter = jni_unbox_getter(&inner_wire);
         let getter_id = format_ident!("{}", getter);
-        let inner_decode = composed_inner_input(inner_entry, quote!(&__unboxed));
+        let inner_decode = composed_inner_input(&inner_entry.as_converter(), quote!(&__unboxed));
         let body: syn::Expr = syn::parse_quote!({
             if !v.is_null() {
                 let __unboxed: #inner_wire = env
@@ -316,7 +319,7 @@ pub(crate) fn option_output(
 ) -> Option<(syn::Type, syn::Expr, Niches)> {
     let inner_entry = registry.output_entry(t1)?;
     let inner_wire = inner_entry.destination.clone();
-    let inner_encode = composed_inner_output(inner_entry, quote!(value));
+    let inner_encode = composed_inner_output(&inner_entry.as_converter(), quote!(value));
 
     // 1. Niche path.
     if let Some((slot, rest)) = inner_entry.niches.clone().carve() {
@@ -332,7 +335,7 @@ pub(crate) fn option_output(
 
     // 2. Boxed-primitive fallback (cached box class + `valueOf` method ID).
     if let Some(helper) = box_helper_for_wire(&inner_wire) {
-        let inner_encode = composed_inner_output(inner_entry, quote!(value));
+        let inner_encode = composed_inner_output(&inner_entry.as_converter(), quote!(value));
         let body: syn::Expr = syn::parse_quote!({
             match v {
                 Some(value) => {

--- a/prebindgen-jni/src/jni/emit/delivery.rs
+++ b/prebindgen-jni/src/jni/emit/delivery.rs
@@ -32,7 +32,7 @@ use super::*;
 /// [`UnfoldShape::Optional`]: prebindgen_registry::unfold::UnfoldShape::Optional
 pub(crate) fn emit_unfold_delivery(
     ext: &Declarations,
-    registry: &Registry<KotlinMeta>,
+    registry: &Registry,
     plan: &prebindgen_registry::unfold::UnfoldPlan,
     iface: Option<&IfaceSpec>,
     call_expr: &TokenStream,
@@ -859,7 +859,7 @@ fn reach_leaf(
 /// `signal_error` with default ze values).
 pub(crate) fn encode_plan_leaves(
     ext: &Declarations,
-    registry: &impl Conversions<KotlinMeta>,
+    registry: &impl Conversions,
     plan: &prebindgen_registry::unfold::UnfoldPlan,
     obj_idents: &[syn::Ident],
     value: &TokenStream,

--- a/prebindgen-jni/src/jni/emit/delivery.rs
+++ b/prebindgen-jni/src/jni/emit/delivery.rs
@@ -447,13 +447,12 @@ fn project_leading_fields(
 /// [`Delivery::Return`]: prebindgen_registry::unfold::Delivery::Return
 pub(crate) fn reach_leaf_flat(
     qualify: &dyn Fn(&syn::Ident) -> syn::Path,
-    leaf: &prebindgen_registry::unfold::UnfoldLeaf,
+    leaf: &crate::jni::compile::OutWire,
     path: &[PathStep],
     base: TokenStream,
     base_is_ref: bool,
     consuming: bool,
 ) -> TokenStream {
-    use prebindgen_registry::unfold::LeafSource;
     // An optional step BEFORE the last one needs a `match` whose `None` arm has
     // somewhere to go. This derivation has none — it yields a plain Rust value,
     // not a `JObject` that could be null — so the shape is refused here rather
@@ -466,8 +465,9 @@ pub(crate) fn reach_leaf_flat(
     // conditional one, which is the case that cannot compose (an `Option<T>`
     // local with a field read hung off it). The full path is what the shape
     // question is about.
+    let own_path = leaf.reach();
     assert!(
-        !leaf.path.iter().rev().skip(1).any(PathStep::is_optional),
+        !own_path.iter().rev().skip(1).any(PathStep::is_optional),
         "jnigen unfold: leaf `{}` reaches through an optional step but is \
          delivered as a single return value, which has no `None` arm — this \
          shape needs callback delivery",
@@ -508,7 +508,7 @@ pub(crate) fn reach_leaf_flat(
     }
     let (e, lead) = project_leading_fields(&base, base_is_ref, path);
     let e = fold_steps(qualify, &path[lead..], e, false);
-    if leaf.source == LeafSource::Field {
+    if leaf.is_field_read() {
         quote!((#e).clone())
     } else {
         e
@@ -1592,7 +1592,15 @@ mod tests {
                 true,
                 LeafSource::Accessor,
             );
-            let got = reach_leaf_flat(&qualify, &l, &path, quote!(__src), false, false).to_string();
+            let got = reach_leaf_flat(
+                &qualify,
+                &crate::jni::compile::OutWire::from_leaf(&l),
+                &path,
+                quote!(__src),
+                false,
+                false,
+            )
+            .to_string();
             assert!(
                 !got.contains('&') && !got.contains("clone"),
                 "a movable place is moved, not borrowed or cloned — got `{got}`"
@@ -1611,7 +1619,15 @@ mod tests {
             true,
             LeafSource::Accessor,
         );
-        let got = reach_leaf_flat(&qualify, &l, &path, quote!(__src), false, false).to_string();
+        let got = reach_leaf_flat(
+            &qualify,
+            &crate::jni::compile::OutWire::from_leaf(&l),
+            &path,
+            quote!(__src),
+            false,
+            false,
+        )
+        .to_string();
         assert!(
             got.contains('&'),
             "a borrowed out_ty keeps its borrow — got `{got}`"
@@ -1635,7 +1651,15 @@ mod tests {
             false,
             LeafSource::Field,
         );
-        let got = reach_leaf_flat(&qualify, &l, &path, quote!(__src), false, false).to_string();
+        let got = reach_leaf_flat(
+            &qualify,
+            &crate::jni::compile::OutWire::from_leaf(&l),
+            &path,
+            quote!(__src),
+            false,
+            false,
+        )
+        .to_string();
         assert!(
             got.contains("clone"),
             "a non-consuming field leaf clones rather than moves — got `{got}`"
@@ -1659,6 +1683,13 @@ mod tests {
         // The suffix a rebase would hand over — the optional call is gone from
         // it, and used to take the guard with it.
         let rest = vec![PathStep::field(syn::parse_quote!(a), false)];
-        let _ = reach_leaf_flat(&qualify, &l, &rest, quote!(__vf0), false, false);
+        let _ = reach_leaf_flat(
+            &qualify,
+            &crate::jni::compile::OutWire::from_leaf(&l),
+            &rest,
+            quote!(__vf0),
+            false,
+            false,
+        );
     }
 }

--- a/prebindgen-jni/src/jni/emit/delivery.rs
+++ b/prebindgen-jni/src/jni/emit/delivery.rs
@@ -1573,7 +1573,7 @@ mod tests {
                 syn::parse_quote!(Owned),
                 path.clone(),
                 true,
-                LeafSource::Accessor,
+                LeafSource::Reach,
             );
             let got = reach_leaf_flat(
                 &qualify,
@@ -1600,7 +1600,7 @@ mod tests {
             syn::parse_quote!(&Owned),
             path.clone(),
             true,
-            LeafSource::Accessor,
+            LeafSource::Reach,
         );
         let got = reach_leaf_flat(
             &qualify,
@@ -1632,7 +1632,7 @@ mod tests {
             syn::parse_quote!(Owned),
             path.clone(),
             false,
-            LeafSource::Field,
+            LeafSource::Reach,
         );
         let got = reach_leaf_flat(
             &qualify,
@@ -1662,7 +1662,7 @@ mod tests {
             PathStep::call(syn::parse_quote!(get_it), true, false),
             PathStep::field(syn::parse_quote!(a), false),
         ];
-        let l = leaf(syn::parse_quote!(Owned), full, false, LeafSource::Accessor);
+        let l = leaf(syn::parse_quote!(Owned), full, false, LeafSource::Reach);
         // The suffix a rebase would hand over — the optional call is gone from
         // it, and used to take the guard with it.
         let rest = vec![PathStep::field(syn::parse_quote!(a), false)];

--- a/prebindgen-jni/src/jni/emit/delivery.rs
+++ b/prebindgen-jni/src/jni/emit/delivery.rs
@@ -62,7 +62,15 @@ pub(crate) fn emit_unfold_delivery(
     // `__elem`) into `__obj0…__objN` (shared with the callback trampoline),
     // yielding the per-leaf typed jvalue arg expressions.
     let encode_leaves = |value: &TokenStream| -> (TokenStream, Vec<TokenStream>) {
-        encode_plan_leaves(ext, registry, plan, &obj_idents, value, &fail, emit)
+        encode_plan_leaves(
+            ext,
+            registry,
+            Delivered::of(plan),
+            &obj_idents,
+            value,
+            &fail,
+            emit,
+        )
     };
 
     // Cached-interface call statics for the builder / folder `run`.
@@ -515,6 +523,37 @@ pub(crate) fn reach_leaf_flat(
     }
 }
 
+/// One delivery site, as the encoder sees it: what it hands out, and the value
+/// forms it evaluates once on the way.
+///
+/// Not an `UnfoldPlan`. A plan carries the delivery's shape as well — whether
+/// it folds, whether it is optional, what the builder's generic is — and none
+/// of that reaches this encoder, which writes only the statements that fill the
+/// slots. Naming exactly what it reads is what lets the caller assemble one
+/// from a row.
+pub(crate) struct Delivered<'a> {
+    /// The values handed out, in the order the builder receives them.
+    pub(crate) wires: Vec<crate::jni::compile::OutWire>,
+    /// The value forms to evaluate once and bind to a local, outermost first.
+    ///
+    /// Per **site** rather than per value: two values reached through one
+    /// accessor share its call, and that is the whole point of a hoist.
+    pub(crate) hoists: &'a [prebindgen_registry::unfold::Hoist],
+    /// Whether the delivered value is reached through a borrow.
+    pub(crate) by_ref: bool,
+}
+
+impl<'a> Delivered<'a> {
+    /// The site one expansion plan describes.
+    pub(crate) fn of(plan: &'a prebindgen_registry::unfold::UnfoldPlan) -> Self {
+        Self {
+            wires: crate::jni::compile::OutWire::from_leaves(&plan.leaves),
+            hoists: &plan.hoists,
+            by_ref: plan.by_ref,
+        }
+    }
+}
+
 /// Every value form on a plan, evaluated **once** and bound to a local
 /// (`__vf0`, `__vf1`, …), so a struct is built once per delivery rather than
 /// once per field. The bound prefixes come back with the statements, since
@@ -860,21 +899,20 @@ fn reach_leaf(
 pub(crate) fn encode_plan_leaves(
     ext: &Declarations,
     registry: &impl Conversions,
-    plan: &prebindgen_registry::unfold::UnfoldPlan,
+    site: Delivered<'_>,
     obj_idents: &[syn::Ident],
     value: &TokenStream,
     fail: &dyn Fn(TokenStream) -> TokenStream,
     emit: &prebindgen_registry::Emit,
 ) -> (TokenStream, Vec<TokenStream>) {
-    // The values this delivery hands out. Every question below is asked of
-    // these; what stays the plan's is the **hoists** — which value forms to
-    // evaluate once and bind to a local — because that is a property of the
-    // site rather than of any one value.
-    let wires = crate::jni::compile::OutWire::from_leaves(&plan.leaves);
+    let Delivered {
+        wires,
+        hoists,
+        by_ref,
+    } = site;
     // Per-fn origin qualification: each accessor call is prefixed with the
     // module of the crate that defines it (multi-source bindings).
     let qualify = |id: &syn::Ident| -> syn::Path { ext.fn_module(registry, id) };
-    let by_ref = plan.by_ref;
     let n = wires.len();
 
     // Typed `jvalue` argument expression per leaf, in leaf order: a non-null
@@ -892,7 +930,7 @@ pub(crate) fn encode_plan_leaves(
         }
     }
 
-    let hoisted = bind_hoists(&qualify, &plan.hoists, value, by_ref);
+    let hoisted = bind_hoists(&qualify, hoists, value, by_ref);
     let mut stmts = hoisted.stmts.clone();
 
     // Reach a leaf off the innermost value form it sits under, with that
@@ -938,8 +976,7 @@ pub(crate) fn encode_plan_leaves(
     // conditional form may carry a sum field and that segment has to land in
     // the arm too: emitted ahead of it, its `match` would reach a binding the
     // arm has not introduced yet.
-    let mut cond_stmts: std::collections::BTreeMap<usize, TokenStream> = plan
-        .hoists
+    let mut cond_stmts: std::collections::BTreeMap<usize, TokenStream> = hoists
         .iter()
         .enumerate()
         .filter_map(|(i, _)| {

--- a/prebindgen-jni/src/jni/emit/delivery.rs
+++ b/prebindgen-jni/src/jni/emit/delivery.rs
@@ -880,7 +880,7 @@ pub(crate) fn encode_plan_leaves(
     let mut arg_exprs: Vec<TokenStream> = Vec::with_capacity(n);
     for (idx, leaf) in plan.leaves.iter().enumerate() {
         let obj_ident = &obj_idents[idx];
-        if leaf_is_prim(ext, leaf) {
+        if leaf_is_prim(ext, &crate::jni::compile::OutWire::from_leaf(leaf)) {
             arg_exprs.push(quote!(#obj_ident));
         } else {
             arg_exprs.push(quote!(jni::sys::jvalue { l: #obj_ident.as_raw() }));
@@ -1019,7 +1019,10 @@ pub(crate) fn encode_plan_leaves(
         let (group_stmts, group_args) = encode_sum_group(
             ext,
             registry,
-            &plan.leaves[seg.clone()],
+            &plan.leaves[seg.clone()]
+                .iter()
+                .map(crate::jni::compile::OutWire::from_leaf)
+                .collect::<Vec<_>>(),
             &obj_idents[seg.clone()],
             matched,
             fail,
@@ -1031,7 +1034,7 @@ pub(crate) fn encode_plan_leaves(
                 let ids: Vec<&syn::Ident> = obj_idents[seg.clone()].iter().collect();
                 let slots: Vec<Slot> = plan.leaves[seg.clone()]
                     .iter()
-                    .map(|l| leaf_slot(ext, l))
+                    .map(|l| leaf_slot(ext, &crate::jni::compile::OutWire::from_leaf(l)))
                     .collect();
                 let tys = slots.iter().map(|s| &s.ty);
                 let defaults = slots.iter().map(|s| &s.default);
@@ -1404,7 +1407,7 @@ pub(crate) fn encode_plan_leaves(
         // value with the leaf's output converter and casts to JObject.
         let wire = out_entry.destination.clone();
         let enc_ident = format_ident!("__enc{}", idx);
-        if leaf_is_prim(ext, leaf) {
+        if leaf_is_prim(ext, &crate::jni::compile::OutWire::from_leaf(leaf)) {
             let letter = jni_field_access(&wire)
                 .expect("leaf_is_prim guarantees a primitive wire")
                 .1;
@@ -1447,10 +1450,20 @@ pub(crate) fn encode_plan_leaves(
             })
             .collect();
         let ids: Vec<&syn::Ident> = idxs.iter().map(|&k| &obj_idents[k]).collect();
-        let tys = idxs.iter().map(|&k| leaf_slot(ext, &plan.leaves[k]).ty);
-        let defaults = idxs
-            .iter()
-            .map(|&k| leaf_slot(ext, &plan.leaves[k]).default);
+        let tys = idxs.iter().map(|&k| {
+            leaf_slot(
+                ext,
+                &crate::jni::compile::OutWire::from_leaf(&plan.leaves[k]),
+            )
+            .ty
+        });
+        let defaults = idxs.iter().map(|&k| {
+            leaf_slot(
+                ext,
+                &crate::jni::compile::OutWire::from_leaf(&plan.leaves[k]),
+            )
+            .default
+        });
         // Matched BY VALUE: the local is this arm's alone (every leaf under the
         // hoist is in it), so a consuming value form's fields move out here
         // exactly as they do at an unconditional one.
@@ -1469,10 +1482,7 @@ pub(crate) fn encode_plan_leaves(
 /// primitive JNI wire. Must agree with the descriptor chunk
 /// [`crate::jni::iface`] derives for the same leaf — a
 /// nullable primitive boxes (object chunk), object wires pass as objects.
-pub(crate) fn leaf_is_prim(
-    ext: &Declarations,
-    leaf: &prebindgen_registry::unfold::UnfoldLeaf,
-) -> bool {
+pub(crate) fn leaf_is_prim(ext: &Declarations, leaf: &crate::jni::compile::OutWire) -> bool {
     // The synthesized sum selector is a `jint` by definition — it is assigned,
     // never converted, so it has no output entry to read a wire from and must
     // not be made to depend on one resolving.
@@ -1481,7 +1491,7 @@ pub(crate) fn leaf_is_prim(
     // the absent case needs a representation the tag's own variants do not
     // provide. A raw `jint` has none — zero is a real variant — so the selector
     // boxes like any other nullable leaf and JVM null means "no value here".
-    if leaf.source == prebindgen_registry::unfold::LeafSource::SumTag {
+    if leaf.is_tag() {
         return !leaf.nullable;
     }
     if leaf.nullable {

--- a/prebindgen-jni/src/jni/emit/delivery.rs
+++ b/prebindgen-jni/src/jni/emit/delivery.rs
@@ -146,7 +146,7 @@ pub(crate) fn emit_unfold_delivery(
             // declares the matching typed param).
             let out_entry = registry
                 .reading(&element.key())
-                .and_then(|tr| registry.output_entry(&tr))
+                .and_then(|tr| ext.out_frag(&tr))
                 .unwrap_or_else(|| {
                     panic!(
                         "emit_unfold_delivery: Vec element `{}` has no registered output converter",
@@ -1093,7 +1093,7 @@ pub(crate) fn encode_plan_leaves(
         };
         let (value, by_ref, path, consuming) = rebase(leaf);
         let value = &value;
-        let out_entry = registry.output_entry(&leaf.out_ty).unwrap_or_else(|| {
+        let out_entry = ext.out_frag(&leaf.out_ty).unwrap_or_else(|| {
             panic!(
                 "jnigen unfold: leaf `{}` has no registered output converter",
                 leaf.out_ty.key()

--- a/prebindgen-jni/src/jni/emit/delivery.rs
+++ b/prebindgen-jni/src/jni/emit/delivery.rs
@@ -898,16 +898,16 @@ pub(crate) fn encode_plan_leaves(
     // A leaf under a CONDITIONAL value form reaches off the name that form's
     // `Some` arm binds — a borrow of the struct, so nothing moves out of it —
     // and its statements are collected into that arm rather than emitted here.
-    let rebase =
-        |leaf: &prebindgen_registry::unfold::UnfoldLeaf| -> (TokenStream, bool, Vec<PathStep>, bool) {
-            if let Some((i, _, bind, rest)) = hoisted.conditional(&leaf.path) {
-                return (quote!(#bind), false, rest, hoisted.consumed(i));
-            }
-            match hoisted.rebase(&leaf.path) {
-                Some((local, rest, consuming)) => (quote!(#local), false, rest, consuming),
-                None => (value.clone(), by_ref, leaf.path.clone(), false),
-            }
-        };
+    let rebase = |leaf: &crate::jni::compile::OutWire| -> (TokenStream, bool, Vec<PathStep>, bool) {
+        let path = leaf.reach();
+        if let Some((i, _, bind, rest)) = hoisted.conditional(path) {
+            return (quote!(#bind), false, rest, hoisted.consumed(i));
+        }
+        match hoisted.rebase(path) {
+            Some((local, rest, consuming)) => (quote!(#local), false, rest, consuming),
+            None => (value.clone(), by_ref, path.to_vec(), false),
+        }
+    };
 
     // A decomposed **sum** is the one shape whose leaves are not independent:
     // only one group is live per value, so its whole segment — the selector
@@ -915,8 +915,9 @@ pub(crate) fn encode_plan_leaves(
     // instead of per-leaf expressions. A plan may carry several: a sum that IS
     // the returned value is the degenerate case of one segment covering
     // everything, while a value form contributes one per sum-typed field.
+    let wires = crate::jni::compile::OutWire::from_leaves(&plan.leaves);
     let sum_segments: Vec<std::ops::Range<usize>> = (0..n)
-        .filter(|&i| plan.leaves[i].source == prebindgen_registry::unfold::LeafSource::SumTag)
+        .filter(|&i| wires[i].is_tag())
         .map(|start| {
             let end = (start + 1..n)
                 .take_while(|&i| plan.leaves[i].group.is_some())
@@ -946,7 +947,7 @@ pub(crate) fn encode_plan_leaves(
         .collect();
 
     for seg in &sum_segments {
-        let leaf = &plan.leaves[seg.start];
+        let leaf = &wires[seg.start];
         let (base, base_is_ref, path, _) = rebase(leaf);
         // The value to `match` on. The selector's own path reaches the sum
         // (empty when the sum IS the value), and a step on it MAY be optional:
@@ -1066,7 +1067,7 @@ pub(crate) fn encode_plan_leaves(
         };
         // The whole segment — its slot declarations and its `match` — is
         // routed like any other leaf under the same form.
-        match hoisted.conditional(&leaf.path) {
+        match hoisted.conditional(leaf.reach()) {
             Some((i, ..)) => cond_stmts
                 .get_mut(&i)
                 .expect("a conditional leaf's hoist has a bucket")
@@ -1094,7 +1095,8 @@ pub(crate) fn encode_plan_leaves(
             Some((i, ..)) => cond_stmts.get_mut(&i).expect("collected above"),
             None => &mut stmts,
         };
-        let (value, by_ref, path, consuming) = rebase(leaf);
+        let (value, by_ref, path, consuming) =
+            rebase(&crate::jni::compile::OutWire::from_leaf(leaf));
         let value = &value;
         let out_entry = ext.out_frag(&leaf.out_ty).unwrap_or_else(|| {
             panic!(

--- a/prebindgen-jni/src/jni/emit/delivery.rs
+++ b/prebindgen-jni/src/jni/emit/delivery.rs
@@ -866,11 +866,16 @@ pub(crate) fn encode_plan_leaves(
     fail: &dyn Fn(TokenStream) -> TokenStream,
     emit: &prebindgen_registry::Emit,
 ) -> (TokenStream, Vec<TokenStream>) {
+    // The values this delivery hands out. Every question below is asked of
+    // these; what stays the plan's is the **hoists** — which value forms to
+    // evaluate once and bind to a local — because that is a property of the
+    // site rather than of any one value.
+    let wires = crate::jni::compile::OutWire::from_leaves(&plan.leaves);
     // Per-fn origin qualification: each accessor call is prefixed with the
     // module of the crate that defines it (multi-source bindings).
     let qualify = |id: &syn::Ident| -> syn::Path { ext.fn_module(registry, id) };
     let by_ref = plan.by_ref;
-    let n = plan.leaves.len();
+    let n = wires.len();
 
     // Typed `jvalue` argument expression per leaf, in leaf order: a non-null
     // primitive-wire leaf passes its raw primitive (`__objN` IS the jvalue);
@@ -878,9 +883,9 @@ pub(crate) fn encode_plan_leaves(
     // slot. Matches the descriptor [`crate::jni::iface`]
     // derives for the same leaf (primitive chunk vs object chunk).
     let mut arg_exprs: Vec<TokenStream> = Vec::with_capacity(n);
-    for (idx, leaf) in plan.leaves.iter().enumerate() {
+    for (idx, leaf) in wires.iter().enumerate() {
         let obj_ident = &obj_idents[idx];
-        if leaf_is_prim(ext, &crate::jni::compile::OutWire::from_leaf(leaf)) {
+        if leaf_is_prim(ext, leaf) {
             arg_exprs.push(quote!(#obj_ident));
         } else {
             arg_exprs.push(quote!(jni::sys::jvalue { l: #obj_ident.as_raw() }));
@@ -915,12 +920,11 @@ pub(crate) fn encode_plan_leaves(
     // instead of per-leaf expressions. A plan may carry several: a sum that IS
     // the returned value is the degenerate case of one segment covering
     // everything, while a value form contributes one per sum-typed field.
-    let wires = crate::jni::compile::OutWire::from_leaves(&plan.leaves);
     let sum_segments: Vec<std::ops::Range<usize>> = (0..n)
         .filter(|&i| wires[i].is_tag())
         .map(|start| {
             let end = (start + 1..n)
-                .take_while(|&i| plan.leaves[i].group.is_some())
+                .take_while(|&i| wires[i].group.is_some())
                 .last()
                 .map_or(start + 1, |i| i + 1);
             start..end
@@ -939,9 +943,9 @@ pub(crate) fn encode_plan_leaves(
         .iter()
         .enumerate()
         .filter_map(|(i, _)| {
-            plan.leaves
+            wires
                 .iter()
-                .any(|l| hoisted.conditional(&l.path).is_some_and(|(j, ..)| j == i))
+                .any(|w| hoisted.conditional(w.reach()).is_some_and(|(j, ..)| j == i))
                 .then_some((i, TokenStream::new()))
         })
         .collect();
@@ -1020,10 +1024,7 @@ pub(crate) fn encode_plan_leaves(
         let (group_stmts, group_args) = encode_sum_group(
             ext,
             registry,
-            &plan.leaves[seg.clone()]
-                .iter()
-                .map(crate::jni::compile::OutWire::from_leaf)
-                .collect::<Vec<_>>(),
+            &wires[seg.clone()],
             &obj_idents[seg.clone()],
             matched,
             fail,
@@ -1033,9 +1034,9 @@ pub(crate) fn encode_plan_leaves(
             None => group_stmts,
             Some((k, opt_e, bind)) => {
                 let ids: Vec<&syn::Ident> = obj_idents[seg.clone()].iter().collect();
-                let slots: Vec<Slot> = plan.leaves[seg.clone()]
+                let slots: Vec<Slot> = wires[seg.clone()]
                     .iter()
-                    .map(|l| leaf_slot(ext, &crate::jni::compile::OutWire::from_leaf(l)))
+                    .map(|l| leaf_slot(ext, l))
                     .collect();
                 let tys = slots.iter().map(|s| &s.ty);
                 let defaults = slots.iter().map(|s| &s.default);
@@ -1081,22 +1082,21 @@ pub(crate) fn encode_plan_leaves(
 
     let in_sum = |i: usize| sum_segments.iter().any(|s| s.contains(&i));
     let mut order: Vec<usize> = (0..n)
-        .filter(|&i| !plan.leaves[i].identity && !in_sum(i))
+        .filter(|&i| !wires[i].identity && !in_sum(i))
         .collect();
-    order.extend((0..n).filter(|&i| plan.leaves[i].identity && !in_sum(i)));
+    order.extend((0..n).filter(|&i| wires[i].identity && !in_sum(i)));
 
     for idx in order {
-        let leaf = &plan.leaves[idx];
+        let leaf = &wires[idx];
         let obj_ident = &obj_idents[idx];
         // Route this leaf's statements: into its conditional arm, or straight
         // out. Shadows `stmts` for the rest of the body, so every `extend`
         // below lands in the right place without knowing which case it is in.
-        let stmts: &mut TokenStream = match hoisted.conditional(&leaf.path) {
+        let stmts: &mut TokenStream = match hoisted.conditional(leaf.reach()) {
             Some((i, ..)) => cond_stmts.get_mut(&i).expect("collected above"),
             None => &mut stmts,
         };
-        let (value, by_ref, path, consuming) =
-            rebase(&crate::jni::compile::OutWire::from_leaf(leaf));
+        let (value, by_ref, path, consuming) = rebase(leaf);
         let value = &value;
         let out_entry = ext.out_frag(&leaf.out_ty).unwrap_or_else(|| {
             panic!(
@@ -1357,25 +1357,25 @@ pub(crate) fn encode_plan_leaves(
         // String, …) carries any nullability, so there is no path `Option` to
         // unwrap. `reach(body)` dispatches on the source and feeds the reached
         // Rust expression to `body`.
-        use prebindgen_registry::unfold::LeafSource;
+        //
+        // Which of the two it is, asked of the wire: a field read ends its
+        // reach in a field step, an accessor's ends at the call. That is what
+        // `LeafSource` said, and saying it off the reach keeps one answer.
         let reach = |body: &dyn Fn(TokenStream) -> TokenStream| -> TokenStream {
-            match &leaf.source {
-                LeafSource::Accessor => {
-                    reach_leaf(&qualify, &path, value.clone(), by_ref, false, 0, body)
-                }
+            match leaf.is_field_read() {
+                false => reach_leaf(&qualify, &path, value.clone(), by_ref, false, 0, body),
                 // Under a CONSUMING value form the leaf owns its field, so it
                 // is **moved** out; the whole point of consuming is that this
                 // clone disappears. Each field is read by exactly one leaf, so
                 // the partial moves are disjoint — but nothing may then borrow
                 // the local as a whole, which is why the reach below projects
                 // the field directly rather than through `&(&local)`.
-                LeafSource::Field if consuming && path.iter().all(PathStep::is_plain_field) => {
+                true if path.iter().all(PathStep::is_plain_field) => {
                     let segs: Vec<&syn::Ident> = path.iter().map(PathStep::ident).collect();
-                    body(quote!(#value #(.#segs)*))
-                }
-                LeafSource::Field if path.iter().all(PathStep::is_plain_field) => {
-                    let segs: Vec<&syn::Ident> = path.iter().map(PathStep::ident).collect();
-                    body(quote!(#value #(.#segs)*.clone()))
+                    match consuming {
+                        true => body(quote!(#value #(.#segs)*)),
+                        false => body(quote!(#value #(.#segs)*.clone())),
+                    }
                 }
                 // A `.fields()` leaf reaches its field through the value-form
                 // accessor, so the path can be mixed: compose it like an
@@ -1383,7 +1383,7 @@ pub(crate) fn encode_plan_leaves(
                 // converter takes the field type as written (`Option` and all)
                 // — and clone the reached borrow, which is what a field leaf
                 // delivers.
-                LeafSource::Field => reach_leaf(
+                true => reach_leaf(
                     &qualify,
                     &path,
                     value.clone(),
@@ -1391,13 +1391,6 @@ pub(crate) fn encode_plan_leaves(
                     false,
                     0,
                     &|reached| body(quote!((#reached).clone())),
-                ),
-                // Group leaves never reach this walk: a plan carrying them is
-                // routed to `encode_sum_leaves` at the top of this function,
-                // because a variant payload has no path — it is bound by a
-                // `match` arm.
-                LeafSource::SumTag | LeafSource::VariantField { .. } => unreachable!(
-                    "sum leaves are encoded by `encode_sum_leaves`, not reached by path"
                 ),
             }
         };
@@ -1409,7 +1402,7 @@ pub(crate) fn encode_plan_leaves(
         // value with the leaf's output converter and casts to JObject.
         let wire = out_entry.destination.clone();
         let enc_ident = format_ident!("__enc{}", idx);
-        if leaf_is_prim(ext, &crate::jni::compile::OutWire::from_leaf(leaf)) {
+        if leaf_is_prim(ext, leaf) {
             let letter = jni_field_access(&wire)
                 .expect("leaf_is_prim guarantees a primitive wire")
                 .1;
@@ -1447,25 +1440,13 @@ pub(crate) fn encode_plan_leaves(
         let idxs: Vec<usize> = (0..n)
             .filter(|&k| {
                 hoisted
-                    .conditional(&plan.leaves[k].path)
+                    .conditional(wires[k].reach())
                     .is_some_and(|(j, ..)| j == i)
             })
             .collect();
         let ids: Vec<&syn::Ident> = idxs.iter().map(|&k| &obj_idents[k]).collect();
-        let tys = idxs.iter().map(|&k| {
-            leaf_slot(
-                ext,
-                &crate::jni::compile::OutWire::from_leaf(&plan.leaves[k]),
-            )
-            .ty
-        });
-        let defaults = idxs.iter().map(|&k| {
-            leaf_slot(
-                ext,
-                &crate::jni::compile::OutWire::from_leaf(&plan.leaves[k]),
-            )
-            .default
-        });
+        let tys = idxs.iter().map(|&k| leaf_slot(ext, &wires[k]).ty);
+        let defaults = idxs.iter().map(|&k| leaf_slot(ext, &wires[k]).default);
         // Matched BY VALUE: the local is this arm's alone (every leaf under the
         // hoist is in it), so a consuming value form's fields move out here
         // exactly as they do at an unconditional one.

--- a/prebindgen-jni/src/jni/emit/delivery.rs
+++ b/prebindgen-jni/src/jni/emit/delivery.rs
@@ -880,7 +880,7 @@ pub(crate) fn encode_plan_leaves(
     let mut arg_exprs: Vec<TokenStream> = Vec::with_capacity(n);
     for (idx, leaf) in plan.leaves.iter().enumerate() {
         let obj_ident = &obj_idents[idx];
-        if leaf_is_prim(registry, leaf) {
+        if leaf_is_prim(ext, leaf) {
             arg_exprs.push(quote!(#obj_ident));
         } else {
             arg_exprs.push(quote!(jni::sys::jvalue { l: #obj_ident.as_raw() }));
@@ -1031,7 +1031,7 @@ pub(crate) fn encode_plan_leaves(
                 let ids: Vec<&syn::Ident> = obj_idents[seg.clone()].iter().collect();
                 let slots: Vec<Slot> = plan.leaves[seg.clone()]
                     .iter()
-                    .map(|l| leaf_slot(registry, l))
+                    .map(|l| leaf_slot(ext, l))
                     .collect();
                 let tys = slots.iter().map(|s| &s.ty);
                 let defaults = slots.iter().map(|s| &s.default);
@@ -1404,7 +1404,7 @@ pub(crate) fn encode_plan_leaves(
         // value with the leaf's output converter and casts to JObject.
         let wire = out_entry.destination.clone();
         let enc_ident = format_ident!("__enc{}", idx);
-        if leaf_is_prim(registry, leaf) {
+        if leaf_is_prim(ext, leaf) {
             let letter = jni_field_access(&wire)
                 .expect("leaf_is_prim guarantees a primitive wire")
                 .1;
@@ -1447,12 +1447,10 @@ pub(crate) fn encode_plan_leaves(
             })
             .collect();
         let ids: Vec<&syn::Ident> = idxs.iter().map(|&k| &obj_idents[k]).collect();
-        let tys = idxs
-            .iter()
-            .map(|&k| leaf_slot(registry, &plan.leaves[k]).ty);
+        let tys = idxs.iter().map(|&k| leaf_slot(ext, &plan.leaves[k]).ty);
         let defaults = idxs
             .iter()
-            .map(|&k| leaf_slot(registry, &plan.leaves[k]).default);
+            .map(|&k| leaf_slot(ext, &plan.leaves[k]).default);
         // Matched BY VALUE: the local is this arm's alone (every leaf under the
         // hoist is in it), so a consuming value form's fields move out here
         // exactly as they do at an unconditional one.
@@ -1472,7 +1470,7 @@ pub(crate) fn encode_plan_leaves(
 /// [`crate::jni::iface`] derives for the same leaf — a
 /// nullable primitive boxes (object chunk), object wires pass as objects.
 pub(crate) fn leaf_is_prim(
-    registry: &impl Conversions<KotlinMeta>,
+    ext: &Declarations,
     leaf: &prebindgen_registry::unfold::UnfoldLeaf,
 ) -> bool {
     // The synthesized sum selector is a `jint` by definition — it is assigned,
@@ -1489,7 +1487,7 @@ pub(crate) fn leaf_is_prim(
     if leaf.nullable {
         return false;
     }
-    leaf_ty_is_prim(registry, &leaf.out_ty)
+    leaf_ty_is_prim(ext, &leaf.out_ty)
 }
 
 /// The wire half of [`leaf_is_prim`]: does a leaf of this type occupy a **raw
@@ -1497,10 +1495,10 @@ pub(crate) fn leaf_is_prim(
 /// about a leaf whose own `nullable` flag it is in the middle of computing (an
 /// inert sum group slot).
 pub(crate) fn leaf_ty_is_prim(
-    registry: &impl Conversions<KotlinMeta>,
+    ext: &Declarations,
     out_ty: &prebindgen_registry::flat::TypeRef,
 ) -> bool {
-    let Some(entry) = registry.output_entry(out_ty) else {
+    let Some(entry) = ext.out_frag(out_ty) else {
         return false;
     };
     // No projection (plain primitive/enum wire) — or an opaque HANDLE, whose

--- a/prebindgen-jni/src/jni/emit/flat_input.rs
+++ b/prebindgen-jni/src/jni/emit/flat_input.rs
@@ -19,7 +19,7 @@ use crate::jni::trait_impl::{build_through_erased_wrappers, build_through_wrappe
 pub(crate) fn struct_input_body(
     ext: &Declarations,
     s: &flat::Struct,
-    registry: &impl Conversions<KotlinMeta>,
+    registry: &impl Conversions,
     emit: &prebindgen_registry::Emit,
 ) -> Option<(syn::Type, syn::Expr)> {
     let struct_name = s.name.to_string();
@@ -321,7 +321,7 @@ pub(crate) fn struct_input_body(
 pub(crate) fn sum_input_body(
     ext: &Declarations,
     v: &flat::Variant,
-    registry: &impl Conversions<KotlinMeta>,
+    registry: &impl Conversions,
     emit: &prebindgen_registry::Emit,
 ) -> Option<(syn::Type, syn::Expr)> {
     let key = TypeKey::from_ident(&v.name);
@@ -598,7 +598,7 @@ fn read_kotlin_property(
 ///
 /// The mirror of [`ConvChain::call`](super::super::struct_plan::ConvChain) on
 /// the output side, and of the structural wrappers' own chain composition:
-/// stopping at [`TypeEntry::converter_ident`] would bind the *representation*
+/// stopping at [`ConverterImpl::converter_ident`] would bind the *representation*
 /// (`u64`) where the Rust value (`Duration`) is required, which does not
 /// compile.
 ///
@@ -1047,7 +1047,7 @@ fn wire_kotlin_type(entry: &prebindgen_registry::ConverterImpl<KotlinMeta>) -> S
 #[allow(clippy::too_many_arguments)]
 fn build_flat_sum_field(
     ext: &Declarations,
-    registry: &Registry<KotlinMeta>,
+    registry: &Registry,
     sum_reading: &TypeRef,
     field: syn::Ident,
     optional: bool,
@@ -1303,7 +1303,7 @@ fn push_handle_leaf(
 /// plan or a validation error — never a silent object fallback.
 pub(crate) fn build_flat_input_plan(
     ext: &Declarations,
-    registry: &Registry<KotlinMeta>,
+    registry: &Registry,
     param_name: &syn::Ident,
     arg: &TypeRef,
 ) -> Result<Option<FlatInputPlan>, FlatInputError> {
@@ -1412,7 +1412,7 @@ pub(crate) fn build_flat_input_plan(
 /// before the rebuild did.
 fn build_flat_struct_node(
     ext: &Declarations,
-    registry: &Registry<KotlinMeta>,
+    registry: &Registry,
     st: &flat::Struct,
     optional: bool,
     native_prefix: &str,

--- a/prebindgen-jni/src/jni/emit/flat_input.rs
+++ b/prebindgen-jni/src/jni/emit/flat_input.rs
@@ -116,7 +116,7 @@ pub(crate) fn struct_input_body(
                             FoldStrategy::Optional(NullableKind::Niche, _)
                         );
                         let inner_conv =
-                            composed_entry_decode(&ext.in_frag(inner)?, &raw_ident, &fname_ident);
+                            composed_entry_decode(&*ext.in_frag(inner)?, &raw_ident, &fname_ident);
                         let tmp_ident = format_ident!("__{}_jobj", fname_ident);
                         let decode = if niche {
                             // The Kotlin data-class property is still `ULong?`
@@ -179,7 +179,7 @@ pub(crate) fn struct_input_body(
             {
                 let sig = format!("L{};", fqn.replace('.', "/"));
                 let inner_conv =
-                    composed_entry_decode(&ext.in_frag(inner)?, &raw_ident, &fname_ident);
+                    composed_entry_decode(&*ext.in_frag(inner)?, &raw_ident, &fname_ident);
                 let tmp_ident = format_ident!("__{}_jobj", fname_ident);
                 let decode = if field_optional {
                     quote! {
@@ -504,7 +504,7 @@ fn read_kotlin_property(
         // Under `Option`, JVM null is `None` and the INNER converter decodes
         // the discriminant; the outer converter would expect a boxed Integer.
         let decode = if optional {
-            let inner_conv = composed_entry_decode(&ext.in_frag(inner)?, &raw, bind);
+            let inner_conv = composed_entry_decode(&*ext.in_frag(inner)?, &raw, bind);
             quote! {
                 let #bind = if #obj.is_null() {
                     ::core::option::Option::None

--- a/prebindgen-jni/src/jni/emit/flat_input.rs
+++ b/prebindgen-jni/src/jni/emit/flat_input.rs
@@ -649,80 +649,97 @@ fn composed_property_decode(
 /// One flattened leaf of a struct **input** param. The mirror of
 /// [`EncSlot`] for the input direction: instead of reading the field with
 /// `env.get_field(...)` out of a single `JObject`, the leaf crosses the JNI
-/// boundary as its own wrapper parameter. Carries every fact the three
-/// coordinated sites (native wrapper signature, `JNINative` extern decl,
-/// Kotlin call-site destructure) need so they cannot drift in order, type, or
+/// boundary as its own wrapper parameter, and the three coordinated sites — the
+/// native wrapper signature, the `JNINative` extern declaration and the Kotlin
+/// call-site destructure — read it so they cannot drift in order, type, or
 /// nullability.
+///
+/// One JNI parameter a flattened `data_class` occupies, as the site names it.
+///
+/// A projection of the fragment's [`Wire`](crate::jni::compile::Wire) and
+/// nothing more: the wire says what crosses and how Kotlin reaches it, and this
+/// pairs that with the one thing a wire cannot know — the parameter name the
+/// site hangs it off.
 pub(crate) struct FlatLeaf {
     /// Native wrapper parameter ident — also the decode source.
     pub native_ident: syn::Ident,
-    /// Native wire type (lifetime-annotated for object wires).
-    pub native_wire_ty: TokenStream,
     /// Kotlin `external fun` parameter name (camelCase).
     pub kt_name: String,
-    /// Kotlin `external fun` parameter type (incl. a trailing `?`).
-    pub kt_wire_ty: String,
-    /// Call-site destructure expression **tail** — everything after the
-    /// object expression (`.field ?: 0`, `?.seq != null`, ` != null`). The
-    /// full access is composed per site via [`Self::kt_access`], so the plan
-    /// itself stays independent of the call form (`payload`, `this`, `__e`).
-    pub kt_access_tail: String,
-    /// Text placed **before** the object expression, so the access is a
-    /// template (`prefix + base + tail`) rather than a suffix.
-    ///
-    /// Empty for every ordinary leaf, whose access really is a suffix. A
-    /// tag-gated variant slot is not: it needs
-    /// `(<base>.field as? Reading.Exact)?.v0 ?: 0L`, where the base sits in
-    /// the middle. Both [`Self::kt_access`] and the handle-target composition
-    /// go through it, because a variant slot can equally be a handle — and a
-    /// handle target that ignored the prefix would silently lock and consume
-    /// the wrong expression.
-    pub kt_access_prefix: String,
-    /// Per-field input converter ident (`None` for the synthetic present flag).
-    pub conv: Option<syn::Ident>,
-    /// Struct field this leaf populates. `None` for the struct-level present
-    /// flag of an `Option<struct>` param. `Some` for ordinary field leaves AND
-    /// for a per-field present flag (Phase 5 `Option<primitive>` field).
-    pub field: Option<syn::Ident>,
-    /// `true` for a synthetic `…Present: Boolean` gate leaf: the struct-level
-    /// gate of an `Option<struct>` param (`field == None`) or a per-field gate
-    /// of an `Option<primitive>`/`Option<enum>` field (`field == Some`).
-    pub is_present_flag: bool,
-    /// Complete converter entry for an ordinary value leaf. Present flags and
-    /// direct owned-handle leaves have no entry here.
-    pub entry: Option<prebindgen_registry::ConverterImpl<KotlinMeta>>,
-    /// A nested owned handle crosses as a raw pointer under the same Kotlin
-    /// locking/consume scaffold as a top-level handle. This stores the typed
-    /// property access tail (`.child.handle` / `?.handle`) used to collect it.
-    pub handle_target_tail: Option<String>,
-    /// Whether the handle access can be null, either because the field itself
-    /// is optional or because an optional ancestor gates it.
-    pub handle_nullable: bool,
+    /// The path through the value that reached this wire, as the fragment
+    /// states it — `tag`, `summary.count`, `reading.exact_v0`. What the rebuild
+    /// names a leaf by, so the tree it builds and the row it builds from cannot
+    /// disagree about which value is which.
+    pub path: String,
+    /// The wire itself.
+    pub wire: crate::jni::compile::Wire,
 }
 
 impl FlatLeaf {
+    /// This wire as one parameter of the site named `param`.
+    fn of(param: &syn::Ident, wire: &crate::jni::compile::Wire) -> Self {
+        let native = format!("{param}_{}", wire.path.replace('.', "_"));
+        Self {
+            native_ident: format_ident!("{native}"),
+            kt_name: snake_to_camel(&native),
+            path: wire.path.clone(),
+            wire: wire.clone(),
+        }
+    }
+
+    /// Native wire type, lifetime-annotated for object wires.
+    pub fn native_wire_ty(&self) -> TokenStream {
+        annotate_jobject_with_lifetime(&self.wire.ty, "a").to_token_stream()
+    }
+
+    /// Kotlin `external fun` parameter type (incl. a trailing `?`).
+    pub fn kt_wire_ty(&self) -> &str {
+        &self.wire.kt_ty
+    }
+
+    /// Per-field input converter ident (`None` for a synthetic gate or tag).
+    pub fn conv(&self) -> Option<&syn::Ident> {
+        self.wire.conv()
+    }
+
+    /// The complete conversion, stages included, or `None` for a gate or tag.
+    pub fn entry(&self) -> Option<&prebindgen_registry::ConverterImpl<KotlinMeta>> {
+        self.wire.entry.as_ref()
+    }
+
+    /// Whether this is a synthetic `…Present: Boolean` gate.
+    pub fn is_present_flag(&self) -> bool {
+        self.wire.is_present_flag()
+    }
+
+    /// Whether the handle access can be null, either because the field itself
+    /// is optional or because an optional ancestor gates it.
+    pub fn handle_nullable(&self) -> bool {
+        self.wire.handle_nullable
+    }
+
     /// Kotlin call-site destructure expression feeding this leaf, rooted at
     /// `base` — the object expression at this call site (the camelCase param
     /// name, `this` for a promoted receiver, `__e` for the vec-build loop
     /// variable).
     pub fn kt_access(&self, base: &str) -> String {
-        format!("{}{base}{}", self.kt_access_prefix, self.kt_access_tail)
+        self.wire.access.render(base)
     }
 
     /// The Kotlin expression yielding the handle this leaf carries, rooted at
     /// `base` — the thing the lock scaffold locks and `markConsumed()`s.
-    /// `None` when the leaf is not a handle. Composed through the same
-    /// template as [`Self::kt_access`].
+    /// `None` when the leaf is not a handle.
     pub fn kt_handle_target(&self, base: &str) -> Option<String> {
-        let tail = self.handle_target_tail.as_ref()?;
-        Some(format!("{}{base}{tail}", self.kt_access_prefix))
+        self.wire
+            .handle_target
+            .as_ref()
+            .map(|walk| crate::jni::compile::reached(base, walk))
     }
 
     /// Native call argument for this leaf. Handle pointers are bound under
     /// the unified lock scaffold; every other leaf is read directly from the
     /// Kotlin object graph.
     pub fn kt_call_arg(&self, base: &str) -> String {
-        if self.handle_target_tail.is_some() {
+        if self.wire.handle_target.is_some() {
             format!("{}_ptr", self.kt_name)
         } else {
             self.kt_access(base)
@@ -1030,20 +1047,15 @@ pub(crate) fn wire_kotlin_type(entry: &prebindgen_registry::ConverterImpl<Kotlin
     }
 }
 
-/// Plan a **data-carrying enum** field as a tag leaf plus one leaf group per
-/// variant, so the sum crosses flattened instead of as one `JObject` per call.
+/// The rebuild for a **data-carrying enum** field the row flattened into a tag
+/// plus one slot group per alternative.
 ///
-/// Returns `None` when some payload cannot be expressed as a flat leaf — a
-/// handle, say, whose ownership the group-gated form does not yet model. That
-/// is deliberately a **graceful degradation, not a rejection**: the caller
-/// falls through to the ordinary value leaf, and the sum crosses as a whole
-/// object through its own converter, exactly as it did before this path
-/// existed. Refusing instead would turn a working binding into a build error
-/// for a shape the generator can already handle.
-///
-/// Kotlin references are emitted **fully qualified** (`is io.x.Reading.Exact`)
-/// so the call site needs no import bookkeeping — these expressions are raw
-/// text spliced into a wrapper whose import set this plan does not own.
+/// Which of the two happened is the fragment's decision, not this walk's:
+/// `Compile::choice` composes the groups where every payload has a slot form
+/// and hands back a single-wire fragment where one does not — a handle, say,
+/// whose ownership the group-gated form does not model. So the caller asks
+/// whether the field is whole before reaching here, and every alternative's
+/// payloads are present when it does.
 #[allow(clippy::too_many_arguments)]
 fn build_flat_sum_field(
     ext: &Declarations,
@@ -1052,255 +1064,92 @@ fn build_flat_sum_field(
     field: syn::Ident,
     optional: bool,
     native_prefix: &str,
-    field_ref: &str,
-    nullable_access: bool,
     field_reading: &TypeRef,
-    leaves: &mut Vec<FlatLeaf>,
-) -> Option<FlatFieldNode> {
-    let rust_ty = field_reading;
-
+    root: &TypeKey,
+    leaves: &mut Leaves<'_>,
+) -> Result<FlatFieldNode, FlatInputError> {
+    let missing = || {
+        flat_error(
+            root,
+            native_prefix,
+            "the row states fewer wires than the model",
+        )
+    };
     // The NAME off the classification, and then the ELEMENT — `enum_item`
     // hands back only the `syn::ItemEnum`, deliberately, so a consumer that
     // acts on the Variant/Enum distinction asks `declared_type` (#289).
     let ident = match sum_reading.unwrapped().kind() {
         flat::TypeKind::Named { id, .. } => id.ident(),
         _ => None,
-    }?;
-    let flat::Type::Variant(sum) = registry.flat().declared_type(&ident)? else {
-        return None;
+    }
+    .ok_or_else(missing)?;
+    let Some(flat::Type::Variant(sum)) = registry.flat().declared_type(&ident) else {
+        return Err(flat_error(
+            root,
+            native_prefix,
+            "a sum row over a type that is not one",
+        ));
     };
-    let cfg = ext.types.get(&TypeKey::from_ident(&ident))?;
-    let sum_cfg = cfg.sum()?;
-    let iface_fqn = cfg.name_spec.as_ref().map(|s| ext.fqn_of(s))?;
 
-    // Plan every group first: a single unflattenable payload means the whole
-    // sum stays object-shaped, so nothing may be pushed until all of them are
-    // known good.
-    struct Planned {
-        rust_ident: syn::Ident,
-        kotlin: String,
-        fields: Vec<(syn::Member, PlannedLeaf)>,
-    }
-    struct PlannedLeaf {
-        native: String,
-        entry: prebindgen_registry::ConverterImpl<KotlinMeta>,
-        access_tail: String,
-        nullable_wire: bool,
-    }
-    let mut planned: Vec<Planned> = Vec::new();
+    let present_leaf = match optional {
+        true => Some(leaves.take().ok_or_else(missing)?),
+        false => None,
+    };
+    let tag_leaf = leaves.take().ok_or_else(missing)?;
+    let mut variants = Vec::new();
     for alt in &sum.alternatives {
-        let kotlin = ext.sum_variant_class_name(sum_cfg, &alt.name);
         let mut fields = Vec::new();
-        for field in &alt.fields {
-            // The payload's own reading straight to its entry.
-            let entry = ext.in_frag(&field.ty)?;
-            // A projection payload (handle) carries ownership
-            // and locking rules the tag-gated group does not model yet.
-            if entry.metadata.projection.is_some() {
-                return None;
-            }
-            // Nested objects would need their own recursive group; today only
-            // leaf-shaped payloads flatten.
-            let prim = JniPrim::from_wire(&entry.destination);
-            let is_string_like = matches!(&entry.destination, syn::Type::Path(tp)
-                if tp.path.segments.last().is_some_and(|s| s.ident == "JString"));
-            if prim.is_none() && !is_string_like {
-                return None;
-            }
-            let member = field.member();
-            let prop = crate::jni::struct_plan::sum_field_prop_name(&member);
-            let slot = crate::jni::struct_plan::sum_slot_fragment(&kotlin, &prop);
-            // `(<base>.field as? io.x.E.V)?.prop` — inert groups yield null,
-            // so a primitive slot takes its zero and an object slot stays
-            // nullable. The Rust side only converts the live group.
-            //
-            // An `enum_class` payload is a Kotlin enum object whose wire is
-            // the `jint` discriminant, so the access reads `.value` — without
-            // it the slot would be `Priority?` where the wire wants `Int`.
-            let read = if ext.is_kotlin_enum_reading(&field.ty) {
-                format!("{prop}?.value")
-            } else {
-                prop.clone()
-            };
-            let cast = format!("{field_ref} as? {iface_fqn}.{kotlin})?.{read}");
-            let (access_tail, nullable_wire) = match &prim {
-                Some(p) => (format!("{cast} ?: {}", p.kotlin_zero()), false),
-                None => (cast, true),
-            };
-            fields.push((
-                member,
-                PlannedLeaf {
-                    native: format!("{native_prefix}_{slot}"),
-                    entry: entry.clone(),
-                    access_tail,
-                    nullable_wire,
-                },
-            ));
+        for f in &alt.fields {
+            fields.push((f.member(), leaves.take().ok_or_else(missing)?));
         }
-        planned.push(Planned {
+        variants.push(FlatSumVariant {
             rust_ident: alt.name.clone(),
-            kotlin,
             fields,
         });
     }
 
-    // Everything flattens — now push the leaves, tag first.
-    let present_leaf = optional.then(|| {
-        push_present_leaf(
-            leaves,
-            &format!("{native_prefix}_present"),
-            format!("{field_ref} != null"),
-            Some(field.clone()),
-        )
-    });
-
-    // The tag is computed once per call site by matching the value against
-    // its own variant classes. A nullable access adds the `null` arm the
-    // present flag already gates on.
-    let mut arms: Vec<String> = Vec::new();
-    if nullable_access || optional {
-        arms.push("null -> 0".to_string());
-    }
-    for (tag, p) in planned.iter().enumerate() {
-        arms.push(format!("is {iface_fqn}.{} -> {tag}", p.kotlin));
-    }
-    let tag_leaf = leaves.len();
-    leaves.push(FlatLeaf {
-        native_ident: format_ident!("{}__tag", native_prefix),
-        native_wire_ty: quote!(jni::sys::jint),
-        kt_name: snake_to_camel(&format!("{native_prefix}__tag")),
-        kt_wire_ty: "Int".to_string(),
-        kt_access_tail: format!("{field_ref}) {{ {} }}", arms.join("; ")),
-        kt_access_prefix: "when (".to_string(),
-        conv: None,
-        field: Some(field.clone()),
-        is_present_flag: false,
-        entry: None,
-        handle_target_tail: None,
-        handle_nullable: false,
-    });
-
-    let variants = planned
-        .into_iter()
-        .map(|p| FlatSumVariant {
-            rust_ident: p.rust_ident,
-            fields: p
-                .fields
-                .into_iter()
-                .map(|(member, l)| {
-                    let idx = push_value_leaf(
-                        leaves,
-                        &l.native,
-                        field.clone(),
-                        &l.entry,
-                        l.access_tail,
-                        l.nullable_wire,
-                    );
-                    // The access is a cast expression, so the base sits in the
-                    // middle rather than at the front.
-                    leaves[idx].kt_access_prefix = "(".to_string();
-                    (member, idx)
-                })
-                .collect(),
-        })
-        .collect();
-
     let module = ext.fn_module(registry, &ident);
-    Some(FlatFieldNode::Sum {
+    Ok(FlatFieldNode::Sum {
         wrappers: field_reading.erased_wrappers(),
         field,
         tag_leaf,
         present_leaf,
         source: syn::parse_quote!(#module::#ident),
         variants,
-        rust_ty: Box::new(rust_ty.clone()),
+        rust_ty: Box::new(field_reading.clone()),
     })
 }
 
-fn push_present_leaf(
-    leaves: &mut Vec<FlatLeaf>,
-    native: &str,
-    access: String,
-    field: Option<syn::Ident>,
-) -> usize {
-    let index = leaves.len();
-    leaves.push(FlatLeaf {
-        native_ident: format_ident!("{native}"),
-        native_wire_ty: quote!(jni::sys::jboolean),
-        kt_name: snake_to_camel(native),
-        kt_wire_ty: "Boolean".to_string(),
-        kt_access_tail: access,
-        kt_access_prefix: String::new(),
-        conv: None,
-        field,
-        is_present_flag: true,
-        entry: None,
-        handle_target_tail: None,
-        handle_nullable: false,
-    });
-    index
+/// The plan's leaves, read in the order the row states them.
+///
+/// A cursor rather than a lookup, because a path is not a key: a nested
+/// `data_class` with a field called `value` reaches the same path a decoupled
+/// pair's slot does, and one called `present` reaches the same path as the gate
+/// over its own struct. What is unambiguous is the **order** — the composition
+/// emits a gate before what it gates, fields in the model's order, and a sum's
+/// tag before its arms' slots — which is the order this walk visits them in.
+struct Leaves<'a> {
+    leaves: &'a [FlatLeaf],
+    next: usize,
 }
 
-fn push_value_leaf(
-    leaves: &mut Vec<FlatLeaf>,
-    native: &str,
-    field: syn::Ident,
-    entry: &prebindgen_registry::ConverterImpl<KotlinMeta>,
-    access: String,
-    nullable_wire: bool,
-) -> usize {
-    let wire = &entry.destination;
-    let mut kt_wire_ty = wire_kotlin_type(entry);
-    if nullable_wire && !kt_wire_ty.ends_with('?') {
-        kt_wire_ty.push('?');
+impl Leaves<'_> {
+    /// The next leaf, consumed.
+    fn take(&mut self) -> Option<usize> {
+        let index = self.next;
+        (index < self.leaves.len()).then(|| {
+            self.next += 1;
+            index
+        })
     }
-    let index = leaves.len();
-    leaves.push(FlatLeaf {
-        native_ident: format_ident!("{native}"),
-        native_wire_ty: annotate_jobject_with_lifetime(wire, "a").to_token_stream(),
-        kt_name: snake_to_camel(native),
-        kt_wire_ty,
-        kt_access_tail: access,
-        kt_access_prefix: String::new(),
-        conv: Some(entry.function.sig.ident.clone()),
-        field: Some(field),
-        is_present_flag: false,
-        entry: Some(entry.clone()),
-        handle_target_tail: None,
-        handle_nullable: false,
-    });
-    index
+
+    /// Whether the next leaf is the whole of what `path` reaches, rather than
+    /// the first of several.
+    fn is_whole(&self, path: &str) -> bool {
+        self.leaves.get(self.next).is_some_and(|l| l.path == path)
+    }
 }
 
-fn push_handle_leaf(
-    leaves: &mut Vec<FlatLeaf>,
-    native: &str,
-    field: syn::Ident,
-    target: String,
-    nullable: bool,
-) -> usize {
-    let index = leaves.len();
-    leaves.push(FlatLeaf {
-        native_ident: format_ident!("{native}"),
-        native_wire_ty: quote!(jni::sys::jlong),
-        kt_name: snake_to_camel(native),
-        kt_wire_ty: "Long".to_string(),
-        kt_access_tail: target.clone(),
-        kt_access_prefix: String::new(),
-        conv: None,
-        field: Some(field),
-        is_present_flag: false,
-        entry: None,
-        handle_target_tail: Some(target),
-        handle_nullable: nullable,
-    });
-    index
-}
-
-/// Build the one shared recursive Kotlin→Rust plan. `Ok(None)` means the
-/// parameter is not an unmarked declared data class (including the explicit
-/// `.jobject_input()` opt-in); an unmarked data class either returns a complete
-/// plan or a validation error — never a silent object fallback.
 pub(crate) fn build_flat_input_plan(
     ext: &Declarations,
     registry: &Registry,
@@ -1316,8 +1165,7 @@ pub(crate) fn build_flat_input_plan(
     // `impl Into<S>` is NOT peeled here, and cannot be: the model refuses
     // `impl Trait` that is not the callback form (`DisallowedImplTrait`), so a
     // parameter spelled that way never becomes a reading and never reaches this
-    // function. The former `impl_into_target` call was already unreachable from
-    // every caller — see the sibling helper's doc.
+    // function.
     // The name off the classification, not off the last path segment: `Box<S>`
     // IS `S` here, and taking the spelling apart would answer about the wrapper.
     let flat::TypeKind::Named { id, .. } = inner.unwrapped().kind() else {
@@ -1333,10 +1181,7 @@ pub(crate) fn build_flat_input_plan(
     };
     // The DECLARATION is keyed by the type, not by the spelling: a
     // `Box<Payload>` parameter is a `Payload` to Kotlin and must find
-    // `Payload`'s data-class declaration. Keying by spelling looked up
-    // `Box < Payload >`, found nothing, and silently dropped the parameter to
-    // the general converter — the flatten lowering was unreachable for every
-    // wrapped core.
+    // `Payload`'s data-class declaration.
     let key = inner.stripped_key();
     let Some(cfg) = ext.types.get(&key) else {
         return Ok(None);
@@ -1350,7 +1195,6 @@ pub(crate) fn build_flat_input_plan(
     // surfaces as `"Any"` Dispatch or a foreign source type). The resolved
     // param's Kotlin type (compared by short name, since metadata carries the
     // FQN) must equal the struct's data-class name.
-    // The parameter's own reading straight to its entry — no spell-and-look-back.
     let Some(entry) = ext.in_frag(arg) else {
         return Ok(None);
     };
@@ -1371,8 +1215,24 @@ pub(crate) fn build_flat_input_plan(
     if entry_short != Some(dc_short.as_str()) {
         return Ok(None);
     }
-    let mut leaves: Vec<FlatLeaf> = Vec::new();
+    drop(entry);
+
+    // 2. The parameters this crossing occupies, as the row states them. What
+    //    used to be walked and named here is composed once per crossing, so
+    //    the only thing left for the site to say is which parameter each wire
+    //    hangs off.
+    let Some(wires) = ext.wires_of(arg) else {
+        return Ok(None);
+    };
+    let leaves: Vec<FlatLeaf> = wires.iter().map(|w| FlatLeaf::of(param_name, w)).collect();
+
+    // 3. The tree the Rust side rebuilds through, over those same wires in the
+    //    order the row states them.
     let mut stack = Vec::new();
+    let mut cursor = Leaves {
+        leaves: &leaves,
+        next: 0,
+    };
     let root = build_flat_struct_node(
         ext,
         registry,
@@ -1380,10 +1240,9 @@ pub(crate) fn build_flat_input_plan(
         optional,
         &param_name.to_string(),
         "",
-        optional,
         &key,
         &mut stack,
-        &mut leaves,
+        &mut cursor,
     )?;
     let contains_nested = root
         .fields
@@ -1398,29 +1257,29 @@ pub(crate) fn build_flat_input_plan(
     }))
 }
 
-#[allow(clippy::too_many_arguments)]
+/// The rebuild tree for one struct, over the wires the row states for it.
+///
 /// Takes the **element**, not the `syn::ItemStruct` it was parsed from (#289):
 /// `flat::Field::ty` is already a `TypeRef`, so every peel below is the model's
 /// answer rather than a last-path-segment test on tokens that had a reading one
 /// level up.
 ///
-/// That matters here and not only on principle. `option_inner_type` reads the
-/// last path segment, so a field spelled `Box<Option<T>>` answered "not
-/// optional" and crossed as one boxed object; the model says `Optional` and it
-/// takes the decoupled `(present, value)` pair like its bare twin. The emitter
-/// then has to put the `Box` back — which is why this migration could not land
-/// before the rebuild did.
+/// How many wires a field occupies is the row's answer, read off the cursor;
+/// which of the composite shapes it took is the model's, read off the field's
+/// type. The walk that used to decide both made the second decision twice — once
+/// to compose and once to rebuild — and two answers are two things to keep in
+/// step.
+#[allow(clippy::too_many_arguments)]
 fn build_flat_struct_node(
     ext: &Declarations,
     registry: &Registry,
     st: &flat::Struct,
     optional: bool,
     native_prefix: &str,
-    access_prefix: &str,
-    nullable_context: bool,
+    path_prefix: &str,
     root: &TypeKey,
     stack: &mut Vec<TypeKey>,
-    leaves: &mut Vec<FlatLeaf>,
+    leaves: &mut Leaves<'_>,
 ) -> Result<FlatStructNode, FlatInputError> {
     let node_key = TypeKey::from_ident(&st.name);
     if stack.contains(&node_key) {
@@ -1438,10 +1297,10 @@ fn build_flat_struct_node(
         ));
     }
     stack.push(node_key);
+    let missing = |at: &str| flat_error(root, at, "the row states fewer wires than the model");
     let present_ident = if optional {
-        let native = format!("{native_prefix}_present");
-        push_present_leaf(leaves, &native, format!("{access_prefix} != null"), None);
-        Some(format_ident!("{native}"))
+        let gate = leaves.take().ok_or_else(|| missing(native_prefix))?;
+        Some(leaves.leaves[gate].native_ident.clone())
     } else {
         None
     };
@@ -1458,54 +1317,81 @@ fn build_flat_struct_node(
                 "only named-field structs can flatten",
             ));
         };
-        let fcamel = kotlin_property_name(&fident);
-        let child_native = format!("{native_prefix}_{}", fident);
-        let field_ref = if nullable_context {
-            format!("{access_prefix}?.{fcamel}")
-        } else {
-            format!("{access_prefix}.{fcamel}")
-        };
+        let path = format!("{path_prefix}{fident}");
+        let child_native = format!("{native_prefix}_{fident}");
         // The optional layer off the MODEL, asked once and reused: every site
         // below that wants "is this field optional" reads this, so they cannot
         // disagree with each other the way seven independent path-segment tests
         // could (#273).
         let field_optional = field.ty.optional_inner().is_some();
         let nested = field.ty.optional_inner().unwrap_or(&field.ty);
-        // A data-carrying enum flattens into a tag plus one group per variant.
-        // `None` means some payload is not leaf-shaped — fall through and let
-        // it cross as one object through its own converter.
-        if matches!(ext.type_kind(registry, &nested.key()), TypeKind::Sum) {
-            if let Some(node) = build_flat_sum_field(
-                ext,
-                registry,
-                nested,
-                fident.clone(),
-                field_optional,
-                &child_native,
-                &field_ref,
-                nullable_context,
-                &field.ty,
-                leaves,
-            ) {
-                fields.push(node);
-                continue;
+        let wrappers = field.ty.erased_wrappers();
+
+        // One wire for the whole field: the ordinary case, and the one an
+        // opaque-handle field takes — the row says which by carrying a handle
+        // target on that wire. Also where a sum or a nested class the row left
+        // whole ends up.
+        if leaves.is_whole(&path) {
+            let index = leaves.take().ok_or_else(|| missing(&child_native))?;
+            let direct_handle = leaves.leaves[index]
+                .wire
+                .handle_target
+                .is_some()
+                .then(|| Box::new(nested.clone()));
+            if direct_handle.is_some()
+                && matches!(
+                    ext.in_frag(&field.ty).and_then(|e| e
+                        .metadata
+                        .projection
+                        .as_ref()
+                        .map(|p| p.strategy.clone())),
+                    Some(FoldStrategy::Iterable(_))
+                )
+            {
+                return Err(flat_error(
+                    root,
+                    &child_native,
+                    "collections of handles retain their collection boundary",
+                ));
             }
+            fields.push(FlatFieldNode::Value {
+                field: fident,
+                value_leaf: index,
+                present_leaf: None,
+                optional_handle: direct_handle.is_some() && field_optional,
+                direct_handle,
+                rust_ty: Box::new(field.ty.clone()),
+                wrappers,
+            });
+            continue;
         }
-        if let TypeKind::DataStruct {
-            st: child,
-            cfg: Some(cfg),
-        } = ext.type_kind(registry, &nested.key())
-        {
-            if cfg.name_spec.is_some() && !cfg.special_decl() && !cfg.jobject_input {
-                let child_optional = field_optional;
+
+        // Several wires, and the field's own type says which shape they take.
+        match ext.type_kind(registry, &nested.key()) {
+            TypeKind::Sum => {
+                fields.push(build_flat_sum_field(
+                    ext,
+                    registry,
+                    nested,
+                    fident,
+                    field_optional,
+                    &child_native,
+                    &field.ty,
+                    root,
+                    leaves,
+                )?);
+            }
+            TypeKind::DataStruct {
+                st: child,
+                cfg: Some(_),
+            } => {
                 let node = build_flat_struct_node(
                     ext,
                     registry,
                     child,
-                    child_optional,
+                    field_optional,
                     &child_native,
-                    &field_ref,
-                    nullable_context || child_optional,
+                    &format!("{path}."),
                     root,
                     stack,
                     leaves,
@@ -1514,217 +1400,23 @@ fn build_flat_struct_node(
                     field: fident,
                     node: Box::new(node),
                 });
-                continue;
+            }
+            // A gate beside a raw slot: the allocation-free pair a nullable
+            // primitive, enum or unsigned representation crosses as.
+            _ => {
+                let present = leaves.take().ok_or_else(|| missing(&child_native))?;
+                let value = leaves.take().ok_or_else(|| missing(&child_native))?;
+                fields.push(FlatFieldNode::Value {
+                    field: fident,
+                    value_leaf: value,
+                    present_leaf: Some(present),
+                    direct_handle: None,
+                    optional_handle: false,
+                    rust_ty: Box::new(field.ty.clone()),
+                    wrappers,
+                });
             }
         }
-
-        let path = child_native.clone();
-        // The field's own reading straight to its entry — the `reading_of` hop
-        // only ever recovered what the field already carried.
-        let Some(fentry) = ext.in_frag(&field.ty) else {
-            return Err(flat_error(
-                root,
-                &path,
-                format!("field type `{}` has no input converter", field.ty.key()),
-            ));
-        };
-
-        // Nullable primitive/enum with no niche: keep the allocation-free
-        // `(present, value)` representation at every recursion depth.
-        if let Some(inner_reading) = field.ty.optional_inner() {
-            if inner_reading.borrow_target().is_none() {
-                if let Some(inner) = ext.in_frag(inner_reading) {
-                    if let Some(prim) = JniPrim::from_wire(&inner.destination) {
-                        if inner.niches.clone().carve().is_none()
-                            && inner.metadata.projection.is_none()
-                            && inner.pre_stages.is_empty()
-                        {
-                            let present_index = push_present_leaf(
-                                leaves,
-                                &format!("{child_native}_present"),
-                                format!("{field_ref} != null"),
-                                Some(fident.clone()),
-                            );
-                            let value_access = if ext.is_kotlin_enum_reading(inner_reading) {
-                                format!("{field_ref}?.value ?: {}", prim.kotlin_zero())
-                            } else {
-                                format!("{field_ref} ?: {}", prim.kotlin_zero())
-                            };
-                            let value_index = push_value_leaf(
-                                leaves,
-                                &format!("{child_native}_value"),
-                                fident.clone(),
-                                &inner,
-                                value_access,
-                                false,
-                            );
-                            fields.push(FlatFieldNode::Value {
-                                field: fident,
-                                value_leaf: value_index,
-                                present_leaf: Some(present_index),
-                                direct_handle: None,
-                                optional_handle: false,
-                                rust_ty: Box::new(field.ty.clone()),
-                                wrappers: field.ty.erased_wrappers(),
-                            });
-                            continue;
-                        }
-                    }
-                }
-            }
-        }
-
-        if let Some(proj) = &fentry.metadata.projection {
-            // `Option<u64>` has no natural niche and its ordinary converter is
-            // object-shaped. Preserve the allocation-free field ABI by
-            // splitting it into presence + raw `jlong`, just like optional
-            // signed primitives. Bounded custom representations whose range
-            // provides a niche already have a primitive destination and stay
-            // a single leaf below.
-            if proj.kind == ProjectionKind::Unsigned64 {
-                if let Some(inner_reading) = field.ty.optional_inner() {
-                    if JniPrim::from_wire(&fentry.destination).is_none() {
-                        let inner = ext.in_frag(inner_reading).ok_or_else(|| {
-                            flat_error(
-                                root,
-                                &path,
-                                format!(
-                                    "unsigned field representation `{}` has no input converter",
-                                    inner_reading.key()
-                                ),
-                            )
-                        })?;
-                        let present_index = push_present_leaf(
-                            leaves,
-                            &format!("{child_native}_present"),
-                            format!("{field_ref} != null"),
-                            Some(fident.clone()),
-                        );
-                        let value_index = push_value_leaf(
-                            leaves,
-                            &format!("{child_native}_value"),
-                            fident.clone(),
-                            &inner,
-                            format!("{field_ref}?.toLong() ?: 0L"),
-                            false,
-                        );
-                        fields.push(FlatFieldNode::Value {
-                            field: fident,
-                            value_leaf: value_index,
-                            present_leaf: Some(present_index),
-                            direct_handle: None,
-                            optional_handle: false,
-                            rust_ty: Box::new(field.ty.clone()),
-                            wrappers: field.ty.erased_wrappers(),
-                        });
-                        continue;
-                    }
-                }
-            }
-            match proj.kind {
-                ProjectionKind::Handle => {
-                    if matches!(proj.strategy, FoldStrategy::Iterable(_)) {
-                        return Err(flat_error(
-                            root,
-                            &path,
-                            "collections of handles retain their collection boundary",
-                        ));
-                    }
-                    let optional_handle = field_optional;
-                    let value_index = push_handle_leaf(
-                        leaves,
-                        &child_native,
-                        fident.clone(),
-                        field_ref,
-                        nullable_context || optional_handle,
-                    );
-                    fields.push(FlatFieldNode::Value {
-                        field: fident,
-                        value_leaf: value_index,
-                        present_leaf: None,
-                        direct_handle: Some(Box::new(nested.clone())),
-                        optional_handle,
-                        rust_ty: Box::new(field.ty.clone()),
-                        wrappers: field.ty.erased_wrappers(),
-                    });
-                    continue;
-                }
-                ProjectionKind::Unsigned64 => {
-                    let is_opt = field_optional;
-                    let access = if is_opt || nullable_context {
-                        let sentinel = proj
-                            .niche_sentinels
-                            .first()
-                            .cloned()
-                            .unwrap_or_else(|| "0L".to_string());
-                        format!("{field_ref}?.toLong() ?: {sentinel}")
-                    } else {
-                        format!("{field_ref}.toLong()")
-                    };
-                    let value_index = push_value_leaf(
-                        leaves,
-                        &child_native,
-                        fident.clone(),
-                        &fentry,
-                        access,
-                        false,
-                    );
-                    fields.push(FlatFieldNode::Value {
-                        field: fident,
-                        value_leaf: value_index,
-                        present_leaf: None,
-                        direct_handle: None,
-                        optional_handle: false,
-                        rust_ty: Box::new(field.ty.clone()),
-                        wrappers: field.ty.erased_wrappers(),
-                    });
-                    continue;
-                }
-            }
-        }
-
-        let field_is_option = field_optional;
-        // The enum branch is self-contained: when it coalesces (`?.value ?: 0`)
-        // it already yields a non-null `Int`, so block (B) below must not append
-        // a second default (which produced the dead `?: 0 ?: 0`, issue #144).
-        let mut enum_coalesced = false;
-        // The enum probe off the MODEL (`enum_probe` peels the same `&`/`Option`
-        // layers `flat_probe_inner` peeled off tokens), so a `Box<Priority>`
-        // field answers as a `Priority` does.
-        let mut access = if ext.is_kotlin_enum_reading(&field.ty) {
-            if field_is_option || nullable_context {
-                enum_coalesced = true;
-                format!("{field_ref}?.value ?: 0")
-            } else {
-                format!("{field_ref}.value")
-            }
-        } else {
-            field_ref.clone()
-        };
-        if nullable_context && !field_is_option && !enum_coalesced {
-            if let Some((sig, _, _)) = jni_field_access(&fentry.destination) {
-                if let Some(default) = kt_leaf_default(sig, false) {
-                    access = format!("{access} ?: {default}");
-                }
-            }
-        }
-        let value_index = push_value_leaf(
-            leaves,
-            &child_native,
-            fident.clone(),
-            &fentry,
-            access,
-            (field_is_option || nullable_context) && is_jobject_shaped_wire(&fentry.destination),
-        );
-        fields.push(FlatFieldNode::Value {
-            field: fident,
-            value_leaf: value_index,
-            present_leaf: None,
-            direct_handle: None,
-            optional_handle: false,
-            rust_ty: Box::new(field.ty.clone()),
-            wrappers: field.ty.erased_wrappers(),
-        });
     }
     stack.pop();
     Ok(FlatStructNode {
@@ -1856,7 +1548,7 @@ fn render_flat_struct_node(
                     let mut inits: Vec<TokenStream> = Vec::new();
                     for (member, leaf_idx) in &v.fields {
                         let leaf = &plan.leaves[*leaf_idx];
-                        let entry = leaf.entry.as_ref().expect("sum payload leaf has an entry");
+                        let entry = leaf.entry().expect("sum payload leaf has an entry");
                         let wire = &leaf.native_ident;
                         let bind = format_ident!("{}_{}", tmp, wire);
                         pre.extend(render_entry_decode(entry, wire, &bind, on_err));
@@ -1964,10 +1656,7 @@ fn render_flat_struct_node(
                         });
                     }
                 } else {
-                    let entry = leaf
-                        .entry
-                        .as_ref()
-                        .expect("ordinary leaf has converter entry");
+                    let entry = leaf.entry().expect("ordinary leaf has converter entry");
                     if let Some(present_index) = present_leaf {
                         let present = &plan.leaves[*present_index].native_ident;
                         let inner_tmp = format_ident!("{}_value", tmp);

--- a/prebindgen-jni/src/jni/emit/flat_input.rs
+++ b/prebindgen-jni/src/jni/emit/flat_input.rs
@@ -1000,7 +1000,7 @@ fn flat_error(root: &TypeKey, path: &str, reason: impl Into<String>) -> FlatInpu
     }
 }
 
-fn wire_kotlin_type(entry: &prebindgen_registry::ConverterImpl<KotlinMeta>) -> String {
+pub(crate) fn wire_kotlin_type(entry: &prebindgen_registry::ConverterImpl<KotlinMeta>) -> String {
     if let Some(p) = JniPrim::from_wire(&entry.destination) {
         return p.kotlin_type().to_string();
     }

--- a/prebindgen-jni/src/jni/emit/flat_input.rs
+++ b/prebindgen-jni/src/jni/emit/flat_input.rs
@@ -45,7 +45,7 @@ pub(crate) fn struct_input_body(
         // fixed-point loop will retry on the next iteration. The field's own
         // reading straight to its entry — the `reading_of` hop only ever
         // recovered what the field already carried.
-        let field_entry = registry.input_entry(&field.ty)?;
+        let field_entry = ext.in_frag(&field.ty)?;
         // The optional layer off the MODEL, asked once and reused: every site
         // below that wants "is this field optional" reads this, so they cannot
         // disagree with each other the way four independent path-segment tests
@@ -56,7 +56,7 @@ pub(crate) fn struct_input_body(
         let field_wire = field_entry.destination.clone();
         // The field's COMPLETE decode, stages included — a `convert!` type
         // reaches its Rust value through them (`jlong -> u64 -> Duration`).
-        let field_conv = composed_entry_decode(field_entry, &raw_ident, &fname_ident);
+        let field_conv = composed_entry_decode(&field_entry, &raw_ident, &fname_ident);
 
         // Projection fields — mirror of `struct_output_body`'s kind branch:
         //  * Handle: read the JNINativeHandle object from the JVM slot,
@@ -115,11 +115,8 @@ pub(crate) fn struct_input_body(
                             proj.strategy,
                             FoldStrategy::Optional(NullableKind::Niche, _)
                         );
-                        let inner_conv = composed_entry_decode(
-                            registry.input_entry(inner)?,
-                            &raw_ident,
-                            &fname_ident,
-                        );
+                        let inner_conv =
+                            composed_entry_decode(&ext.in_frag(inner)?, &raw_ident, &fname_ident);
                         let tmp_ident = format_ident!("__{}_jobj", fname_ident);
                         let decode = if niche {
                             // The Kotlin data-class property is still `ULong?`
@@ -182,7 +179,7 @@ pub(crate) fn struct_input_body(
             {
                 let sig = format!("L{};", fqn.replace('.', "/"));
                 let inner_conv =
-                    composed_entry_decode(registry.input_entry(inner)?, &raw_ident, &fname_ident);
+                    composed_entry_decode(&ext.in_frag(inner)?, &raw_ident, &fname_ident);
                 let tmp_ident = format_ident!("__{}_jobj", fname_ident);
                 let decode = if field_optional {
                     quote! {
@@ -240,8 +237,8 @@ pub(crate) fn struct_input_body(
                 // Kotlin class for a nested data-class field (Option-stripped
                 // — a nullable field keeps the same descriptor), `List` for a
                 // `Vec` field.
-                let sig = registry
-                    .input_entry(inner)
+                let sig = ext
+                    .in_frag(inner)
                     .and_then(|e| jni_field_access(&e.destination))
                     .and_then(|(sig, _, is_obj)| {
                         if is_obj {
@@ -352,7 +349,6 @@ pub(crate) fn sum_input_body(
             let err_prefix = format!("{enum_name}.{kotlin_name}.{prop}: {{}}");
             let (pre, value) = read_kotlin_property(
                 ext,
-                registry,
                 &quote!(__obj),
                 &prop,
                 &field.ty,
@@ -415,7 +411,6 @@ pub(crate) fn sum_input_body(
 #[allow(clippy::too_many_arguments)]
 fn read_kotlin_property(
     ext: &Declarations,
-    registry: &impl Conversions<KotlinMeta>,
     receiver: &TokenStream,
     prop: &str,
     reading: &TypeRef,
@@ -427,7 +422,7 @@ fn read_kotlin_property(
     // below asked of it once — `option_inner_type` compared the last path
     // segment, so a payload spelled `Box<Option<T>>` answered "not optional"
     // four separate times here (#289).
-    let entry = registry.input_entry(reading)?;
+    let entry = ext.in_frag(reading)?;
     let ty = emit.spell(reading);
     let optional = reading.optional_inner().is_some();
     let inner = reading.optional_inner().unwrap_or(reading);
@@ -438,7 +433,7 @@ fn read_kotlin_property(
     // stages that follow (`jlong → u64 → Duration`). Stage bindings are named
     // off `bind`, so two payloads of the same type in one variant do not
     // collide.
-    let conv = composed_property_decode(entry, bind);
+    let conv = composed_property_decode(&entry, bind);
 
     // A handle property is a `NativeHandle` object whose raw pointer comes
     // from `peek()`; an enum property is the Kotlin enum class, decoded
@@ -509,7 +504,7 @@ fn read_kotlin_property(
         // Under `Option`, JVM null is `None` and the INNER converter decodes
         // the discriminant; the outer converter would expect a boxed Integer.
         let decode = if optional {
-            let inner_conv = composed_entry_decode(registry.input_entry(inner)?, &raw, bind);
+            let inner_conv = composed_entry_decode(&ext.in_frag(inner)?, &raw, bind);
             quote! {
                 let #bind = if #obj.is_null() {
                     ::core::option::Option::None
@@ -614,7 +609,7 @@ fn read_kotlin_property(
 /// derive from `stage_base`, so two values of the same type in one scope get
 /// distinct names.
 fn composed_entry_decode(
-    entry: &prebindgen_registry::TypeEntry<KotlinMeta>,
+    entry: &prebindgen_registry::ConverterImpl<KotlinMeta>,
     raw: &syn::Ident,
     stage_base: &syn::Ident,
 ) -> TokenStream {
@@ -641,7 +636,7 @@ fn composed_entry_decode(
 /// [`composed_entry_decode`] for a sealed-class property, whose raw binding is
 /// `<bind>_raw` by construction.
 fn composed_property_decode(
-    entry: &prebindgen_registry::TypeEntry<KotlinMeta>,
+    entry: &prebindgen_registry::ConverterImpl<KotlinMeta>,
     bind: &syn::Ident,
 ) -> TokenStream {
     composed_entry_decode(entry, &format_ident!("{}_raw", bind), bind)
@@ -695,7 +690,7 @@ pub(crate) struct FlatLeaf {
     pub is_present_flag: bool,
     /// Complete converter entry for an ordinary value leaf. Present flags and
     /// direct owned-handle leaves have no entry here.
-    pub entry: Option<prebindgen_registry::TypeEntry<KotlinMeta>>,
+    pub entry: Option<prebindgen_registry::ConverterImpl<KotlinMeta>>,
     /// A nested owned handle crosses as a raw pointer under the same Kotlin
     /// locking/consume scaffold as a top-level handle. This stores the typed
     /// property access tail (`.child.handle` / `?.handle`) used to collect it.
@@ -1005,7 +1000,7 @@ fn flat_error(root: &TypeKey, path: &str, reason: impl Into<String>) -> FlatInpu
     }
 }
 
-fn wire_kotlin_type(entry: &prebindgen_registry::TypeEntry<KotlinMeta>) -> String {
+fn wire_kotlin_type(entry: &prebindgen_registry::ConverterImpl<KotlinMeta>) -> String {
     if let Some(p) = JniPrim::from_wire(&entry.destination) {
         return p.kotlin_type().to_string();
     }
@@ -1088,7 +1083,7 @@ fn build_flat_sum_field(
     }
     struct PlannedLeaf {
         native: String,
-        entry: prebindgen_registry::TypeEntry<KotlinMeta>,
+        entry: prebindgen_registry::ConverterImpl<KotlinMeta>,
         access_tail: String,
         nullable_wire: bool,
     }
@@ -1098,7 +1093,7 @@ fn build_flat_sum_field(
         let mut fields = Vec::new();
         for field in &alt.fields {
             // The payload's own reading straight to its entry.
-            let entry = registry.input_entry(&field.ty)?;
+            let entry = ext.in_frag(&field.ty)?;
             // A projection payload (handle) carries ownership
             // and locking rules the tag-gated group does not model yet.
             if entry.metadata.projection.is_some() {
@@ -1250,7 +1245,7 @@ fn push_value_leaf(
     leaves: &mut Vec<FlatLeaf>,
     native: &str,
     field: syn::Ident,
-    entry: &prebindgen_registry::TypeEntry<KotlinMeta>,
+    entry: &prebindgen_registry::ConverterImpl<KotlinMeta>,
     access: String,
     nullable_wire: bool,
 ) -> usize {
@@ -1356,7 +1351,7 @@ pub(crate) fn build_flat_input_plan(
     // param's Kotlin type (compared by short name, since metadata carries the
     // FQN) must equal the struct's data-class name.
     // The parameter's own reading straight to its entry — no spell-and-look-back.
-    let Some(entry) = registry.input_entry(arg) else {
+    let Some(entry) = ext.in_frag(arg) else {
         return Ok(None);
     };
     if entry.metadata.projection.is_some() {
@@ -1526,7 +1521,7 @@ fn build_flat_struct_node(
         let path = child_native.clone();
         // The field's own reading straight to its entry — the `reading_of` hop
         // only ever recovered what the field already carried.
-        let Some(fentry) = registry.input_entry(&field.ty) else {
+        let Some(fentry) = ext.in_frag(&field.ty) else {
             return Err(flat_error(
                 root,
                 &path,
@@ -1538,7 +1533,7 @@ fn build_flat_struct_node(
         // `(present, value)` representation at every recursion depth.
         if let Some(inner_reading) = field.ty.optional_inner() {
             if inner_reading.borrow_target().is_none() {
-                if let Some(inner) = registry.input_entry(inner_reading) {
+                if let Some(inner) = ext.in_frag(inner_reading) {
                     if let Some(prim) = JniPrim::from_wire(&inner.destination) {
                         if inner.niches.clone().carve().is_none()
                             && inner.metadata.projection.is_none()
@@ -1559,7 +1554,7 @@ fn build_flat_struct_node(
                                 leaves,
                                 &format!("{child_native}_value"),
                                 fident.clone(),
-                                inner,
+                                &inner,
                                 value_access,
                                 false,
                             );
@@ -1589,7 +1584,7 @@ fn build_flat_struct_node(
             if proj.kind == ProjectionKind::Unsigned64 {
                 if let Some(inner_reading) = field.ty.optional_inner() {
                     if JniPrim::from_wire(&fentry.destination).is_none() {
-                        let inner = registry.input_entry(inner_reading).ok_or_else(|| {
+                        let inner = ext.in_frag(inner_reading).ok_or_else(|| {
                             flat_error(
                                 root,
                                 &path,
@@ -1609,7 +1604,7 @@ fn build_flat_struct_node(
                             leaves,
                             &format!("{child_native}_value"),
                             fident.clone(),
-                            inner,
+                            &inner,
                             format!("{field_ref}?.toLong() ?: 0L"),
                             false,
                         );
@@ -1670,7 +1665,7 @@ fn build_flat_struct_node(
                         leaves,
                         &child_native,
                         fident.clone(),
-                        fentry,
+                        &fentry,
                         access,
                         false,
                     );
@@ -1717,7 +1712,7 @@ fn build_flat_struct_node(
             leaves,
             &child_native,
             fident.clone(),
-            fentry,
+            &fentry,
             access,
             (field_is_option || nullable_context) && is_jobject_shaped_wire(&fentry.destination),
         );
@@ -1772,7 +1767,7 @@ pub(crate) fn render_flat_input_decode(
 }
 
 fn render_entry_decode(
-    entry: &prebindgen_registry::TypeEntry<KotlinMeta>,
+    entry: &prebindgen_registry::ConverterImpl<KotlinMeta>,
     wire_ident: &syn::Ident,
     out_ident: &syn::Ident,
     on_err: &TokenStream,
@@ -2097,7 +2092,6 @@ pub(crate) struct OptionScalarInputPlan {
 /// unboxed / ABI-clean) and opaque/value projections are left untouched.
 pub(crate) fn build_option_scalar_input_plan(
     ext: &Declarations,
-    registry: &Registry<KotlinMeta>,
     param_name: &syn::Ident,
     arg: &TypeRef,
 ) -> Option<OptionScalarInputPlan> {
@@ -2114,7 +2108,7 @@ pub(crate) fn build_option_scalar_input_plan(
         return None;
     }
     // The layer's own reading straight to its entry — no spell-and-look-back.
-    let inner_entry = registry.input_entry(inner)?;
+    let inner_entry = ext.in_frag(inner)?;
     let value_wire = inner_entry.destination.clone();
     // Only the boxed-primitive fallback shape: primitive wire, no niche,
     // no projection, no composed pre-stages.

--- a/prebindgen-jni/src/jni/emit/flat_input.rs
+++ b/prebindgen-jni/src/jni/emit/flat_input.rs
@@ -1059,7 +1059,7 @@ pub(crate) fn wire_kotlin_type(entry: &prebindgen_registry::ConverterImpl<Kotlin
 #[allow(clippy::too_many_arguments)]
 fn build_flat_sum_field(
     ext: &Declarations,
-    registry: &Registry,
+    registry: &impl Conversions,
     sum_reading: &TypeRef,
     field: syn::Ident,
     optional: bool,
@@ -1152,7 +1152,7 @@ impl Leaves<'_> {
 
 pub(crate) fn build_flat_input_plan(
     ext: &Declarations,
-    registry: &Registry,
+    registry: &impl Conversions,
     param_name: &syn::Ident,
     arg: &TypeRef,
 ) -> Result<Option<FlatInputPlan>, FlatInputError> {
@@ -1272,7 +1272,7 @@ pub(crate) fn build_flat_input_plan(
 #[allow(clippy::too_many_arguments)]
 fn build_flat_struct_node(
     ext: &Declarations,
-    registry: &Registry,
+    registry: &impl Conversions,
     st: &flat::Struct,
     optional: bool,
     native_prefix: &str,

--- a/prebindgen-jni/src/jni/emit/struct_out.rs
+++ b/prebindgen-jni/src/jni/emit/struct_out.rs
@@ -64,100 +64,50 @@ pub(crate) fn primitive_default_for_descriptor(sig: &str) -> TokenStream {
     }
 }
 
-/// Synthesize the [`LeafSource::Field`](prebindgen_registry::unfold::LeafSource)
-/// leaves of a by-value `data_class` for the fixed-builder output/callback path
-/// — the pre-resolve analog of [`flatten_struct_encode`] (which runs at emit
-/// time). Each named field becomes one field-access leaf
-/// (`name`, `path = [..field idents]`, `out_ty = <field type>`); a non-optional
-/// nested data-class field recurses (inlined), so the whole graph crosses as
-/// decoupled leaves the foreign side reassembles.
+/// The [`LeafSource::Field`](prebindgen_registry::unfold::LeafSource) leaves of
+/// a by-value `data_class`, as the fixed-builder output and callback paths want
+/// them.
 ///
-/// Returns `None` (⇒ the type keeps the whole-value `fromParts` path) when a
-/// field needs a transform this fixed builder can't yet forward verbatim — a
-/// **projection** (opaque handle), an **enum**, or a nested
-/// data-class behind `Option` / `Vec`. (Those are handled by the slower
-/// [`struct_output_body`] until the synthesizer is widened to wrap them.)
+/// The list is [`Declarations::struct_out_wires`]', mapped. Runs BEFORE
+/// `resolve`, which is exactly why it shares that composition rather than
+/// walking the struct a second time: the leaf names reach the foreign
+/// `fromParts` parameters and the row identically, and two walks agreeing was a
+/// property nothing checked.
 ///
-/// Classification reads only `ext.types` (`opaque`/`enum_cfg`) and the parsed
-/// model (`registry.flat()`) — both populated before `resolve` — never the
-/// output converter table (not yet built at this stage).
+/// `None` — the type keeps the whole-value `fromParts` path — when a field needs
+/// a transform this fixed builder cannot forward verbatim. See
+/// [`Declarations::struct_out_wires`] for which fields those are and why one of
+/// them declines the whole value.
 pub(crate) fn synth_value_struct_leaves(
     ext: &Declarations,
     registry: &impl Conversions,
     s: &prebindgen_registry::flat::Struct,
-    path_prefix: &[prebindgen_registry::unfold::PathStep],
-    name_prefix: &str,
-    depth: usize,
 ) -> Option<Vec<prebindgen_registry::unfold::UnfoldLeaf>> {
     use prebindgen_registry::unfold::{LeafSource, PathStep, UnfoldLeaf};
-    if depth > 16 {
-        return None;
-    }
-    // Named by construction — a tuple struct is an `Extern`, not a `Struct`.
-    let mut leaves: Vec<UnfoldLeaf> = Vec::new();
-    for field in &s.fields {
-        let fname = field.name.as_ref()?.clone();
-        let camel = mangle_kotlin_ident(&kt_snake_to_camel(&fname.to_string()));
-        let leaf_name = if name_prefix.is_empty() {
-            camel
-        } else {
-            format!("{name_prefix}__{camel}")
-        };
-        let mut path = path_prefix.to_vec();
-        // The synthesizer declines `Option`-wrapped nesting below, so an
-        // intermediate step is never optional; a TERMINAL `Option` field is not
-        // a nesting step either (its own converter carries the nullability).
-        path.push(PathStep::field(fname, false));
-
-        // A projection field (opaque handle) or an enum field
-        // is delivered with a transform the fixed builder can't forward yet.
-        // A nested data-class field (a *declared* plain struct) inlines when
-        // non-optional (recurse); `Option`/`Vec`-wrapped nesting is deferred
-        // to the whole-value path.
-        // Both layer questions off the field's own reading: `Optional` to look
-        // through, `Vec` to defer — the kinds, not a last path segment.
-        let probe = field.ty.optional_inner().unwrap_or(&field.ty);
-        let nested = match ext.type_kind(registry, &probe.key()) {
-            // A sum joins the kinds this fixed builder cannot forward: it has
-            // no single leaf and no converter of its own — it crosses as a tag
-            // plus one group per variant, which only the whole-value
-            // `fromParts` path (`PlanFieldKind::Sum`) can lay out. Falling
-            // through to the simple-leaf arm below would silently synthesize a
-            // leaf whose `out_ty` is the sum and then REQUIRE an output
-            // converter for it, failing the resolve with the sum named rather
-            // than the unsupported position.
-            TypeKind::Handle | TypeKind::Enum | TypeKind::Sum => return None,
-            TypeKind::DataStruct { st, cfg: Some(_) } => Some(st.clone()),
-            _ => None,
-        };
-        if let Some(child) = nested {
-            if field.ty.optional_inner().is_some()
-                || matches!(field.ty.kind(), prebindgen_registry::flat::TypeKind::Vec(_))
-            {
-                return None;
-            }
-            let child_leaves =
-                synth_value_struct_leaves(ext, registry, &child, &path, &leaf_name, depth + 1)?;
-            leaves.extend(child_leaves);
-            continue;
-        }
-
-        // Simple leaf: scalar / String / Option<Box<String>> / ByteArray / Vec.
-        // The field's own output converter (resolved later) encodes it; the
-        // foreign `fromParts` forwards it verbatim. Nullability is carried by
-        // the converter (e.g. `Option<Box<String>>` → `String?`), so the leaf
-        // itself isn't path-nullable.
-        leaves.push(UnfoldLeaf {
-            name: leaf_name,
-            path,
-            out_ty: field.ty.clone(),
-            identity: false,
-            nullable: false,
-            source: LeafSource::Field,
-            group: None,
-        });
-    }
-    Some(leaves)
+    Some(
+        ext.struct_out_wires_of(registry, &s.name)?
+            .into_iter()
+            .map(|w| UnfoldLeaf {
+                name: w.name,
+                // The synthesizer declines `Option`-wrapped nesting, so an
+                // intermediate step is never optional; a TERMINAL `Option`
+                // field is not a nesting step either, its own converter
+                // carrying the nullability.
+                path: match w.from {
+                    crate::jni::compile::OutFrom::Field { path } => path
+                        .into_iter()
+                        .map(|ident| PathStep::field(ident, false))
+                        .collect(),
+                    _ => Vec::new(),
+                },
+                out_ty: w.out_ty,
+                identity: false,
+                nullable: w.nullable,
+                source: LeafSource::Field,
+                group: w.group,
+            })
+            .collect(),
+    )
 }
 
 /// Recursively flatten a struct's output encode into a list of leaf wire

--- a/prebindgen-jni/src/jni/emit/struct_out.rs
+++ b/prebindgen-jni/src/jni/emit/struct_out.rs
@@ -83,21 +83,14 @@ pub(crate) fn synth_value_struct_leaves(
     registry: &impl Conversions,
     s: &prebindgen_registry::flat::Struct,
 ) -> Option<Vec<prebindgen_registry::unfold::UnfoldLeaf>> {
-    use prebindgen_registry::unfold::{LeafSource, PathStep, UnfoldLeaf};
+    use prebindgen_registry::unfold::{LeafSource, UnfoldLeaf};
     Some(
         ext.struct_out_wires_of(registry, &s.name)?
             .into_iter()
             .map(|w| UnfoldLeaf {
                 name: w.name,
-                // The synthesizer declines `Option`-wrapped nesting, so an
-                // intermediate step is never optional; a TERMINAL `Option`
-                // field is not a nesting step either, its own converter
-                // carrying the nullability.
                 path: match w.from {
-                    crate::jni::compile::OutFrom::Field { path } => path
-                        .into_iter()
-                        .map(|ident| PathStep::field(ident, false))
-                        .collect(),
+                    crate::jni::compile::OutFrom::Reach { path } => path,
                     _ => Vec::new(),
                 },
                 out_ty: w.out_ty,

--- a/prebindgen-jni/src/jni/emit/struct_out.rs
+++ b/prebindgen-jni/src/jni/emit/struct_out.rs
@@ -89,10 +89,7 @@ pub(crate) fn synth_value_struct_leaves(
             .into_iter()
             .map(|w| UnfoldLeaf {
                 name: w.name,
-                path: match w.from {
-                    crate::jni::compile::OutFrom::Reach { path } => path,
-                    _ => Vec::new(),
-                },
+                path: w.reach,
                 out_ty: w.out_ty,
                 identity: false,
                 nullable: w.nullable,

--- a/prebindgen-jni/src/jni/emit/struct_out.rs
+++ b/prebindgen-jni/src/jni/emit/struct_out.rs
@@ -83,7 +83,7 @@ pub(crate) fn primitive_default_for_descriptor(sig: &str) -> TokenStream {
 /// output converter table (not yet built at this stage).
 pub(crate) fn synth_value_struct_leaves(
     ext: &Declarations,
-    registry: &impl Conversions<KotlinMeta>,
+    registry: &impl Conversions,
     s: &prebindgen_registry::flat::Struct,
     path_prefix: &[prebindgen_registry::unfold::PathStep],
     name_prefix: &str,
@@ -174,7 +174,7 @@ pub(crate) fn synth_value_struct_leaves(
 /// order and JVM descriptors agree by construction.
 pub(crate) fn flatten_struct_encode(
     ext: &Declarations,
-    registry: &impl Conversions<KotlinMeta>,
+    registry: &impl Conversions,
     s: &prebindgen_registry::flat::Struct,
     access: &TokenStream,
     prefix: &str,
@@ -591,7 +591,7 @@ fn encode_field(
 pub(crate) fn struct_output_body(
     ext: &Declarations,
     s: &prebindgen_registry::flat::Struct,
-    registry: &impl Conversions<KotlinMeta>,
+    registry: &impl Conversions,
 ) -> Option<(syn::Type, syn::Expr)> {
     let struct_name = s.name.to_string();
     // Prefer the registered Kotlin FQN (`io.zenoh.jni.JniSample`) so the
@@ -652,7 +652,7 @@ pub(crate) fn struct_output_body(
 
 pub(crate) fn struct_module_path(
     ext: &Declarations,
-    registry: &impl Conversions<KotlinMeta>,
+    registry: &impl Conversions,
     name: &syn::Ident,
 ) -> syn::Path {
     // The module the struct is reachable under from the generated file: its

--- a/prebindgen-jni/src/jni/emit/struct_out.rs
+++ b/prebindgen-jni/src/jni/emit/struct_out.rs
@@ -64,7 +64,7 @@ pub(crate) fn primitive_default_for_descriptor(sig: &str) -> TokenStream {
     }
 }
 
-/// The [`LeafSource::Field`](prebindgen_registry::unfold::LeafSource) leaves of
+/// The [`LeafSource::Reach`](prebindgen_registry::unfold::LeafSource) leaves of
 /// a by-value `data_class`, as the fixed-builder output and callback paths want
 /// them.
 ///
@@ -93,7 +93,7 @@ pub(crate) fn synth_value_struct_leaves(
                 out_ty: w.out_ty,
                 identity: false,
                 nullable: w.nullable,
-                source: LeafSource::Field,
+                source: LeafSource::Reach,
                 group: w.group,
             })
             .collect(),

--- a/prebindgen-jni/src/jni/emit/sum_out.rs
+++ b/prebindgen-jni/src/jni/emit/sum_out.rs
@@ -105,11 +105,7 @@ pub(crate) struct Slot {
     pub(crate) default: TokenStream,
 }
 
-pub(crate) fn leaf_slot(
-    ext: &Declarations,
-    leaf: &prebindgen_registry::unfold::UnfoldLeaf,
-) -> Slot {
-    use prebindgen_registry::unfold::LeafSource;
+pub(crate) fn leaf_slot(ext: &Declarations, leaf: &crate::jni::compile::OutWire) -> Slot {
     if !leaf_is_prim(ext, leaf) {
         return Slot {
             prim: false,
@@ -119,7 +115,7 @@ pub(crate) fn leaf_slot(
     }
     // The tag is synthesized, so it has no converter to read a wire from — it
     // is a `jint` by definition.
-    let (sig, letter) = if leaf.source == LeafSource::SumTag {
+    let (sig, letter) = if leaf.is_tag() {
         ("I", format_ident!("i"))
     } else {
         let wire = ext
@@ -165,20 +161,18 @@ pub(crate) fn is_sum_leaves(leaves: &[prebindgen_registry::unfold::UnfoldLeaf]) 
 pub(crate) fn encode_sum_group(
     ext: &Declarations,
     registry: &impl Conversions,
-    leaves: &[prebindgen_registry::unfold::UnfoldLeaf],
+    leaves: &[crate::jni::compile::OutWire],
     obj_idents: &[syn::Ident],
     matched: TokenStream,
     fail: &dyn Fn(TokenStream) -> TokenStream,
     emit: &prebindgen_registry::Emit,
 ) -> (TokenStream, Vec<TokenStream>) {
-    use prebindgen_registry::unfold::LeafSource;
-
     // Which sum this is comes from the selector leaf, not from the plan's
     // source: the plan's source is the *containing* value when the sum is a
     // field of a value form.
     let tag_leaf = leaves
         .iter()
-        .find(|l| l.source == LeafSource::SumTag)
+        .find(|l| l.is_tag())
         .expect("a sum segment carries its selector leaf");
     // The name off the reading — `TypeId` IS the name, so nothing takes a path
     // apart to re-derive one.
@@ -231,7 +225,7 @@ pub(crate) fn encode_sum_group(
     // its pattern binds them in.
     let tag_idx = leaves
         .iter()
-        .position(|l| l.source == LeafSource::SumTag)
+        .position(|l| l.is_tag())
         .expect("a sum plan carries its selector leaf");
     let tag_id = &obj_idents[tag_idx];
     // A unit variant contributes no leaf, so the arm list is driven by the
@@ -339,7 +333,7 @@ pub(crate) fn encode_sum_group(
 /// way.
 fn encode_group_leaf(
     ext: &Declarations,
-    leaf: &prebindgen_registry::unfold::UnfoldLeaf,
+    leaf: &crate::jni::compile::OutWire,
     obj_ident: &syn::Ident,
     prim: bool,
     bind: &syn::Ident,

--- a/prebindgen-jni/src/jni/emit/sum_out.rs
+++ b/prebindgen-jni/src/jni/emit/sum_out.rs
@@ -116,11 +116,11 @@ pub(crate) fn leaf_slot(ext: &Declarations, leaf: &crate::jni::compile::OutWire)
     }
 }
 
-/// True when `plan` decomposes a sum — it carries the synthesized selector.
-/// The one place that question is asked, so every consumer agrees on it.
-pub(crate) fn is_sum_leaves(leaves: &[prebindgen_registry::unfold::UnfoldLeaf]) -> bool {
-    use prebindgen_registry::unfold::LeafSource;
-    leaves.iter().any(|l| l.source == LeafSource::SumTag)
+/// True when these values decompose a sum — they carry the synthesized
+/// selector. The one place that question is asked, so every consumer agrees on
+/// it.
+pub(crate) fn is_sum_row(leaves: &[crate::jni::compile::OutWire]) -> bool {
+    leaves.iter().any(|l| l.is_tag())
 }
 
 /// Emit the Rust-side encode of a decomposed sum: ONE `match` over the value

--- a/prebindgen-jni/src/jni/emit/sum_out.rs
+++ b/prebindgen-jni/src/jni/emit/sum_out.rs
@@ -63,7 +63,7 @@ pub(crate) fn synth_sum_leaves(
                         member,
                     }
                 }
-                crate::jni::compile::OutFrom::Reach { .. } => LeafSource::Field,
+                crate::jni::compile::OutFrom::Place => LeafSource::Field,
             },
             group: w.group,
         })

--- a/prebindgen-jni/src/jni/emit/sum_out.rs
+++ b/prebindgen-jni/src/jni/emit/sum_out.rs
@@ -63,7 +63,7 @@ pub(crate) fn synth_sum_leaves(
                         member,
                     }
                 }
-                crate::jni::compile::OutFrom::Field { .. } => LeafSource::Field,
+                crate::jni::compile::OutFrom::Reach { .. } => LeafSource::Field,
             },
             group: w.group,
         })

--- a/prebindgen-jni/src/jni/emit/sum_out.rs
+++ b/prebindgen-jni/src/jni/emit/sum_out.rs
@@ -164,7 +164,7 @@ pub(crate) fn is_sum_leaves(leaves: &[prebindgen_registry::unfold::UnfoldLeaf]) 
 /// every arm and only one arm computes it.
 pub(crate) fn encode_sum_group(
     ext: &Declarations,
-    registry: &impl Conversions<KotlinMeta>,
+    registry: &impl Conversions,
     leaves: &[prebindgen_registry::unfold::UnfoldLeaf],
     obj_idents: &[syn::Ident],
     matched: TokenStream,

--- a/prebindgen-jni/src/jni/emit/sum_out.rs
+++ b/prebindgen-jni/src/jni/emit/sum_out.rs
@@ -63,7 +63,7 @@ pub(crate) fn synth_sum_leaves(
                         member,
                     }
                 }
-                crate::jni::compile::OutFrom::Place => LeafSource::Field,
+                crate::jni::compile::OutFrom::Place => LeafSource::Reach,
             },
             group: w.group,
         })

--- a/prebindgen-jni/src/jni/emit/sum_out.rs
+++ b/prebindgen-jni/src/jni/emit/sum_out.rs
@@ -25,68 +25,49 @@ use super::*;
 /// variant fragment from its property.
 pub(crate) const SUM_TAG_LEAF: &str = "tag";
 
-/// Synthesize the leaves of one `sealed_class`-declared sum: the
-/// [`LeafSource::SumTag`] selector followed by one
+/// The leaves of one `sealed_class`-declared sum, as the expansion plans want
+/// them: the [`LeafSource::SumTag`] selector followed by one
 /// [`LeafSource::VariantField`] leaf per payload field, in tag order, each
 /// carrying its variant's tag as its [`group`](UnfoldLeaf::group).
 ///
-/// Runs BEFORE `resolve` (like
-/// [`synth_value_struct_leaves`](super::synth_value_struct_leaves)), so it may
-/// only read the declaration (`sum_cfg`) and the enum's syntax — never the
-/// converter tables. Every payload's own `out_ty` is registered as a required
-/// output by the core wiring, so a payload that cannot cross fails naming
-/// itself.
-///
-/// Slot names come from the same [`sum_slot_fragment`] / [`sum_field_prop_name`]
-/// pair the sealed-interface emitter and the struct-field bridge use, so a
-/// `variant!(V).name(...)` rename carries through to the builder's parameter
-/// names too.
+/// The list is `Declarations::sum_out_wires`', mapped. Runs BEFORE `resolve`,
+/// which is exactly why it shares that composition rather than walking the
+/// enum a second time: a `variant!(V).name(..)` rename and the slot naming have
+/// to reach the builder's parameter names and the row identically, and two
+/// walks agreeing was a property nothing checked.
 pub(crate) fn synth_sum_leaves(
     ext: &Declarations,
-    sum_cfg: &SumConfig,
+    registry: &impl Conversions,
+    ident: &syn::Ident,
     sum: &prebindgen_registry::flat::Variant,
 ) -> Vec<prebindgen_registry::unfold::UnfoldLeaf> {
     use prebindgen_registry::unfold::{LeafSource, UnfoldLeaf};
-
-    // The selector rides ahead of the groups it chooses between, and carries
-    // **which sum** it selects over as its `out_ty` — that is how the emitter
-    // finds the enum to `match` when the sum is a field rather than the whole
-    // returned value. Nothing looks up a converter for it (`has_converter()` is
-    // false for a `SumTag`): there is no value to convert, the emitter assigns
-    // the tag literal per arm. Its wire is a `jint` by definition.
-    let mut leaves = vec![UnfoldLeaf {
-        name: SUM_TAG_LEAF.to_string(),
-        path: Vec::new(),
-        // The tag names WHICH sum it selects over, and no source wrote that as
-        // a standalone type — so the DECLARATION answers, rather than this
-        // emitter minting a reading from the name. Nothing resolves a converter
-        // for it (`has_converter()` is false), but the emitter reads it back to
-        // find the enum to `match`.
-        out_ty: sum.type_ref().clone(),
-        identity: false,
-        nullable: false,
-        source: LeafSource::SumTag,
-        group: None,
-    }];
-    for alt in &sum.alternatives {
-        let kotlin_name = ext.sum_variant_class_name(sum_cfg, &alt.name);
-        for field in &alt.fields {
-            let prop = sum_field_prop_name(&field.member());
-            leaves.push(UnfoldLeaf {
-                name: sum_slot_fragment(&kotlin_name, &prop),
-                path: Vec::new(),
-                out_ty: field.ty.clone(),
-                identity: false,
-                nullable: false,
-                source: LeafSource::VariantField {
-                    variant: alt.name.clone(),
-                    member: field.member(),
-                },
-                group: Some(sum_tag(alt)),
-            });
-        }
-    }
-    leaves
+    ext.sum_out_wires(registry, ident, sum.type_ref())
+        .unwrap_or_default()
+        .into_iter()
+        .map(|w| UnfoldLeaf {
+            name: w.name,
+            path: Vec::new(),
+            out_ty: w.out_ty,
+            identity: false,
+            nullable: w.nullable,
+            source: match w.from {
+                // Nothing looks up a converter for the selector
+                // (`has_converter()` is false for a `SumTag`): there is no
+                // value to convert, the emitter assigns the tag literal per
+                // arm. Its wire is a `jint` by definition.
+                crate::jni::compile::OutFrom::Tag => LeafSource::SumTag,
+                crate::jni::compile::OutFrom::Payload { variant, member } => {
+                    LeafSource::VariantField {
+                        variant: variant.expect("a composed payload names its alternative"),
+                        member,
+                    }
+                }
+                crate::jni::compile::OutFrom::Field { .. } => LeafSource::Field,
+            },
+            group: w.group,
+        })
+        .collect()
 }
 
 /// The wire slot one leaf occupies when its value is only computed in SOME arm

--- a/prebindgen-jni/src/jni/emit/sum_out.rs
+++ b/prebindgen-jni/src/jni/emit/sum_out.rs
@@ -106,11 +106,11 @@ pub(crate) struct Slot {
 }
 
 pub(crate) fn leaf_slot(
-    registry: &impl Conversions<KotlinMeta>,
+    ext: &Declarations,
     leaf: &prebindgen_registry::unfold::UnfoldLeaf,
 ) -> Slot {
     use prebindgen_registry::unfold::LeafSource;
-    if !leaf_is_prim(registry, leaf) {
+    if !leaf_is_prim(ext, leaf) {
         return Slot {
             prim: false,
             ty: quote!(jni::objects::JObject),
@@ -122,8 +122,8 @@ pub(crate) fn leaf_slot(
     let (sig, letter) = if leaf.source == LeafSource::SumTag {
         ("I", format_ident!("i"))
     } else {
-        let wire = registry
-            .output_entry(&leaf.out_ty)
+        let wire = ext
+            .out_frag(&leaf.out_ty)
             .expect("leaf_is_prim implies a resolved output entry")
             .destination
             .clone();
@@ -200,7 +200,7 @@ pub(crate) fn encode_sum_group(
     let module = ext.fn_module(registry, &ident);
     let source: syn::Path = syn::parse_quote!(#module::#ident);
 
-    let slots: Vec<Slot> = leaves.iter().map(|l| leaf_slot(registry, l)).collect();
+    let slots: Vec<Slot> = leaves.iter().map(|l| leaf_slot(ext, l)).collect();
 
     let arg_exprs: Vec<TokenStream> = leaves
         .iter()
@@ -281,7 +281,7 @@ pub(crate) fn encode_sum_group(
                 .zip(&binds)
                 .map(|(&idx, bind)| {
                     encode_group_leaf(
-                        registry,
+                        ext,
                         &leaves[idx],
                         &obj_idents[idx],
                         slots[idx].prim,
@@ -338,14 +338,14 @@ pub(crate) fn encode_sum_group(
 /// payload and a struct field of the same type reach their converter the same
 /// way.
 fn encode_group_leaf(
-    registry: &impl Conversions<KotlinMeta>,
+    ext: &Declarations,
     leaf: &prebindgen_registry::unfold::UnfoldLeaf,
     obj_ident: &syn::Ident,
     prim: bool,
     bind: &syn::Ident,
     fail: &dyn Fn(TokenStream) -> TokenStream,
 ) -> TokenStream {
-    let out_entry = registry.output_entry(&leaf.out_ty).unwrap_or_else(|| {
+    let out_entry = ext.out_frag(&leaf.out_ty).unwrap_or_else(|| {
         panic!(
             "jnigen sum unfold: payload leaf `{}` (`{}`) has no registered output converter",
             leaf.name,

--- a/prebindgen-jni/src/jni/emit/vec_build.rs
+++ b/prebindgen-jni/src/jni/emit/vec_build.rs
@@ -53,7 +53,7 @@ pub(crate) struct VecBuildElem {
 /// four sites agree on which params take the handle path.
 pub(crate) fn vec_build_elem(
     ext: &Declarations,
-    registry: &Registry<KotlinMeta>,
+    registry: &Registry,
     arg: &TypeRef,
 ) -> Option<VecBuildElem> {
     // The run and its element off the MODEL. `&mut [T]` is still refused —
@@ -182,7 +182,7 @@ pub(crate) fn vec_build_elem(
 /// the name `payloadVec` (#296).
 pub(crate) fn collect_vec_build_elem_types(
     ext: &Declarations,
-    registry: &Registry<KotlinMeta>,
+    registry: &Registry,
 ) -> Vec<TypeRef> {
     let declared = ext.declared_functions();
     let mut seen: std::collections::BTreeMap<String, TypeRef> = std::collections::BTreeMap::new();
@@ -217,7 +217,7 @@ pub(crate) struct VecBuildHelpers {
 /// the generated methods read naturally (`Payload` → `payloadVec`).
 pub(crate) fn vec_build_helpers(
     ext: &Declarations,
-    registry: &Registry<KotlinMeta>,
+    registry: &Registry,
     elem: &TypeRef,
 ) -> Option<VecBuildHelpers> {
     let plan = build_flat_input_plan(ext, registry, &format_ident!("e"), elem)
@@ -282,7 +282,7 @@ fn vec_helper_symbol(ext: &Declarations, base: &str, suffix: &str) -> String {
 /// push loop free of a per-element failure check.
 pub(crate) fn build_vec_build_helper_items(
     ext: &Declarations,
-    registry: &Registry<KotlinMeta>,
+    registry: &Registry,
     emit: &prebindgen_registry::Emit,
 ) -> Vec<syn::Item> {
     let mut named: Vec<(String, syn::Item)> = Vec::new();

--- a/prebindgen-jni/src/jni/emit/vec_build.rs
+++ b/prebindgen-jni/src/jni/emit/vec_build.rs
@@ -156,9 +156,10 @@ pub(crate) fn vec_build_elem(
     // silently changing the Vec helper ABI.
     if plan.contains_nested
         || plan.leaves.iter().any(|l| {
-            l.is_present_flag
-                || l.handle_target_tail.is_some()
-                || l.entry.as_ref().is_none_or(|e| !e.pre_stages.is_empty())
+            l.is_present_flag()
+                || l.wire.handle_target.is_some()
+                || l.entry().is_none()
+                || l.wire.staged()
         })
     {
         return None;
@@ -225,9 +226,10 @@ pub(crate) fn vec_build_helpers(
         .flatten()?;
     if plan.contains_nested
         || plan.leaves.iter().any(|l| {
-            l.is_present_flag
-                || l.handle_target_tail.is_some()
-                || l.entry.as_ref().is_none_or(|e| !e.pre_stages.is_empty())
+            l.is_present_flag()
+                || l.wire.handle_target.is_some()
+                || l.entry().is_none()
+                || l.wire.staged()
         })
     {
         return None;
@@ -320,19 +322,19 @@ pub(crate) fn build_vec_build_helper_items(
             .plan
             .leaves
             .iter()
-            .filter(|l| !l.is_present_flag)
+            .filter(|l| !l.is_present_flag())
             .map(|l| {
                 let id = &l.native_ident;
-                let ty = &l.native_wire_ty;
+                let ty = &l.native_wire_ty();
                 quote!(#id: #ty)
             })
             .collect();
         let mut decodes: Vec<TokenStream> = Vec::new();
         let mut inits: Vec<TokenStream> = Vec::new();
-        for l in h.plan.leaves.iter().filter(|l| !l.is_present_flag) {
-            let conv = l.conv.as_ref().expect("non-present leaf has a converter");
+        for l in h.plan.leaves.iter().filter(|l| !l.is_present_flag()) {
+            let conv = l.conv().expect("non-present leaf has a converter");
             let wid = &l.native_ident;
-            let fid = l.field.clone().expect("non-present leaf has a field");
+            let fid = format_ident!("{}", l.wire.field().expect("non-present leaf has a field"));
             let tmp = format_ident!("__e_{}", fid);
             decodes.push(quote!(
                 let #tmp = match #conv(&mut env, &#wid) {

--- a/prebindgen-jni/src/jni/emit/vec_build.rs
+++ b/prebindgen-jni/src/jni/emit/vec_build.rs
@@ -53,7 +53,7 @@ pub(crate) struct VecBuildElem {
 /// four sites agree on which params take the handle path.
 pub(crate) fn vec_build_elem(
     ext: &Declarations,
-    registry: &Registry,
+    registry: &impl prebindgen_registry::Conversions,
     arg: &TypeRef,
 ) -> Option<VecBuildElem> {
     // The run and its element off the MODEL. `&mut [T]` is still refused —

--- a/prebindgen-jni/src/jni/emit/wrapper.rs
+++ b/prebindgen-jni/src/jni/emit/wrapper.rs
@@ -554,7 +554,7 @@ fn emit_input_param(
         InputKind::FlattenStruct(plan) => {
             for leaf in &plan.leaves {
                 let pid = &leaf.native_ident;
-                let pty = &leaf.native_wire_ty;
+                let pty = &leaf.native_wire_ty();
                 wire_params.push(quote!(#pid: #pty));
             }
             let (decode, call_arg) = render_flat_input_decode(plan, arg_ident, on_err, emit);
@@ -916,7 +916,7 @@ pub(crate) fn emit_expanded_param(
         if let InputKind::FlattenStruct(flat) = &classified.kind {
             for flat_leaf in &flat.leaves {
                 let ident = &flat_leaf.native_ident;
-                let wire = &flat_leaf.native_wire_ty;
+                let wire = &flat_leaf.native_wire_ty();
                 wire_params.push(quote!(#ident: #wire));
             }
             let (decode, _) = render_flat_input_decode(flat, &local, on_err, emit);

--- a/prebindgen-jni/src/jni/emit/wrapper.rs
+++ b/prebindgen-jni/src/jni/emit/wrapper.rs
@@ -11,7 +11,7 @@ use crate::jni::trait_impl::{
 pub(crate) fn emit_jni_function_wrapper(
     ext: &Declarations,
     f: &prebindgen_registry::flat::Function,
-    registry: &Registry<KotlinMeta>,
+    registry: &Registry,
     emit: &prebindgen_registry::Emit,
 ) -> TokenStream {
     emit_jni_function_wrapper_with_callee(ext, f, registry, None, emit)
@@ -128,7 +128,7 @@ pub(crate) fn validate_constant_fn(ext: &Declarations, f: &prebindgen_registry::
 pub(crate) fn const_expr_getter_fn(
     kotlin_name: &str,
     ty: &syn::Type,
-    registry: &impl Conversions<KotlinMeta>,
+    registry: &impl Conversions,
 ) -> prebindgen_registry::flat::Function {
     let ident = format_ident!("const_get_{}", kotlin_name.to_lowercase());
     // The one lookup this path needs: the type is named by a build script, so
@@ -182,7 +182,7 @@ pub(crate) fn validate_constant_expr(ext: &Declarations, kotlin_name: &str, ty: 
 pub(crate) fn emit_jni_function_wrapper_with_callee(
     ext: &Declarations,
     f: &prebindgen_registry::flat::Function,
-    registry: &Registry<KotlinMeta>,
+    registry: &Registry,
     callee: Option<syn::Expr>,
     emit: &prebindgen_registry::Emit,
 ) -> TokenStream {
@@ -520,7 +520,7 @@ fn unfold_builder_param(iterable_fold: bool) -> TokenStream {
 #[allow(clippy::type_complexity)]
 fn emit_input_param(
     ext: &Declarations,
-    registry: &Registry<KotlinMeta>,
+    registry: &Registry,
     original_ident: &syn::Ident,
     param: &PlanParam,
     on_err: &TokenStream,
@@ -877,7 +877,7 @@ fn emit_plain_decode(
 /// argument is the built value (`&value` when the original parameter was `&T`).
 pub(crate) fn emit_expanded_param(
     ext: &Declarations,
-    registry: &Registry<KotlinMeta>,
+    registry: &Registry,
     plan: &prebindgen_registry::expand::FoldPlan,
     leaves: &[PlanLeaf],
     orig_param: &syn::Ident,

--- a/prebindgen-jni/src/jni/emit/wrapper.rs
+++ b/prebindgen-jni/src/jni/emit/wrapper.rs
@@ -342,7 +342,7 @@ pub(crate) fn emit_jni_function_wrapper_with_callee(
         let (ze_stmts, ze_args) = encode_plan_leaves(
             ext,
             registry,
-            ep,
+            crate::jni::emit::Delivered::of(ep),
             &eze_idents,
             &quote!(__de),
             &ze_fail,

--- a/prebindgen-jni/src/jni/emit/wrapper.rs
+++ b/prebindgen-jni/src/jni/emit/wrapper.rs
@@ -283,12 +283,22 @@ pub(crate) fn emit_jni_function_wrapper_with_callee(
             let hoisted = bind_hoists(&qualify, &uplan.hoists, &base, base_is_ref);
             let stmts = &hoisted.stmts;
             let reached = match hoisted.rebase(&leaf.path) {
-                Some((local, rest, consuming)) => {
-                    reach_leaf_flat(&qualify, leaf, &rest, quote!(#local), false, consuming)
-                }
-                None => {
-                    reach_leaf_flat(&qualify, leaf, &leaf.path, base.clone(), base_is_ref, false)
-                }
+                Some((local, rest, consuming)) => reach_leaf_flat(
+                    &qualify,
+                    &crate::jni::compile::OutWire::from_leaf(leaf),
+                    &rest,
+                    quote!(#local),
+                    false,
+                    consuming,
+                ),
+                None => reach_leaf_flat(
+                    &qualify,
+                    &crate::jni::compile::OutWire::from_leaf(leaf),
+                    &leaf.path,
+                    base.clone(),
+                    base_is_ref,
+                    false,
+                ),
             };
             if stmts.is_empty() && reached.to_string() == base.to_string() {
                 return None;

--- a/prebindgen-jni/src/jni/emit/wrapper.rs
+++ b/prebindgen-jni/src/jni/emit/wrapper.rs
@@ -231,8 +231,7 @@ pub(crate) fn emit_jni_function_wrapper_with_callee(
     // registry borrows for the future build-once stage.
     let output_entry = match &plan.output {
         FnOutputPlan::Value(v) => Some(
-            registry
-                .output_entry(&v.target_ty)
+            ext.out_frag(&v.target_ty)
                 .expect("output entry validated at plan build"),
         ),
         FnOutputPlan::Unfold(_) => None,
@@ -692,8 +691,8 @@ fn emit_input_param(
                 prebindgen_registry::flat::TypeKind::Ref { .. }
             ) =>
         {
-            let entry = registry
-                .input_entry(arg_ty)
+            let entry = ext
+                .in_frag(arg_ty)
                 .expect("plan classified Handle ⇒ entry present");
             let wire_ident = if matches!(&entry.destination, syn::Type::Ptr(_)) {
                 format_ident!("{}_ptr", arg_ident)
@@ -726,7 +725,7 @@ fn emit_input_param(
             // without the round trip. The panic now CALLS the shared message
             // instead of restating it, which is what `PlanError::message`'s doc
             // has always claimed and hand-duplication did not deliver.
-            let entry = registry.input_entry(&leaf.reading).unwrap_or_else(|| {
+            let entry = ext.in_frag(&leaf.reading).unwrap_or_else(|| {
                 panic!(
                     "{}",
                     PlanError::Unresolved {
@@ -735,7 +734,7 @@ fn emit_input_param(
                     .message(original_ident)
                 )
             });
-            emit_plain_decode(entry, arg_ident, arg_ty, on_err)
+            emit_plain_decode(&entry, arg_ident, arg_ty, on_err)
         }
     }
 }
@@ -744,7 +743,7 @@ fn emit_input_param(
 /// wire param + staged decode prelude + the call argument (`&decoded` /
 /// `.as_deref()` per the source param's Rust shape).
 fn emit_plain_decode(
-    entry: &prebindgen_registry::TypeEntry<KotlinMeta>,
+    entry: &prebindgen_registry::ConverterImpl<KotlinMeta>,
     arg_ident: &syn::Ident,
     arg_ty: &prebindgen_registry::flat::TypeRef,
     on_err: &TokenStream,
@@ -897,7 +896,7 @@ pub(crate) fn emit_expanded_param(
         let lookup_entry = || {
             // The leaf's own reading goes straight to the entry: spelling it and
             // looking the same reading back up is the round trip #286 removed.
-            registry.input_entry(&leaf.ty).unwrap_or_else(|| {
+            ext.in_frag(&leaf.ty).unwrap_or_else(|| {
                 // Shared wording, not restated — see the sibling backstop above.
                 panic!(
                     "{}",

--- a/prebindgen-jni/src/jni/fn_plan.rs
+++ b/prebindgen-jni/src/jni/fn_plan.rs
@@ -352,10 +352,7 @@ impl PlanError {
 /// missing.
 ///
 /// [`Prebindgen::validate_resolved`]: prebindgen_registry::Prebindgen::validate_resolved
-pub(crate) fn validate_bindings(
-    ext: &Declarations,
-    registry: &Registry<KotlinMeta>,
-) -> Result<(), String> {
+pub(crate) fn validate_bindings(ext: &Declarations, registry: &Registry) -> Result<(), String> {
     let mut errors: Vec<String> = Vec::new();
 
     if let Err(e) = ext.validate_split_declarations(registry) {
@@ -471,7 +468,7 @@ impl Declarations {
     /// regen check (a plan change alters generated code).
     pub(crate) fn fn_plan(
         &self,
-        registry: &Registry<KotlinMeta>,
+        registry: &Registry,
         f: &prebindgen_registry::flat::Function,
     ) -> Result<std::rc::Rc<JniFunctionPlan>, PlanError> {
         if let Some(hit) = self.fn_plans.borrow().get(&f.name).cloned() {
@@ -491,7 +488,7 @@ impl JniFunctionPlan {
     /// built ONCE per function and shared; this is the underlying derivation.
     pub fn build(
         ext: &Declarations,
-        registry: &Registry<KotlinMeta>,
+        registry: &Registry,
         f: &prebindgen_registry::flat::Function,
     ) -> Result<Self, PlanError> {
         let jni_method = ext.mangle_jni_method(&kt_snake_to_camel(&f.name.to_string()));
@@ -556,7 +553,7 @@ impl JniFunctionPlan {
     fn jvm_parameter_slots(
         &self,
         ext: &Declarations,
-        registry: &Registry<KotlinMeta>,
+        registry: &Registry,
         f: &prebindgen_registry::flat::Function,
     ) -> usize {
         // `JNINative` is a Kotlin object, so its external methods are instance
@@ -607,7 +604,7 @@ fn kotlin_jvm_slots(ty: &str) -> usize {
 /// expansions and reuse the same Rust/Kotlin lowering as ordinary parameters.
 fn classify_leaf(
     ext: &Declarations,
-    registry: &Registry<KotlinMeta>,
+    registry: &Registry,
     ident: &syn::Ident,
     reading: &TypeRef,
     expanded: bool,
@@ -719,7 +716,7 @@ fn classify_leaf(
 /// (render_extern_decl's `ret_decl` reconstruction).
 fn build_output(
     ext: &Declarations,
-    registry: &Registry<KotlinMeta>,
+    registry: &Registry,
     f: &prebindgen_registry::flat::Function,
 ) -> Result<FnOutputPlan, PlanError> {
     use prebindgen_registry::unfold::{Delivery, UnfoldShape};

--- a/prebindgen-jni/src/jni/fn_plan.rs
+++ b/prebindgen-jni/src/jni/fn_plan.rs
@@ -652,10 +652,13 @@ fn classify_leaf(
     let mut adapter = crate::jni::compile::JCompile {
         decls: ext,
         registry,
-        site: Some(crate::jni::compile::PlanSite {
-            ident: ident.clone(),
-            expanded,
-        }),
+        declared_return: None,
+        site: Some(crate::jni::compile::PlanSite::Param(
+            crate::jni::compile::ParamSite {
+                ident: ident.clone(),
+                expanded,
+            },
+        )),
     };
     // The site names the parameter it is, and the position is the source
     // parameter's rather than a running count: a constructor expansion
@@ -669,7 +672,9 @@ fn classify_leaf(
     let planned = compiler.site(&mut adapter, site, crossing);
     *ext.compiled.borrow_mut() = compiler.finish();
     match planned {
-        Ok(Some(leaf)) => Ok(leaf),
+        Ok(Some(plan)) => plan.param().ok_or_else(|| PlanError::Unresolved {
+            ty: Box::new(reading.clone()),
+        }),
         // A site the bindings omitted, which JniGen never declares.
         Ok(None) => Err(PlanError::Unresolved {
             ty: Box::new(reading.clone()),
@@ -690,6 +695,41 @@ fn classify_leaf(
             }
         }),
     }
+}
+
+/// Compile the return of `func` as one site.
+///
+/// `declared` is what the signature says the function returns, when that
+/// differs from the value that crosses — a `Return`-delivery convert crosses
+/// what its decomposition produced. `None` when the two are the same.
+fn return_site(
+    ext: &Declarations,
+    registry: &Registry,
+    func: &syn::Ident,
+    target: &TypeRef,
+    declared: Option<TypeRef>,
+) -> Option<ValueOutputPlan> {
+    use prebindgen_registry::recipe::{Assembly, Compiler, Crossing, Role, Site};
+    let mut compiler = Compiler::resume(
+        registry.flat(),
+        ext.recipe_table(),
+        ext.site_bindings(),
+        ext.compiled.borrow().clone(),
+    );
+    let mut adapter = crate::jni::compile::JCompile {
+        decls: ext,
+        registry,
+        declared_return: declared,
+        site: Some(crate::jni::compile::PlanSite::Return),
+    };
+    let site = Site {
+        owner: func.clone(),
+        role: Role::Return,
+    };
+    let crossing = Crossing::new(target.clone(), Assembly::Deconstruct);
+    let planned = compiler.site(&mut adapter, site, crossing);
+    *ext.compiled.borrow_mut() = compiler.finish();
+    planned.ok().flatten().and_then(|p| p.returned())
 }
 
 /// Lower the output side. Mirrors the historical derivations exactly:
@@ -774,24 +814,34 @@ fn build_output(
             ty: target_ty.key(),
         });
     };
-    let Some(entry) = ext.out_frag(&target) else {
-        return Err(PlanError::UnresolvedOutput {
-            ty: Box::new(target),
-        });
-    };
-    let wire_ty = entry.destination.clone();
-
-    // The Kotlin surface classifies the DECLARED return — `convert_out_ty`
-    // for a convert, else the signature's own output. (Not `target_ty`: the
-    // Kotlin error peel rides the entry's `value_rust_type`, so the full
-    // `Result<T, E>` type is looked up as written.)
-    let ret_decl = if is_convert { target_ty } else { &f.ret };
-    let (surface, enums) = ReturnSurface::classify(ext, ret_decl);
-    let EnumSurface {
+    // The site's own row, compiled through the hook. `Compiler::site` is what
+    // makes this a site rather than a lookup: it picks the row, builds the
+    // fragment, checks the value's validity against what a return tolerates —
+    // the JVM keeps what it is given, so a borrowed one is refused here rather
+    // than emitted — and hands the fragment to `Compile::plan`.
+    //
+    // The Kotlin surface classifies the DECLARED return: `convert_out_ty` for a
+    // convert, else the signature's own output. Not `target_ty` — the Kotlin
+    // error peel rides the conversion's `value_rust_type`, so the full
+    // `Result<T, E>` is what the surface reads, and that is the one fact the
+    // crossing cannot carry.
+    let plan = return_site(
+        ext,
+        registry,
+        ident,
+        &target,
+        is_convert.then(|| target_ty.clone()),
+    )
+    .ok_or_else(|| PlanError::UnresolvedOutput {
+        ty: Box::new(target.clone()),
+    })?;
+    let ValueOutputPlan {
+        wire_ty,
+        surface,
         is_enum,
         is_option_enum,
-    } = enums;
-
+        ..
+    } = plan;
     Ok(FnOutputPlan::Value(Box::new(ValueOutputPlan {
         is_convert,
         target_ty: target_ty.clone(),

--- a/prebindgen-jni/src/jni/fn_plan.rs
+++ b/prebindgen-jni/src/jni/fn_plan.rs
@@ -632,8 +632,8 @@ fn classify_leaf(
             reading: reading.clone(),
             kt_name,
             kt_public: None,
-            kt_meta: registry
-                .input_entry(reading)
+            kt_meta: ext
+                .in_frag(reading)
                 .and_then(|e| e.metadata.kotlin_name.clone()),
             optional,
             as_enum_value,
@@ -643,7 +643,7 @@ fn classify_leaf(
 
     // Every non-callback leaf requires a resolved input entry — the same
     // hard boundary the Rust emitter has always enforced.
-    let Some(entry) = registry.input_entry(reading) else {
+    let Some(entry) = ext.in_frag(reading) else {
         // The reading itself, so the diagnostic can say where the type was
         // written. Reaching here means the type IS classified and merely has no
         // converter, which is why there is something to carry.
@@ -670,7 +670,7 @@ fn classify_leaf(
             by_ref: v.by_ref,
             elem_wrappers: v.elem_wrappers,
         }
-    } else if let Some(sp) = build_option_scalar_input_plan(ext, registry, ident, reading) {
+    } else if let Some(sp) = build_option_scalar_input_plan(ext, ident, reading) {
         InputKind::OptionScalar(sp)
     } else if let Some(plan) = flat_plan {
         InputKind::FlattenStruct(plan)
@@ -793,7 +793,7 @@ fn build_output(
             ty: target_ty.key(),
         });
     };
-    let Some(entry) = registry.output_entry(&target) else {
+    let Some(entry) = ext.out_frag(&target) else {
         return Err(PlanError::UnresolvedOutput {
             ty: Box::new(target),
         });
@@ -805,7 +805,7 @@ fn build_output(
     // Kotlin error peel rides the entry's `value_rust_type`, so the full
     // `Result<T, E>` type is looked up as written.)
     let ret_decl = if is_convert { target_ty } else { &f.ret };
-    let (surface, enums) = ReturnSurface::classify(ext, registry, ret_decl);
+    let (surface, enums) = ReturnSurface::classify(ext, ret_decl);
     let EnumSurface {
         is_enum,
         is_option_enum,
@@ -837,13 +837,12 @@ impl ReturnSurface {
     /// and the former `canonical_return_ty`.
     pub fn classify(
         ext: &Declarations,
-        registry: &impl Conversions<KotlinMeta>,
         ret: &prebindgen_registry::flat::TypeRef,
     ) -> (Self, EnumSurface) {
         // The RETURN, as the model classified it. Both callers used to spell a
         // reading into a `-> #ty` fragment for this to take apart again, and
         // the `ReturnType::Default` arm was a unit the element already states.
-        let outer_meta = registry.output_entry(ret).map(|e| e.metadata.clone());
+        let outer_meta = ext.out_frag(ret).map(|e| e.metadata.clone());
         // Unit returns (incl. `ZResult<()>`, whose inner identity rides
         // `value_rust_type`) declare no Kotlin return type. The peeled type is
         // the one the converter's metadata stored — a canonical `syn::Type`,

--- a/prebindgen-jni/src/jni/fn_plan.rs
+++ b/prebindgen-jni/src/jni/fn_plan.rs
@@ -564,7 +564,7 @@ impl JniFunctionPlan {
                 InputKind::FlattenStruct(plan) => plan
                     .leaves
                     .iter()
-                    .map(|l| kotlin_jvm_slots(&l.kt_wire_ty))
+                    .map(|l| kotlin_jvm_slots(l.kt_wire_ty()))
                     .sum(),
                 InputKind::OptionScalar(plan) => 1 + kotlin_jvm_slots(&plan.value_kt_type),
                 InputKind::Handle { .. } | InputKind::VecBuild { .. } => 2,

--- a/prebindgen-jni/src/jni/fn_plan.rs
+++ b/prebindgen-jni/src/jni/fn_plan.rs
@@ -708,7 +708,7 @@ fn return_site(
     func: &syn::Ident,
     target: &TypeRef,
     declared: Option<TypeRef>,
-) -> Option<ValueOutputPlan> {
+) -> Option<crate::jni::compile::JPlan> {
     use prebindgen_registry::recipe::{Assembly, Compiler, Crossing, Role, Site};
     let mut compiler = Compiler::resume(
         registry.flat(),
@@ -729,7 +729,27 @@ fn return_site(
     let crossing = Crossing::new(target.clone(), Assembly::Deconstruct);
     let planned = compiler.site(&mut adapter, site, crossing);
     *ext.compiled.borrow_mut() = compiler.finish();
-    planned.ok().flatten().and_then(|p| p.returned())
+    planned.ok().flatten()
+}
+
+/// The values one function's decomposed return hands out, compiled through
+/// `Compiler::site`.
+///
+/// Test support until the encode side takes it: this is the whole of what a
+/// decomposed return site produces, and holding it to the expansion plan is
+/// what says the two agree before anything depends on it.
+#[cfg(test)]
+pub(crate) fn decomposed_return_for_test(
+    ext: &Declarations,
+    registry: &Registry,
+    func: &syn::Ident,
+) -> Option<Vec<crate::jni::compile::OutWire>> {
+    let f = registry.flat().function(func)?;
+    let ret = f.ret.borrow_target().unwrap_or(&f.ret);
+    let ret = ret.optional_inner().unwrap_or(ret);
+    let ret = ret.sequence_elem().unwrap_or(ret);
+    let ret = ret.borrow_target().unwrap_or(ret);
+    return_site(ext, registry, func, ret, None).and_then(|p| p.decomposed())
 }
 
 /// Lower the output side. Mirrors the historical derivations exactly:
@@ -832,6 +852,7 @@ fn build_output(
         &target,
         is_convert.then(|| target_ty.clone()),
     )
+    .and_then(|p| p.returned())
     .ok_or_else(|| PlanError::UnresolvedOutput {
         ty: Box::new(target.clone()),
     })?;

--- a/prebindgen-jni/src/jni/fn_plan.rs
+++ b/prebindgen-jni/src/jni/fn_plan.rs
@@ -274,6 +274,11 @@ pub(crate) enum PlanError {
     JvmParameterLimit { slots: usize },
 }
 
+/// A plan failure, as the adapter's own error carries it.
+pub(crate) fn plan_error(e: PlanError) -> crate::jni::compile::JErr {
+    crate::jni::compile::JErr::Plan(Box::new(e))
+}
+
 impl PlanError {
     /// Where the offending type was written, when a file wrote it — the
     /// suffix [`Self::message`] appends.
@@ -610,42 +615,71 @@ fn classify_leaf(
     expanded: bool,
     source_param: &syn::Ident,
 ) -> Result<PlanLeaf, PlanError> {
-    // Every question below is the model's now — the local spelling this function
-    // opened with has no users left.
-    let optional = reading.optional_inner().is_some();
-    // The enum probe off the reading — the layers it peels are the model's own
-    // (`&`, `Option`), so there is nothing to re-spell and nothing to look up.
-    let as_enum_value = ext.is_kotlin_enum_reading(reading);
-    let kt_name = kt_param_name(&ident.to_string());
-
-    // `impl Fn(args)` first: typed entirely from the interface spec — the
-    // erased entry exists but its metadata carries no surface type.
+    use prebindgen_registry::recipe::{Assembly, Compiler, Crossing, Role, Site};
+    // `impl Fn(args)` never reaches the compiler, for the reason
+    // `JniGen::compile_crossing` gives: a callback is answered whole, because a
+    // JniGen callback ARGUMENT does not always have a conversion of its own —
+    // a sealed class reaches the JVM as a selector plus the live arm's slots.
+    // Driving the derived callback row here would ask for the one conversion
+    // that does not exist. This carve-out goes when the arms are rows a
+    // callback can be composed from.
     if let Some(args) = reading.callback_args() {
         // `SpecKey` is a memo key and holds `TypeKey`s, so the args reach it as
         // each arg reading's own identity.
-        // `a_callback_identity_is_the_same_from_the_reading_or_the_syntax`
-        // pins that this is the same identity the signature-derived key gives.
         let iface = ext.iface_spec(registry, &SpecKey::callback(args));
         return Ok(PlanLeaf {
             reading: reading.clone(),
-            kt_name,
+            kt_name: kt_param_name(&ident.to_string()),
             kt_public: None,
             kt_meta: ext
                 .in_frag(reading)
                 .and_then(|e| e.metadata.kotlin_name.clone()),
-            optional,
-            as_enum_value,
+            optional: reading.optional_inner().is_some(),
+            as_enum_value: ext.is_kotlin_enum_reading(reading),
             kind: InputKind::Callback { iface },
         });
     }
-
-    // Every non-callback leaf requires a resolved input entry — the same
-    // hard boundary the Rust emitter has always enforced.
-    let Some(entry) = ext.in_frag(reading) else {
-        // The reading itself, so the diagnostic can say where the type was
-        // written. Reaching here means the type IS classified and merely has no
-        // converter, which is why there is something to carry.
-        return Err(if expanded {
+    // The compiler, resumed over what the build already compiled. Every
+    // fragment this site's row needs is in that store, so `site` finds them
+    // rather than building them again — and the plan it wraps them in is the
+    // one hook the registry calls per site rather than per crossing.
+    let mut compiler = Compiler::resume(
+        registry.flat(),
+        ext.recipe_table(),
+        ext.site_bindings(),
+        ext.compiled.borrow().clone(),
+    );
+    let mut adapter = crate::jni::compile::JCompile {
+        decls: ext,
+        registry,
+        site: Some(crate::jni::compile::PlanSite {
+            ident: ident.clone(),
+            expanded,
+        }),
+    };
+    // The site names the parameter it is, and the position is the source
+    // parameter's rather than a running count: a constructor expansion
+    // contributes leaves the signature does not name, and they all belong to
+    // the one parameter that expanded.
+    let site = Site {
+        owner: source_param.clone(),
+        role: Role::Param { index: 0 },
+    };
+    let crossing = Crossing::new(reading.clone(), Assembly::Construct);
+    let planned = compiler.site(&mut adapter, site, crossing);
+    *ext.compiled.borrow_mut() = compiler.finish();
+    match planned {
+        Ok(Some(leaf)) => Ok(leaf),
+        // A site the bindings omitted, which JniGen never declares.
+        Ok(None) => Err(PlanError::Unresolved {
+            ty: Box::new(reading.clone()),
+        }),
+        Err(prebindgen_registry::recipe::CompileError::Adapter(
+            crate::jni::compile::JErr::Plan(e),
+        )) => Err(*e),
+        // A refusal or a table disagreement, which reach this path only for a
+        // type with no conversion — the same failure the entry lookup reported.
+        Err(_) => Err(if expanded {
             PlanError::UnresolvedLeaf {
                 ty: Box::new(reading.clone()),
                 param: source_param.clone(),
@@ -654,59 +688,8 @@ fn classify_leaf(
             PlanError::Unresolved {
                 ty: Box::new(reading.clone()),
             }
-        });
-    };
-
-    let flat_plan = build_flat_input_plan(ext, registry, ident, reading)
-        .map_err(PlanError::UnflattenableDataClass)?;
-    let kind = if let Some(v) = (!expanded)
-        .then(|| vec_build_elem(ext, registry, reading))
-        .flatten()
-    {
-        InputKind::VecBuild {
-            elem: v.elem,
-            by_ref: v.by_ref,
-            elem_wrappers: v.elem_wrappers,
-        }
-    } else if let Some(sp) = build_option_scalar_input_plan(ext, ident, reading) {
-        InputKind::OptionScalar(sp)
-    } else if let Some(plan) = flat_plan {
-        InputKind::FlattenStruct(plan)
-    } else {
-        match entry.metadata.projection.as_ref().map(|p| p.kind.clone()) {
-            Some(ProjectionKind::Handle) => InputKind::Handle {
-                direct: entry.metadata.is_direct_handle(),
-            },
-            Some(ProjectionKind::Unsigned64) => InputKind::Unsigned64 {
-                niche: entry.metadata.projection.as_ref().and_then(|p| {
-                    reading
-                        .optional_inner()
-                        .is_some()
-                        .then(|| p.niche_sentinels.first().cloned())
-                        .flatten()
-                }),
-            },
-            None => InputKind::Plain,
-        }
-    };
-
-    // Typed surface: handle/value projections show their Kotlin class (from
-    // the projection's leaf key); everything else the entry's resolved name.
-    let kt_meta = entry.metadata.kotlin_name.clone();
-    let kt_public = match entry.metadata.projection.as_ref() {
-        Some(p) => projection_leaf_kt(ext, p),
-        None => kt_meta.clone(),
-    };
-
-    Ok(PlanLeaf {
-        reading: reading.clone(),
-        kt_name,
-        kt_public,
-        kt_meta,
-        optional,
-        as_enum_value,
-        kind,
-    })
+        }),
+    }
 }
 
 /// Lower the output side. Mirrors the historical derivations exactly:

--- a/prebindgen-jni/src/jni/fn_plan.rs
+++ b/prebindgen-jni/src/jni/fn_plan.rs
@@ -537,7 +537,7 @@ impl JniFunctionPlan {
             params,
             output,
         };
-        let slots = result.jvm_parameter_slots(registry, f);
+        let slots = result.jvm_parameter_slots(ext, registry, f);
         if slots > 255 {
             return Err(PlanError::JvmParameterLimit { slots });
         }
@@ -555,6 +555,7 @@ impl JniFunctionPlan {
 
     fn jvm_parameter_slots(
         &self,
+        ext: &Declarations,
         registry: &Registry<KotlinMeta>,
         f: &prebindgen_registry::flat::Function,
     ) -> usize {
@@ -571,8 +572,8 @@ impl JniFunctionPlan {
                 InputKind::OptionScalar(plan) => 1 + kotlin_jvm_slots(&plan.value_kt_type),
                 InputKind::Handle { .. } | InputKind::VecBuild { .. } => 2,
                 InputKind::Callback { .. } => 1,
-                InputKind::Unsigned64 { .. } | InputKind::Plain => registry
-                    .input_entry(&leaf.reading)
+                InputKind::Unsigned64 { .. } | InputKind::Plain => ext
+                    .in_frag(&leaf.reading)
                     .and_then(|entry| JniPrim::from_wire(&entry.destination))
                     .map_or(1, |prim| match prim {
                         JniPrim::Long | JniPrim::Double => 2,

--- a/prebindgen-jni/src/jni/fold.rs
+++ b/prebindgen-jni/src/jni/fold.rs
@@ -190,7 +190,7 @@ pub(crate) type StructFactory = (Vec<(String, KtType)>, String, bool);
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn flatten_struct_factory(
     ext: &Declarations,
-    registry: &Registry<KotlinMeta>,
+    registry: &Registry,
     s: &prebindgen_registry::flat::Struct,
     prefix: &str,
     class_name: &str,

--- a/prebindgen-jni/src/jni/iface.rs
+++ b/prebindgen-jni/src/jni/iface.rs
@@ -23,7 +23,7 @@
 
 use kotlin_codegen::{KtCode, KtDecl, KtFun, KtFunInterface, KtFunSig, KtParam, KtType, KtVis};
 use prebindgen_registry::{
-    unfold::{dedup_names, DeconId, LeafSource, UnfoldPlan},
+    unfold::{dedup_names, DeconId, UnfoldPlan},
     Conversions,
 };
 
@@ -1396,13 +1396,10 @@ pub(crate) fn callback_iface_spec(
             .get(&t.key())
             .filter(|p| !super::render::is_iterable_fold(&p.shape));
         if let Some(plan) = plan {
-            let leaf_names =
-                plan_leaf_names(&crate::jni::compile::OutWire::from_leaves(&plan.leaves));
-            for (n, l) in leaf_names.iter().zip(plan.leaves.iter()) {
-                leaf_tys.push(LeafDesc::Plan(
-                    n.clone(),
-                    crate::jni::compile::OutWire::from_leaf(l),
-                ));
+            let wires = crate::jni::compile::OutWire::from_leaves(&plan.leaves);
+            let leaf_names = plan_leaf_names(&wires);
+            for (n, l) in leaf_names.iter().zip(wires.iter()) {
+                leaf_tys.push(LeafDesc::Plan(n.clone(), l.clone()));
             }
             if plan.fixed_builder {
                 any_fixed = true;
@@ -1410,19 +1407,14 @@ pub(crate) fn callback_iface_spec(
                 // answer to "is this a borrow", not a syn match.
                 let core = t.borrow_target().unwrap_or(t);
                 let fqn = ext.kotlin_fqn(&core.key())?;
-                let (reassemble, imports) = fixed_reassembly(
-                    ext,
-                    registry,
-                    &core.key(),
-                    &crate::jni::compile::OutWire::from_leaves(&plan.leaves),
-                    &fqn,
-                );
+                let (reassemble, imports) =
+                    fixed_reassembly(ext, registry, &core.key(), &wires, &fqn);
                 groups.push(GroupDesc {
                     name: whole_value_name(t, i),
                     typed: Some(KtType::cls(fqn.to_string())),
                     reassemble: Some(reassemble),
                     imports,
-                    leaf_count: plan.leaves.len(),
+                    leaf_count: wires.len(),
                     close: crate::jni::struct_plan::type_close_strategy(ext, registry, core, 0),
                 });
             } else {
@@ -1433,24 +1425,27 @@ pub(crate) fn callback_iface_spec(
                 // `when` over the tag. Handing those slots over raw would defeat
                 // the `sealed_class!` the sum was declared as.
                 let mut k = 0usize;
-                while k < plan.leaves.len() {
-                    let leaf = &plan.leaves[k];
-                    let seg = if leaf.source == LeafSource::SumTag {
-                        (k + 1..plan.leaves.len())
-                            .take_while(|&j| plan.leaves[j].group.is_some())
+                while k < wires.len() {
+                    let leaf = &wires[k];
+                    // A sum's segment is its selector and every slot that
+                    // follows carrying a group — the same span
+                    // `encode_plan_leaves` walks, asked the same way.
+                    let seg = if leaf.is_tag() {
+                        (k + 1..wires.len())
+                            .take_while(|&j| wires[j].group.is_some())
                             .last()
                             .map_or(k + 1, |j| j + 1)
                     } else {
                         k + 1
                     };
-                    if leaf.source == LeafSource::SumTag {
+                    if leaf.is_tag() {
                         any_fixed = true;
                         let fqn = ext.kotlin_fqn(&leaf.out_ty.key())?;
                         let (reassemble, imports) = fixed_reassembly(
                             ext,
                             registry,
                             &leaf.out_ty.key(),
-                            &crate::jni::compile::OutWire::from_leaves(&plan.leaves[k..seg]),
+                            &wires[k..seg],
                             &fqn,
                         );
                         groups.push(GroupDesc {

--- a/prebindgen-jni/src/jni/iface.rs
+++ b/prebindgen-jni/src/jni/iface.rs
@@ -193,7 +193,6 @@ impl IfaceParam {
             .and_then(|key| registry.reading(&key));
         match reading {
             Some(reading) => ext.carry_layers(
-                registry,
                 &self.wrap,
                 self.raw.is_nullable(),
                 &reading,
@@ -935,7 +934,6 @@ fn plan_leaf_param(
     let inert_nullable = leaf.group.is_some() && !leaf_ty_is_prim(registry, &leaf.out_ty);
     leaf_iface_param(
         ext,
-        registry,
         name,
         &leaf.out_ty,
         leaf.nullable || inert_nullable,
@@ -956,7 +954,6 @@ fn plan_leaf_param(
 ///   wrapped object after the invoke.
 fn leaf_iface_param(
     ext: &Declarations,
-    registry: &impl Conversions<KotlinMeta>,
     name: String,
     out_ty: &prebindgen_registry::flat::TypeRef,
     nullable: bool,
@@ -974,16 +971,16 @@ fn leaf_iface_param(
     // servable here (`a_wrapped_borrow_callback_arg_declines`) — peeling it
     // would resolve a shape the wrapper arms own.
     let mut out_ty = out_ty;
-    if registry.output_entry(out_ty).is_none() {
+    if ext.out_frag(out_ty).is_none() {
         if let prebindgen_registry::flat::TypeKind::Ref { inner, .. } = out_ty.kind() {
             out_ty = inner;
         }
     }
     let (builder_kt, _wire_kt, _wrap, is_value_projection) =
-        unfold_leaf_kt(ext, registry, out_ty, nullable, "x")?;
-    let proj = registry
-        .output_entry(out_ty)
-        .and_then(|e| e.metadata.projection.as_ref());
+        unfold_leaf_kt(ext, out_ty, nullable, "x")?;
+    let proj = ext
+        .out_frag(out_ty)
+        .and_then(|e| e.metadata.projection.clone());
     let nullable_kt = |t: KtType| {
         if builder_kt.is_nullable() {
             t.nullable()
@@ -992,9 +989,10 @@ fn leaf_iface_param(
         }
     };
     if is_value_projection {
-        match proj?.kind {
+        let proj = proj.clone()?;
+        match proj.kind {
             ProjectionKind::Unsigned64 => {
-                let mut raw = projection_wire_return(proj?);
+                let mut raw = projection_wire_return(&proj);
                 if nullable && !raw.is_nullable() {
                     raw = raw.nullable();
                 }
@@ -1011,7 +1009,7 @@ fn leaf_iface_param(
                 // `unfold_leaf_kt` makes, so the two derivations of this wrap
                 // cannot disagree.
                 let niche_sentinel = if builder_kt.is_nullable() {
-                    wrap_sentinel(proj?, nullable)
+                    wrap_sentinel(&proj, nullable)
                 } else {
                     None
                 };
@@ -1040,7 +1038,7 @@ fn leaf_iface_param(
             // The sentinel is the other axis: the leaf's own `None`, which rides
             // the niche whatever the ancestor does — a `Box` pointer is never 0.
             let niche_sentinel = if builder_kt.is_nullable() {
-                wrap_sentinel(p, nullable)
+                wrap_sentinel(&p, nullable)
             } else {
                 None
             };
@@ -1104,12 +1102,11 @@ fn leaf_iface_param(
 /// post-invoke `close()`. `None` if the arg's projection FQN can't be resolved.
 pub(crate) fn owned_handle_iface_param(
     ext: &Declarations,
-    registry: &impl Conversions<KotlinMeta>,
     name: String,
     out_ty: &prebindgen_registry::flat::TypeRef,
     nullable: bool,
 ) -> Option<IfaceParam> {
-    let proj = registry.output_entry(out_ty)?.metadata.projection.clone()?;
+    let proj = ext.out_frag(out_ty)?.metadata.projection.clone()?;
     let fqn = ext.kotlin_fqn(&proj.leaf_key)?.to_string();
     let typed = KtType::cls(fqn.clone());
     let (typed, raw) = if nullable {
@@ -1268,9 +1265,7 @@ fn derive_iface_spec(
         // Same round trip, same reason, same answer as the `Callback` arm
         // above: the memo key holds an identity, and the reading behind it is a
         // lookup. `None` defers, exactly as it does there (#291).
-        SpecKey::WholeFolder(el_key) => {
-            whole_folder_iface_spec(ext, registry, &registry.reading(el_key)?)
-        }
+        SpecKey::WholeFolder(el_key) => whole_folder_iface_spec(ext, &registry.reading(el_key)?),
         SpecKey::Handler(d) => error_handler_iface_spec(ext, registry, d),
         SpecKey::JniErrorHandler => Some(jni_error_handler_iface_spec(ext)),
     }
@@ -1500,9 +1495,9 @@ pub(crate) fn callback_iface_spec(
         } else {
             // A plan-less opaque-handle arg is delivered as a raw `jlong` and
             // wrapped + closed Kotlin-side (Phase 3 — no Rust `new_object`).
-            let owned_handle = registry
-                .output_entry(t)
-                .and_then(|e| e.metadata.projection.as_ref())
+            let owned_handle = ext
+                .out_frag(t)
+                .and_then(|e| e.metadata.projection.clone())
                 .map(|p| p.kind == ProjectionKind::Handle)
                 .unwrap_or(false);
             leaf_tys.push(LeafDesc::Whole {
@@ -1533,9 +1528,9 @@ pub(crate) fn callback_iface_spec(
                 nullable,
                 owned_handle: true,
                 ..
-            } => owned_handle_iface_param(ext, registry, name, ty, *nullable)?,
+            } => owned_handle_iface_param(ext, name, ty, *nullable)?,
             LeafDesc::Whole { ty, nullable, .. } => {
-                leaf_iface_param(ext, registry, name, ty, *nullable, false)?
+                leaf_iface_param(ext, name, ty, *nullable, false)?
             }
         };
         params.push(param);
@@ -1645,7 +1640,6 @@ pub(crate) fn folder_iface_spec(
 /// `run(acc: A, element): A`. One shape per element type by construction.
 pub(crate) fn whole_folder_iface_spec(
     ext: &Declarations,
-    registry: &impl Conversions<KotlinMeta>,
     element: &prebindgen_registry::flat::TypeRef,
 ) -> Option<IfaceSpec> {
     let mut params: Vec<IfaceParam> = vec![IfaceParam::same("acc".to_string(), KtType::var_("A"))];
@@ -1656,7 +1650,6 @@ pub(crate) fn whole_folder_iface_spec(
     // unaffected (they ignore the flag; see [`leaf_iface_param`]).
     params.push(leaf_iface_param(
         ext,
-        registry,
         "element".to_string(),
         element,
         false,

--- a/prebindgen-jni/src/jni/iface.rs
+++ b/prebindgen-jni/src/jni/iface.rs
@@ -890,7 +890,6 @@ fn subject_package(ext: &Declarations, subject: &prebindgen_registry::flat::Type
 /// [`plan_leaf_names`], typed + raw views per leaf.
 fn plan_leaf_params(
     ext: &Declarations,
-    registry: &impl Conversions<KotlinMeta>,
     leaves: &[prebindgen_registry::unfold::UnfoldLeaf],
 ) -> Option<Vec<IfaceParam>> {
     // Decomposition leaf names are author-supplied, literal, and unique by
@@ -898,7 +897,7 @@ fn plan_leaf_params(
     let names = plan_leaf_names(leaves);
     let mut out = Vec::with_capacity(leaves.len());
     for (name, leaf) in names.into_iter().zip(leaves.iter()) {
-        out.push(plan_leaf_param(ext, registry, name, leaf)?);
+        out.push(plan_leaf_param(ext, name, leaf)?);
     }
     Some(out)
 }
@@ -910,7 +909,6 @@ fn plan_leaf_params(
 /// not just where the plan happens to be walked as a whole.
 fn plan_leaf_param(
     ext: &Declarations,
-    registry: &impl Conversions<KotlinMeta>,
     name: String,
     leaf: &prebindgen_registry::unfold::UnfoldLeaf,
 ) -> Option<IfaceParam> {
@@ -931,7 +929,7 @@ fn plan_leaf_param(
     // here and re-asserted (`!!`) inside its own live arm — the same rule
     // `nullable_group_part` applies to the parent-inlined `fromParts`. Primitive
     // slots take their `0`/`false` default and stay unboxed.
-    let inert_nullable = leaf.group.is_some() && !leaf_ty_is_prim(registry, &leaf.out_ty);
+    let inert_nullable = leaf.group.is_some() && !leaf_ty_is_prim(ext, &leaf.out_ty);
     leaf_iface_param(
         ext,
         name,
@@ -1331,7 +1329,7 @@ fn fixed_reassembly(
             Vec::new(),
         );
     }
-    let params = plan_leaf_params(ext, registry, leaves).unwrap_or_default();
+    let params = plan_leaf_params(ext, leaves).unwrap_or_default();
     let mut imports: BTreeSet<String> = BTreeSet::new();
     let (_, when) = ext.sum_reconstruct(registry, source, leaves, &params, &slots, &mut imports);
     (when, imports.into_iter().collect())
@@ -1522,7 +1520,7 @@ pub(crate) fn callback_iface_spec(
     for (k, desc) in leaf_tys.iter().enumerate() {
         let name = names[k].clone();
         let param = match desc {
-            LeafDesc::Plan(_, leaf) => plan_leaf_param(ext, registry, name, leaf)?,
+            LeafDesc::Plan(_, leaf) => plan_leaf_param(ext, name, leaf)?,
             LeafDesc::Whole {
                 ty,
                 nullable,
@@ -1593,7 +1591,7 @@ pub(crate) fn builder_iface_spec(
     decon: &DeconId,
 ) -> Option<IfaceSpec> {
     let spec = registry.decon_plans().get(decon)?;
-    let params = plan_leaf_params(ext, registry, &spec.leaves)?;
+    let params = plan_leaf_params(ext, &spec.leaves)?;
     let name = format!(
         "{}Builder",
         decon_base_name(&subject_short(&spec.source), Some(decon))
@@ -1620,7 +1618,7 @@ pub(crate) fn folder_iface_spec(
 ) -> Option<IfaceSpec> {
     let spec = registry.decon_plans().get(decon)?;
     let mut params: Vec<IfaceParam> = vec![IfaceParam::same("acc".to_string(), KtType::var_("A"))];
-    params.extend(plan_leaf_params(ext, registry, &spec.leaves)?);
+    params.extend(plan_leaf_params(ext, &spec.leaves)?);
     let name = format!(
         "{}Folder",
         decon_base_name(&subject_short(&spec.source), Some(decon))
@@ -1752,7 +1750,7 @@ pub(crate) fn error_handler_iface_spec(
     decon: &DeconId,
 ) -> Option<IfaceSpec> {
     let spec = registry.decon_plans().get(decon)?;
-    let params: Vec<IfaceParam> = plan_leaf_params(ext, registry, &spec.leaves)?;
+    let params: Vec<IfaceParam> = plan_leaf_params(ext, &spec.leaves)?;
     let name = format!(
         "{}Handler",
         decon_base_name(&subject_short(&spec.source), Some(decon))

--- a/prebindgen-jni/src/jni/iface.rs
+++ b/prebindgen-jni/src/jni/iface.rs
@@ -180,7 +180,7 @@ impl IfaceParam {
     pub fn conversion(
         &self,
         ext: &crate::jni::Declarations,
-        registry: &impl Conversions<KotlinMeta>,
+        registry: &impl Conversions,
         imports: &mut std::collections::BTreeSet<String>,
     ) -> String {
         // A key the registry no longer knows is not a layer question — it is a
@@ -577,7 +577,7 @@ impl IfaceSpec {
     pub fn to_as_raw_fun(
         &self,
         ext: &crate::jni::Declarations,
-        registry: &impl Conversions<KotlinMeta>,
+        registry: &impl Conversions,
         imports: &mut std::collections::BTreeSet<String>,
     ) -> KtFun {
         let bare_generics: Vec<String> = self
@@ -1169,9 +1169,7 @@ impl SpecKey {
 /// so it is computed per `DeconId` over all plans, shared by the memo
 /// derivation ([`SpecKey::Folder`]'s typed groups) and the declaration
 /// emitter (the hoisted `fromParts`/appender singletons).
-pub(crate) fn fixed_decon_ids(
-    registry: &impl Conversions<KotlinMeta>,
-) -> std::collections::HashSet<DeconId> {
+pub(crate) fn fixed_decon_ids(registry: &impl Conversions) -> std::collections::HashSet<DeconId> {
     let fixed: std::collections::HashSet<DeconId> = registry
         .unfold_plans()
         .values()
@@ -1207,9 +1205,7 @@ pub(crate) fn fixed_decon_ids(
 /// Element type keys whose whole-element fold is fixed (a synthesized
 /// single-leaf `Vec<T>` fold) — the leaf dual of [`fixed_decon_ids`], used
 /// by the declaration emitter for the hoisted appender singleton.
-pub(crate) fn fixed_leaf_element_keys(
-    registry: &Registry<KotlinMeta>,
-) -> std::collections::HashSet<TypeKey> {
+pub(crate) fn fixed_leaf_element_keys(registry: &Registry) -> std::collections::HashSet<TypeKey> {
     registry
         .unfold_plans()
         .values()
@@ -1228,7 +1224,7 @@ pub(crate) fn fixed_leaf_element_keys(
 /// typed-group view in per `DeconId` (see [`fixed_decon_ids`]).
 fn derive_iface_spec(
     ext: &Declarations,
-    registry: &impl Conversions<KotlinMeta>,
+    registry: &impl Conversions,
     key: &SpecKey,
 ) -> Option<IfaceSpec> {
     match key {
@@ -1281,7 +1277,7 @@ impl Declarations {
     /// instead of shipping descriptor drift.
     pub(crate) fn iface_spec(
         &self,
-        registry: &impl Conversions<KotlinMeta>,
+        registry: &impl Conversions,
         key: &SpecKey,
     ) -> Option<std::sync::Arc<IfaceSpec>> {
         let hit = self.iface_specs.borrow().get(key).cloned();
@@ -1316,7 +1312,7 @@ impl Declarations {
 /// `when` over the tag that a sum-typed struct field gets.
 fn fixed_reassembly(
     ext: &Declarations,
-    registry: &impl Conversions<KotlinMeta>,
+    registry: &impl Conversions,
     source: &TypeKey,
     leaves: &[prebindgen_registry::unfold::UnfoldLeaf],
     class_fqn: &str,
@@ -1341,7 +1337,7 @@ fn fixed_reassembly(
 /// placed in the first arg type's package (root for `Fn()`).
 pub(crate) fn callback_iface_spec(
     ext: &Declarations,
-    registry: &impl Conversions<KotlinMeta>,
+    registry: &impl Conversions,
     cb_args: &[prebindgen_registry::flat::TypeRef],
 ) -> Option<IfaceSpec> {
     // Per-arg grouping over the flat raw leaves. A **fixed-builder** (by-value
@@ -1587,7 +1583,7 @@ pub(crate) fn callback_iface_spec(
 /// type's package.
 pub(crate) fn builder_iface_spec(
     ext: &Declarations,
-    registry: &impl Conversions<KotlinMeta>,
+    registry: &impl Conversions,
     decon: &DeconId,
 ) -> Option<IfaceSpec> {
     let spec = registry.decon_plans().get(decon)?;
@@ -1613,7 +1609,7 @@ pub(crate) fn builder_iface_spec(
 /// placed in the element type's package.
 pub(crate) fn folder_iface_spec(
     ext: &Declarations,
-    registry: &impl Conversions<KotlinMeta>,
+    registry: &impl Conversions,
     decon: &DeconId,
 ) -> Option<IfaceSpec> {
     let spec = registry.decon_plans().get(decon)?;
@@ -1671,7 +1667,7 @@ pub(crate) fn whole_folder_iface_spec(
 /// against), not per this plan's own `fixed_builder` flag.
 pub(crate) fn folder_iface_for_plan(
     ext: &Declarations,
-    registry: &impl Conversions<KotlinMeta>,
+    registry: &impl Conversions,
     plan: &UnfoldPlan,
 ) -> Option<std::sync::Arc<IfaceSpec>> {
     debug_assert!(
@@ -1696,7 +1692,7 @@ pub(crate) fn folder_iface_for_plan(
 /// two stay in lockstep.
 pub(crate) fn fixed_folder_typed_groups(
     ext: &Declarations,
-    registry: &impl Conversions<KotlinMeta>,
+    registry: &impl Conversions,
     decon: &DeconId,
 ) -> Option<Vec<TypedGroup>> {
     let spec = registry.decon_plans().get(decon)?;
@@ -1746,7 +1742,7 @@ pub(crate) fn fixed_folder_typed_groups(
 /// `<decl-base>Handler`, placed in the error type's package.
 pub(crate) fn error_handler_iface_spec(
     ext: &Declarations,
-    registry: &impl Conversions<KotlinMeta>,
+    registry: &impl Conversions,
     decon: &DeconId,
 ) -> Option<IfaceSpec> {
     let spec = registry.decon_plans().get(decon)?;
@@ -1828,7 +1824,7 @@ pub(crate) struct ErrorIfaces {
 /// alone always derives.
 pub(crate) fn onerror_iface_spec(
     ext: &Declarations,
-    registry: &Registry<KotlinMeta>,
+    registry: &Registry,
     fn_ident: &syn::Ident,
 ) -> Option<ErrorIfaces> {
     let binding = ext.iface_spec(registry, &SpecKey::JniErrorHandler)?;

--- a/prebindgen-jni/src/jni/iface.rs
+++ b/prebindgen-jni/src/jni/iface.rs
@@ -890,7 +890,7 @@ fn subject_package(ext: &Declarations, subject: &prebindgen_registry::flat::Type
 /// [`plan_leaf_names`], typed + raw views per leaf.
 fn plan_leaf_params(
     ext: &Declarations,
-    leaves: &[prebindgen_registry::unfold::UnfoldLeaf],
+    leaves: &[crate::jni::compile::OutWire],
 ) -> Option<Vec<IfaceParam>> {
     // Decomposition leaf names are author-supplied, literal, and unique by
     // construction (enforced in `core::unfold`) — no dedup/casing here.
@@ -910,14 +910,13 @@ fn plan_leaf_params(
 fn plan_leaf_param(
     ext: &Declarations,
     name: String,
-    leaf: &prebindgen_registry::unfold::UnfoldLeaf,
+    leaf: &crate::jni::compile::OutWire,
 ) -> Option<IfaceParam> {
-    use prebindgen_registry::unfold::LeafSource;
     // The sum selector has no converter behind it — it is a plain `Int` the
     // emitter assigns per `match` arm. Nullable when the sum sits under a
     // conditional value form: null is the absent case, which the tag's own
     // variants cannot express.
-    if leaf.source == LeafSource::SumTag {
+    if leaf.is_tag() {
         let ty = KtType::int();
         let ty = if leaf.nullable { ty.nullable() } else { ty };
         return Some(IfaceParam::same(name, ty));
@@ -1325,9 +1324,10 @@ fn fixed_reassembly(
             Vec::new(),
         );
     }
-    let params = plan_leaf_params(ext, leaves).unwrap_or_default();
+    let wires = crate::jni::compile::OutWire::from_leaves(leaves);
+    let params = plan_leaf_params(ext, &wires).unwrap_or_default();
     let mut imports: BTreeSet<String> = BTreeSet::new();
-    let (_, when) = ext.sum_reconstruct(registry, source, leaves, &params, &slots, &mut imports);
+    let (_, when) = ext.sum_reconstruct(registry, source, &wires, &params, &slots, &mut imports);
     (when, imports.into_iter().collect())
 }
 
@@ -1397,7 +1397,8 @@ pub(crate) fn callback_iface_spec(
             .get(&t.key())
             .filter(|p| !super::render::is_iterable_fold(&p.shape));
         if let Some(plan) = plan {
-            let leaf_names = plan_leaf_names(&plan.leaves);
+            let leaf_names =
+                plan_leaf_names(&crate::jni::compile::OutWire::from_leaves(&plan.leaves));
             for (n, l) in leaf_names.iter().zip(plan.leaves.iter()) {
                 leaf_tys.push(LeafDesc::Plan(n.clone(), l.clone()));
             }
@@ -1516,7 +1517,9 @@ pub(crate) fn callback_iface_spec(
     for (k, desc) in leaf_tys.iter().enumerate() {
         let name = names[k].clone();
         let param = match desc {
-            LeafDesc::Plan(_, leaf) => plan_leaf_param(ext, name, leaf)?,
+            LeafDesc::Plan(_, leaf) => {
+                plan_leaf_param(ext, name, &crate::jni::compile::OutWire::from_leaf(leaf))?
+            }
             LeafDesc::Whole {
                 ty,
                 nullable,
@@ -1587,7 +1590,10 @@ pub(crate) fn builder_iface_spec(
     decon: &DeconId,
 ) -> Option<IfaceSpec> {
     let spec = registry.decon_plans().get(decon)?;
-    let params = plan_leaf_params(ext, &spec.leaves)?;
+    let params = plan_leaf_params(
+        ext,
+        &crate::jni::compile::OutWire::from_leaves(&spec.leaves),
+    )?;
     let name = format!(
         "{}Builder",
         decon_base_name(&subject_short(&spec.source), Some(decon))
@@ -1614,7 +1620,10 @@ pub(crate) fn folder_iface_spec(
 ) -> Option<IfaceSpec> {
     let spec = registry.decon_plans().get(decon)?;
     let mut params: Vec<IfaceParam> = vec![IfaceParam::same("acc".to_string(), KtType::var_("A"))];
-    params.extend(plan_leaf_params(ext, &spec.leaves)?);
+    params.extend(plan_leaf_params(
+        ext,
+        &crate::jni::compile::OutWire::from_leaves(&spec.leaves),
+    )?);
     let name = format!(
         "{}Folder",
         decon_base_name(&subject_short(&spec.source), Some(decon))
@@ -1746,7 +1755,10 @@ pub(crate) fn error_handler_iface_spec(
     decon: &DeconId,
 ) -> Option<IfaceSpec> {
     let spec = registry.decon_plans().get(decon)?;
-    let params: Vec<IfaceParam> = plan_leaf_params(ext, &spec.leaves)?;
+    let params: Vec<IfaceParam> = plan_leaf_params(
+        ext,
+        &crate::jni::compile::OutWire::from_leaves(&spec.leaves),
+    )?;
     let name = format!(
         "{}Handler",
         decon_base_name(&subject_short(&spec.source), Some(decon))

--- a/prebindgen-jni/src/jni/iface.rs
+++ b/prebindgen-jni/src/jni/iface.rs
@@ -1313,21 +1313,20 @@ fn fixed_reassembly(
     ext: &Declarations,
     registry: &impl Conversions,
     source: &TypeKey,
-    leaves: &[prebindgen_registry::unfold::UnfoldLeaf],
+    wires: &[crate::jni::compile::OutWire],
     class_fqn: &str,
 ) -> (String, Vec<String>) {
-    let slots: Vec<String> = (0..leaves.len()).map(|i| format!("${i}")).collect();
-    let wires = crate::jni::compile::OutWire::from_leaves(leaves);
-    if !is_sum_row(&wires) {
+    let slots: Vec<String> = (0..wires.len()).map(|i| format!("${i}")).collect();
+    if !is_sum_row(wires) {
         let class_short = class_fqn.rsplit('.').next().unwrap_or(class_fqn);
         return (
             format!("{class_short}.fromParts({})", slots.join(", ")),
             Vec::new(),
         );
     }
-    let params = plan_leaf_params(ext, &wires).unwrap_or_default();
+    let params = plan_leaf_params(ext, wires).unwrap_or_default();
     let mut imports: BTreeSet<String> = BTreeSet::new();
-    let (_, when) = ext.sum_reconstruct(registry, source, &wires, &params, &slots, &mut imports);
+    let (_, when) = ext.sum_reconstruct(registry, source, wires, &params, &slots, &mut imports);
     (when, imports.into_iter().collect())
 }
 
@@ -1366,7 +1365,7 @@ pub(crate) fn callback_iface_spec(
     /// and `owned_handle` marks a plan-less opaque handle delivered as a raw
     /// `jlong` and wrapped + closed Kotlin-side (Phase 3).
     enum LeafDesc {
-        Plan(String, prebindgen_registry::unfold::UnfoldLeaf),
+        Plan(String, crate::jni::compile::OutWire),
         Whole {
             name: String,
             ty: prebindgen_registry::flat::TypeRef,
@@ -1400,7 +1399,10 @@ pub(crate) fn callback_iface_spec(
             let leaf_names =
                 plan_leaf_names(&crate::jni::compile::OutWire::from_leaves(&plan.leaves));
             for (n, l) in leaf_names.iter().zip(plan.leaves.iter()) {
-                leaf_tys.push(LeafDesc::Plan(n.clone(), l.clone()));
+                leaf_tys.push(LeafDesc::Plan(
+                    n.clone(),
+                    crate::jni::compile::OutWire::from_leaf(l),
+                ));
             }
             if plan.fixed_builder {
                 any_fixed = true;
@@ -1408,8 +1410,13 @@ pub(crate) fn callback_iface_spec(
                 // answer to "is this a borrow", not a syn match.
                 let core = t.borrow_target().unwrap_or(t);
                 let fqn = ext.kotlin_fqn(&core.key())?;
-                let (reassemble, imports) =
-                    fixed_reassembly(ext, registry, &core.key(), &plan.leaves, &fqn);
+                let (reassemble, imports) = fixed_reassembly(
+                    ext,
+                    registry,
+                    &core.key(),
+                    &crate::jni::compile::OutWire::from_leaves(&plan.leaves),
+                    &fqn,
+                );
                 groups.push(GroupDesc {
                     name: whole_value_name(t, i),
                     typed: Some(KtType::cls(fqn.to_string())),
@@ -1443,7 +1450,7 @@ pub(crate) fn callback_iface_spec(
                             ext,
                             registry,
                             &leaf.out_ty.key(),
-                            &plan.leaves[k..seg],
+                            &crate::jni::compile::OutWire::from_leaves(&plan.leaves[k..seg]),
                             &fqn,
                         );
                         groups.push(GroupDesc {
@@ -1517,9 +1524,7 @@ pub(crate) fn callback_iface_spec(
     for (k, desc) in leaf_tys.iter().enumerate() {
         let name = names[k].clone();
         let param = match desc {
-            LeafDesc::Plan(_, leaf) => {
-                plan_leaf_param(ext, name, &crate::jni::compile::OutWire::from_leaf(leaf))?
-            }
+            LeafDesc::Plan(_, leaf) => plan_leaf_param(ext, name, leaf)?,
             LeafDesc::Whole {
                 ty,
                 nullable,
@@ -1706,8 +1711,13 @@ pub(crate) fn fixed_folder_typed_groups(
 ) -> Option<Vec<TypedGroup>> {
     let spec = registry.decon_plans().get(decon)?;
     let fqn = ext.kotlin_fqn(&spec.source.key())?;
-    let (reassemble, imports) =
-        fixed_reassembly(ext, registry, &spec.source.key(), &spec.leaves, &fqn);
+    let (reassemble, imports) = fixed_reassembly(
+        ext,
+        registry,
+        &spec.source.key(),
+        &crate::jni::compile::OutWire::from_leaves(&spec.leaves),
+        &fqn,
+    );
     Some(vec![
         TypedGroup {
             name: "acc".to_string(),

--- a/prebindgen-jni/src/jni/iface.rs
+++ b/prebindgen-jni/src/jni/iface.rs
@@ -1317,14 +1317,14 @@ fn fixed_reassembly(
     class_fqn: &str,
 ) -> (String, Vec<String>) {
     let slots: Vec<String> = (0..leaves.len()).map(|i| format!("${i}")).collect();
-    if !is_sum_leaves(leaves) {
+    let wires = crate::jni::compile::OutWire::from_leaves(leaves);
+    if !is_sum_row(&wires) {
         let class_short = class_fqn.rsplit('.').next().unwrap_or(class_fqn);
         return (
             format!("{class_short}.fromParts({})", slots.join(", ")),
             Vec::new(),
         );
     }
-    let wires = crate::jni::compile::OutWire::from_leaves(leaves);
     let params = plan_leaf_params(ext, &wires).unwrap_or_default();
     let mut imports: BTreeSet<String> = BTreeSet::new();
     let (_, when) = ext.sum_reconstruct(registry, source, &wires, &params, &slots, &mut imports);

--- a/prebindgen-jni/src/jni/kotlin_emit.rs
+++ b/prebindgen-jni/src/jni/kotlin_emit.rs
@@ -1978,10 +1978,10 @@ impl Declarations {
             let mut push = KtFun::new(push_m)
                 .external()
                 .param(KtParam::new("handle", KtType::long()));
-            for leaf in h.plan.leaves.iter().filter(|l| !l.is_present_flag) {
+            for leaf in h.plan.leaves.iter().filter(|l| !l.is_present_flag()) {
                 push = push.param(KtParam::new(
                     leaf.kt_name.clone(),
-                    KtType::cls(leaf.kt_wire_ty.clone()),
+                    KtType::cls(leaf.kt_wire_ty().to_string()),
                 ));
             }
             externs.push(push);

--- a/prebindgen-jni/src/jni/kotlin_emit.rs
+++ b/prebindgen-jni/src/jni/kotlin_emit.rs
@@ -82,7 +82,7 @@ impl Declarations {
     /// was resolved first.
     pub(crate) fn write_kotlin(
         &self,
-        registry: &Registry<KotlinMeta>,
+        registry: &Registry,
         kotlin_root: &Path,
     ) -> Result<Vec<PathBuf>, WriteKotlinError> {
         // Validation already ran once in `RegistryBuilder::build` — this emitter
@@ -536,7 +536,7 @@ impl Declarations {
     /// uniform.
     pub(crate) fn write_enum_classes(
         &self,
-        registry: &Registry<KotlinMeta>,
+        registry: &Registry,
     ) -> Result<Vec<KtFile>, WriteKotlinError> {
         let mut written = Vec::new();
         // Deterministic order by canonical Rust type-key.
@@ -595,7 +595,7 @@ impl Declarations {
     /// and each declarator rejects the other's.
     pub(crate) fn write_sealed_classes(
         &self,
-        registry: &Registry<KotlinMeta>,
+        registry: &Registry,
     ) -> Result<Vec<KtFile>, WriteKotlinError> {
         let mut written = Vec::new();
         // Deterministic order by canonical Rust type-key.
@@ -667,7 +667,7 @@ impl Declarations {
     /// identically.
     fn build_sealed_class(
         &self,
-        registry: &Registry<KotlinMeta>,
+        registry: &Registry,
         class_name: &str,
         sum: &prebindgen_registry::flat::Variant,
         sum_cfg: &SumConfig,
@@ -997,7 +997,7 @@ impl Declarations {
     /// types, so wrappers and data-class declarations stay in sync. A
     /// compatibility-alias fragment is appended when any data class is
     /// renamed relative to its Rust ident.
-    pub(crate) fn write_data_classes(&self, registry: &Registry<KotlinMeta>) -> Vec<KtFile> {
+    pub(crate) fn write_data_classes(&self, registry: &Registry) -> Vec<KtFile> {
         let mut written = Vec::new();
         let mut aliases: Vec<(String, String)> = Vec::new();
         let mut keys: Vec<&TypeKey> = self.types.keys().collect();
@@ -1136,7 +1136,7 @@ impl Declarations {
     /// from the declaration's representative plan (`registry.decon_plans`) —
     /// the same source the native emitters read, so all sites agree by
     /// construction (no dedup, no signature reconciliation).
-    pub(crate) fn write_callback_ifaces(&self, registry: &Registry<KotlinMeta>) -> Vec<KtFile> {
+    pub(crate) fn write_callback_ifaces(&self, registry: &Registry) -> Vec<KtFile> {
         use prebindgen_registry::unfold::{DeconId, Delivery};
 
         // Distinct interface identities in use — [`SpecKey`] (`Ord`, so
@@ -1362,7 +1362,7 @@ impl Declarations {
     /// positionally with `fromParts`.
     fn value_struct_builder_singleton(
         &self,
-        registry: &Registry<KotlinMeta>,
+        registry: &Registry,
         spec: &crate::jni::IfaceSpec,
         decon: &prebindgen_registry::unfold::DeconId,
     ) -> KtDecl {
@@ -1409,7 +1409,7 @@ impl Declarations {
     /// `[acc, leaf0, …]`; `fromParts` takes the element leaves (all but `acc`).
     fn value_struct_folder_singleton(
         &self,
-        registry: &Registry<KotlinMeta>,
+        registry: &Registry,
         spec: &crate::jni::IfaceSpec,
         decon: &prebindgen_registry::unfold::DeconId,
     ) -> KtDecl {
@@ -1469,7 +1469,7 @@ impl Declarations {
     /// `factory_field`, so it is emitted here directly.
     fn sum_builder_singleton(
         &self,
-        registry: &Registry<KotlinMeta>,
+        registry: &Registry,
         spec: &crate::jni::IfaceSpec,
         decon: &prebindgen_registry::unfold::DeconId,
     ) -> KtDecl {
@@ -1512,7 +1512,7 @@ impl Declarations {
     /// `[acc, tag, group-slots…]`, so the reassembly reads all but `acc`.
     fn sum_folder_singleton(
         &self,
-        registry: &Registry<KotlinMeta>,
+        registry: &Registry,
         spec: &crate::jni::IfaceSpec,
         decon: &prebindgen_registry::unfold::DeconId,
     ) -> KtDecl {
@@ -1560,7 +1560,7 @@ impl Declarations {
     /// its variant-constructor argument by [`Self::sum_ctor_arg`].
     pub(crate) fn sum_reconstruct(
         &self,
-        registry: &impl Conversions<KotlinMeta>,
+        registry: &impl Conversions,
         // The sum's **identity**: every use of `source` here was
         // `TypeKey::from_type` or `bare_path_ident`, and a key that is one
         // identifier IS the ident — the same reduction `type_kind` made.
@@ -1785,7 +1785,7 @@ impl Declarations {
 
     pub(crate) fn write_jni_package(
         &self,
-        registry: &Registry<KotlinMeta>,
+        registry: &Registry,
         subpackage: &str,
         pkg_cfg: &crate::jni::PackageConfig,
     ) -> KtFile {
@@ -1900,7 +1900,7 @@ impl Declarations {
     /// inside an `init { … }` block here (e.g. a reference to the consumer's
     /// own loader object). Unset, the holder stays free of any loading logic
     /// and the wrapper layer is responsible for loading.
-    pub(crate) fn write_jni_native(&self, registry: &Registry<KotlinMeta>) -> KtFile {
+    pub(crate) fn write_jni_native(&self, registry: &Registry) -> KtFile {
         let class_name = self.jni_native_class_name();
         let declared = self.declared_functions();
 
@@ -2044,7 +2044,7 @@ impl Declarations {
     /// promoted method's signature).
     pub(crate) fn write_typed_handles(
         &self,
-        registry: &Registry<KotlinMeta>,
+        registry: &Registry,
         handles: &[TypedHandle<'_>],
     ) -> Vec<KtFile> {
         let mut written = Vec::new();

--- a/prebindgen-jni/src/jni/kotlin_emit.rs
+++ b/prebindgen-jni/src/jni/kotlin_emit.rs
@@ -728,7 +728,7 @@ impl Declarations {
             let mut vcloses: Vec<String> = Vec::new();
             for field in &alt.fields {
                 let prop = sum_field_prop_name(&field.member());
-                let ty = self.sum_payload_kt_type(registry, &sum.name, &alt.name, &prop, field);
+                let ty = self.sum_payload_kt_type(&sum.name, &alt.name, &prop, field);
                 if let Some(strategy) = payload_close(field) {
                     vcloses.push(render_handle_close(&strategy, &prop));
                 }
@@ -795,7 +795,7 @@ impl Declarations {
             let vname = self.sum_variant_class_name(sum_cfg, &alt.name);
             for field in &alt.fields {
                 let prop = sum_field_prop_name(&field.member());
-                let ty = self.sum_payload_kt_type(registry, &sum.name, &alt.name, &prop, field);
+                let ty = self.sum_payload_kt_type(&sum.name, &alt.name, &prop, field);
                 factory = factory.param(KtParam::new(sum_slot_fragment(&vname, &prop), ty));
             }
         }
@@ -905,7 +905,6 @@ impl Declarations {
     ///   ABI mismatch at runtime.
     fn sum_payload_kt_type(
         &self,
-        registry: &Registry<KotlinMeta>,
         sum_name: &syn::Ident,
         variant: &syn::Ident,
         prop: &str,
@@ -917,7 +916,7 @@ impl Declarations {
         // below, which is a diagnostic and needs no emission capability.
         let field_ty = &field.ty;
         let where_ = || format!("sealed_class!({}) payload `{variant}.{prop}`", sum_name);
-        let out = registry.output_entry(&field.ty).unwrap_or_else(|| {
+        let out = self.out_frag(&field.ty).unwrap_or_else(|| {
             panic!(
                 "{}: `{}` has no resolved OUTPUT converter, so the Kotlin surface for it \
                  cannot be derived — register converters for the payload type before \
@@ -957,7 +956,7 @@ impl Declarations {
         // boxed value, a present flag, a niche) rather than in the type name.
         // Comparing the rendered types would reject that legitimate shape —
         // which is what an `Option<enum>` payload does.
-        if let Some(inp) = registry.input_entry(&field.ty) {
+        if let Some(inp) = self.in_frag(&field.ty) {
             if let (Some(in_ty), (Some(a), Some(b))) = (
                 inp.metadata.kotlin_name.clone(),
                 (
@@ -1597,7 +1596,7 @@ impl Declarations {
                 .zip(params)
                 .zip(names)
                 .filter(|((l, _), _)| l.group == Some(group))
-                .map(|((l, p), n)| self.sum_ctor_arg(registry, l, p, n, imports))
+                .map(|((l, p), n)| self.sum_ctor_arg(l, p, n, imports))
                 .collect();
             // Kotlin has no `B()` / `B {}` distinction to keep: a payload-less
             // alternative is a `data object`, named bare. The Rust side is where
@@ -1641,7 +1640,6 @@ impl Declarations {
     /// `!!` would turn a legitimately absent value into an exception.
     fn sum_ctor_arg(
         &self,
-        registry: &impl Conversions<KotlinMeta>,
         leaf: &prebindgen_registry::unfold::UnfoldLeaf,
         param: &crate::jni::IfaceParam,
         name: &str,
@@ -1655,7 +1653,6 @@ impl Declarations {
             name.to_string()
         };
         self.carry_layers(
-            registry,
             &param.wrap,
             param.raw.is_nullable(),
             &leaf.out_ty,
@@ -1686,7 +1683,6 @@ impl Declarations {
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn carry_layers(
         &self,
-        registry: &impl Conversions<KotlinMeta>,
         wrap: &crate::jni::WrapKind,
         slot_nullable: bool,
         ty: &prebindgen_registry::flat::TypeRef,
@@ -1696,16 +1692,7 @@ impl Declarations {
         imports: &mut BTreeSet<String>,
     ) -> String {
         if let Some(inner) = ty.optional_inner() {
-            return self.carry_layers(
-                registry,
-                wrap,
-                slot_nullable,
-                inner,
-                recv,
-                true,
-                depth,
-                imports,
-            );
+            return self.carry_layers(wrap, slot_nullable, inner, recv, true, depth, imports);
         }
         if let Some(elem) = ty.sequence_elem() {
             let bound = if depth == 0 {
@@ -1714,7 +1701,6 @@ impl Declarations {
                 format!("__e{depth}")
             };
             let body = self.carry_layers(
-                registry,
                 wrap,
                 slot_nullable,
                 elem,
@@ -1744,8 +1730,8 @@ impl Declarations {
         // same output-converter metadata `factory_field` reads for an enum
         // struct field.
         if self.is_kotlin_enum_reading(ty) {
-            let name = registry
-                .output_entry(ty)
+            let name = self
+                .out_frag(ty)
                 .and_then(|e| e.metadata.kotlin_name.clone())
                 .and_then(|t| t.leaf_name().map(str::to_string))
                 .unwrap_or_else(|| {

--- a/prebindgen-jni/src/jni/kotlin_emit.rs
+++ b/prebindgen-jni/src/jni/kotlin_emit.rs
@@ -1479,7 +1479,7 @@ impl Declarations {
         let (iface_short, when) = self.sum_reconstruct(
             registry,
             &plan.source.key(),
-            &plan.leaves,
+            &crate::jni::compile::OutWire::from_leaves(&plan.leaves),
             &spec.params,
             &names,
             &mut imports,
@@ -1522,7 +1522,7 @@ impl Declarations {
         let (iface_short, when) = self.sum_reconstruct(
             registry,
             &plan.source.key(),
-            &plan.leaves,
+            &crate::jni::compile::OutWire::from_leaves(&plan.leaves),
             &spec.params[1..],
             &names[1..],
             &mut imports,
@@ -1565,7 +1565,7 @@ impl Declarations {
         // `TypeKey::from_type` or `bare_path_ident`, and a key that is one
         // identifier IS the ident — the same reduction `type_kind` made.
         key: &TypeKey,
-        leaves: &[prebindgen_registry::unfold::UnfoldLeaf],
+        leaves: &[crate::jni::compile::OutWire],
         params: &[crate::jni::IfaceParam],
         names: &[String],
         imports: &mut BTreeSet<String>,
@@ -1640,7 +1640,7 @@ impl Declarations {
     /// `!!` would turn a legitimately absent value into an exception.
     fn sum_ctor_arg(
         &self,
-        leaf: &prebindgen_registry::unfold::UnfoldLeaf,
+        leaf: &crate::jni::compile::OutWire,
         param: &crate::jni::IfaceParam,
         name: &str,
         imports: &mut BTreeSet<String>,

--- a/prebindgen-jni/src/jni/kotlin_emit.rs
+++ b/prebindgen-jni/src/jni/kotlin_emit.rs
@@ -1162,7 +1162,7 @@ impl Declarations {
             registry
                 .decon_plans()
                 .get(d)
-                .is_some_and(|p| is_sum_leaves(&p.leaves))
+                .is_some_and(|p| is_sum_row(&crate::jni::compile::OutWire::from_leaves(&p.leaves)))
         };
 
         // Fixedness sets shared with the memo derivation (`iface.rs`): a

--- a/prebindgen-jni/src/jni/metadata.rs
+++ b/prebindgen-jni/src/jni/metadata.rs
@@ -1,4 +1,4 @@
-//! JNI adapter metadata propagated through `TypeEntry`.
+//! JNI adapter metadata, carried on this adapter's own conversions.
 
 use kotlin_codegen::KtType;
 
@@ -82,10 +82,10 @@ pub struct Projection {
 
 /// Per-converter language-specific extras carried by every converter this
 /// adapter produces. Filled by the same handler that builds the wire/body,
-/// propagated by the resolver into
-/// [`prebindgen_registry::TypeEntry::metadata`], and read directly by
-/// the Kotlin emitter — so cross-language facts flow through the existing
-/// wrapper machinery rather than a parallel side channel.
+/// carried in [`prebindgen_registry::ConverterImpl::metadata`], and read
+/// directly by the Kotlin emitter off the fragment that conversion belongs to
+/// — so cross-language facts flow through the existing wrapper machinery
+/// rather than a parallel side channel.
 #[derive(Clone, Debug, Default)]
 pub struct KotlinMeta {
     /// Value-context Kotlin type, structured ([`KtType`]). `Long` for

--- a/prebindgen-jni/src/jni/mod.rs
+++ b/prebindgen-jni/src/jni/mod.rs
@@ -448,7 +448,7 @@ pub struct JniGen {
     /// would be a comment rather than a type.
     decls: Declarations,
     /// Every crossing this binding needs, each with its conversion.
-    registry: prebindgen_registry::Registry<KotlinMeta>,
+    registry: prebindgen_registry::Registry,
 }
 
 // Opaque — exists so `Result<JniGen, _>::expect_err` works in tests.
@@ -484,7 +484,7 @@ impl JniGen {
     }
 
     /// The resolved registry — conversions, decompositions, and the model.
-    pub fn registry(&self) -> &prebindgen_registry::Registry<KotlinMeta> {
+    pub fn registry(&self) -> &prebindgen_registry::Registry {
         &self.registry
     }
 

--- a/prebindgen-jni/src/jni/mod.rs
+++ b/prebindgen-jni/src/jni/mod.rs
@@ -231,6 +231,13 @@ pub(crate) enum DeclaredKind {
     Data,
 }
 
+/// What compiling a site needs beyond the model: which rows exist, and which
+/// row each site takes.
+pub(crate) struct Tables {
+    pub(crate) recipes: prebindgen_registry::recipe::Recipes,
+    pub(crate) bindings: prebindgen_registry::recipe::Bindings,
+}
+
 /// All configuration the structured builder accumulates for one
 /// canonical Rust type key. The declared kind is mandatory (an entry exists
 /// only because some declarator created it); the remaining, cross-kind
@@ -795,6 +802,18 @@ pub struct Declarations {
     pub(crate) compiled: std::rc::Rc<
         std::cell::RefCell<prebindgen_registry::recipe::Compiled<crate::jni::compile::JFrag>>,
     >,
+    /// The row table and the site bindings this binding was built against.
+    ///
+    /// Kept beside the fragment store for the same reason it is: a plan is
+    /// compiled per **site**, and the sites are `fn_plan`'s to enumerate — a
+    /// constructor expansion contributes leaves no signature names. So the
+    /// compiler has to be resumable after `build_with` has returned, and these
+    /// are the two things `Compiler::resume` needs that the model does not
+    /// already carry.
+    ///
+    /// `None` only before the build fills them, which is before anything can
+    /// ask.
+    pub(crate) tables: Option<std::rc::Rc<Tables>>,
 
     /// When `true` (default), generated wrappers wrap each call that
     /// touches an opaque handle in the per-call `withSortedHandleLocks`

--- a/prebindgen-jni/src/jni/mod.rs
+++ b/prebindgen-jni/src/jni/mod.rs
@@ -568,10 +568,9 @@ impl JniGen {
     pub(crate) fn walk_lines_for_test(&self, short: &str) -> Option<Vec<String>> {
         use prebindgen_registry::unfold::{LeafSource, PathStep};
         let ident = syn::Ident::new(short, proc_macro2::Span::call_site());
-        let cfg = self.decls.types.get(&TypeKey::from_ident(&ident))?;
         let leaves = match self.registry.flat().declared_type(&ident)? {
             prebindgen_registry::flat::Type::Variant(sum) => {
-                crate::jni::synth_sum_leaves(&self.decls, cfg.sum()?, sum)
+                crate::jni::synth_sum_leaves(&self.decls, &self.registry, &ident, sum)
             }
             prebindgen_registry::flat::Type::Struct(s) => {
                 crate::jni::synth_value_struct_leaves(&self.decls, &self.registry, s, &[], "", 0)?

--- a/prebindgen-jni/src/jni/mod.rs
+++ b/prebindgen-jni/src/jni/mod.rs
@@ -492,10 +492,12 @@ impl JniGen {
                     name,
                     w.kt_ty.clone(),
                     w.access.render(param),
-                    w.conv.as_ref().map(|c| c.to_string()),
-                    w.handle_target.as_ref().map(|t| format!("{param}{t}")),
+                    w.conv().map(|c| c.to_string()),
+                    w.handle_target
+                        .as_ref()
+                        .map(|t| crate::jni::compile::reached(param, t)),
                     w.handle_nullable,
-                    w.staged,
+                    w.staged(),
                     w.field().map(str::to_string),
                 )
             })

--- a/prebindgen-jni/src/jni/mod.rs
+++ b/prebindgen-jni/src/jni/mod.rs
@@ -451,8 +451,52 @@ pub struct JniGen {
     registry: prebindgen_registry::Registry,
 }
 
+/// One JNI parameter as a signature writes it: its name and its Kotlin type.
+#[cfg(test)]
+pub(crate) type NamedWire = (String, String);
+
 #[cfg(test)]
 impl JniGen {
+    /// The composed wires and the walk's leaves for one `data_class`, named
+    /// the way a parameter would name them.
+    ///
+    /// Test support, and the check that lets the emitter switch happen: the
+    /// `parts` row is meant to say exactly what `build_flat_input_plan` says,
+    /// so this puts the two side by side for a real binding rather than
+    /// asserting a hand-written expectation.
+    pub(crate) fn parts_vs_walk_for_test(
+        &self,
+        short: &str,
+        param: &str,
+    ) -> Option<(Vec<NamedWire>, Vec<NamedWire>)> {
+        let wires = self.parts_wires_for_test(short)?;
+        let composed = wires
+            .iter()
+            .map(|w| {
+                let name =
+                    crate::util::snake_to_camel(&format!("{param}_{}", w.path.replace('.', "_")));
+                (name, w.kt_ty.clone())
+            })
+            .collect();
+
+        let ident = syn::Ident::new(short, proc_macro2::Span::call_site());
+        let ty: syn::Type = syn::parse_quote!(#ident);
+        let arg = prebindgen_registry::Conversions::reading_of(&self.registry, &ty)?;
+        let plan = crate::jni::emit::build_flat_input_plan(
+            &self.decls,
+            &self.registry,
+            &syn::Ident::new(param, proc_macro2::Span::call_site()),
+            &arg,
+        )
+        .ok()??;
+        let walked = plan
+            .leaves
+            .iter()
+            .map(|l| (l.kt_name.clone(), l.kt_wire_ty.clone()))
+            .collect();
+        Some((composed, walked))
+    }
+
     /// The wires a `data_class` composes into, by short type name.
     ///
     /// Test support: the `parts` row is compiled for every declared

--- a/prebindgen-jni/src/jni/mod.rs
+++ b/prebindgen-jni/src/jni/mod.rs
@@ -451,9 +451,12 @@ pub struct JniGen {
     registry: prebindgen_registry::Registry,
 }
 
-/// One JNI parameter as a signature writes it: its name and its Kotlin type.
+/// One JNI parameter as a signature writes it: name, Kotlin type, the Kotlin
+/// expression that fills it, the conversion it crosses through, and — for a
+/// nested owned handle — where Kotlin finds the object to lock and whether that
+/// access can be null.
 #[cfg(test)]
-pub(crate) type NamedWire = (String, String);
+pub(crate) type NamedWire = (String, String, String, Option<String>, Option<String>, bool);
 
 #[cfg(test)]
 impl JniGen {
@@ -475,7 +478,14 @@ impl JniGen {
             .map(|w| {
                 let name =
                     crate::util::snake_to_camel(&format!("{param}_{}", w.path.replace('.', "_")));
-                (name, w.kt_ty.clone())
+                (
+                    name,
+                    w.kt_ty.clone(),
+                    format!("{param}{}", w.access),
+                    w.conv.as_ref().map(|c| c.to_string()),
+                    w.handle_target.as_ref().map(|t| format!("{param}{t}")),
+                    w.handle_nullable,
+                )
             })
             .collect();
 
@@ -492,7 +502,16 @@ impl JniGen {
         let walked = plan
             .leaves
             .iter()
-            .map(|l| (l.kt_name.clone(), l.kt_wire_ty.clone()))
+            .map(|l| {
+                (
+                    l.kt_name.clone(),
+                    l.kt_wire_ty.clone(),
+                    l.kt_access(param),
+                    l.conv.as_ref().map(|c| c.to_string()),
+                    l.kt_handle_target(param),
+                    l.handle_nullable,
+                )
+            })
             .collect();
         Some((composed, walked))
     }

--- a/prebindgen-jni/src/jni/mod.rs
+++ b/prebindgen-jni/src/jni/mod.rs
@@ -475,27 +475,33 @@ pub(crate) type NamedWire = (
     Option<String>,
 );
 
+/// How a reach renders: its field steps, joined — the accessor call every leaf
+/// hangs off is the site's, not the value's, so it is dropped.
+#[cfg(test)]
+fn reach_of(path: &[prebindgen_registry::unfold::PathStep]) -> String {
+    use prebindgen_registry::unfold::PathStep;
+    path.iter()
+        .filter_map(|step| match step {
+            PathStep::Field { ident, .. } => Some(ident.to_string()),
+            PathStep::Call { .. } => None,
+        })
+        .collect::<Vec<_>>()
+        .join(".")
+}
+
 /// How the Rust side reaches one plan leaf, in the form a wire renders it —
 /// the accessor call every leaf hangs off is the site's, not the value's, so it
 /// is dropped to line the two up.
 #[cfg(test)]
 fn leaf_reach(leaf: &prebindgen_registry::unfold::UnfoldLeaf) -> String {
-    use prebindgen_registry::unfold::{LeafSource, PathStep};
+    use prebindgen_registry::unfold::LeafSource;
     match &leaf.source {
         LeafSource::SumTag => "tag".to_string(),
         LeafSource::VariantField { variant, member } => format!(
             "{variant}.{}",
             crate::jni::struct_plan::sum_field_prop_name(member)
         ),
-        _ => leaf
-            .path
-            .iter()
-            .filter_map(|step| match step {
-                PathStep::Field { ident, .. } => Some(ident.to_string()),
-                PathStep::Call { .. } => None,
-            })
-            .collect::<Vec<_>>()
-            .join("."),
+        _ => reach_of(&leaf.path),
     }
 }
 
@@ -566,11 +572,7 @@ impl JniGen {
                 .map(|w| {
                     let from = match &w.from {
                         crate::jni::compile::OutFrom::Tag => "tag".to_string(),
-                        crate::jni::compile::OutFrom::Field { path } => path
-                            .iter()
-                            .map(|p| p.to_string())
-                            .collect::<Vec<_>>()
-                            .join("."),
+                        crate::jni::compile::OutFrom::Reach { path } => reach_of(path),
                         crate::jni::compile::OutFrom::Payload { variant, member } => format!(
                             "{}.{}",
                             variant
@@ -633,11 +635,7 @@ impl JniGen {
                 .map(|w| {
                     let from = match &w.from {
                         crate::jni::compile::OutFrom::Tag => "tag".to_string(),
-                        crate::jni::compile::OutFrom::Field { path } => path
-                            .iter()
-                            .map(|p| p.to_string())
-                            .collect::<Vec<_>>()
-                            .join("."),
+                        crate::jni::compile::OutFrom::Reach { path } => reach_of(path),
                         crate::jni::compile::OutFrom::Payload { variant, member } => format!(
                             "{}.{}",
                             variant

--- a/prebindgen-jni/src/jni/mod.rs
+++ b/prebindgen-jni/src/jni/mod.rs
@@ -598,6 +598,37 @@ impl JniGen {
         )
     }
 
+    /// The leaves the registry's own expansion plans for one function, in the
+    /// form [`Self::out_lines_for_test`] renders a row in.
+    ///
+    /// The walk side of a value form: its leaves come from `unfold::flatten`
+    /// rather than from a JniGen-side synthesis, so the comparison goes through
+    /// a plan rather than through a leaf list.
+    pub(crate) fn plan_lines_for_test(&self, func: &str) -> Option<Vec<String>> {
+        use prebindgen_registry::unfold::PathStep;
+        let ident = syn::Ident::new(func, proc_macro2::Span::call_site());
+        let plan = prebindgen_registry::Conversions::unfold_plans(&self.registry).get(&ident)?;
+        Some(
+            plan.leaves
+                .iter()
+                .map(|l| {
+                    // The accessor call every leaf hangs off is the site's, not
+                    // the wire's, so it is dropped to line the two up.
+                    let from = l
+                        .path
+                        .iter()
+                        .filter_map(|step| match step {
+                            PathStep::Field { ident, .. } => Some(ident.to_string()),
+                            PathStep::Call { .. } => None,
+                        })
+                        .collect::<Vec<_>>()
+                        .join(".");
+                    format!("{}: {} <- {from} @{:?}", l.name, l.out_ty.key(), l.group)
+                })
+                .collect(),
+        )
+    }
+
     /// The wires a crossing composes into, by spelling.
     pub(crate) fn parts_wires_for_test(
         &self,

--- a/prebindgen-jni/src/jni/mod.rs
+++ b/prebindgen-jni/src/jni/mod.rs
@@ -452,11 +452,21 @@ pub struct JniGen {
 }
 
 /// One JNI parameter as a signature writes it: name, Kotlin type, the Kotlin
-/// expression that fills it, the conversion it crosses through, and — for a
-/// nested owned handle — where Kotlin finds the object to lock and whether that
-/// access can be null.
+/// expression that fills it, the conversion it crosses through, where Kotlin
+/// finds the object to lock and whether that access can be null (both for a
+/// nested owned handle only), whether the conversion carries Rust-side stages,
+/// and the struct field it fills.
 #[cfg(test)]
-pub(crate) type NamedWire = (String, String, String, Option<String>, Option<String>, bool);
+pub(crate) type NamedWire = (
+    String,
+    String,
+    String,
+    Option<String>,
+    Option<String>,
+    bool,
+    bool,
+    Option<String>,
+);
 
 #[cfg(test)]
 impl JniGen {
@@ -485,6 +495,8 @@ impl JniGen {
                     w.conv.as_ref().map(|c| c.to_string()),
                     w.handle_target.as_ref().map(|t| format!("{param}{t}")),
                     w.handle_nullable,
+                    w.staged,
+                    w.field().map(str::to_string),
                 )
             })
             .collect();
@@ -510,6 +522,8 @@ impl JniGen {
                     l.conv.as_ref().map(|c| c.to_string()),
                     l.kt_handle_target(param),
                     l.handle_nullable,
+                    l.entry.as_ref().is_some_and(|e| !e.pre_stages.is_empty()),
+                    l.field.as_ref().map(|f| f.to_string()),
                 )
             })
             .collect();

--- a/prebindgen-jni/src/jni/mod.rs
+++ b/prebindgen-jni/src/jni/mod.rs
@@ -508,6 +508,77 @@ impl JniGen {
         )
     }
 
+    /// What a `sealed_class` hands out, as the row states it: one line per
+    /// value, naming it, the alternative it belongs to, and how the Rust side
+    /// reaches it.
+    ///
+    /// Test support. The same list `synth_sum_leaves` produces, in the form
+    /// that compares — a `TypeRef` has no equality and a `syn::Member` prints
+    /// differently by variant, so both sides go through the same rendering.
+    pub(crate) fn sum_out_lines_for_test(&self, short: &str) -> Option<Vec<String>> {
+        use prebindgen_registry::recipe::Assembly;
+        let ident = syn::Ident::new(short, proc_macro2::Span::call_site());
+        let ty: syn::Type = syn::parse_quote!(#ident);
+        let reading = prebindgen_registry::Conversions::reading_of(&self.registry, &ty)?;
+        let compiled = self.decls.compiled.borrow();
+        let wires = compiled
+            .row_fragment(
+                &reading.key(),
+                Assembly::Deconstruct,
+                &crate::jni::rows::parts(),
+            )?
+            .out_wires
+            .clone()?;
+        Some(
+            wires
+                .iter()
+                .map(|w| {
+                    let from = match &w.from {
+                        crate::jni::compile::OutFrom::Tag => "tag".to_string(),
+                        crate::jni::compile::OutFrom::Payload { variant, member } => format!(
+                            "{}.{}",
+                            variant
+                                .as_ref()
+                                .map(|v| v.to_string())
+                                .unwrap_or_else(|| "?".to_string()),
+                            crate::jni::struct_plan::sum_field_prop_name(member)
+                        ),
+                    };
+                    format!("{}: {} <- {from} @{:?}", w.name, w.out_ty.key(), w.group)
+                })
+                .collect(),
+        )
+    }
+
+    /// The same list, taken from the leaf synthesis the row is meant to
+    /// replace.
+    pub(crate) fn sum_walk_lines_for_test(&self, short: &str) -> Option<Vec<String>> {
+        use prebindgen_registry::unfold::LeafSource;
+        let ident = syn::Ident::new(short, proc_macro2::Span::call_site());
+        let cfg = self.decls.types.get(&TypeKey::from_ident(&ident))?;
+        let prebindgen_registry::flat::Type::Variant(sum) =
+            self.registry.flat().declared_type(&ident)?
+        else {
+            return None;
+        };
+        Some(
+            crate::jni::synth_sum_leaves(&self.decls, cfg.sum()?, sum)
+                .iter()
+                .map(|l| {
+                    let from = match &l.source {
+                        LeafSource::SumTag => "tag".to_string(),
+                        LeafSource::VariantField { variant, member } => format!(
+                            "{variant}.{}",
+                            crate::jni::struct_plan::sum_field_prop_name(member)
+                        ),
+                        other => format!("{other:?}"),
+                    };
+                    format!("{}: {} <- {from} @{:?}", l.name, l.out_ty.key(), l.group)
+                })
+                .collect(),
+        )
+    }
+
     /// The wires a crossing composes into, by spelling.
     pub(crate) fn parts_wires_for_test(
         &self,

--- a/prebindgen-jni/src/jni/mod.rs
+++ b/prebindgen-jni/src/jni/mod.rs
@@ -491,7 +491,7 @@ impl JniGen {
                 (
                     name,
                     w.kt_ty.clone(),
-                    format!("{param}{}", w.access),
+                    w.access.render(param),
                     w.conv.as_ref().map(|c| c.to_string()),
                     w.handle_target.as_ref().map(|t| format!("{param}{t}")),
                     w.handle_nullable,

--- a/prebindgen-jni/src/jni/mod.rs
+++ b/prebindgen-jni/src/jni/mod.rs
@@ -451,6 +451,39 @@ pub struct JniGen {
     registry: prebindgen_registry::Registry,
 }
 
+#[cfg(test)]
+impl JniGen {
+    /// The wires a `data_class` composes into, by short type name.
+    ///
+    /// Test support: the `parts` row is compiled for every declared
+    /// `data_class` but taken by no site yet, so this is the only way to see
+    /// what it composed.
+    pub(crate) fn parts_wires_for_test(
+        &self,
+        short: &str,
+    ) -> Option<Vec<crate::jni::compile::Wire>> {
+        let key = self
+            .decls
+            .compiled
+            .borrow()
+            .fragments()
+            .iter()
+            .find_map(|f| {
+                (f.wires.is_some() && f.yields.ty.as_str() == short).then(|| f.yields.ty.clone())
+            })?;
+        self.decls
+            .compiled
+            .borrow()
+            .row_fragment(
+                &key,
+                prebindgen_registry::recipe::Assembly::Construct,
+                &crate::jni::rows::parts(),
+            )?
+            .wires
+            .clone()
+    }
+}
+
 // Opaque — exists so `Result<JniGen, _>::expect_err` works in tests.
 impl std::fmt::Debug for JniGen {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {

--- a/prebindgen-jni/src/jni/mod.rs
+++ b/prebindgen-jni/src/jni/mod.rs
@@ -579,6 +579,23 @@ pub struct Declarations {
     /// function name, so the order here decides which of two same-named
     /// functions wins and not where any of them lands.
     pub(crate) compiled_fns: Vec<syn::ItemFn>,
+    /// Every conversion this binding has compiled so far, keyed by crossing.
+    ///
+    /// What the emitters ask instead of the converter table. A table entry
+    /// carries one `destination`, the single wire type a conversion produces,
+    /// so it can answer only while a crossing occupies one wire value — and the
+    /// answer an emitter wants is this adapter's own fragment.
+    ///
+    /// Shared and interior-mutable because JniGen reads it **while** it is
+    /// being filled: unlike `prebindgen-c`, this adapter's emitters are also
+    /// its conversion builders, and `JniGen::build_with` calls them from inside
+    /// `convert_with`. A conversion for one type is built out of the
+    /// conversions for its inners, which the resolver compiles first — the same
+    /// order that filled the converter table, so a fragment is there exactly
+    /// when a table entry would have been.
+    pub(crate) compiled: std::rc::Rc<
+        std::cell::RefCell<prebindgen_registry::recipe::Compiled<crate::jni::compile::JFrag>>,
+    >,
 
     /// When `true` (default), generated wrappers wrap each call that
     /// touches an opaque handle in the per-call `withSortedHandleLocks`

--- a/prebindgen-jni/src/jni/mod.rs
+++ b/prebindgen-jni/src/jni/mod.rs
@@ -573,7 +573,7 @@ impl JniGen {
                 crate::jni::synth_sum_leaves(&self.decls, &self.registry, &ident, sum)
             }
             prebindgen_registry::flat::Type::Struct(s) => {
-                crate::jni::synth_value_struct_leaves(&self.decls, &self.registry, s, &[], "", 0)?
+                crate::jni::synth_value_struct_leaves(&self.decls, &self.registry, s)?
             }
             _ => return None,
         };

--- a/prebindgen-jni/src/jni/mod.rs
+++ b/prebindgen-jni/src/jni/mod.rs
@@ -478,7 +478,7 @@ impl JniGen {
         Ok(prebindgen_registry::write::write_rust(
             &self.registry,
             &self.decls,
-            prebindgen_registry::write::Conversions::Compiled(&self.decls.compiled_fns),
+            &self.decls.compiled_fns,
             out_path,
         )?)
     }
@@ -572,12 +572,12 @@ pub struct Declarations {
     pub(crate) convert_decls: Vec<ConvertDecl>,
     /// Every conversion this binding compiled.
     ///
-    /// Filled once by `JniGenBuilder::build_with` and handed to `write_rust` as
-    /// `Conversions::Compiled`. It is what reaches the generated file, so
-    /// a fragment no longer has to be expressible as one `ConverterImpl` to be
-    /// emitted — only to be looked up. The writer sorts and de-duplicates by
-    /// function name, so the order here decides which of two same-named
-    /// functions wins and not where any of them lands.
+    /// Filled once by `JniGenBuilder::build_with` and handed to `write_rust`
+    /// directly. It is what reaches the generated file, so a fragment no longer
+    /// has to be expressible as one `ConverterImpl` to be emitted — only to be
+    /// looked up. The writer sorts and de-duplicates by function name, so the
+    /// order here decides which of two same-named functions wins and not where
+    /// any of them lands.
     pub(crate) compiled_fns: Vec<syn::ItemFn>,
     /// Every conversion this binding has compiled so far, keyed by crossing.
     ///

--- a/prebindgen-jni/src/jni/mod.rs
+++ b/prebindgen-jni/src/jni/mod.rs
@@ -676,6 +676,30 @@ impl JniGen {
         )
     }
 
+    /// Whether a declared type states a `parts` row at all, in the given
+    /// direction — asked of the compiled fragments the way an emitter asks.
+    ///
+    /// Test support. A type with nothing to be made of declares no such row,
+    /// and `Compiled::row_fragment` must then answer `None` rather than hand
+    /// back whatever the crossing compiled by default.
+    pub(crate) fn has_parts_row_for_test(&self, short: &str, out: bool) -> bool {
+        use prebindgen_registry::recipe::Assembly;
+        let ident = syn::Ident::new(short, proc_macro2::Span::call_site());
+        let assembly = match out {
+            true => Assembly::Deconstruct,
+            false => Assembly::Construct,
+        };
+        self.decls
+            .compiled
+            .borrow()
+            .row_fragment(
+                &TypeKey::from_ident(&ident),
+                assembly,
+                &crate::jni::rows::parts(),
+            )
+            .is_some()
+    }
+
     /// The wires a crossing composes into, by spelling.
     pub(crate) fn parts_wires_for_test(
         &self,

--- a/prebindgen-jni/src/jni/mod.rs
+++ b/prebindgen-jni/src/jni/mod.rs
@@ -479,10 +479,10 @@ impl JniGen {
     /// asserting a hand-written expectation.
     pub(crate) fn parts_vs_walk_for_test(
         &self,
-        short: &str,
+        spelling: &str,
         param: &str,
     ) -> Option<(Vec<NamedWire>, Vec<NamedWire>)> {
-        let wires = self.parts_wires_for_test(short)?;
+        let wires = self.parts_wires_for_test(spelling)?;
         let composed = wires
             .iter()
             .map(|w| {
@@ -501,8 +501,7 @@ impl JniGen {
             })
             .collect();
 
-        let ident = syn::Ident::new(short, proc_macro2::Span::call_site());
-        let ty: syn::Type = syn::parse_quote!(#ident);
+        let ty: syn::Type = syn::parse_str(spelling).ok()?;
         let arg = prebindgen_registry::Conversions::reading_of(&self.registry, &ty)?;
         let plan = crate::jni::emit::build_flat_input_plan(
             &self.decls,
@@ -537,25 +536,19 @@ impl JniGen {
     /// what it composed.
     pub(crate) fn parts_wires_for_test(
         &self,
-        short: &str,
+        spelling: &str,
     ) -> Option<Vec<crate::jni::compile::Wire>> {
-        let key = self
-            .decls
-            .compiled
-            .borrow()
-            .fragments()
-            .iter()
-            .find_map(|f| {
-                (f.wires.is_some() && f.yields.ty.as_str() == short).then(|| f.yields.ty.clone())
-            })?;
-        self.decls
-            .compiled
-            .borrow()
-            .row_fragment(
-                &key,
-                prebindgen_registry::recipe::Assembly::Construct,
-                &crate::jni::rows::parts(),
-            )?
+        use prebindgen_registry::recipe::Assembly;
+        let ty: syn::Type = syn::parse_str(spelling).ok()?;
+        let reading = prebindgen_registry::Conversions::reading_of(&self.registry, &ty)?;
+        let key = reading.key();
+        let compiled = self.decls.compiled.borrow();
+        // A declared class states its composition under `parts`; an optional
+        // over one has no row of its own and composes on the row the registry
+        // derived, which is the crossing's default.
+        compiled
+            .row_fragment(&key, Assembly::Construct, &crate::jni::rows::parts())
+            .or_else(|| compiled.fragment(&key, Assembly::Construct))?
             .wires
             .clone()
     }

--- a/prebindgen-jni/src/jni/mod.rs
+++ b/prebindgen-jni/src/jni/mod.rs
@@ -508,14 +508,14 @@ impl JniGen {
         )
     }
 
-    /// What a `sealed_class` hands out, as the row states it: one line per
+    /// What a declared type hands out, as the row states it: one line per
     /// value, naming it, the alternative it belongs to, and how the Rust side
     /// reaches it.
     ///
     /// Test support. The same list `synth_sum_leaves` produces, in the form
     /// that compares — a `TypeRef` has no equality and a `syn::Member` prints
     /// differently by variant, so both sides go through the same rendering.
-    pub(crate) fn sum_out_lines_for_test(&self, short: &str) -> Option<Vec<String>> {
+    pub(crate) fn out_lines_for_test(&self, short: &str) -> Option<Vec<String>> {
         use prebindgen_registry::recipe::Assembly;
         let ident = syn::Ident::new(short, proc_macro2::Span::call_site());
         let ty: syn::Type = syn::parse_quote!(#ident);
@@ -535,6 +535,11 @@ impl JniGen {
                 .map(|w| {
                     let from = match &w.from {
                         crate::jni::compile::OutFrom::Tag => "tag".to_string(),
+                        crate::jni::compile::OutFrom::Field { path } => path
+                            .iter()
+                            .map(|p| p.to_string())
+                            .collect::<Vec<_>>()
+                            .join("."),
                         crate::jni::compile::OutFrom::Payload { variant, member } => format!(
                             "{}.{}",
                             variant
@@ -551,18 +556,23 @@ impl JniGen {
     }
 
     /// The same list, taken from the leaf synthesis the row is meant to
-    /// replace.
-    pub(crate) fn sum_walk_lines_for_test(&self, short: &str) -> Option<Vec<String>> {
-        use prebindgen_registry::unfold::LeafSource;
+    /// replace — `synth_sum_leaves` for a `sealed_class`,
+    /// `synth_value_struct_leaves` for a `data_class`.
+    pub(crate) fn walk_lines_for_test(&self, short: &str) -> Option<Vec<String>> {
+        use prebindgen_registry::unfold::{LeafSource, PathStep};
         let ident = syn::Ident::new(short, proc_macro2::Span::call_site());
         let cfg = self.decls.types.get(&TypeKey::from_ident(&ident))?;
-        let prebindgen_registry::flat::Type::Variant(sum) =
-            self.registry.flat().declared_type(&ident)?
-        else {
-            return None;
+        let leaves = match self.registry.flat().declared_type(&ident)? {
+            prebindgen_registry::flat::Type::Variant(sum) => {
+                crate::jni::synth_sum_leaves(&self.decls, cfg.sum()?, sum)
+            }
+            prebindgen_registry::flat::Type::Struct(s) => {
+                crate::jni::synth_value_struct_leaves(&self.decls, &self.registry, s, &[], "", 0)?
+            }
+            _ => return None,
         };
         Some(
-            crate::jni::synth_sum_leaves(&self.decls, cfg.sum()?, sum)
+            leaves
                 .iter()
                 .map(|l| {
                     let from = match &l.source {
@@ -571,6 +581,15 @@ impl JniGen {
                             "{variant}.{}",
                             crate::jni::struct_plan::sum_field_prop_name(member)
                         ),
+                        LeafSource::Field => l
+                            .path
+                            .iter()
+                            .map(|step| match step {
+                                PathStep::Field { ident, .. } => ident.to_string(),
+                                other => format!("{other:?}"),
+                            })
+                            .collect::<Vec<_>>()
+                            .join("."),
                         other => format!("{other:?}"),
                     };
                     format!("{}: {} <- {from} @{:?}", l.name, l.out_ty.key(), l.group)

--- a/prebindgen-jni/src/jni/mod.rs
+++ b/prebindgen-jni/src/jni/mod.rs
@@ -475,6 +475,30 @@ pub(crate) type NamedWire = (
     Option<String>,
 );
 
+/// How the Rust side reaches one plan leaf, in the form a wire renders it —
+/// the accessor call every leaf hangs off is the site's, not the value's, so it
+/// is dropped to line the two up.
+#[cfg(test)]
+fn leaf_reach(leaf: &prebindgen_registry::unfold::UnfoldLeaf) -> String {
+    use prebindgen_registry::unfold::{LeafSource, PathStep};
+    match &leaf.source {
+        LeafSource::SumTag => "tag".to_string(),
+        LeafSource::VariantField { variant, member } => format!(
+            "{variant}.{}",
+            crate::jni::struct_plan::sum_field_prop_name(member)
+        ),
+        _ => leaf
+            .path
+            .iter()
+            .filter_map(|step| match step {
+                PathStep::Field { ident, .. } => Some(ident.to_string()),
+                PathStep::Call { .. } => None,
+            })
+            .collect::<Vec<_>>()
+            .join("."),
+    }
+}
+
 #[cfg(test)]
 impl JniGen {
     /// What one crossing occupies on the wire, named the way a parameter
@@ -566,7 +590,6 @@ impl JniGen {
     /// replace — `synth_sum_leaves` for a `sealed_class`,
     /// `synth_value_struct_leaves` for a `data_class`.
     pub(crate) fn walk_lines_for_test(&self, short: &str) -> Option<Vec<String>> {
-        use prebindgen_registry::unfold::{LeafSource, PathStep};
         let ident = syn::Ident::new(short, proc_macro2::Span::call_site());
         let leaves = match self.registry.flat().declared_type(&ident)? {
             prebindgen_registry::flat::Type::Variant(sum) => {
@@ -581,24 +604,50 @@ impl JniGen {
             leaves
                 .iter()
                 .map(|l| {
-                    let from = match &l.source {
-                        LeafSource::SumTag => "tag".to_string(),
-                        LeafSource::VariantField { variant, member } => format!(
-                            "{variant}.{}",
-                            crate::jni::struct_plan::sum_field_prop_name(member)
-                        ),
-                        LeafSource::Field => l
-                            .path
+                    format!(
+                        "{}: {} <- {} @{:?}",
+                        l.name,
+                        l.out_ty.key(),
+                        leaf_reach(l),
+                        l.group
+                    )
+                })
+                .collect(),
+        )
+    }
+
+    /// What the return **site** of one function composes to, as the row states
+    /// it — rendered exactly as [`Self::out_lines_for_test`] renders a type's
+    /// row, so a site and a type can be compared.
+    ///
+    /// The decomposed-return path through `Compiler::site`: the site asks for
+    /// the `parts` row of its return type and gets the several values that row
+    /// states.
+    pub(crate) fn return_site_lines_for_test(&self, func: &str) -> Option<Vec<String>> {
+        let ident = syn::Ident::new(func, proc_macro2::Span::call_site());
+        let wires =
+            crate::jni::fn_plan::decomposed_return_for_test(&self.decls, &self.registry, &ident)?;
+        Some(
+            wires
+                .iter()
+                .map(|w| {
+                    let from = match &w.from {
+                        crate::jni::compile::OutFrom::Tag => "tag".to_string(),
+                        crate::jni::compile::OutFrom::Field { path } => path
                             .iter()
-                            .map(|step| match step {
-                                PathStep::Field { ident, .. } => ident.to_string(),
-                                other => format!("{other:?}"),
-                            })
+                            .map(|p| p.to_string())
                             .collect::<Vec<_>>()
                             .join("."),
-                        other => format!("{other:?}"),
+                        crate::jni::compile::OutFrom::Payload { variant, member } => format!(
+                            "{}.{}",
+                            variant
+                                .as_ref()
+                                .map(|v| v.to_string())
+                                .unwrap_or_else(|| "?".to_string()),
+                            crate::jni::struct_plan::sum_field_prop_name(member)
+                        ),
                     };
-                    format!("{}: {} <- {from} @{:?}", l.name, l.out_ty.key(), l.group)
+                    format!("{}: {} <- {from} @{:?}", w.name, w.out_ty.key(), w.group)
                 })
                 .collect(),
         )
@@ -611,25 +660,19 @@ impl JniGen {
     /// rather than from a JniGen-side synthesis, so the comparison goes through
     /// a plan rather than through a leaf list.
     pub(crate) fn plan_lines_for_test(&self, func: &str) -> Option<Vec<String>> {
-        use prebindgen_registry::unfold::PathStep;
         let ident = syn::Ident::new(func, proc_macro2::Span::call_site());
         let plan = prebindgen_registry::Conversions::unfold_plans(&self.registry).get(&ident)?;
         Some(
             plan.leaves
                 .iter()
                 .map(|l| {
-                    // The accessor call every leaf hangs off is the site's, not
-                    // the wire's, so it is dropped to line the two up.
-                    let from = l
-                        .path
-                        .iter()
-                        .filter_map(|step| match step {
-                            PathStep::Field { ident, .. } => Some(ident.to_string()),
-                            PathStep::Call { .. } => None,
-                        })
-                        .collect::<Vec<_>>()
-                        .join(".");
-                    format!("{}: {} <- {from} @{:?}", l.name, l.out_ty.key(), l.group)
+                    format!(
+                        "{}: {} <- {} @{:?}",
+                        l.name,
+                        l.out_ty.key(),
+                        leaf_reach(l),
+                        l.group
+                    )
                 })
                 .collect(),
         )

--- a/prebindgen-jni/src/jni/mod.rs
+++ b/prebindgen-jni/src/jni/mod.rs
@@ -470,72 +470,45 @@ pub(crate) type NamedWire = (
 
 #[cfg(test)]
 impl JniGen {
-    /// The composed wires and the walk's leaves for one `data_class`, named
-    /// the way a parameter would name them.
+    /// What one crossing occupies on the wire, named the way a parameter
+    /// names it.
     ///
-    /// Test support, and the check that lets the emitter switch happen: the
-    /// `parts` row is meant to say exactly what `build_flat_input_plan` says,
-    /// so this puts the two side by side for a real binding rather than
-    /// asserting a hand-written expectation.
-    pub(crate) fn parts_vs_walk_for_test(
+    /// Test support: the composition is what the emitters read, and this is it
+    /// in the form the three coordinated sites see — the JNI parameter name,
+    /// its Kotlin type, the Kotlin expression that fills it, the conversion it
+    /// crosses through, where the lock scaffold finds a nested handle and
+    /// whether that can be null, whether the conversion carries Rust-side
+    /// stages, and the struct field it fills.
+    pub(crate) fn named_wires_for_test(
         &self,
         spelling: &str,
         param: &str,
-    ) -> Option<(Vec<NamedWire>, Vec<NamedWire>)> {
-        let wires = self.parts_wires_for_test(spelling)?;
-        let composed = wires
-            .iter()
-            .map(|w| {
-                let name =
-                    crate::util::snake_to_camel(&format!("{param}_{}", w.path.replace('.', "_")));
-                (
-                    name,
-                    w.kt_ty.clone(),
-                    w.access.render(param),
-                    w.conv().map(|c| c.to_string()),
-                    w.handle_target
-                        .as_ref()
-                        .map(|t| crate::jni::compile::reached(param, t)),
-                    w.handle_nullable,
-                    w.staged(),
-                    w.field().map(str::to_string),
-                )
-            })
-            .collect();
-
-        let ty: syn::Type = syn::parse_str(spelling).ok()?;
-        let arg = prebindgen_registry::Conversions::reading_of(&self.registry, &ty)?;
-        let plan = crate::jni::emit::build_flat_input_plan(
-            &self.decls,
-            &self.registry,
-            &syn::Ident::new(param, proc_macro2::Span::call_site()),
-            &arg,
+    ) -> Option<Vec<NamedWire>> {
+        Some(
+            self.parts_wires_for_test(spelling)?
+                .iter()
+                .map(|w| {
+                    (
+                        crate::util::snake_to_camel(&format!(
+                            "{param}_{}",
+                            w.path.replace('.', "_")
+                        )),
+                        w.kt_ty.clone(),
+                        w.access.render(param),
+                        w.conv().map(|c| c.to_string()),
+                        w.handle_target
+                            .as_ref()
+                            .map(|t| crate::jni::compile::reached(param, t)),
+                        w.handle_nullable,
+                        w.staged(),
+                        w.field().map(str::to_string),
+                    )
+                })
+                .collect(),
         )
-        .ok()??;
-        let walked = plan
-            .leaves
-            .iter()
-            .map(|l| {
-                (
-                    l.kt_name.clone(),
-                    l.kt_wire_ty.clone(),
-                    l.kt_access(param),
-                    l.conv.as_ref().map(|c| c.to_string()),
-                    l.kt_handle_target(param),
-                    l.handle_nullable,
-                    l.entry.as_ref().is_some_and(|e| !e.pre_stages.is_empty()),
-                    l.field.as_ref().map(|f| f.to_string()),
-                )
-            })
-            .collect();
-        Some((composed, walked))
     }
 
-    /// The wires a `data_class` composes into, by short type name.
-    ///
-    /// Test support: the `parts` row is compiled for every declared
-    /// `data_class` but taken by no site yet, so this is the only way to see
-    /// what it composed.
+    /// The wires a crossing composes into, by spelling.
     pub(crate) fn parts_wires_for_test(
         &self,
         spelling: &str,

--- a/prebindgen-jni/src/jni/mod.rs
+++ b/prebindgen-jni/src/jni/mod.rs
@@ -572,7 +572,7 @@ impl JniGen {
                 .map(|w| {
                     let from = match &w.from {
                         crate::jni::compile::OutFrom::Tag => "tag".to_string(),
-                        crate::jni::compile::OutFrom::Reach { path } => reach_of(path),
+                        crate::jni::compile::OutFrom::Place => reach_of(&w.reach),
                         crate::jni::compile::OutFrom::Payload { variant, member } => format!(
                             "{}.{}",
                             variant
@@ -635,7 +635,7 @@ impl JniGen {
                 .map(|w| {
                     let from = match &w.from {
                         crate::jni::compile::OutFrom::Tag => "tag".to_string(),
-                        crate::jni::compile::OutFrom::Reach { path } => reach_of(path),
+                        crate::jni::compile::OutFrom::Place => reach_of(&w.reach),
                         crate::jni::compile::OutFrom::Payload { variant, member } => format!(
                             "{}.{}",
                             variant

--- a/prebindgen-jni/src/jni/overloads.rs
+++ b/prebindgen-jni/src/jni/overloads.rs
@@ -50,10 +50,7 @@ impl Declarations {
     /// artifact is written).
     ///
     /// [`validate_resolved`]: prebindgen_registry::Prebindgen::validate_resolved
-    pub(crate) fn validate_split_declarations(
-        &self,
-        registry: &Registry<KotlinMeta>,
-    ) -> Result<(), String> {
+    pub(crate) fn validate_split_declarations(&self, registry: &Registry) -> Result<(), String> {
         let type_level = self
             .param_expand_decls
             .iter()
@@ -113,7 +110,7 @@ impl Declarations {
 /// ambiguity check and the whole-artifact overload table agree on erasure.
 fn arm_erased_sig(
     ext: &Declarations,
-    registry: &Registry<KotlinMeta>,
+    registry: &Registry,
     target: &TypeKey,
     ctor: Option<&syn::Ident>,
 ) -> Vec<ErasedJvmType> {
@@ -246,7 +243,7 @@ fn non_null(mut ty: KtType) -> KtType {
 /// for an `Option<…>` parameter `null` encodes absence (nullable-arm rule).
 /// Returns `None` if any input is not a flat leaf.
 fn variant_typed_params(
-    registry: &impl Conversions<KotlinMeta>,
+    registry: &impl Conversions,
     variant: &prebindgen_registry::expand::FoldVariant,
     origin: &syn::Ident,
     block: &[KtParam],
@@ -315,7 +312,7 @@ fn find_block(params: &[KtParam], leaf_names: &[String]) -> Option<usize> {
 /// validating the parameter is expandable, multi-variant, and in-scope (all
 /// hard errors — the user explicitly asked to split it).
 fn resolve_split<'a>(
-    registry: &'a Registry<KotlinMeta>,
+    registry: &'a Registry,
     f: &prebindgen_registry::flat::Function,
     sel_fun: &KtFun,
     param_name: &str,
@@ -405,7 +402,7 @@ fn resolve_split<'a>(
 pub(crate) fn render_param_overloads(
     ext: &Declarations,
     f: &prebindgen_registry::flat::Function,
-    registry: &Registry<KotlinMeta>,
+    registry: &Registry,
     sel_fun: &KtFun,
 ) -> Vec<KtFun> {
     // Requested split params for this function, in signature order.

--- a/prebindgen-jni/src/jni/overloads.rs
+++ b/prebindgen-jni/src/jni/overloads.rs
@@ -122,7 +122,7 @@ fn arm_erased_sig(
             Some(f) => f
                 .params
                 .iter()
-                .map(|p| rust_type_erased(ext, registry, &p.ty))
+                .map(|p| rust_type_erased(ext, &p.ty))
                 .collect(),
             None => Vec::new(),
         },
@@ -133,7 +133,7 @@ fn arm_erased_sig(
         // form is the identity's own canonical spelling — which is all a
         // declaration has to be told apart by.
         None => vec![match registry.reading(target) {
-            Some(reading) => rust_type_erased(ext, registry, &reading),
+            Some(reading) => rust_type_erased(ext, &reading),
             None => ErasedJvmType::raw(target.as_str().to_string()),
         }],
     }
@@ -145,11 +145,7 @@ fn arm_erased_sig(
 /// there. Falls back to the token string for a
 /// type with no resolved surface. References are peeled first (`&T` erases
 /// like `T`).
-fn rust_type_erased(
-    ext: &Declarations,
-    registry: &Registry<KotlinMeta>,
-    ty: &prebindgen_registry::flat::TypeRef,
-) -> ErasedJvmType {
+fn rust_type_erased(ext: &Declarations, ty: &prebindgen_registry::flat::TypeRef) -> ErasedJvmType {
     // The spelling's own outermost borrow, as `TypeKind::Ref` — not
     // `borrow_target`, which reaches through the erased wrappers (#S31).
     let peeled = match ty.kind() {
@@ -162,8 +158,8 @@ fn rust_type_erased(
             return erase_kt_type(&[], &KtType::cls(fqn));
         }
     }
-    if let Some(kt) = registry
-        .input_entry(peeled)
+    if let Some(kt) = ext
+        .in_frag(peeled)
         .and_then(|e| e.metadata.kotlin_name.clone())
     {
         return erase_kt_type(&[], &kt);

--- a/prebindgen-jni/src/jni/render.rs
+++ b/prebindgen-jni/src/jni/render.rs
@@ -529,7 +529,7 @@ pub(crate) fn render_extern_decl(
                 for l in &plan.leaves {
                     params.push(KtParam::new(
                         l.kt_name.clone(),
-                        KtType::cls(l.kt_wire_ty.clone()),
+                        KtType::cls(l.kt_wire_ty().to_string()),
                     ));
                 }
             }
@@ -1280,7 +1280,7 @@ fn classify_params(
                     .plan
                     .leaves
                     .iter()
-                    .filter(|l| !l.is_present_flag)
+                    .filter(|l| !l.is_present_flag())
                     .map(|l| l.kt_access("__e"))
                     .collect();
                 ParamMode::VecBuild {
@@ -1318,7 +1318,7 @@ fn classify_params(
                         // come from", and deriving it twice is how the two
                         // drift apart.
                         let target = leaf.kt_handle_target(&name)?;
-                        let consume_null = if leaf.handle_nullable {
+                        let consume_null = if leaf.handle_nullable() {
                             format!("{target}?.markConsumed()")
                         } else {
                             format!("{target}.markConsumed()")
@@ -1327,7 +1327,7 @@ fn classify_params(
                             name: leaf.kt_name.clone(),
                             target,
                             consume_null: Some(consume_null),
-                            nullable: leaf.handle_nullable,
+                            nullable: leaf.handle_nullable(),
                             // A flattened leaf carries no Kotlin class name of
                             // its own, so its domain is unknown and it compares
                             // against every other handle — the fail-safe

--- a/prebindgen-jni/src/jni/render.rs
+++ b/prebindgen-jni/src/jni/render.rs
@@ -88,7 +88,7 @@ pub(crate) fn build_data_class(
     ext: &Declarations,
     class_name: &str,
     item_struct: &prebindgen_registry::flat::Struct,
-    registry: &Registry<KotlinMeta>,
+    registry: &Registry,
 ) -> KtClass {
     // A tuple struct is an `Extern` in the model, never a `Struct`, so every
     // field here is named by construction.
@@ -279,7 +279,7 @@ pub(crate) fn build_data_class(
 /// extern on the Rust side (the auto-generated destructor).
 pub(crate) fn build_typed_handle(
     ext: &Declarations,
-    registry: &Registry<KotlinMeta>,
+    registry: &Registry,
     class_name: &str,
     rust_doc_name: &str,
     key: &TypeKey,
@@ -513,7 +513,7 @@ pub(crate) fn is_iterable_fold(shape: &prebindgen_registry::unfold::UnfoldShape)
 pub(crate) fn render_extern_decl(
     ext: &Declarations,
     f: &prebindgen_registry::flat::Function,
-    registry: &Registry<KotlinMeta>,
+    registry: &Registry,
 ) -> Option<KtFun> {
     // The name and wire params come straight off the lowered plan — the
     // same classification the Rust extern and the Kotlin call site consume,
@@ -828,7 +828,7 @@ fn nullable_recovery_type(declared: KtType, generics: &[String]) -> KtType {
 pub(crate) fn build_wrapper_surface(
     ext: &Declarations,
     f: &prebindgen_registry::flat::Function,
-    registry: &Registry<KotlinMeta>,
+    registry: &Registry,
     kotlin_name_override: Option<&str>,
     receiver_key: Option<&TypeKey>,
 ) -> Option<WrapperSurface> {
@@ -845,7 +845,7 @@ pub(crate) fn build_wrapper_surface(
 fn build_wrapper_surface_with_recovery(
     ext: &Declarations,
     f: &prebindgen_registry::flat::Function,
-    registry: &Registry<KotlinMeta>,
+    registry: &Registry,
     kotlin_name_override: Option<&str>,
     receiver_key: Option<&TypeKey>,
     recovery: RecoveryReturn,
@@ -922,7 +922,7 @@ fn build_wrapper_surface_with_recovery(
 pub(crate) fn render_wrapper_fn(
     ext: &Declarations,
     f: &prebindgen_registry::flat::Function,
-    registry: &Registry<KotlinMeta>,
+    registry: &Registry,
     kotlin_name_override: Option<&str>,
     receiver_key: Option<&TypeKey>,
 ) -> Option<KtFun> {
@@ -939,7 +939,7 @@ pub(crate) fn render_wrapper_fn(
 fn render_wrapper_fn_with_recovery(
     ext: &Declarations,
     f: &prebindgen_registry::flat::Function,
-    registry: &Registry<KotlinMeta>,
+    registry: &Registry,
     kotlin_name_override: Option<&str>,
     receiver_key: Option<&TypeKey>,
     recovery: RecoveryReturn,
@@ -1005,7 +1005,7 @@ pub(crate) fn render_const_val(
     ext: &Declarations,
     package: &str,
     c: &prebindgen_registry::flat::Constant,
-    registry: &Registry<KotlinMeta>,
+    registry: &Registry,
     imports: &mut BTreeSet<String>,
     kotlin_name_override: Option<&str>,
 ) -> Option<(KtFun, KtProperty)> {
@@ -1044,7 +1044,7 @@ pub(crate) fn render_constant_fn_val(
     ext: &Declarations,
     package: &str,
     f: &prebindgen_registry::flat::Function,
-    registry: &Registry<KotlinMeta>,
+    registry: &Registry,
     imports: &mut BTreeSet<String>,
     kotlin_name_override: Option<&str>,
 ) -> Option<(KtFun, KtProperty)> {
@@ -1082,7 +1082,7 @@ pub(crate) fn render_const_expr_val(
     ext: &Declarations,
     package: &str,
     decl: &crate::jni::decl::ConstExprDecl,
-    registry: &Registry<KotlinMeta>,
+    registry: &Registry,
     imports: &mut BTreeSet<String>,
 ) -> Option<(KtFun, KtProperty)> {
     let getter = const_expr_getter_fn(&decl.kotlin_name, &decl.ty, registry);
@@ -1120,7 +1120,7 @@ pub(crate) fn render_const_expr_val(
 /// not fire one JNI call per `val` at class-load (issue #58).
 fn render_val_over_helper(
     ext: &Declarations,
-    registry: &Registry<KotlinMeta>,
+    registry: &Registry,
     mut helper: KtFun,
     val_name: String,
     kdoc: String,
@@ -1211,7 +1211,7 @@ struct DomainSink {
 fn classify_params(
     ext: &Declarations,
     fplan: &JniFunctionPlan,
-    registry: &Registry<KotlinMeta>,
+    registry: &Registry,
     imports: &mut BTreeSet<String>,
     receiver_key: Option<&TypeKey>,
 ) -> Option<(Vec<Param>, Option<usize>)> {
@@ -1407,7 +1407,7 @@ fn classify_output(
     ext: &Declarations,
     f: &prebindgen_registry::flat::Function,
     fplan: &JniFunctionPlan,
-    registry: &Registry<KotlinMeta>,
+    registry: &Registry,
     imports: &mut BTreeSet<String>,
 ) -> Option<OutputPlan> {
     let unfold = registry.unfold_plans().get(&f.name);
@@ -1754,7 +1754,7 @@ fn collect_opaques(params: &[Param]) -> Vec<Opaque> {
 fn error_sink_parts(
     f: &prebindgen_registry::flat::Function,
     fplan: &JniFunctionPlan,
-    registry: &Registry<KotlinMeta>,
+    registry: &Registry,
     imports: &mut BTreeSet<String>,
     r_ty: &KtType,
 ) -> Option<ErrorSink> {
@@ -2361,10 +2361,7 @@ pub(crate) fn kt_param_name(rust_ident: &str) -> String {
 /// documenting the REAL prototype after all expansions — one note per
 /// position a plan reshaped, phrased for the caller. `None` for an
 /// undocumented, unshaped fn.
-fn wrapper_kdoc(
-    f: &prebindgen_registry::flat::Function,
-    registry: &Registry<KotlinMeta>,
-) -> Option<String> {
+fn wrapper_kdoc(f: &prebindgen_registry::flat::Function, registry: &Registry) -> Option<String> {
     let prose = f.docs();
     let notes = shape_notes(f, registry);
     match (prose, notes) {
@@ -2380,10 +2377,7 @@ fn wrapper_kdoc(
 /// returns (what the builder/fold receives), and error decompositions
 /// (what `onError` receives). Reads the same resolved plan maps the C7
 /// report uses.
-fn shape_notes(
-    f: &prebindgen_registry::flat::Function,
-    registry: &Registry<KotlinMeta>,
-) -> Option<String> {
+fn shape_notes(f: &prebindgen_registry::flat::Function, registry: &Registry) -> Option<String> {
     let fn_ident = &f.name;
     let mut notes: Vec<String> = Vec::new();
 
@@ -2470,7 +2464,7 @@ fn shape_notes(
 
 /// The `///` doc of the `#[prebindgen]` struct/enum behind a declared type
 /// key, when the item is indexed (a re-exported foreign type has none).
-pub(crate) fn source_item_doc<M>(registry: &Registry<M>, key: &TypeKey) -> Option<String> {
+pub(crate) fn source_item_doc(registry: &Registry, key: &TypeKey) -> Option<String> {
     // Whichever of the three shapes the name declares — the docs are the
     // element's answer, so there is no `attrs` slice to unify across them.
     match registry.flat().declared_type(&key.ident()?)? {

--- a/prebindgen-jni/src/jni/render.rs
+++ b/prebindgen-jni/src/jni/render.rs
@@ -2209,7 +2209,7 @@ pub(crate) fn unfold_leaf_kt(
 /// `core::unfold`).
 ///
 /// [`UnfoldLeaf::name`]: prebindgen_registry::unfold::UnfoldLeaf::name
-pub(crate) fn plan_leaf_names(leaves: &[prebindgen_registry::unfold::UnfoldLeaf]) -> Vec<String> {
+pub(crate) fn plan_leaf_names(leaves: &[crate::jni::compile::OutWire]) -> Vec<String> {
     leaves.iter().map(|leaf| leaf.name.clone()).collect()
 }
 

--- a/prebindgen-jni/src/jni/render.rs
+++ b/prebindgen-jni/src/jni/render.rs
@@ -139,8 +139,8 @@ pub(crate) fn build_data_class(
         // ordinary leaf, so the property and its own factory parameter
         // disagreed. Reject it at the declaration instead.
         if !matches!(pf.kind, PlanFieldKind::Projection { .. }) {
-            if let Some(proj) = registry
-                .input_entry(&field.ty)
+            if let Some(proj) = ext
+                .in_frag(&field.ty)
                 .and_then(|e| e.metadata.projection.clone())
             {
                 panic!(
@@ -2148,13 +2148,12 @@ fn render_body(
 /// Shared by the unfold builder/fold lambda and the callback lambda params.
 pub(crate) fn unfold_leaf_kt(
     ext: &Declarations,
-    registry: &impl Conversions<KotlinMeta>,
     out_ty: &prebindgen_registry::flat::TypeRef,
     nullable: bool,
     pk: &str,
 ) -> Option<(KtType, String, String, bool)> {
-    let proj = registry
-        .output_entry(out_ty)
+    let proj = ext
+        .out_frag(out_ty)
         .and_then(|e| e.metadata.projection.clone());
     let is_value_projection = proj
         .as_ref()
@@ -2165,7 +2164,7 @@ pub(crate) fn unfold_leaf_kt(
     let builder_kt = if ext.is_kotlin_enum_reading(out_ty) {
         KtType::int()
     } else {
-        classify_return(ext, out_ty, registry)?.0?
+        classify_return(ext, out_ty)?.0?
     };
     let (mut wire_kt, wrap) = if is_value_projection {
         let p = proj.as_ref().unwrap();
@@ -2271,9 +2270,8 @@ pub(crate) fn kotlin_for_wire(wire: &syn::Type) -> Option<KtType> {
 pub(crate) fn classify_return(
     ext: &Declarations,
     output: &prebindgen_registry::flat::TypeRef,
-    registry: &impl Conversions<KotlinMeta>,
 ) -> Option<(Option<KtType>, Option<crate::jni::Projection>)> {
-    let (surface, _canonical) = ReturnSurface::classify(ext, registry, output);
+    let (surface, _canonical) = ReturnSurface::classify(ext, output);
     render_return_surface(&surface)
 }
 

--- a/prebindgen-jni/src/jni/report.rs
+++ b/prebindgen-jni/src/jni/report.rs
@@ -135,7 +135,7 @@ impl super::JniGen {
                 .unwrap_or_else(|| key.as_str().to_string());
             let wire = registry
                 .reading(key)
-                .and_then(|tr| registry.output_entry(&tr))
+                .and_then(|tr| ext.out_frag(&tr))
                 .map(|e| e.wire_type().to_token_stream().to_string())
                 .unwrap_or_else(|| "?".to_string());
             out.push_str(&format!(

--- a/prebindgen-jni/src/jni/rows.rs
+++ b/prebindgen-jni/src/jni/rows.rs
@@ -17,7 +17,7 @@ use std::collections::BTreeMap;
 
 use prebindgen_registry::{
     flat::{Flat, TypeRef},
-    recipe::{Construct, Constructing, Deconstructing, RecipeError, RecipeId, Recipes},
+    recipe::{Arm, Construct, Constructing, Deconstructing, RecipeError, RecipeId, Recipes},
 };
 
 use super::*;
@@ -44,6 +44,30 @@ fn element_types(element: &prebindgen_registry::Element) -> Vec<&TypeRef> {
         prebindgen_registry::Element::Constant(c) => vec![&c.ty],
         _ => Vec::new(),
     }
+}
+
+/// One arm per alternative of a declared sum, each assembled from its own
+/// payload fields.
+///
+/// Empty for anything the model does not hold as a data-carrying enum, which
+/// includes a `sealed_class!` declared over a type the scan dropped — the scan
+/// reports that, and a row over no arms would report it a second time.
+fn alternatives(model: &Flat, ty: &TypeRef) -> Vec<Arm<Construct>> {
+    let prebindgen_registry::flat::TypeKind::Named { id, .. } = ty.unwrapped().kind() else {
+        return Vec::new();
+    };
+    let Some(prebindgen_registry::flat::Type::Variant(v)) =
+        id.ident().and_then(|ident| model.declared_type(&ident))
+    else {
+        return Vec::new();
+    };
+    v.alternatives
+        .iter()
+        .map(|alt| Arm {
+            alternative: alt.index,
+            op: Construct::Fields,
+        })
+        .collect()
 }
 
 /// The row a type with no parts takes: the adapter emits the conversion itself.
@@ -108,14 +132,25 @@ impl Declarations {
             // A `data_class` also has a row that says what it is made of, so
             // its constructing side names which of the two a site takes by
             // default. See [`parts`] for why that is still `whole`.
-            if matches!(
-                self.types.get(&ty.key()).map(|c| &c.kind),
-                Some(DeclaredKind::Data)
-            ) {
-                rows.declare_default(ty.clone(), whole(), Constructing::Atomic)
-                    .declare(ty, parts(), Constructing::Product(Construct::Fields));
-            } else {
-                rows.declare(ty, whole(), Constructing::Atomic);
+            match self.types.get(&ty.key()).map(|c| &c.kind) {
+                Some(DeclaredKind::Data) => {
+                    rows.declare_default(ty.clone(), whole(), Constructing::Atomic)
+                        .declare(ty, parts(), Constructing::Product(Construct::Fields));
+                }
+                // A `sealed_class` has one too, and it is a choice rather than
+                // a product: exactly one alternative is live, every one of them
+                // still crosses, and the tag says which. The arms are the
+                // model's — a row states which parts, never what they are.
+                Some(DeclaredKind::Sealed(_)) => {
+                    let arms = alternatives(model, &ty);
+                    rows.declare_default(ty.clone(), whole(), Constructing::Atomic);
+                    if !arms.is_empty() {
+                        rows.declare(ty, parts(), Constructing::Choice { arms });
+                    }
+                }
+                _ => {
+                    rows.declare(ty, whole(), Constructing::Atomic);
+                }
             }
         }
 
@@ -165,7 +200,16 @@ impl Declarations {
     fn field_crosses_as_its_fields(&self, ty: &TypeRef) -> bool {
         self.types
             .get(&ty.stripped_key())
-            .is_some_and(|c| matches!(c.kind, DeclaredKind::Data) && !c.jobject_input)
+            .is_some_and(|c| match c.kind {
+                DeclaredKind::Data => !c.jobject_input,
+                // A `sealed_class` field crosses as a tag plus every alternative's
+                // slots. Whether it *can* is the adapter's answer at compile time,
+                // not a declaration: a payload with no slot form leaves the sum
+                // object-shaped, which is the fragment `Compile::choice` hands
+                // back. So the site asks, and the row answers.
+                DeclaredKind::Sealed(_) => true,
+                _ => false,
+            })
     }
 
     pub(crate) fn bindings(

--- a/prebindgen-jni/src/jni/rows.rs
+++ b/prebindgen-jni/src/jni/rows.rs
@@ -157,12 +157,25 @@ impl Declarations {
     ///
     /// Without it a nested class contributes a single wire and the flattening
     /// stops one layer down.
+    /// Whether a `data_class` field is itself flattened, or stays one value.
+    ///
+    /// A `data_class` declared `.jobject_input()` crosses Kotlin → Rust as a
+    /// single `JObject` — that is the whole point of the opt-in — so binding
+    /// its parts would flatten a boundary the declaration drew.
+    fn field_crosses_as_its_fields(&self, ty: &TypeRef) -> bool {
+        self.types
+            .get(&ty.stripped_key())
+            .is_some_and(|c| matches!(c.kind, DeclaredKind::Data) && !c.jobject_input)
+    }
+
     pub(crate) fn bindings(
         &self,
         model: &Flat,
         recipes: &prebindgen_registry::recipe::Recipes,
     ) -> Result<prebindgen_registry::recipe::Bindings, Vec<RecipeError>> {
-        use prebindgen_registry::recipe::{Ask, Assembly, Bindings, Crossing, Origin, Site};
+        use prebindgen_registry::recipe::{
+            Ask, Assembly, Bindings, Crossing, Origin, RecipeId, Site,
+        };
 
         let mut bound = Bindings::builder();
         let mut declared: Vec<TypeKey> = self
@@ -184,18 +197,36 @@ impl Declarations {
             };
             let of = Crossing::new(ty, Assembly::Construct);
             for (index, field) in s.fields.iter().enumerate() {
-                if !matches!(
-                    self.types.get(&field.ty.stripped_key()).map(|c| &c.kind),
-                    Some(DeclaredKind::Data)
-                ) {
+                // An `Option<D>` field reaches D through the optional's own
+                // row, so the part bound here is the optional and the inner is
+                // bound below.
+                let target = field.ty.optional_inner().unwrap_or(&field.ty);
+                if !self.field_crosses_as_its_fields(target) {
                     continue;
                 }
-                bound.bind(
-                    Site::part(&of, &parts(), index),
-                    Crossing::new(field.ty.clone(), Assembly::Construct),
-                    Ask::Recipe(parts()),
-                    Origin::Part,
-                );
+                match field.ty.optional_inner() {
+                    // The field IS the class: its part takes the `parts` row.
+                    None => bound.bind(
+                        Site::part(&of, &parts(), index),
+                        Crossing::new(field.ty.clone(), Assembly::Construct),
+                        Ask::Recipe(parts()),
+                        Origin::Part,
+                    ),
+                    // The field is an `Option<D>`. That crossing keeps the row
+                    // the registry derived from its shape — it has no `parts`
+                    // row of its own — and it is D, one layer in, that takes
+                    // `parts`.
+                    Some(_) => bound.bind(
+                        Site::part(
+                            &Crossing::new(field.ty.clone(), Assembly::Construct),
+                            &RecipeId::derived(),
+                            0,
+                        ),
+                        Crossing::new(target.clone(), Assembly::Construct),
+                        Ask::Recipe(parts()),
+                        Origin::Part,
+                    ),
+                };
             }
         }
         bound.build(recipes)

--- a/prebindgen-jni/src/jni/rows.rs
+++ b/prebindgen-jni/src/jni/rows.rs
@@ -223,15 +223,19 @@ impl Declarations {
 /// `data_class!` over a type the scan dropped — the scan reports that, and a
 /// row over no fields would report it a second time.
 fn out_fields(model: &Flat, ty: &TypeRef) -> Vec<Reach> {
+    (0..fields_of(model, ty).len()).map(Reach::Field).collect()
+}
+
+/// The fields of a declared struct, or none for anything the model does not
+/// hold as one.
+fn fields_of<'a>(model: &'a Flat, ty: &TypeRef) -> &'a [prebindgen_registry::flat::Field] {
     let prebindgen_registry::flat::TypeKind::Named { id, .. } = ty.unwrapped().kind() else {
-        return Vec::new();
+        return &[];
     };
-    let Some(prebindgen_registry::flat::Type::Struct(s)) =
-        id.ident().and_then(|ident| model.declared_type(&ident))
-    else {
-        return Vec::new();
-    };
-    (0..s.fields.len()).map(Reach::Field).collect()
+    match id.ident().and_then(|ident| model.declared_type(&ident)) {
+        Some(prebindgen_registry::flat::Type::Struct(s)) => &s.fields,
+        _ => &[],
+    }
 }
 
 /// The row a type with no parts takes: the adapter emits the conversion itself.
@@ -345,7 +349,11 @@ impl Declarations {
             // its constructing side names which of the two a site takes by
             // default. See [`parts`] for why that is still `whole`.
             match self.types.get(&ty.key()).map(|c| &c.kind) {
-                Some(DeclaredKind::Data) => {
+                // A struct with no fields is nothing to be made of, so it
+                // states no `parts` row — the same condition the deconstructing
+                // side applies, and the reason `row_of` may be asked for the
+                // row by name.
+                Some(DeclaredKind::Data) if !fields_of(model, &ty).is_empty() => {
                     rows.declare_default(ty.clone(), whole(), Constructing::Atomic)
                         .declare(ty, parts(), Constructing::Product(Construct::Fields));
                 }

--- a/prebindgen-jni/src/jni/rows.rs
+++ b/prebindgen-jni/src/jni/rows.rs
@@ -100,6 +100,31 @@ fn out_alternatives(model: &Flat, ty: &TypeRef) -> Vec<Arm<Deconstruct>> {
 }
 
 impl Declarations {
+    /// How many values this type hands out, or 0 if it hands out none.
+    ///
+    /// Model and declaration only, like the compositions it asks — so a
+    /// declaration-time caller may ask it, which is what binding a return site
+    /// needs.
+    fn out_wire_count(
+        &self,
+        registry: &impl prebindgen_registry::Conversions,
+        ty: &TypeRef,
+    ) -> usize {
+        let prebindgen_registry::flat::TypeKind::Named { id, .. } = ty.unwrapped().kind() else {
+            return 0;
+        };
+        let Some(ident) = id.ident() else { return 0 };
+        match registry.flat().declared_type(&ident) {
+            Some(prebindgen_registry::flat::Type::Variant(_)) => self
+                .sum_out_wires(registry, &ident, ty)
+                .map_or(0, |w| w.len()),
+            Some(prebindgen_registry::flat::Type::Struct(_)) => {
+                self.struct_out_wires(registry, ty).map_or(0, |w| w.len())
+            }
+            _ => 0,
+        }
+    }
+
     /// The accessor a type's value form names, and one reach per field of the
     /// struct it returns.
     ///
@@ -404,6 +429,7 @@ impl Declarations {
     pub(crate) fn bindings(
         &self,
         model: &Flat,
+        registry: &impl prebindgen_registry::Conversions,
         recipes: &prebindgen_registry::recipe::Recipes,
     ) -> Result<prebindgen_registry::recipe::Bindings, Vec<RecipeError>> {
         use prebindgen_registry::recipe::{
@@ -496,6 +522,49 @@ impl Declarations {
                 }
             }
         }
+        // Every function whose return the binding takes apart, bound to the
+        // `parts` row of its return type.
+        //
+        // This is what a site naming several values is: `Ask::Recipe` already
+        // lets a site pick a row, and a `parts` fragment already occupies
+        // several wires — the two facts stages 3 and 4 established, meeting.
+        // The registry needs nothing new to express a decomposed return.
+        for f in model.functions() {
+            // The value that crosses, through the layers a decomposition looks
+            // through: a `&T` return decomposes T, and so does an `Option<T>`
+            // or a `Vec<T>` — the shape rides the delivery, not the row.
+            let ret = f.ret.borrow_target().unwrap_or(&f.ret);
+            let ret = ret.optional_inner().unwrap_or(ret);
+            let ret = ret.sequence_elem().unwrap_or(ret);
+            let ret = ret.borrow_target().unwrap_or(ret);
+            let crossing = Crossing::new(ret.clone(), Assembly::Deconstruct);
+            // Only where the type states one. A `sealed_class` always does; a
+            // `data_class` states one unless a field of it declines, and a
+            // return whose type states none crosses whole.
+            if recipes.get(&crossing.key(), &parts()).is_none() {
+                continue;
+            }
+            // And only where it is genuinely several. A decomposition that
+            // yields ONE value takes `Delivery::Return`: the wrapper hands that
+            // value back through its own conversion rather than through a
+            // builder, so the return site's crossing is the value's, not this
+            // type's. Asked of the composition, which is model and declaration
+            // only and so answerable here — the same property that let one
+            // composition serve both sides of `resolve`.
+            if self.out_wire_count(registry, ret) < 2 {
+                continue;
+            }
+            bound.bind(
+                Site {
+                    owner: f.name.clone(),
+                    role: prebindgen_registry::recipe::Role::Return,
+                },
+                crossing,
+                Ask::Recipe(parts()),
+                Origin::Adapter,
+            );
+        }
+
         bound.build(recipes)
     }
 }

--- a/prebindgen-jni/src/jni/rows.rs
+++ b/prebindgen-jni/src/jni/rows.rs
@@ -99,6 +99,23 @@ fn out_alternatives(model: &Flat, ty: &TypeRef) -> Vec<Arm<Deconstruct>> {
         .collect()
 }
 
+/// One reach per field of a declared struct, in the model's order.
+///
+/// Empty for anything the model does not hold as a struct, which includes a
+/// `data_class!` over a type the scan dropped — the scan reports that, and a
+/// row over no fields would report it a second time.
+fn out_fields(model: &Flat, ty: &TypeRef) -> Vec<Reach> {
+    let prebindgen_registry::flat::TypeKind::Named { id, .. } = ty.unwrapped().kind() else {
+        return Vec::new();
+    };
+    let Some(prebindgen_registry::flat::Type::Struct(s)) =
+        id.ident().and_then(|ident| model.declared_type(&ident))
+    else {
+        return Vec::new();
+    };
+    (0..s.fields.len()).map(Reach::Field).collect()
+}
+
 /// The row a type with no parts takes: the adapter emits the conversion itself.
 fn whole() -> RecipeId {
     RecipeId::new("whole")
@@ -168,6 +185,20 @@ impl Declarations {
                     rows.declare_default(ty.clone(), whole(), Deconstructing::Atomic);
                     if !arms.is_empty() {
                         rows.declare(ty.clone(), parts(), Deconstructing::Choice { arms });
+                    }
+                }
+                // A `data_class` hands its value out as its fields too, so the
+                // foreign side reassembles the object and nothing builds one on
+                // the Rust side.
+                Some(DeclaredKind::Data) => {
+                    let reaches = out_fields(model, &ty);
+                    rows.declare_default(ty.clone(), whole(), Deconstructing::Atomic);
+                    if !reaches.is_empty() {
+                        rows.declare(
+                            ty.clone(),
+                            parts(),
+                            Deconstructing::Product(Deconstruct::Fields(reaches)),
+                        );
                     }
                 }
                 _ => {
@@ -325,7 +356,8 @@ impl Declarations {
             let Ok(ty) = model.classify(&syn::parse_quote!(#ident)) else {
                 continue;
             };
-            let of = Crossing::new(ty, Assembly::Construct);
+            let building = Crossing::new(ty.clone(), Assembly::Construct);
+            let handing_out = Crossing::new(ty, Assembly::Deconstruct);
             for (index, field) in s.fields.iter().enumerate() {
                 // An `Option<D>` field reaches D through the optional's own
                 // row, so the part bound here is the optional and the inner is
@@ -337,14 +369,19 @@ impl Declarations {
                 // An `Option<D>` field reaches D through the optional's own
                 // part site, which the model-wide scan above already bound. What
                 // is left is the field that IS the class: its part takes the
-                // `parts` row.
+                // `parts` row, in both directions.
                 if field.ty.optional_inner().is_none() {
-                    bound.bind(
-                        Site::part(&of, &parts(), index),
-                        Crossing::new(field.ty.clone(), Assembly::Construct),
-                        Ask::Recipe(parts()),
-                        Origin::Part,
-                    );
+                    for (of, assembly) in [
+                        (&building, Assembly::Construct),
+                        (&handing_out, Assembly::Deconstruct),
+                    ] {
+                        bound.bind(
+                            Site::part(of, &parts(), index),
+                            Crossing::new(field.ty.clone(), assembly),
+                            Ask::Recipe(parts()),
+                            Origin::Part,
+                        );
+                    }
                 }
             }
         }

--- a/prebindgen-jni/src/jni/rows.rs
+++ b/prebindgen-jni/src/jni/rows.rs
@@ -17,7 +17,10 @@ use std::collections::BTreeMap;
 
 use prebindgen_registry::{
     flat::{Flat, TypeRef},
-    recipe::{Arm, Construct, Constructing, Deconstructing, RecipeError, RecipeId, Recipes},
+    recipe::{
+        Arm, Construct, Constructing, Deconstruct, Deconstructing, Reach, RecipeError, RecipeId,
+        Recipes,
+    },
 };
 
 use super::*;
@@ -66,6 +69,32 @@ fn alternatives(model: &Flat, ty: &TypeRef) -> Vec<Arm<Construct>> {
         .map(|alt| Arm {
             alternative: alt.index,
             op: Construct::Fields,
+        })
+        .collect()
+}
+
+/// One arm per alternative of a declared sum, each taken apart into its own
+/// payload fields.
+///
+/// The deconstructing twin of [`alternatives`]. Separate because the two jobs
+/// name different operations — building an alternative is `Construct::Fields`,
+/// reading one is `Deconstruct::Fields` over the reaches that get there — and
+/// a shared helper would have to be generic over an operation neither side
+/// chooses.
+fn out_alternatives(model: &Flat, ty: &TypeRef) -> Vec<Arm<Deconstruct>> {
+    let prebindgen_registry::flat::TypeKind::Named { id, .. } = ty.unwrapped().kind() else {
+        return Vec::new();
+    };
+    let Some(prebindgen_registry::flat::Type::Variant(v)) =
+        id.ident().and_then(|ident| model.declared_type(&ident))
+    else {
+        return Vec::new();
+    };
+    v.alternatives
+        .iter()
+        .map(|alt| Arm {
+            alternative: alt.index,
+            op: Deconstruct::Fields((0..alt.fields.len()).map(Reach::Field).collect()),
         })
         .collect()
 }
@@ -128,7 +157,23 @@ impl Declarations {
             // the adapter emits the conversion itself, and how many wire values
             // that costs is its own business — so it describes the adapter as it
             // stands rather than as it will be.
-            rows.declare(ty.clone(), whole(), Deconstructing::Atomic);
+            // A `sealed_class` hands its value out as a tag plus every
+            // alternative's payloads, laid side by side — the deconstructing
+            // twin of the constructing row below, and the direction that
+            // actually has no alternative: a sum has no whole-value output
+            // conversion, because a tag plus groups is not one wire.
+            match self.types.get(&ty.key()).map(|c| &c.kind) {
+                Some(DeclaredKind::Sealed(_)) => {
+                    let arms = out_alternatives(model, &ty);
+                    rows.declare_default(ty.clone(), whole(), Deconstructing::Atomic);
+                    if !arms.is_empty() {
+                        rows.declare(ty.clone(), parts(), Deconstructing::Choice { arms });
+                    }
+                }
+                _ => {
+                    rows.declare(ty.clone(), whole(), Deconstructing::Atomic);
+                }
+            }
             // A `data_class` also has a row that says what it is made of, so
             // its constructing side names which of the two a site takes by
             // default. See [`parts`] for why that is still `whole`.

--- a/prebindgen-jni/src/jni/rows.rs
+++ b/prebindgen-jni/src/jni/rows.rs
@@ -198,18 +198,20 @@ impl Declarations {
     /// single `JObject` — that is the whole point of the opt-in — so binding
     /// its parts would flatten a boundary the declaration drew.
     fn field_crosses_as_its_fields(&self, ty: &TypeRef) -> bool {
-        self.types
-            .get(&ty.stripped_key())
-            .is_some_and(|c| match c.kind {
-                DeclaredKind::Data => !c.jobject_input,
-                // A `sealed_class` field crosses as a tag plus every alternative's
-                // slots. Whether it *can* is the adapter's answer at compile time,
-                // not a declaration: a payload with no slot form leaves the sum
-                // object-shaped, which is the fragment `Compile::choice` hands
-                // back. So the site asks, and the row answers.
-                DeclaredKind::Sealed(_) => true,
-                _ => false,
-            })
+        // The field's own key, not the stripped one: a `Box<Leaf>` field
+        // crosses as one value through `Box<Leaf>`'s conversion, and only a
+        // parameter spelled that way is peeled back to the class. Binding the
+        // stripped key here would flatten a field the rebuild has no node for.
+        self.types.get(&ty.key()).is_some_and(|c| match c.kind {
+            DeclaredKind::Data => !c.jobject_input,
+            // A `sealed_class` field crosses as a tag plus every alternative's
+            // slots. Whether it *can* is the adapter's answer at compile time,
+            // not a declaration: a payload with no slot form leaves the sum
+            // object-shaped, which is the fragment `Compile::choice` hands
+            // back. So the site asks, and the row answers.
+            DeclaredKind::Sealed(_) => true,
+            _ => false,
+        })
     }
 
     pub(crate) fn bindings(

--- a/prebindgen-jni/src/jni/rows.rs
+++ b/prebindgen-jni/src/jni/rows.rs
@@ -230,6 +230,45 @@ impl Declarations {
             .collect();
         declared.sort_by(|a, b| a.as_str().cmp(b.as_str()));
 
+        // Every optional over a flattenable value, wherever the model spells
+        // one: a parameter, a field, a callback argument. A `Site` keys a part
+        // by the crossing's **stripped** key, so `Option<Payload>` and
+        // `Box<Option<Payload>>` are one site and binding it once answers for
+        // both spellings.
+        //
+        // Enumerated from the model rather than from the declarations, for the
+        // same reason the array rows are: what has to be bound is what the
+        // model names, and a declaration says nothing about where its type is
+        // used.
+        let mut optionals: BTreeMap<TypeKey, (&TypeRef, &TypeRef)> = BTreeMap::new();
+        for ty in model
+            .elements()
+            .flat_map(element_types)
+            .flat_map(|t| t.walk())
+        {
+            let Some(inner) = ty.optional_inner() else {
+                continue;
+            };
+            if self.field_crosses_as_its_fields(inner) {
+                optionals.entry(ty.stripped_key()).or_insert((ty, inner));
+            }
+        }
+        for (outer, inner) in optionals.into_values() {
+            // The optional keeps the row the registry derived from its shape —
+            // it has no `parts` row of its own — and it is the value one layer
+            // in that crosses as its parts.
+            bound.bind(
+                Site::part(
+                    &Crossing::new(outer.clone(), Assembly::Construct),
+                    &RecipeId::derived(),
+                    0,
+                ),
+                Crossing::new(inner.clone(), Assembly::Construct),
+                Ask::Recipe(parts()),
+                Origin::Part,
+            );
+        }
+
         for key in declared {
             let Some(ident) = key.ident() else { continue };
             let Some(prebindgen_registry::flat::Type::Struct(s)) = model.declared_type(&ident)
@@ -248,29 +287,18 @@ impl Declarations {
                 if !self.field_crosses_as_its_fields(target) {
                     continue;
                 }
-                match field.ty.optional_inner() {
-                    // The field IS the class: its part takes the `parts` row.
-                    None => bound.bind(
+                // An `Option<D>` field reaches D through the optional's own
+                // part site, which the model-wide scan above already bound. What
+                // is left is the field that IS the class: its part takes the
+                // `parts` row.
+                if field.ty.optional_inner().is_none() {
+                    bound.bind(
                         Site::part(&of, &parts(), index),
                         Crossing::new(field.ty.clone(), Assembly::Construct),
                         Ask::Recipe(parts()),
                         Origin::Part,
-                    ),
-                    // The field is an `Option<D>`. That crossing keeps the row
-                    // the registry derived from its shape — it has no `parts`
-                    // row of its own — and it is D, one layer in, that takes
-                    // `parts`.
-                    Some(_) => bound.bind(
-                        Site::part(
-                            &Crossing::new(field.ty.clone(), Assembly::Construct),
-                            &RecipeId::derived(),
-                            0,
-                        ),
-                        Crossing::new(target.clone(), Assembly::Construct),
-                        Ask::Recipe(parts()),
-                        Origin::Part,
-                    ),
-                };
+                    );
+                }
             }
         }
         bound.build(recipes)

--- a/prebindgen-jni/src/jni/rows.rs
+++ b/prebindgen-jni/src/jni/rows.rs
@@ -99,6 +99,99 @@ fn out_alternatives(model: &Flat, ty: &TypeRef) -> Vec<Arm<Deconstruct>> {
         .collect()
 }
 
+impl Declarations {
+    /// The accessor a type's value form names, and one reach per field of the
+    /// struct it returns.
+    ///
+    /// `None` unless the declaration is exactly one `.fields(fields!(f))` whose
+    /// every field is a plain leaf. A record that states its own decomposition
+    /// — a per-field `expand_return!` override, an inlined nested class, a sum
+    /// laid out as a selector and its groups — is a shape this row does not
+    /// state yet, and stating half of one would describe a boundary nothing
+    /// emits.
+    fn value_form_of(
+        &self,
+        model: &Flat,
+        registry: &impl prebindgen_registry::Conversions,
+        ty: &TypeRef,
+    ) -> Option<(syn::Ident, Vec<Reach>)> {
+        use prebindgen_registry::unfold::{FieldDecon, FieldRecord};
+        let decl = self
+            .return_expand_decls
+            .iter()
+            .find(|d| *d.key() == ty.stripped_key())?;
+        let [crate::jni::LocalField::Fields(fields)] = decl.field_list() else {
+            return None;
+        };
+        let records: Vec<FieldRecord> = self.lower_value_form(registry, decl.key(), fields);
+        let ret = model.function(fields.func())?.ret.clone();
+        let ret = ret.borrow_target().unwrap_or(&ret);
+        let prebindgen_registry::flat::TypeKind::Named { id, .. } = ret.unwrapped().kind() else {
+            return None;
+        };
+        let prebindgen_registry::flat::Type::Struct(st) =
+            id.ident().and_then(|i| model.declared_type(&i))?
+        else {
+            return None;
+        };
+        let mut reaches = Vec::new();
+        for record in &records {
+            if !matches!(record.decon, FieldDecon::Default) {
+                return None;
+            }
+            let [member] = record.members.as_slice() else {
+                return None;
+            };
+            let index = st
+                .fields
+                .iter()
+                .position(|f| f.name.as_ref() == Some(member))?;
+            // A field that reaches the type being taken apart. The leaf
+            // synthesis treats `Box<T>` as a spelling of its own and stops
+            // there; a recipe keys a crossing by the value that crosses, so
+            // `Box<ZSample>` inside `ZSample`'s own value form is that row
+            // reaching itself. Refused here rather than by `Recipes::build`,
+            // which would refuse the whole binding over a shape the leaf
+            // synthesis handles.
+            if st.fields[index].ty.stripped_key() == ty.stripped_key() {
+                return None;
+            }
+            reaches.push(Reach::Field(index));
+        }
+        Some((fields.func().clone(), reaches))
+    }
+}
+
+impl Declarations {
+    /// What a value form calls each of its fields, by the Rust field ident.
+    ///
+    /// The declaration's answer, so a `.name(..)` rename carries through to the
+    /// builder parameter. `None` for a type with no value form, or one whose
+    /// records this row does not state — the same test [`Self::value_form_of`]
+    /// makes when it declares the row.
+    pub(crate) fn value_form_names(
+        &self,
+        registry: &impl prebindgen_registry::Conversions,
+        ty: &TypeRef,
+    ) -> Option<std::collections::HashMap<String, String>> {
+        use prebindgen_registry::unfold::FieldDecon;
+        let decl = self
+            .return_expand_decls
+            .iter()
+            .find(|d| *d.key() == ty.stripped_key())?;
+        let [crate::jni::LocalField::Fields(fields)] = decl.field_list() else {
+            return None;
+        };
+        self.lower_value_form(registry, decl.key(), fields)
+            .into_iter()
+            .map(|r| match (r.members.as_slice(), &r.decon) {
+                ([member], FieldDecon::Default) => Some((member.to_string(), r.name)),
+                _ => None,
+            })
+            .collect()
+    }
+}
+
 /// One reach per field of a declared struct, in the model's order.
 ///
 /// Empty for anything the model does not hold as a struct, which includes a
@@ -137,7 +230,11 @@ impl Declarations {
     /// A type declared but absent from the model is skipped rather than
     /// refused: the scan already reports it, and reporting it twice in
     /// different words helps nobody.
-    pub(crate) fn recipes(&self, model: &Flat) -> Result<Recipes, Vec<RecipeError>> {
+    pub(crate) fn recipes(
+        &self,
+        model: &Flat,
+        registry: &impl prebindgen_registry::Conversions,
+    ) -> Result<Recipes, Vec<RecipeError>> {
         let mut rows = Recipes::builder();
         // Every Kotlin class declaration, and every `convert!`-declared
         // conversion. The second matters as much as the first: a conversion may
@@ -202,8 +299,22 @@ impl Declarations {
                     }
                 }
                 _ => {
-                    rows.declare(ty.clone(), whole(), Deconstructing::Atomic);
+                    rows.declare_default(ty.clone(), whole(), Deconstructing::Atomic);
                 }
+            }
+            // A value form: `expand_return!(T).fields(fields!(f))` calls `f`
+            // once and hands out the fields of the struct it returns. The one
+            // declaration shape that names its own accessor, and the reason
+            // `Deconstruct::ValueForm` exists.
+            if let Some((func, reaches)) = self.value_form_of(model, registry, &ty) {
+                rows.declare(
+                    ty.clone(),
+                    parts(),
+                    Deconstructing::Product(Deconstruct::ValueForm {
+                        func,
+                        parts: reaches,
+                    }),
+                );
             }
             // A `data_class` also has a row that says what it is made of, so
             // its constructing side names which of the two a site takes by

--- a/prebindgen-jni/src/jni/rows.rs
+++ b/prebindgen-jni/src/jni/rows.rs
@@ -17,7 +17,7 @@ use std::collections::BTreeMap;
 
 use prebindgen_registry::{
     flat::{Flat, TypeRef},
-    recipe::{Constructing, Deconstructing, RecipeError, RecipeId, Recipes},
+    recipe::{Construct, Constructing, Deconstructing, RecipeError, RecipeId, Recipes},
 };
 
 use super::*;
@@ -49,6 +49,16 @@ fn element_types(element: &prebindgen_registry::Element) -> Vec<&TypeRef> {
 /// The row a type with no parts takes: the adapter emits the conversion itself.
 fn whole() -> RecipeId {
     RecipeId::new("whole")
+}
+
+/// The row a `data_class` takes when it crosses **as its fields**.
+///
+/// Not the default yet. `whole()` still answers for every site, and this one is
+/// compiled only where something asks for it by name — which is what lets the
+/// composed wire list be checked against the walk it will replace before
+/// anything depends on it.
+pub(crate) fn parts() -> RecipeId {
+    RecipeId::new("parts")
 }
 
 impl Declarations {
@@ -94,8 +104,19 @@ impl Declarations {
             // the adapter emits the conversion itself, and how many wire values
             // that costs is its own business — so it describes the adapter as it
             // stands rather than as it will be.
-            rows.declare(ty.clone(), whole(), Deconstructing::Atomic)
-                .declare(ty, whole(), Constructing::Atomic);
+            rows.declare(ty.clone(), whole(), Deconstructing::Atomic);
+            // A `data_class` also has a row that says what it is made of, so
+            // its constructing side names which of the two a site takes by
+            // default. See [`parts`] for why that is still `whole`.
+            if matches!(
+                self.types.get(&ty.key()).map(|c| &c.kind),
+                Some(DeclaredKind::Data)
+            ) {
+                rows.declare_default(ty.clone(), whole(), Constructing::Atomic)
+                    .declare(ty, parts(), Constructing::Product(Construct::Fields));
+            } else {
+                rows.declare(ty, whole(), Constructing::Atomic);
+            }
         }
 
         // A fixed-size array of JNI primitives is one Kotlin `ByteArray` or
@@ -123,5 +144,60 @@ impl Declarations {
         }
 
         rows.build(model)
+    }
+}
+
+impl Declarations {
+    /// Which row each part of a `data_class` takes.
+    ///
+    /// A field that is itself a `data_class` crosses as **its** fields too, so
+    /// the part site asks for [`parts`] rather than letting the field take its
+    /// own default. That is the one thing a site can say that a row cannot: the
+    /// same crossing is read one way on its own and another inside a product.
+    ///
+    /// Without it a nested class contributes a single wire and the flattening
+    /// stops one layer down.
+    pub(crate) fn bindings(
+        &self,
+        model: &Flat,
+        recipes: &prebindgen_registry::recipe::Recipes,
+    ) -> Result<prebindgen_registry::recipe::Bindings, Vec<RecipeError>> {
+        use prebindgen_registry::recipe::{Ask, Assembly, Bindings, Crossing, Origin, Site};
+
+        let mut bound = Bindings::builder();
+        let mut declared: Vec<TypeKey> = self
+            .types
+            .iter()
+            .filter(|(_, c)| matches!(c.kind, DeclaredKind::Data))
+            .map(|(k, _)| k.clone())
+            .collect();
+        declared.sort_by(|a, b| a.as_str().cmp(b.as_str()));
+
+        for key in declared {
+            let Some(ident) = key.ident() else { continue };
+            let Some(prebindgen_registry::flat::Type::Struct(s)) = model.declared_type(&ident)
+            else {
+                continue;
+            };
+            let Ok(ty) = model.classify(&syn::parse_quote!(#ident)) else {
+                continue;
+            };
+            let of = Crossing::new(ty, Assembly::Construct);
+            for (index, field) in s.fields.iter().enumerate() {
+                if !matches!(
+                    self.types.get(&field.ty.stripped_key()).map(|c| &c.kind),
+                    Some(DeclaredKind::Data)
+                ) {
+                    continue;
+                }
+                bound.bind(
+                    Site::part(&of, &parts(), index),
+                    Crossing::new(field.ty.clone(), Assembly::Construct),
+                    Ask::Recipe(parts()),
+                    Origin::Part,
+                );
+            }
+        }
+        bound.build(recipes)
     }
 }

--- a/prebindgen-jni/src/jni/selector.rs
+++ b/prebindgen-jni/src/jni/selector.rs
@@ -126,7 +126,7 @@ impl Declarations {
     pub(crate) fn result_shape(
         &self,
         ty: &prebindgen_registry::flat::TypeRef,
-        registry: &impl Conversions<KotlinMeta>,
+        registry: &impl Conversions,
         emit: &prebindgen_registry::Emit,
     ) -> Option<ConverterImpl<KotlinMeta>> {
         let (ok, err) = fallible_parts(ty, emit)?;

--- a/prebindgen-jni/src/jni/selector.rs
+++ b/prebindgen-jni/src/jni/selector.rs
@@ -185,7 +185,7 @@ impl Declarations {
             return None;
         }
         let elem = inner.sequence_elem()?;
-        self.output_slice(elem, registry, emit)
+        self.output_slice(elem, emit)
     }
 }
 

--- a/prebindgen-jni/src/jni/selector.rs
+++ b/prebindgen-jni/src/jni/selector.rs
@@ -47,7 +47,6 @@ impl Declarations {
     pub(crate) fn input_optional(
         &self,
         ty: &prebindgen_registry::flat::TypeRef,
-        registry: &impl Conversions<KotlinMeta>,
         emit: &prebindgen_registry::Emit,
     ) -> Option<ConverterImpl<KotlinMeta>> {
         // What the converter YIELDS: this crossing's own reading, so a
@@ -60,7 +59,6 @@ impl Declarations {
                 WrapperShape::OptionRef { mutable },
                 &produced,
                 target,
-                registry,
                 emit,
             ) {
                 c.subs = vec![target.key()];
@@ -76,8 +74,7 @@ impl Declarations {
         if inner.borrow_target().is_some() && !ty.erased_wrappers().is_empty() {
             return None;
         }
-        let mut c =
-            self.input_wrapper_shape(WrapperShape::Optional, &produced, inner, registry, emit)?;
+        let mut c = self.input_wrapper_shape(WrapperShape::Optional, &produced, inner, emit)?;
         c.subs = vec![inner.key()];
         Some(c)
     }
@@ -92,13 +89,11 @@ impl Declarations {
     pub(crate) fn input_run(
         &self,
         ty: &prebindgen_registry::flat::TypeRef,
-        registry: &impl Conversions<KotlinMeta>,
         emit: &prebindgen_registry::Emit,
     ) -> Option<ConverterImpl<KotlinMeta>> {
         let produced = crate::jni::trait_impl::Produced::Reading(ty);
         if let Some(elem) = ty.sequence_elem().filter(|_| !is_unsized_spelling(ty)) {
-            let mut c =
-                self.input_wrapper_shape(WrapperShape::Sequence, &produced, elem, registry, emit)?;
+            let mut c = self.input_wrapper_shape(WrapperShape::Sequence, &produced, elem, emit)?;
             c.subs = vec![elem.key()];
             return Some(c);
         }
@@ -120,8 +115,7 @@ impl Declarations {
         // owned `[T]` to decode into, so the converter yields an owned `Vec<T>`
         // and the call site borrows it.
         let produced = crate::jni::trait_impl::Produced::Composed(syn::parse_quote!(Vec<#elem_ty>));
-        let mut c =
-            self.input_wrapper_shape(WrapperShape::Sequence, &produced, elem, registry, emit)?;
+        let mut c = self.input_wrapper_shape(WrapperShape::Sequence, &produced, elem, emit)?;
         c.subs = vec![elem.key()];
         Some(c)
     }
@@ -146,13 +140,11 @@ impl Declarations {
     pub(crate) fn output_optional(
         &self,
         ty: &prebindgen_registry::flat::TypeRef,
-        registry: &impl Conversions<KotlinMeta>,
         emit: &prebindgen_registry::Emit,
     ) -> Option<ConverterImpl<KotlinMeta>> {
         let produced = crate::jni::trait_impl::Produced::Reading(ty);
         let inner = ty.optional_inner()?;
-        let mut c =
-            self.output_wrapper_shape(WrapperShape::Optional, &produced, inner, registry, emit)?;
+        let mut c = self.output_wrapper_shape(WrapperShape::Optional, &produced, inner, emit)?;
         c.subs = vec![inner.key()];
         Some(c)
     }
@@ -167,13 +159,11 @@ impl Declarations {
     pub(crate) fn output_run(
         &self,
         ty: &prebindgen_registry::flat::TypeRef,
-        registry: &impl Conversions<KotlinMeta>,
         emit: &prebindgen_registry::Emit,
     ) -> Option<ConverterImpl<KotlinMeta>> {
         let produced = crate::jni::trait_impl::Produced::Reading(ty);
         if let Some(elem) = ty.sequence_elem().filter(|_| !is_unsized_spelling(ty)) {
-            let mut c =
-                self.output_wrapper_shape(WrapperShape::Sequence, &produced, elem, registry, emit)?;
+            let mut c = self.output_wrapper_shape(WrapperShape::Sequence, &produced, elem, emit)?;
             c.subs = vec![elem.key()];
             return Some(c);
         }

--- a/prebindgen-jni/src/jni/struct_plan.rs
+++ b/prebindgen-jni/src/jni/struct_plan.rs
@@ -48,7 +48,7 @@ pub(crate) enum LeafForm {
 /// followed by the wire-facing converter (`u64 → jlong`).
 ///
 /// A leaf must carry the whole chain, not just
-/// [`TypeEntry::converter_ident`](prebindgen_registry::TypeEntry::converter_ident):
+/// [`converter_ident`](prebindgen_registry::ConverterImpl::converter_ident):
 /// calling only the wire-facing function would hand it the *semantic* value
 /// (a `Duration`) where it expects the *representation* (a `u64`), which does
 /// not compile. Structural wrappers (`Option<_>`, `Vec<_>`) already compose
@@ -186,7 +186,7 @@ pub(crate) struct SumPlanField {
 /// could silently diverge on such edge cases.
 pub(crate) fn build_struct_plan(
     ext: &Declarations,
-    registry: &impl Conversions<KotlinMeta>,
+    registry: &impl Conversions,
     s: &prebindgen_registry::flat::Struct,
     depth: usize,
 ) -> Option<StructPlan> {
@@ -250,7 +250,7 @@ fn kind_mints_handle(kind: &PlanFieldKind) -> bool {
 /// `Reading::Exact.v0`).
 pub(crate) fn classify_field(
     ext: &Declarations,
-    registry: &impl Conversions<KotlinMeta>,
+    registry: &impl Conversions,
     reading: &prebindgen_registry::flat::TypeRef,
     owner: &str,
     depth: usize,
@@ -626,7 +626,7 @@ fn whole_value_close(optional: bool, sequence: bool) -> FoldStrategy {
 /// leak direction — for a shape nobody can compile anyway.
 pub(crate) fn type_close_strategy(
     ext: &Declarations,
-    registry: &impl Conversions<KotlinMeta>,
+    registry: &impl Conversions,
     ty: &prebindgen_registry::flat::TypeRef,
     depth: usize,
 ) -> Option<FoldStrategy> {
@@ -697,7 +697,7 @@ pub(crate) fn type_close_strategy(
 /// was first attempted.
 fn sum_plan_kind(
     ext: &Declarations,
-    registry: &impl Conversions<KotlinMeta>,
+    registry: &impl Conversions,
     ty: &prebindgen_registry::flat::TypeRef,
     owner: &str,
     optional: bool,

--- a/prebindgen-jni/src/jni/struct_plan.rs
+++ b/prebindgen-jni/src/jni/struct_plan.rs
@@ -64,7 +64,7 @@ pub(crate) struct ConvChain {
 
 impl ConvChain {
     /// Read the chain off a resolved output entry.
-    fn of(entry: &prebindgen_registry::TypeEntry<KotlinMeta>) -> Self {
+    fn of(entry: &prebindgen_registry::ConverterImpl<KotlinMeta>) -> Self {
         ConvChain {
             stages: entry
                 .output_stage_order()
@@ -301,8 +301,8 @@ pub(crate) fn classify_field(
         );
     }
 
-    let field_entry = registry.output_entry(reading)?;
-    let conv = ConvChain::of(field_entry);
+    let field_entry = ext.out_frag(reading)?;
+    let conv = ConvChain::of(&field_entry);
 
     {
         // Projection leaf (opaque handle / `ULong`).
@@ -338,7 +338,7 @@ pub(crate) fn classify_field(
                     Some(PlanFieldKind::Enum { conv, kotlin })
                 }
                 Some(inner) => {
-                    let kotlin = registry.output_entry(inner)?.metadata.kotlin_name.clone()?;
+                    let kotlin = ext.out_frag(inner)?.metadata.kotlin_name.clone()?;
                     Some(PlanFieldKind::OptionEnum { conv, kotlin })
                 }
             };
@@ -385,8 +385,8 @@ pub(crate) fn classify_field(
                 // Option-stripped off the MODEL: `optional_inner` is the
                 // layer's own reading, so there is nothing to re-look-up.
                 let slot = optional_inner.unwrap_or(reading);
-                let descriptor = registry
-                    .output_entry(slot)
+                let descriptor = ext
+                    .out_frag(slot)
                     .and_then(|e| jni_field_access(&e.destination))
                     .and_then(|(sig, _, is_obj)| {
                         if is_obj {
@@ -639,10 +639,7 @@ pub(crate) fn type_close_strategy(
     // something: a `ULong` owns nothing, and a borrowed handle is not ours to
     // release. Asked of the whole reading, so the `Option`/`Vec` folds the
     // projection carries come back in its own strategy.
-    if let Some(proj) = registry
-        .output_entry(ty)
-        .and_then(|e| e.metadata.projection.as_ref())
-    {
+    if let Some(proj) = ext.out_frag(ty).and_then(|e| e.metadata.projection.clone()) {
         return (matches!(proj.kind, ProjectionKind::Handle) && proj.owned)
             .then(|| proj.strategy.clone());
     }

--- a/prebindgen-jni/src/jni/symbols.rs
+++ b/prebindgen-jni/src/jni/symbols.rs
@@ -40,7 +40,7 @@ use super::*;
 ///   names colliding in one package, including a collision the mangler
 ///   created.
 /// * **Warnings** — where the default mangler sanitized a Rust-derived name.
-pub(crate) fn validate_symbols(ext: &Declarations, registry: &Registry<KotlinMeta>) -> Vec<String> {
+pub(crate) fn validate_symbols(ext: &Declarations, registry: &Registry) -> Vec<String> {
     let mut errors: Vec<String> = Vec::new();
     // (package, name) → origin, for top-level-unique Kotlin declarations.
     let mut top_level: BTreeMap<(String, String), String> = BTreeMap::new();
@@ -264,7 +264,7 @@ fn check_ident(name: &str, origin: &str, errors: &mut Vec<String>) {
 
 /// Emit a `cargo:warning` for each Rust struct field (data-class property) or
 /// enum variant whose Kotlin name the default mangler had to change.
-fn warn_derived_name_changes(ext: &Declarations, registry: &Registry<KotlinMeta>) {
+fn warn_derived_name_changes(ext: &Declarations, registry: &Registry) {
     let warn = |raw: &str, mangled: &str, what: &str, owner: &str| {
         if raw != mangled {
             println!(
@@ -318,7 +318,7 @@ fn warn_derived_name_changes(ext: &Declarations, registry: &Registry<KotlinMeta>
 /// `syn::ItemEnum`; the model states them as two elements, and both carry the
 /// names this asks for. `None` when `ident` names neither.
 fn declared_member_names(
-    registry: &impl prebindgen_registry::Conversions<KotlinMeta>,
+    registry: &impl prebindgen_registry::Conversions,
     ident: &syn::Ident,
 ) -> Option<Vec<syn::Ident>> {
     use prebindgen_registry::flat::Type;

--- a/prebindgen-jni/src/jni/tests/flatten.rs
+++ b/prebindgen-jni/src/jni/tests/flatten.rs
@@ -2154,6 +2154,14 @@ fn a_data_class_crosses_as_its_fields_and_a_nested_one_as_its_own() {
         );
     let gen = jni.build_with(registry).expect("resolve");
 
+    let (composed, walked) = gen
+        .parts_vs_walk_for_test("Holder", "h")
+        .expect("Holder states a parts row and the walk plans it");
+    // The row says exactly what the walk it will replace says — names, types
+    // and order — which is what makes pointing the emitters at the fragment a
+    // move rather than a rewrite.
+    assert_eq!(composed, walked, "the row and the walk disagree");
+
     let wires = gen
         .parts_wires_for_test("Holder")
         .expect("Holder states a parts row");

--- a/prebindgen-jni/src/jni/tests/flatten.rs
+++ b/prebindgen-jni/src/jni/tests/flatten.rs
@@ -2154,14 +2154,6 @@ fn a_data_class_crosses_as_its_fields_and_a_nested_one_as_its_own() {
         );
     let gen = jni.build_with(registry).expect("resolve");
 
-    let (composed, walked) = gen
-        .parts_vs_walk_for_test("Holder", "h")
-        .expect("Holder states a parts row and the walk plans it");
-    // The row says exactly what the walk it will replace says — names, types
-    // and order — which is what makes pointing the emitters at the fragment a
-    // move rather than a rewrite.
-    assert_eq!(composed, walked, "the row and the walk disagree");
-
     let wires = gen
         .parts_wires_for_test("Holder")
         .expect("Holder states a parts row");
@@ -2240,12 +2232,21 @@ fn a_gate_inside_a_gate_supplies_one_absent_value() {
                 .fun(prebindgen_registry::fun!(outer_use)),
         );
     let gen = jni.build_with(registry).expect("resolve");
-    for (name, param) in [("Outer", "o"), ("Mid", "m")] {
-        let (composed, walked) = gen
-            .parts_vs_walk_for_test(name, param)
-            .unwrap_or_else(|| panic!("{name} states a parts row and the walk plans it"));
-        assert_eq!(composed, walked, "the row and the walk disagree on {name}");
-    }
+    assert_eq!(
+        wire_lines(&gen, "Outer", "o"),
+        vec![
+            "oMidPresent: Boolean = o.mid != null",
+            "oMidInnerPresent: Boolean = o.mid?.inner != null",
+            "oMidInnerId: Long = o.mid?.inner?.id ?: 0L",
+        ],
+    );
+    assert_eq!(
+        wire_lines(&gen, "Mid", "m"),
+        vec![
+            "mInnerPresent: Boolean = m.inner != null",
+            "mInnerId: Long = m.inner?.id ?: 0L",
+        ],
+    );
 }
 
 /// A nullable primitive keeps the allocation-free `(present, value)` pair
@@ -2286,8 +2287,19 @@ fn a_nullable_primitive_field_crosses_as_a_pair() {
                 .fun(prebindgen_registry::fun!(scal_use)),
         );
     let gen = jni.build_with(registry).expect("resolve");
-    let (composed, walked) = gen.parts_vs_walk_for_test("Scal", "s").expect("plan");
-    assert_eq!(composed, walked, "the row and the walk disagree");
+    assert_eq!(
+        wire_lines(&gen, "Scal", "s"),
+        vec![
+            "sNPresent: Boolean = s.n != null",
+            "sNValue: Long = s.n ?: 0L",
+            "sK: Long = s.k",
+        ],
+    );
+    // Neither half of the pair names a field of its own; the field they were
+    // decoupled from is what both answer with.
+    let wires = gen.parts_wires_for_test("Scal").expect("row");
+    assert_eq!(wires[0].field(), Some("n"));
+    assert_eq!(wires[1].field(), Some("n"));
 }
 
 /// A `sealed_class` field crosses as a tag plus every alternative's slots, and
@@ -2355,43 +2367,30 @@ fn a_sealed_class_field_crosses_as_a_tag_and_every_arm_s_slots() {
         );
     let gen = jni.build_with(registry).expect("resolve");
 
-    let (composed, walked) = gen
-        .parts_vs_walk_for_test("Observation", "o")
-        .expect("Observation states a parts row and the walk plans it");
-    assert_eq!(composed, walked, "the row and the walk disagree");
-
-    // What the two agree on, stated once so a change to both at the same time
-    // still has to be meant: the required field is a tag and six slots, the
-    // optional one adds a presence flag and a `null` arm.
-    let accesses: Vec<String> = composed.iter().map(|w| w.2.clone()).collect();
-    assert!(
-        accesses.contains(&"(o.reading as? io.test.jni.Reading.Exact)?.v0 ?: 0L".to_string()),
-        "{accesses:#?}"
-    );
-    assert!(
-        accesses
-            .contains(&"(o.reading as? io.test.jni.Reading.Tagged)?.v1?.value ?: 0".to_string()),
-        "a Kotlin enum payload is read through its discriminant: {accesses:#?}"
-    );
-    assert!(
-        accesses.contains(&"(o.reading as? io.test.jni.Reading.Tagged)?.v0".to_string()),
-        "a string payload rides a JVM null rather than a literal: {accesses:#?}"
-    );
-    assert!(
-        accesses.contains(&"o.fallback != null".to_string()),
-        "{accesses:#?}"
-    );
-    assert!(
-        accesses
-            .iter()
-            .any(|a| a.starts_with("when (o.fallback) { null -> 0;")),
-        "an optional sum gates on null in its own arm: {accesses:#?}"
-    );
-    assert!(
-        accesses
-            .iter()
-            .any(|a| a.starts_with("when (o.reading) { is io.test.jni.Reading.Missing -> 0;")),
-        "a required sum has no null arm: {accesses:#?}"
+    // The whole signature, in the order the three coordinated sites read it.
+    // Between them the alternatives cover a scalar payload, a two-field
+    // payload, a string payload that rides a JVM `null` rather than a literal,
+    // and a Kotlin enum payload read through its discriminant.
+    assert_eq!(
+        wire_lines(&gen, "Observation", "o"),
+        vec![
+            "oId: Long = o.id",
+            "oReadingTag: Int = when (o.reading) { is io.test.jni.Reading.Missing -> 0; is io.test.jni.Reading.Exact -> 1; is io.test.jni.Reading.Range -> 2; is io.test.jni.Reading.Tagged -> 3 }",
+            "oReadingExactV0: Long = (o.reading as? io.test.jni.Reading.Exact)?.v0 ?: 0L",
+            "oReadingRangeLow: Long = (o.reading as? io.test.jni.Reading.Range)?.low ?: 0L",
+            "oReadingRangeHigh: Long = (o.reading as? io.test.jni.Reading.Range)?.high ?: 0L",
+            "oReadingTaggedV0: String? = (o.reading as? io.test.jni.Reading.Tagged)?.v0",
+            "oReadingTaggedV1: Int = (o.reading as? io.test.jni.Reading.Tagged)?.v1?.value ?: 0",
+            // The optional field adds the gate, and its `when` adds the arm the
+            // required one has no need of.
+            "oFallbackPresent: Boolean = o.fallback != null",
+            "oFallbackTag: Int = when (o.fallback) { null -> 0; is io.test.jni.Reading.Missing -> 0; is io.test.jni.Reading.Exact -> 1; is io.test.jni.Reading.Range -> 2; is io.test.jni.Reading.Tagged -> 3 }",
+            "oFallbackExactV0: Long = (o.fallback as? io.test.jni.Reading.Exact)?.v0 ?: 0L",
+            "oFallbackRangeLow: Long = (o.fallback as? io.test.jni.Reading.Range)?.low ?: 0L",
+            "oFallbackRangeHigh: Long = (o.fallback as? io.test.jni.Reading.Range)?.high ?: 0L",
+            "oFallbackTaggedV0: String? = (o.fallback as? io.test.jni.Reading.Tagged)?.v0",
+            "oFallbackTaggedV1: Int = (o.fallback as? io.test.jni.Reading.Tagged)?.v1?.value ?: 0",
+        ],
     );
 }
 
@@ -2491,23 +2490,29 @@ fn every_spelling_the_walk_flattens_states_the_same_row() {
         "Box<Holder>",
         "Box<Option<Holder>>",
     ] {
-        let (composed, walked) = gen
-            .parts_vs_walk_for_test(spelling, "h")
-            .unwrap_or_else(|| panic!("{spelling} states a row and the walk plans it"));
-        assert_eq!(
-            composed, walked,
-            "the row and the walk disagree on {spelling}"
-        );
+        let optional = spelling.contains("Option");
+        let mut expected = vec![
+            "hTag: Long = h.tag",
+            "hSummaryCount: Long = h.summary.count",
+            "hSummaryTotal: Double = h.summary.total",
+            "hNotePresent: Boolean = h.note != null",
+            "hNoteValue: Long = h.note ?: 0L",
+        ];
+        // The two optional spellings carry one wire more, and every read below
+        // that gate is a safe call.
+        let gated = vec![
+            "hPresent: Boolean = h != null",
+            "hTag: Long = h?.tag ?: 0L",
+            "hSummaryCount: Long = h?.summary?.count ?: 0L",
+            "hSummaryTotal: Double = h?.summary?.total ?: 0.0",
+            "hNotePresent: Boolean = h?.note != null",
+            "hNoteValue: Long = h?.note ?: 0L",
+        ];
+        if optional {
+            expected = gated;
+        }
+        assert_eq!(wire_lines(&gen, spelling, "h"), expected, "{spelling}");
     }
-
-    // The optional spellings carry a presence flag the bare ones do not, so
-    // "they all agree with the walk" is not the same claim as "they are all
-    // the same list".
-    let bare = gen.parts_wires_for_test("Holder").expect("bare row");
-    let opt = gen
-        .parts_wires_for_test("Option<Holder>")
-        .expect("optional row");
-    assert_eq!(opt.len(), bare.len() + 1, "the gate is one more wire");
 }
 
 /// Every field shape the walk reads specially, held to the row.
@@ -2603,10 +2608,68 @@ fn every_field_shape_the_walk_reads_specially_states_the_same_row() {
                 .fun(prebindgen_registry::fun!(bits_opt)),
         );
     let gen = jni.build_with(registry).expect("resolve");
-    for spelling in ["Bits", "Option<Bits>"] {
-        let (composed, walked) = gen
-            .parts_vs_walk_for_test(spelling, "b")
-            .unwrap_or_else(|| panic!("{spelling}"));
-        assert_eq!(composed, walked, "disagree on {spelling}");
-    }
+    assert_eq!(
+        wire_lines(&gen, "Bits", "b"),
+        vec![
+            "bPri: Int = b.pri.value",
+            "bMaybePriPresent: Boolean = b.maybePri != null",
+            "bMaybePriValue: Int = b.maybePri?.value ?: 0",
+            "bBig: Long = b.big.toLong()",
+            "bMaybeBigPresent: Boolean = b.maybeBig != null",
+            "bMaybeBigValue: Long = b.maybeBig?.toLong() ?: 0L",
+            "bName: String = b.name",
+            "bMaybeName: String? = b.maybeName",
+            "bFlag: Boolean = b.flag",
+            "bMaybeFlagPresent: Boolean = b.maybeFlag != null",
+            "bMaybeFlagValue: Boolean = b.maybeFlag ?: false",
+            "bBytes: ByteArray = b.bytes",
+            "bOpaque: Long = b.opaque",
+            "bMaybeOpaque: Long = b.maybeOpaque",
+            "bNestedK: Long = b.nested.k",
+            "bNestedS: String = b.nested.s",
+            "bMaybeNestedPresent: Boolean = b.maybeNested != null",
+            "bMaybeNestedK: Long = b.maybeNested?.k ?: 0L",
+            "bMaybeNestedS: String? = b.maybeNested?.s ?: \"\"",
+        ],
+    );
+    // The same fields one layer down, where a gate above turns every read into
+    // a safe call and states what a non-nullable slot carries meanwhile.
+    assert_eq!(
+        wire_lines(&gen, "Option<Bits>", "b"),
+        vec![
+            "bPresent: Boolean = b != null",
+            "bPri: Int = b?.pri?.value ?: 0",
+            "bMaybePriPresent: Boolean = b?.maybePri != null",
+            "bMaybePriValue: Int = b?.maybePri?.value ?: 0",
+            "bBig: Long = b?.big?.toLong() ?: 0L",
+            "bMaybeBigPresent: Boolean = b?.maybeBig != null",
+            "bMaybeBigValue: Long = b?.maybeBig?.toLong() ?: 0L",
+            "bName: String? = b?.name ?: \"\"",
+            "bMaybeName: String? = b?.maybeName",
+            "bFlag: Boolean = b?.flag ?: false",
+            "bMaybeFlagPresent: Boolean = b?.maybeFlag != null",
+            "bMaybeFlagValue: Boolean = b?.maybeFlag ?: false",
+            "bBytes: ByteArray? = b?.bytes ?: ByteArray(0)",
+            "bOpaque: Long = b?.opaque",
+            "bMaybeOpaque: Long = b?.maybeOpaque",
+            "bNestedK: Long = b?.nested?.k ?: 0L",
+            "bNestedS: String? = b?.nested?.s ?: \"\"",
+            "bMaybeNestedPresent: Boolean = b?.maybeNested != null",
+            "bMaybeNestedK: Long = b?.maybeNested?.k ?: 0L",
+            "bMaybeNestedS: String? = b?.maybeNested?.s ?: \"\"",
+        ],
+    );
+}
+
+/// One line per JNI parameter a crossing occupies: the name a site gives it,
+/// its Kotlin type, and the Kotlin expression that fills it.
+///
+/// What the three coordinated sites read, in the order they read it — so a
+/// fixture states the whole signature rather than one fact about it.
+fn wire_lines(gen: &crate::jni::JniGen, spelling: &str, param: &str) -> Vec<String> {
+    gen.named_wires_for_test(spelling, param)
+        .unwrap_or_else(|| panic!("{spelling} states no composition"))
+        .into_iter()
+        .map(|(name, kt_ty, access, ..)| format!("{name}: {kt_ty} = {access}"))
+        .collect()
 }

--- a/prebindgen-jni/src/jni/tests/flatten.rs
+++ b/prebindgen-jni/src/jni/tests/flatten.rs
@@ -2509,3 +2509,104 @@ fn every_spelling_the_walk_flattens_states_the_same_row() {
         .expect("optional row");
     assert_eq!(opt.len(), bare.len() + 1, "the gate is one more wire");
 }
+
+/// Every field shape the walk reads specially, held to the row.
+///
+/// A `data_class` field is not always one property read: an `enum_class`
+/// property holds the enum object where the wire holds its discriminant, an
+/// unsigned representation's property is a `ULong` over a `Long` wire, an
+/// optional primitive is decoupled into a presence flag and a raw slot rather
+/// than boxed, an optional whose wire is a JVM object rides a `null`, and a
+/// nested handle is locked through the object rather than the pointer it
+/// carries. Each of those is a place the composition and the walk could differ
+/// silently, so the fixture carries all of them at once — and again one layer
+/// down, where a closed gate above turns every read into a safe call and
+/// substitutes what a non-nullable slot carries meanwhile.
+#[test]
+fn every_field_shape_the_walk_reads_specially_states_the_same_row() {
+    let loc = myflat_loc();
+    let items: Vec<(syn::Item, SourceLocation)> = vec![
+        (
+            syn::Item::Enum(syn::parse_quote!(
+                pub enum Priority {
+                    Low = 0,
+                    High = 1,
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Struct(syn::parse_quote!(
+                pub struct Bits {
+                    pub pri: Priority,
+                    pub maybe_pri: Option<Priority>,
+                    pub big: u64,
+                    pub maybe_big: Option<u64>,
+                    pub name: String,
+                    pub maybe_name: Option<String>,
+                    pub flag: bool,
+                    pub maybe_flag: Option<bool>,
+                    pub bytes: [u8; 4],
+                    pub opaque: Opaque,
+                    pub maybe_opaque: Option<Opaque>,
+                    pub nested: Nested,
+                    pub maybe_nested: Option<Nested>,
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Struct(syn::parse_quote!(
+                pub struct Opaque {
+                    pub v: i64,
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Struct(syn::parse_quote!(
+                pub struct Nested {
+                    pub k: i64,
+                    pub s: String,
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn bits_use(b: Bits) -> i64 {
+                    unimplemented!()
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn bits_opt(b: Option<Bits>) -> i64 {
+                    unimplemented!()
+                }
+            )),
+            loc.clone(),
+        ),
+    ];
+    let registry =
+        crate::test_util::reg_from_items(declare_referenced(items)).expect("index items");
+    let jni = JniGenBuilder::new()
+        .set_package_prefix("io.test.jni")
+        .package(
+            crate::package!()
+                .class(crate::enum_class!(Priority))
+                .class(crate::ptr_class!(Opaque))
+                .class(crate::data_class!(Nested))
+                .class(crate::data_class!(Bits))
+                .fun(prebindgen_registry::fun!(bits_use))
+                .fun(prebindgen_registry::fun!(bits_opt)),
+        );
+    let gen = jni.build_with(registry).expect("resolve");
+    for spelling in ["Bits", "Option<Bits>"] {
+        let (composed, walked) = gen
+            .parts_vs_walk_for_test(spelling, "b")
+            .unwrap_or_else(|| panic!("{spelling}"));
+        assert_eq!(composed, walked, "disagree on {spelling}");
+    }
+}

--- a/prebindgen-jni/src/jni/tests/flatten.rs
+++ b/prebindgen-jni/src/jni/tests/flatten.rs
@@ -2247,3 +2247,45 @@ fn a_gate_inside_a_gate_supplies_one_absent_value() {
         assert_eq!(composed, walked, "the row and the walk disagree on {name}");
     }
 }
+
+/// A nullable primitive keeps the allocation-free `(present, value)` pair
+/// rather than boxing, at field depth as at parameter depth.
+///
+/// The value crosses through the **inner's** conversion — there is no boxed
+/// `Option` on that wire to decode — and neither half names a field of its own:
+/// both were decoupled from one, which is the field they answer with.
+#[test]
+fn a_nullable_primitive_field_crosses_as_a_pair() {
+    let loc = myflat_loc();
+    let items: Vec<(syn::Item, SourceLocation)> = vec![
+        (
+            syn::Item::Struct(syn::parse_quote!(
+                pub struct Scal {
+                    pub n: Option<i64>,
+                    pub k: i64,
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn scal_use(s: Scal) -> i64 {
+                    unimplemented!()
+                }
+            )),
+            loc.clone(),
+        ),
+    ];
+    let registry =
+        crate::test_util::reg_from_items(declare_referenced(items)).expect("index items");
+    let jni = JniGenBuilder::new()
+        .set_package_prefix("io.test.jni")
+        .package(
+            crate::package!()
+                .class(crate::data_class!(Scal))
+                .fun(prebindgen_registry::fun!(scal_use)),
+        );
+    let gen = jni.build_with(registry).expect("resolve");
+    let (composed, walked) = gen.parts_vs_walk_for_test("Scal", "s").expect("plan");
+    assert_eq!(composed, walked, "the row and the walk disagree");
+}

--- a/prebindgen-jni/src/jni/tests/flatten.rs
+++ b/prebindgen-jni/src/jni/tests/flatten.rs
@@ -1403,7 +1403,7 @@ fn gc_managed_handle_lifecycle() {
 /// #52 shared fixture: a `ZSummary` ptr class, its `(count, total)` builder, a
 /// splittable 2-variant type-level `expand_param!`, and functions taking one or
 /// two `ZSummary` params. `extra` fns are appended before indexing.
-fn split_fixture(extra: &[&str]) -> RegistryBuilder<KotlinMeta> {
+fn split_fixture(extra: &[&str]) -> RegistryBuilder {
     let loc = myflat_loc();
     let base: &[&str] = &[
         "pub fn z_summary_new(count: i64, total: f64) -> ZSummary { unimplemented!() }",

--- a/prebindgen-jni/src/jni/tests/flatten.rs
+++ b/prebindgen-jni/src/jni/tests/flatten.rs
@@ -2289,3 +2289,108 @@ fn a_nullable_primitive_field_crosses_as_a_pair() {
     let (composed, walked) = gen.parts_vs_walk_for_test("Scal", "s").expect("plan");
     assert_eq!(composed, walked, "the row and the walk disagree");
 }
+
+/// A `sealed_class` field crosses as a tag plus every alternative's slots, and
+/// the row says so where the walk did.
+///
+/// The shape covertest carries: `Observation` holds a required `Reading` and an
+/// optional one, whose alternatives between them cover a scalar payload, a
+/// two-field payload, a string payload that rides a JVM `null`, and a Kotlin
+/// enum payload read through `.value`. Both fields go through the same
+/// composition, and the optional one takes the `null` arm and the presence flag
+/// on top of it.
+#[test]
+fn a_sealed_class_field_crosses_as_a_tag_and_every_arm_s_slots() {
+    let loc = myflat_loc();
+    let items: Vec<(syn::Item, SourceLocation)> = vec![
+        (
+            syn::Item::Enum(syn::parse_quote!(
+                pub enum Priority {
+                    Low = 0,
+                    High = 1,
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Enum(syn::parse_quote!(
+                pub enum Reading {
+                    Missing,
+                    Exact(i64),
+                    Range { low: i64, high: i64 },
+                    Tagged(String, Priority),
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Struct(syn::parse_quote!(
+                pub struct Observation {
+                    pub id: i64,
+                    pub reading: Reading,
+                    pub fallback: Option<Reading>,
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn observation_which(o: Observation) -> i32 {
+                    unimplemented!()
+                }
+            )),
+            loc.clone(),
+        ),
+    ];
+    let registry =
+        crate::test_util::reg_from_items(declare_referenced(items)).expect("index items");
+    let jni = JniGenBuilder::new()
+        .set_package_prefix("io.test.jni")
+        .package(
+            crate::package!()
+                .class(crate::enum_class!(Priority))
+                .class(crate::sealed_class!(Reading))
+                .class(crate::data_class!(Observation))
+                .fun(prebindgen_registry::fun!(observation_which)),
+        );
+    let gen = jni.build_with(registry).expect("resolve");
+
+    let (composed, walked) = gen
+        .parts_vs_walk_for_test("Observation", "o")
+        .expect("Observation states a parts row and the walk plans it");
+    assert_eq!(composed, walked, "the row and the walk disagree");
+
+    // What the two agree on, stated once so a change to both at the same time
+    // still has to be meant: the required field is a tag and six slots, the
+    // optional one adds a presence flag and a `null` arm.
+    let accesses: Vec<String> = composed.iter().map(|w| w.2.clone()).collect();
+    assert!(
+        accesses.contains(&"(o.reading as? io.test.jni.Reading.Exact)?.v0 ?: 0L".to_string()),
+        "{accesses:#?}"
+    );
+    assert!(
+        accesses
+            .contains(&"(o.reading as? io.test.jni.Reading.Tagged)?.v1?.value ?: 0".to_string()),
+        "a Kotlin enum payload is read through its discriminant: {accesses:#?}"
+    );
+    assert!(
+        accesses.contains(&"(o.reading as? io.test.jni.Reading.Tagged)?.v0".to_string()),
+        "a string payload rides a JVM null rather than a literal: {accesses:#?}"
+    );
+    assert!(
+        accesses.contains(&"o.fallback != null".to_string()),
+        "{accesses:#?}"
+    );
+    assert!(
+        accesses
+            .iter()
+            .any(|a| a.starts_with("when (o.fallback) { null -> 0;")),
+        "an optional sum gates on null in its own arm: {accesses:#?}"
+    );
+    assert!(
+        accesses
+            .iter()
+            .any(|a| a.starts_with("when (o.reading) { is io.test.jni.Reading.Missing -> 0;")),
+        "a required sum has no null arm: {accesses:#?}"
+    );
+}

--- a/prebindgen-jni/src/jni/tests/flatten.rs
+++ b/prebindgen-jni/src/jni/tests/flatten.rs
@@ -2394,3 +2394,118 @@ fn a_sealed_class_field_crosses_as_a_tag_and_every_arm_s_slots() {
         "a required sum has no null arm: {accesses:#?}"
     );
 }
+
+/// Every spelling the walk flattens states the same row.
+///
+/// `build_flat_input_plan` accepts a `data_class` parameter through five
+/// spellings — bare, `&`, `Option`, `Box`, and `Box<Option<…>>` — and all five
+/// appear in `covertest-kotlin` or `perftest-kotlin`. A borrow and a transparent
+/// wrapper find the class's own `parts` row, because a crossing is keyed by the
+/// value that crosses; an optional has no such row and composes on the one the
+/// registry derives for it, which is why `Declarations::bindings` binds its
+/// part.
+#[test]
+fn every_spelling_the_walk_flattens_states_the_same_row() {
+    let loc = myflat_loc();
+    let items: Vec<(syn::Item, SourceLocation)> = vec![
+        (
+            syn::Item::Struct(syn::parse_quote!(
+                pub struct Summary {
+                    pub count: i64,
+                    pub total: f64,
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Struct(syn::parse_quote!(
+                pub struct Holder {
+                    pub tag: i64,
+                    pub summary: Summary,
+                    pub note: Option<i64>,
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn bare(h: Holder) -> i64 {
+                    unimplemented!()
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn borrowed(h: &Holder) -> i64 {
+                    unimplemented!()
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn optional(h: Option<Holder>) -> i64 {
+                    unimplemented!()
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn boxed(h: Box<Holder>) -> i64 {
+                    unimplemented!()
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn boxed_optional(h: Box<Option<Holder>>) -> i64 {
+                    unimplemented!()
+                }
+            )),
+            loc.clone(),
+        ),
+    ];
+    let registry =
+        crate::test_util::reg_from_items(declare_referenced(items)).expect("index items");
+    let jni = JniGenBuilder::new()
+        .set_package_prefix("io.test.jni")
+        .package(
+            crate::package!()
+                .class(crate::data_class!(Summary))
+                .class(crate::data_class!(Holder))
+                .fun(prebindgen_registry::fun!(bare))
+                .fun(prebindgen_registry::fun!(borrowed))
+                .fun(prebindgen_registry::fun!(optional))
+                .fun(prebindgen_registry::fun!(boxed))
+                .fun(prebindgen_registry::fun!(boxed_optional)),
+        );
+    let gen = jni.build_with(registry).expect("resolve");
+
+    for spelling in [
+        "Holder",
+        "&Holder",
+        "Option<Holder>",
+        "Box<Holder>",
+        "Box<Option<Holder>>",
+    ] {
+        let (composed, walked) = gen
+            .parts_vs_walk_for_test(spelling, "h")
+            .unwrap_or_else(|| panic!("{spelling} states a row and the walk plans it"));
+        assert_eq!(
+            composed, walked,
+            "the row and the walk disagree on {spelling}"
+        );
+    }
+
+    // The optional spellings carry a presence flag the bare ones do not, so
+    // "they all agree with the walk" is not the same claim as "they are all
+    // the same list".
+    let bare = gen.parts_wires_for_test("Holder").expect("bare row");
+    let opt = gen
+        .parts_wires_for_test("Option<Holder>")
+        .expect("optional row");
+    assert_eq!(opt.len(), bare.len() + 1, "the gate is one more wire");
+}

--- a/prebindgen-jni/src/jni/tests/flatten.rs
+++ b/prebindgen-jni/src/jni/tests/flatten.rs
@@ -2103,3 +2103,74 @@ fn qualified_signature_spelling_matches_bare_ptr_class() {
         "{all}"
     );
 }
+
+/// A `data_class` states a row saying what it is made of, and a field that is
+/// itself one contributes its own wires rather than a single value.
+///
+/// The composition every binding compiles (see `JniGen::compile_crossing`),
+/// asserted here on the shape that makes the recursion visible: `Holder` is a
+/// scalar plus a nested `Summary`, so it crosses as three JNI values and not
+/// as two.
+#[test]
+fn a_data_class_crosses_as_its_fields_and_a_nested_one_as_its_own() {
+    let loc = myflat_loc();
+    let items: Vec<(syn::Item, SourceLocation)> = vec![
+        (
+            syn::Item::Struct(syn::parse_quote!(
+                pub struct Summary {
+                    pub count: i64,
+                    pub total: f64,
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Struct(syn::parse_quote!(
+                pub struct Holder {
+                    pub tag: i64,
+                    pub summary: Summary,
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn holder_tag(h: Holder) -> i64 {
+                    unimplemented!()
+                }
+            )),
+            loc.clone(),
+        ),
+    ];
+    let registry =
+        crate::test_util::reg_from_items(declare_referenced(items)).expect("index items");
+    let jni = JniGenBuilder::new()
+        .set_package_prefix("io.test.jni")
+        .package(
+            crate::package!()
+                .class(crate::data_class!(Summary))
+                .class(crate::data_class!(Holder))
+                .fun(prebindgen_registry::fun!(holder_tag)),
+        );
+    let gen = jni.build_with(registry).expect("resolve");
+
+    let wires = gen
+        .parts_wires_for_test("Holder")
+        .expect("Holder states a parts row");
+    let described: Vec<String> = wires
+        .iter()
+        .map(|w| {
+            let ty = &w.ty;
+            format!("{}: {}", w.path, quote::quote!(#ty))
+        })
+        .collect();
+    assert_eq!(
+        described,
+        vec![
+            "tag: jni :: sys :: jlong",
+            "summary.count: jni :: sys :: jlong",
+            "summary.total: jni :: sys :: jdouble",
+        ],
+        "a nested data class contributes its own wires, under its field's path"
+    );
+}

--- a/prebindgen-jni/src/jni/tests/flatten.rs
+++ b/prebindgen-jni/src/jni/tests/flatten.rs
@@ -2182,3 +2182,68 @@ fn a_data_class_crosses_as_its_fields_and_a_nested_one_as_its_own() {
         "a nested data class contributes its own wires, under its field's path"
     );
 }
+
+/// Two gates deep, the inner one supplies the absent value and the outer one
+/// must not supply a second.
+///
+/// `Outer { mid: Option<Mid> }` where `Mid { inner: Option<Leaf> }`: reaching
+/// `Leaf.id` passes through both. The value slot reads
+/// `o.mid?.inner?.id ?: 0L` — one elvis, from the innermost gate — and the
+/// presence flags read as plain comparisons, which are already non-null and
+/// which Kotlin refuses to elvis at all.
+#[test]
+fn a_gate_inside_a_gate_supplies_one_absent_value() {
+    let loc = myflat_loc();
+    let items: Vec<(syn::Item, SourceLocation)> = vec![
+        (
+            syn::Item::Struct(syn::parse_quote!(
+                pub struct Leaf {
+                    pub id: i64,
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Struct(syn::parse_quote!(
+                pub struct Mid {
+                    pub inner: Option<Leaf>,
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Struct(syn::parse_quote!(
+                pub struct Outer {
+                    pub mid: Option<Mid>,
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn outer_use(o: Option<Outer>) -> i64 {
+                    unimplemented!()
+                }
+            )),
+            loc.clone(),
+        ),
+    ];
+    let registry =
+        crate::test_util::reg_from_items(declare_referenced(items)).expect("index items");
+    let jni = JniGenBuilder::new()
+        .set_package_prefix("io.test.jni")
+        .package(
+            crate::package!()
+                .class(crate::data_class!(Leaf))
+                .class(crate::data_class!(Mid))
+                .class(crate::data_class!(Outer))
+                .fun(prebindgen_registry::fun!(outer_use)),
+        );
+    let gen = jni.build_with(registry).expect("resolve");
+    for (name, param) in [("Outer", "o"), ("Mid", "m")] {
+        let (composed, walked) = gen
+            .parts_vs_walk_for_test(name, param)
+            .unwrap_or_else(|| panic!("{name} states a parts row and the walk plans it"));
+        assert_eq!(composed, walked, "the row and the walk disagree on {name}");
+    }
+}

--- a/prebindgen-jni/src/jni/tests/mod.rs
+++ b/prebindgen-jni/src/jni/tests/mod.rs
@@ -62,22 +62,45 @@ fn entry(wire: syn::Type, conv_name: &str, niches: Niches) -> TypeEntry<KotlinMe
 
 // BLOCKED: `Registry::insert_crossing` is `pub(crate)` in `prebindgen::core` —
 // see the `niches` module gate above.
-fn install_input(
+/// Put one conversion where both a registry query and an adapter lookup can
+/// find it: in the registry the test builds, and in `decls` as the fragment a
+/// compiled binding would have filed. Helpers under test read the second.
+fn install(
     reg: &mut Registry<KotlinMeta>,
+    decls: &Declarations,
+    direction: Direction,
     ty_str: &str,
-    _rank: usize,
     e: TypeEntry<KotlinMeta>,
 ) {
     let ty: syn::Type = syn::parse_str(ty_str).expect("test type");
-    reg.insert_crossing(Direction::Input, &ty, true, Some(e));
+    let key = TypeKey::from_type(&ty);
+    let assembly = match direction {
+        Direction::Input => prebindgen_registry::recipe::Assembly::Construct,
+        Direction::Output => prebindgen_registry::recipe::Assembly::Deconstruct,
+    };
+    decls.compiled.borrow_mut().record(
+        key.clone(),
+        assembly,
+        prebindgen_registry::recipe::RecipeId::new("whole"),
+        crate::jni::compile::JFrag::by_hand(key, e.as_converter()),
+    );
+    reg.insert_crossing(direction, &ty, true, Some(e));
+}
+
+fn install_input(
+    reg: &mut Registry<KotlinMeta>,
+    decls: &Declarations,
+    ty_str: &str,
+    e: TypeEntry<KotlinMeta>,
+) {
+    install(reg, decls, Direction::Input, ty_str, e);
 }
 
 fn install_output(
     reg: &mut Registry<KotlinMeta>,
+    decls: &Declarations,
     ty_str: &str,
-    _rank: usize,
     e: TypeEntry<KotlinMeta>,
 ) {
-    let ty: syn::Type = syn::parse_str(ty_str).expect("test type");
-    reg.insert_crossing(Direction::Output, &ty, true, Some(e));
+    install(reg, decls, Direction::Output, ty_str, e);
 }

--- a/prebindgen-jni/src/jni/tests/mod.rs
+++ b/prebindgen-jni/src/jni/tests/mod.rs
@@ -1,6 +1,5 @@
-// Only `entry` (below, gated off with the `niches` module) needs `TypeEntry`.
 pub(crate) use prebindgen::SourceLocation;
-use prebindgen_registry::TypeEntry;
+use prebindgen_registry::{Answer, ConverterImpl};
 use quote::ToTokens;
 
 use super::*;
@@ -37,10 +36,10 @@ mod symbols;
 mod value_form;
 mod values;
 
-/// Build a `TypeEntry` for use in tests. The function body is not
-/// inspected by `option_input` / `option_output`; only the ident,
-/// destination, and niches matter, so we use a stub `ItemFn`.
-fn entry(wire: syn::Type, conv_name: &str, niches: Niches) -> TypeEntry<KotlinMeta> {
+/// Build a conversion for use in tests. The function body is not inspected by
+/// `option_input` / `option_output`; only the ident, destination, and niches
+/// matter, so we use a stub `ItemFn`.
+fn entry(wire: syn::Type, conv_name: &str, niches: Niches) -> ConverterImpl<KotlinMeta> {
     let ident = syn::Ident::new(conv_name, proc_macro2::Span::call_site());
     let func: syn::ItemFn = syn::parse_quote!(
         unsafe fn #ident<'env, 'v>(
@@ -50,7 +49,7 @@ fn entry(wire: syn::Type, conv_name: &str, niches: Niches) -> TypeEntry<KotlinMe
             Ok(())
         }
     );
-    TypeEntry {
+    ConverterImpl {
         destination: wire,
         function: func,
         pre_stages: vec![],
@@ -66,11 +65,11 @@ fn entry(wire: syn::Type, conv_name: &str, niches: Niches) -> TypeEntry<KotlinMe
 /// find it: in the registry the test builds, and in `decls` as the fragment a
 /// compiled binding would have filed. Helpers under test read the second.
 fn install(
-    reg: &mut Registry<KotlinMeta>,
+    reg: &mut Registry,
     decls: &Declarations,
     direction: Direction,
     ty_str: &str,
-    e: TypeEntry<KotlinMeta>,
+    e: ConverterImpl<KotlinMeta>,
 ) {
     let ty: syn::Type = syn::parse_str(ty_str).expect("test type");
     let key = TypeKey::from_type(&ty);
@@ -82,25 +81,25 @@ fn install(
         key.clone(),
         assembly,
         prebindgen_registry::recipe::RecipeId::new("whole"),
-        crate::jni::compile::JFrag::by_hand(key, e.as_converter()),
+        crate::jni::compile::JFrag::by_hand(key, e.clone()),
     );
-    reg.insert_crossing(direction, &ty, true, Some(e));
+    reg.insert_crossing(direction, &ty, true, Some(Answer::over(e.subs)));
 }
 
 fn install_input(
-    reg: &mut Registry<KotlinMeta>,
+    reg: &mut Registry,
     decls: &Declarations,
     ty_str: &str,
-    e: TypeEntry<KotlinMeta>,
+    e: ConverterImpl<KotlinMeta>,
 ) {
     install(reg, decls, Direction::Input, ty_str, e);
 }
 
 fn install_output(
-    reg: &mut Registry<KotlinMeta>,
+    reg: &mut Registry,
     decls: &Declarations,
     ty_str: &str,
-    e: TypeEntry<KotlinMeta>,
+    e: ConverterImpl<KotlinMeta>,
 ) {
     install(reg, decls, Direction::Output, ty_str, e);
 }

--- a/prebindgen-jni/src/jni/tests/niches.rs
+++ b/prebindgen-jni/src/jni/tests/niches.rs
@@ -7,10 +7,11 @@ use super::*;
 #[test]
 fn option_carves_single_niche() {
     let mut reg = Registry::empty_for_test();
+    let decls = Declarations::default();
     install_input(
         &mut reg,
+        &decls,
         "TestType",
-        0,
         entry(
             syn::parse_quote!(jni::sys::jlong),
             "jlong_to_TestType_aaaa",
@@ -21,7 +22,7 @@ fn option_carves_single_niche() {
     let inner_ty: syn::Type = syn::parse_quote!(TestType);
     let (wire, _body, niches) = option_input(
         &reg.reading_of(&inner_ty).expect("interned"),
-        &reg,
+        &decls,
         &prebindgen_registry::Emit::for_test(),
     )
     .expect("Option<TestType> resolves");
@@ -39,12 +40,13 @@ fn option_carves_single_niche() {
 #[test]
 fn option_cascades_through_multi_niche() {
     let mut reg = Registry::empty_for_test();
+    let decls = Declarations::default();
 
     // TestType: jint with two niches (MIN, MAX).
     install_input(
         &mut reg,
+        &decls,
         "TestType",
-        0,
         entry(
             syn::parse_quote!(jni::sys::jint),
             "jint_to_TestType_aaaa",
@@ -65,7 +67,7 @@ fn option_cascades_through_multi_niche() {
     let layer1_ty: syn::Type = syn::parse_quote!(TestType);
     let (w1, _, n1) = option_input(
         &reg.reading_of(&layer1_ty).expect("interned"),
-        &reg,
+        &decls,
         &prebindgen_registry::Emit::for_test(),
     )
     .expect("layer 1 resolves");
@@ -77,8 +79,8 @@ fn option_cascades_through_multi_niche() {
     // here we mimic it by installing the produced ConverterImpl.)
     install_input(
         &mut reg,
+        &decls,
         "Option < TestType >",
-        1,
         entry(w1.clone(), "jint_to_OptionTestType_bbbb", n1),
     );
 
@@ -86,7 +88,7 @@ fn option_cascades_through_multi_niche() {
     let layer2_ty: syn::Type = syn::parse_quote!(Option<TestType>);
     let (w2, _, n2) = option_input(
         &reg.reading_of(&layer2_ty).expect("interned"),
-        &reg,
+        &decls,
         &prebindgen_registry::Emit::for_test(),
     )
     .expect("layer 2 resolves");
@@ -100,8 +102,8 @@ fn option_cascades_through_multi_niche() {
     // Install layer-2 wrapper for the layer-3 lookup.
     install_input(
         &mut reg,
+        &decls,
         "Option < Option < TestType > >",
-        1,
         entry(w2.clone(), "jint_to_OptionOptionTestType_cccc", n2),
     );
 
@@ -110,7 +112,7 @@ fn option_cascades_through_multi_niche() {
     let layer3_ty: syn::Type = syn::parse_quote!(Option<Option<TestType>>);
     let (w3, _, n3) = option_input(
         &reg.reading_of(&layer3_ty).expect("interned"),
-        &reg,
+        &decls,
         &prebindgen_registry::Emit::for_test(),
     )
     .expect("layer 3 resolves via box fallback");
@@ -130,10 +132,11 @@ fn option_cascades_through_multi_niche() {
 #[test]
 fn option_output_cascades_through_multi_niche() {
     let mut reg = Registry::empty_for_test();
+    let decls = Declarations::default();
     install_output(
         &mut reg,
+        &decls,
         "TestType",
-        0,
         entry(
             syn::parse_quote!(jni::sys::jint),
             "TestType_to_jint_aaaa",
@@ -151,7 +154,7 @@ fn option_output_cascades_through_multi_niche() {
     );
 
     let inner_ty: syn::Type = syn::parse_quote!(TestType);
-    let (w1, body1, n1) = option_output(&reg.reading_of(&inner_ty).expect("interned"), &reg)
+    let (w1, body1, n1) = option_output(&reg.reading_of(&inner_ty).expect("interned"), &decls)
         .expect("Option<TestType> output resolves");
     assert_eq!(w1.to_token_stream().to_string(), "jni :: sys :: jint");
     assert_eq!(n1.len(), 1, "one slot left after carving the first");
@@ -165,13 +168,13 @@ fn option_output_cascades_through_multi_niche() {
 
     install_output(
         &mut reg,
+        &decls,
         "Option < TestType >",
-        1,
         entry(w1.clone(), "OptionTestType_to_jint_bbbb", n1),
     );
 
     let layer2_ty: syn::Type = syn::parse_quote!(Option<TestType>);
-    let (w2, body2, n2) = option_output(&reg.reading_of(&layer2_ty).expect("interned"), &reg)
+    let (w2, body2, n2) = option_output(&reg.reading_of(&layer2_ty).expect("interned"), &decls)
         .expect("Option<Option<TestType>> output resolves");
     assert_eq!(w2.to_token_stream().to_string(), "jni :: sys :: jint");
     assert!(n2.is_empty());
@@ -189,10 +192,11 @@ fn option_output_cascades_through_multi_niche() {
 #[test]
 fn option_over_jobject_uses_default_null_niche() {
     let mut reg = Registry::empty_for_test();
+    let decls = Declarations::default();
     install_input(
         &mut reg,
+        &decls,
         "MyStruct",
-        0,
         entry(
             syn::parse_quote!(jni::objects::JObject),
             "JObject_to_MyStruct_aaaa",
@@ -203,7 +207,7 @@ fn option_over_jobject_uses_default_null_niche() {
     let ty: syn::Type = syn::parse_quote!(MyStruct);
     let (wire, _, rest) = option_input(
         &reg.reading_of(&ty).expect("interned"),
-        &reg,
+        &decls,
         &prebindgen_registry::Emit::for_test(),
     )
     .expect("Option<MyStruct> resolves");
@@ -220,10 +224,11 @@ fn option_over_jobject_uses_default_null_niche() {
 #[test]
 fn option_fails_when_no_niche_and_non_primitive_wire() {
     let mut reg = Registry::empty_for_test();
+    let decls = Declarations::default();
     install_input(
         &mut reg,
+        &decls,
         "MyStruct",
-        0,
         entry(
             syn::parse_quote!(jni::objects::JObject),
             "JObject_to_MyStruct_aaaa",
@@ -233,7 +238,7 @@ fn option_fails_when_no_niche_and_non_primitive_wire() {
     let ty: syn::Type = syn::parse_quote!(MyStruct);
     assert!(option_input(
         &reg.reading_of(&ty).expect("interned"),
-        &reg,
+        &decls,
         &prebindgen_registry::Emit::for_test()
     )
     .is_none());
@@ -245,10 +250,11 @@ fn option_fails_when_no_niche_and_non_primitive_wire() {
 #[test]
 fn option_box_fallback_exposes_no_niches() {
     let mut reg = Registry::empty_for_test();
+    let decls = Declarations::default();
     install_input(
         &mut reg,
+        &decls,
         "i64",
-        0,
         entry(
             syn::parse_quote!(jni::sys::jlong),
             "jlong_to_i64_aaaa",
@@ -258,7 +264,7 @@ fn option_box_fallback_exposes_no_niches() {
     let ty: syn::Type = syn::parse_quote!(i64);
     let (wire, _, rest) = option_input(
         &reg.reading_of(&ty).expect("interned"),
-        &reg,
+        &decls,
         &prebindgen_registry::Emit::for_test(),
     )
     .expect("Option<i64> via box fallback");

--- a/prebindgen-jni/src/jni/tests/sealed.rs
+++ b/prebindgen-jni/src/jni/tests/sealed.rs
@@ -2388,3 +2388,80 @@ fn a_types_close_answer_matches_its_plans() {
         "the fixture must cover reaching a handle four ways AND not reaching one"
     );
 }
+
+/// A `sealed_class` states a row saying what it hands out, and it says exactly
+/// what the leaf synthesis it will replace says.
+///
+/// One `jint` naming which alternative is live, then one group of values per
+/// alternative laid beside the others — names, types, groups and the pattern
+/// binding each is reached through. The fixture carries a unit alternative
+/// (which contributes nothing), a positional payload, a two-field payload and a
+/// named-field payload, so the slot naming is exercised in every form it takes.
+#[test]
+fn a_sealed_class_states_what_it_hands_out() {
+    let loc = myflat_loc();
+    let items: Vec<(syn::Item, SourceLocation)> = vec![
+        (
+            syn::Item::Enum(syn::parse_quote!(
+                pub enum Priority {
+                    Low = 0,
+                    High = 1,
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Enum(syn::parse_quote!(
+                pub enum Reading {
+                    Missing,
+                    Exact(i64),
+                    Range { low: i64, high: i64 },
+                    Tagged(String, Priority),
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn read_one(which: i32) -> Reading {
+                    unimplemented!()
+                }
+            )),
+            loc.clone(),
+        ),
+    ];
+    let registry =
+        crate::test_util::reg_from_items(declare_referenced(items)).expect("index items");
+    let jni = JniGenBuilder::new()
+        .set_package_prefix("io.test.jni")
+        .package(
+            crate::package!()
+                .class(crate::enum_class!(Priority))
+                .class(crate::sealed_class!(Reading))
+                .fun(prebindgen_registry::fun!(read_one)),
+        );
+    let gen = jni.build_with(registry).expect("resolve");
+
+    let composed = gen
+        .sum_out_lines_for_test("Reading")
+        .expect("Reading states a deconstructing parts row");
+    assert_eq!(
+        composed,
+        vec![
+            "tag: Reading <- tag @None",
+            "exact_v0: i64 <- Exact.v0 @Some(1)",
+            "range_low: i64 <- Range.low @Some(2)",
+            "range_high: i64 <- Range.high @Some(2)",
+            "tagged_v0: String <- Tagged.v0 @Some(3)",
+            "tagged_v1: Priority <- Tagged.v1 @Some(3)",
+        ],
+        "the row states the tag, then one group per alternative",
+    );
+    // And it is the same list the synthesis it replaces produces, which is what
+    // makes pointing the emitters at the fragment a move rather than a rewrite.
+    assert_eq!(
+        composed,
+        gen.sum_walk_lines_for_test("Reading").expect("the walk"),
+        "the row and the leaf synthesis disagree",
+    );
+}

--- a/prebindgen-jni/src/jni/tests/sealed.rs
+++ b/prebindgen-jni/src/jni/tests/sealed.rs
@@ -2443,7 +2443,7 @@ fn a_sealed_class_states_what_it_hands_out() {
     let gen = jni.build_with(registry).expect("resolve");
 
     let composed = gen
-        .sum_out_lines_for_test("Reading")
+        .out_lines_for_test("Reading")
         .expect("Reading states a deconstructing parts row");
     assert_eq!(
         composed,
@@ -2461,7 +2461,113 @@ fn a_sealed_class_states_what_it_hands_out() {
     // makes pointing the emitters at the fragment a move rather than a rewrite.
     assert_eq!(
         composed,
-        gen.sum_walk_lines_for_test("Reading").expect("the walk"),
+        gen.walk_lines_for_test("Reading").expect("the walk"),
         "the row and the leaf synthesis disagree",
+    );
+}
+
+/// A `data_class` states a row saying what it hands out, and a field that is
+/// itself one contributes its own values under the parent's name and chain.
+///
+/// The row declines for the **whole** value rather than per field, because the
+/// emitter it feeds does: a handle, an `enum_class`, a sum, or a `data_class`
+/// behind an `Option` or a `Vec` is delivered with a transform the decoupled
+/// form does not carry, and one such field sends the whole object down the
+/// whole-value `fromParts` path. So `Wrapped` composes and `Opaque`-bearing
+/// `Guarded` does not, and both agree with the synthesis they will replace.
+#[test]
+fn a_data_class_states_what_it_hands_out() {
+    let loc = myflat_loc();
+    let items: Vec<(syn::Item, SourceLocation)> = vec![
+        (
+            syn::Item::Struct(syn::parse_quote!(
+                pub struct Inner {
+                    pub count: i64,
+                    pub label: String,
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Struct(syn::parse_quote!(
+                pub struct Wrapped {
+                    pub id: i64,
+                    pub inner: Inner,
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Struct(syn::parse_quote!(
+                pub struct Opaque {
+                    pub v: i64,
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Struct(syn::parse_quote!(
+                pub struct Guarded {
+                    pub id: i64,
+                    pub held: Opaque,
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn wrapped_new() -> Wrapped {
+                    unimplemented!()
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn guarded_new() -> Guarded {
+                    unimplemented!()
+                }
+            )),
+            loc.clone(),
+        ),
+    ];
+    let registry =
+        crate::test_util::reg_from_items(declare_referenced(items)).expect("index items");
+    let jni = JniGenBuilder::new()
+        .set_package_prefix("io.test.jni")
+        .package(
+            crate::package!()
+                .class(crate::data_class!(Inner))
+                .class(crate::data_class!(Wrapped))
+                .class(crate::ptr_class!(Opaque))
+                .class(crate::data_class!(Guarded))
+                .fun(prebindgen_registry::fun!(wrapped_new))
+                .fun(prebindgen_registry::fun!(guarded_new)),
+        );
+    let gen = jni.build_with(registry).expect("resolve");
+
+    assert_eq!(
+        gen.out_lines_for_test("Wrapped")
+            .expect("Wrapped states a deconstructing parts row"),
+        vec![
+            "id: i64 <- id @None",
+            "inner__count: i64 <- inner.count @None",
+            "inner__label: String <- inner.label @None",
+        ],
+        "a nested data class contributes its own values, under its field's name",
+    );
+    // Compared as options, because declining is one of the two answers: a row
+    // that states nothing and a synthesis that returns nothing are the same
+    // claim, and `Guarded` makes it.
+    for short in ["Wrapped", "Inner", "Guarded"] {
+        assert_eq!(
+            gen.out_lines_for_test(short),
+            gen.walk_lines_for_test(short),
+            "the row and the leaf synthesis disagree on {short}",
+        );
+    }
+    assert!(
+        gen.out_lines_for_test("Guarded").is_none(),
+        "a handle field sends the whole object down the whole-value path",
     );
 }

--- a/prebindgen-jni/src/jni/tests/sealed.rs
+++ b/prebindgen-jni/src/jni/tests/sealed.rs
@@ -2571,3 +2571,82 @@ fn a_data_class_states_what_it_hands_out() {
         "a handle field sends the whole object down the whole-value path",
     );
 }
+
+/// A decomposed return is a **site** asking for its type's `parts` row, and it
+/// composes to what the expansion plan delivers.
+///
+/// The registry needed nothing new to express this: `Ask::Recipe` already lets
+/// a site name a row, and a `parts` fragment already occupies several wires.
+/// The two facts stages 3 and 4 established, meeting.
+#[test]
+fn a_decomposed_return_is_a_site_asking_for_the_parts_row() {
+    let loc = myflat_loc();
+    let items: Vec<(syn::Item, SourceLocation)> = vec![
+        (
+            syn::Item::Enum(syn::parse_quote!(
+                pub enum Reading {
+                    Missing,
+                    Exact(i64),
+                    Range { low: i64, high: i64 },
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn read_one(which: i32) -> Reading {
+                    unimplemented!()
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn read_maybe(which: i32) -> Option<Reading> {
+                    unimplemented!()
+                }
+            )),
+            loc.clone(),
+        ),
+    ];
+    let registry =
+        crate::test_util::reg_from_items(declare_referenced(items)).expect("index items");
+    let jni = JniGenBuilder::new()
+        .set_package_prefix("io.test.jni")
+        .package(
+            crate::package!()
+                .class(crate::sealed_class!(Reading))
+                .fun(prebindgen_registry::fun!(read_one))
+                .fun(prebindgen_registry::fun!(read_maybe)),
+        );
+    let gen = jni.build_with(registry).expect("resolve");
+
+    let expected = vec![
+        "tag: Reading <- tag @None",
+        "exact_v0: i64 <- Exact.v0 @Some(1)",
+        "range_low: i64 <- Range.low @Some(2)",
+        "range_high: i64 <- Range.high @Some(2)",
+    ];
+    assert_eq!(
+        gen.return_site_lines_for_test("read_one")
+            .expect("read_one's return is a site"),
+        expected,
+        "the site composes the sum's parts",
+    );
+    // The shape rides the delivery, not the row: an `Option<Reading>` return
+    // hands out the same values, and the optional is what the builder's
+    // nullability says.
+    assert_eq!(
+        gen.return_site_lines_for_test("read_maybe")
+            .expect("read_maybe's return is a site"),
+        expected,
+        "an optional return decomposes the same type",
+    );
+    // And it is what the expansion plan delivers, which is what the emitters
+    // read today.
+    assert_eq!(
+        gen.return_site_lines_for_test("read_one"),
+        gen.plan_lines_for_test("read_one"),
+        "the site and the expansion plan disagree",
+    );
+}

--- a/prebindgen-jni/src/jni/tests/sealed.rs
+++ b/prebindgen-jni/src/jni/tests/sealed.rs
@@ -868,9 +868,13 @@ fn recursive_sum_shapes_fail_deterministically() {
         }
     };
 
-    // `Vec<Node>` — variable arity, rejected with the intended message.
+    // `Vec<Node>` — the row saying what `Node` is made of reaches `Node`
+    // again, and the table refuses it by name before anything is compiled.
+    // The same refusal the emitter used to phrase as "variable arity", now
+    // stating which crossings close the loop.
     let msg = attempt(quote::quote!(Branch(Vec<Node>)), "rec_vec").expect_err("must fail");
-    assert!(msg.contains("variable arity"), "{msg}");
+    assert!(msg.contains("reaches its own crossing"), "{msg}");
+    assert!(msg.contains("Node"), "{msg}");
 
     // `Box<Node>` — not a bare ident, so it never classifies as a sum; it
     // fails as an unresolvable payload rather than recursing.

--- a/prebindgen-jni/src/jni/tests/sealed.rs
+++ b/prebindgen-jni/src/jni/tests/sealed.rs
@@ -291,7 +291,7 @@ fn reopened_ptr_class_keeps_gc_managed() {
         )]
     };
     let gc_managed_of = |first: crate::PtrClassDecl, second: crate::PtrClassDecl| {
-        let registry: RegistryBuilder<KotlinMeta> =
+        let registry: RegistryBuilder =
             crate::test_util::reg_from_items(declare_referenced(items())).expect("index items");
         let jni = JniGenBuilder::new()
             .set_package_prefix("io.test.jni")
@@ -349,7 +349,7 @@ fn a_type_gets_one_class_declarator() {
         ]
     };
     let declare = |first: crate::ClassDecl, second: crate::ClassDecl| {
-        let registry: RegistryBuilder<KotlinMeta> =
+        let registry: RegistryBuilder =
             crate::test_util::reg_from_items(declare_referenced(items())).expect("index items");
         let _ = JniGenBuilder::new()
             .set_package_prefix("io.test.jni")

--- a/prebindgen-jni/src/jni/tests/symbols.rs
+++ b/prebindgen-jni/src/jni/tests/symbols.rs
@@ -11,11 +11,7 @@ use super::*;
 /// `validate_symbols`) now runs inside `resolve`, so an invalid binding fails
 /// here and no `JniGen` is produced (nothing can be written). On success,
 /// a real `write_rust` confirms the valid binding also emits.
-fn resolve_result(
-    tag: &str,
-    registry: RegistryBuilder<KotlinMeta>,
-    jni: JniGenBuilder,
-) -> Result<(), String> {
+fn resolve_result(tag: &str, registry: RegistryBuilder, jni: JniGenBuilder) -> Result<(), String> {
     match jni.build_with(registry) {
         Ok(gen) => {
             let dir = unique_test_dir(tag);
@@ -29,7 +25,7 @@ fn resolve_result(
     }
 }
 
-fn one_fn(src: &str) -> RegistryBuilder<KotlinMeta> {
+fn one_fn(src: &str) -> RegistryBuilder {
     let f: syn::ItemFn = syn::parse_str(src).unwrap();
     crate::test_util::reg_from_items(declare_referenced(vec![(syn::Item::Fn(f), myflat_loc())]))
         .expect("index")

--- a/prebindgen-jni/src/jni/tests/value_form.rs
+++ b/prebindgen-jni/src/jni/tests/value_form.rs
@@ -3335,3 +3335,76 @@ fn nullability_ignores_how_rust_spells_the_optional() {
         "a transparent wrapper must not change the Kotlin surface"
     );
 }
+
+/// A value form states a row saying what it hands out, and it says what the
+/// expansion plan it will replace says.
+///
+/// `expand_return!(Vault).fields(fields!(vault_to_struct))` calls the accessor
+/// once and hands out the fields of the struct it returns, named as the
+/// declaration names them — a `.name(..)` rename included, which is why the row
+/// asks the declaration rather than deriving a Kotlin property a second time.
+#[test]
+fn a_value_form_states_what_it_hands_out() {
+    let loc = myflat_loc();
+    let items: Vec<(syn::Item, SourceLocation)> = vec![
+        (
+            syn::Item::Struct(syn::parse_quote!(
+                pub struct Vault {
+                    pub inner: i64,
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Struct(syn::parse_quote!(
+                pub struct VaultStruct {
+                    pub seq: i64,
+                    pub label: String,
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn vault_to_struct(v: &Vault) -> VaultStruct {
+                    unimplemented!()
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn vault_new() -> Vault {
+                    unimplemented!()
+                }
+            )),
+            loc.clone(),
+        ),
+    ];
+    let registry =
+        crate::test_util::reg_from_items(declare_referenced(items)).expect("index items");
+    let jni = JniGenBuilder::new()
+        .set_package_prefix("io.test.jni")
+        .expand(
+            prebindgen_registry::expand_return!(Vault)
+                .fields(prebindgen_registry::fields!(vault_to_struct).name("label", "tag")),
+        )
+        .package(
+            crate::package!()
+                .class(crate::ptr_class!(Vault))
+                .fun(prebindgen_registry::fun!(vault_new)),
+        );
+    let gen = jni.build_with(registry).expect("resolve");
+
+    assert_eq!(
+        gen.out_lines_for_test("Vault")
+            .expect("Vault states a value-form row"),
+        vec!["seq: i64 <- seq @None", "tag: String <- label @None"],
+        "the row hands out the value form's fields, named as declared",
+    );
+    assert_eq!(
+        gen.out_lines_for_test("Vault"),
+        gen.plan_lines_for_test("vault_new"),
+        "the row and the expansion plan disagree",
+    );
+}

--- a/prebindgen-jni/src/jni/tests/values.rs
+++ b/prebindgen-jni/src/jni/tests/values.rs
@@ -2896,3 +2896,67 @@ fn an_exclusive_borrow_parameter_crosses_only_over_a_handle() {
         );
     }
 }
+
+/// A declared type with nothing to be made of states no `parts` row, and no
+/// fragment is filed under that name.
+///
+/// `Declarations::recipes` declares `parts` only where there is something to
+/// decompose — an empty struct has no fields, so it gets the `whole` row and
+/// nothing else. The build then asks each declared type for `parts` by name,
+/// and `Compiler::row_of` refuses a name the crossing lacks rather than
+/// compiling the default and filing it under the asked-for name.
+///
+/// Without that refusal `row_fragment(.., parts)` answered with the whole-value
+/// fragment for a row nobody declared — an emitter reading it would take a
+/// single atomic conversion for a list of parts.
+#[test]
+fn a_type_with_no_parts_files_no_parts_row() {
+    let loc = myflat_loc();
+    let items = vec![
+        (
+            syn::Item::Struct(syn::parse_quote!(
+                pub struct EmptyNamed {}
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Struct(syn::parse_quote!(
+                pub struct HasOne {
+                    pub id: i64,
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn use_both(a: EmptyNamed, b: HasOne) -> i64 {
+                    unimplemented!()
+                }
+            )),
+            loc,
+        ),
+    ];
+    let registry =
+        crate::test_util::reg_from_items(declare_referenced(items)).expect("index items");
+    let gen = JniGenBuilder::new()
+        .set_package_prefix("io.test.jni")
+        .package(
+            crate::package!()
+                .class(crate::data_class!(EmptyNamed))
+                .class(crate::data_class!(HasOne))
+                .fun(prebindgen_registry::fun!(use_both)),
+        )
+        .build_with(registry)
+        .expect("resolve");
+
+    for out in [false, true] {
+        assert!(
+            !gen.has_parts_row_for_test("EmptyNamed", out),
+            "an empty struct states no parts row (out={out})",
+        );
+        assert!(
+            gen.has_parts_row_for_test("HasOne", out),
+            "a struct with a field states one (out={out})",
+        );
+    }
+}

--- a/prebindgen-jni/src/jni/tests/values.rs
+++ b/prebindgen-jni/src/jni/tests/values.rs
@@ -1025,16 +1025,27 @@ fn jobject_input_is_an_explicit_hybrid_leaf_escape_hatch() {
     let _ = std::fs::remove_dir_all(&dir);
     std::fs::create_dir_all(&dir).unwrap();
     let generation = jni.build_with(registry).expect("resolve");
-    // The `parts` row has to agree with the walk on the two boundaries this
-    // fixture draws, not just on plain fields: `object` is declared
-    // `.jobject_input()` and stays ONE value, and `maybe` is an
-    // `Option<data_class>`, which is a presence flag plus the inner's wires.
-    // Composing either wrongly is invisible until an emitter reads the row,
-    // which is why it is asserted here rather than after the switch.
-    let (composed, walked) = generation
-        .parts_vs_walk_for_test("Hybrid", "h")
-        .expect("Hybrid states a parts row and the walk plans it");
-    assert_eq!(composed, walked, "the row and the walk disagree");
+    // The two boundaries this fixture draws, stated as the row states them:
+    // `object` is declared `.jobject_input()` and stays ONE value, and `maybe`
+    // is an `Option<data_class>`, which is a presence flag plus the inner's
+    // wires.
+    let hybrid: Vec<String> = generation
+        .named_wires_for_test("Hybrid", "h")
+        .expect("Hybrid states a composition")
+        .into_iter()
+        .map(|(name, kt_ty, access, ..)| format!("{name}: {kt_ty} = {access}"))
+        .collect();
+    assert_eq!(
+        hybrid,
+        vec![
+            "hFlatId: Long = h.flat.id",
+            "hMaybePresent: Boolean = h.maybe != null",
+            "hMaybeId: Long = h.maybe?.id ?: 0L",
+            // The `.jobject_input()` child stays one value, and its own fields
+            // never reach the signature.
+            "hObject: io.test.jni.ObjectChild = h.object_",
+        ],
+    );
     let rust = std::fs::read_to_string(generation.write_rust(dir.join("gen.rs")).unwrap()).unwrap();
     let kotlin = generation
         .write_kotlin(&dir.join("kotlin"))
@@ -1865,10 +1876,17 @@ fn an_optional_handle_field_mints_through_the_factory() {
     // lock-and-consume scaffold reads. Asserted here because `Bag`'s field is
     // an `Option<Handle>`, where the access is nullable and the pointer still
     // is not.
-    let (composed, walked) = generation
-        .parts_vs_walk_for_test("Bag", "b")
-        .expect("Bag states a parts row and the walk plans it");
-    assert_eq!(composed, walked, "the row and the walk disagree");
+    let bag = generation
+        .named_wires_for_test("Bag", "b")
+        .expect("Bag states a composition");
+    assert_eq!(
+        bag.iter()
+            .map(|(name, kt_ty, access, _, target, nullable, ..)| format!(
+                "{name}: {kt_ty} = {access} @ {target:?} null={nullable}"
+            ))
+            .collect::<Vec<_>>(),
+        vec!["bHandle: Long = b.handle @ Some(\"b.handle\") null=true"],
+    );
     let kotlin = generation
         .write_kotlin(&dir.join("kotlin"))
         .unwrap()

--- a/prebindgen-jni/src/jni/tests/values.rs
+++ b/prebindgen-jni/src/jni/tests/values.rs
@@ -1025,6 +1025,16 @@ fn jobject_input_is_an_explicit_hybrid_leaf_escape_hatch() {
     let _ = std::fs::remove_dir_all(&dir);
     std::fs::create_dir_all(&dir).unwrap();
     let generation = jni.build_with(registry).expect("resolve");
+    // The `parts` row has to agree with the walk on the two boundaries this
+    // fixture draws, not just on plain fields: `object` is declared
+    // `.jobject_input()` and stays ONE value, and `maybe` is an
+    // `Option<data_class>`, which is a presence flag plus the inner's wires.
+    // Composing either wrongly is invisible until an emitter reads the row,
+    // which is why it is asserted here rather than after the switch.
+    let (composed, walked) = generation
+        .parts_vs_walk_for_test("Hybrid", "h")
+        .expect("Hybrid states a parts row and the walk plans it");
+    assert_eq!(composed, walked, "the row and the walk disagree");
     let rust = std::fs::read_to_string(generation.write_rust(dir.join("gen.rs")).unwrap()).unwrap();
     let kotlin = generation
         .write_kotlin(&dir.join("kotlin"))

--- a/prebindgen-jni/src/jni/tests/values.rs
+++ b/prebindgen-jni/src/jni/tests/values.rs
@@ -1860,6 +1860,15 @@ fn an_optional_handle_field_mints_through_the_factory() {
     let _ = std::fs::remove_dir_all(&dir);
     std::fs::create_dir_all(&dir).unwrap();
     let generation = jni.build_with(registry).expect("resolve");
+    // A nested owned handle crosses as a `Long` and is locked through the
+    // handle OBJECT, so the row has to carry both — the facts the Kotlin
+    // lock-and-consume scaffold reads. Asserted here because `Bag`'s field is
+    // an `Option<Handle>`, where the access is nullable and the pointer still
+    // is not.
+    let (composed, walked) = generation
+        .parts_vs_walk_for_test("Bag", "b")
+        .expect("Bag states a parts row and the walk plans it");
+    assert_eq!(composed, walked, "the row and the walk disagree");
     let kotlin = generation
         .write_kotlin(&dir.join("kotlin"))
         .unwrap()

--- a/prebindgen-jni/src/jni/trait_impl.rs
+++ b/prebindgen-jni/src/jni/trait_impl.rs
@@ -1816,9 +1816,9 @@ impl Declarations {
         keys.sort_by(|a, b| a.as_str().cmp(b.as_str()));
         let mut out = Vec::new();
         for key in keys {
-            let Some(sum_cfg) = self.types[key].sum() else {
+            if self.types[key].sum().is_none() {
                 continue;
-            };
+            }
             // The `sealed_class!` declaration's own IDENTITY. This runs during
             // the declare phase, where a `reading()` would legitimately answer
             // `None` for a type nothing has interned yet — the declaration is
@@ -1839,7 +1839,7 @@ impl Declarations {
                 // `Variant::type_ref` exists for exactly this, and it works in
                 // the declare phase where a `reading()` lookup could not.
                 source: sum.type_ref().clone(),
-                leaves: crate::jni::synth_sum_leaves(self, sum_cfg, sum),
+                leaves: crate::jni::synth_sum_leaves(self, registry, &ident, sum),
             });
         }
         out

--- a/prebindgen-jni/src/jni/trait_impl.rs
+++ b/prebindgen-jni/src/jni/trait_impl.rs
@@ -1434,6 +1434,10 @@ impl JniGenBuilder {
                     .join("; "),
             }
         })?;
+        // Both tables go on `decls`, because compiling a **site** happens after
+        // this function has returned: the sites are `fn_plan`'s to enumerate,
+        // and `Compiler::resume` needs these two beside the model.
+        decls.tables = Some(std::rc::Rc::new(crate::jni::Tables { recipes, bindings }));
         // The driver's state lives on `decls` rather than here, because the
         // adapter reads it **while** it compiles: a conversion for one type is
         // built out of the conversions for its inners, which are compiled
@@ -1452,8 +1456,8 @@ impl JniGenBuilder {
             .convert_with(|crossing, built, emit| {
                 let mut compiler = prebindgen_registry::recipe::Compiler::resume(
                     &model,
-                    &recipes,
-                    &bindings,
+                    decls.recipe_table(),
+                    decls.site_bindings(),
                     decls.compiled.borrow().clone(),
                 );
                 let conv =
@@ -1568,13 +1572,14 @@ impl JniGenBuilder {
             );
             let mut compiler = prebindgen_registry::recipe::Compiler::resume(
                 &model,
-                &recipes,
-                &bindings,
+                decls.recipe_table(),
+                decls.site_bindings(),
                 decls.compiled.borrow().clone(),
             );
             let mut adapter = crate::jni::compile::JCompile {
                 decls: &decls,
                 registry: &registry,
+                site: None,
             };
             if let Err(e) = compiler.row_of(&mut adapter, &crossing, &crate::jni::rows::parts()) {
                 refusals.push(format!(
@@ -1650,6 +1655,7 @@ impl Declarations {
         let mut adapter = crate::jni::compile::JCompile {
             decls: self,
             registry: built,
+            site: None,
         };
         let crossing = prebindgen_registry::recipe::Crossing::new(reading, assembly);
         let fragment = compiler.crossing(&mut adapter, &crossing).ok()?;
@@ -3260,6 +3266,16 @@ impl Declarations {
             .map(|(k, c)| (k.clone(), c.rust_type.clone()))
             .collect()
     }
+    /// The row table this binding was built against.
+    pub(crate) fn recipe_table(&self) -> &prebindgen_registry::recipe::Recipes {
+        &self.tables.as_ref().expect("built").recipes
+    }
+
+    /// Which row each site takes.
+    pub(crate) fn site_bindings(&self) -> &prebindgen_registry::recipe::Bindings {
+        &self.tables.as_ref().expect("built").bindings
+    }
+
     /// Every type that states what it hands out — `sealed_class!` and
     /// `data_class!` — in a stable order.
     ///

--- a/prebindgen-jni/src/jni/trait_impl.rs
+++ b/prebindgen-jni/src/jni/trait_impl.rs
@@ -1496,12 +1496,13 @@ impl JniGenBuilder {
             .borrow()
             .fragments()
             .into_iter()
-            // A fragment that carries only a wire list has no conversion to
-            // emit: the `parts` row states what a `data_class` is made of, and
-            // the function that reads those several values and rebuilds the
-            // struct is what the emitter switch brings. Its marker would
-            // otherwise reach the file.
-            .filter(|f| f.wires.is_none())
+            // A composed-only fragment has no conversion to emit: the `parts`
+            // row states what a `data_class` is made of, and the function that
+            // reads those several values and rebuilds the struct is what the
+            // emitter switch brings. Its marker would otherwise reach the file.
+            // Deliberately not "has wires" — an `Option<data_class>` has both a
+            // wire list and a conversion of its own.
+            .filter(|f| !f.composed_only)
             // A JNI conversion already emits more than one function: a
             // `convert!` with a fallible or binding-local step carries it as a
             // pre-stage, and every one of them has to reach the file. This is

--- a/prebindgen-jni/src/jni/trait_impl.rs
+++ b/prebindgen-jni/src/jni/trait_impl.rs
@@ -1423,8 +1423,17 @@ impl JniGenBuilder {
                     .join("; "),
             }
         })?;
-        // JniGen overrides no site yet: every crossing takes its type's own row.
-        let bindings = prebindgen_registry::recipe::Bindings::default();
+        // A `data_class` field that is itself one takes the `parts` row rather
+        // than its own default — see `Declarations::bindings`.
+        let bindings = decls.bindings(&model, &recipes).map_err(|errors| {
+            prebindgen_registry::ScanError::AdapterInvariant {
+                message: errors
+                    .iter()
+                    .map(|e| e.to_string())
+                    .collect::<Vec<_>>()
+                    .join("; "),
+            }
+        })?;
         // The driver's state lives on `decls` rather than here, because the
         // adapter reads it **while** it compiles: a conversion for one type is
         // built out of the conversions for its inners, which are compiled
@@ -1436,6 +1445,9 @@ impl JniGenBuilder {
         // than papered over: this list empties when the derived callback row
         // takes over.
         let mut uncompiled: Vec<syn::ItemFn> = Vec::new();
+        // Compositions that refused. See `compile_crossing`: these are adapter
+        // invariants, reported together once the walk is done.
+        let mut refusals: Vec<String> = Vec::new();
         let registry = declared
             .convert_with(|crossing, built, emit| {
                 let mut compiler = prebindgen_registry::recipe::Compiler::resume(
@@ -1444,7 +1456,8 @@ impl JniGenBuilder {
                     &bindings,
                     decls.compiled.borrow().clone(),
                 );
-                let conv = decls.compile_crossing(&mut compiler, crossing, built, emit);
+                let conv =
+                    decls.compile_crossing(&mut compiler, crossing, built, emit, &mut refusals);
                 *decls.compiled.borrow_mut() = compiler.finish();
                 if let (Some(c), true) =
                     (conv.as_ref(), decls.is_callback_crossing(crossing, built))
@@ -1470,6 +1483,12 @@ impl JniGenBuilder {
                 conv.map(|c| prebindgen_registry::Answer::over(c.subs))
             })?
             .build()?;
+        if !refusals.is_empty() {
+            return Err(prebindgen_registry::ScanError::AdapterInvariant {
+                message: refusals.join("; "),
+            }
+            .into());
+        }
         // What the compilation produced, kept for emission. The converter table
         // stays the lookup index; this is what reaches the file.
         decls.compiled_fns = decls
@@ -1477,6 +1496,12 @@ impl JniGenBuilder {
             .borrow()
             .fragments()
             .into_iter()
+            // A fragment that carries only a wire list has no conversion to
+            // emit: the `parts` row states what a `data_class` is made of, and
+            // the function that reads those several values and rebuilds the
+            // struct is what the emitter switch brings. Its marker would
+            // otherwise reach the file.
+            .filter(|f| f.wires.is_none())
             // A JNI conversion already emits more than one function: a
             // `convert!` with a fallible or binding-local step carries it as a
             // pre-stage, and every one of them has to reach the file. This is
@@ -1525,6 +1550,7 @@ impl Declarations {
         crossing: &Crossing,
         built: &'v R,
         emit: &prebindgen_registry::Emit,
+        refusals: &mut Vec<String>,
     ) -> Option<ConverterImpl<KotlinMeta>> {
         let (dir, key) = crossing;
         // The reading the scan already took for this crossing, fetched by the
@@ -1555,6 +1581,31 @@ impl Declarations {
         };
         let crossing = prebindgen_registry::recipe::Crossing::new(reading, assembly);
         let fragment = compiler.crossing(&mut adapter, &crossing).ok()?;
+        // A `data_class` also states a row that says what it is made of, and
+        // compiling it here is what holds the composition to every binding this
+        // crate builds rather than to one fixture. Nothing reads the result
+        // yet: `whole` is still the row every site takes, so a failure here is
+        // a failure to compose parts that already cross individually.
+        if assembly == prebindgen_registry::recipe::Assembly::Construct
+            && matches!(
+                self.types.get(&crossing.value().key()).map(|c| &c.kind),
+                Some(DeclaredKind::Data)
+            )
+        {
+            // A refusal is a bug in the composition, not a gap in the binding:
+            // every part of a `data_class` is a crossing that already resolved
+            // on its own, so nothing here can legitimately be missing.
+            // Returning `None` would report an unresolved crossing and blame
+            // the declaration, so the reason is collected and surfaced as an
+            // adapter invariant — beside whatever else the walk found, and
+            // through the same `Result` every other refusal takes.
+            if let Err(e) = compiler.row_of(&mut adapter, &crossing, &crate::jni::rows::parts()) {
+                refusals.push(format!(
+                    "`{}` crosses as its fields, but composing them failed: {e:?}",
+                    crossing.spelled().key()
+                ));
+            }
+        }
         Some((*fragment).clone().conv)
     }
 

--- a/prebindgen-jni/src/jni/trait_impl.rs
+++ b/prebindgen-jni/src/jni/trait_impl.rs
@@ -422,7 +422,7 @@ impl Declarations {
 
     fn emitted_source_type_names(
         &self,
-        registry: &Registry<KotlinMeta>,
+        registry: &Registry,
     ) -> std::collections::HashMap<String, syn::Path> {
         let mut names = std::collections::HashMap::new();
         let mut add = |key: &TypeKey| {
@@ -467,7 +467,7 @@ impl Declarations {
     /// time via [`Prebindgen::post_process_item`] so converter bodies,
     /// type ascriptions, and casts all stay in sync without each emit
     /// site having to remember to qualify.
-    fn qualify_item(&self, item: &mut syn::Item, registry: &Registry<KotlinMeta>) {
+    fn qualify_item(&self, item: &mut syn::Item, registry: &Registry) {
         let source_names = self.emitted_source_type_names(registry);
         // Names reachable from an array LENGTH (`[u8; MAX]`, `[u8; Holder::N]`).
         //
@@ -633,7 +633,7 @@ pub(crate) fn build_signal_domain_error_item() -> syn::Item {
 /// producing destructors that reference types not in scope.
 pub(crate) fn build_handle_destructor_items(
     ext: &Declarations,
-    registry: &Registry<KotlinMeta>,
+    registry: &Registry,
     emit: &prebindgen_registry::Emit,
 ) -> Vec<syn::Item> {
     let mut named: Vec<(String, syn::Item)> = Vec::new();
@@ -1407,7 +1407,7 @@ impl JniGenBuilder {
     /// route to a `JniGenBuilder` at all.
     pub(crate) fn build_with(
         self,
-        registry: prebindgen_registry::RegistryBuilder<KotlinMeta>,
+        registry: prebindgen_registry::RegistryBuilder,
     ) -> Result<JniGen, prebindgen_registry::WriteRustError> {
         let mut decls = self.decls;
         let declared = decls.declare_into(registry)?.validate_with(&decls)?;
@@ -1464,7 +1464,10 @@ impl JniGenBuilder {
                         crate::jni::compile::JFrag::by_hand(key.clone(), c.clone()),
                     );
                 }
-                conv
+                // The conversion stays here; what the registry gets back is
+                // which other crossings this one delegates to, which is what
+                // its reachability walk needs.
+                conv.map(|c| prebindgen_registry::Answer::over(c.subs))
             })?
             .build()?;
         // What the compilation produced, kept for emission. The converter table
@@ -1502,11 +1505,7 @@ impl Declarations {
     /// so everything this could compose from is already in `built`.
     /// Whether this crossing is the callback shape `compile_crossing` answers
     /// without the compiler.
-    fn is_callback_crossing<R: Conversions<KotlinMeta>>(
-        &self,
-        crossing: &Crossing,
-        built: &R,
-    ) -> bool {
+    fn is_callback_crossing<R: Conversions>(&self, crossing: &Crossing, built: &R) -> bool {
         let (dir, key) = crossing;
         matches!(dir, Direction::Input)
             && built.reading(key).is_some_and(|r| {
@@ -1517,7 +1516,7 @@ impl Declarations {
             })
     }
 
-    fn compile_crossing<'v, R: Conversions<KotlinMeta>>(
+    fn compile_crossing<'v, R: Conversions>(
         &'v self,
         compiler: &mut prebindgen_registry::recipe::Compiler<
             '_,
@@ -1561,8 +1560,8 @@ impl Declarations {
 
     pub fn declare_into(
         &self,
-        mut registry: RegistryBuilder<KotlinMeta>,
-    ) -> Result<RegistryBuilder<KotlinMeta>, prebindgen_registry::ScanError> {
+        mut registry: RegistryBuilder,
+    ) -> Result<RegistryBuilder, prebindgen_registry::ScanError> {
         // Binding-local fns first: they become model, and everything below may
         // name one.
         for (item_fn, origin) in self.collect_local_functions() {
@@ -1640,7 +1639,7 @@ impl Declarations {
 impl Declarations {
     pub(crate) fn build_value_struct_decons(
         &self,
-        registry: &impl Conversions<KotlinMeta>,
+        registry: &impl Conversions,
     ) -> Vec<prebindgen_registry::unfold::ValueDecon> {
         let mut out = Vec::new();
         for item_struct in registry.flat().types().filter_map(|t| match t {
@@ -1677,7 +1676,7 @@ impl Declarations {
 
     pub(crate) fn build_sum_decons(
         &self,
-        registry: &impl Conversions<KotlinMeta>,
+        registry: &impl Conversions,
     ) -> Vec<prebindgen_registry::unfold::SumDecon> {
         let mut keys: Vec<&TypeKey> = self.types.keys().collect();
         keys.sort_by(|a, b| a.as_str().cmp(b.as_str()));
@@ -1712,10 +1711,7 @@ impl Declarations {
         out
     }
 
-    pub(crate) fn build_leaf_vec_fold_elements(
-        &self,
-        registry: &impl Conversions<KotlinMeta>,
-    ) -> Vec<TypeKey> {
+    pub(crate) fn build_leaf_vec_fold_elements(&self, registry: &impl Conversions) -> Vec<TypeKey> {
         let mut seen = std::collections::HashSet::new();
         let mut out = Vec::new();
         let mut consider = |bare: &prebindgen_registry::flat::TypeRef| {
@@ -1774,7 +1770,7 @@ fn peel_one_borrow(t: &prebindgen_registry::flat::TypeRef) -> &prebindgen_regist
 /// classification the model makes once, at parse time, and expresses as two
 /// different elements.
 fn flat_unit_enum<'r>(
-    registry: &'r impl Conversions<KotlinMeta>,
+    registry: &'r impl Conversions,
     name: &syn::Ident,
     declarator: &str,
 ) -> Option<&'r prebindgen_registry::flat::Enum> {
@@ -1802,7 +1798,7 @@ impl Declarations {
     pub(crate) fn dispatch_fn_input(
         &self,
         args: &[prebindgen_registry::flat::TypeRef],
-        registry: &impl Conversions<KotlinMeta>,
+        registry: &impl Conversions,
         emit: &prebindgen_registry::Emit,
     ) -> Option<ConverterImpl<KotlinMeta>> {
         let outer_ty = build_fn_type(args, emit);
@@ -1824,14 +1820,6 @@ impl Declarations {
 }
 
 impl Prebindgen for Declarations {
-    /// Cross-language extras every JNI converter carries — currently
-    /// the Kotlin value-context type name. Filled by the rank-N
-    /// handlers at the same point they build the wire/body; the
-    /// resolver propagates it into [`prebindgen_registry::TypeEntry::metadata`];
-    /// the Kotlin emitter reads it back to drive every wrapper /
-    /// typed-handle / `JNIWrappers` signature.
-    type Metadata = KotlinMeta;
-
     // ── Structural type resolution ──────────────────────────────────────
     // Try the terminal categories, then the `Result` peel, then the built-in
     // wrapper shapes — peel
@@ -1842,7 +1830,7 @@ impl Prebindgen for Declarations {
     /// the earliest possible moment. Without this, a receiver-less `.method()`
     /// member would silently emit a method that ignores `this`, and a
     /// wrong-return `.constructor()` a factory of the wrong type.
-    fn validate(&self, binding: &Building<'_, Self::Metadata>) -> Result<(), String> {
+    fn validate(&self, binding: &Building<'_>) -> Result<(), String> {
         // Report what this binding left unclaimed. Here because it is the
         // earliest generator-owned hook that sees the model, and it runs
         // exactly where the binding used to print these itself. Moves into
@@ -2030,7 +2018,7 @@ impl Prebindgen for Declarations {
     /// The post-resolve validation boundary (issue #90): every bound
     /// function's lowered plan must build, and the split declarations must
     /// be unambiguous, before ANY artifact writer touches disk.
-    fn validate_resolved(&self, registry: &Registry<KotlinMeta>) -> Result<(), String> {
+    fn validate_resolved(&self, registry: &Registry) -> Result<(), String> {
         validate_bindings(self, registry)
     }
 
@@ -2048,7 +2036,7 @@ impl Prebindgen for Declarations {
     /// crate's source tree.
     fn prerequisites(
         &self,
-        registry: &Registry<KotlinMeta>,
+        registry: &Registry,
         emit: &prebindgen_registry::Emit,
     ) -> Vec<syn::Item> {
         // `__JniErr` is the **framework** error type alias — always the
@@ -2114,7 +2102,7 @@ impl Prebindgen for Declarations {
     fn post_process_item(
         &self,
         item: &mut syn::Item,
-        registry: &Registry<KotlinMeta>,
+        registry: &Registry,
         _emit: &prebindgen_registry::Emit,
     ) {
         self.qualify_item(item, registry);
@@ -2125,7 +2113,7 @@ impl Prebindgen for Declarations {
     fn on_function(
         &self,
         f: &prebindgen_registry::flat::Function,
-        registry: &Registry<KotlinMeta>,
+        registry: &Registry,
         emit: &prebindgen_registry::Emit,
     ) -> TokenStream {
         emit_jni_function_wrapper(self, f, registry, emit)
@@ -2134,7 +2122,7 @@ impl Prebindgen for Declarations {
     fn on_struct(
         &self,
         _s: &prebindgen_registry::flat::Struct,
-        _registry: &Registry<KotlinMeta>,
+        _registry: &Registry,
         _emit: &prebindgen_registry::Emit,
     ) -> TokenStream {
         // Struct converter bodies are emitted by the resolver via
@@ -2146,7 +2134,7 @@ impl Prebindgen for Declarations {
     fn on_variant(
         &self,
         _v: &prebindgen_registry::flat::Variant,
-        _registry: &Registry<KotlinMeta>,
+        _registry: &Registry,
         _emit: &prebindgen_registry::Emit,
     ) -> TokenStream {
         TokenStream::new()
@@ -2155,7 +2143,7 @@ impl Prebindgen for Declarations {
     fn on_enum(
         &self,
         _e: &prebindgen_registry::flat::Enum,
-        _registry: &Registry<KotlinMeta>,
+        _registry: &Registry,
         _emit: &prebindgen_registry::Emit,
     ) -> TokenStream {
         TokenStream::new()
@@ -2171,7 +2159,7 @@ impl Prebindgen for Declarations {
     fn on_const(
         &self,
         c: &prebindgen_registry::flat::Constant,
-        registry: &Registry<KotlinMeta>,
+        registry: &Registry,
         emit: &prebindgen_registry::Emit,
     ) -> TokenStream {
         reject_handle_const(self, c);
@@ -2201,7 +2189,7 @@ impl Declarations {
     pub(crate) fn input_terminal(
         &self,
         reading: &prebindgen_registry::flat::TypeRef,
-        registry: &impl Conversions<KotlinMeta>,
+        registry: &impl Conversions,
         emit: &prebindgen_registry::Emit,
     ) -> Option<ConverterImpl<KotlinMeta>> {
         // Classify off `kind`, spell with `spell()`: the arms below that ask what
@@ -2433,7 +2421,7 @@ impl Declarations {
     pub(crate) fn output_transparent_bridge(
         &self,
         reading: &prebindgen_registry::flat::TypeRef,
-        registry: &impl Conversions<KotlinMeta>,
+        registry: &impl Conversions,
         emit: &prebindgen_registry::Emit,
     ) -> Option<ConverterImpl<KotlinMeta>> {
         if reading.erased_wrappers().is_empty() {
@@ -2507,7 +2495,7 @@ impl Declarations {
     pub(crate) fn input_transparent_bridge(
         &self,
         reading: &prebindgen_registry::flat::TypeRef,
-        registry: &impl Conversions<KotlinMeta>,
+        registry: &impl Conversions,
         emit: &prebindgen_registry::Emit,
     ) -> Option<ConverterImpl<KotlinMeta>> {
         if reading.erased_wrappers().is_empty() {
@@ -2595,7 +2583,7 @@ impl Declarations {
     pub(crate) fn output_terminal(
         &self,
         reading: &prebindgen_registry::flat::TypeRef,
-        registry: &impl Conversions<KotlinMeta>,
+        registry: &impl Conversions,
         emit: &prebindgen_registry::Emit,
     ) -> Option<ConverterImpl<KotlinMeta>> {
         // Classify off `kind`, spell with `spell()` — see `input_terminal`.

--- a/prebindgen-jni/src/jni/trait_impl.rs
+++ b/prebindgen-jni/src/jni/trait_impl.rs
@@ -1579,6 +1579,7 @@ impl JniGenBuilder {
             let mut adapter = crate::jni::compile::JCompile {
                 decls: &decls,
                 registry: &registry,
+                declared_return: None,
                 site: None,
             };
             if let Err(e) = compiler.row_of(&mut adapter, &crossing, &crate::jni::rows::parts()) {
@@ -1655,6 +1656,7 @@ impl Declarations {
         let mut adapter = crate::jni::compile::JCompile {
             decls: self,
             registry: built,
+            declared_return: None,
             site: None,
         };
         let crossing = prebindgen_registry::recipe::Crossing::new(reading, assembly);

--- a/prebindgen-jni/src/jni/trait_impl.rs
+++ b/prebindgen-jni/src/jni/trait_impl.rs
@@ -1220,7 +1220,6 @@ impl Declarations {
         shape: WrapperShape,
         produced: &Produced<'_>,
         t1: &prebindgen_registry::flat::TypeRef,
-        registry: &impl Conversions<KotlinMeta>,
         emit: &prebindgen_registry::Emit,
     ) -> Option<ConverterImpl<KotlinMeta>> {
         // `t1`'s spelling, for the parts that ask spelling questions — the
@@ -1289,7 +1288,7 @@ impl Declarations {
         if shape == WrapperShape::Optional {
             let outer_ty = produced.key();
             let build = build_from_canonical(produced, quote::quote!(__v))?;
-            let (wire, inner_body, niches) = option_input(t1, registry, emit)?;
+            let (wire, inner_body, niches) = option_input(t1, self, emit)?;
             // `option_input` yields the canonical `Option<T>`; the converter
             // yields the spelling.
             let body: syn::Expr = syn::parse_quote!({
@@ -1307,7 +1306,7 @@ impl Declarations {
             // an inner niche, the wire stays identical to the inner's
             // destination and `None` is the niche slot sentinel; the boxed
             // fallback widens the wire to `JObject`.
-            let nullable_kind = nullable_kind_for(&wire, t1, registry);
+            let nullable_kind = nullable_kind_for(&wire, t1, self);
             let projection = self
                 .in_frag(t1)
                 .and_then(|e| e.metadata.projection.clone())
@@ -2577,7 +2576,6 @@ impl Declarations {
         shape: WrapperShape,
         produced: &Produced<'_>,
         t1: &prebindgen_registry::flat::TypeRef,
-        registry: &impl Conversions<KotlinMeta>,
         emit: &prebindgen_registry::Emit,
     ) -> Option<ConverterImpl<KotlinMeta>> {
         // Disjoint shapes (see [`WrapperShape`]), tried in priority order. The
@@ -2586,7 +2584,7 @@ impl Declarations {
         self.input_borrow(shape, produced, t1)
             .or_else(|| self.input_option_ref(shape, produced, t1, emit))
             .or_else(|| self.input_vec(shape, produced, t1, emit))
-            .or_else(|| self.input_option(shape, produced, t1, registry, emit))
+            .or_else(|| self.input_option(shape, produced, t1, emit))
     }
 
     // ── Output converters ────────────────────────────────────────────
@@ -2779,7 +2777,6 @@ impl Declarations {
         shape: WrapperShape,
         produced: &Produced<'_>,
         t1: &prebindgen_registry::flat::TypeRef,
-        registry: &impl Conversions<KotlinMeta>,
         emit: &prebindgen_registry::Emit,
     ) -> Option<ConverterImpl<KotlinMeta>> {
         // `t1`'s spelling, for the parts that ask spelling questions — the
@@ -2831,7 +2828,7 @@ impl Declarations {
             // Bridgeable first: an unsupported representation must not resolve
             // and then emit code the consumer cannot compile.
             let read = read_as_canonical(produced)?;
-            let (wire, inner_body, niches) = option_output(t1, registry)?;
+            let (wire, inner_body, niches) = option_output(t1, self)?;
             let body: syn::Expr = syn::parse_quote!({
                 let v: #canonical = #read;
                 #inner_body
@@ -2845,7 +2842,7 @@ impl Declarations {
             // [`nullable_kind_for`]): niche-fulfilled keeps the inner wire
             // and treats the slot value as `None`; boxed widens to `JObject`
             // and uses JVM null.
-            let nullable_kind = nullable_kind_for_output(&wire, t1, registry);
+            let nullable_kind = nullable_kind_for_output(&wire, t1, self);
             let projection = self
                 .out_frag(t1)
                 .and_then(|e| e.metadata.projection.clone())

--- a/prebindgen-jni/src/jni/trait_impl.rs
+++ b/prebindgen-jni/src/jni/trait_impl.rs
@@ -1519,19 +1519,20 @@ impl JniGenBuilder {
         decls
             .validate_resolved(&registry)
             .map_err(|message| prebindgen_registry::ScanError::AdapterInvariant { message })?;
-        // A `sealed_class`'s deconstructing composition, last of all.
+        // What each declared class hands out, composed last of all.
         //
-        // After `validate_resolved`, so a binding whose payload simply has no
-        // output conversion gets the diagnostic that names the payload rather
-        // than this one, which can only say that composing failed. What is left
-        // for this to catch is a composition that fails over parts which did
-        // resolve — a bug here rather than a gap in the binding.
-        // Driven here rather than from `compile_crossing`
-        // because a sum has **no** deconstructing crossing to be driven from: it
-        // is boundary-only, so nothing ever asks for its whole-value output
-        // conversion and the walk never reaches it. Nothing reads the result
-        // yet; compiling it is what holds the composition to every binding this
-        // crate builds rather than to one fixture.
+        // Driven here rather than from `compile_crossing` because a
+        // `sealed_class` has **no** deconstructing crossing to be driven from:
+        // it is boundary-only, so nothing ever asks for its whole-value output
+        // conversion and the converter walk never reaches it. A `data_class`
+        // does have one, and goes through the same loop so that both sides of
+        // the same question are answered in one place.
+        //
+        // After `validate_resolved`, so a binding whose part simply has no
+        // output conversion gets the diagnostic that names the part rather than
+        // this one, which could only say that composing failed. Nothing reads
+        // the result yet; compiling it is what holds the composition to every
+        // binding this crate builds rather than to one fixture.
         for key in decls.declared_decompositions() {
             let Some(ident) = key.ident() else { continue };
             let Ok(ty) = model.classify(&syn::parse_quote!(#ident)) else {
@@ -1541,20 +1542,20 @@ impl JniGenBuilder {
             // not is a gap in the binding, and the writers report it against
             // the part — `Reading.Exact.v0 has no OUTPUT converter` — where
             // this could only say that composing failed.
-            let parts: Vec<&prebindgen_registry::flat::TypeRef> = match model.declared_type(&ident)
-            {
-                Some(prebindgen_registry::flat::Type::Variant(sum)) => sum
-                    .alternatives
-                    .iter()
-                    .flat_map(|alt| &alt.fields)
-                    .map(|f| &f.ty)
-                    .collect(),
-                Some(prebindgen_registry::flat::Type::Struct(s)) => {
-                    s.fields.iter().map(|f| &f.ty).collect()
-                }
-                _ => continue,
-            };
-            if parts.iter().any(|ty| decls.out_frag(ty).is_none()) {
+            let part_types: Vec<&prebindgen_registry::flat::TypeRef> =
+                match model.declared_type(&ident) {
+                    Some(prebindgen_registry::flat::Type::Variant(sum)) => sum
+                        .alternatives
+                        .iter()
+                        .flat_map(|alt| &alt.fields)
+                        .map(|f| &f.ty)
+                        .collect(),
+                    Some(prebindgen_registry::flat::Type::Struct(s)) => {
+                        s.fields.iter().map(|f| &f.ty).collect()
+                    }
+                    _ => continue,
+                };
+            if part_types.iter().any(|ty| decls.out_frag(ty).is_none()) {
                 continue;
             }
             let crossing = prebindgen_registry::recipe::Crossing::new(
@@ -1576,8 +1577,8 @@ impl JniGenBuilder {
                     "`{key}` hands out its parts, but composing them failed: {e:?}"
                 ));
             }
-            let done = compiler.finish();
-            *decls.compiled.borrow_mut() = done;
+            let compiled = compiler.finish();
+            *decls.compiled.borrow_mut() = compiled;
         }
         if !refusals.is_empty() {
             return Err(prebindgen_registry::ScanError::AdapterInvariant {

--- a/prebindgen-jni/src/jni/trait_impl.rs
+++ b/prebindgen-jni/src/jni/trait_impl.rs
@@ -648,7 +648,7 @@ pub(crate) fn build_handle_destructor_items(
         let Some(reading) = registry.reading(key) else {
             continue;
         };
-        if registry.input_entry(&reading).is_none() && registry.output_entry(&reading).is_none() {
+        if ext.in_frag(&reading).is_none() && ext.out_frag(&reading).is_none() {
             continue;
         }
         let ty = emit.spell(&reading);
@@ -1031,7 +1031,6 @@ impl Declarations {
         shape: WrapperShape,
         produced: &Produced<'_>,
         t1: &prebindgen_registry::flat::TypeRef,
-        registry: &impl Conversions<KotlinMeta>,
     ) -> Option<ConverterImpl<KotlinMeta>> {
         let WrapperShape::Borrow { .. } = shape else {
             return None;
@@ -1044,7 +1043,7 @@ impl Declarations {
         if !produced.is_canonical() {
             return None;
         }
-        let inner = registry.input_entry(t1)?;
+        let inner = self.in_frag(t1)?;
         let outer_ty = produced.key();
         // `&T` / `&mut T` are Kotlin-side no-ops — inherit the inner
         // type's name, unless the user pinned an explicit override
@@ -1082,7 +1081,6 @@ impl Declarations {
         shape: WrapperShape,
         produced: &Produced<'_>,
         t1: &prebindgen_registry::flat::TypeRef,
-        registry: &impl Conversions<KotlinMeta>,
         emit: &prebindgen_registry::Emit,
     ) -> Option<ConverterImpl<KotlinMeta>> {
         // `t1`'s spelling, for the parts that ask spelling questions — the
@@ -1099,7 +1097,7 @@ impl Declarations {
         if !produced.is_canonical() {
             return None;
         }
-        let inner = registry.input_entry(t1)?;
+        let inner = self.in_frag(t1)?;
         if !inner.metadata.is_direct_handle() {
             // Non-opaque: let the general `Option<_>` handler take it.
             return None;
@@ -1152,7 +1150,6 @@ impl Declarations {
         shape: WrapperShape,
         produced: &Produced<'_>,
         t1: &prebindgen_registry::flat::TypeRef,
-        registry: &impl Conversions<KotlinMeta>,
         emit: &prebindgen_registry::Emit,
     ) -> Option<ConverterImpl<KotlinMeta>> {
         // `t1`'s spelling, for the parts that ask spelling questions — the
@@ -1163,7 +1160,7 @@ impl Declarations {
         if shape != WrapperShape::Sequence {
             return None;
         }
-        let inner = registry.input_entry(t1)?;
+        let inner = self.in_frag(t1)?;
         reject_vec_of_handle(&inner.metadata.projection, t1);
         let inner_wire = inner.destination.clone();
         if !is_jobject_shaped_wire(&inner_wire) {
@@ -1172,7 +1169,8 @@ impl Declarations {
         // The element's COMPLETE wire -> Rust chain: a `convert!` element
         // (`Label` -> `String`) reaches its value through the rust-side stages,
         // not through the wire-facing converter alone.
-        let inner_conv = crate::jni::emit::composed_inner_input(inner, quote::quote!(&__elem_wire));
+        let inner_conv =
+            crate::jni::emit::composed_inner_input(&inner, quote::quote!(&__elem_wire));
         let outer_ty = produced.key();
         // Bridgeable first — see `box_layers_to`.
         let build = build_from_canonical(produced, quote::quote!(__out))?;
@@ -1231,7 +1229,7 @@ impl Declarations {
         // the READING itself (#284).
         let t1_ty = emit.spell(t1);
         if shape == WrapperShape::Optional {
-            let inner = registry.input_entry(t1)?;
+            let inner = self.in_frag(t1)?;
             if inner.metadata.is_direct_handle() {
                 let inner_wire = inner.destination.clone();
                 let outer_ty = produced.key();
@@ -1300,8 +1298,8 @@ impl Declarations {
             });
             // Inherit the inner's name; user pins on `Option<T>` win.
             // The nullability marker (`?`) is added by the use site.
-            let inherited = registry
-                .input_entry(t1)
+            let inherited = self
+                .in_frag(t1)
                 .and_then(|e| e.metadata.kotlin_name.clone());
             let kotlin_name = self.override_kotlin_name(&outer_ty, inherited);
             // Fold a Nullable layer over the inner projection (if any). The
@@ -1310,8 +1308,8 @@ impl Declarations {
             // destination and `None` is the niche slot sentinel; the boxed
             // fallback widens the wire to `JObject`.
             let nullable_kind = nullable_kind_for(&wire, t1, registry);
-            let projection = registry
-                .input_entry(t1)
+            let projection = self
+                .in_frag(t1)
                 .and_then(|e| e.metadata.projection.clone())
                 .map(|h| Projection {
                     strategy: FoldStrategy::Optional(nullable_kind, Box::new(h.strategy)),
@@ -1428,12 +1426,11 @@ impl JniGenBuilder {
         })?;
         // JniGen overrides no site yet: every crossing takes its type's own row.
         let bindings = prebindgen_registry::recipe::Bindings::default();
-        // The driver's state, carried between calls. The adapter borrows the
-        // partial registry view, which is lent per call and so is a different
-        // type each time; what it built is not, and outlives every one of them.
-        let mut compiled = Some(prebindgen_registry::recipe::Compiled::<
-            crate::jni::compile::JFrag,
-        >::default());
+        // The driver's state lives on `decls` rather than here, because the
+        // adapter reads it **while** it compiles: a conversion for one type is
+        // built out of the conversions for its inners, which are compiled
+        // first. That is the same order the converter table was filled in, so
+        // a fragment is there exactly when a table entry would have been.
         // A callback is still answered without the compiler — see
         // `compile_crossing` — so no fragment carries its conversion and the
         // fragment list alone would not reach the file. Collected here rather
@@ -1446,22 +1443,36 @@ impl JniGenBuilder {
                     &model,
                     &recipes,
                     &bindings,
-                    compiled.take().expect("the state is put back every call"),
+                    decls.compiled.borrow().clone(),
                 );
                 let conv = decls.compile_crossing(&mut compiler, crossing, built, emit);
-                compiled = Some(compiler.finish());
+                *decls.compiled.borrow_mut() = compiler.finish();
                 if let (Some(c), true) =
                     (conv.as_ref(), decls.is_callback_crossing(crossing, built))
                 {
                     uncompiled.push(c.function.clone());
+                    // File it as this crossing's fragment even though no row
+                    // built it, so every emitter has one lookup rather than a
+                    // fall-back for the one crossing kind the compiler skips.
+                    let (dir, key) = crossing;
+                    decls.compiled.borrow_mut().record(
+                        key.clone(),
+                        match dir {
+                            Direction::Input => prebindgen_registry::recipe::Assembly::Construct,
+                            Direction::Output => prebindgen_registry::recipe::Assembly::Deconstruct,
+                        },
+                        prebindgen_registry::recipe::RecipeId::new("callback"),
+                        crate::jni::compile::JFrag::by_hand(key.clone(), c.clone()),
+                    );
                 }
                 conv
             })?
             .build()?;
         // What the compilation produced, kept for emission. The converter table
         // stays the lookup index; this is what reaches the file.
-        decls.compiled_fns = compiled
-            .expect("the state is put back every call")
+        decls.compiled_fns = decls
+            .compiled
+            .borrow()
             .fragments()
             .into_iter()
             // A JNI conversion already emits more than one function: a
@@ -2448,7 +2459,7 @@ impl Declarations {
         // It has to be a type this binding already crosses; if it is not, the
         // ordinary "unresolved" diagnostic names it, which is the better error.
         let inner = registry.reading(&stripped)?;
-        let entry = registry.output_entry(&inner)?;
+        let entry = self.out_frag(&inner)?;
         let wire = entry.destination.clone();
         // Take the wrappers off what the caller handed us. `None` is `Cow`'s
         // policy refusal — the crossing then stays unresolved and names the
@@ -2457,7 +2468,7 @@ impl Declarations {
         let read = read_through_erased_wrappers(reading, quote!(v))?;
         // The inner's COMPLETE chain, stages included: a `convert!` type reaches
         // its wire through them.
-        let inner_call = crate::jni::emit::composed_inner_output(entry, quote!(__inner));
+        let inner_call = crate::jni::emit::composed_inner_output(&entry, quote!(__inner));
         let body: syn::Expr = syn::parse_quote!({
             let __inner = #read;
             #inner_call
@@ -2523,7 +2534,7 @@ impl Declarations {
         // It has to be a type this binding already crosses; if it is not, the
         // ordinary "unresolved" diagnostic names it, which is the better error.
         let inner = registry.reading(&stripped)?;
-        let entry = registry.input_entry(&inner)?;
+        let entry = self.in_frag(&inner)?;
         let wire = entry.destination.clone();
         // Wrap what the inner converter produced. `None` here is `Cow`'s policy
         // refusal — the crossing then stays unresolved and names the type,
@@ -2535,7 +2546,7 @@ impl Declarations {
         // stages (`jlong -> u64 -> Duration`), so a `Box` over one arrived
         // un-staged. Every other composing arm goes through this helper for
         // exactly that reason (#309).
-        let inner_call = crate::jni::emit::composed_inner_input(entry, quote!(v));
+        let inner_call = crate::jni::emit::composed_inner_input(&entry, quote!(v));
         let body: syn::Expr = syn::parse_quote!({
             let __inner = #inner_call;
             #built
@@ -2572,9 +2583,9 @@ impl Declarations {
         // Disjoint shapes (see [`WrapperShape`]), tried in priority order. The
         // borrow/option-ref/vec shapes are mutually exclusive; the two
         // `Optional` sub-cases share a method.
-        self.input_borrow(shape, produced, t1, registry)
-            .or_else(|| self.input_option_ref(shape, produced, t1, registry, emit))
-            .or_else(|| self.input_vec(shape, produced, t1, registry, emit))
+        self.input_borrow(shape, produced, t1)
+            .or_else(|| self.input_option_ref(shape, produced, t1, emit))
+            .or_else(|| self.input_vec(shape, produced, t1, emit))
             .or_else(|| self.input_option(shape, produced, t1, registry, emit))
     }
 
@@ -2825,8 +2836,8 @@ impl Declarations {
                 let v: #canonical = #read;
                 #inner_body
             });
-            let inherited = registry
-                .output_entry(t1)
+            let inherited = self
+                .out_frag(t1)
                 .and_then(|e| e.metadata.kotlin_name.clone());
             let kotlin_name = self.override_kotlin_name(&outer_ty, inherited);
             // Fold a Nullable layer over the inner projection (if any). The
@@ -2835,8 +2846,8 @@ impl Declarations {
             // and treats the slot value as `None`; boxed widens to `JObject`
             // and uses JVM null.
             let nullable_kind = nullable_kind_for_output(&wire, t1, registry);
-            let projection = registry
-                .output_entry(t1)
+            let projection = self
+                .out_frag(t1)
                 .and_then(|e| e.metadata.projection.clone())
                 .map(|h| Projection {
                     strategy: FoldStrategy::Optional(nullable_kind, Box::new(h.strategy)),
@@ -2868,7 +2879,7 @@ impl Declarations {
         // Symmetric to the input handler. `Vec<u8>` is special-cased at
         // rank-0 (primitive_output → JByteArray) so rank-1 never sees it.
         if shape == WrapperShape::Sequence {
-            let inner = registry.output_entry(t1)?;
+            let inner = self.out_frag(t1)?;
             // `Vec<opaque-handle>` output is delivered by the Kotlin-side leaf
             // fold (`apply_leaf_vec_folds` → typed-handle wrap), so this
             // whole-`ArrayList` converter is bypassed for it. A handle's `jlong`
@@ -2879,7 +2890,7 @@ impl Declarations {
                 return None;
             }
             // The element's COMPLETE Rust -> wire chain (see the input peer).
-            let inner_conv = crate::jni::emit::composed_inner_output(inner, quote::quote!(__elem));
+            let inner_conv = crate::jni::emit::composed_inner_output(&inner, quote::quote!(__elem));
             let outer_ty = produced.key();
             let canonical: syn::Type = syn::parse_quote!(Vec<#t1_ty>);
             let read = read_as_canonical(produced)?;
@@ -2946,10 +2957,9 @@ impl Declarations {
     pub(crate) fn output_slice(
         &self,
         elem: &prebindgen_registry::flat::TypeRef,
-        registry: &impl Conversions<KotlinMeta>,
         emit: &prebindgen_registry::Emit,
     ) -> Option<ConverterImpl<KotlinMeta>> {
-        let inner = registry.output_entry(elem)?;
+        let inner = self.out_frag(elem)?;
         let elem_key = elem.key();
         // The element as the source spelled it — the slice type this converter
         // yields is re-emitted, never re-derived.
@@ -2963,7 +2973,7 @@ impl Declarations {
         }
         // The element's COMPLETE Rust -> wire chain (see the `Vec<_>` peer).
         let inner_conv = crate::jni::emit::composed_inner_output(
-            inner,
+            &inner,
             quote::quote!(::core::clone::Clone::clone(__elem)),
         );
         let outer_ty: syn::Type = syn::parse_quote!(&[#elem]);

--- a/prebindgen-jni/src/jni/trait_impl.rs
+++ b/prebindgen-jni/src/jni/trait_impl.rs
@@ -1532,25 +1532,29 @@ impl JniGenBuilder {
         // conversion and the walk never reaches it. Nothing reads the result
         // yet; compiling it is what holds the composition to every binding this
         // crate builds rather than to one fixture.
-        for key in decls.declared_sums() {
+        for key in decls.declared_decompositions() {
             let Some(ident) = key.ident() else { continue };
             let Ok(ty) = model.classify(&syn::parse_quote!(#ident)) else {
                 continue;
             };
-            // Only a sum every payload of which already crosses. One that does
+            // Only a type every part of which already crosses. One that does
             // not is a gap in the binding, and the writers report it against
-            // the payload — `Reading.Exact.v0 has no OUTPUT converter` — where
+            // the part — `Reading.Exact.v0 has no OUTPUT converter` — where
             // this could only say that composing failed.
-            let Some(prebindgen_registry::flat::Type::Variant(sum)) = model.declared_type(&ident)
-            else {
-                continue;
-            };
-            if sum
-                .alternatives
-                .iter()
-                .flat_map(|alt| &alt.fields)
-                .any(|f| decls.out_frag(&f.ty).is_none())
+            let parts: Vec<&prebindgen_registry::flat::TypeRef> = match model.declared_type(&ident)
             {
+                Some(prebindgen_registry::flat::Type::Variant(sum)) => sum
+                    .alternatives
+                    .iter()
+                    .flat_map(|alt| &alt.fields)
+                    .map(|f| &f.ty)
+                    .collect(),
+                Some(prebindgen_registry::flat::Type::Struct(s)) => {
+                    s.fields.iter().map(|f| &f.ty).collect()
+                }
+                _ => continue,
+            };
+            if parts.iter().any(|ty| decls.out_frag(ty).is_none()) {
                 continue;
             }
             let crossing = prebindgen_registry::recipe::Crossing::new(
@@ -1569,7 +1573,7 @@ impl JniGenBuilder {
             };
             if let Err(e) = compiler.row_of(&mut adapter, &crossing, &crate::jni::rows::parts()) {
                 refusals.push(format!(
-                    "`{key}` hands out its alternatives, but composing them failed: {e:?}"
+                    "`{key}` hands out its parts, but composing them failed: {e:?}"
                 ));
             }
             let done = compiler.finish();
@@ -3251,15 +3255,16 @@ impl Declarations {
             .map(|(k, c)| (k.clone(), c.rust_type.clone()))
             .collect()
     }
-    /// Every type declared `sealed_class!`, in a stable order.
+    /// Every type that states what it hands out — `sealed_class!` and
+    /// `data_class!` — in a stable order.
     ///
     /// Sorted, because what reads it drives compilation and a refusal has to
     /// name the same type run to run.
-    pub(crate) fn declared_sums(&self) -> Vec<TypeKey> {
+    pub(crate) fn declared_decompositions(&self) -> Vec<TypeKey> {
         let mut keys: Vec<TypeKey> = self
             .types
             .iter()
-            .filter(|(_, c)| matches!(c.kind, DeclaredKind::Sealed(_)))
+            .filter(|(_, c)| matches!(c.kind, DeclaredKind::Sealed(_) | DeclaredKind::Data))
             .map(|(k, _)| k.clone())
             .collect();
         keys.sort_by(|a, b| a.as_str().cmp(b.as_str()));

--- a/prebindgen-jni/src/jni/trait_impl.rs
+++ b/prebindgen-jni/src/jni/trait_impl.rs
@@ -1587,9 +1587,14 @@ impl Declarations {
         // crate builds rather than to one fixture. Nothing reads the result
         // yet: `whole` is still the row every site takes, so a failure here is
         // a failure to compose parts that already cross individually.
+        // The **stripped** key, so `Box<Payload>` and `&Payload` compile the
+        // row too: all three spellings find one row and each gets its own
+        // fragment, which is what a site taking a wrapped spelling reads.
         if assembly == prebindgen_registry::recipe::Assembly::Construct
             && matches!(
-                self.types.get(&crossing.value().key()).map(|c| &c.kind),
+                self.types
+                    .get(&crossing.value().stripped_key())
+                    .map(|c| &c.kind),
                 Some(DeclaredKind::Data)
             )
         {

--- a/prebindgen-jni/src/jni/trait_impl.rs
+++ b/prebindgen-jni/src/jni/trait_impl.rs
@@ -1414,7 +1414,7 @@ impl JniGenBuilder {
         // A second holding of the model: `convert_with` consumes the builder,
         // and the table outlives that call.
         let model = declared.flat().clone();
-        let recipes = decls.recipes(&model).map_err(|errors| {
+        let recipes = decls.recipes(&model, &declared).map_err(|errors| {
             prebindgen_registry::ScanError::AdapterInvariant {
                 message: errors
                     .iter()
@@ -1553,6 +1553,10 @@ impl JniGenBuilder {
                     Some(prebindgen_registry::flat::Type::Struct(s)) => {
                         s.fields.iter().map(|f| &f.ty).collect()
                     }
+                    // A value form's parts belong to the struct its accessor
+                    // returns, not to this type — so there is nothing to
+                    // pre-check here, and the compiler's own deferral answers.
+                    _ if decls.value_form_names(&registry, &ty).is_some() => Vec::new(),
                     _ => continue,
                 };
             if part_types.iter().any(|ty| decls.out_frag(ty).is_none()) {
@@ -3267,8 +3271,13 @@ impl Declarations {
             .iter()
             .filter(|(_, c)| matches!(c.kind, DeclaredKind::Sealed(_) | DeclaredKind::Data))
             .map(|(k, _)| k.clone())
+            // And every type whose value form says what it hands out, whatever
+            // kind of class it is — `expand_return!` is declared over a
+            // `ptr_class` as readily as over anything else.
+            .chain(self.return_expand_decls.iter().map(|d| d.key().clone()))
             .collect();
         keys.sort_by(|a, b| a.as_str().cmp(b.as_str()));
+        keys.dedup();
         keys
     }
 

--- a/prebindgen-jni/src/jni/trait_impl.rs
+++ b/prebindgen-jni/src/jni/trait_impl.rs
@@ -1425,15 +1425,15 @@ impl JniGenBuilder {
         })?;
         // A `data_class` field that is itself one takes the `parts` row rather
         // than its own default — see `Declarations::bindings`.
-        let bindings = decls.bindings(&model, &recipes).map_err(|errors| {
-            prebindgen_registry::ScanError::AdapterInvariant {
+        let bindings = decls
+            .bindings(&model, &declared, &recipes)
+            .map_err(|errors| prebindgen_registry::ScanError::AdapterInvariant {
                 message: errors
                     .iter()
                     .map(|e| e.to_string())
                     .collect::<Vec<_>>()
                     .join("; "),
-            }
-        })?;
+            })?;
         // Both tables go on `decls`, because compiling a **site** happens after
         // this function has returned: the sites are `fn_plan`'s to enumerate,
         // and `Compiler::resume` needs these two beside the model.

--- a/prebindgen-jni/src/jni/trait_impl.rs
+++ b/prebindgen-jni/src/jni/trait_impl.rs
@@ -1793,8 +1793,7 @@ impl Declarations {
             if !is_data_class {
                 continue;
             }
-            if let Some(leaves) =
-                crate::jni::synth_value_struct_leaves(self, registry, item_struct, &[], "", 0)
+            if let Some(leaves) = crate::jni::synth_value_struct_leaves(self, registry, item_struct)
             {
                 if !leaves.is_empty() {
                     out.push(prebindgen_registry::unfold::ValueDecon {

--- a/prebindgen-jni/src/jni/trait_impl.rs
+++ b/prebindgen-jni/src/jni/trait_impl.rs
@@ -1519,6 +1519,68 @@ impl JniGenBuilder {
         decls
             .validate_resolved(&registry)
             .map_err(|message| prebindgen_registry::ScanError::AdapterInvariant { message })?;
+        // A `sealed_class`'s deconstructing composition, last of all.
+        //
+        // After `validate_resolved`, so a binding whose payload simply has no
+        // output conversion gets the diagnostic that names the payload rather
+        // than this one, which can only say that composing failed. What is left
+        // for this to catch is a composition that fails over parts which did
+        // resolve — a bug here rather than a gap in the binding.
+        // Driven here rather than from `compile_crossing`
+        // because a sum has **no** deconstructing crossing to be driven from: it
+        // is boundary-only, so nothing ever asks for its whole-value output
+        // conversion and the walk never reaches it. Nothing reads the result
+        // yet; compiling it is what holds the composition to every binding this
+        // crate builds rather than to one fixture.
+        for key in decls.declared_sums() {
+            let Some(ident) = key.ident() else { continue };
+            let Ok(ty) = model.classify(&syn::parse_quote!(#ident)) else {
+                continue;
+            };
+            // Only a sum every payload of which already crosses. One that does
+            // not is a gap in the binding, and the writers report it against
+            // the payload — `Reading.Exact.v0 has no OUTPUT converter` — where
+            // this could only say that composing failed.
+            let Some(prebindgen_registry::flat::Type::Variant(sum)) = model.declared_type(&ident)
+            else {
+                continue;
+            };
+            if sum
+                .alternatives
+                .iter()
+                .flat_map(|alt| &alt.fields)
+                .any(|f| decls.out_frag(&f.ty).is_none())
+            {
+                continue;
+            }
+            let crossing = prebindgen_registry::recipe::Crossing::new(
+                ty,
+                prebindgen_registry::recipe::Assembly::Deconstruct,
+            );
+            let mut compiler = prebindgen_registry::recipe::Compiler::resume(
+                &model,
+                &recipes,
+                &bindings,
+                decls.compiled.borrow().clone(),
+            );
+            let mut adapter = crate::jni::compile::JCompile {
+                decls: &decls,
+                registry: &registry,
+            };
+            if let Err(e) = compiler.row_of(&mut adapter, &crossing, &crate::jni::rows::parts()) {
+                refusals.push(format!(
+                    "`{key}` hands out its alternatives, but composing them failed: {e:?}"
+                ));
+            }
+            let done = compiler.finish();
+            *decls.compiled.borrow_mut() = done;
+        }
+        if !refusals.is_empty() {
+            return Err(prebindgen_registry::ScanError::AdapterInvariant {
+                message: refusals.join("; "),
+            }
+            .into());
+        }
         Ok(JniGen { decls, registry })
     }
 }
@@ -3189,6 +3251,21 @@ impl Declarations {
             .map(|(k, c)| (k.clone(), c.rust_type.clone()))
             .collect()
     }
+    /// Every type declared `sealed_class!`, in a stable order.
+    ///
+    /// Sorted, because what reads it drives compilation and a refusal has to
+    /// name the same type run to run.
+    pub(crate) fn declared_sums(&self) -> Vec<TypeKey> {
+        let mut keys: Vec<TypeKey> = self
+            .types
+            .iter()
+            .filter(|(_, c)| matches!(c.kind, DeclaredKind::Sealed(_)))
+            .map(|(k, _)| k.clone())
+            .collect();
+        keys.sort_by(|a, b| a.as_str().cmp(b.as_str()));
+        keys
+    }
+
     /// Types acknowledged-but-undeclared via [`JniGenBuilder::ignore`].
     pub(crate) fn ignored_types(&self) -> std::collections::HashSet<TypeKey> {
         self.ignored_class_types.clone()

--- a/prebindgen-jni/src/jni/trait_impl.rs
+++ b/prebindgen-jni/src/jni/trait_impl.rs
@@ -1570,6 +1570,17 @@ impl JniGenBuilder {
                 ty,
                 prebindgen_registry::recipe::Assembly::Deconstruct,
             );
+            // A type with nothing to hand out states no `parts` row — an empty
+            // struct, or an enum with no alternatives. Asking for one by name
+            // is refused now rather than answered with the default, so the
+            // condition that declared it is the condition asked here.
+            if decls
+                .recipe_table()
+                .get(&crossing.key(), &crate::jni::rows::parts())
+                .is_none()
+            {
+                continue;
+            }
             let mut compiler = prebindgen_registry::recipe::Compiler::resume(
                 &model,
                 decls.recipe_table(),
@@ -1669,6 +1680,11 @@ impl Declarations {
         // The **stripped** key, so `Box<Payload>` and `&Payload` compile the
         // row too: all three spellings find one row and each gets its own
         // fragment, which is what a site taking a wrapped spelling reads.
+        // A `data_class` with no fields states no `parts` row — there is
+        // nothing for it to be made of — so the row is asked for by name only
+        // where it was declared. `row_of` refuses an absent name rather than
+        // answering with the default, which is what makes that condition the
+        // one that has to match.
         if assembly == prebindgen_registry::recipe::Assembly::Construct
             && matches!(
                 self.types
@@ -1676,6 +1692,10 @@ impl Declarations {
                     .map(|c| &c.kind),
                 Some(DeclaredKind::Data)
             )
+            && compiler
+                .recipes()
+                .get(&crossing.key(), &crate::jni::rows::parts())
+                .is_some()
         {
             // A refusal is a bug in the composition, not a gap in the binding:
             // every part of a `data_class` is a crossing that already resolved

--- a/prebindgen-jni/src/test_util.rs
+++ b/prebindgen-jni/src/test_util.rs
@@ -15,9 +15,7 @@ use prebindgen_registry::{Registry, RegistryBuilder};
 ///
 /// Test-only sugar: the two steps are one line each in a build script, but they
 /// appear in dozens of fixtures here.
-pub(crate) fn reg_from_items<M, I>(
-    items: I,
-) -> Result<RegistryBuilder<M>, prebindgen_registry::ScanError>
+pub(crate) fn reg_from_items<I>(items: I) -> Result<RegistryBuilder, prebindgen_registry::ScanError>
 where
     I: IntoIterator<Item = (syn::Item, prebindgen::SourceLocation)>,
 {

--- a/prebindgen-registry/src/expand.rs
+++ b/prebindgen-registry/src/expand.rs
@@ -171,8 +171,8 @@ fn validate_declarations(exp: &Expansions) -> Result<(), ExpandError> {
 ///
 /// Runs inside the builder's scan, before any conversion is built, so
 /// leaf converters resolve through the normal rank machinery.
-pub(crate) fn apply<M>(
-    registry: &mut Registry<M>,
+pub(crate) fn apply(
+    registry: &mut Registry,
     exp: &Expansions,
     declared_fns: &std::collections::HashSet<syn::Ident>,
     accessor_fns: &std::collections::HashSet<syn::Ident>,
@@ -272,8 +272,8 @@ pub(crate) fn apply<M>(
 /// `spell()` and digging the parameter out of `sig.inputs` — what these
 /// three sites used to do — re-derives a fact the model was already handing over,
 /// which is `origin` used for reasoning rather than for emission.
-fn param_reading<M>(
-    registry: &Registry<M>,
+fn param_reading(
+    registry: &Registry,
     func: &syn::Ident,
     param: &syn::Ident,
 ) -> Result<prebindgen_flat::flat::TypeRef, ExpandError> {
@@ -289,8 +289,8 @@ fn param_reading<M>(
 }
 
 /// Build + store the fold plan for one `.construct` declaration.
-fn process_expand<M>(
-    registry: &mut Registry<M>,
+fn process_expand(
+    registry: &mut Registry,
     exp: &Expansions,
     ed: &ExpandDecl,
 ) -> Result<(), ExpandError> {
@@ -326,9 +326,9 @@ fn process_expand<M>(
 /// Pick the constructor (its variants) for one `.expand`/`.expand_with`
 /// declaration. A constructor is keyed by its declared `target`; `TopLevel`
 /// requires it to be unique for the parameter's target type.
-fn resolve_constructor<M>(
+fn resolve_constructor(
     exp: &Expansions,
-    _registry: &Registry<M>,
+    _registry: &Registry,
     target_key: &TypeKey,
     ed: &ExpandDecl,
 ) -> Result<Vec<Variant>, ExpandError> {
@@ -359,8 +359,8 @@ fn resolve_constructor<M>(
 /// supposed to build, so the check cannot be the thing a new declarator forgets
 /// (#223). The comparison is [`check_declared_target`], shared with the output
 /// side's accessor lookup.
-fn ctor_signature<M>(
-    registry: &Registry<M>,
+fn ctor_signature(
+    registry: &Registry,
     func: &syn::Ident,
     expected: &TypeKey,
 ) -> Result<CtorSig, ExpandError> {
@@ -399,9 +399,9 @@ struct CtorSig {
 /// selector-dispatched — so a "single" constructor and a 1-variant combined emit
 /// identical code.
 #[allow(clippy::too_many_arguments)]
-fn build_plan<M>(
+fn build_plan(
     exp: &Expansions,
-    registry: &Registry<M>,
+    registry: &Registry,
     ed: &ExpandDecl,
     optional: bool,
     by_ref: bool,
@@ -549,9 +549,9 @@ fn build_plan<M>(
 /// [`FoldArg::Build`] (recursive input). Used by both the top-level [`build_plan`]
 /// and each nested build. `prefix` disambiguates leaf names across the tree.
 #[allow(clippy::too_many_arguments)]
-fn build_core<M>(
+fn build_core(
     exp: &Expansions,
-    registry: &Registry<M>,
+    registry: &Registry,
     ed: &ExpandDecl,
     target: &prebindgen_flat::flat::TypeRef,
     variants: &[Variant],
@@ -647,9 +647,9 @@ fn build_core<M>(
 /// its own default constructor, recurse into a nested [`FoldArg::Build`]
 /// (recursive input); otherwise it is a flat wire [`FoldArg::Leaf`].
 #[allow(clippy::too_many_arguments)]
-fn build_arg<M>(
+fn build_arg(
     exp: &Expansions,
-    registry: &Registry<M>,
+    registry: &Registry,
     ed: &ExpandDecl,
     pty: &prebindgen_flat::flat::TypeRef,
     name: syn::Ident,

--- a/prebindgen-registry/src/expand/tests.rs
+++ b/prebindgen-registry/src/expand/tests.rs
@@ -26,7 +26,7 @@ fn src_qualify(id: &syn::Ident) -> syn::Path {
 
 #[test]
 fn single_constructor_plan_and_fold() {
-    let mut reg: Registry<()> = reg_with(&[
+    let mut reg: Registry = reg_with(&[
         "fn z_keyexpr_try_from(s: String) -> Result<ZKeyExpr, Error> { todo!() }",
         "fn z_keyexpr_intersects(a: &ZKeyExpr, b: &ZKeyExpr) -> bool { todo!() }",
     ]);
@@ -68,7 +68,7 @@ fn single_constructor_plan_and_fold() {
 
 #[test]
 fn constructor_plan_and_fold() {
-    let mut reg: Registry<()> = reg_with(&[
+    let mut reg: Registry = reg_with(&[
         "fn z_keyexpr_try_from(s: String) -> Result<ZKeyExpr, Error> { todo!() }",
         "fn z_keyexpr_intersects(a: &ZKeyExpr, b: &ZKeyExpr) -> bool { todo!() }",
     ]);
@@ -131,7 +131,7 @@ fn constructor_plan_and_fold() {
 #[test]
 fn optional_byvalue_single_ctor() {
     // `attachment: Option<ZZBytes>` with single `z_zbytes_from_vec(Vec<u8>)`.
-    let mut reg: Registry<()> = reg_with(&[
+    let mut reg: Registry = reg_with(&[
         "fn z_zbytes_from_vec(bytes: Vec<u8>) -> ZZBytes { todo!() }",
         "fn z_session_delete(s: &ZSession, attachment: Option<ZZBytes>) -> bool { todo!() }",
     ]);
@@ -184,7 +184,7 @@ fn optional_byvalue_single_ctor() {
 fn optional_byref_single_ctor() {
     // `encoding: Option<&ZEncoding>` with single, infallible
     // `z_encoding_from_string(String) -> ZEncoding`.
-    let mut reg: Registry<()> = reg_with(&[
+    let mut reg: Registry = reg_with(&[
         "fn z_encoding_from_string(s: String) -> ZEncoding { todo!() }",
         "fn z_session_put(s: &ZSession, encoding: Option<&ZEncoding>) -> bool { todo!() }",
     ]);
@@ -227,7 +227,7 @@ fn optional_byref_multi_arg_ctor() {
     // `encoding: Option<&ZEncoding>` built from a TWO-arg, infallible
     // `z_encoding_from_id(i32, Option<String>) -> ZEncoding`: an explicit
     // `present: bool` flag + two plain (non-`Option`-wrapped) arg leaves.
-    let mut reg: Registry<()> = reg_with(&[
+    let mut reg: Registry = reg_with(&[
         "fn z_encoding_from_id(id: i32, schema: Option<String>) -> ZEncoding { todo!() }",
         "fn z_session_put(s: &ZSession, encoding: Option<&ZEncoding>) -> bool { todo!() }",
     ]);
@@ -296,7 +296,7 @@ fn optional_combined_selector_encodes_absence() {
     // absence (`-1` = `None`). The ctor's own `Option<String>` arg is a
     // PASSTHROUGH leaf (kept as `Option<String>`, not double-wrapped —
     // `None` is a legitimate value for the taken arm).
-    let mut reg: Registry<()> = reg_with(&[
+    let mut reg: Registry = reg_with(&[
         "fn z_encoding_from_id(id: i32, schema: Option<String>) -> ZEncoding { todo!() }",
         "fn z_session_put(s: &ZSession, encoding: Option<&ZEncoding>) -> bool { todo!() }",
     ]);
@@ -420,7 +420,7 @@ fn iterable_emit_shape() {
 fn default_constructor_auto_applies_and_skips() {
     // A `.default()` ZKeyExpr constructor auto-`construct`s every matching
     // param of every declared fn — except where `.skip_default_construct`'d.
-    let mut reg: Registry<()> = reg_with(&[
+    let mut reg: Registry = reg_with(&[
         "fn z_keyexpr_try_from(s: String) -> Result<ZKeyExpr, Error> { todo!() }",
         "fn z_keyexpr_intersects(a: &ZKeyExpr, b: &ZKeyExpr) -> bool { todo!() }",
         "fn z_session_undeclare(s: &ZSession, k: ZKeyExpr) -> bool { todo!() }",
@@ -464,7 +464,7 @@ fn default_constructor_auto_applies_and_skips() {
 
 #[test]
 fn default_constructor_skips_accessor_and_explicit_construct_errors() {
-    let mut reg: Registry<()> = reg_with(&[
+    let mut reg: Registry = reg_with(&[
         "fn z_keyexpr_try_from(s: String) -> Result<ZKeyExpr, Error> { todo!() }",
         "fn z_keyexpr_intersects(a: &ZKeyExpr, b: &ZKeyExpr) -> bool { todo!() }",
         "fn z_keyexpr_clone(ke: &ZKeyExpr) -> ZKeyExpr { todo!() }",
@@ -493,7 +493,7 @@ fn default_constructor_skips_accessor_and_explicit_construct_errors() {
         .contains_key(&(ident("z_keyexpr_clone"), ident("ke"))));
 
     // An explicit per-fn input flatten on an accessor is a build error.
-    let mut reg2: Registry<()> = reg_with(&[
+    let mut reg2: Registry = reg_with(&[
         "fn z_keyexpr_try_from(s: String) -> Result<ZKeyExpr, Error> { todo!() }",
         "fn z_keyexpr_clone(ke: &ZKeyExpr) -> ZKeyExpr { todo!() }",
     ]);
@@ -514,7 +514,7 @@ fn recursive_input_nests_param_constructors() {
     // by z_reply_sample(sample: ZSample). ZSample's default input expands
     // the `sample` param into z_sample_new's params, each of which (ZKeyExpr,
     // ZZBytes) recursively expands per ITS default input.
-    let mut reg: Registry<()> = reg_with(&[
+    let mut reg: Registry = reg_with(&[
         "fn z_sample_new(key_expr: ZKeyExpr, payload: ZZBytes) -> ZSample { todo!() }",
         "fn z_keyexpr_try_from(s: String) -> ZKeyExpr { todo!() }",
         "fn z_zbytes_from_vec(b: Vec<u8>) -> ZZBytes { todo!() }",
@@ -604,7 +604,7 @@ fn recursive_input_nests_param_constructors() {
 #[test]
 fn recursive_input_cycle_errors() {
     // A → B → A constructor cycle is a build error (not an infinite expansion).
-    let mut reg: Registry<()> = reg_with(&[
+    let mut reg: Registry = reg_with(&[
         "fn make_a(b: B) -> A { todo!() }",
         "fn make_b(a: A) -> B { todo!() }",
         "fn consume_a(a: A) -> bool { todo!() }",
@@ -642,7 +642,7 @@ fn recursive_input_cycle_errors() {
 #[test]
 fn unknown_constructor_errors() {
     use prebindgen_flat::types_util::ident;
-    let mut reg: Registry<()> =
+    let mut reg: Registry =
         reg_with(&["fn z_keyexpr_intersects(a: &ZKeyExpr, b: &ZKeyExpr) -> bool { todo!() }"]);
     let mut exp = Expansions::default();
     exp.expands.push(ExpandDecl {
@@ -671,7 +671,7 @@ fn unknown_constructor_errors() {
 #[test]
 fn constructor_target_mismatch_errors() {
     use prebindgen_flat::types_util::ident;
-    let mut reg: Registry<()> = reg_with(&[
+    let mut reg: Registry = reg_with(&[
         "fn z_sample_new(s: String) -> ZSample { todo!() }",
         "fn z_keyexpr_intersects(a: &ZKeyExpr, b: &ZKeyExpr) -> bool { todo!() }",
     ]);
@@ -699,7 +699,7 @@ fn constructor_target_mismatch_errors() {
 #[test]
 fn invalid_declarations_collected() {
     use prebindgen_flat::types_util::ident;
-    let mut reg: Registry<()> = reg_with(&[
+    let mut reg: Registry = reg_with(&[
         "fn z_keyexpr_try_from(s: String) -> Result<ZKeyExpr, Error> { todo!() }",
         "fn z_session_get(s: &ZSession, k: &ZKeyExpr) -> bool { todo!() }",
     ]);
@@ -776,7 +776,7 @@ fn invalid_declarations_collected() {
 /// parameter whose element is constructible. That is what this fixture is.
 #[test]
 fn a_vec_param_does_not_match_its_elements_constructor() {
-    let mut reg: Registry<()> = reg_with(&[
+    let mut reg: Registry = reg_with(&[
         "fn z_keyexpr_try_from(s: String) -> Result<ZKeyExpr, Error> { todo!() }",
         "fn z_keyexpr_join_all(parts: Vec<ZKeyExpr>) -> bool { todo!() }",
     ]);

--- a/prebindgen-registry/src/lib.rs
+++ b/prebindgen-registry/src/lib.rs
@@ -51,10 +51,10 @@
 //!
 //! 1. [`flat::Flat::builder`] parses the declared sources into the model, and
 //!    [`Registry::builder`] starts describing a binding over it.
-//! 2. The generator states that binding, then [`RegistryBuilder::crossings`]
-//!    hands over every crossing needing a conversion — inner types first, so
-//!    each one can be built from those already done. `convert_with` answers
-//!    them and `build` names any gap.
+//! 2. The generator states that binding, then
+//!    [`RegistryBuilder::convert_with`] walks every crossing needing a
+//!    conversion — inner types first, so each one can be built from those
+//!    already done — and `build` names any gap.
 //! 3. The resolved registry becomes a field of the built generator, whose
 //!    `write_*` methods emit the artifacts — Rust wrappers, and whatever else
 //!    that language needs (a C header, Kotlin sources, …).

--- a/prebindgen-registry/src/lib.rs
+++ b/prebindgen-registry/src/lib.rs
@@ -25,12 +25,11 @@
 //!   `on_function` / `on_struct` / `on_enum` / `on_const` on the
 //!   [`Prebindgen`] trait.
 //!
-//! Everything language-specific that must travel through the pipeline rides in
-//! the back-end's chosen [`Metadata`](Prebindgen::Metadata) type (a JNI
-//! back-end's Kotlin class names and exception info, a C back-end's header
-//! names, …). It is set on each converter, propagated into the registry's
-//! [`TypeEntry`], and read back by the back-end's own emitter — no side
-//! channels. Back-ends needing no extras leave it at the default `()`.
+//! Everything language-specific that must travel through the pipeline rides on
+//! the adapter's own conversions — a JNI back-end's Kotlin class names and
+//! exception info in [`ConverterImpl::metadata`], a C back-end's header names.
+//! The registry does not carry it: an adapter keeps its own conversions, sets
+//! the extras where it builds them, and reads them back in its own emitter.
 //!
 //! # Flow
 //!
@@ -132,9 +131,9 @@ pub use self::{
     niches::{NicheSlot, Niches},
     prebindgen::{ConverterImpl, NamePredicate, Prebindgen, Stage},
     registry::{
-        Building, Conversions, Crossing, Decompositions, Direction, DuplicateNameError,
-        NotExpressibleEntry, Registry, RegistryBuilder, ScanError, TypeEntry, TypeKey,
-        TypeKeyParseError, WriteRustError,
+        Answer, Building, Conversions, Crossing, Decompositions, Direction, DuplicateNameError,
+        NotExpressibleEntry, Registry, RegistryBuilder, ScanError, TypeKey, TypeKeyParseError,
+        WriteRustError,
     },
 };
 

--- a/prebindgen-registry/src/prebindgen.rs
+++ b/prebindgen-registry/src/prebindgen.rs
@@ -40,14 +40,12 @@ pub struct Stage<M = ()> {
     /// [`ConverterImpl::function`] but typed for this stage's own `In →
     /// Out` and own error type.
     pub function: syn::ItemFn,
-    /// Adapter-specific extras for this stage — same [`Metadata`] type as
-    /// the owning converter ([`ConverterImpl::metadata`]). The core never
+    /// Adapter-specific extras for this stage — the same type as the owning
+    /// converter's ([`ConverterImpl::metadata`]). The core never
     /// inspects this; the adapter's emitter reads it to decide how the
     /// stage's `Err` arm is surfaced (e.g. a JNI adapter stores the JVM
     /// exception class and `throw_*` fn to call here; a C adapter might
     /// store the error-code sentinel). Defaults to `()`.
-    ///
-    /// [`Metadata`]: Prebindgen::Metadata
     pub metadata: M,
 }
 
@@ -93,32 +91,30 @@ pub struct ConverterImpl<M = ()> {
     /// Default is empty (no niche optimisation).
     pub niches: Niches,
     /// Adapter-specific extras carried alongside the converter. Filled by
-    /// the same handler that produces `destination` / `function` /
-    /// `niches`, copied through into `TypeEntry::metadata` by the resolver,
-    /// and read by the adapter's language-side emitters. Set this where you
-    /// build the converter, not in a side channel.
+    /// the same handler that produces `destination` / `function` / `niches`,
+    /// and read by the adapter's language-side emitters off the fragment this
+    /// conversion belongs to. Set this where you build the converter, not in a
+    /// side channel.
     pub metadata: M,
-    /// Inner types this converter composed from — the types whose
-    /// `input_entry`/`output_entry` the adapter looked up to build a wrapper
-    /// (`Option<X>` → `[X]`, `Result<T,E>` → `[T, E]`, `&T` → `[&T]`). Empty
-    /// for a terminal converter (scalar, opaque handle, string) and for
-    /// a callback's own converter (callback args are cross-direction — their
-    /// required-ness flows through the registry's type-graph edges, not here). The
-    /// resolver copies these into `TypeEntry::subs`, which `propagate_required`
-    /// walks to mark reachable types required.
+    /// Inner crossings this converter composed from — the ones the adapter
+    /// looked up to build a wrapper (`Option<X>` → `[X]`, `Result<T,E>` →
+    /// `[T, E]`, `&T` → `[&T]`). Empty for a terminal converter (scalar, opaque
+    /// handle, string) and for a callback's own converter (callback args are
+    /// cross-direction — their required-ness flows through the registry's
+    /// type-graph edges, not here).
+    ///
+    /// This is what an adapter reports back as an
+    /// [`Answer`](crate::Answer), and what `propagate_required` walks to mark
+    /// reachable crossings required.
     ///
     /// **Identities, not spellings.** They are looked up and walked, never
-    /// emitted — [`TypeEntry::subs`](crate::registry::TypeEntry::subs)
-    /// was already `Vec<TypeKey>` and the resolver keyed these on arrival, so
-    /// the spelling existed only to be converted. An adapter that composed the
-    /// inner type keys it (`TypeKey::from_type`); one that read it off the model
-    /// asks the reading (`TypeRef::key`), and names no escape to do it.
+    /// emitted. An adapter that composed the inner type keys it
+    /// (`TypeKey::from_type`); one that read it off the model asks the reading
+    /// (`TypeRef::key`), and names no escape to do it.
     pub subs: Vec<crate::registry::TypeKey>,
 }
 
-/// The same reads [`TypeEntry`](crate::TypeEntry) offers, on the conversion an
-/// adapter built. A `TypeEntry` is this type with its inners keyed, so an
-/// emitter reading a compiled fragment asks it the same questions.
+/// What an emitter asks of a conversion it holds.
 impl<M> ConverterImpl<M> {
     /// Identifier of the wire-facing converter function.
     pub fn converter_ident(&self) -> &syn::Ident {
@@ -163,11 +159,10 @@ impl<M> ConverterImpl<M> {
 /// trait entirely (prebindgen#251 phase E).
 ///
 /// Anything language-specific the rest of the pipeline must carry — a JNI
-/// adapter's Kotlin class names and exception info, a C adapter's header
-/// names, etc. — rides in [`Self::Metadata`], an opaque type the adapter
-/// chooses. It is set in each `ConverterImpl::metadata`, propagated by the
-/// resolver into `TypeEntry::metadata`, and read back by the adapter's own
-/// emitter. Adapters that need no extras leave it at the default `()`.
+/// adapter's Kotlin class names and exception info, a C adapter's header names,
+/// etc. — rides in [`ConverterImpl::metadata`], and is read back by the
+/// adapter's own emitter off the fragment that conversion belongs to. The
+/// registry neither stores it nor names its type.
 ///
 /// # The rule an adapter must obey
 ///
@@ -206,12 +201,6 @@ impl<M> ConverterImpl<M> {
 /// Reusing a mirror's spelling test in a converted position is how the rule
 /// gets broken (prebindgen#230, #292).
 pub trait Prebindgen {
-    /// Adapter-specific extras every resolved converter carries. The
-    /// resolver copies this from each `ConverterImpl` it accepts into
-    /// the matching `TypeEntry`, so emitter code reads metadata off
-    /// the registry rather than through a parallel side channel.
-    type Metadata: Clone + Default;
-
     /// Rust items the adapter's emitted converters depend on (helper
     /// structs, type aliases, runtime-support code). Emitted at the top
     /// of the destination file, before all auto-generated converters.
@@ -222,11 +211,7 @@ pub trait Prebindgen {
     /// (feature-aware) scan actually contains — e.g. emitting a
     /// per-opaque-handle item only for handles a scanned `#[prebindgen]`
     /// fn references.
-    fn prerequisites(
-        &self,
-        _registry: &Registry<Self::Metadata>,
-        _emit: &crate::Emit,
-    ) -> Vec<syn::Item> {
+    fn prerequisites(&self, _registry: &Registry, _emit: &crate::Emit) -> Vec<syn::Item> {
         Vec::new()
     }
 
@@ -241,13 +226,7 @@ pub trait Prebindgen {
     /// converter bodies compile in the binding crate's scope. Walks the
     /// entire AST, not just signatures, so type ascriptions and casts
     /// inside function bodies are covered.
-    fn post_process_item(
-        &self,
-        _item: &mut syn::Item,
-        _registry: &Registry<Self::Metadata>,
-        _emit: &crate::Emit,
-    ) {
-    }
+    fn post_process_item(&self, _item: &mut syn::Item, _registry: &Registry, _emit: &crate::Emit) {}
 
     /// Adapter-invariant checks that need registry **signatures** — the
     /// earliest they can run (decl objects are built before any source is
@@ -259,10 +238,7 @@ pub trait Prebindgen {
     /// receiver parameter of the class type.
     ///
     /// Default: no checks.
-    fn validate(
-        &self,
-        _binding: &crate::registry::Building<'_, Self::Metadata>,
-    ) -> Result<(), String> {
+    fn validate(&self, _binding: &crate::registry::Building<'_>) -> Result<(), String> {
         Ok(())
     }
 
@@ -276,7 +252,7 @@ pub trait Prebindgen {
     /// order-independent.
     ///
     /// Default: no checks.
-    fn validate_resolved(&self, _registry: &Registry<Self::Metadata>) -> Result<(), String> {
+    fn validate_resolved(&self, _registry: &Registry) -> Result<(), String> {
         Ok(())
     }
 
@@ -306,7 +282,7 @@ pub trait Prebindgen {
     fn on_function(
         &self,
         f: &prebindgen_flat::flat::Function,
-        registry: &Registry<Self::Metadata>,
+        registry: &Registry,
         emit: &crate::Emit,
     ) -> TokenStream;
 
@@ -315,7 +291,7 @@ pub trait Prebindgen {
     fn on_struct(
         &self,
         s: &prebindgen_flat::flat::Struct,
-        registry: &Registry<Self::Metadata>,
+        registry: &Registry,
         emit: &crate::Emit,
     ) -> TokenStream;
 
@@ -328,7 +304,7 @@ pub trait Prebindgen {
     fn on_variant(
         &self,
         v: &prebindgen_flat::flat::Variant,
-        registry: &Registry<Self::Metadata>,
+        registry: &Registry,
         emit: &crate::Emit,
     ) -> TokenStream;
 
@@ -336,7 +312,7 @@ pub trait Prebindgen {
     fn on_enum(
         &self,
         e: &prebindgen_flat::flat::Enum,
-        registry: &Registry<Self::Metadata>,
+        registry: &Registry,
         emit: &crate::Emit,
     ) -> TokenStream;
 
@@ -352,7 +328,7 @@ pub trait Prebindgen {
     fn on_const(
         &self,
         c: &prebindgen_flat::flat::Constant,
-        _registry: &Registry<Self::Metadata>,
+        _registry: &Registry,
         emit: &crate::Emit,
     ) -> TokenStream {
         match self.source_module() {

--- a/prebindgen-registry/src/prebindgen.rs
+++ b/prebindgen-registry/src/prebindgen.rs
@@ -5,10 +5,10 @@
 //! items they depend on (`prerequisites`), a cross-cutting rewrite
 //! (`post_process_item`) and two invariant checks.
 //!
-//! **Conversion is not here.** A generator builds those itself, against the
-//! demand `RegistryBuilder::crossings` hands it, and gives them back through
-//! `RegistryBuilder::convert_with` — so there is no `on_input_type`, no deferral, and no
-//! fixed-point loop retrying until it converges.
+//! **Conversion is not here.** A generator builds those itself, one per
+//! crossing, inside `RegistryBuilder::convert_with` — so there is no
+//! `on_input_type`, no deferral, and no fixed-point loop retrying until it
+//! converges.
 //!
 //! [`ConverterImpl::function`] is the **complete** Rust function for a
 //! converter — signature, body, attributes, lifetimes. The generator owns 100%
@@ -158,9 +158,8 @@ impl<M> ConverterImpl<M> {
 /// What used to be here and is not any more: which items to build, how
 /// composites decompose, and the wire form of each type. A generator states the
 /// first two into the builder (`RegistryBuilder::export`,
-/// `RegistryBuilder::decompose`)
-/// and answers the third by filling `RegistryBuilder::crossings` — so nothing in
-/// core calls back to ask. Moving emission out too is what would delete this
+/// `RegistryBuilder::decompose`) and answers the third inside
+/// `RegistryBuilder::convert_with` — so nothing in core calls back to ask. Moving emission out too is what would delete this
 /// trait entirely (prebindgen#251 phase E).
 ///
 /// Anything language-specific the rest of the pipeline must carry — a JNI

--- a/prebindgen-registry/src/prebindgen.rs
+++ b/prebindgen-registry/src/prebindgen.rs
@@ -116,6 +116,33 @@ pub struct ConverterImpl<M = ()> {
     pub subs: Vec<crate::registry::TypeKey>,
 }
 
+/// The same reads [`TypeEntry`](crate::TypeEntry) offers, on the conversion an
+/// adapter built. A `TypeEntry` is this type with its inners keyed, so an
+/// emitter reading a compiled fragment asks it the same questions.
+impl<M> ConverterImpl<M> {
+    /// Identifier of the wire-facing converter function.
+    pub fn converter_ident(&self) -> &syn::Ident {
+        &self.function.sig.ident
+    }
+
+    /// Wire type this conversion carries on success.
+    pub fn wire_type(&self) -> &syn::Type {
+        &self.destination
+    }
+
+    /// Rust-side stages in input execution order, after the wire-facing
+    /// converter has decoded the wire value.
+    pub fn input_stage_order(&self) -> impl Iterator<Item = (usize, &Stage<M>)> {
+        self.pre_stages.iter().enumerate().rev()
+    }
+
+    /// Rust-side stages in output execution order, before the wire-facing
+    /// converter encodes the final wire value.
+    pub fn output_stage_order(&self) -> impl Iterator<Item = (usize, &Stage<M>)> {
+        self.pre_stages.iter().enumerate()
+    }
+}
+
 /// The single extension point of the pipeline: implement this trait once per
 /// **destination language** (C/cbindgen, JNI/Kotlin, Swift, Python, …) to teach
 /// the language-agnostic [`Registry`] how that language represents Rust types

--- a/prebindgen-registry/src/recipe.rs
+++ b/prebindgen-registry/src/recipe.rs
@@ -1104,6 +1104,19 @@ pub enum RecipeError {
         /// The name the site asked for.
         recipe: RecipeId,
     },
+    /// A caller named a row the crossing does not have.
+    ///
+    /// Distinct from [`UnknownRow`](Self::UnknownRow), which is a **site**
+    /// asking for one. This is a caller compiling a named row directly through
+    /// [`Compiler::row_of`](crate::recipe::Compiler::row_of), where there is no
+    /// site to name — an adapter checking a row it declared conditionally, and
+    /// getting the condition wrong.
+    NoSuchRow {
+        /// The crossing that has no such row.
+        crossing: CrossingKey,
+        /// The name the caller asked for.
+        recipe: RecipeId,
+    },
     /// Two declarations of equal precedence bound one site to different rows.
     Rebound {
         /// The site both named.
@@ -1215,6 +1228,11 @@ impl fmt::Display for RecipeError {
             RecipeError::NotAProduct { row, recipe } => write!(
                 f,
                 "row `{recipe}` takes {row} apart, and the model gives that type no parts"
+            ),
+            RecipeError::NoSuchRow { crossing, recipe } => write!(
+                f,
+                "{crossing} has no row `{recipe}` — it was compiled by name, not \
+                 through a site"
             ),
             RecipeError::UnknownRow {
                 site,

--- a/prebindgen-registry/src/recipe.rs
+++ b/prebindgen-registry/src/recipe.rs
@@ -52,7 +52,7 @@ mod tests;
 pub use self::{
     compile::{
         At, Carrier, Compile, CompileError, Compiled, Compiler, Cx, Frag, Part, PartSource, Parts,
-        RequirementId, Validity, Yield,
+        Validity, Yield,
     },
     site::{Ask, Bindings, BindingsBuilder, Bound, Origin, Role, Site},
 };
@@ -124,12 +124,6 @@ pub enum Construct {
     ///
     /// Inside a [`Shape::Choice`] arm the fields are that alternative's.
     Fields,
-    /// The single part named here already is the value.
-    ///
-    /// Boxed because a `TypeRef` is many times the size of the identifier
-    /// [`Call`](Self::Call) carries, and a call is the common form. The same
-    /// trade-off the model makes for an array's extent.
-    Identity(Box<TypeRef>),
 }
 
 impl Operation for Construct {
@@ -767,7 +761,6 @@ impl<'a> Check<'a, '_> {
 
     fn construct(&mut self, ty: &TypeRef, op: &Construct) -> Vec<TypeRef> {
         match op {
-            Construct::Identity(inner) => vec![(**inner).clone()],
             Construct::Call(func) => match self.function(func) {
                 Some(f) => {
                     let parts = f.params.iter().map(|p| p.ty.clone()).collect();

--- a/prebindgen-registry/src/recipe/compile.rs
+++ b/prebindgen-registry/src/recipe/compile.rs
@@ -389,6 +389,18 @@ impl<F> Default for Compiled<F> {
     }
 }
 
+/// Cheap: a fragment sits behind an `Rc`, so a clone shares the fragments
+/// rather than copying them, and needs nothing of `F`.
+impl<F> Clone for Compiled<F> {
+    fn clone(&self) -> Self {
+        Self {
+            fragments: self.fragments.clone(),
+            defaults: self.defaults.clone(),
+            required: self.required.clone(),
+        }
+    }
+}
+
 impl<F> Compiled<F> {
     /// How many fragments have been built, which is what makes the
     /// per-crossing promise observable.
@@ -418,6 +430,22 @@ impl<F> Compiled<F> {
     pub fn fragment(&self, ty: &TypeKey, assembly: Assembly) -> Option<&F> {
         let row = self.defaults.get(&(ty.clone(), assembly))?;
         self.row_fragment(ty, assembly, row)
+    }
+
+    /// Record a fragment an adapter built **without** the compiler, as this
+    /// crossing's whole answer.
+    ///
+    /// The escape hatch for a crossing the adapter still answers by hand:
+    /// `Compiler::crossing` never saw it, so nothing would file it, and
+    /// [`Self::fragment`] would have no answer to give. Recording it keeps the
+    /// adapter's emitters on one lookup instead of a per-site fall-back to
+    /// whatever else knows.
+    pub fn record(&mut self, ty: TypeKey, assembly: Assembly, row: RecipeId, fragment: F) {
+        self.fragments.insert(
+            (ty.clone(), assembly, row.clone()),
+            std::rc::Rc::new(fragment),
+        );
+        self.defaults.insert((ty, assembly), row);
     }
 
     /// The fragment for one crossing and one named row.

--- a/prebindgen-registry/src/recipe/compile.rs
+++ b/prebindgen-registry/src/recipe/compile.rs
@@ -427,7 +427,12 @@ impl<F> Compiled<F> {
     /// row has the row and asks through [`Self::row_fragment`].
     ///
     /// `None` means no site ever crossed this type in this direction.
-    pub fn fragment(&self, ty: &TypeKey, assembly: Assembly) -> Option<&F> {
+    ///
+    /// Handed back as the `Rc` it is stored under: an adapter that reads its
+    /// store while compilation is still filling it cannot hold a borrow across
+    /// the next write, and a fragment holds a whole `syn::ItemFn` that a
+    /// recursive lookup should not be copying.
+    pub fn fragment(&self, ty: &TypeKey, assembly: Assembly) -> Option<Rc<F>> {
         let row = self.defaults.get(&(ty.clone(), assembly))?;
         self.row_fragment(ty, assembly, row)
     }
@@ -449,10 +454,10 @@ impl<F> Compiled<F> {
     }
 
     /// The fragment for one crossing and one named row.
-    pub fn row_fragment(&self, ty: &TypeKey, assembly: Assembly, row: &RecipeId) -> Option<&F> {
+    pub fn row_fragment(&self, ty: &TypeKey, assembly: Assembly, row: &RecipeId) -> Option<Rc<F>> {
         self.fragments
             .get(&(ty.clone(), assembly, row.clone()))
-            .map(|f| &**f)
+            .cloned()
     }
 
     /// Every fragment this compilation built, in a deterministic order.

--- a/prebindgen-registry/src/recipe/compile.rs
+++ b/prebindgen-registry/src/recipe/compile.rs
@@ -27,11 +27,7 @@
 //! one, and rebuilding a `Box` are three different pieces of Rust. Sharing the
 //! row is the declaration's business; sharing the code is not.
 
-use std::{
-    collections::{BTreeSet, HashMap},
-    fmt,
-    rc::Rc,
-};
+use std::{collections::HashMap, fmt, rc::Rc};
 
 use super::{
     Assembly, Bindings, Bound, Construct, Crossing, Deconstruct, Mode, Reach, RecipeError,
@@ -97,37 +93,16 @@ pub struct At<'a> {
     pub recipe: &'a RecipeId,
 }
 
-/// An adapter-minted name for a helper the generated prelude must carry.
+/// What every hook receives: a read-only view of the model and the table, and
+/// the capability to emit Rust.
 ///
-/// The registry only de-duplicates these; what one names is the adapter's.
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
-pub struct RequirementId(String);
-
-impl RequirementId {
-    /// Name one helper.
-    pub fn new(name: impl Into<String>) -> Self {
-        Self(name.into())
-    }
-
-    /// The name as written.
-    pub fn as_str(&self) -> &str {
-        &self.0
-    }
-}
-
-impl fmt::Display for RequirementId {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(&self.0)
-    }
-}
-
-/// What every hook receives: the read-only view of the model and the table,
-/// plus the one thing a hook may ask the registry to record.
+/// A hook asks the registry nothing and records nothing in it. What it produces
+/// is its fragment, and what the registry reads of that is
+/// [`Carrier::yields`].
 pub struct Cx<'a> {
     model: &'a Flat,
     recipes: &'a Recipes,
     emit: &'a Emit,
-    required: &'a mut BTreeSet<RequirementId>,
 }
 
 impl Cx<'_> {
@@ -156,11 +131,6 @@ impl Cx<'_> {
     /// row.
     pub fn rows(&self, crossing: &Crossing) -> Vec<&RecipeId> {
         self.recipes.rows(&crossing.key())
-    }
-
-    /// A helper the compiled fragment calls, so the generated prelude emits it.
-    pub fn require(&mut self, req: RequirementId) {
-        self.required.insert(req);
     }
 }
 
@@ -253,9 +223,6 @@ pub trait Compile {
         func: &Function,
         args: Parts<'_, Self>,
     ) -> Frag<Self>;
-
-    /// The single part is the value.
-    fn identity(&mut self, cx: &mut Cx<'_>, at: At<'_>, inner: &Self::Fragment) -> Frag<Self>;
 
     /// Read the parts off the value where it stands.
     fn fields(&mut self, cx: &mut Cx<'_>, at: At<'_>, parts: Parts<'_, Self>) -> Frag<Self>;
@@ -371,7 +338,6 @@ pub struct Compiled<F> {
     /// so [`Compiled::fragment`] can give back that same answer instead of
     /// choosing between the rows a crossing happens to have.
     defaults: HashMap<(TypeKey, Assembly), RecipeId>,
-    required: BTreeSet<RequirementId>,
 }
 
 /// What a fragment is memoised under: the type **as the site spelled it**, the
@@ -384,7 +350,6 @@ impl<F> Default for Compiled<F> {
         Self {
             fragments: HashMap::new(),
             defaults: HashMap::new(),
-            required: BTreeSet::new(),
         }
     }
 }
@@ -396,7 +361,6 @@ impl<F> Clone for Compiled<F> {
         Self {
             fragments: self.fragments.clone(),
             defaults: self.defaults.clone(),
-            required: self.required.clone(),
         }
     }
 }
@@ -411,11 +375,6 @@ impl<F> Compiled<F> {
     /// Whether nothing has been compiled yet.
     pub fn is_empty(&self) -> bool {
         self.fragments.is_empty()
-    }
-
-    /// Every helper a compiled fragment asked for, de-duplicated.
-    pub fn required(&self) -> impl Iterator<Item = &RequirementId> {
-        self.required.iter()
     }
 
     /// The fragment for one crossing, compiled **as a whole**.
@@ -512,11 +471,6 @@ impl<'a, C: Compile> Compiler<'a, C> {
         self.compiled
     }
 
-    /// Every helper a compiled fragment asked for, de-duplicated.
-    pub fn required(&self) -> impl Iterator<Item = &RequirementId> {
-        self.compiled.required.iter()
-    }
-
     /// How many fragments have been built, which is what makes the
     /// per-crossing promise observable.
     pub fn compiled_fragments(&self) -> usize {
@@ -551,7 +505,6 @@ impl<'a, C: Compile> Compiler<'a, C> {
             model: self.model,
             recipes: self.recipes,
             emit: &self.emit,
-            required: &mut self.compiled.required,
         };
         adapter
             .plan(&mut cx, &bound, &root)
@@ -862,14 +815,9 @@ impl<'a, C: Compile> Compiler<'a, C> {
             model: self.model,
             recipes: self.recipes,
             emit: &self.emit,
-            required: &mut self.compiled.required,
         };
         match kind {
             ProductKind::Construct(func) => adapter.construct(&mut cx, at, func, &paired),
-            ProductKind::Identity => {
-                let (_, inner) = &paired[0];
-                adapter.identity(&mut cx, at, inner)
-            }
             ProductKind::Fields => adapter.fields(&mut cx, at, &paired),
             ProductKind::ValueForm(func) => adapter.value_form(&mut cx, at, func, &paired),
         }
@@ -887,7 +835,6 @@ impl<'a, C: Compile> Compiler<'a, C> {
             model: self.model,
             recipes: self.recipes,
             emit: &self.emit,
-            required: &mut self.compiled.required,
         };
         adapter
             .choice(&mut cx, at, &paired)
@@ -901,7 +848,6 @@ impl<'a, C: Compile> Compiler<'a, C> {
             model: self.model,
             recipes: self.recipes,
             emit: &self.emit,
-            required: &mut self.compiled.required,
         }
     }
 
@@ -929,15 +875,6 @@ impl<'a, C: Compile> Compiler<'a, C> {
                     .collect();
                 Ok((ProductKind::Fields, parts))
             }
-            Construct::Identity(inner) => Ok((
-                ProductKind::Identity,
-                vec![Part {
-                    from: PartSource::Argument { index: 0 },
-                    mode: mode_of(inner),
-                    ty: (**inner).clone(),
-                    name: "value".to_owned(),
-                }],
-            )),
             Construct::Call(name) => {
                 let func = self.function(at, name)?;
                 let parts = func
@@ -1095,7 +1032,6 @@ fn field_name(field: &Field, index: usize) -> String {
 /// Which of the four product hooks composes a set of parts.
 enum ProductKind<'a> {
     Construct(&'a Function),
-    Identity,
     Fields,
     ValueForm(&'a Function),
 }

--- a/prebindgen-registry/src/recipe/compile.rs
+++ b/prebindgen-registry/src/recipe/compile.rs
@@ -365,6 +365,12 @@ type Built<C> = Result<Rc<<C as Compile>::Fragment>, CompileError<<C as Compile>
 /// nothing and outlive any of them.
 pub struct Compiled<F> {
     fragments: HashMap<FragmentKey, Rc<F>>,
+    /// Which row answered when a crossing was compiled **as a whole**, rather
+    /// than as one part of a container. Recorded by [`Compiler::crossing`],
+    /// which is the only entry point that consults the crossing's default —
+    /// so [`Compiled::fragment`] can give back that same answer instead of
+    /// choosing between the rows a crossing happens to have.
+    defaults: HashMap<(TypeKey, Assembly), RecipeId>,
     required: BTreeSet<RequirementId>,
 }
 
@@ -377,6 +383,7 @@ impl<F> Default for Compiled<F> {
     fn default() -> Self {
         Self {
             fragments: HashMap::new(),
+            defaults: HashMap::new(),
             required: BTreeSet::new(),
         }
     }
@@ -397,6 +404,27 @@ impl<F> Compiled<F> {
     /// Every helper a compiled fragment asked for, de-duplicated.
     pub fn required(&self) -> impl Iterator<Item = &RequirementId> {
         self.required.iter()
+    }
+
+    /// The fragment for one crossing, compiled **as a whole**.
+    ///
+    /// What an adapter's emitters ask once they stop reading the converter
+    /// table. The answer is the one [`Compiler::crossing`] built — the
+    /// crossing's default row — and not one of the rows that answer for this
+    /// type only as a part of some container. A caller that wants a particular
+    /// row has the row and asks through [`Self::row_fragment`].
+    ///
+    /// `None` means no site ever crossed this type in this direction.
+    pub fn fragment(&self, ty: &TypeKey, assembly: Assembly) -> Option<&F> {
+        let row = self.defaults.get(&(ty.clone(), assembly))?;
+        self.row_fragment(ty, assembly, row)
+    }
+
+    /// The fragment for one crossing and one named row.
+    pub fn row_fragment(&self, ty: &TypeKey, assembly: Assembly, row: &RecipeId) -> Option<&F> {
+        self.fragments
+            .get(&(ty.clone(), assembly, row.clone()))
+            .map(|f| &**f)
     }
 
     /// Every fragment this compilation built, in a deterministic order.
@@ -509,7 +537,13 @@ impl<'a, C: Compile> Compiler<'a, C> {
         crossing: &Crossing,
     ) -> Result<Rc<C::Fragment>, CompileError<C::Error>> {
         let recipe = self.recipes.row(crossing).0;
-        self.row(adapter, crossing, &recipe)
+        let fragment = self.row(adapter, crossing, &recipe)?;
+        // The whole-crossing answer, so the emitters can ask for it back
+        // without re-deriving which row a crossing defaults to.
+        self.compiled
+            .defaults
+            .insert((crossing.spelled().key(), crossing.assembly()), recipe);
+        Ok(fragment)
     }
 
     /// The fragment for one row, built once and reused.

--- a/prebindgen-registry/src/recipe/compile.rs
+++ b/prebindgen-registry/src/recipe/compile.rs
@@ -531,6 +531,15 @@ impl<'a, C: Compile> Compiler<'a, C> {
         Ok(fragment)
     }
 
+    /// The rows this compilation was built against.
+    ///
+    /// So a caller can ask whether a crossing has a row before compiling it by
+    /// name — the check [`Self::row_of`] enforces, available ahead of the
+    /// error rather than only through it.
+    pub fn recipes(&self) -> &Recipes {
+        self.recipes
+    }
+
     /// The fragment for one crossing under a **named** row, rather than the one
     /// the crossing defaults to.
     ///
@@ -539,12 +548,28 @@ impl<'a, C: Compile> Compiler<'a, C> {
     /// checked, or read through
     /// [`Compiled::row_fragment`](Compiled::row_fragment), before any site
     /// takes it.
+    ///
+    /// Refuses a name the crossing does not have. Compiling a row falls back to
+    /// the derived row when the lookup misses, which is right for the two
+    /// callers that pass a name they got **from** the table — a crossing's
+    /// default, or a site's binding — and wrong here, where the name is the
+    /// caller's own claim. Without the check a conditionally-declared row that was not
+    /// declared compiles the default instead and files it under the asked-for
+    /// name, leaving [`Compiled::row_fragment`] to answer for a row that does
+    /// not exist.
     pub fn row_of(
         &mut self,
         adapter: &mut C,
         crossing: &Crossing,
         recipe: &RecipeId,
     ) -> Result<Rc<C::Fragment>, CompileError<C::Error>> {
+        if self.recipes.get(&crossing.key(), recipe).is_none() {
+            return Err(RecipeError::NoSuchRow {
+                crossing: crossing.key(),
+                recipe: recipe.clone(),
+            }
+            .into());
+        }
         self.row(adapter, crossing, recipe)
     }
 

--- a/prebindgen-registry/src/recipe/compile.rs
+++ b/prebindgen-registry/src/recipe/compile.rs
@@ -578,6 +578,23 @@ impl<'a, C: Compile> Compiler<'a, C> {
         Ok(fragment)
     }
 
+    /// The fragment for one crossing under a **named** row, rather than the one
+    /// the crossing defaults to.
+    ///
+    /// For an adapter that states more than one row for a type and wants both:
+    /// the default answers every site, and this compiles the other so it can be
+    /// checked, or read through
+    /// [`Compiled::row_fragment`](Compiled::row_fragment), before any site
+    /// takes it.
+    pub fn row_of(
+        &mut self,
+        adapter: &mut C,
+        crossing: &Crossing,
+        recipe: &RecipeId,
+    ) -> Result<Rc<C::Fragment>, CompileError<C::Error>> {
+        self.row(adapter, crossing, recipe)
+    }
+
     /// The fragment for one row, built once and reused.
     fn row(&mut self, adapter: &mut C, crossing: &Crossing, recipe: &RecipeId) -> Built<C> {
         // Keyed by the spelling, not by the row's identity: one row can answer

--- a/prebindgen-registry/src/recipe/compile.rs
+++ b/prebindgen-registry/src/recipe/compile.rs
@@ -464,10 +464,9 @@ impl<F> Compiled<F> {
     ///
     /// What an adapter emits from once it stops routing its conversions back
     /// through the converter table — handed to
-    /// [`write_rust`](crate::write::write_rust) as
-    /// [`Conversions::Compiled`](crate::write::Conversions::Compiled). The
-    /// order is by crossing key and then by row name, so a file written from
-    /// this is stable across runs.
+    /// [`write_rust`](crate::write::write_rust) directly. The order is by
+    /// crossing key and then by row name, so a file written from this is
+    /// stable across runs.
     pub fn fragments(&self) -> Vec<&F> {
         let mut keyed: Vec<(&FragmentKey, &Rc<F>)> = self.fragments.iter().collect();
         keyed.sort_by(|a, b| {

--- a/prebindgen-registry/src/recipe/tests.rs
+++ b/prebindgen-registry/src/recipe/tests.rs
@@ -2301,3 +2301,50 @@ fn an_emitter_asking_for_a_crossing_gets_the_row_the_crossing_defaults_to() {
     // The other direction was never crossed, so there is no answer to give.
     assert!(compiled.fragment(&key, Assembly::Construct).is_none());
 }
+
+/// Compiling a row **by name** refuses a name the crossing does not have,
+/// rather than answering with the row it would have derived.
+///
+/// The two callers that reach [`Compiler::row`] with a name they got *from* the
+/// table — a crossing's default, and a site's binding — rely on that fallback,
+/// and it is right for them. [`Compiler::row_of`] takes the caller's own claim,
+/// so the same fallback would compile the default and file it under the asked-for
+/// name, leaving [`Compiled::row_fragment`] to answer for a row nobody declared.
+///
+/// The shape that hits it is a conditionally-declared row: an adapter that
+/// declares `fields` only for a type that has some, then asks every declared
+/// type for `fields` anyway.
+#[test]
+fn compiling_a_row_by_name_refuses_a_name_the_crossing_lacks() {
+    let model = model(&[SAMPLE]);
+    let recipes = two_rows(&model);
+    let bindings = Bindings::default();
+    let crossing = Crossing::new(ty(&model, "Sample"), Assembly::Deconstruct);
+    let mut adapter = Recorder::default();
+    let mut compiler = Compiler::new(&model, &recipes, &bindings);
+
+    let err = compiler
+        .row_of(&mut adapter, &crossing, &id("nonesuch"))
+        .expect_err("`Sample` declares `whole` and `fields`, and nothing else");
+    let message = err.to_string();
+    assert!(message.contains("nonesuch"), "{message}");
+    assert!(message.contains("Sample"), "{message}");
+
+    // And nothing was filed under the name, so no emitter can read one back.
+    let compiled = compiler.finish();
+    assert!(compiled
+        .row_fragment(
+            &ty(&model, "Sample").key(),
+            Assembly::Deconstruct,
+            &id("nonesuch")
+        )
+        .is_none());
+
+    // The two rows that DO exist still compile by name.
+    let mut compiler = Compiler::new(&model, &recipes, &bindings);
+    for name in ["whole", "fields"] {
+        compiler
+            .row_of(&mut adapter, &crossing, &id(name))
+            .unwrap_or_else(|e| panic!("`{name}` is declared: {e}"));
+    }
+}

--- a/prebindgen-registry/src/recipe/tests.rs
+++ b/prebindgen-registry/src/recipe/tests.rs
@@ -2274,3 +2274,46 @@ fn a_value_form_binds_the_accessors_result_and_reads_its_fields() {
         "{plan}"
     );
 }
+
+#[test]
+fn an_emitter_asking_for_a_crossing_gets_the_row_the_crossing_defaults_to() {
+    let model = model(&[SAMPLE]);
+    let sample = ty(&model, "Sample");
+    // `fields` sorts before `whole`, so a lookup that ranked the rows by name
+    // rather than asking which one the crossing defaults to would answer with
+    // the wrong one.
+    let recipes = two_rows(&model);
+    let crossing = Crossing::new(sample.clone(), Assembly::Deconstruct);
+    let mut builder = Bindings::builder();
+    builder.bind(
+        site("z_put", 0),
+        crossing.clone(),
+        Ask::Recipe(id("fields")),
+        Origin::Function,
+    );
+    let bindings = builder.build(&recipes).expect("bindings");
+    let mut adapter = Recorder::default();
+    let mut compiler = Compiler::new(&model, &recipes, &bindings);
+
+    // One site takes `fields`; the crossing on its own takes its default.
+    compiler
+        .site(&mut adapter, site("z_put", 0), crossing.clone())
+        .expect("site");
+    compiler.crossing(&mut adapter, &crossing).expect("whole");
+    let compiled = compiler.finish();
+
+    let key = sample.key();
+    // An emitter asks by crossing and gets the default …
+    assert_eq!(
+        compiled
+            .fragment(&key, Assembly::Deconstruct)
+            .map(|n| n.text.as_str()),
+        Some("atomic Sample deconstruct: Sample"),
+    );
+    // … and a caller holding a row still reaches that row.
+    assert!(compiled
+        .row_fragment(&key, Assembly::Deconstruct, &id("fields"))
+        .is_some());
+    // The other direction was never crossed, so there is no answer to give.
+    assert!(compiled.fragment(&key, Assembly::Construct).is_none());
+}

--- a/prebindgen-registry/src/recipe/tests.rs
+++ b/prebindgen-registry/src/recipe/tests.rs
@@ -932,11 +932,6 @@ impl Compile for Recorder {
         self.hook(at, "construct", detail)
     }
 
-    fn identity(&mut self, _cx: &mut Cx<'_>, at: At<'_>, inner: &Note) -> Frag<Self> {
-        let detail = inner.text.clone();
-        self.hook(at, "identity", detail)
-    }
-
     fn fields(&mut self, _cx: &mut Cx<'_>, at: At<'_>, parts: Parts<'_, Self>) -> Frag<Self> {
         let detail = part_names::<Self>(parts);
         self.hook(at, "fields", detail)
@@ -969,12 +964,11 @@ impl Compile for Recorder {
 
     fn callback(
         &mut self,
-        cx: &mut Cx<'_>,
+        _cx: &mut Cx<'_>,
         at: At<'_>,
         args: &[&Note],
         result: Option<&Note>,
     ) -> Frag<Self> {
-        cx.require(RequirementId::new("callback-shim"));
         let detail = format!(
             "({}) -> {:?}",
             args.iter()
@@ -1516,13 +1510,6 @@ fn a_callbacks_arguments_do_the_other_job() {
         adapter.calls
     );
     assert!(adapter.calls[1].contains("callback"), "{:?}", adapter.calls);
-    assert_eq!(
-        compiler
-            .required()
-            .map(|r| r.to_string())
-            .collect::<Vec<_>>(),
-        vec!["callback-shim".to_string()]
-    );
 }
 
 #[test]
@@ -1964,9 +1951,6 @@ fn what_a_role_tolerates_is_the_adapters_own_answer() {
             args: Parts<'_, Self>,
         ) -> Frag<Self> {
             self.0.construct(cx, at, func, args)
-        }
-        fn identity(&mut self, cx: &mut Cx<'_>, at: At<'_>, inner: &Note) -> Frag<Self> {
-            self.0.identity(cx, at, inner)
         }
         fn fields(&mut self, cx: &mut Cx<'_>, at: At<'_>, parts: Parts<'_, Self>) -> Frag<Self> {
             self.0.fields(cx, at, parts)

--- a/prebindgen-registry/src/recipe/tests.rs
+++ b/prebindgen-registry/src/recipe/tests.rs
@@ -2307,8 +2307,8 @@ fn an_emitter_asking_for_a_crossing_gets_the_row_the_crossing_defaults_to() {
     assert_eq!(
         compiled
             .fragment(&key, Assembly::Deconstruct)
-            .map(|n| n.text.as_str()),
-        Some("atomic Sample deconstruct: Sample"),
+            .map(|n| n.text.clone()),
+        Some("atomic Sample deconstruct: Sample".to_string()),
     );
     // … and a caller holding a row still reaches that row.
     assert!(compiled

--- a/prebindgen-registry/src/registry/cell.rs
+++ b/prebindgen-registry/src/registry/cell.rs
@@ -83,6 +83,27 @@ impl<M> TypeEntry<M> {
         }
     }
 
+    /// This entry as the conversion an adapter built.
+    ///
+    /// The two types carry the same six fields — an entry is what the resolver
+    /// stored, a conversion is what the adapter handed it. An emitter reading a
+    /// compiled fragment gets a [`ConverterImpl`](crate::ConverterImpl), so a
+    /// helper it shares with a caller that still holds a table entry speaks
+    /// that type, and the entry converts.
+    pub fn as_converter(&self) -> crate::ConverterImpl<M>
+    where
+        M: Clone,
+    {
+        crate::ConverterImpl {
+            destination: self.destination.clone(),
+            function: self.function.clone(),
+            pre_stages: self.pre_stages.clone(),
+            niches: self.niches.clone(),
+            metadata: self.metadata.clone(),
+            subs: self.subs.clone(),
+        }
+    }
+
     /// Identifier of the wire-facing converter function.
     pub fn converter_ident(&self) -> &syn::Ident {
         &self.function.sig.ident

--- a/prebindgen-registry/src/registry/cell.rs
+++ b/prebindgen-registry/src/registry/cell.rs
@@ -4,7 +4,7 @@
 use super::*;
 
 /// One type-table cell: what the key names, and the adapter's answer for it.
-pub(crate) struct TypeCell<M = ()> {
+pub(crate) struct TypeCell {
     /// The frontend's reading of this type, reused whole — so its classification
     /// and its origin are already here rather than re-derived per consumer.
     ///
@@ -19,8 +19,8 @@ pub(crate) struct TypeCell<M = ()> {
     /// less than its neighbours.
     pub subject: Box<prebindgen_flat::flat::TypeRef>,
     /// The binding asks for this cell **directly** — a declared fn's signature, a
-    /// declared type, an `unfold` leaf — as opposed to reaching it through some
-    /// converter's [`TypeEntry::subs`].
+    /// declared type, an `unfold` leaf — as opposed to reaching it through
+    /// another crossing's [`Answer::subs`].
     ///
     /// A scan fact. Whether a converter is *needed* here is reachability from
     /// these roots, which [`crate::resolve`] derives rather than
@@ -28,108 +28,38 @@ pub(crate) struct TypeCell<M = ()> {
     /// position, every struct in both directions), so the roots are what say
     /// which of it has to work.
     pub root: bool,
-    /// The adapter's converter, once resolved.
-    pub entry: Option<TypeEntry<M>>,
+    /// What the adapter said about this crossing, once it answered.
+    ///
+    /// `Some` means the adapter has a conversion for it. The conversion itself
+    /// stays in the adapter, which is the only thing that reads one; what the
+    /// registry keeps is in [`Answer`].
+    pub entry: Option<Answer>,
 }
 
-/// Per-cell registry entry.
-#[derive(Clone)]
-pub struct TypeEntry<M = ()> {
-    /// Wire/destination type — the form the value takes on the wire as
-    /// chosen by the adapter (e.g. an `i64` handle for a JNI adapter, or
-    /// a `*const T` raw pointer for a C adapter). Other converters that
-    /// ask "what's the wire form of this rust type?" read this.
-    pub destination: syn::Type,
-    /// Complete generated function for the **wire-facing** stage of the
-    /// converter (signature, body, attributes, lifetimes). The adapter
-    /// owns the shape. Callers compute this stage's name via
-    /// `function.sig.ident`.
-    pub function: syn::ItemFn,
-    /// **Rust-side** stages that compose with [`Self::function`] to form
-    /// the full chain — copied verbatim from the resolving
-    /// [`crate::prebindgen::ConverterImpl::pre_stages`]. See
-    /// that field's docs for the chain-order semantics.
-    pub pre_stages: Vec<Stage<M>>,
-    /// Inner types whose function delegates to their converters. Empty for
-    /// terminal converters; populated by wrapper converters. Used by the
-    /// post-resolution propagation pass.
+/// What the registry keeps of an adapter's answer for one crossing.
+///
+/// Not the conversion. An adapter emits from its own fragments and looks up its
+/// own answers, so generated Rust never travels through here. What the registry
+/// does with an answer is walk it: the resolver follows `subs` to decide which
+/// crossings a binding actually has to be able to make.
+#[derive(Clone, Default, Debug)]
+pub struct Answer {
+    /// The crossings this one is built out of — an `Option<T>` conversion names
+    /// `T`, a `Result<T, E>` names both. Empty for a terminal conversion.
+    ///
+    /// **Identities, not spellings**, so `T`, `&T` and `Box<T>` reach one cell.
     pub subs: Vec<TypeKey>,
-    /// Wire bit-patterns this converter never produces / always rejects.
-    /// Wrappers (`Option<_>`, sum-typed enums) carve from this set for
-    /// their own discriminants. See [`Niches`] for the cascade model.
-    pub niches: Niches,
-    /// Adapter-specific extras carried in by the
-    /// [`crate::prebindgen::ConverterImpl`] that filled this
-    /// slot. Emitter code reads this directly — the registry is the
-    /// single source of truth for cross-language facts (C header names,
-    /// JVM class names, etc.). Defaults to `()` for adapters that don't
-    /// need any.
-    pub metadata: M,
 }
 
-impl<M> TypeEntry<M> {
-    /// The resolved form of what a generator built.
-    ///
-    /// The only difference is `subs`: a generator names its inners as types,
-    /// and the table keys them.
-    pub fn from_converter(c: crate::ConverterImpl<M>) -> Self {
-        Self {
-            destination: c.destination,
-            function: c.function,
-            pre_stages: c.pre_stages,
-            subs: c.subs.clone(),
-            niches: c.niches,
-            metadata: c.metadata,
-        }
+impl Answer {
+    /// An answer that delegates to no other crossing.
+    pub fn terminal() -> Self {
+        Self::default()
     }
 
-    /// This entry as the conversion an adapter built.
-    ///
-    /// The two types carry the same six fields — an entry is what the resolver
-    /// stored, a conversion is what the adapter handed it. An emitter reading a
-    /// compiled fragment gets a [`ConverterImpl`](crate::ConverterImpl), so a
-    /// helper it shares with a caller that still holds a table entry speaks
-    /// that type, and the entry converts.
-    pub fn as_converter(&self) -> crate::ConverterImpl<M>
-    where
-        M: Clone,
-    {
-        crate::ConverterImpl {
-            destination: self.destination.clone(),
-            function: self.function.clone(),
-            pre_stages: self.pre_stages.clone(),
-            niches: self.niches.clone(),
-            metadata: self.metadata.clone(),
-            subs: self.subs.clone(),
-        }
-    }
-
-    /// Identifier of the wire-facing converter function.
-    pub fn converter_ident(&self) -> &syn::Ident {
-        &self.function.sig.ident
-    }
-
-    /// Wire/destination type carried by this converter on success.
-    pub fn wire_type(&self) -> &syn::Type {
-        &self.destination
-    }
-
-    /// Rust-side stages in input execution order, after the wire-facing
-    /// converter has decoded the wire value.
-    pub fn input_stage_order(&self) -> impl Iterator<Item = (usize, &Stage<M>)> {
-        self.pre_stages.iter().enumerate().rev()
-    }
-
-    /// Rust-side stages in output execution order, before the wire-facing
-    /// converter encodes the final wire value.
-    pub fn output_stage_order(&self) -> impl Iterator<Item = (usize, &Stage<M>)> {
-        self.pre_stages.iter().enumerate()
-    }
-
-    /// Immediate converter dependencies recorded by the adapter when this entry
-    /// resolved.
-    pub fn dependency_keys(&self) -> &[TypeKey] {
-        &self.subs
+    /// An answer built out of the crossings `subs` names.
+    pub fn over(subs: Vec<TypeKey>) -> Self {
+        Self { subs }
     }
 }
 

--- a/prebindgen-registry/src/registry/declare.rs
+++ b/prebindgen-registry/src/registry/declare.rs
@@ -30,7 +30,7 @@ pub struct RegistryBuilder<M> {
     /// Conversions handed over so far, applied at [`Self::build`].
     built: HashMap<Crossing, TypeEntry<M>>,
     /// The scan runs once, on demand: it needs every declaration, and
-    /// [`Self::crossings`] / [`Self::convert_with`] / [`Self::build`] each need
+    /// [`Self::convert_with`] and [`Self::build`] each need
     /// it to have run. `Some` holds the derived demand, in order.
     order: Option<Vec<Crossing>>,
 }
@@ -173,7 +173,7 @@ impl<M> RegistryBuilder<M> {
 
     /// `from`'s conversion needs `on`'s to exist first.
     ///
-    /// [`Self::crossings`] derives its order from the type structure, which
+    /// [`Self::convert_with`] derives its order from the type structure, which
     /// covers almost everything: an `Option<T>` visibly contains a `T`. It
     /// cannot see a dependency the *declaration* creates — a `convert!` whose
     /// body chains through a helper function's parameter type, say, where
@@ -347,16 +347,6 @@ impl<M> RegistryBuilder<M> {
         Ok(self)
     }
 
-    /// Every crossing this binding needs a conversion for, **inner types
-    /// first** — see [`Self::crossings`] for what the order guarantees.
-    ///
-    /// Take this when you want to drive the loop yourself and hand the result
-    /// back through [`Self::conversions`]. [`Self::convert_with`] is the same
-    /// walk with the loop written for you.
-    pub fn crossings(&mut self) -> Result<Vec<Crossing>, WriteRustError> {
-        Ok(self.derive()?.to_vec())
-    }
-
     /// Build a conversion for each crossing, in dependency order.
     ///
     /// `f` is called once per crossing with the conversions already built, so
@@ -364,10 +354,9 @@ impl<M> RegistryBuilder<M> {
     /// `None` records a gap — whether that gap matters is decided by
     /// [`Self::build`], not here.
     ///
-    /// This is a convenience over [`Self::crossings`] + [`Self::conversions`],
-    /// not a second mechanism: it is the same list, walked in the same order.
-    /// Nothing about it lets the registry choose when to call back — the
-    /// closure is yours, and the walk is finished before this returns.
+    /// The one way to supply them. Nothing about it lets the registry choose
+    /// when to call back — the closure is yours, and the walk is finished
+    /// before this returns.
     pub fn convert_with<F>(mut self, mut f: F) -> Result<Self, WriteRustError>
     where
         F: FnMut(
@@ -390,16 +379,6 @@ impl<M> RegistryBuilder<M> {
             }
         }
         Ok(self)
-    }
-
-    /// Hand over conversions built elsewhere — the bulk peer of
-    /// [`Self::convert_with`], for a generator that walked
-    /// [`Self::crossings`] itself.
-    ///
-    /// Accumulates, so it composes with `convert_with` and with itself.
-    pub fn conversions(mut self, conversions: HashMap<Crossing, TypeEntry<M>>) -> Self {
-        self.built.extend(conversions);
-        self
     }
 
     /// The scanned registry, with no conversions applied and no completeness

--- a/prebindgen-registry/src/registry/declare.rs
+++ b/prebindgen-registry/src/registry/declare.rs
@@ -25,17 +25,18 @@ use super::*;
 /// The result is read-only. Nothing can add a crossing to a `Registry`, which
 /// is what makes "every crossing has a conversion" a fact about the type rather
 /// than a phase you have to be careful about.
-pub struct RegistryBuilder<M> {
-    registry: Registry<M>,
-    /// Conversions handed over so far, applied at [`Self::build`].
-    built: HashMap<Crossing, TypeEntry<M>>,
+pub struct RegistryBuilder {
+    registry: Registry,
+    /// What has been answered so far, applied at [`Self::build`]. Not the
+    /// conversions — those stay with the adapter; see [`Answer`].
+    built: HashMap<Crossing, Answer>,
     /// The scan runs once, on demand: it needs every declaration, and
     /// [`Self::convert_with`] and [`Self::build`] each need
     /// it to have run. `Some` holds the derived demand, in order.
     order: Option<Vec<Crossing>>,
 }
 
-impl<M> Registry<M> {
+impl Registry {
     /// Start describing a binding over this model.
     ///
     /// A `Flat` is what a registry projects, and reading captured prebindgen
@@ -50,7 +51,7 @@ impl<M> Registry<M> {
     /// let flat = Flat::builder().source("source_ffi").build()?;
     /// // Annotated only because nothing here resolves: in a build script `M` is
     /// // fixed by the adapter passed to `resolve`, so no call site names it.
-    /// let registry: Registry<()> = Registry::builder(flat)?.build()?;
+    /// let registry: Registry = Registry::builder(flat)?.build()?;
     /// assert!(registry.flat().function("test_function").is_some());
     /// # Ok::<_, Box<dyn std::error::Error>>(())
     /// ```
@@ -70,7 +71,7 @@ impl<M> Registry<M> {
     /// a source crate that needs migrating sees one list instead of one rebuild
     /// per item. This is independent of what any binding declares: an
     /// inexpressible item is a hard error whether or not it is ever named.
-    pub fn builder(flat: prebindgen_flat::flat::Flat) -> Result<RegistryBuilder<M>, ScanError> {
+    pub fn builder(flat: prebindgen_flat::flat::Flat) -> Result<RegistryBuilder, ScanError> {
         let entries: Vec<NotExpressibleEntry> = flat
             .unsupported()
             .map(|u| NotExpressibleEntry {
@@ -93,7 +94,7 @@ impl<M> Registry<M> {
     }
 }
 
-impl<M> RegistryBuilder<M> {
+impl RegistryBuilder {
     // ── configure: what this binding builds ───────────────────────────
     //
     // Pushed in by the generator before `resolve`. The registry never asks —
@@ -263,7 +264,7 @@ impl<M> RegistryBuilder<M> {
     }
 }
 
-impl<M> RegistryBuilder<M> {
+impl RegistryBuilder {
     /// The model being described. Complete from the first call: everything that
     /// adds to it ([`Self::local_function`]) is a declaration, not a derivation.
     pub fn flat(&self) -> &prebindgen_flat::flat::Flat {
@@ -322,13 +323,9 @@ impl<M> RegistryBuilder<M> {
     }
 
     /// What a conversion — or a validation — is written against right now: the
-    /// model, the full crossing population, and whatever has been built so far.
-    fn view(&self) -> Building<'_, M> {
-        Building::new(
-            &self.registry,
-            &self.built,
-            self.order.as_deref().unwrap_or_default(),
-        )
+    /// model and the full crossing population.
+    fn view(&self) -> Building<'_> {
+        Building::new(&self.registry, self.order.as_deref().unwrap_or_default())
     }
 
     /// Check this binding against a generator's own invariants, now that the
@@ -336,10 +333,7 @@ impl<M> RegistryBuilder<M> {
     ///
     /// Earliest it can run: a missing declaration has already hard-errored, so
     /// a check here sees only items that exist.
-    pub fn validate_with<E>(mut self, adapter: &E) -> Result<Self, WriteRustError>
-    where
-        E: Prebindgen<Metadata = M>,
-    {
+    pub fn validate_with<E: Prebindgen>(mut self, adapter: &E) -> Result<Self, WriteRustError> {
         self.derive()?;
         adapter
             .validate(&self.view())
@@ -349,21 +343,21 @@ impl<M> RegistryBuilder<M> {
 
     /// Build a conversion for each crossing, in dependency order.
     ///
-    /// `f` is called once per crossing with the conversions already built, so
-    /// by the time it sees `Option<Handle>` it can look up `Handle`. Returning
-    /// `None` records a gap — whether that gap matters is decided by
-    /// [`Self::build`], not here.
+    /// `f` is called once per crossing, and answers with an [`Answer`] rather
+    /// than the conversion itself: the conversion belongs to the adapter, which
+    /// emits from it and looks it up, and what the registry needs back is which
+    /// other crossings this one is built out of. Returning `None` records a gap
+    /// — whether that gap matters is decided by [`Self::build`], not here.
+    ///
+    /// The walk is inner types first, so by the time `f` sees `Option<Handle>`
+    /// it has already answered `Handle`.
     ///
     /// The one way to supply them. Nothing about it lets the registry choose
     /// when to call back — the closure is yours, and the walk is finished
     /// before this returns.
     pub fn convert_with<F>(mut self, mut f: F) -> Result<Self, WriteRustError>
     where
-        F: FnMut(
-            &Crossing,
-            &Building<'_, M>,
-            &crate::Emit,
-        ) -> Option<crate::prebindgen::ConverterImpl<M>>,
+        F: FnMut(&Crossing, &Building<'_>, &crate::Emit) -> Option<Answer>,
     {
         // A converter IS generated Rust — `ConverterImpl::function` is a
         // complete `syn::ItemFn` the adapter writes — so this closure is an
@@ -372,10 +366,8 @@ impl<M> RegistryBuilder<M> {
         let emit = crate::Emit::new();
         let order = self.derive()?.to_vec();
         for crossing in &order {
-            let conv = f(crossing, &self.view(), &emit);
-            if let Some(c) = conv {
-                self.built
-                    .insert(crossing.clone(), TypeEntry::from_converter(c));
+            if let Some(answer) = f(crossing, &self.view(), &emit) {
+                self.built.insert(crossing.clone(), answer);
             }
         }
         Ok(self)
@@ -388,7 +380,7 @@ impl<M> RegistryBuilder<M> {
     /// "answerable", which is exactly what the split exists to keep out of
     /// everyone else's hands.
     #[cfg(test)]
-    pub(crate) fn scanned(mut self) -> Result<Registry<M>, ScanError> {
+    pub(crate) fn scanned(mut self) -> Result<Registry, ScanError> {
         // Narrower than `build`'s error on purpose: the scan is the only phase
         // this runs, so a test matching on `ScanError` says what it means.
         match self.derive() {
@@ -404,7 +396,7 @@ impl<M> RegistryBuilder<M> {
     /// A crossing with no conversion is not itself a failure — the scan
     /// over-approximates on purpose. What fails is a crossing *reachable from
     /// an export* with none, and the error names every one at once.
-    pub fn build(mut self) -> Result<Registry<M>, WriteRustError> {
+    pub fn build(mut self) -> Result<Registry, WriteRustError> {
         self.derive()?;
         for ((dir, key), entry) in self.built {
             if let Some(cell) = self.registry.type_table_mut(dir).get_mut(&key) {
@@ -416,28 +408,17 @@ impl<M> RegistryBuilder<M> {
     }
 }
 
-/// A builder answers the same questions a finished registry does — with one
-/// difference that is the whole point of the split: [`conversion`] sees only
-/// what has been handed over *so far*.
-///
-/// That is what a generator writing a conversion needs (its inners, already
-/// built) and it is all it should be able to see. Everything else — the model,
-/// the decompositions — is complete from the moment it is declared.
-///
-/// [`conversion`]: Conversions::conversion
-impl<M> Conversions<M> for RegistryBuilder<M> {
+/// A builder answers the same questions a finished registry does. It used to
+/// answer one fewer — it lent out conversions handed over *so far*, so a
+/// generator writing one could see its inners and nothing else. An adapter
+/// keeps its own conversions now, so that read is gone and the rest — the
+/// model, the decompositions — is complete from the moment it is declared.
+impl Conversions for RegistryBuilder {
     fn reading(&self, key: &TypeKey) -> Option<prebindgen_flat::flat::TypeRef> {
         self.registry.reading(key)
     }
     fn flat(&self) -> &prebindgen_flat::flat::Flat {
         &self.registry.flat
-    }
-    fn conversion(
-        &self,
-        dir: Direction,
-        reading: &prebindgen_flat::flat::TypeRef,
-    ) -> Option<&TypeEntry<M>> {
-        self.built.get(&(dir, reading.key()))
     }
     fn crossing_keys(&self, dir: Direction) -> Vec<TypeKey> {
         self.order

--- a/prebindgen-registry/src/registry/mod.rs
+++ b/prebindgen-registry/src/registry/mod.rs
@@ -25,10 +25,9 @@
 //!
 //! # What a conversion is
 //!
-//! A [`TypeEntry`]: a `destination` (the wire type), a wire-facing `function`,
-//! and `pre_stages` — the Rust-side stages that compose with it. **A chain, not a
-//! function**, which is how composition works: `Option<Handle>`'s chain embeds
-//! `Handle`'s.
+//! The adapter's business. It keeps the conversion itself; what it hands back
+//! is an [`Answer`], naming the crossings this one delegates to. That is what
+//! reachability walks, and it is all the registry needs to know.
 //!
 //! A composite need not cross whole. `Option<T>` may cross as a `T` carrying a
 //! niche value, as a `(bool, T)` pair, or as leaves delivered separately — which,
@@ -162,10 +161,7 @@ use std::collections::{HashMap, HashSet};
 use prebindgen::SourceLocation;
 use prebindgen_flat::{flat::Origin, types_util::bare_path_ident};
 
-use crate::{
-    niches::Niches,
-    prebindgen::{Prebindgen, Stage},
-};
+use crate::prebindgen::Prebindgen;
 
 mod cell;
 pub(crate) use self::cell::TypeCell;
@@ -182,7 +178,7 @@ mod view;
 pub use prebindgen_flat::flat::{TypeKey, TypeKeyParseError};
 
 pub use self::{
-    cell::{Direction, TypeEntry},
+    cell::{Answer, Direction},
     declare::RegistryBuilder,
     error::{DuplicateNameError, NotExpressibleEntry, ScanError, WriteRustError},
     view::{Building, Conversions, Crossing},
@@ -190,13 +186,11 @@ pub use self::{
 
 /// Single owner of everything parsed from the prebindgen source stream.
 ///
-/// The metadata parameter `M` is the language adapter's per-converter
-/// extra type, supplied via
-/// [`crate::prebindgen::Prebindgen::Metadata`]. Each
-/// [`TypeEntry`] carries one `M` copied in by the resolver from the
-/// [`crate::prebindgen::ConverterImpl`] that produced it.
-/// Adapters that don't carry extras leave `M = ()`.
-pub struct Registry<M = ()> {
+/// Carries no adapter metadata. It used to be generic over one, so a converter's
+/// language-specific extras could be stored beside it and read back; an adapter
+/// keeps its own conversions now, so both the storage and the parameter are
+/// gone.
+pub struct Registry {
     /// The parsed model these maps project. Held rather than discarded, so a
     /// later stage can ask it what a name means through the registry it already
     /// has — see [`Self::flat`].
@@ -217,8 +211,8 @@ pub struct Registry<M = ()> {
     /// [`Conversions::conversion`] — which is what makes direction a parameter
     /// rather than half of a field name, and what stops anyone observing a cell
     /// before `RegistryBuilder::build` has graded it.
-    pub(crate) input_types: HashMap<TypeKey, TypeCell<M>>,
-    pub(crate) output_types: HashMap<TypeKey, TypeCell<M>>,
+    pub(crate) input_types: HashMap<TypeKey, TypeCell>,
+    pub(crate) output_types: HashMap<TypeKey, TypeCell>,
 
     /// Resolved constructor-expansion plans, keyed by `(function, parameter)`.
     /// Filled by [`crate::expand::apply`] before resolution; read
@@ -259,13 +253,13 @@ pub struct Registry<M = ()> {
 
 // Opaque — exists so `Result<Registry, _>::expect_err` works in tests, the way
 // `Generation`'s did before the generators took ownership of the built object.
-impl<M> std::fmt::Debug for Registry<M> {
+impl std::fmt::Debug for Registry {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.write_str("Registry(..)")
     }
 }
 
-impl<M> Registry<M> {
+impl Registry {
     /// An empty registry: no model, no items, no types.
     ///
     /// **Not public.** A `Registry` is a projection of a [`Flat`](prebindgen_flat::Flat), and one built
@@ -293,11 +287,11 @@ impl<M> Registry<M> {
         self.type_table(dir).get(key).map(|cell| cell.root)
     }
 
-    /// Whether `key`'s cell in `dir` has a resolved converter.
+    /// Whether `key`'s cell in `dir` has been answered.
     ///
-    /// Test support, `testing`-gated. The public [`Self::input_entry`] /
-    /// [`Self::output_entry`] answer this from a reading; a fixture that built
-    /// the type itself holds only its identity.
+    /// Test support, `testing`-gated: a fixture that built the type itself
+    /// holds only its identity, and this is the one question about a cell that
+    /// does not need a reading.
     #[cfg(any(test, feature = "testing"))]
     pub fn has_entry_for_test(&self, dir: Direction, key: &TypeKey) -> Option<bool> {
         self.type_table(dir)

--- a/prebindgen-registry/src/registry/model.rs
+++ b/prebindgen-registry/src/registry/model.rs
@@ -7,7 +7,7 @@ use super::{
     *,
 };
 
-impl<M> Registry<M> {
+impl Registry {
     /// The parameter-side fold for each `(function, parameter)` position.
     ///
     /// Inherent rather than on [`Conversions`]: a fold is read when a wrapper's

--- a/prebindgen-registry/src/registry/order.rs
+++ b/prebindgen-registry/src/registry/order.rs
@@ -1,14 +1,15 @@
 //! Hand the demand over, and grade the answers.
 //!
 //! The two halves of the exchange with a generator: [`Registry::crossings`]
-//! sorts the derived set inner-first, `RegistryBuilder::build` takes every
-//! conversion back at once and names whatever is missing.
+//! sorts the derived set inner-first, and `RegistryBuilder::build` grades what
+//! came back — every crossing answered, or a report naming the ones that were
+//! not.
 
 use std::collections::HashSet;
 
 use super::*;
 
-impl<M> Registry<M> {
+impl Registry {
     /// Every crossing this binding needs a conversion for, **inner types
     /// first**.
     ///

--- a/prebindgen-registry/src/registry/run.rs
+++ b/prebindgen-registry/src/registry/run.rs
@@ -2,7 +2,7 @@
 
 use super::*;
 
-impl<M> Registry<M> {
+impl Registry {
     pub(super) fn apply_adapter_plans(
         &mut self,
         declared: &mut Declared,

--- a/prebindgen-registry/src/registry/scan.rs
+++ b/prebindgen-registry/src/registry/scan.rs
@@ -23,7 +23,7 @@ fn canonical_of(declared_ty: &prebindgen_flat::flat::Origin<syn::Type>) -> syn::
         .expect("a `TypeKey` is a normalized `syn::Type`, so it re-parses")
 }
 
-impl<M> Registry<M> {
+impl Registry {
     pub(super) fn scan_declared_items(&mut self, declared: &Declared) -> Result<(), ScanError> {
         // Source-qualified declared types are a hard error (issue #95). The
         // key's own normalization already reduced `crate::`/`self::` and std
@@ -589,7 +589,7 @@ impl<M> Registry<M> {
         dir: Direction,
         ty: &syn::Type,
         root: bool,
-        entry: Option<TypeEntry<M>>,
+        entry: Option<Answer>,
     ) {
         self.intern(dir, ty, root).unwrap_or_else(|e| {
             panic!(
@@ -698,7 +698,7 @@ impl<M> Registry<M> {
     }
 
     /// Direction-indexed read access to the type-resolution tables.
-    pub(crate) fn type_table(&self, dir: Direction) -> &HashMap<TypeKey, TypeCell<M>> {
+    pub(crate) fn type_table(&self, dir: Direction) -> &HashMap<TypeKey, TypeCell> {
         match dir {
             Direction::Input => &self.input_types,
             Direction::Output => &self.output_types,
@@ -719,38 +719,10 @@ impl<M> Registry<M> {
     }
 
     /// Direction-indexed mutable access to the type-resolution tables.
-    pub(crate) fn type_table_mut(&mut self, dir: Direction) -> &mut HashMap<TypeKey, TypeCell<M>> {
+    pub(crate) fn type_table_mut(&mut self, dir: Direction) -> &mut HashMap<TypeKey, TypeCell> {
         match dir {
             Direction::Input => &mut self.input_types,
             Direction::Output => &mut self.output_types,
         }
-    }
-
-    /// Look up the resolved input entry for `reading`, returning `None` if it
-    /// was never registered or is still unresolved. The returned entry's
-    /// `function.sig.ident` is the converter's call name; `destination` is
-    /// its wire form.
-    ///
-    /// Takes a `TypeRef` for the reason the trait methods do (#284) — and this
-    /// pair matters more than they do, because an **inherent** method wins over
-    /// a trait method on a concrete `Registry`. While these took a spelling they
-    /// were a second door into the table that the trait's signature could not
-    /// close, and every caller with a `Registry` in hand silently used it. The
-    /// same "second door inside the room" that hid `classify` behind
-    /// `Registry::reading` until #267.
-    pub fn input_entry(&self, reading: &prebindgen_flat::flat::TypeRef) -> Option<&TypeEntry<M>> {
-        self.type_table(Direction::Input)
-            .get(&reading.key())?
-            .entry
-            .as_ref()
-    }
-
-    /// Look up the resolved output entry for `reading`. See
-    /// [`Self::input_entry`].
-    pub fn output_entry(&self, reading: &prebindgen_flat::flat::TypeRef) -> Option<&TypeEntry<M>> {
-        self.type_table(Direction::Output)
-            .get(&reading.key())?
-            .entry
-            .as_ref()
     }
 }

--- a/prebindgen-registry/src/registry/tests.rs
+++ b/prebindgen-registry/src/registry/tests.rs
@@ -14,16 +14,16 @@ use crate::{
 /// Push-then-resolve, the way a real generator's `resolve` does. Test-only:
 /// production generators own this pairing themselves (`JniGenBuilder::resolve`).
 trait DeclareAndResolve<M> {
-    fn declare_and_resolve<E>(self, ext: E) -> Result<Registry<()>, WriteRustError>
+    fn declare_and_resolve<E>(self, ext: E) -> Result<Registry, WriteRustError>
     where
-        E: Prebindgen<Metadata = M> + AsStub;
+        E: Prebindgen + AsStub;
 }
 
 /// How a test stub states what it declares, and what it can convert.
 trait AsStub {
     fn stub(&self) -> &StubExt;
     /// Default: converts nothing, so every required crossing is a gap.
-    fn converter(&self, _ty: &syn::Type) -> Option<ConverterImpl<()>> {
+    fn converter(&self, _ty: &syn::Type) -> Option<ConverterImpl> {
         None
     }
 }
@@ -33,10 +33,10 @@ impl AsStub for StubExt {
     }
 }
 
-impl DeclareAndResolve<()> for RegistryBuilder<()> {
-    fn declare_and_resolve<E>(self, ext: E) -> Result<Registry<()>, WriteRustError>
+impl DeclareAndResolve<()> for RegistryBuilder {
+    fn declare_and_resolve<E>(self, ext: E) -> Result<Registry, WriteRustError>
     where
-        E: Prebindgen<Metadata = ()> + AsStub,
+        E: Prebindgen + AsStub,
     {
         let registry = ext
             .stub()
@@ -45,7 +45,8 @@ impl DeclareAndResolve<()> for RegistryBuilder<()> {
             // The reading, not a spelling re-derived from the key: this is the
             // route a real generator takes, so the stub takes it too (#291).
             .convert_with(|crossing, built, emit| {
-                ext.converter(&emit.spell_ty(&built.reading(&crossing.1)?))
+                let conv = ext.converter(&emit.spell_ty(&built.reading(&crossing.1)?))?;
+                Some(Answer::over(conv.subs))
             })?
             .build()?;
         ext.validate_resolved(&registry)
@@ -71,10 +72,7 @@ struct StubExt {
 impl StubExt {
     /// Push what this stub declares, the way a real generator does. Generic
     /// over `M` so a stub can configure any adapter's registry.
-    fn declare_into_any<M>(
-        &self,
-        mut reg: RegistryBuilder<M>,
-    ) -> Result<RegistryBuilder<M>, ScanError> {
+    fn declare_into_any(&self, mut reg: RegistryBuilder) -> Result<RegistryBuilder, ScanError> {
         for (item_fn, origin) in self.local_fns.clone() {
             reg = reg.local_function(item_fn, origin)?;
         }
@@ -98,12 +96,10 @@ impl StubExt {
 }
 
 impl Prebindgen for StubExt {
-    type Metadata = ();
-
     fn on_function(
         &self,
         _f: &prebindgen_flat::flat::Function,
-        _registry: &Registry<()>,
+        _registry: &Registry,
         _emit: &crate::Emit,
     ) -> TokenStream {
         TokenStream::new()
@@ -111,7 +107,7 @@ impl Prebindgen for StubExt {
     fn on_struct(
         &self,
         _s: &prebindgen_flat::flat::Struct,
-        _registry: &Registry<()>,
+        _registry: &Registry,
         _emit: &crate::Emit,
     ) -> TokenStream {
         TokenStream::new()
@@ -119,7 +115,7 @@ impl Prebindgen for StubExt {
     fn on_variant(
         &self,
         _v: &prebindgen_flat::flat::Variant,
-        _registry: &Registry<()>,
+        _registry: &Registry,
         _emit: &crate::Emit,
     ) -> TokenStream {
         TokenStream::new()
@@ -127,7 +123,7 @@ impl Prebindgen for StubExt {
     fn on_enum(
         &self,
         _e: &prebindgen_flat::flat::Enum,
-        _registry: &Registry<()>,
+        _registry: &Registry,
         _emit: &crate::Emit,
     ) -> TokenStream {
         TokenStream::new()
@@ -148,7 +144,7 @@ fn fn_item(src: &str) -> (syn::Item, SourceLocation) {
 #[test]
 fn scan_declared_empty_ext_marks_nothing_required() {
     let items = vec![fn_item("fn good(x: u64) -> u64 { x }")];
-    let reg: RegistryBuilder<()> = crate::test_util::reg_from_items(items).unwrap();
+    let reg: RegistryBuilder = crate::test_util::reg_from_items(items).unwrap();
     let ext = StubExt::default();
     let reg = ext
         .declare_into_any(reg)
@@ -165,7 +161,7 @@ fn scan_declared_marks_types_required_only_for_declared_fns() {
         fn_item("fn a(x: u64) -> u64 { x }"),
         fn_item("fn b(x: u32) -> u32 { x }"),
     ];
-    let reg: RegistryBuilder<()> = crate::test_util::reg_from_items(items).unwrap();
+    let reg: RegistryBuilder = crate::test_util::reg_from_items(items).unwrap();
     let mut ext = StubExt::default();
     ext.functions.insert(syn::parse_str("a").unwrap());
     let reg = ext
@@ -173,7 +169,7 @@ fn scan_declared_marks_types_required_only_for_declared_fns() {
         .expect("declare")
         .scanned()
         .unwrap();
-    let is_root = |t: &HashMap<TypeKey, TypeCell<()>>, k: &str| {
+    let is_root = |t: &HashMap<TypeKey, TypeCell>, k: &str| {
         t.get(&TypeKey::parse(k).expect("test type"))
             .is_some_and(|c| c.root)
     };
@@ -188,7 +184,7 @@ fn scan_declared_marks_types_required_only_for_declared_fns() {
 #[test]
 fn scan_declared_missing_function_is_hard_error() {
     let items = vec![fn_item("fn good(x: u64) -> u64 { x }")];
-    let reg: RegistryBuilder<()> = crate::test_util::reg_from_items(items).unwrap();
+    let reg: RegistryBuilder = crate::test_util::reg_from_items(items).unwrap();
     let mut ext = StubExt::default();
     ext.functions.insert(syn::parse_str("good").unwrap());
     ext.functions.insert(syn::parse_str("typo_fn").unwrap());
@@ -206,7 +202,7 @@ fn scan_declared_missing_function_is_hard_error() {
 #[test]
 fn scan_declared_collects_all_missing_kinds_in_one_error() {
     let items = vec![fn_item("fn good(x: u64) -> u64 { x }")];
-    let reg: RegistryBuilder<()> = crate::test_util::reg_from_items(items).unwrap();
+    let reg: RegistryBuilder = crate::test_util::reg_from_items(items).unwrap();
     let mut ext = StubExt::default();
     ext.functions.insert(syn::parse_str("typo_fn").unwrap());
     ext.helper_functions
@@ -232,8 +228,8 @@ fn scan_declared_collects_all_missing_kinds_in_one_error() {
 }
 
 #[test]
-fn type_entry_helpers_expose_converter_chain_contract() {
-    let entry = TypeEntry {
+fn conversion_helpers_expose_converter_chain_contract() {
+    let entry = crate::ConverterImpl {
         destination: syn::parse_quote!(jni::sys::jlong),
         function: syn::parse_quote!(
             fn __wire(v: Owned) -> jni::sys::jlong {
@@ -241,7 +237,7 @@ fn type_entry_helpers_expose_converter_chain_contract() {
             }
         ),
         pre_stages: vec![
-            Stage {
+            crate::Stage {
                 function: syn::parse_quote!(
                     fn __stage_rust(v: Rust) -> Result<Mid, Err> {
                         todo!()
@@ -249,7 +245,7 @@ fn type_entry_helpers_expose_converter_chain_contract() {
                 ),
                 metadata: (),
             },
-            Stage {
+            crate::Stage {
                 function: syn::parse_quote!(
                     fn __stage_wire(v: Mid) -> Result<Owned, Err> {
                         todo!()
@@ -286,11 +282,7 @@ fn type_entry_helpers_expose_converter_chain_contract() {
         vec!["__stage_wire", "__stage_rust"]
     );
     assert_eq!(
-        entry
-            .dependency_keys()
-            .iter()
-            .map(TypeKey::as_str)
-            .collect::<Vec<_>>(),
+        entry.subs.iter().map(TypeKey::as_str).collect::<Vec<_>>(),
         vec!["Rust", "Mid"]
     );
 }
@@ -309,7 +301,7 @@ fn type_entry_helpers_expose_converter_chain_contract() {
 /// judgement now, and its diagnosis is richer: it names the parameter.
 #[test]
 fn from_items_rejects_what_the_language_cannot_express() {
-    let err = match crate::test_util::reg_from_items::<(), _>(vec![
+    let err = match crate::test_util::reg_from_items::<_>(vec![
         fn_item("fn bogus(x: u64) -> impl std::fmt::Debug { 0u64 }"),
         fn_item("fn worse(self) -> u64 { 0 }"),
     ]) {
@@ -354,7 +346,7 @@ fn duplicate_name_across_sources_names_both_crates() {
 
     let a = make_source("first-crate");
     let b = make_source("second-crate");
-    let msg = match crate::test_util::reg_from_items::<(), _>(a.items_all().chain(b.items_all())) {
+    let msg = match crate::test_util::reg_from_items::<_>(a.items_all().chain(b.items_all())) {
         Ok(_) => panic!("collision must fail"),
         Err(e) => e.to_string(),
     };
@@ -378,8 +370,7 @@ fn from_items_records_origins_from_location_stamps() {
     let f_b: syn::ItemFn = syn::parse_str("fn from_helper(x: u64) -> u64 { x }").unwrap();
     let a = vec![(syn::Item::Fn(f_a), loc("flat-crate"))];
     let b = vec![(syn::Item::Fn(f_b), loc("helper-crate"))];
-    let reg: RegistryBuilder<()> =
-        crate::test_util::reg_from_items(a.into_iter().chain(b)).unwrap();
+    let reg: RegistryBuilder = crate::test_util::reg_from_items(a.into_iter().chain(b)).unwrap();
 
     let path = |p: syn::Path| p.to_token_stream().to_string();
     assert_eq!(
@@ -418,14 +409,13 @@ fn resolve_surfaces_adapter_invariant_errors() {
         }
     }
     impl Prebindgen for FailingExt {
-        type Metadata = ();
-        fn validate(&self, _binding: &Building<'_, ()>) -> Result<(), String> {
+        fn validate(&self, _binding: &Building<'_>) -> Result<(), String> {
             Err("member fun `f` has no receiver".to_string())
         }
         fn on_function(
             &self,
             f: &prebindgen_flat::flat::Function,
-            r: &Registry<()>,
+            r: &Registry,
             _emit: &crate::Emit,
         ) -> TokenStream {
             self.0.on_function(f, r, _emit)
@@ -433,7 +423,7 @@ fn resolve_surfaces_adapter_invariant_errors() {
         fn on_struct(
             &self,
             s: &prebindgen_flat::flat::Struct,
-            r: &Registry<()>,
+            r: &Registry,
             _emit: &crate::Emit,
         ) -> TokenStream {
             self.0.on_struct(s, r, _emit)
@@ -441,7 +431,7 @@ fn resolve_surfaces_adapter_invariant_errors() {
         fn on_variant(
             &self,
             v: &prebindgen_flat::flat::Variant,
-            r: &Registry<()>,
+            r: &Registry,
             _emit: &crate::Emit,
         ) -> TokenStream {
             self.0.on_variant(v, r, _emit)
@@ -449,14 +439,14 @@ fn resolve_surfaces_adapter_invariant_errors() {
         fn on_enum(
             &self,
             e: &prebindgen_flat::flat::Enum,
-            r: &Registry<()>,
+            r: &Registry,
             _emit: &crate::Emit,
         ) -> TokenStream {
             self.0.on_enum(e, r, _emit)
         }
     }
     let items = vec![fn_item("fn good(x: u64) -> u64 { x }")];
-    let reg: RegistryBuilder<()> = crate::test_util::reg_from_items(items).unwrap();
+    let reg: RegistryBuilder = crate::test_util::reg_from_items(items).unwrap();
     let err = reg
         .declare_and_resolve(FailingExt(StubExt::default()))
         .expect_err("validate Err must abort resolve");
@@ -529,7 +519,7 @@ fn qualified_signature_matches_bare_declaration() {
         (syn::Item::Struct(s), crate_loc("myflat")),
         (syn::Item::Fn(f), crate_loc("myflat")),
     ];
-    let reg: RegistryBuilder<()> = crate::test_util::reg_from_items(items).unwrap();
+    let reg: RegistryBuilder = crate::test_util::reg_from_items(items).unwrap();
     let mut ext = StubExt::default();
     ext.functions.insert(syn::parse_str("get").unwrap());
     ext.types.push(syn::parse_str("Thing").expect("test type"));
@@ -541,8 +531,7 @@ fn qualified_signature_matches_bare_declaration() {
     assert!(reg.input_types[&TypeKey::parse("&Thing").expect("test type")].root);
     assert!(reg.output_types[&TypeKey::parse("Vec<Thing>").expect("test type")].root);
     // No spelling-variant duplicate cells survive anywhere.
-    let no_paths =
-        |t: &HashMap<TypeKey, TypeCell<()>>| !t.keys().any(|k| k.as_str().contains("::"));
+    let no_paths = |t: &HashMap<TypeKey, TypeCell>| !t.keys().any(|k| k.as_str().contains("::"));
     assert!(no_paths(&reg.input_types));
     assert!(no_paths(&reg.output_types));
 }
@@ -562,7 +551,7 @@ fn multi_source_rename_cross_reference_normalizes() {
         (syn::Item::Struct(b_ty), crate_loc("cov-helpers")),
         (syn::Item::Struct(a_ty), crate_loc("srca")),
     ];
-    let reg: RegistryBuilder<()> = crate::test_util::reg_from_items(items).unwrap();
+    let reg: RegistryBuilder = crate::test_util::reg_from_items(items).unwrap();
     let mut ext = StubExt::default();
     ext.functions.insert(syn::parse_str("use_a").unwrap());
     ext.types.push(syn::parse_str("TypeA").expect("test type"));
@@ -583,7 +572,7 @@ fn qualified_declared_type_is_hard_error() {
     // a collected hard error with the bare fix-it, not a silent miss.
     let s: syn::ItemStruct = syn::parse_str("pub struct Thing { pub v: u64 }").unwrap();
     let items = vec![(syn::Item::Struct(s), crate_loc("myflat"))];
-    let reg: RegistryBuilder<()> = crate::test_util::reg_from_items(items).unwrap();
+    let reg: RegistryBuilder = crate::test_util::reg_from_items(items).unwrap();
     let mut ext = StubExt::default();
     ext.types
         .push(syn::parse_str("myflat::Thing").expect("test type"));
@@ -606,7 +595,7 @@ fn foreign_qualified_declared_type_stays_supported() {
     // module, so the declaration passes through verbatim and is marked
     // required under its own spelling (the no-indexed-body arm).
     let items = vec![fn_item("fn touch(x: u64) -> u64 { x }")];
-    let reg: RegistryBuilder<()> = crate::test_util::reg_from_items(items).unwrap();
+    let reg: RegistryBuilder = crate::test_util::reg_from_items(items).unwrap();
     let mut ext = StubExt::default();
     let foreign_ty: syn::Type = syn::parse_str("zenoh::KeyExpr<'static>").expect("test type");
     let foreign = TypeKey::from_type(&foreign_ty);
@@ -658,7 +647,7 @@ fn fn_ident(name: &str) -> syn::Ident {
 #[test]
 fn builder_reads_a_source_directory() {
     let dir = write_source_dir("plain", "flat-crate", "marked_fn");
-    let registry: RegistryBuilder<()> =
+    let registry: RegistryBuilder =
         Registry::builder(Flat::builder().source(&dir).build().expect("parses")).expect("indexes");
 
     assert!(registry
@@ -684,14 +673,14 @@ fn builder_source_named_overrides_the_captured_crate() {
     let dir = write_source_dir("renamed", "real-package-name", "helper_fn");
 
     // Without the override, the registry believes the package name.
-    let plain: RegistryBuilder<()> =
+    let plain: RegistryBuilder =
         Registry::builder(Flat::builder().source(&dir).build().expect("parses")).expect("indexes");
     assert_eq!(
         plain.origin_module(&fn_ident("helper_fn")).map(module),
         Some("real_package_name".to_string())
     );
 
-    let renamed: RegistryBuilder<()> = Registry::builder(
+    let renamed: RegistryBuilder = Registry::builder(
         Flat::builder()
             .source_named(&dir, "as_renamed")
             .build()
@@ -716,7 +705,7 @@ fn builder_composes_directories_and_streams() {
     let flat = write_source_dir("multi_flat", "flat-crate", "flat_fn");
     let helper = write_source_dir("multi_helper", "real-helper-name", "helper_fn");
 
-    let registry: RegistryBuilder<()> = Registry::builder(
+    let registry: RegistryBuilder = Registry::builder(
         Flat::builder()
             .source(&flat)
             .source_named(&helper, "renamed_helper")
@@ -773,9 +762,9 @@ fn builder_composes_directories_and_streams() {
 fn builder_and_from_items_agree() {
     let dir = write_source_dir("agree", "flat-crate", "marked_fn");
 
-    let built: RegistryBuilder<()> =
+    let built: RegistryBuilder =
         Registry::builder(Flat::builder().source(&dir).build().expect("parses")).expect("indexes");
-    let streamed: RegistryBuilder<()> =
+    let streamed: RegistryBuilder =
         crate::test_util::reg_from_items(prebindgen::Source::new(&dir).items_all())
             .expect("indexes");
 
@@ -809,7 +798,7 @@ fn a_source_type_cell_carries_the_models_typeref() {
         crate_name: Some("myflat".into()),
     };
     let item: syn::Item = syn::parse_str("pub fn f(v: Option<u64>) -> u64 { v.unwrap() }").unwrap();
-    let reg: RegistryBuilder<()> = crate::test_util::reg_from_items([(item, loc.clone())]).unwrap();
+    let reg: RegistryBuilder = crate::test_util::reg_from_items([(item, loc.clone())]).unwrap();
 
     let mut ext = StubExt::default();
     ext.functions.insert(syn::parse_str("f").unwrap());
@@ -876,7 +865,7 @@ fn a_composed_reading_reaches_the_cell_unchanged() {
             loc.clone(),
         ),
     ];
-    let reg: RegistryBuilder<()> = crate::test_util::reg_from_items(items).unwrap();
+    let reg: RegistryBuilder = crate::test_util::reg_from_items(items).unwrap();
     let mut ext = StubExt::default();
     ext.functions.insert(syn::parse_str("f").unwrap());
     ext.types.push(syn::parse_str("Thing").unwrap());
@@ -927,7 +916,7 @@ fn a_composed_reading_reaches_the_cell_unchanged() {
 #[test]
 fn reading_is_a_lookup_not_a_classification() {
     let items = vec![fn_item("fn f(x: u64) -> u64 { x }")];
-    let reg: RegistryBuilder<()> = crate::test_util::reg_from_items(items).unwrap();
+    let reg: RegistryBuilder = crate::test_util::reg_from_items(items).unwrap();
     let mut ext = StubExt::default();
     ext.functions.insert(syn::parse_str("f").unwrap());
     let reg = ext
@@ -969,7 +958,7 @@ fn an_adapter_authored_type_cell_is_classified_but_placeless() {
     use prebindgen_flat::flat::TypeKind;
 
     let items = vec![fn_item("fn f(x: u64) -> u64 { x }")];
-    let reg: RegistryBuilder<()> = crate::test_util::reg_from_items(items).unwrap();
+    let reg: RegistryBuilder = crate::test_util::reg_from_items(items).unwrap();
 
     let mut ext = StubExt::default();
     ext.types
@@ -1078,7 +1067,7 @@ fn from_flat_projects_each_element_kind() {
         .items(items)
         .build()
         .expect("parse");
-    let reg: RegistryBuilder<()> = Registry::builder(flat).expect("project");
+    let reg: RegistryBuilder = Registry::builder(flat).expect("project");
 
     let id = |n: &str| syn::parse_str::<syn::Ident>(n).unwrap();
     let is_enum = |name: &str| {
@@ -1150,7 +1139,7 @@ fn not_expressible_report_names_the_crate_of_each_offender() {
             at("helpers"),
         ),
     ];
-    let Err(err) = crate::test_util::reg_from_items::<(), _>(items) else {
+    let Err(err) = crate::test_util::reg_from_items::<_>(items) else {
         panic!("both items are inexpressible")
     };
     let msg = err.to_string();
@@ -1187,7 +1176,7 @@ fn a_binding_local_fn_is_checked_against_the_grammar() {
         ("fn takes_impl(x: impl std::fmt::Debug) {}", "impl Trait"),
         ("async fn is_async() {}", "async"),
     ] {
-        let reg: RegistryBuilder<()> =
+        let reg: RegistryBuilder =
             crate::test_util::reg_from_items(vec![fn_item("fn good(x: u64) -> u64 { x }")])
                 .unwrap();
         let ext = StubExt {
@@ -1214,7 +1203,7 @@ fn a_binding_local_fn_is_checked_against_the_grammar() {
 /// declared, which a binding-local fn legitimately may not be.
 #[test]
 fn a_well_formed_binding_local_fn_passes() {
-    let reg: RegistryBuilder<()> =
+    let reg: RegistryBuilder =
         crate::test_util::reg_from_items(vec![fn_item("fn good(x: u64) -> u64 { x }")]).unwrap();
     let ext = StubExt {
         local_fns: vec![(
@@ -1259,7 +1248,7 @@ fn a_guard_never_reaches_the_const_surface() {
             loc.clone(),
         ),
     ];
-    let reg: RegistryBuilder<()> = crate::test_util::reg_from_items(items).unwrap();
+    let reg: RegistryBuilder = crate::test_util::reg_from_items(items).unwrap();
 
     assert_eq!(reg.flat().guards().count(), 2);
     assert_eq!(reg.flat().constants().count(), 1);
@@ -1287,7 +1276,7 @@ fn a_guard_never_reaches_the_const_surface() {
 /// one would move generated output. This is the assertion that keeps the filter.
 #[test]
 fn named_item_idents_omits_aliases() {
-    let reg: RegistryBuilder<()> = crate::test_util::reg_with(&[
+    let reg: RegistryBuilder = crate::test_util::reg_with(&[
         "pub fn f(x: u64) -> u64 { x }",
         "pub struct S { pub a: u64 }",
         "pub enum E { A }",
@@ -1315,7 +1304,7 @@ fn a_binding_local_fn_joins_the_index_but_not_the_source_modules() {
         crate_name: Some("myflat".into()),
         ..SourceLocation::default()
     };
-    let reg: RegistryBuilder<()> = crate::test_util::reg_from_items(vec![(
+    let reg: RegistryBuilder = crate::test_util::reg_from_items(vec![(
         syn::parse_quote!(
             pub fn captured(x: u64) -> u64 {
                 x
@@ -1356,7 +1345,7 @@ fn a_binding_local_fn_joins_the_index_but_not_the_source_modules() {
 /// Both enum shapes remain distinct and directly usable through the flat model.
 #[test]
 fn both_enum_shapes_are_available_from_the_model() {
-    let reg: RegistryBuilder<()> = crate::test_util::reg_with(&[
+    let reg: RegistryBuilder = crate::test_util::reg_with(&[
         "pub enum Sum { A(u64), B }",
         "pub enum Flags { X = 1, Y = 2 }",
         "pub struct S { pub a: u64 }",
@@ -1389,7 +1378,7 @@ fn both_enum_shapes_are_available_from_the_model() {
 /// captured item" about it is simply false.
 #[test]
 fn every_declared_type_counts_including_an_alias() {
-    let reg: RegistryBuilder<()> = crate::test_util::reg_with(&[
+    let reg: RegistryBuilder = crate::test_util::reg_with(&[
         "pub struct S { pub a: u64 }",
         "pub enum Sum { A(u64), B }",
         "pub enum Flags { X = 1 }",
@@ -1424,7 +1413,7 @@ fn every_declared_type_counts_including_an_alias() {
 /// `core::diagnostics::ignoring_an_alias_is_not_stale`.
 #[test]
 fn a_qualified_alias_warns_rather_than_failing() {
-    let reg: RegistryBuilder<()> = crate::test_util::reg_with(&[
+    let reg: RegistryBuilder = crate::test_util::reg_with(&[
         "pub type Handle = other::Inner;",
         "pub fn f(x: u64) -> u64 { x }",
     ]);
@@ -1457,12 +1446,12 @@ fn a_type_only_a_local_fn_writes_still_has_a_reading() {
         fn stub(&self) -> &StubExt {
             &self.0
         }
-        fn converter(&self, ty: &syn::Type) -> Option<ConverterImpl<()>> {
+        fn converter(&self, ty: &syn::Type) -> Option<ConverterImpl> {
             Self::converter(ty)
         }
     }
     impl AnyConverterExt {
-        fn converter(ty: &syn::Type) -> Option<ConverterImpl<()>> {
+        fn converter(ty: &syn::Type) -> Option<ConverterImpl> {
             Some(ConverterImpl {
                 destination: ty.clone(),
                 function: syn::parse_quote!(
@@ -1476,11 +1465,10 @@ fn a_type_only_a_local_fn_writes_still_has_a_reading() {
         }
     }
     impl Prebindgen for AnyConverterExt {
-        type Metadata = ();
         fn on_function(
             &self,
             f: &prebindgen_flat::flat::Function,
-            r: &Registry<()>,
+            r: &Registry,
             _emit: &crate::Emit,
         ) -> TokenStream {
             self.0.on_function(f, r, _emit)
@@ -1488,7 +1476,7 @@ fn a_type_only_a_local_fn_writes_still_has_a_reading() {
         fn on_struct(
             &self,
             st: &prebindgen_flat::flat::Struct,
-            r: &Registry<()>,
+            r: &Registry,
             _emit: &crate::Emit,
         ) -> TokenStream {
             self.0.on_struct(st, r, _emit)
@@ -1496,7 +1484,7 @@ fn a_type_only_a_local_fn_writes_still_has_a_reading() {
         fn on_variant(
             &self,
             v: &prebindgen_flat::flat::Variant,
-            r: &Registry<()>,
+            r: &Registry,
             _emit: &crate::Emit,
         ) -> TokenStream {
             self.0.on_variant(v, r, _emit)
@@ -1504,7 +1492,7 @@ fn a_type_only_a_local_fn_writes_still_has_a_reading() {
         fn on_enum(
             &self,
             e: &prebindgen_flat::flat::Enum,
-            r: &Registry<()>,
+            r: &Registry,
             _emit: &crate::Emit,
         ) -> TokenStream {
             self.0.on_enum(e, r, _emit)
@@ -1512,7 +1500,7 @@ fn a_type_only_a_local_fn_writes_still_has_a_reading() {
     }
 
     // `Option<u64>` appears nowhere in the captured stream.
-    let reg: RegistryBuilder<()> =
+    let reg: RegistryBuilder =
         crate::test_util::reg_from_items(vec![fn_item("fn captured(x: u64) -> u64 { x }")])
             .unwrap();
     assert!(
@@ -1563,7 +1551,7 @@ fn a_type_only_a_local_fn_writes_still_has_a_reading() {
 /// the location has a position at all, which is the only thing that now gates it.
 #[test]
 fn an_unresolved_type_without_a_position_reports_none() {
-    let reg: RegistryBuilder<()> =
+    let reg: RegistryBuilder =
         crate::test_util::reg_from_items(vec![fn_item("fn captured(x: u64) -> u64 { x }")])
             .unwrap();
     let ext = StubExt {
@@ -1594,7 +1582,7 @@ fn an_unresolved_type_without_a_position_reports_none() {
     );
 
     // A captured item that DOES have a position still reports it.
-    let located: RegistryBuilder<()> = crate::test_util::reg_from_items(vec![(
+    let located: RegistryBuilder = crate::test_util::reg_from_items(vec![(
         syn::parse_quote!(
             pub fn f(x: u64) -> u64 {
                 x
@@ -1630,7 +1618,7 @@ fn an_unresolved_type_without_a_position_reports_none() {
 /// binding author reaches for and the source language refuses.
 #[test]
 fn a_declared_crossing_the_grammar_refuses_is_not_called_a_prebindgen_item() {
-    let reg: RegistryBuilder<()> =
+    let reg: RegistryBuilder =
         crate::test_util::reg_from_items(vec![fn_item("fn f(x: u64) -> u64 { x }")]).unwrap();
 
     let mut ext = StubExt::default();
@@ -1719,7 +1707,7 @@ fn a_not_expressible_report_omits_a_position_it_does_not_have() {
 fn a_recursive_type_is_handed_out_once_and_terminates() {
     use std::collections::HashSet as Set;
 
-    let reg: RegistryBuilder<()> = crate::test_util::reg_with(&[
+    let reg: RegistryBuilder = crate::test_util::reg_with(&[
         "pub struct Node { pub next: Option<Box<Node>>, pub value: u64 }",
         "pub fn walk(n: &Node) -> u64 { n.value }",
     ]);

--- a/prebindgen-registry/src/registry/view.rs
+++ b/prebindgen-registry/src/registry/view.rs
@@ -22,8 +22,8 @@ pub type Crossing = (Direction, TypeKey);
 /// [`Building`] is the partial view a generator sees while it is still
 /// producing conversions; [`Registry`] is the total one everything else sees.
 /// A helper that serves both — reading a signature off the model, say — takes
-/// `&impl Conversions<M>` and works either side of the boundary.
-pub trait Conversions<M> {
+/// `&impl Conversions` and works either side of the boundary.
+pub trait Conversions {
     /// The model.
     fn flat(&self) -> &Flat;
 
@@ -45,15 +45,6 @@ pub trait Conversions<M> {
     /// rest take one precisely because this exists to hand them one (#284).
     fn reading(&self, key: &TypeKey) -> Option<TypeRef>;
 
-    /// The conversion for `reading` in `dir`, if there is one.
-    ///
-    /// Takes the **reading**, not a spelling. A caller that has to ask what a
-    /// type converts to has already established what the type *is*; asking with
-    /// tokens instead let a spelling nobody classified reach the table, and cost
-    /// a `TypeKey::from_type` on every call for an identity the reading already
-    /// carries.
-    fn conversion(&self, dir: Direction, reading: &TypeRef) -> Option<&TypeEntry<M>>;
-
     /// The reading for a **spelling** — identify, then look up.
     ///
     /// The door for a caller holding tokens it peeled or composed itself, which
@@ -67,16 +58,6 @@ pub trait Conversions<M> {
     /// tokens is a visible step with a `None` to handle.
     fn reading_of(&self, ty: &syn::Type) -> Option<TypeRef> {
         self.reading(&TypeKey::from_type(ty))
-    }
-
-    /// Wire → rust.
-    fn input_entry(&self, reading: &TypeRef) -> Option<&TypeEntry<M>> {
-        self.conversion(Direction::Input, reading)
-    }
-
-    /// Rust → wire.
-    fn output_entry(&self, reading: &TypeRef) -> Option<&TypeEntry<M>> {
-        self.conversion(Direction::Output, reading)
     }
 
     /// The decomposition of a callback argument type, if it has one.
@@ -116,15 +97,12 @@ pub trait Conversions<M> {
     }
 }
 
-impl<M> Conversions<M> for Building<'_, M> {
+impl Conversions for Building<'_> {
     fn flat(&self) -> &Flat {
         &self.registry.flat
     }
     fn reading(&self, key: &TypeKey) -> Option<TypeRef> {
         self.registry.reading(key)
-    }
-    fn conversion(&self, dir: Direction, reading: &TypeRef) -> Option<&TypeEntry<M>> {
-        self.built.get(&(dir, reading.key()))
     }
     fn callback_arg_plan(&self, key: &TypeKey) -> Option<&UnfoldPlan> {
         self.registry.callback_arg_plans.get(key)
@@ -150,15 +128,12 @@ impl<M> Conversions<M> for Building<'_, M> {
     }
 }
 
-impl<M> Conversions<M> for Registry<M> {
+impl Conversions for Registry {
     fn flat(&self) -> &Flat {
         &self.flat
     }
     fn reading(&self, key: &TypeKey) -> Option<TypeRef> {
         Registry::reading(self, key)
-    }
-    fn conversion(&self, dir: Direction, reading: &TypeRef) -> Option<&TypeEntry<M>> {
-        self.type_table(dir).get(&reading.key())?.entry.as_ref()
     }
     fn callback_arg_plan(&self, key: &TypeKey) -> Option<&UnfoldPlan> {
         self.callback_arg_plans.get(key)
@@ -182,36 +157,28 @@ impl<M> Conversions<M> for Registry<M> {
 
 /// The registry mid-fill: the model, plus the conversions supplied so far.
 ///
-/// What a generator builds a conversion *against*. It sees every crossing it
-/// can compose from — `RegistryBuilder::crossings` hands them out inner-first, so by
-/// the time `Option<Handle>` is asked for, `Handle` is already in here.
+/// What a generator builds a conversion *against*: the model, the
+/// decompositions, and the full crossing population.
 ///
 /// It exposes exactly the reads a conversion needs, which is what keeps the
 /// half-filled state from leaking anywhere else: the resolved [`Registry`] is
 /// what the emitters get, and it is total.
-pub struct Building<'a, M> {
-    /// The prepared registry: model, decompositions and the full crossing
-    /// population. Its conversion cells are still empty — [`Self::conversion`]
-    /// deliberately reads [`Self::built`] instead, so a generator can only see
-    /// what it has actually produced.
-    registry: &'a Registry<M>,
-    built: &'a HashMap<Crossing, TypeEntry<M>>,
+///
+/// It no longer lends out conversions built so far. An adapter composes from
+/// its own fragments, which it keeps itself, so what the registry could offer
+/// here — one `ConverterImpl` per crossing — was both less than the adapter
+/// already had and less than a multi-wire crossing needs.
+pub struct Building<'a> {
+    /// The prepared registry. Its cells are still empty at this point.
+    registry: &'a Registry,
     /// Every crossing in the binding, resolved or not — the niche allocator
     /// reads the population, not just what is built so far.
     all_keys: &'a [Crossing],
 }
 
-impl<'a, M> Building<'a, M> {
-    pub(crate) fn new(
-        registry: &'a Registry<M>,
-        built: &'a HashMap<Crossing, TypeEntry<M>>,
-        all_keys: &'a [Crossing],
-    ) -> Self {
-        Self {
-            registry,
-            built,
-            all_keys,
-        }
+impl<'a> Building<'a> {
+    pub(crate) fn new(registry: &'a Registry, all_keys: &'a [Crossing]) -> Self {
+        Self { registry, all_keys }
     }
 }
 

--- a/prebindgen-registry/src/resolve.rs
+++ b/prebindgen-registry/src/resolve.rs
@@ -1,12 +1,12 @@
 //! Completeness: which conversions a binding actually needs, and whether it has
 //! them.
 //!
-//! What survives here is the completeness check. The generator fills the cells
-//! itself (`RegistryBuilder::crossings` → `convert_with`); this decides whether the
-//! set it produced covers everything reachable from an exported root.
+//! What survives here is the completeness check. The generator answers the
+//! crossings itself, in `RegistryBuilder::convert_with`; this decides whether
+//! the set it answered covers everything reachable from an exported root.
 //!
-//! There is no loop. `Registry::crossings` hands the demand out inner-first, so
-//! a generator answers each crossing once, with everything it composes from
+//! There is no loop. `convert_with` hands the demand out inner-first, so a
+//! generator answers each crossing once, with everything it composes from
 //! already built — including across the `impl Fn` seam, whose args cross in the
 //! opposite direction.
 //!
@@ -80,7 +80,7 @@ impl std::error::Error for ResolveError {}
 /// Derived, never stored. Needing a converter is a property of the graph, and the
 /// graph is not complete until resolution has run — so computing it once here
 /// beats maintaining a flag that every edge discovery has to write back.
-fn required_set<M>(registry: &Registry<M>) -> HashSet<(Direction, TypeKey)> {
+fn required_set(registry: &Registry) -> HashSet<(Direction, TypeKey)> {
     let mut required: HashSet<(Direction, TypeKey)> = HashSet::new();
     let mut queue: VecDeque<(Direction, TypeKey)> = VecDeque::new();
     for dir in [Direction::Input, Direction::Output] {
@@ -117,8 +117,8 @@ fn required_set<M>(registry: &Registry<M>) -> HashSet<(Direction, TypeKey)> {
 /// `subs` were already walked by `required_set`, so traversing through
 /// them risks reporting dependents the resolved converter doesn't actually
 /// need.
-fn collect_unresolved_descendants<M>(
-    registry: &Registry<M>,
+fn collect_unresolved_descendants(
+    registry: &Registry,
     seeds: &[(Direction, TypeKey)],
     seen: &mut std::collections::HashSet<(Direction, TypeKey)>,
     out: &mut Vec<UnresolvedEntry>,
@@ -169,7 +169,7 @@ fn collect_unresolved_descendants<M>(
     }
 }
 
-pub(crate) fn check_complete<M>(registry: &Registry<M>) -> Result<(), ResolveError> {
+pub(crate) fn check_complete(registry: &Registry) -> Result<(), ResolveError> {
     let required = required_set(registry);
     let mut entries: Vec<UnresolvedEntry> = Vec::new();
     let mut unresolved_required_roots: Vec<(Direction, TypeKey)> = Vec::new();

--- a/prebindgen-registry/src/resolve/tests.rs
+++ b/prebindgen-registry/src/resolve/tests.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::registry::TypeEntry;
+use crate::registry::Answer;
 
 /// Regression: when a required type is itself unresolved AND has fields
 /// that are also unresolved, the diagnostic must list both. Previously
@@ -15,7 +15,7 @@ fn final_invariant_reports_unresolved_field_of_unresolved_struct() {
     // gets a cell that is NOT a root — exactly the case the BFS is here to
     // catch. Driven through the real scan rather than simulated, so the state
     // under test is one the pipeline can actually produce.
-    let mut reg: Registry<()> =
+    let mut reg: Registry =
         crate::test_util::scanned_with(&["pub struct Outer { pub inner: ZKeyExpr }"]);
     let outer = reg
         .intern(
@@ -51,11 +51,11 @@ fn final_invariant_reports_unresolved_field_of_unresolved_struct() {
 /// that the resolved converter doesn't actually depend on.
 #[test]
 fn final_invariant_stops_at_resolved_nodes() {
-    use crate::registry::{Direction, Registry, TypeEntry};
+    use crate::registry::{Answer, Direction, Registry};
 
     // Through the real scan, so the state under test is one the pipeline can
     // actually produce: `Unrelated` is a field type nothing declares.
-    let mut reg: Registry<()> = crate::test_util::scanned_with(&[
+    let mut reg: Registry = crate::test_util::scanned_with(&[
         "pub struct Outer { pub inner: Inner }",
         "pub struct Inner { pub unused: Unrelated }",
     ]);
@@ -72,16 +72,7 @@ fn final_invariant_stops_at_resolved_nodes() {
         Direction::Input,
         &inner_ty,
         false,
-        Some(TypeEntry {
-            destination: syn::parse_quote!(i64),
-            function: syn::parse_quote!(
-                fn __dummy() {}
-            ),
-            pre_stages: vec![],
-            subs: vec![],
-            niches: crate::niches::Niches::empty(),
-            metadata: (),
-        }),
+        Some(Answer::over(vec![])),
     );
 
     reg.insert_crossing(Direction::Input, &unrelated_ty, false, None);
@@ -112,7 +103,7 @@ fn final_invariant_stops_at_resolved_nodes() {
 fn a_type_reachable_only_through_subs_must_still_resolve() {
     use crate::registry::{Registry, TypeKey};
 
-    let mut reg: Registry<()> = Registry::empty();
+    let mut reg: Registry = Registry::empty();
     let outer: syn::Type = syn::parse_quote!(Outer);
     let mid: syn::Type = syn::parse_quote!(Mid);
 
@@ -122,16 +113,7 @@ fn a_type_reachable_only_through_subs_must_still_resolve() {
         Direction::Input,
         &outer,
         true,
-        Some(TypeEntry {
-            destination: syn::parse_quote!(i64),
-            function: syn::parse_quote!(
-                fn __outer() {}
-            ),
-            pre_stages: vec![],
-            subs: vec![TypeKey::from_type(&mid)],
-            niches: crate::niches::Niches::empty(),
-            metadata: (),
-        }),
+        Some(Answer::over(vec![TypeKey::from_type(&mid)])),
     );
     // `Mid` is present, unresolved, and NOT a root.
     reg.insert_crossing(Direction::Input, &mid, false, None);

--- a/prebindgen-registry/src/test_util.rs
+++ b/prebindgen-registry/src/test_util.rs
@@ -16,7 +16,7 @@ use crate::registry::{Registry, RegistryBuilder};
 /// Whatever it does *not* declare is supplied by [`declare_referenced`], because
 /// these fixtures exist to exercise plan shapes and a handle declaration is noise
 /// in them.
-pub(crate) fn reg_with<M>(sources: &[&str]) -> RegistryBuilder<M> {
+pub(crate) fn reg_with(sources: &[&str]) -> RegistryBuilder {
     let items = sources
         .iter()
         .map(|src| {
@@ -30,7 +30,7 @@ pub(crate) fn reg_with<M>(sources: &[&str]) -> RegistryBuilder<M> {
 /// A **scanned** registry from item sources — for tests that drive `expand` /
 /// `unfold` directly and need the type tables populated, without going through
 /// a generator's conversion loop.
-pub(crate) fn scanned_with<M>(sources: &[&str]) -> Registry<M> {
+pub(crate) fn scanned_with(sources: &[&str]) -> Registry {
     reg_with(sources).scanned().expect("scan")
 }
 
@@ -47,7 +47,7 @@ pub(crate) fn declared_origin(ty: syn::Type) -> prebindgen_flat::flat::Origin<sy
 ///
 /// Test-only sugar: the two steps are one line each in a build script, but they
 /// appear in dozens of fixtures here.
-pub(crate) fn reg_from_items<M, I>(items: I) -> Result<RegistryBuilder<M>, crate::ScanError>
+pub(crate) fn reg_from_items<I>(items: I) -> Result<RegistryBuilder, crate::ScanError>
 where
     I: IntoIterator<Item = (syn::Item, SourceLocation)>,
 {

--- a/prebindgen-registry/src/unfold.rs
+++ b/prebindgen-registry/src/unfold.rs
@@ -478,7 +478,7 @@ pub(crate) fn apply(
 /// classes) and handed over as
 /// [`Decompositions::value_structs`](crate::Decompositions::value_structs).
 /// Its [`leaves`](Self::leaves)
-/// are [`LeafSource::Field`] leaves: each crosses the boundary as its own field
+/// are [`LeafSource::Reach`] leaves: each crosses the boundary as its own field
 /// value and the foreign side reassembles the object (no Java object is built
 /// on the Rust side).
 pub struct ValueDecon {
@@ -1403,7 +1403,7 @@ fn flatten(
                     out_ty,
                     identity: true,
                     nullable,
-                    source: LeafSource::Accessor,
+                    source: LeafSource::Reach,
                     group: None,
                 });
             }
@@ -1586,7 +1586,7 @@ fn flatten(
                             out_ty: fr.ty.clone(),
                             identity: false,
                             nullable,
-                            source: LeafSource::Field,
+                            source: LeafSource::Reach,
                             group: None,
                         });
                     }
@@ -1687,7 +1687,7 @@ fn flatten(
                         out_ty,
                         identity,
                         nullable,
-                        source: LeafSource::Accessor,
+                        source: LeafSource::Reach,
                         group: None,
                     });
                 }

--- a/prebindgen-registry/src/unfold.rs
+++ b/prebindgen-registry/src/unfold.rs
@@ -279,8 +279,8 @@ fn validate_declarations(acc: &Deconstructors) -> Result<(), UnfoldError> {
 ///
 /// Runs inside `write_rust` after `expand::apply` and before `resolve`, so leaf
 /// converters resolve through the normal rank machinery.
-pub(crate) fn apply<M>(
-    registry: &mut Registry<M>,
+pub(crate) fn apply(
+    registry: &mut Registry,
     acc: &Deconstructors,
     declared_fns: &std::collections::HashSet<syn::Ident>,
     accessor_fns: &std::collections::HashSet<syn::Ident>,
@@ -502,8 +502,8 @@ pub struct ValueDecon {
 /// stays non-generic.
 ///
 /// Runs in `write_rust` right after [`apply`] and before `resolve`.
-pub(crate) fn apply_value_structs<M>(
-    registry: &mut Registry<M>,
+pub(crate) fn apply_value_structs(
+    registry: &mut Registry,
     decons: Vec<ValueDecon>,
     declared_fns: &std::collections::HashSet<syn::Ident>,
 ) -> Result<(), UnfoldError> {
@@ -577,7 +577,7 @@ pub struct SumDecon {
 /// true for jnigen via `export_type`, and not true at all for a registry
 /// assembled without declarations. The invariant holds by construction now
 /// rather than by declaration order.
-fn register_leaves<M>(registry: &mut crate::registry::Registry<M>, leaves: &[UnfoldLeaf]) {
+fn register_leaves(registry: &mut crate::registry::Registry, leaves: &[UnfoldLeaf]) {
     for leaf in leaves {
         if leaf.has_converter() {
             registry.require_output(&leaf.out_ty);
@@ -588,8 +588,8 @@ fn register_leaves<M>(registry: &mut crate::registry::Registry<M>, leaves: &[Unf
 }
 
 /// Runs in `write_rust` right after [`apply_value_structs`] and before `resolve`.
-pub(crate) fn apply_sum_returns<M>(
-    registry: &mut Registry<M>,
+pub(crate) fn apply_sum_returns(
+    registry: &mut Registry,
     decons: Vec<SumDecon>,
     declared_fns: &std::collections::HashSet<syn::Ident>,
 ) -> Result<(), UnfoldError> {
@@ -608,8 +608,8 @@ pub(crate) fn apply_sum_returns<M>(
 
 /// Register the declaration-canonical [`DeconSpec`] of a synthesized
 /// decomposition (first writer wins) and return its identity.
-fn wire_fixed_decon<M>(
-    registry: &mut Registry<M>,
+fn wire_fixed_decon(
+    registry: &mut Registry,
     key: &TypeKey,
     source: &prebindgen_flat::flat::TypeRef,
     leaves: &[UnfoldLeaf],
@@ -631,8 +631,8 @@ fn wire_fixed_decon<M>(
 /// marks a type that has no whole-value converter at all (a sum), so the
 /// declared return's scan-time output requirement is dropped as the plan
 /// replaces it.
-fn wire_fixed_returns<M>(
-    registry: &mut Registry<M>,
+fn wire_fixed_returns(
+    registry: &mut Registry,
     vd: &ValueDecon,
     decon: &DeconId,
     declared_fns: &std::collections::HashSet<syn::Ident>,
@@ -696,8 +696,8 @@ fn wire_fixed_returns<M>(
 /// instead of a whole value built on the Rust side. Separate from the
 /// output-position wiring so the callback path (which needs the foreign-side
 /// group-reassembly adapter) can be enabled on its own.
-fn wire_fixed_callbacks<M>(
-    registry: &mut Registry<M>,
+fn wire_fixed_callbacks(
+    registry: &mut Registry,
     vd: &ValueDecon,
     decon: &DeconId,
     declared_fns: &std::collections::HashSet<syn::Ident>,
@@ -772,8 +772,8 @@ fn wire_fixed_callbacks<M>(
 /// Runs right after [`apply_value_structs`]; skips any function/arg that already
 /// carries a plan (an explicit `.deconstruct_output`, a `data_class` fold, …) so
 /// declared decompositions and value-struct folds win.
-pub(crate) fn apply_leaf_vec_folds<M>(
-    registry: &mut Registry<M>,
+pub(crate) fn apply_leaf_vec_folds(
+    registry: &mut Registry,
     elements: Vec<TypeKey>,
     declared_fns: &std::collections::HashSet<syn::Ident>,
 ) -> Result<(), UnfoldError> {
@@ -980,8 +980,8 @@ fn returns_type(ret: &prebindgen_flat::flat::TypeRef, key: &TypeKey) -> bool {
 }
 
 /// Build one output/error plan for `ed` and store it in the right registry map.
-fn process_decl<M>(
-    registry: &mut Registry<M>,
+fn process_decl(
+    registry: &mut Registry,
     acc: &Deconstructors,
     ed: &OutputDecl,
 ) -> Result<(), UnfoldError> {
@@ -1175,8 +1175,8 @@ fn decl_id(type_key: &TypeKey, _decl: &DeconstructorDecl) -> DeconId {
 /// already present): re-flatten the records with normalized inputs —
 /// borrowed identity, no outer shape — so the stored spec is independent of
 /// the using function's return shape and of processing order.
-fn register_decon_spec<M>(
-    registry: &mut Registry<M>,
+fn register_decon_spec(
+    registry: &mut Registry,
     acc: &Deconstructors,
     decon: &DeconId,
     records: &[DeconRecord],
@@ -1251,9 +1251,9 @@ fn find_deconstructor_by_type<'a>(
 /// recursively flattened ([`flatten`]) — nested accessors contribute
 /// their leaves with the access path prefixed.
 #[allow(clippy::too_many_arguments)]
-fn build_plan<M>(
+fn build_plan(
     acc: &Deconstructors,
-    registry: &Registry<M>,
+    registry: &Registry,
     ed: &OutputDecl,
     by_ref: bool,
     source: &prebindgen_flat::flat::TypeRef,
@@ -1340,9 +1340,9 @@ fn require_root_identity_last(
 /// * `visited` — type keys on the current nesting chain (cycle guard; entries
 ///   are removed after each nested recursion so sibling records may reuse a type).
 #[allow(clippy::too_many_arguments)]
-fn flatten<M>(
+fn flatten(
     acc: &Deconstructors,
-    registry: &Registry<M>,
+    registry: &Registry,
     records: &[DeconRecord],
     source: &prebindgen_flat::flat::TypeRef,
     path_prefix: &[PathStep],
@@ -1744,8 +1744,8 @@ pub fn dedup_names(names: &mut [String]) {
 /// to be about, so the check cannot be the thing a new declarator forgets
 /// (#223). The comparison is [`check_declared_target`], shared with the input
 /// side's constructor lookup.
-fn accessor_signature<M>(
-    registry: &Registry<M>,
+fn accessor_signature(
+    registry: &Registry,
     func: &syn::Ident,
     expected: &TypeKey,
 ) -> Result<prebindgen_flat::flat::TypeRef, UnfoldError> {
@@ -1797,7 +1797,7 @@ fn place_is_owned(hoists: &[Hoist], path_prefix: &[PathStep], by_ref: bool) -> b
 /// Asked separately because [`accessor_signature`] peels the `&` in order to
 /// compare target types, so `f(v: T)` and `f(v: &T)` are indistinguishable
 /// there by design.
-fn accessor_consumes<M>(registry: &Registry<M>, func: &syn::Ident) -> bool {
+fn accessor_consumes(registry: &Registry, func: &syn::Ident) -> bool {
     registry
         .flat()
         .function(&func)

--- a/prebindgen-registry/src/unfold/plan.rs
+++ b/prebindgen-registry/src/unfold/plan.rs
@@ -176,19 +176,17 @@ pub fn steps_are_movable(steps: &[PathStep]) -> bool {
 /// How a leaf's [`UnfoldLeaf::path`] is reached from the decomposed value.
 #[derive(Clone, PartialEq, Eq, Debug, Default)]
 pub enum LeafSource {
-    /// The path is a chain of `#[prebindgen]` **accessor functions**:
-    /// `source_module::f(&value)`, composing nested accessors. Nesting steps
-    /// that return `Option` make the leaf nullable. This is the form produced
-    /// by `.deconstructor_record*` / `.fun_accessor` declarations.
+    /// The value is **reached off** the decomposed value: an accessor chain, a
+    /// field chain, or the two mixed, which is what
+    /// [`UnfoldLeaf::path`] spells.
+    ///
+    /// One variant rather than two. `Accessor` and `Field` were separate while
+    /// an adapter branched on which it was; none does — the difference is
+    /// whether the path ENDS in a field read, which the path itself says. Two
+    /// spellings of one fact are two things to keep in step, and this is the
+    /// one that had no reader left.
     #[default]
-    Accessor,
-    /// The path is a chain of **struct field idents** reached by field access
-    /// and cloned: `value.a.b.clone()`. Produced by the synthesized
-    /// decomposition of a by-value `data_class` (see
-    /// [`ValueDecon`](crate::unfold::ValueDecon)); the value's own
-    /// fields cross as decoupled leaves and the foreign side reassembles the
-    /// object (so no Java object is built on the Rust side).
-    Field,
+    Reach,
     /// The **synthesized selector** of a decomposed sum: an `i32` naming which
     /// alternative is live. It is not read off the value at all — the emitter
     /// assigns it per `match` arm — so it has no path. Emitted once, ahead of
@@ -205,14 +203,14 @@ pub enum LeafSource {
     /// — never from an adapter composing one out of a name.
     SumTag,
     /// A payload field of ONE alternative of a decomposed sum, reached through
-    /// a **variant pattern** rather than an accessor chain or a field chain:
-    /// the emitter binds `member` inside `variant`'s `match` arm. The leaf is
-    /// live only when [`UnfoldLeaf::group`] equals the value's tag; in every
-    /// other arm its slot carries the wire default.
+    /// a **variant pattern** rather than a path: the emitter binds `member`
+    /// inside `variant`'s `match` arm. The leaf is live only when
+    /// [`UnfoldLeaf::group`] equals the value's tag; in every other arm its
+    /// slot carries the wire default.
     ///
-    /// This is the selector [`Accessor`](Self::Accessor) and
-    /// [`Field`](Self::Field) deliberately lack — both are deterministic
-    /// products, every record contributing unconditionally.
+    /// This is the selector [`Reach`](Self::Reach) deliberately lacks — a
+    /// reached value is a deterministic product, every one of them
+    /// contributing unconditionally.
     VariantField {
         /// The variant's ident as declared in the source enum.
         variant: syn::Ident,

--- a/prebindgen-registry/src/unfold/tests.rs
+++ b/prebindgen-registry/src/unfold/tests.rs
@@ -1085,7 +1085,7 @@ fn value_struct_vec_is_fixed_iterable_fold() {
         out_ty: tref(ty),
         identity: false,
         nullable: false,
-        source: LeafSource::Field,
+        source: LeafSource::Reach,
         group: None,
     };
     let vd = ValueDecon {
@@ -1118,7 +1118,7 @@ fn value_struct_vec_is_fixed_iterable_fold() {
         "decomposed-leaf fold, not whole-element"
     );
     assert_eq!(plan.leaves.len(), 2, "field leaves cross raw per element");
-    assert!(plan.leaves.iter().all(|l| l.source == LeafSource::Field));
+    assert!(plan.leaves.iter().all(|l| l.source == LeafSource::Reach));
     assert!(!plan.by_ref, "owned Vec<Payload> elements");
 }
 
@@ -1138,7 +1138,7 @@ fn value_struct_slice_callback_is_fixed_iterable_fold() {
         out_ty: tref(ty),
         identity: false,
         nullable: false,
-        source: LeafSource::Field,
+        source: LeafSource::Reach,
         group: None,
     };
     let vd = ValueDecon {
@@ -1167,7 +1167,7 @@ fn value_struct_slice_callback_is_fixed_iterable_fold() {
     assert!(plan.decon.is_some(), "carries the field decon");
     assert!(plan.element.is_none(), "decomposed-leaf fold");
     assert_eq!(plan.leaves.len(), 2);
-    assert!(plan.leaves.iter().all(|l| l.source == LeafSource::Field));
+    assert!(plan.leaves.iter().all(|l| l.source == LeafSource::Reach));
     // A scalar `&Payload` callback arg must stay a Base fixed builder.
     let mut reg2: Registry = reg_with(&[
         "fn storage_callback(f: impl Fn(&Payload) + Send + Sync + 'static) { todo!() }",
@@ -1873,7 +1873,7 @@ fn a_vec_of_optionals_installs_no_fixed_fold() {
         out_ty: tref(ty),
         identity: false,
         nullable: false,
-        source: LeafSource::Field,
+        source: LeafSource::Reach,
         group: None,
     };
     let vd = ValueDecon {

--- a/prebindgen-registry/src/unfold/tests.rs
+++ b/prebindgen-registry/src/unfold/tests.rs
@@ -79,7 +79,7 @@ fn accessor_optional_primitive() {
     // M2: `z_sample_timestamp(&ZSample) -> Option<&ZTimestamp>` decomposed
     // into a single primitive leaf `z_timestamp_ntp64(&ZTimestamp) -> i64`
     // (no identity). Outer shape is `Optional(Decompose)`.
-    let mut reg: Registry<()> = reg_with(&[
+    let mut reg: Registry = reg_with(&[
         "fn z_sample_timestamp(s: &ZSample) -> Option<&ZTimestamp> { todo!() }",
         "fn z_timestamp_ntp64(t: &ZTimestamp) -> i64 { todo!() }",
     ]);
@@ -130,7 +130,7 @@ fn accessor_optional_primitive() {
 fn accessor_plan_byref() {
     // `z_sample_key_expr(&ZSample) -> &ZKeyExpr` decomposed into the keyexpr
     // handle (identity) + its string form (`z_keyexpr_as_str`).
-    let mut reg: Registry<()> = reg_with(&[
+    let mut reg: Registry = reg_with(&[
         "fn z_sample_key_expr(s: &ZSample) -> &ZKeyExpr { todo!() }",
         "fn z_keyexpr_as_str(ke: &ZKeyExpr) -> &str { todo!() }",
     ]);
@@ -194,7 +194,7 @@ fn root_identity_before_nested_identity_errors() {
     // Owned return: the root `.field_self()` MOVES the value, a nested
     // identity (spliced ZKeyExpr handle) borrows it — id-first is the
     // order that would generate non-compiling Rust, caught at apply time.
-    let mut reg: Registry<()> = reg_with(&[
+    let mut reg: Registry = reg_with(&[
         "fn z_take_query(q: &ZQuery) -> ZQuery { todo!() }",
         "fn z_query_key_expr(q: &ZQuery) -> &ZKeyExpr { todo!() }",
     ]);
@@ -228,7 +228,7 @@ fn root_identity_before_nested_identity_errors() {
     assert!(matches!(err, UnfoldError::RootIdentityBeforeNested { .. }));
 
     // Root identity LAST (the zenoh `Query` shape) is accepted.
-    let mut reg2: Registry<()> = reg_with(&[
+    let mut reg2: Registry = reg_with(&[
         "fn z_take_query(q: &ZQuery) -> ZQuery { todo!() }",
         "fn z_query_key_expr(q: &ZQuery) -> &ZKeyExpr { todo!() }",
     ]);
@@ -261,7 +261,7 @@ fn root_identity_before_nested_identity_errors() {
 #[test]
 fn accessor_target_mismatch_errors() {
     // Accessor takes a different type than the accessor's target.
-    let mut reg: Registry<()> = reg_with(&[
+    let mut reg: Registry = reg_with(&[
         "fn z_foo() -> ZKeyExpr { todo!() }",
         "fn wrong(x: &ZSample) -> &str { todo!() }",
     ]);
@@ -286,7 +286,7 @@ fn accessor_target_mismatch_errors() {
 
 #[test]
 fn multiple_identity_errors() {
-    let mut reg: Registry<()> = reg_with(&["fn z_foo() -> ZKeyExpr { todo!() }"]);
+    let mut reg: Registry = reg_with(&["fn z_foo() -> ZKeyExpr { todo!() }"]);
     let mut acc = Deconstructors::default();
     acc.deconstructors.push(DeconstructorDecl {
         target: key("ZKeyExpr"),
@@ -307,7 +307,7 @@ fn multiple_identity_errors() {
 #[test]
 fn record_must_be_fun_accessor() {
     // A deconstructor record referencing a non-`.fun_accessor` fn errors.
-    let mut reg: Registry<()> = reg_with(&[
+    let mut reg: Registry = reg_with(&[
         "fn z_foo(s: &ZSample) -> &ZKeyExpr { todo!() }",
         "fn z_keyexpr_as_str(ke: &ZKeyExpr) -> &str { todo!() }",
     ]);
@@ -346,7 +346,7 @@ fn record_must_be_fun_accessor() {
 fn duplicate_leaf_name_errors() {
     // Two records of one deconstructor given the same literal name ⇒ hard
     // error (names are emitted verbatim; never auto-disambiguated).
-    let mut reg: Registry<()> = reg_with(&[
+    let mut reg: Registry = reg_with(&[
         "fn z_foo() -> ZSample { todo!() }",
         "fn z_sample_key_expr(s: &ZSample) -> &str { todo!() }",
         "fn z_sample_payload(s: &ZSample) -> Vec<u8> { todo!() }",
@@ -383,7 +383,7 @@ fn duplicate_leaf_name_errors() {
 #[test]
 fn reserved_separator_in_name_errors() {
     // A record name containing the reserved `"__"` chain separator ⇒ error.
-    let mut reg: Registry<()> = reg_with(&[
+    let mut reg: Registry = reg_with(&[
         "fn z_foo() -> ZSample { todo!() }",
         "fn z_sample_key_expr(s: &ZSample) -> &str { todo!() }",
     ]);
@@ -420,7 +420,7 @@ fn nested_accessor_flatten() {
     // accessor nests ZKeyExpr (handle+string), ZZBytes (bytes), and a
     // nullable ZTimestamp (Option<&ZTimestamp> → ntp64), plus a direct enum
     // leaf. Verifies path prefixes + nullable propagation.
-    let mut reg: Registry<()> = reg_with(&[
+    let mut reg: Registry = reg_with(&[
         "fn z_reply_sample(r: &ZReply) -> Option<&ZSample> { todo!() }",
         "fn z_sample_key_expr(s: &ZSample) -> &ZKeyExpr { todo!() }",
         "fn z_sample_payload(s: &ZSample) -> &ZZBytes { todo!() }",
@@ -545,7 +545,7 @@ fn reply_product_double_option_flatten() {
     // `Option<ZZenohId>` Acc record with NO default child, which keeps
     // the full `Option<…>` as its leaf `out_ty` (its own `Option` is the
     // converter's business, not a nesting step ⇒ NOT nullable).
-    let mut reg: Registry<()> = reg_with(&[
+    let mut reg: Registry = reg_with(&[
         "fn z_recv_reply(q: &ZQuery) -> ZReply { todo!() }",
         "fn z_reply_replier_zid(r: &ZReply) -> Option<ZZenohId> { todo!() }",
         "fn z_reply_is_ok(r: &ZReply) -> bool { todo!() }",
@@ -694,7 +694,7 @@ fn reply_product_double_option_flatten() {
 #[test]
 fn nested_cycle_errors() {
     // A → B → A nesting is rejected.
-    let mut reg: Registry<()> = reg_with(&[
+    let mut reg: Registry = reg_with(&[
         "fn z_foo() -> ZA { todo!() }",
         "fn a_to_b(a: &ZA) -> &ZB { todo!() }",
         "fn b_to_a(b: &ZB) -> &ZA { todo!() }",
@@ -736,7 +736,7 @@ fn iterable_whole_element_plan() {
     // each element delivered WHOLE (no accessor, no leaves): a per-fn
     // flatten with an empty record list on an element type that has no
     // deconstructor of its own.
-    let mut reg: Registry<()> =
+    let mut reg: Registry =
         reg_with(&["fn z_session_peers_zid(s: &ZSession) -> Vec<ZZenohId> { todo!() }"]);
     let mut acc = Deconstructors::default();
     acc.outputs.push(OutputDecl {
@@ -784,7 +784,7 @@ fn iterable_decomposed_plan() {
     // accessor → Iterable with per-element leaves: the string form + the
     // value itself via `record_id` (an identity leaf, owned at the
     // root since `Vec<ZZenohId>` owns its elements).
-    let mut reg: Registry<()> = reg_with(&[
+    let mut reg: Registry = reg_with(&[
         "fn z_session_peers_zid(s: &ZSession) -> Vec<ZZenohId> { todo!() }",
         "fn z_zenoh_id_to_string(z: &ZZenohId) -> String { todo!() }",
     ]);
@@ -837,7 +837,7 @@ fn convert_output_single_value() {
     // `.converter(ZTimestamp, z_timestamp_ntp64)` + `.convert_output()` on
     // `z_sample_timestamp -> Option<&ZTimestamp>` ⇒ Return delivery, single
     // leaf, convert_out_ty = Option<i64>.
-    let mut reg: Registry<()> = reg_with(&[
+    let mut reg: Registry = reg_with(&[
         "fn z_sample_timestamp(s: &ZSample) -> Option<&ZTimestamp> { todo!() }",
         "fn z_timestamp_ntp64(t: &ZTimestamp) -> i64 { todo!() }",
     ]);
@@ -878,7 +878,7 @@ fn convert_output_single_value() {
 #[test]
 fn multi_leaf_output_is_callback() {
     // A two-record deconstructor (handle + string) ⇒ Callback delivery (>1 leaf).
-    let mut reg: Registry<()> = reg_with(&[
+    let mut reg: Registry = reg_with(&[
         "fn z_sample_key_expr(s: &ZSample) -> &ZKeyExpr { todo!() }",
         "fn z_keyexpr_as_str(ke: &ZKeyExpr) -> &str { todo!() }",
     ]);
@@ -914,7 +914,7 @@ fn multi_leaf_output_is_callback() {
 #[test]
 fn vec_output_is_iterable_callback() {
     // A `Vec` return ⇒ Iterable + Callback (a fold), never a single Return.
-    let mut reg: Registry<()> = reg_with(&[
+    let mut reg: Registry = reg_with(&[
         "fn z_session_peers_zid(s: &ZSession) -> Vec<ZZenohId> { todo!() }",
         "fn z_zenoh_id_to_string(z: &ZZenohId) -> String { todo!() }",
     ]);
@@ -962,7 +962,7 @@ fn option_vec_output_is_optional_iterable_callback() {
     // a RECORD-BUILT `Optional(Iterable)` fold (issue #105): the auto-apply
     // peels the `Option` before probing the `Vec`, the elements decompose
     // into leaves (M5), and `None` skips the fold to deliver a null result.
-    let mut reg: Registry<()> = reg_with(&[
+    let mut reg: Registry = reg_with(&[
         "fn z_routers_zid(s: &ZSession) -> Option<Vec<ZZenohId>> { todo!() }",
         "fn z_zenoh_id_to_string(z: &ZZenohId) -> String { todo!() }",
     ]);
@@ -1005,7 +1005,7 @@ fn option_vec_single_leaf_stays_callback() {
     // single-Return reclassification is gated on "no Iterable at any layer",
     // not just a top-level `Iterable` (an `Option<Vec<T>>` fold has no single
     // value to return through `convert_out_ty`).
-    let mut reg: Registry<()> = reg_with(&[
+    let mut reg: Registry = reg_with(&[
         "fn z_routers_zid(s: &ZSession) -> Option<Vec<ZZenohId>> { todo!() }",
         "fn z_zenoh_id_to_string(z: &ZZenohId) -> String { todo!() }",
     ]);
@@ -1036,7 +1036,7 @@ fn option_vec_whole_element_plan() {
     // M4 dual of the decomposed case: an `Option<Vec<T>>` return with an
     // inline EMPTY record list delivers each element whole through its own
     // output converter, wrapped in the `Optional` layer.
-    let mut reg: Registry<()> =
+    let mut reg: Registry =
         reg_with(&["fn z_routers_zid(s: &ZSession) -> Option<Vec<ZZenohId>> { todo!() }"]);
     let mut acc = Deconstructors::default();
     acc.outputs.push(OutputDecl {
@@ -1077,7 +1077,7 @@ fn value_struct_vec_is_fixed_iterable_fold() {
     // an Optional layer: the field leaves cross raw per element and the
     // foreign folder rebuilds + appends them (no Java object is built on the
     // Rust side); `None` ⇒ a null list. Closes the data_class→Vec milestone.
-    let mut reg: Registry<()> =
+    let mut reg: Registry =
         reg_with(&["fn storage_get_vec(s: &Storage) -> Option<Vec<Payload>> { todo!() }"]);
     let leaf = |name: &str, ty: syn::Type| UnfoldLeaf {
         name: name.to_string(),
@@ -1129,7 +1129,7 @@ fn value_struct_slice_callback_is_fixed_iterable_fold() {
     // `callback_arg_plans` entry keyed by the `&[Payload]` arg: the
     // trampoline folds each element's field leaves into a foreign list, the
     // user callback still sees the whole `List<Payload>`.
-    let mut reg: Registry<()> = reg_with(&[
+    let mut reg: Registry = reg_with(&[
         "fn storage_callback_vec(f: impl Fn(&[Payload]) + Send + Sync + 'static) { todo!() }",
     ]);
     let leaf = |name: &str, ty: syn::Type| UnfoldLeaf {
@@ -1169,7 +1169,7 @@ fn value_struct_slice_callback_is_fixed_iterable_fold() {
     assert_eq!(plan.leaves.len(), 2);
     assert!(plan.leaves.iter().all(|l| l.source == LeafSource::Field));
     // A scalar `&Payload` callback arg must stay a Base fixed builder.
-    let mut reg2: Registry<()> = reg_with(&[
+    let mut reg2: Registry = reg_with(&[
         "fn storage_callback(f: impl Fn(&Payload) + Send + Sync + 'static) { todo!() }",
     ]);
     let vd2 = ValueDecon {
@@ -1192,7 +1192,7 @@ fn convert_error_decomposes_result_e() {
     // The ZError deconstructor (`z_error_message`) auto-applies to every fn
     // returning `Result<_, ZError>`, storing the plan in `error_plans`. Error
     // delivery is always Callback (its leaves are the `ze` callback args).
-    let mut reg: Registry<()> = reg_with(&[
+    let mut reg: Registry = reg_with(&[
         "fn z_keyexpr_try_from(s: String) -> Result<ZKeyExpr, ZError> { todo!() }",
         "fn z_error_message(e: &ZError) -> String { todo!() }",
         "fn z_infallible(s: &ZSample) -> bool { todo!() }",
@@ -1240,7 +1240,7 @@ fn default_output_applies_to_owned_and_borrow_returns() {
     // Default-everywhere: the ZKeyExpr deconstructor auto-applies to BOTH a
     // `&ZKeyExpr` (borrow) and an owned `ZKeyExpr` return. (`Result<…>` returns
     // are excluded — they keep a handle — and `fun_accessor`s are skipped.)
-    let mut reg: Registry<()> = reg_with(&[
+    let mut reg: Registry = reg_with(&[
         "fn z_borrow_keyexpr(s: &ZSession) -> &ZKeyExpr { todo!() }",
         "fn z_make_keyexpr(s: &ZSession) -> ZKeyExpr { todo!() }",
         "fn z_keyexpr_as_str(k: &ZKeyExpr) -> &str { todo!() }",
@@ -1285,7 +1285,7 @@ fn callback_arg_plan_derived() {
     // An `impl Fn(ZSample)` parameter of a declared fn gets a type-level
     // plan from ZSample's default deconstructor — same leaves a return of
     // ZSample would produce, but owned (`by_ref = false`).
-    let mut reg: Registry<()> = reg_with(&[
+    let mut reg: Registry = reg_with(&[
         "fn z_declare_sub(cb: impl Fn(ZSample) + Send + Sync + 'static) { todo!() }",
         "fn z_sample_key_expr(s: &ZSample) -> &ZKeyExpr { todo!() }",
         "fn z_sample_kind(s: &ZSample) -> SampleKind { todo!() }",
@@ -1362,7 +1362,7 @@ fn callback_arg_borrowed_decomposed() {
     // deconstructor as the by-value case, but with `by_ref = true` (leaves
     // read through the reference) and keyed under the actual `&ZSample` arg
     // type — so `callback_input`/`callback_iface_spec` find it.
-    let mut reg: Registry<()> = reg_with(&[
+    let mut reg: Registry = reg_with(&[
         "fn z_declare_sub(cb: impl Fn(&ZSample) + Send + Sync + 'static) { todo!() }",
         "fn z_sample_key_expr(s: &ZSample) -> &ZKeyExpr { todo!() }",
         "fn z_sample_kind(s: &ZSample) -> SampleKind { todo!() }",
@@ -1426,7 +1426,7 @@ fn callback_arg_borrowed_decomposed() {
 #[test]
 fn callback_arg_identity_fallback() {
     // No deconstructor for ZQuery ⇒ no plan: the arg is delivered whole.
-    let mut reg: Registry<()> = reg_with(&[
+    let mut reg: Registry = reg_with(&[
         "fn z_declare_queryable(cb: impl Fn(ZQuery) + Send + Sync + 'static) { todo!() }",
     ]);
     let acc = Deconstructors::default();
@@ -1438,7 +1438,7 @@ fn callback_arg_identity_fallback() {
 
 #[test]
 fn callback_zero_arg_no_plan() {
-    let mut reg: Registry<()> =
+    let mut reg: Registry =
         reg_with(&["fn z_with_close(on_close: impl Fn() + Send + Sync + 'static) { todo!() }"]);
     let acc = Deconstructors::default();
     let declared: std::collections::HashSet<syn::Ident> =
@@ -1451,7 +1451,7 @@ fn callback_zero_arg_no_plan() {
 fn callback_arg_nonbare_skipped() {
     // `impl Fn(Vec<ZSample>)`: the arg type key (`Vec<ZSample>`) matches no
     // deconstructor target ⇒ whole-value fallback, no plan.
-    let mut reg: Registry<()> = reg_with(&[
+    let mut reg: Registry = reg_with(&[
         "fn z_batched(cb: impl Fn(Vec<ZSample>) + Send + Sync + 'static) { todo!() }",
         "fn z_sample_kind(s: &ZSample) -> SampleKind { todo!() }",
     ]);
@@ -1490,7 +1490,7 @@ fn leaf_vec_fold_synthesizes_whole_element_plans() {
     // `Vec<String>` / `Option<Vec<ZenohId>>` returns and an `impl Fn(&[String])`
     // callback arg synthesize FIXED **whole-element** folds (no decon, element
     // set, no leaves) — the single-leaf dual of the `data_class` Vec fold.
-    let mut reg: Registry<()> = reg_with(&[
+    let mut reg: Registry = reg_with(&[
         "fn hello_get_locators(h: &Hello) -> Vec<String> { todo!() }",
         "fn session_peers(s: &Session) -> Option<Vec<ZenohId>> { todo!() }",
         "fn on_strings(f: impl Fn(&[String]) + Send + Sync + 'static) { todo!() }",
@@ -1548,7 +1548,7 @@ fn leaf_vec_fold_synthesizes_whole_element_plans() {
 fn leaf_vec_fold_skips_unnominated_and_preexisting() {
     // An un-nominated element is left on the ArrayList path (no plan); a fn
     // that already has a plan is never overwritten.
-    let mut reg: Registry<()> = reg_with(&[
+    let mut reg: Registry = reg_with(&[
         "fn other(x: &X) -> Vec<NotNominated> { todo!() }",
         "fn strings() -> Vec<String> { todo!() }",
     ]);
@@ -1588,7 +1588,7 @@ fn leaf_vec_fold_skips_unnominated_and_preexisting() {
 /// that stands on its own for any adapter.)
 #[test]
 fn unknown_accessor_errors() {
-    let mut reg: Registry<()> = reg_with(&["fn z_foo() -> ZKeyExpr { todo!() }"]);
+    let mut reg: Registry = reg_with(&["fn z_foo() -> ZKeyExpr { todo!() }"]);
     let mut acc = Deconstructors::default();
     acc.deconstructors.push(DeconstructorDecl {
         target: key("ZKeyExpr"),
@@ -1614,7 +1614,7 @@ fn unknown_accessor_errors() {
 /// delivery form.)
 #[test]
 fn duplicate_declarations_collected() {
-    let mut reg: Registry<()> = reg_with(&[
+    let mut reg: Registry = reg_with(&[
         "fn z_keyexpr_as_str(ke: &ZKeyExpr) -> &str { todo!() }",
         "fn z_session_key(s: &ZSession) -> ZKeyExpr { todo!() }",
     ]);
@@ -1707,7 +1707,7 @@ fn reading_sum_decon() -> SumDecon {
 /// would fail the resolve on a converter that must not exist.
 #[test]
 fn sum_return_is_a_fixed_builder_plan() {
-    let mut reg: Registry<()> = reg_with(&["fn read_one(which: i32) -> Reading { todo!() }"]);
+    let mut reg: Registry = reg_with(&["fn read_one(which: i32) -> Reading { todo!() }"]);
     let declared: std::collections::HashSet<syn::Ident> =
         ["read_one"].iter().map(|s| ident(s)).collect();
     apply_sum_returns(&mut reg, vec![reading_sum_decon()], &declared).expect("apply_sum_returns");
@@ -1760,7 +1760,7 @@ fn sum_return_is_a_fixed_builder_plan() {
 /// dropped along with the bare type's.
 #[test]
 fn sum_return_layers_ride_the_shape_fold() {
-    let mut reg: Registry<()> = reg_with(&[
+    let mut reg: Registry = reg_with(&[
         "fn read_maybe(w: i32) -> Option<Reading> { todo!() }",
         "fn read_all(n: i32) -> Vec<Reading> { todo!() }",
     ]);
@@ -1802,7 +1802,7 @@ fn sum_return_layers_ride_the_shape_fold() {
 /// unrequire exists for.
 #[test]
 fn a_vec_only_sum_return_drops_the_bare_requirement() {
-    let mut reg: Registry<()> = reg_with(&["fn read_all(n: i32) -> Vec<Reading> { todo!() }"]);
+    let mut reg: Registry = reg_with(&["fn read_all(n: i32) -> Vec<Reading> { todo!() }"]);
     let bare: syn::Type = syn::parse_quote!(Reading);
     let bare_reading = reg
         .intern(crate::registry::Direction::Output, &bare, true)
@@ -1834,7 +1834,7 @@ fn a_vec_only_sum_return_drops_the_bare_requirement() {
 /// groups instead of a whole value built on the Rust side.
 #[test]
 fn sum_callback_arg_is_a_fixed_builder_plan() {
-    let mut reg: Registry<()> = reg_with(&[
+    let mut reg: Registry = reg_with(&[
         "fn read_each(n: i32, f: impl Fn(Reading) + Send + Sync + 'static) { todo!() }",
     ]);
     let declared: std::collections::HashSet<syn::Ident> =
@@ -1865,7 +1865,7 @@ fn sum_callback_arg_is_a_fixed_builder_plan() {
 /// verified by sabotage, not assumed.
 #[test]
 fn a_vec_of_optionals_installs_no_fixed_fold() {
-    let mut reg: Registry<()> =
+    let mut reg: Registry =
         reg_with(&["fn storage_get_vec(s: &Storage) -> Vec<Option<Payload>> { todo!() }"]);
     let leaf = |name: &str, ty: syn::Type| UnfoldLeaf {
         name: name.to_string(),

--- a/prebindgen-registry/src/write.rs
+++ b/prebindgen-registry/src/write.rs
@@ -1,10 +1,13 @@
 //! Rust file emission for the resolved `Registry`.
 //!
-//! `write_rust` collects every resolved input/output converter (each entry
-//! already carries its full `ItemFn`), every per-item `on_<kind>` output,
-//! and every anonymous const; concatenates them; and hands them to
-//! `Destination::write` (which does prettyplease formatting and
-//! resolves the path against `OUT_DIR`).
+//! `write_rust` takes the conversions the adapter compiled, as a slice of
+//! `ItemFn`; adds every per-item `on_<kind>` output and every anonymous const;
+//! concatenates them; and hands them to `Destination::write` (which does
+//! prettyplease formatting and resolves the path against `OUT_DIR`).
+//!
+//! The conversions arrive from the adapter rather than being collected from the
+//! registry, which is what lets one crossing contribute more than one function
+//! — or one that occupies more than a single wire value.
 //!
 //! This module is `pub`, so **every `pub` item in it is public API of the
 //! crate**. That is meant to be exactly two — [`write_rust`] and
@@ -22,26 +25,8 @@ use proc_macro2::TokenStream;
 use crate::{
     destination::Destination,
     prebindgen::Prebindgen,
-    registry::{Registry, TypeEntry, TypeKey},
+    registry::{Registry, TypeKey},
 };
-
-/// Where the generated conversions come from.
-///
-/// The converter table is the **lookup** index either way; this says only what
-/// reaches the file. An adapter that compiles its own fragments hands them over
-/// directly, and is then free to emit a conversion the table cannot hold —
-/// several functions for one crossing, or one occupying more than a single wire
-/// value, which is what a `ConverterImpl`'s single `destination` cannot name.
-pub enum Conversions<'a> {
-    /// What the adapter's compilation produced, in the order it produced it.
-    ///
-    /// Sorted and de-duplicated by function name here, so the order decides
-    /// which of two same-named functions wins and not where any of them lands.
-    Compiled(&'a [syn::ItemFn]),
-    /// Read them off the converter table, where they lived when a conversion
-    /// could only ever be one `ConverterImpl` per crossing.
-    Table,
-}
 
 /// Errors surfaced by the file-emission phase.
 ///
@@ -77,12 +62,19 @@ impl std::error::Error for WriteError {}
 
 /// Emit the resolved registry to a Rust file.
 ///
+/// `conversions` is what the adapter's compilation produced. It is sorted and
+/// de-duplicated by function name here, so the order decides which of two
+/// same-named functions wins and not where any of them lands. Handing them
+/// over directly is what frees an adapter to emit a conversion the converter
+/// table could not hold — several functions for one crossing, or one occupying
+/// more than a single wire value.
+///
 /// `out_path` may be relative (resolved against `OUT_DIR` by prebindgen) or
 /// absolute. Returns the path actually written.
 pub fn write_rust<P: AsRef<Path>, E: Prebindgen>(
     registry: &Registry<E::Metadata>,
     ext: &E,
-    conversions: Conversions<'_>,
+    conversions: &[syn::ItemFn],
     out_path: P,
 ) -> Result<PathBuf, WriteError> {
     // Validation already ran ONCE in the generator's `build` — a built generator
@@ -101,10 +93,7 @@ pub fn write_rust<P: AsRef<Path>, E: Prebindgen>(
     items.extend(ext.prerequisites(registry, &emit));
 
     // 1. Auto-generated converter wrappers (sorted by ident, deduped).
-    for (_, item_fn) in match conversions {
-        Conversions::Compiled(functions) => dedup_by_name(functions.to_vec()),
-        Conversions::Table => collect_converter_items(registry),
-    } {
+    for (_, item_fn) in dedup_by_name(conversions.to_vec()) {
         items.push(syn::Item::Fn(item_fn));
     }
 
@@ -187,57 +176,6 @@ pub fn write_rust<P: AsRef<Path>, E: Prebindgen>(
     Ok(dest.write(out_path))
 }
 
-/// Walk both type tables, dedupe each entry's stored `function` AND each
-/// of its [`crate::prebindgen::Stage`] functions by name, sort
-/// for determinism. Names are read directly off `function.sig.ident` —
-/// the adapter owns the naming.
-///
-/// Private: an internal step of [`write_rust`], not part of the
-/// adapter-facing surface this module exposes.
-/// Sort by name and keep the first of each, which is what the converter table
-/// does for the entries it holds — one function per name reaches the file
-/// however many crossings produced it.
-fn dedup_by_name(functions: Vec<syn::ItemFn>) -> Vec<(syn::Ident, syn::ItemFn)> {
-    let mut by_name: BTreeMap<String, (syn::Ident, syn::ItemFn)> = BTreeMap::new();
-    for function in functions {
-        let name = function.sig.ident.clone();
-        by_name.entry(name.to_string()).or_insert((name, function));
-    }
-    by_name.into_values().collect()
-}
-
-fn collect_converter_items<M>(registry: &Registry<M>) -> Vec<(syn::Ident, syn::ItemFn)> {
-    let mut by_name: BTreeMap<String, (syn::Ident, syn::ItemFn)> = BTreeMap::new();
-    let mut collect = |entry: &TypeEntry<M>| {
-        let name = entry.function.sig.ident.clone();
-        by_name
-            .entry(name.to_string())
-            .or_insert_with(|| (name, entry.function.clone()));
-        for stage in &entry.pre_stages {
-            let sname = stage.function.sig.ident.clone();
-            by_name
-                .entry(sname.to_string())
-                .or_insert_with(|| (sname, stage.function.clone()));
-        }
-    };
-    walk_resolved(&registry.input_types, |_, entry| collect(entry));
-    walk_resolved(&registry.output_types, |_, entry| collect(entry));
-    by_name.into_values().collect()
-}
-
-fn walk_resolved<M, F: FnMut(&TypeKey, &TypeEntry<M>)>(
-    table: &std::collections::HashMap<TypeKey, crate::registry::TypeCell<M>>,
-    mut f: F,
-) {
-    let mut keys: Vec<&TypeKey> = table.keys().collect();
-    keys.sort_by(|a, b| a.as_str().cmp(b.as_str()));
-    for key in keys {
-        if let Some(entry) = table.get(key).and_then(|c| c.entry.as_ref()) {
-            f(key, entry);
-        }
-    }
-}
-
 /// Name-sorted, because emission order is part of the generated file and the
 /// model is in source order. Was `sorted_items_by_ident` over the registry's
 /// maps; same ordering, read from the one index.
@@ -272,3 +210,14 @@ fn parse_items_from_tokens<I: IntoIterator<Item = TokenStream>>(
 
 #[cfg(test)]
 mod tests;
+
+/// Sort by name and keep the first of each: one function per name reaches the
+/// file however many crossings produced it.
+fn dedup_by_name(functions: Vec<syn::ItemFn>) -> Vec<(syn::Ident, syn::ItemFn)> {
+    let mut by_name: BTreeMap<String, (syn::Ident, syn::ItemFn)> = BTreeMap::new();
+    for function in functions {
+        let name = function.sig.ident.clone();
+        by_name.entry(name.to_string()).or_insert((name, function));
+    }
+    by_name.into_values().collect()
+}

--- a/prebindgen-registry/src/write.rs
+++ b/prebindgen-registry/src/write.rs
@@ -72,7 +72,7 @@ impl std::error::Error for WriteError {}
 /// `out_path` may be relative (resolved against `OUT_DIR` by prebindgen) or
 /// absolute. Returns the path actually written.
 pub fn write_rust<P: AsRef<Path>, E: Prebindgen>(
-    registry: &Registry<E::Metadata>,
+    registry: &Registry,
     ext: &E,
     conversions: &[syn::ItemFn],
     out_path: P,

--- a/prebindgen-registry/src/write/tests.rs
+++ b/prebindgen-registry/src/write/tests.rs
@@ -9,7 +9,7 @@ use crate::registry::RegistryBuilder;
 struct IdentityExt;
 
 impl IdentityExt {
-    fn declare_into(&self, mut reg: RegistryBuilder<()>) -> RegistryBuilder<()> {
+    fn declare_into(&self, mut reg: RegistryBuilder) -> RegistryBuilder {
         for f in [syn::parse_quote!(a_fn), syn::parse_quote!(b_fn)] {
             reg = reg.export(&f);
         }
@@ -23,12 +23,10 @@ impl IdentityExt {
 }
 
 impl Prebindgen for IdentityExt {
-    type Metadata = ();
-
     fn on_function(
         &self,
         f: &prebindgen_flat::flat::Function,
-        _registry: &Registry<Self::Metadata>,
+        _registry: &Registry,
         emit: &crate::Emit,
     ) -> TokenStream {
         emit.verbatim_fn(f)
@@ -37,7 +35,7 @@ impl Prebindgen for IdentityExt {
     fn on_struct(
         &self,
         s: &prebindgen_flat::flat::Struct,
-        _registry: &Registry<Self::Metadata>,
+        _registry: &Registry,
         emit: &crate::Emit,
     ) -> TokenStream {
         emit.verbatim_struct(s)
@@ -46,7 +44,7 @@ impl Prebindgen for IdentityExt {
     fn on_variant(
         &self,
         v: &prebindgen_flat::flat::Variant,
-        _registry: &Registry<Self::Metadata>,
+        _registry: &Registry,
         emit: &crate::Emit,
     ) -> TokenStream {
         emit.verbatim_variant(v)
@@ -55,7 +53,7 @@ impl Prebindgen for IdentityExt {
     fn on_enum(
         &self,
         e: &prebindgen_flat::flat::Enum,
-        _registry: &Registry<Self::Metadata>,
+        _registry: &Registry,
         emit: &crate::Emit,
     ) -> TokenStream {
         emit.verbatim_enum(e)
@@ -147,7 +145,7 @@ fn write_rust_sorts_declared_items_by_ident() {
             loc,
         ),
     ];
-    let reg: Registry<()> = IdentityExt
+    let reg: Registry = IdentityExt
         .declare_into(crate::test_util::reg_from_items(items).expect("index"))
         .scanned()
         .expect("scan");
@@ -196,14 +194,10 @@ fn guards_emit_ungated_and_in_stream_order() {
     struct ConstGatingExt;
 
     trait ResolveGating {
-        fn resolve_gating(self, ext: ConstGatingExt)
-            -> Result<Registry<()>, crate::WriteRustError>;
+        fn resolve_gating(self, ext: ConstGatingExt) -> Result<Registry, crate::WriteRustError>;
     }
-    impl ResolveGating for RegistryBuilder<()> {
-        fn resolve_gating(
-            self,
-            ext: ConstGatingExt,
-        ) -> Result<Registry<()>, crate::WriteRustError> {
+    impl ResolveGating for RegistryBuilder {
+        fn resolve_gating(self, ext: ConstGatingExt) -> Result<Registry, crate::WriteRustError> {
             let registry = self.declares_consts().build()?;
             let _ = &ext;
             Ok(registry)
@@ -211,12 +205,10 @@ fn guards_emit_ungated_and_in_stream_order() {
     }
 
     impl Prebindgen for ConstGatingExt {
-        type Metadata = ();
-
         fn on_function(
             &self,
             f: &prebindgen_flat::flat::Function,
-            _r: &Registry<()>,
+            _r: &Registry,
             _emit: &crate::Emit,
         ) -> TokenStream {
             _emit.verbatim_fn(f)
@@ -224,7 +216,7 @@ fn guards_emit_ungated_and_in_stream_order() {
         fn on_struct(
             &self,
             s: &prebindgen_flat::flat::Struct,
-            _r: &Registry<()>,
+            _r: &Registry,
             _emit: &crate::Emit,
         ) -> TokenStream {
             _emit.verbatim_struct(s)
@@ -232,7 +224,7 @@ fn guards_emit_ungated_and_in_stream_order() {
         fn on_variant(
             &self,
             v: &prebindgen_flat::flat::Variant,
-            _r: &Registry<()>,
+            _r: &Registry,
             _emit: &crate::Emit,
         ) -> TokenStream {
             _emit.verbatim_variant(v)
@@ -240,7 +232,7 @@ fn guards_emit_ungated_and_in_stream_order() {
         fn on_enum(
             &self,
             e: &prebindgen_flat::flat::Enum,
-            _r: &Registry<()>,
+            _r: &Registry,
             _emit: &crate::Emit,
         ) -> TokenStream {
             _emit.verbatim_enum(e)
@@ -274,7 +266,7 @@ fn guards_emit_ungated_and_in_stream_order() {
             loc.clone(),
         ),
     ];
-    let registry: RegistryBuilder<()> = crate::test_util::reg_from_items(items).expect("index");
+    let registry: RegistryBuilder = crate::test_util::reg_from_items(items).expect("index");
     assert_eq!(registry.flat().guards().count(), 2);
 
     let dir = crate::test_util::unique_test_dir("write_guards");

--- a/prebindgen-registry/src/write/tests.rs
+++ b/prebindgen-registry/src/write/tests.rs
@@ -4,7 +4,7 @@ use prebindgen::SourceLocation;
 use proc_macro2::TokenStream;
 
 use super::*;
-use crate::registry::{Direction, RegistryBuilder};
+use crate::registry::RegistryBuilder;
 
 struct IdentityExt;
 
@@ -64,49 +64,24 @@ impl Prebindgen for IdentityExt {
 
 #[test]
 fn dedup_and_sort() {
-    let mut reg: Registry<()> = Registry::empty();
-    let ty_a: syn::Type = syn::parse_quote!(u64);
-    let ty_b: syn::Type = syn::parse_quote!(Sample);
-    let wire: syn::Type = syn::parse_quote!(i64);
-    let wire2: syn::Type = syn::parse_quote!(*const u8);
-
-    reg.insert_crossing(
-        Direction::Input,
-        &ty_a,
-        true,
-        Some(TypeEntry {
-            destination: wire.clone(),
-            function: syn::parse_quote!(
-                fn handle_to_u64_aaaa(v: i64) -> u64 {
-                    v as u64
-                }
-            ),
-            pre_stages: vec![],
-            subs: vec![],
-            niches: crate::niches::Niches::empty(),
-            metadata: (),
-        }),
+    // Two crossings can compile the same conversion, and an adapter hands over
+    // whatever its compilation produced. One function per name reaches the
+    // file, in name order — a generated file that reordered between runs would
+    // show up as a diff in `examples/regen-check.sh`.
+    let handle: syn::ItemFn = syn::parse_quote!(
+        fn handle_to_u64_aaaa(v: i64) -> u64 {
+            v as u64
+        }
     );
-    reg.insert_crossing(
-        Direction::Input,
-        &ty_b,
-        true,
-        Some(TypeEntry {
-            destination: wire2.clone(),
-            function: syn::parse_quote!(
-                fn Ptr_to_Sample_bbbb(v: *const u8) -> Sample {
-                    decode_sample(v)
-                }
-            ),
-            pre_stages: vec![],
-            subs: vec![],
-            niches: crate::niches::Niches::empty(),
-            metadata: (),
-        }),
+    let sample: syn::ItemFn = syn::parse_quote!(
+        fn Ptr_to_Sample_bbbb(v: *const u8) -> Sample {
+            decode_sample(v)
+        }
     );
 
-    let items = collect_converter_items(&reg);
-    assert_eq!(items.len(), 2);
+    let items = crate::write::dedup_by_name(vec![handle.clone(), sample.clone(), handle.clone()]);
+
+    assert_eq!(items.len(), 2, "the repeated conversion lands once");
     // Sorted ASCII: "Ptr_to_Sample_bbbb" < "handle_to_u64_aaaa"
     // (uppercase P < lowercase h).
     assert_eq!(items[0].0.to_string(), "Ptr_to_Sample_bbbb");
@@ -182,8 +157,7 @@ fn write_rust_sorts_declared_items_by_ident() {
         .expect("clock drift")
         .as_nanos();
     let path = std::env::temp_dir().join(format!("prebindgen-write-rust-{unique}.rs"));
-    let written = write_rust(&reg, &IdentityExt, crate::write::Conversions::Table, &path)
-        .expect("write_rust");
+    let written = write_rust(&reg, &IdentityExt, &[], &path).expect("write_rust");
     let content = std::fs::read_to_string(&written).expect("read generated file");
     let _ = std::fs::remove_file(&written);
 
@@ -306,13 +280,8 @@ fn guards_emit_ungated_and_in_stream_order() {
     let dir = crate::test_util::unique_test_dir("write_guards");
     std::fs::create_dir_all(&dir).unwrap();
     let registry = registry.resolve_gating(ConstGatingExt).expect("resolve");
-    let path = crate::write::write_rust(
-        &registry,
-        &ConstGatingExt,
-        crate::write::Conversions::Table,
-        dir.join("gen.rs"),
-    )
-    .expect("write_rust");
+    let path = crate::write::write_rust(&registry, &ConstGatingExt, &[], dir.join("gen.rs"))
+        .expect("write_rust");
     let src = std::fs::read_to_string(&path).unwrap();
 
     // The named const is gated out; both guards emit regardless.


### PR DESCRIPTION
**Draft, and long-lived.** Child PRs target **`registry-api-switch`**, not `main`. This body is the only place stage state is edited.

Finishes [#450](https://github.com/milyin/prebindgen/issues/450): both adapters fully on the registry API, and the machinery that predates it deleted.

[#465](https://github.com/milyin/prebindgen/pull/465) is **merged**, and this branch is rebased onto `main` — the diff here is only the work beyond it.

## Where #465 leaves things

`prebindgen-c` composes from parts — a `data_struct` is its fields, a tagged union is its arms — with seven hand-written walks deleted, the C ABI unchanged and ASan clean. `prebindgen-jni` **selects** from the table but composes nothing. `Compile::plan` is called and returns `()`; `identity`, `value_form`, `Cx::require` and `Compiled::required` have no caller at all.

## The one fact the plan turns on

Three times during #465 I claimed a fragment cannot occupy several wire values and that this blocked composition. It does not, and it never did:

- `Compile::Fragment` is bounded by `Carrier` and nothing else. An adapter may define it with a list of wire values today.
- `Carrier::yields()` returns `{ ty, mode, validity }` — the **Rust value**. It names no wire type. The registry never asks how many wire values a fragment occupies, exactly as #450 specifies.

**The limit is that the old pipeline is still the spine.** `RegistryBuilder::convert_with` takes `Option<ConverterImpl<M>>` back for every crossing, and `ConverterImpl::destination` is one `syn::Type`. Both adapters call it, which is why `CFrag` and `JFrag` each carry one `destination` — not because a fragment must, but because they have to answer that protocol.

`prebindgen-c` never noticed: a `data_struct` composes to **one** C struct by value, and its only genuinely multi-wire shape is refused at declaration time. A JniGen `data_class` is N JNI parameters, so it hits the protocol immediately.

And the round-trip is not even a hard stop: an adapter may hand back a **marker** converter and keep the real answer in its own fragment. `prebindgen-c` already does exactly that in four places, with `destination: ()`.

So the precise statement — after getting this wrong three times on #465 — is neither "the API cannot express it" nor "the protocol forbids it":

> For a crossing that occupies several wire values, **the converter table's `destination` stops being able to answer**, and its readers are the problem. `prebindgen-c` reads the table at **26** sites and `prebindgen-jni` at **73**.

That is why the lookup sites move first. Not to unblock arity in principle, but because the moment a JNI `data_class` becomes multi-wire, 73 readers are asking a question the table can no longer answer.

## What the converter table is still for

Measured, not assumed. After #465 moved emission off it, the adapters read the index at **65 sites** for five fields:

| Field | Reads |
|---|---:|
| `entry.destination` | 41 |
| `entry.function` | 21 |
| `entry.metadata` | 20 |
| `entry.pre_stages` | 10 |
| `entry.niches` | 8 |

and calls the index itself at 99 sites — 26 in `prebindgen-c`, 73 in `prebindgen-jni`.

Every one of those is a fact the adapter's own fragment already holds — `Compiled` keys them by `(TypeKey, Assembly, RecipeId)`. What the **registry** still needs from an entry is `subs`, for reachability. That asymmetry is what stages 1 and 2 exploit.

## What stages 1 and 1b measured

`prebindgen-c` splits into two phases: it compiles, then its per-item emitters
run and read what compilation produced. Three helpers — `lower_shape`,
`encode_value` and `output_is_fallible` — run in **both**, because
`dispatch_fn_input` reaches them while a callback's closure struct is still
being compiled. Those stay on the table until stage 2.

`prebindgen-jni` does not split. Its emitters **are** its conversion builders:
`struct_input_body`, `callback_input`, and the whole `struct_plan` / `iface` /
`render` / `delivery` layer are called from inside `convert_with`. They still
read fragments, because a conversion for one type is built out of the
conversions for its inners and the resolver compiles the inners first — the same
order that filled the table, so a fragment is there exactly when an entry would
have been. The store is therefore shared and read while it fills.

The trap is in the driver: handing the compiler the store by `mem::take` leaves
it **empty for the duration of every call**, which is exactly when the adapter
reads it. Cloning instead — the store is a map of `Rc`s — is the whole
difference, and it is what made a first attempt at 1b look blocked on stage 5.
It is not. The stage order below is unchanged.

The one crossing the compiler never sees is a callback, which
`JniGen::compile_crossing` answers by hand. The driver files that conversion as
the crossing's fragment through `Compiled::record`, so the emitters keep one
lookup; both go with the derived callback row.

## Stages

- [x] **1 — `prebindgen-c` reads its own fragments.** ([#474](https://github.com/milyin/prebindgen/pull/474)) Its emission-time lookups read `Compiled<CFrag>` instead of `input_entry` / `output_entry`. Byte-identical.
- [x] **1b — `prebindgen-jni` reads its own fragments.** ([#475](https://github.com/milyin/prebindgen/pull/475)) 57 of its 65 lookup sites read `Declarations::compiled`, read while it fills. The other 8 are free functions holding no `Declarations`; they go with the table in stage 2. Byte-identical.
- [x] **2a — both adapters off the table.** ([#476](https://github.com/milyin/prebindgen/pull/476)) The 18 lookups stages 1 and 1b left behind. `prebindgen-c` gets the in-flight store, which is what its four dual-phase helpers needed; `prebindgen-jni`'s seven free functions take a `Declarations`, and the `option_*` pair's test harness files each conversion in both places. Byte-identical.
- [x] **2b-i — delete the paths that read conversions off the table.** ([#477](https://github.com/milyin/prebindgen/pull/477)) `Conversions` (down to one variant, so `write_rust` takes `&[syn::ItemFn]`), `collect_converter_items`, `walk_resolved`, and the dead `RegistryBuilder::conversions` / `crossings` pair. 160 lines out. Byte-identical.
- [x] **2b — `convert_with` stops flattening.** ([#478](https://github.com/milyin/prebindgen/pull/478)) `TypeEntry` gone, `Answer` in its place, and the metadata parameter `M` with it. **The gate is through.**

  **Measured after the fact: the gate is open.** The registry now reads a wire type in exactly **one** place — `ConverterImpl::wire_type`, the accessor it hands adapters. `prebindgen-c` reads `destination` 24 times and `prebindgen-jni` 46, all on their own fragments. Nothing in the pipeline asks how many wire values a crossing occupies, so a fragment that carries several costs nothing to introduce.
 It takes back what reachability needs rather than a whole `ConverterImpl`. The round-trip goes, and `CFrag` / `JFrag` stop mirroring a type they no longer answer to. Byte-identical. **This is the gate**: after it, arity costs nothing, because `Fragment` is the adapter's own type.

  What 2a leaves for it, counted rather than guessed. Of a stored entry the registry reads only `subs`, the dependency keys `propagate_required` walks, plus whether an entry exists at all. Everything else that reads one is already dead or nearly so: `Conversions::input_entry` and `output_entry` have **no caller outside the registry crate**, `RegistryBuilder::conversions` — the bulk peer of `convert_with` — has **no caller at all**, and `Conversions::Table` has **two, both registry tests**, since each adapter now writes from `Conversions::Compiled`.

  It reaches further than the table, and the compiler says so: strip a cell down to `subs` and `M` — the metadata type parameter — goes unconstrained across `prebindgen-registry`. `M` exists to carry a `KotlinMeta` or a `()` through the converter table, and an adapter now reads its metadata off its own fragment. So `Registry<M>`, `Conversions<M>`, `Building<'_, M>` and the `Prebindgen::Metadata` that feeds them all lose the parameter, and `ConverterImpl<M>` keeps it, being what an adapter's fragment carries. That is most of the stage's diff and nearly all of it is deleting a type argument.
- [x] **3a — compose what a data class is made of.** ([#479](https://github.com/milyin/prebindgen/pull/479)) `JFrag` gains a wire list, `Compile::fields` composes it, and `Declarations::bindings` binds a nested `data_class` field to the `parts` row — without which the flattening stops one layer down. Declared but taken by nobody, so byte-identical, and every one of the 264 lib tests compiles it.
- [x] **3b-i — hold the composed row to the walk.** ([#480](https://github.com/milyin/prebindgen/pull/480)) `Wire` carries the Kotlin type, and a test asserts the row states exactly what `build_flat_input_plan` states, for a struct with a nested `data_class`. Byte-identical. A wire's path stays relative — the `h` in `hTag` is the parameter's, so the site prepends it.
- [x] **3c — carry what Kotlin reads and what the value converts through.** ([#481](https://github.com/milyin/prebindgen/pull/481)) `Wire` gains the Kotlin access and the converter, so the row reproduces the walk exactly for a fixture with a flat child, an `Option<data_class>` child and a `.jobject_input()` child. Byte-identical.
- [x] **3d — complete the wire.** ([#482](https://github.com/milyin/prebindgen/pull/482)) The last two facts the five input-side readers take from a leaf: whether the conversion is staged, and the struct field the value fills. Byte-identical. After it the row states everything they read.
- [x] **3 — a JNI data class is its fields.** The first multi-wire fragment, in two PRs: [#486](https://github.com/milyin/prebindgen/pull/486) composes every wire a `data_class` parameter occupies, and [#487](https://github.com/milyin/prebindgen/pull/487) points the emitters at them. `FlatInputPlan::leaves` **is** the fragment's wire list, and 780 lines of `emit/flat_input.rs` go with the walk that used to compute names, JNI types, Kotlin types, access expressions and nullability.

  **Byte-identical, which was not the plan.** Stage 3 was written expecting output to change. It does not, and the reason is worth recording: the composition was held to `build_flat_input_plan` fixture by fixture until the two agreed on every shape either could produce — a sealed-class field, all five parameter spellings, and the five field reads a `data_class` does not do literally (an `enum_class` property over a discriminant wire, an unsigned `ULong` over a `Long`, a decoupled nullable primitive, an optional riding a JVM `null`, a nested handle locked through its object). Each disagreement was a bug the row had and the walk did not.

  What remains of `flat_input.rs` is the **rebuild** — the tree the generated Rust reconstructs the struct through — and `InputKind::FlattenStruct` with it. That is per-site emission, so it goes at stage 5 rather than here: a fragment carrying its own wire values is what stage 3 was for, and `render.rs` builds a signature from it today.
- [x] **4 — a JNI sealed class is its arms.** The output half, and the larger: `unfold`'s five dependants — `sum_out.rs`, `delivery.rs`, `iface.rs`, `render.rs`, `kotlin_emit.rs`. Lights up `Deconstruct::ValueForm`, which is what `expand_return!(…).fields(fields!(accessor))` has always meant. Closes [#459](https://github.com/milyin/prebindgen/issues/459).

  **Output did not change.** Every sub-stage came out byte-identical, which the stage was not written expecting. The reason is the one 4d-ii and 4d-iii turn on: a composition reads no conversions, so the row and the pre-`resolve` leaf synthesis can be *the same code* rather than two walks that agree. Where the two could have differed, they were made one.

  - [x] **4a/4b — what a sealed class and a data class hand out.** ([#489](https://github.com/milyin/prebindgen/pull/489)) `Deconstructing::Choice` for a `sealed_class` — a `jint` selector ahead of one group of values per alternative — and `Deconstructing::Product` for a `data_class`, whose nested `data_class` field contributes its own values. Held to `synth_sum_leaves` and `synth_value_struct_leaves`; byte-identical on the examples and on `zenoh-flat-jni`.

    A sum's row is the direction with no alternative: a sum has **no** whole-value output conversion, because a tag plus groups is not one wire. A product's declines for the whole value rather than per field, because the emitter it feeds does — one handle, `enum_class`, sum or wrapped class field sends the whole object down the `fromParts` path.

  - [x] **4c — `Deconstruct::ValueForm`.** ([#490](https://github.com/milyin/prebindgen/pull/490)) `expand_return!(T).fields(fields!(f))` calls an accessor once and hands out the fields of the struct it returns, named as the declaration names them. Held to the expansion plan rather than to a leaf list, because a value form's leaves come from `unfold::flatten` rather than from a JniGen-side synthesis.

    Declared for the shape it states — one `.fields(fields!(f))` whose every record is a plain leaf. A record carrying its own decomposition (a per-field override, an inlined nested class, a sum) needs the nested type read **as inlined** rather than as the by-value decomposition 4b gave it, which is a second row for one crossing. Left for the switch, where a reader exists to want it.

  - [ ] **4d — the emitters take the row.** Blocked on nothing; it is the work itself. An earlier revision of this line claimed it was blocked on the declare/resolve ordering, and that was wrong — `registry/run.rs` shows why. `apply_sum_returns` and `apply_value_structs` run before `resolve` to **register** which output conversions the binding demands, and the `UnfoldPlan`s they build are only **read** at emission, which is after the rows are compiled. So an emitter can read the row where it reads a leaf, and `Decompositions` keeps its registration duty until stage 6 takes it.

    What is real is the size: `sum_out.rs`, `delivery.rs`, `iface.rs`, `render.rs` and `kotlin_emit.rs` walk `UnfoldLeaf`s.

    - [x] **4d-i — the sum emitters speak the row's vocabulary.** ([#492](https://github.com/milyin/prebindgen/pull/492)) `sum_out.rs` walks `OutWire`s; the plans that still feed it arrive through `OutWire::from_leaf`. What those emitters read of a leaf is exactly what a wire states, so the vocabulary could change ahead of the source and each call site moves separately.
    - [x] **4d-ii — one sum composition.** ([#493](https://github.com/milyin/prebindgen/pull/493)) `Declarations::sum_out_wires` is the single statement, and `synth_sum_leaves` maps it.
    - [x] **4d-iii — one data-class composition.** ([#494](https://github.com/milyin/prebindgen/pull/494)) The same for `synth_value_struct_leaves`, via `Declarations::struct_out_wires`.

    **The ordering question is settled by those three, not argued.** Both syntheses run before `resolve` and both are now the composed row, mapped — which is possible because a composition reads **no conversions**, only the model and the declaration. `Compile::choice` ignores its arm fragments outright, and `Compile::fields` read its own for one thing only: whether a field nests, which is the model's answer.

    - [x] **4d-iv — the interface and Kotlin emitters.** ([#495](https://github.com/milyin/prebindgen/pull/495)) `plan_leaf_param`, which classifies one delivered value for every builder, folder, handler and callback signature, and `sum_reconstruct`, which writes the `when` that rebuilds a sealed class.
    - [x] **4d-v — `is_sum_row`.** ([#496](https://github.com/milyin/prebindgen/pull/496)) The one place the "is this a sum" question is asked.

    **Where the vocabulary switch stops, and why.** What still reads `UnfoldLeaf` is the encode side: `reach_leaf_flat` and `encode_plan_leaves` read a leaf's **path** — the accessor chain that reaches the value, the hoist it sits under, the rebase a splice applies, the gate a conditional value form puts over it. A wire says which values cross and in what order; where the Rust side reaches one is the plan's.

    So 4d's remainder is not another vocabulary change. It is `Compile::plan` on the return side — the site wrapping a fragment, which is what the hook exists for — and that is 5b. The two are one piece of work seen from opposite ends.
- [x] **5 — plans own per-site emission.** `Compile::plan` returns a real plan — a parameter's, a single-value return's, or a decomposed return's — and every site of an exported function goes through `Compiler::site`.

  **The deletions this line also named are stage 6's**, and they are listed there: `fn_plan.rs` and `InputKind` cannot go while the encode side still reads `UnfoldPlan`, which is what 5c's fixture holds the composed row against. Deliberately **after** 3 and 4: a fragment that carries its own wire values is enough for `render.rs` to build a signature, so composition did not have to wait on this.

  - [x] **5a — a parameter is planned through the hook.** ([#491](https://github.com/milyin/prebindgen/pull/491)) `fn_plan::classify_leaf` is `Compile::plan`'s body. The move was small because the function had already stopped looking anything up: since [#476](https://github.com/milyin/prebindgen/pull/476) it reads the crossing's own fragment, which is what the registry hands a plan. `Declarations` keeps the `Recipes` and `Bindings` so a `Compiler` can be resumed after `build_with` returns, and `Compile::Error` widened to carry `fn_plan`'s typed error whole. Byte-identical.

    What is genuinely per-**site** turns out to be one fact: whether the leaf is a constructor expansion's argument rather than a parameter the signature names. A `Vec` builds through a collection helper in the first case and crosses as one value in the second.

  - [x] **5b — a return that crosses as one value.** ([#497](https://github.com/milyin/prebindgen/pull/497)) `build_output`'s value path goes through `Compiler::site`, which checks the value's validity against what a return tolerates before handing the fragment to the hook. The JVM keeps what it is given, so a borrowed return is refused at the site — an invariant JniGen held by construction and the registry holds now.

    `Compile::Plan` becomes a two-way `JPlan`: a site is a parameter or a return, and one hook answers both.

  - [x] **5c — a decomposed return.** ([#498](https://github.com/milyin/prebindgen/pull/498)) A site asking for its return type's `parts` row. **The registry needed nothing new**: `Ask::Recipe` already lets a site name a row and a `parts` fragment already occupies several wires, so the two facts stages 3 and 4 established are the whole mechanism. An earlier revision of this line claimed it needed a change to what `prebindgen-registry` accepts as input — that was wrong.

    The two return cases are not told apart: `Compile::plan` answers `Decomposed` when the fragment it was handed occupies several wires, and what a fragment occupies **is** the answer. Two conditions on the binding, both measured — a type stating no `parts` row crosses whole, and a decomposition yielding ONE value takes `Delivery::Return`, where the site's crossing is the value's rather than the type's.

  **Where it started**, scouted after 4c landed. `Compiler::site` is the entry point that calls `Compile::plan`, and neither adapter calls it. Naming a site is not the obstacle — `Site`'s fields are public and the registry's own tests build a `Role::Param` one directly. Two things stand between `Compiler::site` and `fn_plan::classify_leaf`, whose body is already a pure function of the fragment, the declaration and the model:

  - **The compiler is not reachable at emission time.** `Declarations` keeps the fragment store but not the `Recipes` and `Bindings` a `Compiler::resume` needs, and `classify_leaf` runs after `build_with` has returned. Two fields, stored the way `compiled` already is.
  - **`Compile::Error` is a `String`.** `classify_leaf` returns a typed `PlanError` that its callers read, so the associated type has to widen before a plan can travel through the hook.

  Which sites to compile is `fn_plan`'s own answer, not the model's — a constructor expansion contributes leaves no signature names — so the drive belongs where the enumeration already is rather than in `build_with`.
- [x] **6 — the machinery stops being read.** The deletion itself is [#506](https://github.com/milyin/prebindgen/issues/506). The one stage still open, and the only one whose work is deletion rather than composition. Scoped by measurement after stage 5 landed, because "what is stranded" is now answerable rather than estimated.

  **Already gone**, without this stage doing anything: `Cx::require`, `Compiled::required`, `RequirementId` and `TypeEntry` have **zero** mentions left across all three crates — stages 2b and 7 took them.

  **What this branch does and does not do.** It finishes the *reading* half — no emitter reads a plan's vocabulary any more — and makes the two deletions that fell out of it. The deletion of `expand`, `unfold` and `Decompositions` themselves is [#506](https://github.com/milyin/prebindgen/issues/506), because both of the remaining items turn on a design choice about a surface `prebindgen-c` sits on, and each was attempted here and reverted rather than guessed at.

  **What is not stranded yet, and why.** `expand` (1,111 lines) and `unfold` (1,821) are load-bearing: `prebindgen-jni` reads their plans at 39 call sites across 11 files.

  | plan surface | jni call sites |
  |---|---:|
  | `unfold_plans` | 12 |
  | `decon_plans` | 9 |
  | `error_plans` | 9 |
  | `expansion_plans` | 5 |
  | `callback_arg_plans` | 4 |

  - [x] **6a — a wire says where the Rust side reaches it.** ([#499](https://github.com/milyin/prebindgen/pull/499)) The fact 4d stopped at. Spelled in the plans' own `PathStep` rather than a second vocabulary, because a reach **is** a path. `reach_leaf_flat` takes a wire, and `identity` and `LeafSource::Field` (as `is_field_read`) move onto it.
  - [x] **6b — the reach is every value's.** ([#500](https://github.com/milyin/prebindgen/pull/500)) 6a put it inside a variant, which said only a field-or-accessor value has one; a selector spliced into a value form reaches the sum it selects over, and two tests caught the segment landing outside its arm. `encode_plan_leaves`'s rebase and sum-segment scan read wires.
  - [x] **6c — the interface emitter holds wires.** ([#501](https://github.com/milyin/prebindgen/pull/501)) `LeafDesc::Plan` and `fixed_reassembly`.

  - [x] **6d — the delivery encoder walks wires.** ([#502](https://github.com/milyin/prebindgen/pull/502)) `encode_plan_leaves` converts once at the top and asks every question of wires. `LeafSource::Accessor` against `LeafSource::Field` becomes `is_field_read`, and the two `unreachable!` arms beside them go — they guarded a routing decision made ten lines up.
  - [x] **6e — the callback interface walks wires.** ([#503](https://github.com/milyin/prebindgen/pull/503)) The last two `LeafSource` reads.

  **The direction has reversed.** Neither `UnfoldLeaf` nor `LeafSource` is **read** anywhere in `prebindgen-jni`: what mentions the type is `synth_sum_leaves` and `synth_value_struct_leaves`, which map wires INTO leaves for `Decompositions`, plus two test helpers. The row is the statement; the leaf list is derived from it.

  - [x] **6f — `LeafSource::Accessor` and `::Field` were one thing.** ([#504](https://github.com/milyin/prebindgen/pull/504)) The first deletion, and it fell out of the reading work: nothing branched on which of the two a leaf was. The difference is whether the path ends in a field read, which the path says.
  - [x] **6g — the delivery encoder names what it reads.** ([#505](https://github.com/milyin/prebindgen/pull/505)) `encode_plan_leaves` took an `UnfoldPlan` and used three of its seven fields; it takes a `Delivered` — the values, the hoists, the borrow — and the four it never touched are the delivery's shape, which belongs to the wrapper and the Kotlin surface instead.

  What keeps `unfold` load-bearing is now what it **does** rather than what it says, and it is exactly two jobs:

  1. **Registering** which conversions the binding demands, before `resolve`. **Measured, and it is not what it looked like.** Stubbing `register_leaves` out leaves every JniGen binding working — 274 lib tests, both example bindings, byte-identical output — because the adapter already requires those types through its own declarations. Exactly one test fails: `unfold::tests::sum_return_is_a_fixed_builder_plan`, which assembles a registry with **no adapter declarations at all** and supplies its leaves directly.

     So rows cannot take this over. A declaration-less caller has no rows, and registering from them would register nothing. `register_leaves` is what makes `Decompositions` work as a **public input** — supply leaves, get their conversions demanded — and removing it removes that capability rather than stranded machinery. Deleting it is a decision about whether `Decompositions` stays an input, not a refactor, and it belongs to whoever owns that surface.
  2. Holding the **hoists** a value form binds — evaluate it once, bind it to a local. That is per-site, so it follows `Compile::plan` rather than the wire.

  Both are tractable and neither is a vocabulary change. What made this stage look like a 3,900-line migration was the reading, and the reading is done — `Delivered` is the seam the second job goes through, and the first is a registry-side change to where `require_output` is driven from.

  `fn_plan.rs` (970) and `InputKind` go with them, not before: `InputKind` is read at 32 sites outside its own file, and every one is an emitter branching on a wire layout the plan still supplies.

  **`expand_param!` / `expand_return!` / `fields!` cannot move yet, and the obstacle is not what it looks like.** The five decl types appear in `prebindgen-registry` only in its `lib.rs` re-export list — the pipeline uses none of them — so the move looks mechanical. Attempted, and it is not: `FunctionDecl` carries `param_expands` and `return_expand`, and it is **shared**, because `convert!(T).input(fun!(f))` puts `fun!` in `prebindgen-c`'s path too.

  The registry never interprets those two fields — it stores them and hands them back — so what blocks the move is the chaining API rather than any pipeline dependency: `fun!(f).expand_param(…)` needs `FunctionDecl` to hold the payload, and `FunctionDecl` has to stay where `fun!` is. The move therefore needs `fun!` to produce an adapter-specific decl, or the shared `FunctionDecl` to be generic over what an adapter hangs on it. Both are real designs; neither is a rename.

- [x] **7 — the surface nothing uses.** ([#483](https://github.com/milyin/prebindgen/pull/483)) `Cx::require` / `Compiled::required` / `RequirementId` removed — both adapters emit their runtime helpers through `prerequisites`, so the mechanism duplicated a working route. `Construct::Identity` and `Compile::identity` removed together: nothing built the shape, yet the hook was required, so both adapters carried a refusal for a shape they could never be handed. 102 lines out, byte-identical.
- [x] **8 — the zenoh chain, end to end.** ([comment](https://github.com/milyin/prebindgen/pull/472#issuecomment-5372817161)) `zenoh-flat` → `zenoh-flat-jni` → `zenoh-java`, built and run: `./gradlew :zenoh-java:jvmTest` is **BUILD SUCCESSFUL** with **112 tests, 0 failures**. `zenoh-flat-jni` regenerates byte-identically against this branch and `./gradlew jvmJar` builds it — 425 compiled classes plus the dylib.

  **One thing does not work, and it is `main`'s.** Compiling `zenoh-java` against a **regenerated** `zenoh-flat-jni` fails with 28 Kotlin errors, all "inferred type is `T?` but `T` was expected". Measured against three generators: the committed files compile, prebindgen `main` gives 28 errors, this branch gives the same 28. Fallible getters return a nullable type on `main` and `zenoh-java`'s committed source predates that — a `zenoh-java` change, owed to whichever PR made returns nullable there.

## How each stage is checked

Stages 1, 2 and 5 must leave `examples/regen-check.sh` **byte-identical** — they move where an answer comes from, not what it is. That property is what made #465's 5,000 lines reviewable and it is deliberately kept for the mechanical stages.

Stages 3 and 4 **change generated Rust and Kotlin**, and there the regen diff is the review surface. Each will say what moved and why, and the covertest JVM harness plus the zenoh chain are what say it still works.

## What #465 established that this branch assumes

- **One crossing read two ways is two rows**, with the site picking. C needed it three times; JniGen will need it wherever a value crosses differently as a class field than as a parameter.
- **A holding form belongs to the container**, not the value: C's mirror wraps a nested enum in `MaybeUninit` and the value's own conversion is untouched. The JVM equivalent is a slot's boxing.
- **`Role::Part` carries the alternative**, because every arm numbers its parts from zero. A sealed class is exactly that shape.
- **What a role tolerates is the target's answer**, through `Compile::tolerates` — C hands out non-owning pointers, the JVM keeps what it is given.










































