### PR TITLE
A declared whole-value row must not strand the field reading (#450)

### DIFF
--- a/prebindgen-c/src/rows.rs
+++ b/prebindgen-c/src/rows.rs
@@ -73,15 +73,25 @@ impl CbindgenBuilder {
     /// different words helps nobody.
     pub(crate) fn recipes(&self, model: &Flat) -> Result<Recipes, Vec<RecipeError>> {
         let mut rows = Recipes::builder();
-        // The crossings a payload row will also land on. `Crossing::key` peels
-        // `Box`, so a `Box<Blob>` payload shares `Blob`'s crossing — which is
-        // right for lookup, and means the handle's own row has to say it is
-        // what a site gets when it names neither.
-        let shared: std::collections::HashSet<TypeKey> = self
+        // The crossings a second row will also land on, so the loop below knows
+        // to make the whole-value one the default rather than leaving two rows
+        // with no answer between them.
+        //
+        // Two sources. A payload row shares a crossing with its handle's own,
+        // because `Crossing::key` peels `Box` — right for lookup, and it means
+        // `Blob` and `Box<Blob>` are one crossing. And `bool` and `String` each
+        // get a field row unconditionally, which collides with a whole-value
+        // row a binding declared itself.
+        let mut shared: std::collections::HashSet<TypeKey> = self
             .boxed_payloads(model)
             .iter()
             .map(|t| t.borrow_target().unwrap_or(t).stripped_key())
             .collect();
+        for builtin in [syn::parse_quote!(bool), syn::parse_quote!(String)] {
+            if let Ok(ty) = model.classify(&builtin) {
+                shared.insert(ty.key());
+            }
+        }
         // Every per-type policy, and every `convert!`-declared conversion. The
         // second matters as much as the first: a conversion may be declared on
         // a type the registry would otherwise read as an arity layer, and
@@ -177,27 +187,35 @@ impl CbindgenBuilder {
                 .declare(ty, payload(), Constructing::Atomic);
         }
 
-        // `bool`'s second row. Declared for every binding rather than only
-        // where a struct has such a field: a row for a crossing nobody uses is
-        // inert, and the alternative is walking every declared struct twice to
-        // find out.
+        // The field rows. Declared for every binding rather than only where a
+        // struct has such a field: a row for a crossing nobody uses is inert,
+        // and the alternative is walking every declared struct twice to find
+        // out.
+        //
+        // **Always**, whether or not the type's whole-value row was declared
+        // above. The two are independent readings — the hand-written walks kept
+        // them so — and a binding may declare the whole-value one itself:
+        // `convert!` refuses a builtin, but `opaque_ptr(String)` is accepted and
+        // `out_terminal` has an arm for it. Suppressing the field row there
+        // stranded every string field, because `bindings` asks each one for it.
         let boolean = model
             .classify(&syn::parse_quote!(bool))
             .expect("bool is a scalar the model always classifies");
-        rows.declare_default(boolean.clone(), whole(), Deconstructing::Atomic)
-            .declare(boolean.clone(), in_field(), Deconstructing::Atomic)
-            .declare_default(boolean.clone(), whole(), Constructing::Atomic)
+        // A whole-value row the loop already filed stays as it is and only has
+        // to become the default; otherwise it is declared here.
+        if !declared_keys.contains(&boolean.key()) {
+            rows.declare_default(boolean.clone(), whole(), Deconstructing::Atomic)
+                .declare_default(boolean.clone(), whole(), Constructing::Atomic);
+        }
+        rows.declare(boolean.clone(), in_field(), Deconstructing::Atomic)
             .declare(boolean, in_field(), Constructing::Atomic);
-        // `String`'s second row, unless the binding already declared one for it
-        // — a `convert!(String => ..)` states the whole-value reading itself,
-        // and the loop above has already filed it.
         if let Ok(string) = model.classify(&syn::parse_quote!(String)) {
+            // Output only ever has one reading, so `String` gets a second row in
+            // the constructing direction alone.
             if !declared_keys.contains(&string.key()) {
-                // Output only ever has one reading, so `String` gets a second
-                // row in the constructing direction alone.
-                rows.declare_default(string.clone(), whole(), Constructing::Atomic)
-                    .declare(string, in_field(), Constructing::Atomic);
+                rows.declare_default(string.clone(), whole(), Constructing::Atomic);
             }
+            rows.declare(string, in_field(), Constructing::Atomic);
         }
 
         rows.build(model)

--- a/prebindgen-c/src/tests/rows.rs
+++ b/prebindgen-c/src/tests/rows.rs
@@ -170,3 +170,36 @@ fn an_undeclared_arity_layer_takes_the_row_the_registry_derives() {
         "construct derived:atomic, deconstruct derived:atomic"
     );
 }
+
+/// A `String` declared as a handle must not strand the **field** reading.
+///
+/// `convert!` refuses a builtin outright, so a custom `String` conversion is
+/// not the route in — but `opaque_ptr` accepts one, and `out_terminal` has an
+/// arm for exactly that shape. Declaring it that way used to suppress the field
+/// row while `bindings` still asked every string field for it.
+#[test]
+fn a_string_declared_as_a_handle_keeps_the_field_reading() {
+    let loc = SourceLocation::default();
+    let items: Vec<(syn::Item, SourceLocation)> = [
+        "pub struct Caption { pub id: u64, pub text: String }",
+        "pub fn caption_id(c: Caption) -> u64 { unimplemented!() }",
+    ]
+    .into_iter()
+    .map(|src| (syn::parse_str(src).expect("parse"), loc.clone()))
+    .collect();
+    let model = prebindgen_registry::Flat::builder()
+        .items(declare_referenced(items))
+        .build()
+        .expect("parse");
+
+    let gen = Cbindgen::builder()
+        .source_module(syn::parse_quote!(myflat))
+        .free_memory_function("myflat_free")
+        .opaque_ptr(syn::parse_quote!(String))
+        .data_struct(syn::parse_quote!(Caption));
+    let recipes = gen
+        .recipes(&model)
+        .expect("a String handle declaration leaves the field row in place");
+    gen.bindings(&model, &recipes)
+        .expect("every string field still finds the field row");
+}


### PR DESCRIPTION
Addresses the [row-construction review](https://github.com/milyin/prebindgen/pull/465#issuecomment-5362993720) of [#465](https://github.com/milyin/prebindgen/pull/465). Targets `recipe-finish`.

**One of the two reported blockers is real, by a different route than the one named. The other is unreachable.** Both were checked by writing the reported case first.

## Not reachable: `convert!(bool)`

`reject_builtin_convert_type` (`decl.rs:1414`) refuses a `convert!` on any builtin, and its list contains both `bool` and `String`:

```
convert!(bool): builtins already have converters — wrap the builtin in a newtype instead
```

So neither declaration can be written, and the duplicate-`whole` collision the review describes cannot be constructed. The reading of the code was right; the route in does not exist.

## Real, via `opaque_ptr(String)`

`convert!` is not the only way `String` enters `declared_keys` — `declared_types()` also carries `opaque_ptr`, and `out_terminal` has an arm for exactly that shape ("a `String` explicitly declared `opaque_ptr`, held by C as `string_t *`"). Declaring it that way suppressed the field row while `bindings()` still asked every string field for it:

```
UnknownRow { crossing: String (construct), recipe: "field",
             site: Caption's part 1 of row `parts` }
```

So the second finding stands, and the mechanism it named was the wrong one. Given the first is unreachable, the review's own framing — *both* going through the public `convert` path — does not hold, but it still found a real bug.

## The fix

The two readings are **independent** — the hand-written walks kept them so — so the field rows are declared unconditionally. Where that collides with a whole-value row a binding declared itself, the declared one becomes the default.

That is the same treatment a `Box`-over-handle payload already gets, for the same reason: `Crossing::key` peels `Box`, so `Blob` and `Box<Blob>` are one crossing, and two rows on one crossing need one of them to say which a site gets when it names neither. `bool` and `String` now join that set.

## Checks

- One regression pinning the reachable shape: `String` declared `opaque_ptr` alongside a `data_struct` with a string field, checking both `recipes()` and `bindings()`.
- 94 `prebindgen-c` tests pass.
- Output **byte-identical** — no in-tree binding declares a `String` handle, which is why nothing caught this.

Local gate clean: clippy and rustfmt on 1.85.0 and stable, `cargo doc` with warnings denied, `cargo test --all`, `examples/regen-check.sh`.
