### PR TITLE
prebindgen-c's emitters read their own fragments

### DIFF
--- a/prebindgen-c/src/compile.rs
+++ b/prebindgen-c/src/compile.rs
@@ -397,7 +397,7 @@ impl<R: Conversions<()>> Compile for CCompile<'_, R> {
                     // to the value's own conversion.
                     match (
                         at.crossing.assembly(),
-                        self.gen.payload_field_wire(&part.ty, self.registry),
+                        self.gen.payload_field_wire(&part.ty),
                     ) {
                         (Assembly::Deconstruct, Ok(w)) if held_uninit(&w, &frag.destination) => {
                             quote!(::core::mem::MaybeUninit::new(#call))

--- a/prebindgen-c/src/emit.rs
+++ b/prebindgen-c/src/emit.rs
@@ -12,7 +12,7 @@ impl CbindgenBuilder {
         // `opaque_ptr` (then it crosses as `string_t *`, freed by `string_drop`).
         if registry
             .reading_of(&string_ty)
-            .and_then(|tr| registry.output_entry(&tr))
+            .and_then(|tr| self.out_frag(&tr))
             .is_some()
             && !self.opaque.contains_key(&TypeKey::from_type(&string_ty))
         {
@@ -22,7 +22,7 @@ impl CbindgenBuilder {
         if self.opaque_errors.keys().any(|key| {
             registry
                 .reading(key)
-                .and_then(|tr| registry.output_entry(&tr))
+                .and_then(|tr| self.out_frag(&tr))
                 .is_some()
         }) {
             return true;
@@ -33,7 +33,7 @@ impl CbindgenBuilder {
             let Some(reading) = registry.reading(key) else {
                 return false;
             };
-            registry.output_entry(&reading).is_some()
+            self.out_frag(&reading).is_some()
                 && self
                     .enum_alternatives(registry, key)
                     .map(|alts| {
@@ -49,7 +49,7 @@ impl CbindgenBuilder {
             let Some(reading) = registry.reading(key) else {
                 return false;
             };
-            registry.output_entry(&reading).is_some()
+            self.out_frag(&reading).is_some()
                 && self
                     .struct_fields(registry, key)
                     .map(|fields| fields.iter().any(|(_, fty)| r_is_string(fty)))
@@ -135,11 +135,7 @@ impl CbindgenBuilder {
         Ok(())
     }
 
-    pub(super) fn payload_field_wire(
-        &self,
-        fty: &TypeRef,
-        registry: &impl Conversions<()>,
-    ) -> Result<syn::Type, String> {
+    pub(super) fn payload_field_wire(&self, fty: &TypeRef) -> Result<syn::Type, String> {
         // `String` is the one type whose two directions disagree on the wire
         // (`*const c_char` in, `*mut c_char` out), so the union field fixes the
         // OWNING form and the per-arm expressions convert by hand.
@@ -214,7 +210,7 @@ impl CbindgenBuilder {
         // legitimately differ (a `String`'s const-ness above), which is why a
         // disagreement is `None` — a rejection naming the payload — rather
         // than a silent pick of one side.
-        let out_entry = registry.output_entry(fty).ok_or_else(|| {
+        let out_entry = self.out_frag(fty).ok_or_else(|| {
             "no resolved OUTPUT converter — a payload crosses as its converter's destination, so \
              it must be a scalar, a `String`, or a type this binding declares (`enum_type`, \
              `data_struct`, `opaque_ptr`, or a `convert!` conversion)"
@@ -231,7 +227,7 @@ impl CbindgenBuilder {
             );
         }
         let out = out_entry.destination.clone();
-        if let Some(inp) = registry.input_entry(fty) {
+        if let Some(inp) = self.in_frag(fty) {
             if TypeKey::from_type(&inp.destination) != TypeKey::from_type(&out) {
                 return Err(format!(
                     "its input and output converters disagree on the wire (`{}` in, `{}` out) \
@@ -333,14 +329,14 @@ impl CbindgenBuilder {
     /// cannot be freed through a symbol that was never emitted. `false` for
     /// anything that is not a declared tagged union.
     pub(super) fn tagged_union_has_drop(&self, fty: &TypeRef, registry: &Registry<()>) -> bool {
-        if !self.tagged_unions.contains_key(&fty.key()) || registry.output_entry(fty).is_none() {
+        if !self.tagged_unions.contains_key(&fty.key()) || self.out_frag(fty).is_none() {
             return false;
         }
         self.enum_alternatives(registry, &fty.key())
             .unwrap_or_default()
             .iter()
             .flat_map(|a| a.fields.iter())
-            .any(|f| match self.payload_field_wire(&f.ty, registry) {
+            .any(|f| match self.payload_field_wire(&f.ty) {
                 // A rejected payload is reported from the emission site, which
                 // panics before any of this matters.
                 Err(_) => false,
@@ -527,7 +523,7 @@ impl CbindgenBuilder {
             );
             let entry = registry
                 .reading_of(err_ty)
-                .and_then(|tr| registry.output_entry(&tr))
+                .and_then(|tr| self.out_frag(&tr))
                 .unwrap_or_else(|| {
                     panic!(
                         "Cbindgen::on_function: error type `{}` of `{}` has no output converter",
@@ -1160,7 +1156,7 @@ impl CbindgenBuilder {
 
             let entry = registry
                 .reading_of(arg_ty)
-                .and_then(|tr| registry.input_entry(&tr))
+                .and_then(|tr| self.in_frag(&tr))
                 .unwrap_or_else(|| {
                     panic!(
                         "Cbindgen::on_function: input type `{}` of `{}` has no input converter",

--- a/prebindgen-c/src/lib.rs
+++ b/prebindgen-c/src/lib.rs
@@ -444,6 +444,13 @@ pub struct CbindgenBuilder {
     /// Where the `#[prebindgen]` items come from — see
     /// `JniGenBuilder::source`.
     pub(crate) sources: prebindgen_registry::flat::FlatBuilder,
+    /// Every conversion this binding compiled, keyed by crossing.
+    ///
+    /// What the emitters ask instead of the converter table. The table can only
+    /// name **one** wire type per crossing, so it stops being able to answer as
+    /// soon as a crossing occupies several — and the answer an emitter wants
+    /// was always the adapter's own.
+    pub(crate) compiled: Option<prebindgen_registry::recipe::Compiled<crate::compile::CFrag>>,
     /// Every conversion this binding compiled.
     ///
     /// Filled once by [`Self::build_with`] and handed to `write_rust` as

--- a/prebindgen-c/src/trait_impl.rs
+++ b/prebindgen-c/src/trait_impl.rs
@@ -1,6 +1,28 @@
-use prebindgen_registry::{Building, Conversions, Crossing, RegistryBuilder};
+use prebindgen_registry::{recipe::Assembly, Building, Conversions, Crossing, RegistryBuilder};
 
 use super::{builder::callback_fn_type, *};
+
+/// What an emitter asks instead of the converter table.
+///
+/// [`CbindgenBuilder::compiled`] holds every fragment this binding compiled,
+/// keyed by crossing. A fragment answers for a crossing that occupies several
+/// wire values; the converter table's single `destination` cannot.
+impl CbindgenBuilder {
+    /// The fragment for `ty` crossing in the given direction, if one compiled.
+    pub(crate) fn frag(&self, ty: &TypeRef, assembly: Assembly) -> Option<&crate::compile::CFrag> {
+        self.compiled.as_ref()?.fragment(&ty.key(), assembly)
+    }
+
+    /// The fragment that builds a Rust `ty` out of C parts.
+    pub(crate) fn in_frag(&self, ty: &TypeRef) -> Option<&crate::compile::CFrag> {
+        self.frag(ty, Assembly::Construct)
+    }
+
+    /// The fragment that takes a Rust `ty` apart into C parts.
+    pub(crate) fn out_frag(&self, ty: &TypeRef) -> Option<&crate::compile::CFrag> {
+        self.frag(ty, Assembly::Deconstruct)
+    }
+}
 
 /// Per-category **input** terminal converter builders. Each returns
 /// `Some(ConverterImpl)` only for the type category it claims (and `None`
@@ -770,8 +792,7 @@ impl CbindgenBuilder {
             let Some(reading) = registry.reading(key) else {
                 continue;
             };
-            if registry.input_entry(&reading).is_none() && registry.output_entry(&reading).is_none()
-            {
+            if self.in_frag(&reading).is_none() && self.out_frag(&reading).is_none() {
                 continue;
             }
             let c_struct = self.c_type_ident(&reading.key());
@@ -808,8 +829,7 @@ impl CbindgenBuilder {
             let Some(reading) = registry.reading(key) else {
                 continue;
             };
-            if registry.input_entry(&reading).is_none() && registry.output_entry(&reading).is_none()
-            {
+            if self.in_frag(&reading).is_none() && self.out_frag(&reading).is_none() {
                 continue;
             }
             let Some(fields) = self.struct_fields(registry, &reading.key()) else {
@@ -853,8 +873,7 @@ impl CbindgenBuilder {
             let Some(reading) = registry.reading(key) else {
                 continue;
             };
-            if registry.input_entry(&reading).is_none() && registry.output_entry(&reading).is_none()
-            {
+            if self.in_frag(&reading).is_none() && self.out_frag(&reading).is_none() {
                 continue;
             }
             let src = self.src_ty_of(&reading.key());
@@ -1060,8 +1079,7 @@ impl CbindgenBuilder {
             let Some(reading) = registry.reading(key) else {
                 continue;
             };
-            if registry.input_entry(&reading).is_none() && registry.output_entry(&reading).is_none()
-            {
+            if self.in_frag(&reading).is_none() && self.out_frag(&reading).is_none() {
                 continue;
             }
             let Some(e) = unit_enum(registry, &reading.key()) else {
@@ -1111,8 +1129,7 @@ impl CbindgenBuilder {
             let Some(reading) = registry.reading(key) else {
                 continue;
             };
-            if registry.input_entry(&reading).is_none() && registry.output_entry(&reading).is_none()
-            {
+            if self.in_frag(&reading).is_none() && self.out_frag(&reading).is_none() {
                 continue;
             }
             let Some(e) = payload_enum(registry, &reading.key()) else {
@@ -1129,7 +1146,7 @@ impl CbindgenBuilder {
                 let wires: Vec<syn::Type> = a
                     .fields
                     .iter()
-                    .map(|f| self.payload_wire_of(&reading.key(), vident, f, registry))
+                    .map(|f| self.payload_wire_of(&reading.key(), vident, f))
                     .collect();
                 // `Alternative::spell` writes the delimiters the source wrote,
                 // which is what the three-armed `syn::Fields` match was doing —
@@ -1221,27 +1238,20 @@ impl CbindgenBuilder {
 
     /// The wire of one payload field, or a generation error naming the
     /// offending variant field and the supported set.
-    fn payload_wire_of(
-        &self,
-        key: &TypeKey,
-        variant: &syn::Ident,
-        field: &Field,
-        registry: &Registry<()>,
-    ) -> syn::Type {
-        self.payload_field_wire(&field.ty, registry)
-            .unwrap_or_else(|reason| {
-                panic!(
-                    "Cbindgen::tagged_union: payload `{}::{}{}` of type `{}` cannot cross: {}",
-                    type_short(key),
-                    variant,
-                    match &field.name {
-                        Some(n) => format!(".{n}"),
-                        None => String::new(),
-                    },
-                    field.ty,
-                    reason,
-                )
-            })
+    fn payload_wire_of(&self, key: &TypeKey, variant: &syn::Ident, field: &Field) -> syn::Type {
+        self.payload_field_wire(&field.ty).unwrap_or_else(|reason| {
+            panic!(
+                "Cbindgen::tagged_union: payload `{}::{}{}` of type `{}` cannot cross: {}",
+                type_short(key),
+                variant,
+                match &field.name {
+                    Some(n) => format!(".{n}"),
+                    None => String::new(),
+                },
+                field.ty,
+                reason,
+            )
+        })
     }
 
     /// Release one owning payload slot held behind `binding` (a `&mut` to the
@@ -1364,7 +1374,7 @@ impl CbindgenBuilder {
             // declared-but-unused signature.
             if registry
                 .reading_of(&callback_fn_type(&args))
-                .and_then(|tr| registry.input_entry(&tr))
+                .and_then(|tr| self.in_frag(&tr))
                 .is_none()
             {
                 continue;
@@ -1385,8 +1395,8 @@ impl CbindgenBuilder {
                         a.to_token_stream()
                     )
                 });
-                let wire = registry
-                    .output_entry(&reading)
+                let wire = self
+                    .out_frag(&reading)
                     .unwrap_or_else(|| {
                         panic!(
                             "Cbindgen: callback arg `{}` has no output converter (declare it \
@@ -1538,13 +1548,13 @@ impl CbindgenBuilder {
                 .map_err(|message| prebindgen_registry::ScanError::AdapterInvariant { message })?;
             compiled = compiler.finish();
         }
-        // What the compilation produced, kept for emission. The converter table
-        // stays the lookup index; this is what reaches the file.
+        // What the compilation produced, kept for emission and for lookup.
         self.compiled_fns = compiled
             .fragments()
             .into_iter()
             .map(|f| f.function.clone())
             .collect();
+        self.compiled = Some(compiled);
         self.validate_resolved(&registry)
             .map_err(|message| prebindgen_registry::ScanError::AdapterInvariant { message })?;
         Ok(Cbindgen {

--- a/prebindgen-registry/src/recipe/compile.rs
+++ b/prebindgen-registry/src/recipe/compile.rs
@@ -365,6 +365,12 @@ type Built<C> = Result<Rc<<C as Compile>::Fragment>, CompileError<<C as Compile>
 /// nothing and outlive any of them.
 pub struct Compiled<F> {
     fragments: HashMap<FragmentKey, Rc<F>>,
+    /// Which row answered when a crossing was compiled **as a whole**, rather
+    /// than as one part of a container. Recorded by [`Compiler::crossing`],
+    /// which is the only entry point that consults the crossing's default —
+    /// so [`Compiled::fragment`] can give back that same answer instead of
+    /// choosing between the rows a crossing happens to have.
+    defaults: HashMap<(TypeKey, Assembly), RecipeId>,
     required: BTreeSet<RequirementId>,
 }
 
@@ -377,6 +383,7 @@ impl<F> Default for Compiled<F> {
     fn default() -> Self {
         Self {
             fragments: HashMap::new(),
+            defaults: HashMap::new(),
             required: BTreeSet::new(),
         }
     }
@@ -397,6 +404,27 @@ impl<F> Compiled<F> {
     /// Every helper a compiled fragment asked for, de-duplicated.
     pub fn required(&self) -> impl Iterator<Item = &RequirementId> {
         self.required.iter()
+    }
+
+    /// The fragment for one crossing, compiled **as a whole**.
+    ///
+    /// What an adapter's emitters ask once they stop reading the converter
+    /// table. The answer is the one [`Compiler::crossing`] built — the
+    /// crossing's default row — and not one of the rows that answer for this
+    /// type only as a part of some container. A caller that wants a particular
+    /// row has the row and asks through [`Self::row_fragment`].
+    ///
+    /// `None` means no site ever crossed this type in this direction.
+    pub fn fragment(&self, ty: &TypeKey, assembly: Assembly) -> Option<&F> {
+        let row = self.defaults.get(&(ty.clone(), assembly))?;
+        self.row_fragment(ty, assembly, row)
+    }
+
+    /// The fragment for one crossing and one named row.
+    pub fn row_fragment(&self, ty: &TypeKey, assembly: Assembly, row: &RecipeId) -> Option<&F> {
+        self.fragments
+            .get(&(ty.clone(), assembly, row.clone()))
+            .map(|f| &**f)
     }
 
     /// Every fragment this compilation built, in a deterministic order.
@@ -509,7 +537,13 @@ impl<'a, C: Compile> Compiler<'a, C> {
         crossing: &Crossing,
     ) -> Result<Rc<C::Fragment>, CompileError<C::Error>> {
         let recipe = self.recipes.row(crossing).0;
-        self.row(adapter, crossing, &recipe)
+        let fragment = self.row(adapter, crossing, &recipe)?;
+        // The whole-crossing answer, so the emitters can ask for it back
+        // without re-deriving which row a crossing defaults to.
+        self.compiled
+            .defaults
+            .insert((crossing.spelled().key(), crossing.assembly()), recipe);
+        Ok(fragment)
     }
 
     /// The fragment for one row, built once and reused.

--- a/prebindgen-registry/src/recipe/tests.rs
+++ b/prebindgen-registry/src/recipe/tests.rs
@@ -2274,3 +2274,46 @@ fn a_value_form_binds_the_accessors_result_and_reads_its_fields() {
         "{plan}"
     );
 }
+
+#[test]
+fn an_emitter_asking_for_a_crossing_gets_the_row_the_crossing_defaults_to() {
+    let model = model(&[SAMPLE]);
+    let sample = ty(&model, "Sample");
+    // `fields` sorts before `whole`, so a lookup that ranked the rows by name
+    // rather than asking which one the crossing defaults to would answer with
+    // the wrong one.
+    let recipes = two_rows(&model);
+    let crossing = Crossing::new(sample.clone(), Assembly::Deconstruct);
+    let mut builder = Bindings::builder();
+    builder.bind(
+        site("z_put", 0),
+        crossing.clone(),
+        Ask::Recipe(id("fields")),
+        Origin::Function,
+    );
+    let bindings = builder.build(&recipes).expect("bindings");
+    let mut adapter = Recorder::default();
+    let mut compiler = Compiler::new(&model, &recipes, &bindings);
+
+    // One site takes `fields`; the crossing on its own takes its default.
+    compiler
+        .site(&mut adapter, site("z_put", 0), crossing.clone())
+        .expect("site");
+    compiler.crossing(&mut adapter, &crossing).expect("whole");
+    let compiled = compiler.finish();
+
+    let key = sample.key();
+    // An emitter asks by crossing and gets the default …
+    assert_eq!(
+        compiled
+            .fragment(&key, Assembly::Deconstruct)
+            .map(|n| n.text.as_str()),
+        Some("atomic Sample deconstruct: Sample"),
+    );
+    // … and a caller holding a row still reaches that row.
+    assert!(compiled
+        .row_fragment(&key, Assembly::Deconstruct, &id("fields"))
+        .is_some());
+    // The other direction was never crossed, so there is no answer to give.
+    assert!(compiled.fragment(&key, Assembly::Construct).is_none());
+}


### PR DESCRIPTION
Stage 1 of #472.

## What the table cannot answer

`prebindgen-c` asks the converter table — the registry's record of one
resolved conversion per crossing — what a type crosses as, everywhere it
emits something about that type. A table entry carries one `destination`,
the single wire type the conversion produces. That is enough only while a
crossing occupies one wire value. It stops being enough the moment one
does not, and the answer an emitter wants was always the adapter's own
fragment, which the adapter has already built and is already emitting
from.

## What moves

Fifteen emission-time lookups in `prebindgen-c` now read
`CbindgenBuilder::{in_frag, out_frag}` instead of
`Conversions::{input_entry, output_entry}`. Both helpers read the
`Compiled<CFrag>` — the compiled fragments, keyed by crossing — that
`CbindgenBuilder::build_with` now keeps after compilation.

The sites are the ones that decide what to declare, not how to convert:
the five `prereq_*` walks (opaque handles, data structs, value opaques,
enums, tagged unions) that skip a declared type nothing ever crossed,
`prereq_callbacks`, `needs_free`, the union payload wire, and the error
and input wires of an exported wrapper.

`payload_field_wire` and `payload_wire_of` lose their registry parameter
outright.

## What does not move, and why

`lower_shape`, `encode_value` and `output_is_fallible` stay on the table.
Each runs in **both** phases: `dispatch_fn_input`, which builds a
callback's closure struct, reaches all three while compilation is still
in progress, and at that point there are no fragments to read. Giving
them a phase-independent answer is stage 2 — `convert_with` stops
flattening — so they wait for it.

## `Compiled::fragment`

A crossing can have several rows: `prebindgen-c` declares `whole` for how
a type crosses on its own and `in_field` / `parts` / `payload` for how it
crosses inside a container. An emitter asking about a type on its own
wants the first kind.

`Compiler::crossing` is the entry point that consults which row a
crossing defaults to, so it now records that choice, and
`Compiled::fragment` gives it back. The alternative — ranking a
crossing's rows by name — picks whichever name sorts first, which for a
`data_struct` is the container row. The new test in
`prebindgen-registry/src/recipe/tests.rs` fails against that ranking.

## Checks

- `cargo test --all` — green
- clippy and rustfmt on 1.85.0 and stable — clean
- `examples/regen-check.sh` — **byte-identical**, which is what this
  stage has to hold: it changes where an answer comes from, not what the
  answer is
- `examples/smoke-asan.sh` — clean under ASan/LSan/UBSan