### PR TITLE
prebindgen-jni's emitters read their own fragments

### DIFF
--- a/prebindgen-jni/src/jni/builder.rs
+++ b/prebindgen-jni/src/jni/builder.rs
@@ -148,6 +148,7 @@ impl Default for Declarations {
     fn default() -> Self {
         Self {
             compiled_fns: Vec::new(),
+            compiled: Default::default(),
             package: String::new(),
             fun_name_mangle: None,
             ptr_class_name_mangle: None,
@@ -1939,9 +1940,7 @@ impl Declarations {
         let inner = if is_self {
             None
         } else {
-            registry
-                .reading_of(&ty)
-                .and_then(|tr| registry.input_entry(&tr))
+            registry.reading_of(&ty).and_then(|tr| self.in_frag(&tr))
         };
         match inner {
             None if is_self || is_wire_type(&ty) => {
@@ -2085,9 +2084,7 @@ impl Declarations {
         let inner = if is_self {
             None
         } else {
-            registry
-                .reading_of(&ty)
-                .and_then(|tr| registry.output_entry(&tr))
+            registry.reading_of(&ty).and_then(|tr| self.out_frag(&tr))
         };
         match inner {
             None if is_self || is_wire_type(&ty) => {
@@ -2095,7 +2092,7 @@ impl Declarations {
                 let (kotlin_name, value_rust_type) = if let Some(a0) = arg0 {
                     registry
                         .reading_of(a0)
-                        .and_then(|tr| registry.output_entry(&tr))
+                        .and_then(|tr| self.out_frag(&tr))
                         .map(|e| {
                             (
                                 e.metadata.kotlin_name.clone(),

--- a/prebindgen-jni/src/jni/compile.rs
+++ b/prebindgen-jni/src/jni/compile.rs
@@ -33,6 +33,25 @@ impl Carrier for JFrag {
 }
 
 impl JFrag {
+    /// A conversion this adapter built without the compiler.
+    ///
+    /// A callback crossing is the only one: `JniGen::compile_crossing` answers
+    /// it with `dispatch_fn_input` rather than through a row, so there is no
+    /// `At` to take a crossing's own mode from. It is an owned, self-sufficient
+    /// value — a callback is delivered as a JVM object the wrapper holds — and
+    /// nothing composes a callback as an inner, so no row ever reads this
+    /// `Yield`. Goes with the derived callback row.
+    pub(crate) fn by_hand(ty: TypeKey, conv: ConverterImpl<KotlinMeta>) -> Self {
+        Self {
+            conv,
+            yields: Yield {
+                ty,
+                mode: Mode::Owned,
+                validity: Validity::SelfSufficient,
+            },
+        }
+    }
+
     fn new(at: At<'_>, conv: ConverterImpl<KotlinMeta>) -> Self {
         let validity = validity_of(&conv, at.crossing.assembly());
         Self {
@@ -294,5 +313,44 @@ impl<R: Conversions<KotlinMeta>> Compile for JCompile<'_, R> {
 
     fn plan(&mut self, _cx: &mut Cx<'_>, _bound: &Bound, _root: &JFrag) -> Result<(), String> {
         Ok(())
+    }
+}
+
+/// What an emitter asks instead of the converter table.
+///
+/// Each hands back the fragment's `ConverterImpl`, which is what a table entry
+/// was, so a call site reads the same fields it always did — from this
+/// adapter's own answer rather than from the shared index. Cloned rather than
+/// borrowed because [`Declarations::compiled`] is read while it is still being
+/// filled; a conversion is built once per crossing, so the clone is not on any
+/// hot path.
+///
+/// `None` means nothing has compiled that crossing. During compilation that is
+/// the deferral the resolver already understands — it retries — and after it,
+/// the only crossing without a fragment is a callback, which
+/// `JniGen::compile_crossing` answers without the compiler.
+impl crate::jni::Declarations {
+    /// The conversion for `ty` in the given direction, from the fragments
+    /// compiled so far.
+    pub(crate) fn frag(
+        &self,
+        ty: &TypeRef,
+        assembly: Assembly,
+    ) -> Option<ConverterImpl<KotlinMeta>> {
+        Some(
+            self.compiled
+                .borrow()
+                .fragment(&ty.key(), assembly)?
+                .conv
+                .clone(),
+        )
+    }
+
+    pub(crate) fn in_frag(&self, ty: &TypeRef) -> Option<ConverterImpl<KotlinMeta>> {
+        self.frag(ty, Assembly::Construct)
+    }
+
+    pub(crate) fn out_frag(&self, ty: &TypeRef) -> Option<ConverterImpl<KotlinMeta>> {
+        self.frag(ty, Assembly::Deconstruct)
     }
 }

--- a/prebindgen-jni/src/jni/emit/callback.rs
+++ b/prebindgen-jni/src/jni/emit/callback.rs
@@ -85,7 +85,7 @@ pub(crate) fn callback_input(
             // Every leaf converter must already be resolved (deferral safety).
             // A synthesized leaf (a sum's tag) has no converter to wait for.
             for leaf in plan.leaves.iter().filter(|l| l.has_converter()) {
-                registry.output_entry(&leaf.out_ty)?;
+                ext.out_frag(&leaf.out_ty)?;
             }
             let spec = folder_iface_for_plan(ext, registry, plan)?;
             let holder_slash =
@@ -182,7 +182,7 @@ pub(crate) fn callback_input(
             // would make the trampoline wait forever on an `i32` crossing the
             // binding may not have.
             for leaf in plan.leaves.iter().filter(|l| l.has_converter()) {
-                let e = registry.output_entry(&leaf.out_ty)?;
+                let e = ext.out_frag(&leaf.out_ty)?;
                 if leaf.identity && e.metadata.projection.is_none() {
                     return None;
                 }
@@ -212,7 +212,7 @@ pub(crate) fn callback_input(
         // converter and clone the borrow (the callback only borrows the value). The
         // `data_class` converter composes the whole object via `fromParts`, so the
         // Kotlin `run(t: T)` receives a ready-made `T`.
-        let (cb_val, arg_entry) = match registry.output_entry(arg_ty) {
+        let (cb_val, arg_entry) = match ext.out_frag(arg_ty) {
             Some(e) => (quote!(#cb_arg), e),
             // A borrow: the callback hands out a reference, and the value is
             // cloned for the JVM.
@@ -237,7 +237,7 @@ pub(crate) fn callback_input(
             // `Box<&ZThing>`, and added a classification that never fires.
             None => {
                 let core = arg_ty.borrow_target()?;
-                (quote!((#cb_arg).clone()), registry.output_entry(core)?)
+                (quote!((#cb_arg).clone()), ext.out_frag(core)?)
             }
         };
         let arg_wire = arg_entry.destination.clone();

--- a/prebindgen-jni/src/jni/emit/convert.rs
+++ b/prebindgen-jni/src/jni/emit/convert.rs
@@ -1,6 +1,6 @@
 //! Scalar / `Option` / enum converter bodies and their wire probes.
 
-use prebindgen_registry::{Conversions, TypeEntry};
+use prebindgen_registry::Conversions;
 
 use super::*;
 
@@ -173,7 +173,10 @@ pub(crate) fn primitive_output(key: &TypeKey) -> Option<(syn::Type, syn::Expr)> 
 /// conversions may carry semantic steps in `pre_stages` (for example
 /// `jlong -> u64 -> Duration`). Keep those steps inside the `Some` arm so a
 /// niche discriminator is tested before any conversion runs.
-pub(crate) fn composed_inner_input(inner: &TypeEntry<KotlinMeta>, wire: TokenStream) -> syn::Expr {
+pub(crate) fn composed_inner_input(
+    inner: &ConverterImpl<KotlinMeta>,
+    wire: TokenStream,
+) -> syn::Expr {
     let converter = inner.converter_ident();
     if inner.pre_stages.is_empty() {
         return syn::parse2(quote!(#converter(env, #wire)?))
@@ -199,7 +202,7 @@ pub(crate) fn composed_inner_input(inner: &TypeEntry<KotlinMeta>, wire: TokenStr
 /// Invoke an inner output converter's complete `Rust -> wire` chain.
 /// Mirror of [`composed_inner_input`].
 pub(crate) fn composed_inner_output(
-    inner: &TypeEntry<KotlinMeta>,
+    inner: &ConverterImpl<KotlinMeta>,
     value: TokenStream,
 ) -> syn::Expr {
     let converter = inner.converter_ident();
@@ -250,7 +253,7 @@ pub(crate) fn option_input(
     let inner_entry = registry.input_entry(t1)?;
     let t1_spelled = emit.spell(t1);
     let inner_wire = inner_entry.destination.clone();
-    let inner_decode = composed_inner_input(inner_entry, quote!(v));
+    let inner_decode = composed_inner_input(&inner_entry.as_converter(), quote!(v));
 
     // 1. Niche path.
     if let Some((slot, rest)) = inner_entry.niches.clone().carve() {
@@ -285,7 +288,7 @@ pub(crate) fn option_input(
         let unbox_sig = jni_unbox_sig(&inner_wire);
         let getter = jni_unbox_getter(&inner_wire);
         let getter_id = format_ident!("{}", getter);
-        let inner_decode = composed_inner_input(inner_entry, quote!(&__unboxed));
+        let inner_decode = composed_inner_input(&inner_entry.as_converter(), quote!(&__unboxed));
         let body: syn::Expr = syn::parse_quote!({
             if !v.is_null() {
                 let __unboxed: #inner_wire = env
@@ -316,7 +319,7 @@ pub(crate) fn option_output(
 ) -> Option<(syn::Type, syn::Expr, Niches)> {
     let inner_entry = registry.output_entry(t1)?;
     let inner_wire = inner_entry.destination.clone();
-    let inner_encode = composed_inner_output(inner_entry, quote!(value));
+    let inner_encode = composed_inner_output(&inner_entry.as_converter(), quote!(value));
 
     // 1. Niche path.
     if let Some((slot, rest)) = inner_entry.niches.clone().carve() {
@@ -332,7 +335,7 @@ pub(crate) fn option_output(
 
     // 2. Boxed-primitive fallback (cached box class + `valueOf` method ID).
     if let Some(helper) = box_helper_for_wire(&inner_wire) {
-        let inner_encode = composed_inner_output(inner_entry, quote!(value));
+        let inner_encode = composed_inner_output(&inner_entry.as_converter(), quote!(value));
         let body: syn::Expr = syn::parse_quote!({
             match v {
                 Some(value) => {

--- a/prebindgen-jni/src/jni/emit/convert.rs
+++ b/prebindgen-jni/src/jni/emit/convert.rs
@@ -169,7 +169,7 @@ pub(crate) fn primitive_output(key: &TypeKey) -> Option<(syn::Type, syn::Expr)> 
 
 /// Invoke an inner input converter's complete `wire -> Rust` chain.
 ///
-/// Structural wrappers cannot call only [`TypeEntry::function`]: custom
+/// Structural wrappers cannot call only [`ConverterImpl::function`]: custom
 /// conversions may carry semantic steps in `pre_stages` (for example
 /// `jlong -> u64 -> Duration`). Keep those steps inside the `Some` arm so a
 /// niche discriminator is tested before any conversion runs.

--- a/prebindgen-jni/src/jni/emit/delivery.rs
+++ b/prebindgen-jni/src/jni/emit/delivery.rs
@@ -146,7 +146,7 @@ pub(crate) fn emit_unfold_delivery(
             // declares the matching typed param).
             let out_entry = registry
                 .reading(&element.key())
-                .and_then(|tr| registry.output_entry(&tr))
+                .and_then(|tr| ext.out_frag(&tr))
                 .unwrap_or_else(|| {
                     panic!(
                         "emit_unfold_delivery: Vec element `{}` has no registered output converter",
@@ -1093,7 +1093,7 @@ pub(crate) fn encode_plan_leaves(
         };
         let (value, by_ref, path, consuming) = rebase(leaf);
         let value = &value;
-        let out_entry = registry.output_entry(&leaf.out_ty).unwrap_or_else(|| {
+        let out_entry = ext.out_frag(&leaf.out_ty).unwrap_or_else(|| {
             panic!(
                 "jnigen unfold: leaf `{}` has no registered output converter",
                 leaf.out_ty.key()

--- a/prebindgen-jni/src/jni/emit/flat_input.rs
+++ b/prebindgen-jni/src/jni/emit/flat_input.rs
@@ -45,7 +45,7 @@ pub(crate) fn struct_input_body(
         // fixed-point loop will retry on the next iteration. The field's own
         // reading straight to its entry — the `reading_of` hop only ever
         // recovered what the field already carried.
-        let field_entry = registry.input_entry(&field.ty)?;
+        let field_entry = ext.in_frag(&field.ty)?;
         // The optional layer off the MODEL, asked once and reused: every site
         // below that wants "is this field optional" reads this, so they cannot
         // disagree with each other the way four independent path-segment tests
@@ -56,7 +56,7 @@ pub(crate) fn struct_input_body(
         let field_wire = field_entry.destination.clone();
         // The field's COMPLETE decode, stages included — a `convert!` type
         // reaches its Rust value through them (`jlong -> u64 -> Duration`).
-        let field_conv = composed_entry_decode(field_entry, &raw_ident, &fname_ident);
+        let field_conv = composed_entry_decode(&field_entry, &raw_ident, &fname_ident);
 
         // Projection fields — mirror of `struct_output_body`'s kind branch:
         //  * Handle: read the JNINativeHandle object from the JVM slot,
@@ -115,11 +115,8 @@ pub(crate) fn struct_input_body(
                             proj.strategy,
                             FoldStrategy::Optional(NullableKind::Niche, _)
                         );
-                        let inner_conv = composed_entry_decode(
-                            registry.input_entry(inner)?,
-                            &raw_ident,
-                            &fname_ident,
-                        );
+                        let inner_conv =
+                            composed_entry_decode(&ext.in_frag(inner)?, &raw_ident, &fname_ident);
                         let tmp_ident = format_ident!("__{}_jobj", fname_ident);
                         let decode = if niche {
                             // The Kotlin data-class property is still `ULong?`
@@ -182,7 +179,7 @@ pub(crate) fn struct_input_body(
             {
                 let sig = format!("L{};", fqn.replace('.', "/"));
                 let inner_conv =
-                    composed_entry_decode(registry.input_entry(inner)?, &raw_ident, &fname_ident);
+                    composed_entry_decode(&ext.in_frag(inner)?, &raw_ident, &fname_ident);
                 let tmp_ident = format_ident!("__{}_jobj", fname_ident);
                 let decode = if field_optional {
                     quote! {
@@ -240,8 +237,8 @@ pub(crate) fn struct_input_body(
                 // Kotlin class for a nested data-class field (Option-stripped
                 // — a nullable field keeps the same descriptor), `List` for a
                 // `Vec` field.
-                let sig = registry
-                    .input_entry(inner)
+                let sig = ext
+                    .in_frag(inner)
                     .and_then(|e| jni_field_access(&e.destination))
                     .and_then(|(sig, _, is_obj)| {
                         if is_obj {
@@ -352,7 +349,6 @@ pub(crate) fn sum_input_body(
             let err_prefix = format!("{enum_name}.{kotlin_name}.{prop}: {{}}");
             let (pre, value) = read_kotlin_property(
                 ext,
-                registry,
                 &quote!(__obj),
                 &prop,
                 &field.ty,
@@ -415,7 +411,6 @@ pub(crate) fn sum_input_body(
 #[allow(clippy::too_many_arguments)]
 fn read_kotlin_property(
     ext: &Declarations,
-    registry: &impl Conversions<KotlinMeta>,
     receiver: &TokenStream,
     prop: &str,
     reading: &TypeRef,
@@ -427,7 +422,7 @@ fn read_kotlin_property(
     // below asked of it once — `option_inner_type` compared the last path
     // segment, so a payload spelled `Box<Option<T>>` answered "not optional"
     // four separate times here (#289).
-    let entry = registry.input_entry(reading)?;
+    let entry = ext.in_frag(reading)?;
     let ty = emit.spell(reading);
     let optional = reading.optional_inner().is_some();
     let inner = reading.optional_inner().unwrap_or(reading);
@@ -438,7 +433,7 @@ fn read_kotlin_property(
     // stages that follow (`jlong → u64 → Duration`). Stage bindings are named
     // off `bind`, so two payloads of the same type in one variant do not
     // collide.
-    let conv = composed_property_decode(entry, bind);
+    let conv = composed_property_decode(&entry, bind);
 
     // A handle property is a `NativeHandle` object whose raw pointer comes
     // from `peek()`; an enum property is the Kotlin enum class, decoded
@@ -509,7 +504,7 @@ fn read_kotlin_property(
         // Under `Option`, JVM null is `None` and the INNER converter decodes
         // the discriminant; the outer converter would expect a boxed Integer.
         let decode = if optional {
-            let inner_conv = composed_entry_decode(registry.input_entry(inner)?, &raw, bind);
+            let inner_conv = composed_entry_decode(&ext.in_frag(inner)?, &raw, bind);
             quote! {
                 let #bind = if #obj.is_null() {
                     ::core::option::Option::None
@@ -614,7 +609,7 @@ fn read_kotlin_property(
 /// derive from `stage_base`, so two values of the same type in one scope get
 /// distinct names.
 fn composed_entry_decode(
-    entry: &prebindgen_registry::TypeEntry<KotlinMeta>,
+    entry: &prebindgen_registry::ConverterImpl<KotlinMeta>,
     raw: &syn::Ident,
     stage_base: &syn::Ident,
 ) -> TokenStream {
@@ -641,7 +636,7 @@ fn composed_entry_decode(
 /// [`composed_entry_decode`] for a sealed-class property, whose raw binding is
 /// `<bind>_raw` by construction.
 fn composed_property_decode(
-    entry: &prebindgen_registry::TypeEntry<KotlinMeta>,
+    entry: &prebindgen_registry::ConverterImpl<KotlinMeta>,
     bind: &syn::Ident,
 ) -> TokenStream {
     composed_entry_decode(entry, &format_ident!("{}_raw", bind), bind)
@@ -695,7 +690,7 @@ pub(crate) struct FlatLeaf {
     pub is_present_flag: bool,
     /// Complete converter entry for an ordinary value leaf. Present flags and
     /// direct owned-handle leaves have no entry here.
-    pub entry: Option<prebindgen_registry::TypeEntry<KotlinMeta>>,
+    pub entry: Option<prebindgen_registry::ConverterImpl<KotlinMeta>>,
     /// A nested owned handle crosses as a raw pointer under the same Kotlin
     /// locking/consume scaffold as a top-level handle. This stores the typed
     /// property access tail (`.child.handle` / `?.handle`) used to collect it.
@@ -1005,7 +1000,7 @@ fn flat_error(root: &TypeKey, path: &str, reason: impl Into<String>) -> FlatInpu
     }
 }
 
-fn wire_kotlin_type(entry: &prebindgen_registry::TypeEntry<KotlinMeta>) -> String {
+fn wire_kotlin_type(entry: &prebindgen_registry::ConverterImpl<KotlinMeta>) -> String {
     if let Some(p) = JniPrim::from_wire(&entry.destination) {
         return p.kotlin_type().to_string();
     }
@@ -1088,7 +1083,7 @@ fn build_flat_sum_field(
     }
     struct PlannedLeaf {
         native: String,
-        entry: prebindgen_registry::TypeEntry<KotlinMeta>,
+        entry: prebindgen_registry::ConverterImpl<KotlinMeta>,
         access_tail: String,
         nullable_wire: bool,
     }
@@ -1098,7 +1093,7 @@ fn build_flat_sum_field(
         let mut fields = Vec::new();
         for field in &alt.fields {
             // The payload's own reading straight to its entry.
-            let entry = registry.input_entry(&field.ty)?;
+            let entry = ext.in_frag(&field.ty)?;
             // A projection payload (handle) carries ownership
             // and locking rules the tag-gated group does not model yet.
             if entry.metadata.projection.is_some() {
@@ -1250,7 +1245,7 @@ fn push_value_leaf(
     leaves: &mut Vec<FlatLeaf>,
     native: &str,
     field: syn::Ident,
-    entry: &prebindgen_registry::TypeEntry<KotlinMeta>,
+    entry: &prebindgen_registry::ConverterImpl<KotlinMeta>,
     access: String,
     nullable_wire: bool,
 ) -> usize {
@@ -1356,7 +1351,7 @@ pub(crate) fn build_flat_input_plan(
     // param's Kotlin type (compared by short name, since metadata carries the
     // FQN) must equal the struct's data-class name.
     // The parameter's own reading straight to its entry — no spell-and-look-back.
-    let Some(entry) = registry.input_entry(arg) else {
+    let Some(entry) = ext.in_frag(arg) else {
         return Ok(None);
     };
     if entry.metadata.projection.is_some() {
@@ -1526,7 +1521,7 @@ fn build_flat_struct_node(
         let path = child_native.clone();
         // The field's own reading straight to its entry — the `reading_of` hop
         // only ever recovered what the field already carried.
-        let Some(fentry) = registry.input_entry(&field.ty) else {
+        let Some(fentry) = ext.in_frag(&field.ty) else {
             return Err(flat_error(
                 root,
                 &path,
@@ -1538,7 +1533,7 @@ fn build_flat_struct_node(
         // `(present, value)` representation at every recursion depth.
         if let Some(inner_reading) = field.ty.optional_inner() {
             if inner_reading.borrow_target().is_none() {
-                if let Some(inner) = registry.input_entry(inner_reading) {
+                if let Some(inner) = ext.in_frag(inner_reading) {
                     if let Some(prim) = JniPrim::from_wire(&inner.destination) {
                         if inner.niches.clone().carve().is_none()
                             && inner.metadata.projection.is_none()
@@ -1559,7 +1554,7 @@ fn build_flat_struct_node(
                                 leaves,
                                 &format!("{child_native}_value"),
                                 fident.clone(),
-                                inner,
+                                &inner,
                                 value_access,
                                 false,
                             );
@@ -1589,7 +1584,7 @@ fn build_flat_struct_node(
             if proj.kind == ProjectionKind::Unsigned64 {
                 if let Some(inner_reading) = field.ty.optional_inner() {
                     if JniPrim::from_wire(&fentry.destination).is_none() {
-                        let inner = registry.input_entry(inner_reading).ok_or_else(|| {
+                        let inner = ext.in_frag(inner_reading).ok_or_else(|| {
                             flat_error(
                                 root,
                                 &path,
@@ -1609,7 +1604,7 @@ fn build_flat_struct_node(
                             leaves,
                             &format!("{child_native}_value"),
                             fident.clone(),
-                            inner,
+                            &inner,
                             format!("{field_ref}?.toLong() ?: 0L"),
                             false,
                         );
@@ -1670,7 +1665,7 @@ fn build_flat_struct_node(
                         leaves,
                         &child_native,
                         fident.clone(),
-                        fentry,
+                        &fentry,
                         access,
                         false,
                     );
@@ -1717,7 +1712,7 @@ fn build_flat_struct_node(
             leaves,
             &child_native,
             fident.clone(),
-            fentry,
+            &fentry,
             access,
             (field_is_option || nullable_context) && is_jobject_shaped_wire(&fentry.destination),
         );
@@ -1772,7 +1767,7 @@ pub(crate) fn render_flat_input_decode(
 }
 
 fn render_entry_decode(
-    entry: &prebindgen_registry::TypeEntry<KotlinMeta>,
+    entry: &prebindgen_registry::ConverterImpl<KotlinMeta>,
     wire_ident: &syn::Ident,
     out_ident: &syn::Ident,
     on_err: &TokenStream,
@@ -2097,7 +2092,6 @@ pub(crate) struct OptionScalarInputPlan {
 /// unboxed / ABI-clean) and opaque/value projections are left untouched.
 pub(crate) fn build_option_scalar_input_plan(
     ext: &Declarations,
-    registry: &Registry<KotlinMeta>,
     param_name: &syn::Ident,
     arg: &TypeRef,
 ) -> Option<OptionScalarInputPlan> {
@@ -2114,7 +2108,7 @@ pub(crate) fn build_option_scalar_input_plan(
         return None;
     }
     // The layer's own reading straight to its entry — no spell-and-look-back.
-    let inner_entry = registry.input_entry(inner)?;
+    let inner_entry = ext.in_frag(inner)?;
     let value_wire = inner_entry.destination.clone();
     // Only the boxed-primitive fallback shape: primitive wire, no niche,
     // no projection, no composed pre-stages.

--- a/prebindgen-jni/src/jni/emit/wrapper.rs
+++ b/prebindgen-jni/src/jni/emit/wrapper.rs
@@ -231,8 +231,7 @@ pub(crate) fn emit_jni_function_wrapper_with_callee(
     // registry borrows for the future build-once stage.
     let output_entry = match &plan.output {
         FnOutputPlan::Value(v) => Some(
-            registry
-                .output_entry(&v.target_ty)
+            ext.out_frag(&v.target_ty)
                 .expect("output entry validated at plan build"),
         ),
         FnOutputPlan::Unfold(_) => None,
@@ -692,8 +691,8 @@ fn emit_input_param(
                 prebindgen_registry::flat::TypeKind::Ref { .. }
             ) =>
         {
-            let entry = registry
-                .input_entry(arg_ty)
+            let entry = ext
+                .in_frag(arg_ty)
                 .expect("plan classified Handle ⇒ entry present");
             let wire_ident = if matches!(&entry.destination, syn::Type::Ptr(_)) {
                 format_ident!("{}_ptr", arg_ident)
@@ -726,7 +725,7 @@ fn emit_input_param(
             // without the round trip. The panic now CALLS the shared message
             // instead of restating it, which is what `PlanError::message`'s doc
             // has always claimed and hand-duplication did not deliver.
-            let entry = registry.input_entry(&leaf.reading).unwrap_or_else(|| {
+            let entry = ext.in_frag(&leaf.reading).unwrap_or_else(|| {
                 panic!(
                     "{}",
                     PlanError::Unresolved {
@@ -735,7 +734,7 @@ fn emit_input_param(
                     .message(original_ident)
                 )
             });
-            emit_plain_decode(entry, arg_ident, arg_ty, on_err)
+            emit_plain_decode(&entry, arg_ident, arg_ty, on_err)
         }
     }
 }
@@ -744,7 +743,7 @@ fn emit_input_param(
 /// wire param + staged decode prelude + the call argument (`&decoded` /
 /// `.as_deref()` per the source param's Rust shape).
 fn emit_plain_decode(
-    entry: &prebindgen_registry::TypeEntry<KotlinMeta>,
+    entry: &prebindgen_registry::ConverterImpl<KotlinMeta>,
     arg_ident: &syn::Ident,
     arg_ty: &prebindgen_registry::flat::TypeRef,
     on_err: &TokenStream,
@@ -897,7 +896,7 @@ pub(crate) fn emit_expanded_param(
         let lookup_entry = || {
             // The leaf's own reading goes straight to the entry: spelling it and
             // looking the same reading back up is the round trip #286 removed.
-            registry.input_entry(&leaf.ty).unwrap_or_else(|| {
+            ext.in_frag(&leaf.ty).unwrap_or_else(|| {
                 // Shared wording, not restated — see the sibling backstop above.
                 panic!(
                     "{}",

--- a/prebindgen-jni/src/jni/fn_plan.rs
+++ b/prebindgen-jni/src/jni/fn_plan.rs
@@ -632,8 +632,8 @@ fn classify_leaf(
             reading: reading.clone(),
             kt_name,
             kt_public: None,
-            kt_meta: registry
-                .input_entry(reading)
+            kt_meta: ext
+                .in_frag(reading)
                 .and_then(|e| e.metadata.kotlin_name.clone()),
             optional,
             as_enum_value,
@@ -643,7 +643,7 @@ fn classify_leaf(
 
     // Every non-callback leaf requires a resolved input entry — the same
     // hard boundary the Rust emitter has always enforced.
-    let Some(entry) = registry.input_entry(reading) else {
+    let Some(entry) = ext.in_frag(reading) else {
         // The reading itself, so the diagnostic can say where the type was
         // written. Reaching here means the type IS classified and merely has no
         // converter, which is why there is something to carry.
@@ -670,7 +670,7 @@ fn classify_leaf(
             by_ref: v.by_ref,
             elem_wrappers: v.elem_wrappers,
         }
-    } else if let Some(sp) = build_option_scalar_input_plan(ext, registry, ident, reading) {
+    } else if let Some(sp) = build_option_scalar_input_plan(ext, ident, reading) {
         InputKind::OptionScalar(sp)
     } else if let Some(plan) = flat_plan {
         InputKind::FlattenStruct(plan)
@@ -793,7 +793,7 @@ fn build_output(
             ty: target_ty.key(),
         });
     };
-    let Some(entry) = registry.output_entry(&target) else {
+    let Some(entry) = ext.out_frag(&target) else {
         return Err(PlanError::UnresolvedOutput {
             ty: Box::new(target),
         });
@@ -805,7 +805,7 @@ fn build_output(
     // Kotlin error peel rides the entry's `value_rust_type`, so the full
     // `Result<T, E>` type is looked up as written.)
     let ret_decl = if is_convert { target_ty } else { &f.ret };
-    let (surface, enums) = ReturnSurface::classify(ext, registry, ret_decl);
+    let (surface, enums) = ReturnSurface::classify(ext, ret_decl);
     let EnumSurface {
         is_enum,
         is_option_enum,
@@ -837,13 +837,12 @@ impl ReturnSurface {
     /// and the former `canonical_return_ty`.
     pub fn classify(
         ext: &Declarations,
-        registry: &impl Conversions<KotlinMeta>,
         ret: &prebindgen_registry::flat::TypeRef,
     ) -> (Self, EnumSurface) {
         // The RETURN, as the model classified it. Both callers used to spell a
         // reading into a `-> #ty` fragment for this to take apart again, and
         // the `ReturnType::Default` arm was a unit the element already states.
-        let outer_meta = registry.output_entry(ret).map(|e| e.metadata.clone());
+        let outer_meta = ext.out_frag(ret).map(|e| e.metadata.clone());
         // Unit returns (incl. `ZResult<()>`, whose inner identity rides
         // `value_rust_type`) declare no Kotlin return type. The peeled type is
         // the one the converter's metadata stored — a canonical `syn::Type`,

--- a/prebindgen-jni/src/jni/iface.rs
+++ b/prebindgen-jni/src/jni/iface.rs
@@ -193,7 +193,6 @@ impl IfaceParam {
             .and_then(|key| registry.reading(&key));
         match reading {
             Some(reading) => ext.carry_layers(
-                registry,
                 &self.wrap,
                 self.raw.is_nullable(),
                 &reading,
@@ -935,7 +934,6 @@ fn plan_leaf_param(
     let inert_nullable = leaf.group.is_some() && !leaf_ty_is_prim(registry, &leaf.out_ty);
     leaf_iface_param(
         ext,
-        registry,
         name,
         &leaf.out_ty,
         leaf.nullable || inert_nullable,
@@ -956,7 +954,6 @@ fn plan_leaf_param(
 ///   wrapped object after the invoke.
 fn leaf_iface_param(
     ext: &Declarations,
-    registry: &impl Conversions<KotlinMeta>,
     name: String,
     out_ty: &prebindgen_registry::flat::TypeRef,
     nullable: bool,
@@ -974,16 +971,16 @@ fn leaf_iface_param(
     // servable here (`a_wrapped_borrow_callback_arg_declines`) — peeling it
     // would resolve a shape the wrapper arms own.
     let mut out_ty = out_ty;
-    if registry.output_entry(out_ty).is_none() {
+    if ext.out_frag(out_ty).is_none() {
         if let prebindgen_registry::flat::TypeKind::Ref { inner, .. } = out_ty.kind() {
             out_ty = inner;
         }
     }
     let (builder_kt, _wire_kt, _wrap, is_value_projection) =
-        unfold_leaf_kt(ext, registry, out_ty, nullable, "x")?;
-    let proj = registry
-        .output_entry(out_ty)
-        .and_then(|e| e.metadata.projection.as_ref());
+        unfold_leaf_kt(ext, out_ty, nullable, "x")?;
+    let proj = ext
+        .out_frag(out_ty)
+        .and_then(|e| e.metadata.projection.clone());
     let nullable_kt = |t: KtType| {
         if builder_kt.is_nullable() {
             t.nullable()
@@ -992,9 +989,10 @@ fn leaf_iface_param(
         }
     };
     if is_value_projection {
-        match proj?.kind {
+        let proj = proj.clone()?;
+        match proj.kind {
             ProjectionKind::Unsigned64 => {
-                let mut raw = projection_wire_return(proj?);
+                let mut raw = projection_wire_return(&proj);
                 if nullable && !raw.is_nullable() {
                     raw = raw.nullable();
                 }
@@ -1011,7 +1009,7 @@ fn leaf_iface_param(
                 // `unfold_leaf_kt` makes, so the two derivations of this wrap
                 // cannot disagree.
                 let niche_sentinel = if builder_kt.is_nullable() {
-                    wrap_sentinel(proj?, nullable)
+                    wrap_sentinel(&proj, nullable)
                 } else {
                     None
                 };
@@ -1040,7 +1038,7 @@ fn leaf_iface_param(
             // The sentinel is the other axis: the leaf's own `None`, which rides
             // the niche whatever the ancestor does — a `Box` pointer is never 0.
             let niche_sentinel = if builder_kt.is_nullable() {
-                wrap_sentinel(p, nullable)
+                wrap_sentinel(&p, nullable)
             } else {
                 None
             };
@@ -1104,12 +1102,11 @@ fn leaf_iface_param(
 /// post-invoke `close()`. `None` if the arg's projection FQN can't be resolved.
 pub(crate) fn owned_handle_iface_param(
     ext: &Declarations,
-    registry: &impl Conversions<KotlinMeta>,
     name: String,
     out_ty: &prebindgen_registry::flat::TypeRef,
     nullable: bool,
 ) -> Option<IfaceParam> {
-    let proj = registry.output_entry(out_ty)?.metadata.projection.clone()?;
+    let proj = ext.out_frag(out_ty)?.metadata.projection.clone()?;
     let fqn = ext.kotlin_fqn(&proj.leaf_key)?.to_string();
     let typed = KtType::cls(fqn.clone());
     let (typed, raw) = if nullable {
@@ -1268,9 +1265,7 @@ fn derive_iface_spec(
         // Same round trip, same reason, same answer as the `Callback` arm
         // above: the memo key holds an identity, and the reading behind it is a
         // lookup. `None` defers, exactly as it does there (#291).
-        SpecKey::WholeFolder(el_key) => {
-            whole_folder_iface_spec(ext, registry, &registry.reading(el_key)?)
-        }
+        SpecKey::WholeFolder(el_key) => whole_folder_iface_spec(ext, &registry.reading(el_key)?),
         SpecKey::Handler(d) => error_handler_iface_spec(ext, registry, d),
         SpecKey::JniErrorHandler => Some(jni_error_handler_iface_spec(ext)),
     }
@@ -1500,9 +1495,9 @@ pub(crate) fn callback_iface_spec(
         } else {
             // A plan-less opaque-handle arg is delivered as a raw `jlong` and
             // wrapped + closed Kotlin-side (Phase 3 — no Rust `new_object`).
-            let owned_handle = registry
-                .output_entry(t)
-                .and_then(|e| e.metadata.projection.as_ref())
+            let owned_handle = ext
+                .out_frag(t)
+                .and_then(|e| e.metadata.projection.clone())
                 .map(|p| p.kind == ProjectionKind::Handle)
                 .unwrap_or(false);
             leaf_tys.push(LeafDesc::Whole {
@@ -1533,9 +1528,9 @@ pub(crate) fn callback_iface_spec(
                 nullable,
                 owned_handle: true,
                 ..
-            } => owned_handle_iface_param(ext, registry, name, ty, *nullable)?,
+            } => owned_handle_iface_param(ext, name, ty, *nullable)?,
             LeafDesc::Whole { ty, nullable, .. } => {
-                leaf_iface_param(ext, registry, name, ty, *nullable, false)?
+                leaf_iface_param(ext, name, ty, *nullable, false)?
             }
         };
         params.push(param);
@@ -1645,7 +1640,6 @@ pub(crate) fn folder_iface_spec(
 /// `run(acc: A, element): A`. One shape per element type by construction.
 pub(crate) fn whole_folder_iface_spec(
     ext: &Declarations,
-    registry: &impl Conversions<KotlinMeta>,
     element: &prebindgen_registry::flat::TypeRef,
 ) -> Option<IfaceSpec> {
     let mut params: Vec<IfaceParam> = vec![IfaceParam::same("acc".to_string(), KtType::var_("A"))];
@@ -1656,7 +1650,6 @@ pub(crate) fn whole_folder_iface_spec(
     // unaffected (they ignore the flag; see [`leaf_iface_param`]).
     params.push(leaf_iface_param(
         ext,
-        registry,
         "element".to_string(),
         element,
         false,

--- a/prebindgen-jni/src/jni/kotlin_emit.rs
+++ b/prebindgen-jni/src/jni/kotlin_emit.rs
@@ -728,7 +728,7 @@ impl Declarations {
             let mut vcloses: Vec<String> = Vec::new();
             for field in &alt.fields {
                 let prop = sum_field_prop_name(&field.member());
-                let ty = self.sum_payload_kt_type(registry, &sum.name, &alt.name, &prop, field);
+                let ty = self.sum_payload_kt_type(&sum.name, &alt.name, &prop, field);
                 if let Some(strategy) = payload_close(field) {
                     vcloses.push(render_handle_close(&strategy, &prop));
                 }
@@ -795,7 +795,7 @@ impl Declarations {
             let vname = self.sum_variant_class_name(sum_cfg, &alt.name);
             for field in &alt.fields {
                 let prop = sum_field_prop_name(&field.member());
-                let ty = self.sum_payload_kt_type(registry, &sum.name, &alt.name, &prop, field);
+                let ty = self.sum_payload_kt_type(&sum.name, &alt.name, &prop, field);
                 factory = factory.param(KtParam::new(sum_slot_fragment(&vname, &prop), ty));
             }
         }
@@ -905,7 +905,6 @@ impl Declarations {
     ///   ABI mismatch at runtime.
     fn sum_payload_kt_type(
         &self,
-        registry: &Registry<KotlinMeta>,
         sum_name: &syn::Ident,
         variant: &syn::Ident,
         prop: &str,
@@ -917,7 +916,7 @@ impl Declarations {
         // below, which is a diagnostic and needs no emission capability.
         let field_ty = &field.ty;
         let where_ = || format!("sealed_class!({}) payload `{variant}.{prop}`", sum_name);
-        let out = registry.output_entry(&field.ty).unwrap_or_else(|| {
+        let out = self.out_frag(&field.ty).unwrap_or_else(|| {
             panic!(
                 "{}: `{}` has no resolved OUTPUT converter, so the Kotlin surface for it \
                  cannot be derived — register converters for the payload type before \
@@ -957,7 +956,7 @@ impl Declarations {
         // boxed value, a present flag, a niche) rather than in the type name.
         // Comparing the rendered types would reject that legitimate shape —
         // which is what an `Option<enum>` payload does.
-        if let Some(inp) = registry.input_entry(&field.ty) {
+        if let Some(inp) = self.in_frag(&field.ty) {
             if let (Some(in_ty), (Some(a), Some(b))) = (
                 inp.metadata.kotlin_name.clone(),
                 (
@@ -1597,7 +1596,7 @@ impl Declarations {
                 .zip(params)
                 .zip(names)
                 .filter(|((l, _), _)| l.group == Some(group))
-                .map(|((l, p), n)| self.sum_ctor_arg(registry, l, p, n, imports))
+                .map(|((l, p), n)| self.sum_ctor_arg(l, p, n, imports))
                 .collect();
             // Kotlin has no `B()` / `B {}` distinction to keep: a payload-less
             // alternative is a `data object`, named bare. The Rust side is where
@@ -1641,7 +1640,6 @@ impl Declarations {
     /// `!!` would turn a legitimately absent value into an exception.
     fn sum_ctor_arg(
         &self,
-        registry: &impl Conversions<KotlinMeta>,
         leaf: &prebindgen_registry::unfold::UnfoldLeaf,
         param: &crate::jni::IfaceParam,
         name: &str,
@@ -1655,7 +1653,6 @@ impl Declarations {
             name.to_string()
         };
         self.carry_layers(
-            registry,
             &param.wrap,
             param.raw.is_nullable(),
             &leaf.out_ty,
@@ -1686,7 +1683,6 @@ impl Declarations {
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn carry_layers(
         &self,
-        registry: &impl Conversions<KotlinMeta>,
         wrap: &crate::jni::WrapKind,
         slot_nullable: bool,
         ty: &prebindgen_registry::flat::TypeRef,
@@ -1696,16 +1692,7 @@ impl Declarations {
         imports: &mut BTreeSet<String>,
     ) -> String {
         if let Some(inner) = ty.optional_inner() {
-            return self.carry_layers(
-                registry,
-                wrap,
-                slot_nullable,
-                inner,
-                recv,
-                true,
-                depth,
-                imports,
-            );
+            return self.carry_layers(wrap, slot_nullable, inner, recv, true, depth, imports);
         }
         if let Some(elem) = ty.sequence_elem() {
             let bound = if depth == 0 {
@@ -1714,7 +1701,6 @@ impl Declarations {
                 format!("__e{depth}")
             };
             let body = self.carry_layers(
-                registry,
                 wrap,
                 slot_nullable,
                 elem,
@@ -1744,8 +1730,8 @@ impl Declarations {
         // same output-converter metadata `factory_field` reads for an enum
         // struct field.
         if self.is_kotlin_enum_reading(ty) {
-            let name = registry
-                .output_entry(ty)
+            let name = self
+                .out_frag(ty)
                 .and_then(|e| e.metadata.kotlin_name.clone())
                 .and_then(|t| t.leaf_name().map(str::to_string))
                 .unwrap_or_else(|| {

--- a/prebindgen-jni/src/jni/mod.rs
+++ b/prebindgen-jni/src/jni/mod.rs
@@ -579,6 +579,23 @@ pub struct Declarations {
     /// function name, so the order here decides which of two same-named
     /// functions wins and not where any of them lands.
     pub(crate) compiled_fns: Vec<syn::ItemFn>,
+    /// Every conversion this binding has compiled so far, keyed by crossing.
+    ///
+    /// What the emitters ask instead of the converter table. A table entry
+    /// carries one `destination`, the single wire type a conversion produces,
+    /// so it can answer only while a crossing occupies one wire value — and the
+    /// answer an emitter wants is this adapter's own fragment.
+    ///
+    /// Shared and interior-mutable because JniGen reads it **while** it is
+    /// being filled: unlike `prebindgen-c`, this adapter's emitters are also
+    /// its conversion builders, and `JniGen::build_with` calls them from inside
+    /// `convert_with`. A conversion for one type is built out of the
+    /// conversions for its inners, which the resolver compiles first — the same
+    /// order that filled the converter table, so a fragment is there exactly
+    /// when a table entry would have been.
+    pub(crate) compiled: std::rc::Rc<
+        std::cell::RefCell<prebindgen_registry::recipe::Compiled<crate::jni::compile::JFrag>>,
+    >,
 
     /// When `true` (default), generated wrappers wrap each call that
     /// touches an opaque handle in the per-call `withSortedHandleLocks`

--- a/prebindgen-jni/src/jni/overloads.rs
+++ b/prebindgen-jni/src/jni/overloads.rs
@@ -122,7 +122,7 @@ fn arm_erased_sig(
             Some(f) => f
                 .params
                 .iter()
-                .map(|p| rust_type_erased(ext, registry, &p.ty))
+                .map(|p| rust_type_erased(ext, &p.ty))
                 .collect(),
             None => Vec::new(),
         },
@@ -133,7 +133,7 @@ fn arm_erased_sig(
         // form is the identity's own canonical spelling — which is all a
         // declaration has to be told apart by.
         None => vec![match registry.reading(target) {
-            Some(reading) => rust_type_erased(ext, registry, &reading),
+            Some(reading) => rust_type_erased(ext, &reading),
             None => ErasedJvmType::raw(target.as_str().to_string()),
         }],
     }
@@ -145,11 +145,7 @@ fn arm_erased_sig(
 /// there. Falls back to the token string for a
 /// type with no resolved surface. References are peeled first (`&T` erases
 /// like `T`).
-fn rust_type_erased(
-    ext: &Declarations,
-    registry: &Registry<KotlinMeta>,
-    ty: &prebindgen_registry::flat::TypeRef,
-) -> ErasedJvmType {
+fn rust_type_erased(ext: &Declarations, ty: &prebindgen_registry::flat::TypeRef) -> ErasedJvmType {
     // The spelling's own outermost borrow, as `TypeKind::Ref` — not
     // `borrow_target`, which reaches through the erased wrappers (#S31).
     let peeled = match ty.kind() {
@@ -162,8 +158,8 @@ fn rust_type_erased(
             return erase_kt_type(&[], &KtType::cls(fqn));
         }
     }
-    if let Some(kt) = registry
-        .input_entry(peeled)
+    if let Some(kt) = ext
+        .in_frag(peeled)
         .and_then(|e| e.metadata.kotlin_name.clone())
     {
         return erase_kt_type(&[], &kt);

--- a/prebindgen-jni/src/jni/render.rs
+++ b/prebindgen-jni/src/jni/render.rs
@@ -139,8 +139,8 @@ pub(crate) fn build_data_class(
         // ordinary leaf, so the property and its own factory parameter
         // disagreed. Reject it at the declaration instead.
         if !matches!(pf.kind, PlanFieldKind::Projection { .. }) {
-            if let Some(proj) = registry
-                .input_entry(&field.ty)
+            if let Some(proj) = ext
+                .in_frag(&field.ty)
                 .and_then(|e| e.metadata.projection.clone())
             {
                 panic!(
@@ -2148,13 +2148,12 @@ fn render_body(
 /// Shared by the unfold builder/fold lambda and the callback lambda params.
 pub(crate) fn unfold_leaf_kt(
     ext: &Declarations,
-    registry: &impl Conversions<KotlinMeta>,
     out_ty: &prebindgen_registry::flat::TypeRef,
     nullable: bool,
     pk: &str,
 ) -> Option<(KtType, String, String, bool)> {
-    let proj = registry
-        .output_entry(out_ty)
+    let proj = ext
+        .out_frag(out_ty)
         .and_then(|e| e.metadata.projection.clone());
     let is_value_projection = proj
         .as_ref()
@@ -2165,7 +2164,7 @@ pub(crate) fn unfold_leaf_kt(
     let builder_kt = if ext.is_kotlin_enum_reading(out_ty) {
         KtType::int()
     } else {
-        classify_return(ext, out_ty, registry)?.0?
+        classify_return(ext, out_ty)?.0?
     };
     let (mut wire_kt, wrap) = if is_value_projection {
         let p = proj.as_ref().unwrap();
@@ -2271,9 +2270,8 @@ pub(crate) fn kotlin_for_wire(wire: &syn::Type) -> Option<KtType> {
 pub(crate) fn classify_return(
     ext: &Declarations,
     output: &prebindgen_registry::flat::TypeRef,
-    registry: &impl Conversions<KotlinMeta>,
 ) -> Option<(Option<KtType>, Option<crate::jni::Projection>)> {
-    let (surface, _canonical) = ReturnSurface::classify(ext, registry, output);
+    let (surface, _canonical) = ReturnSurface::classify(ext, output);
     render_return_surface(&surface)
 }
 

--- a/prebindgen-jni/src/jni/report.rs
+++ b/prebindgen-jni/src/jni/report.rs
@@ -135,7 +135,7 @@ impl super::JniGen {
                 .unwrap_or_else(|| key.as_str().to_string());
             let wire = registry
                 .reading(key)
-                .and_then(|tr| registry.output_entry(&tr))
+                .and_then(|tr| ext.out_frag(&tr))
                 .map(|e| e.wire_type().to_token_stream().to_string())
                 .unwrap_or_else(|| "?".to_string());
             out.push_str(&format!(

--- a/prebindgen-jni/src/jni/selector.rs
+++ b/prebindgen-jni/src/jni/selector.rs
@@ -185,7 +185,7 @@ impl Declarations {
             return None;
         }
         let elem = inner.sequence_elem()?;
-        self.output_slice(elem, registry, emit)
+        self.output_slice(elem, emit)
     }
 }
 

--- a/prebindgen-jni/src/jni/struct_plan.rs
+++ b/prebindgen-jni/src/jni/struct_plan.rs
@@ -64,7 +64,7 @@ pub(crate) struct ConvChain {
 
 impl ConvChain {
     /// Read the chain off a resolved output entry.
-    fn of(entry: &prebindgen_registry::TypeEntry<KotlinMeta>) -> Self {
+    fn of(entry: &prebindgen_registry::ConverterImpl<KotlinMeta>) -> Self {
         ConvChain {
             stages: entry
                 .output_stage_order()
@@ -301,8 +301,8 @@ pub(crate) fn classify_field(
         );
     }
 
-    let field_entry = registry.output_entry(reading)?;
-    let conv = ConvChain::of(field_entry);
+    let field_entry = ext.out_frag(reading)?;
+    let conv = ConvChain::of(&field_entry);
 
     {
         // Projection leaf (opaque handle / `ULong`).
@@ -338,7 +338,7 @@ pub(crate) fn classify_field(
                     Some(PlanFieldKind::Enum { conv, kotlin })
                 }
                 Some(inner) => {
-                    let kotlin = registry.output_entry(inner)?.metadata.kotlin_name.clone()?;
+                    let kotlin = ext.out_frag(inner)?.metadata.kotlin_name.clone()?;
                     Some(PlanFieldKind::OptionEnum { conv, kotlin })
                 }
             };
@@ -385,8 +385,8 @@ pub(crate) fn classify_field(
                 // Option-stripped off the MODEL: `optional_inner` is the
                 // layer's own reading, so there is nothing to re-look-up.
                 let slot = optional_inner.unwrap_or(reading);
-                let descriptor = registry
-                    .output_entry(slot)
+                let descriptor = ext
+                    .out_frag(slot)
                     .and_then(|e| jni_field_access(&e.destination))
                     .and_then(|(sig, _, is_obj)| {
                         if is_obj {
@@ -639,10 +639,7 @@ pub(crate) fn type_close_strategy(
     // something: a `ULong` owns nothing, and a borrowed handle is not ours to
     // release. Asked of the whole reading, so the `Option`/`Vec` folds the
     // projection carries come back in its own strategy.
-    if let Some(proj) = registry
-        .output_entry(ty)
-        .and_then(|e| e.metadata.projection.as_ref())
-    {
+    if let Some(proj) = ext.out_frag(ty).and_then(|e| e.metadata.projection.clone()) {
         return (matches!(proj.kind, ProjectionKind::Handle) && proj.owned)
             .then(|| proj.strategy.clone());
     }

--- a/prebindgen-jni/src/jni/trait_impl.rs
+++ b/prebindgen-jni/src/jni/trait_impl.rs
@@ -648,7 +648,7 @@ pub(crate) fn build_handle_destructor_items(
         let Some(reading) = registry.reading(key) else {
             continue;
         };
-        if registry.input_entry(&reading).is_none() && registry.output_entry(&reading).is_none() {
+        if ext.in_frag(&reading).is_none() && ext.out_frag(&reading).is_none() {
             continue;
         }
         let ty = emit.spell(&reading);
@@ -1031,7 +1031,6 @@ impl Declarations {
         shape: WrapperShape,
         produced: &Produced<'_>,
         t1: &prebindgen_registry::flat::TypeRef,
-        registry: &impl Conversions<KotlinMeta>,
     ) -> Option<ConverterImpl<KotlinMeta>> {
         let WrapperShape::Borrow { .. } = shape else {
             return None;
@@ -1044,7 +1043,7 @@ impl Declarations {
         if !produced.is_canonical() {
             return None;
         }
-        let inner = registry.input_entry(t1)?;
+        let inner = self.in_frag(t1)?;
         let outer_ty = produced.key();
         // `&T` / `&mut T` are Kotlin-side no-ops — inherit the inner
         // type's name, unless the user pinned an explicit override
@@ -1082,7 +1081,6 @@ impl Declarations {
         shape: WrapperShape,
         produced: &Produced<'_>,
         t1: &prebindgen_registry::flat::TypeRef,
-        registry: &impl Conversions<KotlinMeta>,
         emit: &prebindgen_registry::Emit,
     ) -> Option<ConverterImpl<KotlinMeta>> {
         // `t1`'s spelling, for the parts that ask spelling questions — the
@@ -1099,7 +1097,7 @@ impl Declarations {
         if !produced.is_canonical() {
             return None;
         }
-        let inner = registry.input_entry(t1)?;
+        let inner = self.in_frag(t1)?;
         if !inner.metadata.is_direct_handle() {
             // Non-opaque: let the general `Option<_>` handler take it.
             return None;
@@ -1152,7 +1150,6 @@ impl Declarations {
         shape: WrapperShape,
         produced: &Produced<'_>,
         t1: &prebindgen_registry::flat::TypeRef,
-        registry: &impl Conversions<KotlinMeta>,
         emit: &prebindgen_registry::Emit,
     ) -> Option<ConverterImpl<KotlinMeta>> {
         // `t1`'s spelling, for the parts that ask spelling questions — the
@@ -1163,7 +1160,7 @@ impl Declarations {
         if shape != WrapperShape::Sequence {
             return None;
         }
-        let inner = registry.input_entry(t1)?;
+        let inner = self.in_frag(t1)?;
         reject_vec_of_handle(&inner.metadata.projection, t1);
         let inner_wire = inner.destination.clone();
         if !is_jobject_shaped_wire(&inner_wire) {
@@ -1172,7 +1169,8 @@ impl Declarations {
         // The element's COMPLETE wire -> Rust chain: a `convert!` element
         // (`Label` -> `String`) reaches its value through the rust-side stages,
         // not through the wire-facing converter alone.
-        let inner_conv = crate::jni::emit::composed_inner_input(inner, quote::quote!(&__elem_wire));
+        let inner_conv =
+            crate::jni::emit::composed_inner_input(&inner, quote::quote!(&__elem_wire));
         let outer_ty = produced.key();
         // Bridgeable first — see `box_layers_to`.
         let build = build_from_canonical(produced, quote::quote!(__out))?;
@@ -1231,7 +1229,7 @@ impl Declarations {
         // the READING itself (#284).
         let t1_ty = emit.spell(t1);
         if shape == WrapperShape::Optional {
-            let inner = registry.input_entry(t1)?;
+            let inner = self.in_frag(t1)?;
             if inner.metadata.is_direct_handle() {
                 let inner_wire = inner.destination.clone();
                 let outer_ty = produced.key();
@@ -1300,8 +1298,8 @@ impl Declarations {
             });
             // Inherit the inner's name; user pins on `Option<T>` win.
             // The nullability marker (`?`) is added by the use site.
-            let inherited = registry
-                .input_entry(t1)
+            let inherited = self
+                .in_frag(t1)
                 .and_then(|e| e.metadata.kotlin_name.clone());
             let kotlin_name = self.override_kotlin_name(&outer_ty, inherited);
             // Fold a Nullable layer over the inner projection (if any). The
@@ -1310,8 +1308,8 @@ impl Declarations {
             // destination and `None` is the niche slot sentinel; the boxed
             // fallback widens the wire to `JObject`.
             let nullable_kind = nullable_kind_for(&wire, t1, registry);
-            let projection = registry
-                .input_entry(t1)
+            let projection = self
+                .in_frag(t1)
                 .and_then(|e| e.metadata.projection.clone())
                 .map(|h| Projection {
                     strategy: FoldStrategy::Optional(nullable_kind, Box::new(h.strategy)),
@@ -1428,12 +1426,11 @@ impl JniGenBuilder {
         })?;
         // JniGen overrides no site yet: every crossing takes its type's own row.
         let bindings = prebindgen_registry::recipe::Bindings::default();
-        // The driver's state, carried between calls. The adapter borrows the
-        // partial registry view, which is lent per call and so is a different
-        // type each time; what it built is not, and outlives every one of them.
-        let mut compiled = Some(prebindgen_registry::recipe::Compiled::<
-            crate::jni::compile::JFrag,
-        >::default());
+        // The driver's state lives on `decls` rather than here, because the
+        // adapter reads it **while** it compiles: a conversion for one type is
+        // built out of the conversions for its inners, which are compiled
+        // first. That is the same order the converter table was filled in, so
+        // a fragment is there exactly when a table entry would have been.
         // A callback is still answered without the compiler — see
         // `compile_crossing` — so no fragment carries its conversion and the
         // fragment list alone would not reach the file. Collected here rather
@@ -1446,22 +1443,36 @@ impl JniGenBuilder {
                     &model,
                     &recipes,
                     &bindings,
-                    compiled.take().expect("the state is put back every call"),
+                    decls.compiled.borrow().clone(),
                 );
                 let conv = decls.compile_crossing(&mut compiler, crossing, built, emit);
-                compiled = Some(compiler.finish());
+                *decls.compiled.borrow_mut() = compiler.finish();
                 if let (Some(c), true) =
                     (conv.as_ref(), decls.is_callback_crossing(crossing, built))
                 {
                     uncompiled.push(c.function.clone());
+                    // File it as this crossing's fragment even though no row
+                    // built it, so every emitter has one lookup rather than a
+                    // fall-back for the one crossing kind the compiler skips.
+                    let (dir, key) = crossing;
+                    decls.compiled.borrow_mut().record(
+                        key.clone(),
+                        match dir {
+                            Direction::Input => prebindgen_registry::recipe::Assembly::Construct,
+                            Direction::Output => prebindgen_registry::recipe::Assembly::Deconstruct,
+                        },
+                        prebindgen_registry::recipe::RecipeId::new("callback"),
+                        crate::jni::compile::JFrag::by_hand(key.clone(), c.clone()),
+                    );
                 }
                 conv
             })?
             .build()?;
         // What the compilation produced, kept for emission. The converter table
         // stays the lookup index; this is what reaches the file.
-        decls.compiled_fns = compiled
-            .expect("the state is put back every call")
+        decls.compiled_fns = decls
+            .compiled
+            .borrow()
             .fragments()
             .into_iter()
             // A JNI conversion already emits more than one function: a
@@ -2448,7 +2459,7 @@ impl Declarations {
         // It has to be a type this binding already crosses; if it is not, the
         // ordinary "unresolved" diagnostic names it, which is the better error.
         let inner = registry.reading(&stripped)?;
-        let entry = registry.output_entry(&inner)?;
+        let entry = self.out_frag(&inner)?;
         let wire = entry.destination.clone();
         // Take the wrappers off what the caller handed us. `None` is `Cow`'s
         // policy refusal — the crossing then stays unresolved and names the
@@ -2457,7 +2468,7 @@ impl Declarations {
         let read = read_through_erased_wrappers(reading, quote!(v))?;
         // The inner's COMPLETE chain, stages included: a `convert!` type reaches
         // its wire through them.
-        let inner_call = crate::jni::emit::composed_inner_output(entry, quote!(__inner));
+        let inner_call = crate::jni::emit::composed_inner_output(&entry, quote!(__inner));
         let body: syn::Expr = syn::parse_quote!({
             let __inner = #read;
             #inner_call
@@ -2523,7 +2534,7 @@ impl Declarations {
         // It has to be a type this binding already crosses; if it is not, the
         // ordinary "unresolved" diagnostic names it, which is the better error.
         let inner = registry.reading(&stripped)?;
-        let entry = registry.input_entry(&inner)?;
+        let entry = self.in_frag(&inner)?;
         let wire = entry.destination.clone();
         // Wrap what the inner converter produced. `None` here is `Cow`'s policy
         // refusal — the crossing then stays unresolved and names the type,
@@ -2535,7 +2546,7 @@ impl Declarations {
         // stages (`jlong -> u64 -> Duration`), so a `Box` over one arrived
         // un-staged. Every other composing arm goes through this helper for
         // exactly that reason (#309).
-        let inner_call = crate::jni::emit::composed_inner_input(entry, quote!(v));
+        let inner_call = crate::jni::emit::composed_inner_input(&entry, quote!(v));
         let body: syn::Expr = syn::parse_quote!({
             let __inner = #inner_call;
             #built
@@ -2572,9 +2583,9 @@ impl Declarations {
         // Disjoint shapes (see [`WrapperShape`]), tried in priority order. The
         // borrow/option-ref/vec shapes are mutually exclusive; the two
         // `Optional` sub-cases share a method.
-        self.input_borrow(shape, produced, t1, registry)
-            .or_else(|| self.input_option_ref(shape, produced, t1, registry, emit))
-            .or_else(|| self.input_vec(shape, produced, t1, registry, emit))
+        self.input_borrow(shape, produced, t1)
+            .or_else(|| self.input_option_ref(shape, produced, t1, emit))
+            .or_else(|| self.input_vec(shape, produced, t1, emit))
             .or_else(|| self.input_option(shape, produced, t1, registry, emit))
     }
 
@@ -2825,8 +2836,8 @@ impl Declarations {
                 let v: #canonical = #read;
                 #inner_body
             });
-            let inherited = registry
-                .output_entry(t1)
+            let inherited = self
+                .out_frag(t1)
                 .and_then(|e| e.metadata.kotlin_name.clone());
             let kotlin_name = self.override_kotlin_name(&outer_ty, inherited);
             // Fold a Nullable layer over the inner projection (if any). The
@@ -2835,8 +2846,8 @@ impl Declarations {
             // and treats the slot value as `None`; boxed widens to `JObject`
             // and uses JVM null.
             let nullable_kind = nullable_kind_for_output(&wire, t1, registry);
-            let projection = registry
-                .output_entry(t1)
+            let projection = self
+                .out_frag(t1)
                 .and_then(|e| e.metadata.projection.clone())
                 .map(|h| Projection {
                     strategy: FoldStrategy::Optional(nullable_kind, Box::new(h.strategy)),
@@ -2868,7 +2879,7 @@ impl Declarations {
         // Symmetric to the input handler. `Vec<u8>` is special-cased at
         // rank-0 (primitive_output → JByteArray) so rank-1 never sees it.
         if shape == WrapperShape::Sequence {
-            let inner = registry.output_entry(t1)?;
+            let inner = self.out_frag(t1)?;
             // `Vec<opaque-handle>` output is delivered by the Kotlin-side leaf
             // fold (`apply_leaf_vec_folds` → typed-handle wrap), so this
             // whole-`ArrayList` converter is bypassed for it. A handle's `jlong`
@@ -2879,7 +2890,7 @@ impl Declarations {
                 return None;
             }
             // The element's COMPLETE Rust -> wire chain (see the input peer).
-            let inner_conv = crate::jni::emit::composed_inner_output(inner, quote::quote!(__elem));
+            let inner_conv = crate::jni::emit::composed_inner_output(&inner, quote::quote!(__elem));
             let outer_ty = produced.key();
             let canonical: syn::Type = syn::parse_quote!(Vec<#t1_ty>);
             let read = read_as_canonical(produced)?;
@@ -2946,10 +2957,9 @@ impl Declarations {
     pub(crate) fn output_slice(
         &self,
         elem: &prebindgen_registry::flat::TypeRef,
-        registry: &impl Conversions<KotlinMeta>,
         emit: &prebindgen_registry::Emit,
     ) -> Option<ConverterImpl<KotlinMeta>> {
-        let inner = registry.output_entry(elem)?;
+        let inner = self.out_frag(elem)?;
         let elem_key = elem.key();
         // The element as the source spelled it — the slice type this converter
         // yields is re-emitted, never re-derived.
@@ -2963,7 +2973,7 @@ impl Declarations {
         }
         // The element's COMPLETE Rust -> wire chain (see the `Vec<_>` peer).
         let inner_conv = crate::jni::emit::composed_inner_output(
-            inner,
+            &inner,
             quote::quote!(::core::clone::Clone::clone(__elem)),
         );
         let outer_ty: syn::Type = syn::parse_quote!(&[#elem]);

--- a/prebindgen-registry/src/prebindgen.rs
+++ b/prebindgen-registry/src/prebindgen.rs
@@ -116,6 +116,33 @@ pub struct ConverterImpl<M = ()> {
     pub subs: Vec<crate::registry::TypeKey>,
 }
 
+/// The same reads [`TypeEntry`](crate::TypeEntry) offers, on the conversion an
+/// adapter built. A `TypeEntry` is this type with its inners keyed, so an
+/// emitter reading a compiled fragment asks it the same questions.
+impl<M> ConverterImpl<M> {
+    /// Identifier of the wire-facing converter function.
+    pub fn converter_ident(&self) -> &syn::Ident {
+        &self.function.sig.ident
+    }
+
+    /// Wire type this conversion carries on success.
+    pub fn wire_type(&self) -> &syn::Type {
+        &self.destination
+    }
+
+    /// Rust-side stages in input execution order, after the wire-facing
+    /// converter has decoded the wire value.
+    pub fn input_stage_order(&self) -> impl Iterator<Item = (usize, &Stage<M>)> {
+        self.pre_stages.iter().enumerate().rev()
+    }
+
+    /// Rust-side stages in output execution order, before the wire-facing
+    /// converter encodes the final wire value.
+    pub fn output_stage_order(&self) -> impl Iterator<Item = (usize, &Stage<M>)> {
+        self.pre_stages.iter().enumerate()
+    }
+}
+
 /// The single extension point of the pipeline: implement this trait once per
 /// **destination language** (C/cbindgen, JNI/Kotlin, Swift, Python, …) to teach
 /// the language-agnostic [`Registry`] how that language represents Rust types

--- a/prebindgen-registry/src/recipe/compile.rs
+++ b/prebindgen-registry/src/recipe/compile.rs
@@ -389,6 +389,18 @@ impl<F> Default for Compiled<F> {
     }
 }
 
+/// Cheap: a fragment sits behind an `Rc`, so a clone shares the fragments
+/// rather than copying them, and needs nothing of `F`.
+impl<F> Clone for Compiled<F> {
+    fn clone(&self) -> Self {
+        Self {
+            fragments: self.fragments.clone(),
+            defaults: self.defaults.clone(),
+            required: self.required.clone(),
+        }
+    }
+}
+
 impl<F> Compiled<F> {
     /// How many fragments have been built, which is what makes the
     /// per-crossing promise observable.
@@ -418,6 +430,22 @@ impl<F> Compiled<F> {
     pub fn fragment(&self, ty: &TypeKey, assembly: Assembly) -> Option<&F> {
         let row = self.defaults.get(&(ty.clone(), assembly))?;
         self.row_fragment(ty, assembly, row)
+    }
+
+    /// Record a fragment an adapter built **without** the compiler, as this
+    /// crossing's whole answer.
+    ///
+    /// The escape hatch for a crossing the adapter still answers by hand:
+    /// `Compiler::crossing` never saw it, so nothing would file it, and
+    /// [`Self::fragment`] would have no answer to give. Recording it keeps the
+    /// adapter's emitters on one lookup instead of a per-site fall-back to
+    /// whatever else knows.
+    pub fn record(&mut self, ty: TypeKey, assembly: Assembly, row: RecipeId, fragment: F) {
+        self.fragments.insert(
+            (ty.clone(), assembly, row.clone()),
+            std::rc::Rc::new(fragment),
+        );
+        self.defaults.insert((ty, assembly), row);
     }
 
     /// The fragment for one crossing and one named row.

--- a/prebindgen-registry/src/registry/cell.rs
+++ b/prebindgen-registry/src/registry/cell.rs
@@ -85,11 +85,11 @@ impl<M> TypeEntry<M> {
 
     /// This entry as the conversion an adapter built.
     ///
-    /// The two types differ only in `subs`, which an entry keys and a
-    /// conversion spells. An emitter reading a compiled fragment gets a
-    /// [`ConverterImpl`](crate::ConverterImpl), so a helper it shares with a
-    /// caller that still holds a table entry speaks that type, and the entry
-    /// converts.
+    /// The two types carry the same six fields — an entry is what the resolver
+    /// stored, a conversion is what the adapter handed it. An emitter reading a
+    /// compiled fragment gets a [`ConverterImpl`](crate::ConverterImpl), so a
+    /// helper it shares with a caller that still holds a table entry speaks
+    /// that type, and the entry converts.
     pub fn as_converter(&self) -> crate::ConverterImpl<M>
     where
         M: Clone,
@@ -100,7 +100,7 @@ impl<M> TypeEntry<M> {
             pre_stages: self.pre_stages.clone(),
             niches: self.niches.clone(),
             metadata: self.metadata.clone(),
-            subs: Vec::new(),
+            subs: self.subs.clone(),
         }
     }
 

--- a/prebindgen-registry/src/registry/cell.rs
+++ b/prebindgen-registry/src/registry/cell.rs
@@ -83,6 +83,27 @@ impl<M> TypeEntry<M> {
         }
     }
 
+    /// This entry as the conversion an adapter built.
+    ///
+    /// The two types differ only in `subs`, which an entry keys and a
+    /// conversion spells. An emitter reading a compiled fragment gets a
+    /// [`ConverterImpl`](crate::ConverterImpl), so a helper it shares with a
+    /// caller that still holds a table entry speaks that type, and the entry
+    /// converts.
+    pub fn as_converter(&self) -> crate::ConverterImpl<M>
+    where
+        M: Clone,
+    {
+        crate::ConverterImpl {
+            destination: self.destination.clone(),
+            function: self.function.clone(),
+            pre_stages: self.pre_stages.clone(),
+            niches: self.niches.clone(),
+            metadata: self.metadata.clone(),
+            subs: Vec::new(),
+        }
+    }
+
     /// Identifier of the wire-facing converter function.
     pub fn converter_ident(&self) -> &syn::Ident {
         &self.function.sig.ident


### PR DESCRIPTION
Stage 1b of #472. Peer of [#474](https://github.com/milyin/prebindgen/pull/474), which did the same for `prebindgen-c`.

## What moves

`prebindgen-jni` asked the converter table — the registry's index of one
resolved conversion per crossing — what a type crosses as, at **65** sites. A
table entry carries one `destination`, the single wire type that conversion
produces, so it can answer only while a crossing occupies one wire value.

**57 of the 65** now read `Declarations::compiled`, the fragments this binding
built, through `Declarations::{in_frag, out_frag}`.

The other 8 are free functions with no `Declarations` in scope. Four are the
`Option<_>` conversion builders in `emit/convert.rs`, which have nine test
callers that construct none; the rest are in `sum_out.rs`, `delivery.rs` and
`fn_plan.rs`. They go with the table in stage 2 rather than growing a parameter
here.

## Why this is not the same change as #474

`prebindgen-c` splits into two phases: it compiles, then its per-item emitters
run and read what compilation produced. `prebindgen-jni` does not split. Its
emitters **are** its conversion builders — `struct_input_body`,
`callback_input`, `struct_plan`, `iface`, `render`, `delivery` are all called
from inside `convert_with` — so they ask while the store is still filling.

That is fine, and for the reason the table worked: a conversion for one type is
built out of the conversions for its inners, and the resolver compiles the
inners first. A fragment is there exactly when a table entry would have been. So
`Declarations::compiled` is an `Rc<RefCell<…>>`, read during compilation rather
than after it.

The trap is in the driver. Handing the compiler the store with `mem::take` and
putting the result back afterwards leaves the store **empty for the duration of
every call**, which is precisely when the adapter reads it. `Compiled` is a map
of `Rc`s, so the driver clones it instead — 46 of the 264 tests turn on this
alone.

## The one crossing the compiler never sees

`JniGen::compile_crossing` answers a callback with `dispatch_fn_input` rather
than through a row, so no row builds a callback crossing and nothing would file
a fragment for it. That is pre-existing and already noted in the driver.

`Compiled::record` is the escape hatch: the driver files the conversion it built
by hand as that crossing's fragment, so every emitter keeps **one** lookup
rather than a fall-back for the one crossing kind the compiler skips.
`JFrag::by_hand` supplies the `Yield` no row was there to derive — owned and
self-sufficient, which a callback delivered as a JVM object is, and which
nothing reads because nothing composes a callback as an inner. Both go with the
derived callback row.

## Registry support

`ConverterImpl` gains the four reads `TypeEntry` already offered
(`converter_ident`, `wire_type`, `input_stage_order`, `output_stage_order`). The
two types carry the same six fields — an entry is what the resolver stored, a
conversion is what the adapter handed it — so every read an emitter makes works
on either.

`TypeEntry::as_converter` bridges the compile-time callers that still hold an
entry. Both it and those reads go with the table in stage 2.

Fourteen parameters became dead and are removed, including one `carry_layers`
argument clippy flagged as used only in its own recursion.

## Checks

- `cargo test --all` — green (264 in `prebindgen-jni`)
- clippy and rustfmt on 1.85.0 and stable — clean
- `cargo doc` with `-D warnings` — clean
- `examples/regen-check.sh` — **byte-identical**
- `examples/smoke-asan.sh` — clean

