### PR TITLE
Take both adapters off the converter table

### DIFF
--- a/prebindgen-c/src/emit.rs
+++ b/prebindgen-c/src/emit.rs
@@ -493,8 +493,7 @@ impl CbindgenBuilder {
         // the `ReturnType::Default` arm this used to write.
 
         let has_fallible_input = f.params.iter().any(|p| {
-            registry
-                .input_entry(&p.ty)
+            self.in_frag(&p.ty)
                 .map(|e| returns_result(&e.function.sig.output))
                 .unwrap_or(false)
         });
@@ -508,7 +507,7 @@ impl CbindgenBuilder {
             None => (&f.ret, None),
         };
         let err_ty: Option<syn::Type> = err_reading.map(|t| spelled(t, emit));
-        let has_fallible_output = Self::output_is_fallible(value_ty, registry);
+        let has_fallible_output = self.output_is_fallible(value_ty);
 
         // Error wiring: the error type must be declared via `.error()`.
         let err_bits = err_ty.as_ref().map(|err_ty| {
@@ -716,14 +715,14 @@ impl CbindgenBuilder {
         // own; decomposing it anyway would describe a different ABI from the one
         // the converter table hands out, and the two must agree (#428 review).
         // The base case below already does this for a type with no shape arm.
-        if !r_has_own_wire(ty, registry) {
+        if !self.has_own_wire(ty) {
             // `Vec<T>` → `T_wire* + size_t`. The element must lower to a single C
             // value (one converter); a composite element is unsupported.
             // `TypeKind::Vec` and not `sequence_elem`: that reading peels the
             // erased wrappers first, so a `Cow<'_, [u8]>` would answer here and
             // take the `Vec` lowering instead of its own arm below.
             if let TypeKind::Vec(elem) = ty.kind() {
-                let entry = registry.output_entry(elem).unwrap_or_else(|| {
+                let entry = self.out_frag(elem).unwrap_or_else(|| {
                     panic!(
                         "Cbindgen: `Vec` element `{}` has no output converter",
                         elem.key()
@@ -767,7 +766,7 @@ impl CbindgenBuilder {
             // lowering, so the wrapper returned nothing and called the marker with
             // an argument it does not take (#413).
             if let Some(elem) = r_cow_slice_elem(ty).or_else(|| r_scalar_slice_elem(ty)) {
-                let entry = registry.output_entry(elem).unwrap_or_else(|| {
+                let entry = self.out_frag(elem).unwrap_or_else(|| {
                     panic!(
                         "Cbindgen: `Cow` slice element `{}` has no output converter",
                         elem.key()
@@ -813,7 +812,7 @@ impl CbindgenBuilder {
         // Base value: one wire component from its rank-0/1 converter. Custom
         // conversions may declare scalar niches; otherwise a pointer wire
         // (String, opaque handle, `&'static`) carries a free NULL niche.
-        let entry = registry.output_entry(ty).unwrap_or_else(|| {
+        let entry = self.out_frag(ty).unwrap_or_else(|| {
             panic!(
                 "Cbindgen::on_function: type `{}` has no output converter",
                 ty.key()
@@ -848,9 +847,9 @@ impl CbindgenBuilder {
         // The peer of `lower_shape`'s guard: a node with a wire of its own is
         // encoded by its own converter, whatever its shape. The two walk the
         // same value and must stop at the same places (#428 review).
-        if !r_has_own_wire(ty, registry) {
+        if !self.has_own_wire(ty) {
             if let TypeKind::Vec(elem) = ty.kind() {
-                let entry = registry.output_entry(elem).expect("Vec element converter");
+                let entry = self.out_frag(elem).expect("Vec element converter");
                 let elem_conv = entry.function.sig.ident.clone();
                 let elem_map = map_arg(&elem_conv, entry.function.sig.unsafety.is_some());
                 let elem_wire = entry.destination.clone();
@@ -878,9 +877,7 @@ impl CbindgenBuilder {
                 }
             }
             if let Some(elem) = r_cow_slice_elem(ty).or_else(|| r_scalar_slice_elem(ty)) {
-                let entry = registry
-                    .output_entry(elem)
-                    .expect("slice element converter");
+                let entry = self.out_frag(elem).expect("slice element converter");
                 let elem_conv = entry.function.sig.ident.clone();
                 let elem_map = map_arg(&elem_conv, entry.function.sig.unsafety.is_some());
                 let elem_wire = entry.destination.clone();
@@ -935,7 +932,7 @@ impl CbindgenBuilder {
             }
         }
         // Base value: run its output converter into the single target.
-        let entry = registry.output_entry(ty).expect("base value converter");
+        let entry = self.out_frag(ty).expect("base value converter");
         let conv = entry.function.sig.ident.clone();
         let t0 = &targets[0];
         if returns_result(&entry.function.sig.output) {
@@ -946,7 +943,7 @@ impl CbindgenBuilder {
         }
     }
 
-    fn output_is_fallible(ty: &TypeRef, registry: &impl Conversions<()>) -> bool {
+    fn output_is_fallible(&self, ty: &TypeRef) -> bool {
         // The third walk over the same value, and it stops where the other two
         // do: a node with a wire of its own is encoded by its own converter, so
         // whether the encode can fail is THAT converter's answer. Peeling past
@@ -954,7 +951,7 @@ impl CbindgenBuilder {
         // binding needs `.panic()`, so the two disagreeing is a wrapper that
         // aborts where nothing opted in, or an opt-in demanded for a conversion
         // that cannot fail (#428 review).
-        if !r_has_own_wire(ty, registry) {
+        if !self.has_own_wire(ty) {
             let vec_elem = match ty.kind() {
                 TypeKind::Vec(e) => Some(&**e),
                 _ => None,
@@ -965,11 +962,10 @@ impl CbindgenBuilder {
                 .or_else(|| r_cow_slice_elem(ty))
                 .or_else(|| r_scalar_slice_elem(ty))
             {
-                return Self::output_is_fallible(inner, registry);
+                return self.output_is_fallible(inner);
             }
         }
-        registry
-            .output_entry(ty)
+        self.out_frag(ty)
             .is_some_and(|entry| returns_result(&entry.function.sig.output))
     }
 

--- a/prebindgen-c/src/lib.rs
+++ b/prebindgen-c/src/lib.rs
@@ -450,7 +450,16 @@ pub struct CbindgenBuilder {
     /// name **one** wire type per crossing, so it stops being able to answer as
     /// soon as a crossing occupies several — and the answer an emitter wants
     /// was always the adapter's own.
-    pub(crate) compiled: Option<prebindgen_registry::recipe::Compiled<crate::compile::CFrag>>,
+    ///
+    /// Shared and interior-mutable because the emitters that run *during*
+    /// compilation read it too: `dispatch_fn_input` builds a callback's closure
+    /// struct out of `lower_shape` and `encode_value`, and those ask what a
+    /// type crosses as. A conversion for one type is built out of the
+    /// conversions for its inners, which the resolver compiles first, so a
+    /// fragment is there exactly when a table entry would have been.
+    pub(crate) compiled: std::rc::Rc<
+        std::cell::RefCell<prebindgen_registry::recipe::Compiled<crate::compile::CFrag>>,
+    >,
     /// Every conversion this binding compiled.
     ///
     /// Filled once by [`Self::build_with`] and handed to `write_rust` as
@@ -639,9 +648,12 @@ fn marker_destination(ty: &syn::Type) -> bool {
 /// `out_wrappers` gives that destination to a `Result` too, and no arm lowers
 /// one — so a destination test answers `yes` for a shape nothing can emit, and
 /// the caller ends up calling the marker it was trying to avoid (#428 review).
-fn r_is_lowered_composite(t: &TypeRef, registry: &impl Conversions<()>) -> bool {
-    let composite = t.optional_inner().is_some() || r_is_vec(t) || r_cow_slice_elem(t).is_some();
-    composite && r_shape_is_lowerable(t, registry)
+impl CbindgenBuilder {
+    fn is_lowered_composite(&self, t: &TypeRef) -> bool {
+        let composite =
+            t.optional_inner().is_some() || r_is_vec(t) || r_cow_slice_elem(t).is_some();
+        composite && self.shape_is_lowerable(t)
+    }
 }
 
 /// Whether this node already has a wire of its own: a real converter rather
@@ -651,10 +663,11 @@ fn r_is_lowered_composite(t: &TypeRef, registry: &impl Conversions<()>) -> bool 
 /// conversion answers here — and the shape lowering has to agree with the
 /// converter table at **every** level, not only the outermost, or the two
 /// describe different ABIs for the same argument (#428 review).
-fn r_has_own_wire(t: &TypeRef, registry: &impl Conversions<()>) -> bool {
-    registry
-        .output_entry(t)
-        .is_some_and(|e| !marker_destination(&e.destination))
+impl CbindgenBuilder {
+    fn has_own_wire(&self, t: &TypeRef) -> bool {
+        self.out_frag(t)
+            .is_some_and(|e| !marker_destination(&e.destination))
+    }
 }
 
 /// Whether [`Cbindgen::lower_shape`] decomposes `t` **all the way down**.
@@ -670,20 +683,22 @@ fn r_has_own_wire(t: &TypeRef, registry: &impl Conversions<()>) -> bool {
 /// Enumerating the wrapper kinds instead missed `Vec<&'static [u8]>`, whose
 /// element is a plain borrow by every shape test and a shared-slice marker in
 /// the table (#428 review).
-fn r_shape_is_lowerable(t: &TypeRef, registry: &impl Conversions<()>) -> bool {
-    // A node with a wire of its own IS the bottom: `lower_shape` stops there
-    // too, so the recursion must not walk past it into a shape that node no
-    // longer describes.
-    if r_has_own_wire(t, registry) {
-        return true;
+impl CbindgenBuilder {
+    fn shape_is_lowerable(&self, t: &TypeRef) -> bool {
+        // A node with a wire of its own IS the bottom: `lower_shape` stops
+        // there too, so the recursion must not walk past it into a shape that
+        // node no longer describes.
+        if self.has_own_wire(t) {
+            return true;
+        }
+        if let Some(inner) = t.optional_inner() {
+            return self.shape_is_lowerable(inner);
+        }
+        // A run's element must lower to one wire of its own — the same rule
+        // `lower_shape` asserts when it builds the `(ptr, len)` pair.
+        let leaf = r_vec_elem(t).or_else(|| r_cow_slice_elem(t)).unwrap_or(t);
+        self.has_own_wire(leaf)
     }
-    if let Some(inner) = t.optional_inner() {
-        return r_shape_is_lowerable(inner, registry);
-    }
-    // A run's element must lower to one wire of its own — the same rule
-    // `lower_shape` asserts when it builds the `(ptr, len)` pair.
-    let leaf = r_vec_elem(t).or_else(|| r_cow_slice_elem(t)).unwrap_or(t);
-    r_has_own_wire(leaf, registry)
 }
 
 /// The element of a `Vec<E>`.

--- a/prebindgen-c/src/trait_impl.rs
+++ b/prebindgen-c/src/trait_impl.rs
@@ -9,17 +9,20 @@ use super::{builder::callback_fn_type, *};
 /// wire values; the converter table's single `destination` cannot.
 impl CbindgenBuilder {
     /// The fragment for `ty` crossing in the given direction, if one compiled.
-    pub(crate) fn frag(&self, ty: &TypeRef, assembly: Assembly) -> Option<&crate::compile::CFrag> {
-        self.compiled.as_ref()?.fragment(&ty.key(), assembly)
+    pub(crate) fn frag(&self, ty: &TypeRef, assembly: Assembly) -> Option<crate::compile::CFrag> {
+        self.compiled
+            .borrow()
+            .fragment(&ty.key(), assembly)
+            .cloned()
     }
 
     /// The fragment that builds a Rust `ty` out of C parts.
-    pub(crate) fn in_frag(&self, ty: &TypeRef) -> Option<&crate::compile::CFrag> {
+    pub(crate) fn in_frag(&self, ty: &TypeRef) -> Option<crate::compile::CFrag> {
         self.frag(ty, Assembly::Construct)
     }
 
     /// The fragment that takes a Rust `ty` apart into C parts.
-    pub(crate) fn out_frag(&self, ty: &TypeRef) -> Option<&crate::compile::CFrag> {
+    pub(crate) fn out_frag(&self, ty: &TypeRef) -> Option<crate::compile::CFrag> {
         self.frag(ty, Assembly::Deconstruct)
     }
 }
@@ -1417,7 +1420,7 @@ impl CbindgenBuilder {
                 // leaves its slot unwritten, and the wrapper must not build a
                 // Rust value to fill it with. `#[repr(transparent)]` keeps both
                 // the C ABI and the header spelling.
-                if marker_destination(&wire) && r_is_lowered_composite(&reading, registry) {
+                if marker_destination(&wire) && self.is_lowered_composite(&reading) {
                     for field in self.lower_shape(&reading, registry).fields {
                         let w = field.wire;
                         arg_wires.push(syn::parse_quote!(::core::mem::MaybeUninit<#w>));
@@ -1516,21 +1519,22 @@ impl CbindgenBuilder {
                     .join("; "),
             }
         })?;
-        // The driver's state, carried between calls. The adapter borrows the
-        // partial registry view, which is lent per call and so is a different
-        // type each time; what it built is not, and outlives every one of them.
-        let mut compiled =
-            prebindgen_registry::recipe::Compiled::<crate::compile::CFrag>::default();
+        // The driver's state lives on `self` rather than here, because the
+        // adapter reads it **while** it compiles: `dispatch_fn_input` builds a
+        // callback's closure struct out of `lower_shape` and `encode_value`,
+        // both of which ask what a type crosses as. Handing the compiler the
+        // store by `mem::take` would empty it for exactly the span of that
+        // call, so it is cloned — a map of `Rc`s.
         let registry = declared
             .convert_with(|crossing, built, _emit| {
                 let mut compiler = prebindgen_registry::recipe::Compiler::resume(
                     &model,
                     &recipes,
                     &bindings,
-                    std::mem::take(&mut compiled),
+                    self.compiled.borrow().clone(),
                 );
                 let conv = self.compile_crossing(&mut compiler, crossing, built);
-                compiled = compiler.finish();
+                *self.compiled.borrow_mut() = compiler.finish();
                 conv
             })?
             .build()?;
@@ -1542,19 +1546,23 @@ impl CbindgenBuilder {
         // borrowed return where the JVM must not.
         {
             let mut compiler = prebindgen_registry::recipe::Compiler::resume(
-                &model, &recipes, &bindings, compiled,
+                &model,
+                &recipes,
+                &bindings,
+                self.compiled.borrow().clone(),
             );
             self.check_sites(&mut compiler, &registry)
                 .map_err(|message| prebindgen_registry::ScanError::AdapterInvariant { message })?;
-            compiled = compiler.finish();
+            *self.compiled.borrow_mut() = compiler.finish();
         }
         // What the compilation produced, kept for emission and for lookup.
-        self.compiled_fns = compiled
+        self.compiled_fns = self
+            .compiled
+            .borrow()
             .fragments()
             .into_iter()
             .map(|f| f.function.clone())
             .collect();
-        self.compiled = Some(compiled);
         self.validate_resolved(&registry)
             .map_err(|message| prebindgen_registry::ScanError::AdapterInvariant { message })?;
         Ok(Cbindgen {
@@ -1649,7 +1657,7 @@ impl CbindgenBuilder {
                 call_args.push(quote!(#ai.len()));
                 continue;
             }
-            let entry = registry.output_entry(arg)?;
+            let entry = self.out_frag(arg)?;
             let conv = entry.function.sig.ident.clone();
             let opaque = entry.destination.clone();
             let fallible = matches!(
@@ -1680,7 +1688,7 @@ impl CbindgenBuilder {
             // converter call can produce.
             if !is_takeable
                 && marker_destination(&entry.destination)
-                && !r_is_lowered_composite(arg, registry)
+                && !self.is_lowered_composite(arg)
             {
                 panic!(
                     "Cbindgen: callback argument `{}` has no C ABI — it resolves to a marker \
@@ -1699,7 +1707,7 @@ impl CbindgenBuilder {
             // (#428 review).
             let composite = !is_takeable
                 && marker_destination(&entry.destination)
-                && r_is_lowered_composite(arg, registry);
+                && self.is_lowered_composite(arg);
             if composite {
                 let shape = self.lower_shape(arg, registry);
                 closure_params.push(quote!(#ai: #src));

--- a/prebindgen-c/src/trait_impl.rs
+++ b/prebindgen-c/src/trait_impl.rs
@@ -9,20 +9,26 @@ use super::{builder::callback_fn_type, *};
 /// wire values; the converter table's single `destination` cannot.
 impl CbindgenBuilder {
     /// The fragment for `ty` crossing in the given direction, if one compiled.
-    pub(crate) fn frag(&self, ty: &TypeRef, assembly: Assembly) -> Option<crate::compile::CFrag> {
-        self.compiled
-            .borrow()
-            .fragment(&ty.key(), assembly)
-            .cloned()
+    ///
+    /// Shares the fragment rather than copying it: the store is read while
+    /// compilation is still writing to it, so a borrow cannot be held across
+    /// the next write, and `shape_is_lowerable` walks a type's layers asking
+    /// this at every one.
+    pub(crate) fn frag(
+        &self,
+        ty: &TypeRef,
+        assembly: Assembly,
+    ) -> Option<std::rc::Rc<crate::compile::CFrag>> {
+        self.compiled.borrow().fragment(&ty.key(), assembly)
     }
 
     /// The fragment that builds a Rust `ty` out of C parts.
-    pub(crate) fn in_frag(&self, ty: &TypeRef) -> Option<crate::compile::CFrag> {
+    pub(crate) fn in_frag(&self, ty: &TypeRef) -> Option<std::rc::Rc<crate::compile::CFrag>> {
         self.frag(ty, Assembly::Construct)
     }
 
     /// The fragment that takes a Rust `ty` apart into C parts.
-    pub(crate) fn out_frag(&self, ty: &TypeRef) -> Option<crate::compile::CFrag> {
+    pub(crate) fn out_frag(&self, ty: &TypeRef) -> Option<std::rc::Rc<crate::compile::CFrag>> {
         self.frag(ty, Assembly::Deconstruct)
     }
 }

--- a/prebindgen-jni/src/jni/compile.rs
+++ b/prebindgen-jni/src/jni/compile.rs
@@ -153,7 +153,6 @@ impl<R: Conversions<KotlinMeta>> JCompile<'_, R> {
                 WrapperShape::Borrow { mutable },
                 &produced,
                 inner,
-                self.registry,
                 emit,
             )?;
             c.subs = vec![inner.key()];
@@ -164,7 +163,6 @@ impl<R: Conversions<KotlinMeta>> JCompile<'_, R> {
                 WrapperShape::Borrow { mutable },
                 &produced,
                 inner,
-                self.registry,
                 emit,
             )?;
             c.subs = vec![inner.key()];
@@ -221,11 +219,11 @@ impl<R: Conversions<KotlinMeta>> Compile for JCompile<'_, R> {
             Assembly::Construct => self
                 .decls
                 .input_terminal(ty, self.registry, emit)
-                .or_else(|| self.decls.input_optional(ty, self.registry, emit)),
+                .or_else(|| self.decls.input_optional(ty, emit)),
             Assembly::Deconstruct => self
                 .decls
                 .output_terminal(ty, self.registry, emit)
-                .or_else(|| self.decls.output_optional(ty, self.registry, emit)),
+                .or_else(|| self.decls.output_optional(ty, emit)),
         };
         self.wrap(at, "no JNI representation for this optional", conv)
     }
@@ -243,13 +241,13 @@ impl<R: Conversions<KotlinMeta>> Compile for JCompile<'_, R> {
             Assembly::Construct => self
                 .decls
                 .input_terminal(ty, self.registry, emit)
-                .or_else(|| self.decls.input_run(ty, self.registry, emit))
+                .or_else(|| self.decls.input_run(ty, emit))
                 .or_else(|| self.borrow(ty, emit, true))
                 .or_else(|| self.decls.input_transparent_bridge(ty, self.registry, emit)),
             Assembly::Deconstruct => self
                 .decls
                 .output_terminal(ty, self.registry, emit)
-                .or_else(|| self.decls.output_run(ty, self.registry, emit))
+                .or_else(|| self.decls.output_run(ty, emit))
                 .or_else(|| self.borrow(ty, emit, false))
                 .or_else(|| {
                     self.decls

--- a/prebindgen-jni/src/jni/compile.rs
+++ b/prebindgen-jni/src/jni/compile.rs
@@ -330,25 +330,31 @@ impl<R: Conversions<KotlinMeta>> Compile for JCompile<'_, R> {
 impl crate::jni::Declarations {
     /// The conversion for `ty` in the given direction, from the fragments
     /// compiled so far.
-    pub(crate) fn frag(
-        &self,
-        ty: &TypeRef,
-        assembly: Assembly,
-    ) -> Option<ConverterImpl<KotlinMeta>> {
-        Some(
-            self.compiled
-                .borrow()
-                .fragment(&ty.key(), assembly)?
-                .conv
-                .clone(),
-        )
+    pub(crate) fn frag(&self, ty: &TypeRef, assembly: Assembly) -> Option<Conv> {
+        Some(Conv(self.compiled.borrow().fragment(&ty.key(), assembly)?))
     }
 
-    pub(crate) fn in_frag(&self, ty: &TypeRef) -> Option<ConverterImpl<KotlinMeta>> {
+    pub(crate) fn in_frag(&self, ty: &TypeRef) -> Option<Conv> {
         self.frag(ty, Assembly::Construct)
     }
 
-    pub(crate) fn out_frag(&self, ty: &TypeRef) -> Option<ConverterImpl<KotlinMeta>> {
+    pub(crate) fn out_frag(&self, ty: &TypeRef) -> Option<Conv> {
         self.frag(ty, Assembly::Deconstruct)
+    }
+}
+
+/// A fragment's conversion, read without copying it.
+///
+/// The store is read while compilation is still writing to it, so a caller
+/// cannot hold a borrow into it; sharing the fragment's `Rc` and reaching the
+/// conversion through it costs a refcount instead of a whole `syn::ItemFn` per
+/// lookup.
+pub(crate) struct Conv(std::rc::Rc<JFrag>);
+
+impl std::ops::Deref for Conv {
+    type Target = ConverterImpl<KotlinMeta>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0.conv
     }
 }

--- a/prebindgen-jni/src/jni/emit/convert.rs
+++ b/prebindgen-jni/src/jni/emit/convert.rs
@@ -247,13 +247,13 @@ pub(crate) fn composed_inner_output(
 /// fails and the resolver falls through to other rank-1 attempts.
 pub(crate) fn option_input(
     t1: &prebindgen_registry::flat::TypeRef,
-    registry: &impl Conversions<KotlinMeta>,
+    ext: &Declarations,
     emit: &prebindgen_registry::Emit,
 ) -> Option<(syn::Type, syn::Expr, Niches)> {
-    let inner_entry = registry.input_entry(t1)?;
+    let inner_entry = ext.in_frag(t1)?;
     let t1_spelled = emit.spell(t1);
     let inner_wire = inner_entry.destination.clone();
-    let inner_decode = composed_inner_input(&inner_entry.as_converter(), quote!(v));
+    let inner_decode = composed_inner_input(&inner_entry, quote!(v));
 
     // 1. Niche path.
     if let Some((slot, rest)) = inner_entry.niches.clone().carve() {
@@ -288,7 +288,7 @@ pub(crate) fn option_input(
         let unbox_sig = jni_unbox_sig(&inner_wire);
         let getter = jni_unbox_getter(&inner_wire);
         let getter_id = format_ident!("{}", getter);
-        let inner_decode = composed_inner_input(&inner_entry.as_converter(), quote!(&__unboxed));
+        let inner_decode = composed_inner_input(&inner_entry, quote!(&__unboxed));
         let body: syn::Expr = syn::parse_quote!({
             if !v.is_null() {
                 let __unboxed: #inner_wire = env
@@ -315,11 +315,11 @@ pub(crate) fn option_input(
 /// Build `Option<T>`'s output converter — symmetric to [`option_input`].
 pub(crate) fn option_output(
     t1: &prebindgen_registry::flat::TypeRef,
-    registry: &impl Conversions<KotlinMeta>,
+    ext: &Declarations,
 ) -> Option<(syn::Type, syn::Expr, Niches)> {
-    let inner_entry = registry.output_entry(t1)?;
+    let inner_entry = ext.out_frag(t1)?;
     let inner_wire = inner_entry.destination.clone();
-    let inner_encode = composed_inner_output(&inner_entry.as_converter(), quote!(value));
+    let inner_encode = composed_inner_output(&inner_entry, quote!(value));
 
     // 1. Niche path.
     if let Some((slot, rest)) = inner_entry.niches.clone().carve() {
@@ -335,7 +335,7 @@ pub(crate) fn option_output(
 
     // 2. Boxed-primitive fallback (cached box class + `valueOf` method ID).
     if let Some(helper) = box_helper_for_wire(&inner_wire) {
-        let inner_encode = composed_inner_output(&inner_entry.as_converter(), quote!(value));
+        let inner_encode = composed_inner_output(&inner_entry, quote!(value));
         let body: syn::Expr = syn::parse_quote!({
             match v {
                 Some(value) => {
@@ -479,15 +479,12 @@ pub(crate) fn enum_output_body(
 pub(crate) fn nullable_kind_for(
     outer_wire: &syn::Type,
     inner_ty: &prebindgen_registry::flat::TypeRef,
-    registry: &impl Conversions<KotlinMeta>,
+    ext: &Declarations,
 ) -> NullableKind {
-    let inner_dest = registry
-        .input_entry(inner_ty)
-        .map(|e| e.destination.clone())
-        .expect(
-            "nullable_kind_for: Option<_> input handler reached here only after option_input \
+    let inner_dest = ext.in_frag(inner_ty).map(|e| e.destination.clone()).expect(
+        "nullable_kind_for: Option<_> input handler reached here only after option_input \
              returned Some, so the inner's input entry must exist",
-        );
+    );
     if outer_wire == &inner_dest {
         NullableKind::Niche
     } else {
@@ -498,10 +495,10 @@ pub(crate) fn nullable_kind_for(
 pub(crate) fn nullable_kind_for_output(
     outer_wire: &syn::Type,
     inner_ty: &prebindgen_registry::flat::TypeRef,
-    registry: &impl Conversions<KotlinMeta>,
+    ext: &Declarations,
 ) -> NullableKind {
-    let inner_dest = registry
-        .output_entry(inner_ty)
+    let inner_dest = ext
+        .out_frag(inner_ty)
         .map(|e| e.destination.clone())
         .expect(
             "nullable_kind_for_output: Option<_> output handler reached here only after \

--- a/prebindgen-jni/src/jni/emit/delivery.rs
+++ b/prebindgen-jni/src/jni/emit/delivery.rs
@@ -880,7 +880,7 @@ pub(crate) fn encode_plan_leaves(
     let mut arg_exprs: Vec<TokenStream> = Vec::with_capacity(n);
     for (idx, leaf) in plan.leaves.iter().enumerate() {
         let obj_ident = &obj_idents[idx];
-        if leaf_is_prim(registry, leaf) {
+        if leaf_is_prim(ext, leaf) {
             arg_exprs.push(quote!(#obj_ident));
         } else {
             arg_exprs.push(quote!(jni::sys::jvalue { l: #obj_ident.as_raw() }));
@@ -1031,7 +1031,7 @@ pub(crate) fn encode_plan_leaves(
                 let ids: Vec<&syn::Ident> = obj_idents[seg.clone()].iter().collect();
                 let slots: Vec<Slot> = plan.leaves[seg.clone()]
                     .iter()
-                    .map(|l| leaf_slot(registry, l))
+                    .map(|l| leaf_slot(ext, l))
                     .collect();
                 let tys = slots.iter().map(|s| &s.ty);
                 let defaults = slots.iter().map(|s| &s.default);
@@ -1404,7 +1404,7 @@ pub(crate) fn encode_plan_leaves(
         // value with the leaf's output converter and casts to JObject.
         let wire = out_entry.destination.clone();
         let enc_ident = format_ident!("__enc{}", idx);
-        if leaf_is_prim(registry, leaf) {
+        if leaf_is_prim(ext, leaf) {
             let letter = jni_field_access(&wire)
                 .expect("leaf_is_prim guarantees a primitive wire")
                 .1;
@@ -1447,12 +1447,10 @@ pub(crate) fn encode_plan_leaves(
             })
             .collect();
         let ids: Vec<&syn::Ident> = idxs.iter().map(|&k| &obj_idents[k]).collect();
-        let tys = idxs
-            .iter()
-            .map(|&k| leaf_slot(registry, &plan.leaves[k]).ty);
+        let tys = idxs.iter().map(|&k| leaf_slot(ext, &plan.leaves[k]).ty);
         let defaults = idxs
             .iter()
-            .map(|&k| leaf_slot(registry, &plan.leaves[k]).default);
+            .map(|&k| leaf_slot(ext, &plan.leaves[k]).default);
         // Matched BY VALUE: the local is this arm's alone (every leaf under the
         // hoist is in it), so a consuming value form's fields move out here
         // exactly as they do at an unconditional one.
@@ -1472,7 +1470,7 @@ pub(crate) fn encode_plan_leaves(
 /// [`crate::jni::iface`] derives for the same leaf — a
 /// nullable primitive boxes (object chunk), object wires pass as objects.
 pub(crate) fn leaf_is_prim(
-    registry: &impl Conversions<KotlinMeta>,
+    ext: &Declarations,
     leaf: &prebindgen_registry::unfold::UnfoldLeaf,
 ) -> bool {
     // The synthesized sum selector is a `jint` by definition — it is assigned,
@@ -1489,7 +1487,7 @@ pub(crate) fn leaf_is_prim(
     if leaf.nullable {
         return false;
     }
-    leaf_ty_is_prim(registry, &leaf.out_ty)
+    leaf_ty_is_prim(ext, &leaf.out_ty)
 }
 
 /// The wire half of [`leaf_is_prim`]: does a leaf of this type occupy a **raw
@@ -1497,10 +1495,10 @@ pub(crate) fn leaf_is_prim(
 /// about a leaf whose own `nullable` flag it is in the middle of computing (an
 /// inert sum group slot).
 pub(crate) fn leaf_ty_is_prim(
-    registry: &impl Conversions<KotlinMeta>,
+    ext: &Declarations,
     out_ty: &prebindgen_registry::flat::TypeRef,
 ) -> bool {
-    let Some(entry) = registry.output_entry(out_ty) else {
+    let Some(entry) = ext.out_frag(out_ty) else {
         return false;
     };
     // No projection (plain primitive/enum wire) — or an opaque HANDLE, whose

--- a/prebindgen-jni/src/jni/emit/flat_input.rs
+++ b/prebindgen-jni/src/jni/emit/flat_input.rs
@@ -116,7 +116,7 @@ pub(crate) fn struct_input_body(
                             FoldStrategy::Optional(NullableKind::Niche, _)
                         );
                         let inner_conv =
-                            composed_entry_decode(&ext.in_frag(inner)?, &raw_ident, &fname_ident);
+                            composed_entry_decode(&*ext.in_frag(inner)?, &raw_ident, &fname_ident);
                         let tmp_ident = format_ident!("__{}_jobj", fname_ident);
                         let decode = if niche {
                             // The Kotlin data-class property is still `ULong?`
@@ -179,7 +179,7 @@ pub(crate) fn struct_input_body(
             {
                 let sig = format!("L{};", fqn.replace('.', "/"));
                 let inner_conv =
-                    composed_entry_decode(&ext.in_frag(inner)?, &raw_ident, &fname_ident);
+                    composed_entry_decode(&*ext.in_frag(inner)?, &raw_ident, &fname_ident);
                 let tmp_ident = format_ident!("__{}_jobj", fname_ident);
                 let decode = if field_optional {
                     quote! {
@@ -504,7 +504,7 @@ fn read_kotlin_property(
         // Under `Option`, JVM null is `None` and the INNER converter decodes
         // the discriminant; the outer converter would expect a boxed Integer.
         let decode = if optional {
-            let inner_conv = composed_entry_decode(&ext.in_frag(inner)?, &raw, bind);
+            let inner_conv = composed_entry_decode(&*ext.in_frag(inner)?, &raw, bind);
             quote! {
                 let #bind = if #obj.is_null() {
                     ::core::option::Option::None

--- a/prebindgen-jni/src/jni/emit/sum_out.rs
+++ b/prebindgen-jni/src/jni/emit/sum_out.rs
@@ -106,11 +106,11 @@ pub(crate) struct Slot {
 }
 
 pub(crate) fn leaf_slot(
-    registry: &impl Conversions<KotlinMeta>,
+    ext: &Declarations,
     leaf: &prebindgen_registry::unfold::UnfoldLeaf,
 ) -> Slot {
     use prebindgen_registry::unfold::LeafSource;
-    if !leaf_is_prim(registry, leaf) {
+    if !leaf_is_prim(ext, leaf) {
         return Slot {
             prim: false,
             ty: quote!(jni::objects::JObject),
@@ -122,8 +122,8 @@ pub(crate) fn leaf_slot(
     let (sig, letter) = if leaf.source == LeafSource::SumTag {
         ("I", format_ident!("i"))
     } else {
-        let wire = registry
-            .output_entry(&leaf.out_ty)
+        let wire = ext
+            .out_frag(&leaf.out_ty)
             .expect("leaf_is_prim implies a resolved output entry")
             .destination
             .clone();
@@ -200,7 +200,7 @@ pub(crate) fn encode_sum_group(
     let module = ext.fn_module(registry, &ident);
     let source: syn::Path = syn::parse_quote!(#module::#ident);
 
-    let slots: Vec<Slot> = leaves.iter().map(|l| leaf_slot(registry, l)).collect();
+    let slots: Vec<Slot> = leaves.iter().map(|l| leaf_slot(ext, l)).collect();
 
     let arg_exprs: Vec<TokenStream> = leaves
         .iter()
@@ -281,7 +281,7 @@ pub(crate) fn encode_sum_group(
                 .zip(&binds)
                 .map(|(&idx, bind)| {
                     encode_group_leaf(
-                        registry,
+                        ext,
                         &leaves[idx],
                         &obj_idents[idx],
                         slots[idx].prim,
@@ -338,14 +338,14 @@ pub(crate) fn encode_sum_group(
 /// payload and a struct field of the same type reach their converter the same
 /// way.
 fn encode_group_leaf(
-    registry: &impl Conversions<KotlinMeta>,
+    ext: &Declarations,
     leaf: &prebindgen_registry::unfold::UnfoldLeaf,
     obj_ident: &syn::Ident,
     prim: bool,
     bind: &syn::Ident,
     fail: &dyn Fn(TokenStream) -> TokenStream,
 ) -> TokenStream {
-    let out_entry = registry.output_entry(&leaf.out_ty).unwrap_or_else(|| {
+    let out_entry = ext.out_frag(&leaf.out_ty).unwrap_or_else(|| {
         panic!(
             "jnigen sum unfold: payload leaf `{}` (`{}`) has no registered output converter",
             leaf.name,

--- a/prebindgen-jni/src/jni/fn_plan.rs
+++ b/prebindgen-jni/src/jni/fn_plan.rs
@@ -537,7 +537,7 @@ impl JniFunctionPlan {
             params,
             output,
         };
-        let slots = result.jvm_parameter_slots(registry, f);
+        let slots = result.jvm_parameter_slots(ext, registry, f);
         if slots > 255 {
             return Err(PlanError::JvmParameterLimit { slots });
         }
@@ -555,6 +555,7 @@ impl JniFunctionPlan {
 
     fn jvm_parameter_slots(
         &self,
+        ext: &Declarations,
         registry: &Registry<KotlinMeta>,
         f: &prebindgen_registry::flat::Function,
     ) -> usize {
@@ -571,8 +572,8 @@ impl JniFunctionPlan {
                 InputKind::OptionScalar(plan) => 1 + kotlin_jvm_slots(&plan.value_kt_type),
                 InputKind::Handle { .. } | InputKind::VecBuild { .. } => 2,
                 InputKind::Callback { .. } => 1,
-                InputKind::Unsigned64 { .. } | InputKind::Plain => registry
-                    .input_entry(&leaf.reading)
+                InputKind::Unsigned64 { .. } | InputKind::Plain => ext
+                    .in_frag(&leaf.reading)
                     .and_then(|entry| JniPrim::from_wire(&entry.destination))
                     .map_or(1, |prim| match prim {
                         JniPrim::Long | JniPrim::Double => 2,

--- a/prebindgen-jni/src/jni/iface.rs
+++ b/prebindgen-jni/src/jni/iface.rs
@@ -890,7 +890,6 @@ fn subject_package(ext: &Declarations, subject: &prebindgen_registry::flat::Type
 /// [`plan_leaf_names`], typed + raw views per leaf.
 fn plan_leaf_params(
     ext: &Declarations,
-    registry: &impl Conversions<KotlinMeta>,
     leaves: &[prebindgen_registry::unfold::UnfoldLeaf],
 ) -> Option<Vec<IfaceParam>> {
     // Decomposition leaf names are author-supplied, literal, and unique by
@@ -898,7 +897,7 @@ fn plan_leaf_params(
     let names = plan_leaf_names(leaves);
     let mut out = Vec::with_capacity(leaves.len());
     for (name, leaf) in names.into_iter().zip(leaves.iter()) {
-        out.push(plan_leaf_param(ext, registry, name, leaf)?);
+        out.push(plan_leaf_param(ext, name, leaf)?);
     }
     Some(out)
 }
@@ -910,7 +909,6 @@ fn plan_leaf_params(
 /// not just where the plan happens to be walked as a whole.
 fn plan_leaf_param(
     ext: &Declarations,
-    registry: &impl Conversions<KotlinMeta>,
     name: String,
     leaf: &prebindgen_registry::unfold::UnfoldLeaf,
 ) -> Option<IfaceParam> {
@@ -931,7 +929,7 @@ fn plan_leaf_param(
     // here and re-asserted (`!!`) inside its own live arm — the same rule
     // `nullable_group_part` applies to the parent-inlined `fromParts`. Primitive
     // slots take their `0`/`false` default and stay unboxed.
-    let inert_nullable = leaf.group.is_some() && !leaf_ty_is_prim(registry, &leaf.out_ty);
+    let inert_nullable = leaf.group.is_some() && !leaf_ty_is_prim(ext, &leaf.out_ty);
     leaf_iface_param(
         ext,
         name,
@@ -1331,7 +1329,7 @@ fn fixed_reassembly(
             Vec::new(),
         );
     }
-    let params = plan_leaf_params(ext, registry, leaves).unwrap_or_default();
+    let params = plan_leaf_params(ext, leaves).unwrap_or_default();
     let mut imports: BTreeSet<String> = BTreeSet::new();
     let (_, when) = ext.sum_reconstruct(registry, source, leaves, &params, &slots, &mut imports);
     (when, imports.into_iter().collect())
@@ -1522,7 +1520,7 @@ pub(crate) fn callback_iface_spec(
     for (k, desc) in leaf_tys.iter().enumerate() {
         let name = names[k].clone();
         let param = match desc {
-            LeafDesc::Plan(_, leaf) => plan_leaf_param(ext, registry, name, leaf)?,
+            LeafDesc::Plan(_, leaf) => plan_leaf_param(ext, name, leaf)?,
             LeafDesc::Whole {
                 ty,
                 nullable,
@@ -1593,7 +1591,7 @@ pub(crate) fn builder_iface_spec(
     decon: &DeconId,
 ) -> Option<IfaceSpec> {
     let spec = registry.decon_plans().get(decon)?;
-    let params = plan_leaf_params(ext, registry, &spec.leaves)?;
+    let params = plan_leaf_params(ext, &spec.leaves)?;
     let name = format!(
         "{}Builder",
         decon_base_name(&subject_short(&spec.source), Some(decon))
@@ -1620,7 +1618,7 @@ pub(crate) fn folder_iface_spec(
 ) -> Option<IfaceSpec> {
     let spec = registry.decon_plans().get(decon)?;
     let mut params: Vec<IfaceParam> = vec![IfaceParam::same("acc".to_string(), KtType::var_("A"))];
-    params.extend(plan_leaf_params(ext, registry, &spec.leaves)?);
+    params.extend(plan_leaf_params(ext, &spec.leaves)?);
     let name = format!(
         "{}Folder",
         decon_base_name(&subject_short(&spec.source), Some(decon))
@@ -1752,7 +1750,7 @@ pub(crate) fn error_handler_iface_spec(
     decon: &DeconId,
 ) -> Option<IfaceSpec> {
     let spec = registry.decon_plans().get(decon)?;
-    let params: Vec<IfaceParam> = plan_leaf_params(ext, registry, &spec.leaves)?;
+    let params: Vec<IfaceParam> = plan_leaf_params(ext, &spec.leaves)?;
     let name = format!(
         "{}Handler",
         decon_base_name(&subject_short(&spec.source), Some(decon))

--- a/prebindgen-jni/src/jni/selector.rs
+++ b/prebindgen-jni/src/jni/selector.rs
@@ -47,7 +47,6 @@ impl Declarations {
     pub(crate) fn input_optional(
         &self,
         ty: &prebindgen_registry::flat::TypeRef,
-        registry: &impl Conversions<KotlinMeta>,
         emit: &prebindgen_registry::Emit,
     ) -> Option<ConverterImpl<KotlinMeta>> {
         // What the converter YIELDS: this crossing's own reading, so a
@@ -60,7 +59,6 @@ impl Declarations {
                 WrapperShape::OptionRef { mutable },
                 &produced,
                 target,
-                registry,
                 emit,
             ) {
                 c.subs = vec![target.key()];
@@ -76,8 +74,7 @@ impl Declarations {
         if inner.borrow_target().is_some() && !ty.erased_wrappers().is_empty() {
             return None;
         }
-        let mut c =
-            self.input_wrapper_shape(WrapperShape::Optional, &produced, inner, registry, emit)?;
+        let mut c = self.input_wrapper_shape(WrapperShape::Optional, &produced, inner, emit)?;
         c.subs = vec![inner.key()];
         Some(c)
     }
@@ -92,13 +89,11 @@ impl Declarations {
     pub(crate) fn input_run(
         &self,
         ty: &prebindgen_registry::flat::TypeRef,
-        registry: &impl Conversions<KotlinMeta>,
         emit: &prebindgen_registry::Emit,
     ) -> Option<ConverterImpl<KotlinMeta>> {
         let produced = crate::jni::trait_impl::Produced::Reading(ty);
         if let Some(elem) = ty.sequence_elem().filter(|_| !is_unsized_spelling(ty)) {
-            let mut c =
-                self.input_wrapper_shape(WrapperShape::Sequence, &produced, elem, registry, emit)?;
+            let mut c = self.input_wrapper_shape(WrapperShape::Sequence, &produced, elem, emit)?;
             c.subs = vec![elem.key()];
             return Some(c);
         }
@@ -120,8 +115,7 @@ impl Declarations {
         // owned `[T]` to decode into, so the converter yields an owned `Vec<T>`
         // and the call site borrows it.
         let produced = crate::jni::trait_impl::Produced::Composed(syn::parse_quote!(Vec<#elem_ty>));
-        let mut c =
-            self.input_wrapper_shape(WrapperShape::Sequence, &produced, elem, registry, emit)?;
+        let mut c = self.input_wrapper_shape(WrapperShape::Sequence, &produced, elem, emit)?;
         c.subs = vec![elem.key()];
         Some(c)
     }
@@ -146,13 +140,11 @@ impl Declarations {
     pub(crate) fn output_optional(
         &self,
         ty: &prebindgen_registry::flat::TypeRef,
-        registry: &impl Conversions<KotlinMeta>,
         emit: &prebindgen_registry::Emit,
     ) -> Option<ConverterImpl<KotlinMeta>> {
         let produced = crate::jni::trait_impl::Produced::Reading(ty);
         let inner = ty.optional_inner()?;
-        let mut c =
-            self.output_wrapper_shape(WrapperShape::Optional, &produced, inner, registry, emit)?;
+        let mut c = self.output_wrapper_shape(WrapperShape::Optional, &produced, inner, emit)?;
         c.subs = vec![inner.key()];
         Some(c)
     }
@@ -167,13 +159,11 @@ impl Declarations {
     pub(crate) fn output_run(
         &self,
         ty: &prebindgen_registry::flat::TypeRef,
-        registry: &impl Conversions<KotlinMeta>,
         emit: &prebindgen_registry::Emit,
     ) -> Option<ConverterImpl<KotlinMeta>> {
         let produced = crate::jni::trait_impl::Produced::Reading(ty);
         if let Some(elem) = ty.sequence_elem().filter(|_| !is_unsized_spelling(ty)) {
-            let mut c =
-                self.output_wrapper_shape(WrapperShape::Sequence, &produced, elem, registry, emit)?;
+            let mut c = self.output_wrapper_shape(WrapperShape::Sequence, &produced, elem, emit)?;
             c.subs = vec![elem.key()];
             return Some(c);
         }

--- a/prebindgen-jni/src/jni/tests/mod.rs
+++ b/prebindgen-jni/src/jni/tests/mod.rs
@@ -62,22 +62,45 @@ fn entry(wire: syn::Type, conv_name: &str, niches: Niches) -> TypeEntry<KotlinMe
 
 // BLOCKED: `Registry::insert_crossing` is `pub(crate)` in `prebindgen::core` —
 // see the `niches` module gate above.
-fn install_input(
+/// Put one conversion where both a registry query and an adapter lookup can
+/// find it: in the registry the test builds, and in `decls` as the fragment a
+/// compiled binding would have filed. Helpers under test read the second.
+fn install(
     reg: &mut Registry<KotlinMeta>,
+    decls: &Declarations,
+    direction: Direction,
     ty_str: &str,
-    _rank: usize,
     e: TypeEntry<KotlinMeta>,
 ) {
     let ty: syn::Type = syn::parse_str(ty_str).expect("test type");
-    reg.insert_crossing(Direction::Input, &ty, true, Some(e));
+    let key = TypeKey::from_type(&ty);
+    let assembly = match direction {
+        Direction::Input => prebindgen_registry::recipe::Assembly::Construct,
+        Direction::Output => prebindgen_registry::recipe::Assembly::Deconstruct,
+    };
+    decls.compiled.borrow_mut().record(
+        key.clone(),
+        assembly,
+        prebindgen_registry::recipe::RecipeId::new("whole"),
+        crate::jni::compile::JFrag::by_hand(key, e.as_converter()),
+    );
+    reg.insert_crossing(direction, &ty, true, Some(e));
+}
+
+fn install_input(
+    reg: &mut Registry<KotlinMeta>,
+    decls: &Declarations,
+    ty_str: &str,
+    e: TypeEntry<KotlinMeta>,
+) {
+    install(reg, decls, Direction::Input, ty_str, e);
 }
 
 fn install_output(
     reg: &mut Registry<KotlinMeta>,
+    decls: &Declarations,
     ty_str: &str,
-    _rank: usize,
     e: TypeEntry<KotlinMeta>,
 ) {
-    let ty: syn::Type = syn::parse_str(ty_str).expect("test type");
-    reg.insert_crossing(Direction::Output, &ty, true, Some(e));
+    install(reg, decls, Direction::Output, ty_str, e);
 }

--- a/prebindgen-jni/src/jni/tests/niches.rs
+++ b/prebindgen-jni/src/jni/tests/niches.rs
@@ -7,10 +7,11 @@ use super::*;
 #[test]
 fn option_carves_single_niche() {
     let mut reg = Registry::empty_for_test();
+    let decls = Declarations::default();
     install_input(
         &mut reg,
+        &decls,
         "TestType",
-        0,
         entry(
             syn::parse_quote!(jni::sys::jlong),
             "jlong_to_TestType_aaaa",
@@ -21,7 +22,7 @@ fn option_carves_single_niche() {
     let inner_ty: syn::Type = syn::parse_quote!(TestType);
     let (wire, _body, niches) = option_input(
         &reg.reading_of(&inner_ty).expect("interned"),
-        &reg,
+        &decls,
         &prebindgen_registry::Emit::for_test(),
     )
     .expect("Option<TestType> resolves");
@@ -39,12 +40,13 @@ fn option_carves_single_niche() {
 #[test]
 fn option_cascades_through_multi_niche() {
     let mut reg = Registry::empty_for_test();
+    let decls = Declarations::default();
 
     // TestType: jint with two niches (MIN, MAX).
     install_input(
         &mut reg,
+        &decls,
         "TestType",
-        0,
         entry(
             syn::parse_quote!(jni::sys::jint),
             "jint_to_TestType_aaaa",
@@ -65,7 +67,7 @@ fn option_cascades_through_multi_niche() {
     let layer1_ty: syn::Type = syn::parse_quote!(TestType);
     let (w1, _, n1) = option_input(
         &reg.reading_of(&layer1_ty).expect("interned"),
-        &reg,
+        &decls,
         &prebindgen_registry::Emit::for_test(),
     )
     .expect("layer 1 resolves");
@@ -77,8 +79,8 @@ fn option_cascades_through_multi_niche() {
     // here we mimic it by installing the produced ConverterImpl.)
     install_input(
         &mut reg,
+        &decls,
         "Option < TestType >",
-        1,
         entry(w1.clone(), "jint_to_OptionTestType_bbbb", n1),
     );
 
@@ -86,7 +88,7 @@ fn option_cascades_through_multi_niche() {
     let layer2_ty: syn::Type = syn::parse_quote!(Option<TestType>);
     let (w2, _, n2) = option_input(
         &reg.reading_of(&layer2_ty).expect("interned"),
-        &reg,
+        &decls,
         &prebindgen_registry::Emit::for_test(),
     )
     .expect("layer 2 resolves");
@@ -100,8 +102,8 @@ fn option_cascades_through_multi_niche() {
     // Install layer-2 wrapper for the layer-3 lookup.
     install_input(
         &mut reg,
+        &decls,
         "Option < Option < TestType > >",
-        1,
         entry(w2.clone(), "jint_to_OptionOptionTestType_cccc", n2),
     );
 
@@ -110,7 +112,7 @@ fn option_cascades_through_multi_niche() {
     let layer3_ty: syn::Type = syn::parse_quote!(Option<Option<TestType>>);
     let (w3, _, n3) = option_input(
         &reg.reading_of(&layer3_ty).expect("interned"),
-        &reg,
+        &decls,
         &prebindgen_registry::Emit::for_test(),
     )
     .expect("layer 3 resolves via box fallback");
@@ -130,10 +132,11 @@ fn option_cascades_through_multi_niche() {
 #[test]
 fn option_output_cascades_through_multi_niche() {
     let mut reg = Registry::empty_for_test();
+    let decls = Declarations::default();
     install_output(
         &mut reg,
+        &decls,
         "TestType",
-        0,
         entry(
             syn::parse_quote!(jni::sys::jint),
             "TestType_to_jint_aaaa",
@@ -151,7 +154,7 @@ fn option_output_cascades_through_multi_niche() {
     );
 
     let inner_ty: syn::Type = syn::parse_quote!(TestType);
-    let (w1, body1, n1) = option_output(&reg.reading_of(&inner_ty).expect("interned"), &reg)
+    let (w1, body1, n1) = option_output(&reg.reading_of(&inner_ty).expect("interned"), &decls)
         .expect("Option<TestType> output resolves");
     assert_eq!(w1.to_token_stream().to_string(), "jni :: sys :: jint");
     assert_eq!(n1.len(), 1, "one slot left after carving the first");
@@ -165,13 +168,13 @@ fn option_output_cascades_through_multi_niche() {
 
     install_output(
         &mut reg,
+        &decls,
         "Option < TestType >",
-        1,
         entry(w1.clone(), "OptionTestType_to_jint_bbbb", n1),
     );
 
     let layer2_ty: syn::Type = syn::parse_quote!(Option<TestType>);
-    let (w2, body2, n2) = option_output(&reg.reading_of(&layer2_ty).expect("interned"), &reg)
+    let (w2, body2, n2) = option_output(&reg.reading_of(&layer2_ty).expect("interned"), &decls)
         .expect("Option<Option<TestType>> output resolves");
     assert_eq!(w2.to_token_stream().to_string(), "jni :: sys :: jint");
     assert!(n2.is_empty());
@@ -189,10 +192,11 @@ fn option_output_cascades_through_multi_niche() {
 #[test]
 fn option_over_jobject_uses_default_null_niche() {
     let mut reg = Registry::empty_for_test();
+    let decls = Declarations::default();
     install_input(
         &mut reg,
+        &decls,
         "MyStruct",
-        0,
         entry(
             syn::parse_quote!(jni::objects::JObject),
             "JObject_to_MyStruct_aaaa",
@@ -203,7 +207,7 @@ fn option_over_jobject_uses_default_null_niche() {
     let ty: syn::Type = syn::parse_quote!(MyStruct);
     let (wire, _, rest) = option_input(
         &reg.reading_of(&ty).expect("interned"),
-        &reg,
+        &decls,
         &prebindgen_registry::Emit::for_test(),
     )
     .expect("Option<MyStruct> resolves");
@@ -220,10 +224,11 @@ fn option_over_jobject_uses_default_null_niche() {
 #[test]
 fn option_fails_when_no_niche_and_non_primitive_wire() {
     let mut reg = Registry::empty_for_test();
+    let decls = Declarations::default();
     install_input(
         &mut reg,
+        &decls,
         "MyStruct",
-        0,
         entry(
             syn::parse_quote!(jni::objects::JObject),
             "JObject_to_MyStruct_aaaa",
@@ -233,7 +238,7 @@ fn option_fails_when_no_niche_and_non_primitive_wire() {
     let ty: syn::Type = syn::parse_quote!(MyStruct);
     assert!(option_input(
         &reg.reading_of(&ty).expect("interned"),
-        &reg,
+        &decls,
         &prebindgen_registry::Emit::for_test()
     )
     .is_none());
@@ -245,10 +250,11 @@ fn option_fails_when_no_niche_and_non_primitive_wire() {
 #[test]
 fn option_box_fallback_exposes_no_niches() {
     let mut reg = Registry::empty_for_test();
+    let decls = Declarations::default();
     install_input(
         &mut reg,
+        &decls,
         "i64",
-        0,
         entry(
             syn::parse_quote!(jni::sys::jlong),
             "jlong_to_i64_aaaa",
@@ -258,7 +264,7 @@ fn option_box_fallback_exposes_no_niches() {
     let ty: syn::Type = syn::parse_quote!(i64);
     let (wire, _, rest) = option_input(
         &reg.reading_of(&ty).expect("interned"),
-        &reg,
+        &decls,
         &prebindgen_registry::Emit::for_test(),
     )
     .expect("Option<i64> via box fallback");

--- a/prebindgen-jni/src/jni/trait_impl.rs
+++ b/prebindgen-jni/src/jni/trait_impl.rs
@@ -1220,7 +1220,6 @@ impl Declarations {
         shape: WrapperShape,
         produced: &Produced<'_>,
         t1: &prebindgen_registry::flat::TypeRef,
-        registry: &impl Conversions<KotlinMeta>,
         emit: &prebindgen_registry::Emit,
     ) -> Option<ConverterImpl<KotlinMeta>> {
         // `t1`'s spelling, for the parts that ask spelling questions — the
@@ -1289,7 +1288,7 @@ impl Declarations {
         if shape == WrapperShape::Optional {
             let outer_ty = produced.key();
             let build = build_from_canonical(produced, quote::quote!(__v))?;
-            let (wire, inner_body, niches) = option_input(t1, registry, emit)?;
+            let (wire, inner_body, niches) = option_input(t1, self, emit)?;
             // `option_input` yields the canonical `Option<T>`; the converter
             // yields the spelling.
             let body: syn::Expr = syn::parse_quote!({
@@ -1307,7 +1306,7 @@ impl Declarations {
             // an inner niche, the wire stays identical to the inner's
             // destination and `None` is the niche slot sentinel; the boxed
             // fallback widens the wire to `JObject`.
-            let nullable_kind = nullable_kind_for(&wire, t1, registry);
+            let nullable_kind = nullable_kind_for(&wire, t1, self);
             let projection = self
                 .in_frag(t1)
                 .and_then(|e| e.metadata.projection.clone())
@@ -2577,7 +2576,6 @@ impl Declarations {
         shape: WrapperShape,
         produced: &Produced<'_>,
         t1: &prebindgen_registry::flat::TypeRef,
-        registry: &impl Conversions<KotlinMeta>,
         emit: &prebindgen_registry::Emit,
     ) -> Option<ConverterImpl<KotlinMeta>> {
         // Disjoint shapes (see [`WrapperShape`]), tried in priority order. The
@@ -2586,7 +2584,7 @@ impl Declarations {
         self.input_borrow(shape, produced, t1)
             .or_else(|| self.input_option_ref(shape, produced, t1, emit))
             .or_else(|| self.input_vec(shape, produced, t1, emit))
-            .or_else(|| self.input_option(shape, produced, t1, registry, emit))
+            .or_else(|| self.input_option(shape, produced, t1, emit))
     }
 
     // ── Output converters ────────────────────────────────────────────
@@ -2779,7 +2777,6 @@ impl Declarations {
         shape: WrapperShape,
         produced: &Produced<'_>,
         t1: &prebindgen_registry::flat::TypeRef,
-        registry: &impl Conversions<KotlinMeta>,
         emit: &prebindgen_registry::Emit,
     ) -> Option<ConverterImpl<KotlinMeta>> {
         // `t1`'s spelling, for the parts that ask spelling questions — the
@@ -2831,7 +2828,7 @@ impl Declarations {
             // Bridgeable first: an unsupported representation must not resolve
             // and then emit code the consumer cannot compile.
             let read = read_as_canonical(produced)?;
-            let (wire, inner_body, niches) = option_output(t1, registry)?;
+            let (wire, inner_body, niches) = option_output(t1, self)?;
             let body: syn::Expr = syn::parse_quote!({
                 let v: #canonical = #read;
                 #inner_body
@@ -2845,7 +2842,7 @@ impl Declarations {
             // [`nullable_kind_for`]): niche-fulfilled keeps the inner wire
             // and treats the slot value as `None`; boxed widens to `JObject`
             // and uses JVM null.
-            let nullable_kind = nullable_kind_for_output(&wire, t1, registry);
+            let nullable_kind = nullable_kind_for_output(&wire, t1, self);
             let projection = self
                 .out_frag(t1)
                 .and_then(|e| e.metadata.projection.clone())

--- a/prebindgen-registry/src/recipe/compile.rs
+++ b/prebindgen-registry/src/recipe/compile.rs
@@ -427,7 +427,12 @@ impl<F> Compiled<F> {
     /// row has the row and asks through [`Self::row_fragment`].
     ///
     /// `None` means no site ever crossed this type in this direction.
-    pub fn fragment(&self, ty: &TypeKey, assembly: Assembly) -> Option<&F> {
+    ///
+    /// Handed back as the `Rc` it is stored under: an adapter that reads its
+    /// store while compilation is still filling it cannot hold a borrow across
+    /// the next write, and a fragment holds a whole `syn::ItemFn` that a
+    /// recursive lookup should not be copying.
+    pub fn fragment(&self, ty: &TypeKey, assembly: Assembly) -> Option<Rc<F>> {
         let row = self.defaults.get(&(ty.clone(), assembly))?;
         self.row_fragment(ty, assembly, row)
     }
@@ -449,10 +454,10 @@ impl<F> Compiled<F> {
     }
 
     /// The fragment for one crossing and one named row.
-    pub fn row_fragment(&self, ty: &TypeKey, assembly: Assembly, row: &RecipeId) -> Option<&F> {
+    pub fn row_fragment(&self, ty: &TypeKey, assembly: Assembly, row: &RecipeId) -> Option<Rc<F>> {
         self.fragments
             .get(&(ty.clone(), assembly, row.clone()))
-            .map(|f| &**f)
+            .cloned()
     }
 
     /// Every fragment this compilation built, in a deterministic order.

--- a/prebindgen-registry/src/recipe/tests.rs
+++ b/prebindgen-registry/src/recipe/tests.rs
@@ -2307,8 +2307,8 @@ fn an_emitter_asking_for_a_crossing_gets_the_row_the_crossing_defaults_to() {
     assert_eq!(
         compiled
             .fragment(&key, Assembly::Deconstruct)
-            .map(|n| n.text.as_str()),
-        Some("atomic Sample deconstruct: Sample"),
+            .map(|n| n.text.clone()),
+        Some("atomic Sample deconstruct: Sample".to_string()),
     );
     // … and a caller holding a row still reaches that row.
     assert!(compiled


### PR DESCRIPTION
First half of stage 2 in #472.

## Where this starts

Stages [1](https://github.com/milyin/prebindgen/pull/474) and
[1b](https://github.com/milyin/prebindgen/pull/475) moved the bulk of both
adapters' lookups from the converter table — the registry's index of one
resolved conversion per crossing — to the fragments each adapter compiled.
They left **18**: 10 in `prebindgen-c` and 8 in `prebindgen-jni`.

Both counts are now **zero**. That is what stage 2b needs: while an adapter
still reads the table, `convert_with` has to keep handing back a whole
`ConverterImpl` for the table to hold.

## `prebindgen-c`: the same in-flight store `prebindgen-jni` has

Four `prebindgen-c` helpers run during compilation as well as after it —
`lower_shape`, `encode_value`, `output_is_fallible`, and the
`has_own_wire` / `shape_is_lowerable` / `is_lowered_composite` cluster.
`dispatch_fn_input` builds a callback's closure struct out of them while
compilation is still in progress, which is why #474 left them behind.

`CbindgenBuilder::compiled` is now an `Rc<RefCell<…>>` fed after every
crossing, exactly as `Declarations::compiled` is. A conversion for one type
is built out of the conversions for its inners, which the resolver compiles
first, so a fragment is there when the helper asks. The same `mem::take`
trap applies and the driver clones instead.

The three lowering predicates were free functions taking a registry. They
are methods on `CbindgenBuilder` now — "does this binding give this type a
wire" was always its question, not the registry's.

## `prebindgen-jni`: seven parameters and one test harness

Seven of the eight were free functions with no `Declarations` in scope —
`leaf_is_prim`, `leaf_ty_is_prim`, `leaf_slot`, `encode_group_leaf`,
`nullable_kind_for`, `nullable_kind_for_output`, `jvm_parameter_slots`.
Each takes one now; every caller already had it.

The eighth pair, `option_input` / `option_output`, is why #475 left this
group alone: nine tests in `jni/tests/niches.rs` call them against a bare
`Registry` built by `install_input` / `install_output`, with no
`Declarations` anywhere. Those installers now file each conversion in
**both** places — the registry the test builds and the `Declarations` as
the fragment a compiled binding would have recorded. A test still installs
one entry per type; the helper under test reads the adapter's own answer.

## Left over

Nine more parameters became dead and are removed.

What still reads a table entry is the registry itself, and only for `subs`,
the dependency keys reachability walks. Narrowing `convert_with` to exactly
that is stage 2b.

## Checks

- `cargo test --all` — green
- clippy and rustfmt on 1.85.0 and stable — clean
- `cargo doc` with `-D warnings` — clean
- `examples/regen-check.sh` — **byte-identical**
- `examples/smoke-asan.sh` — clean