### PR TITLE
Delete the paths that read conversions off the table

### DIFF
--- a/prebindgen-c/src/lib.rs
+++ b/prebindgen-c/src/lib.rs
@@ -462,12 +462,12 @@ pub struct CbindgenBuilder {
     >,
     /// Every conversion this binding compiled.
     ///
-    /// Filled once by [`Self::build_with`] and handed to `write_rust` as
-    /// `Conversions::Compiled`. It is what reaches the generated file,
-    /// so a fragment no longer has to be expressible as one `ConverterImpl` to
-    /// be emitted — only to be looked up. The writer sorts and de-duplicates by
-    /// function name, so the order here decides which of two same-named
-    /// functions wins and not where any of them lands.
+    /// Filled once by [`Self::build_with`] and handed to `write_rust` directly. It is what
+    /// reaches the generated file, so a fragment no longer has to be
+    /// expressible as one `ConverterImpl` to be emitted — only to be looked up.
+    /// The writer sorts and de-duplicates by function name, so the order here
+    /// decides which of two same-named functions wins and not where any of them
+    /// lands.
     pub(crate) compiled_fns: Vec<syn::ItemFn>,
 }
 

--- a/prebindgen-c/src/lib.rs
+++ b/prebindgen-c/src/lib.rs
@@ -359,7 +359,7 @@ impl Cbindgen {
         Ok(prebindgen_registry::write::write_rust(
             &self.registry,
             &self.gen,
-            prebindgen_registry::write::Conversions::Compiled(&self.gen.compiled_fns),
+            &self.gen.compiled_fns,
             out_path,
         )?)
     }

--- a/prebindgen-jni/src/jni/mod.rs
+++ b/prebindgen-jni/src/jni/mod.rs
@@ -572,12 +572,12 @@ pub struct Declarations {
     pub(crate) convert_decls: Vec<ConvertDecl>,
     /// Every conversion this binding compiled.
     ///
-    /// Filled once by `JniGenBuilder::build_with` and handed to `write_rust` as
-    /// `Conversions::Compiled`. It is what reaches the generated file, so
-    /// a fragment no longer has to be expressible as one `ConverterImpl` to be
-    /// emitted — only to be looked up. The writer sorts and de-duplicates by
-    /// function name, so the order here decides which of two same-named
-    /// functions wins and not where any of them lands.
+    /// Filled once by `JniGenBuilder::build_with` and handed to `write_rust`
+    /// directly. It is what reaches the generated file, so a fragment no longer
+    /// has to be expressible as one `ConverterImpl` to be emitted — only to be
+    /// looked up. The writer sorts and de-duplicates by function name, so the
+    /// order here decides which of two same-named functions wins and not where
+    /// any of them lands.
     pub(crate) compiled_fns: Vec<syn::ItemFn>,
     /// Every conversion this binding has compiled so far, keyed by crossing.
     ///

--- a/prebindgen-jni/src/jni/mod.rs
+++ b/prebindgen-jni/src/jni/mod.rs
@@ -478,7 +478,7 @@ impl JniGen {
         Ok(prebindgen_registry::write::write_rust(
             &self.registry,
             &self.decls,
-            prebindgen_registry::write::Conversions::Compiled(&self.decls.compiled_fns),
+            &self.decls.compiled_fns,
             out_path,
         )?)
     }

--- a/prebindgen-registry/src/lib.rs
+++ b/prebindgen-registry/src/lib.rs
@@ -51,10 +51,10 @@
 //!
 //! 1. [`flat::Flat::builder`] parses the declared sources into the model, and
 //!    [`Registry::builder`] starts describing a binding over it.
-//! 2. The generator states that binding, then [`RegistryBuilder::crossings`]
-//!    hands over every crossing needing a conversion — inner types first, so
-//!    each one can be built from those already done. `convert_with` answers
-//!    them and `build` names any gap.
+//! 2. The generator states that binding, then
+//!    [`RegistryBuilder::convert_with`] walks every crossing needing a
+//!    conversion — inner types first, so each one can be built from those
+//!    already done — and `build` names any gap.
 //! 3. The resolved registry becomes a field of the built generator, whose
 //!    `write_*` methods emit the artifacts — Rust wrappers, and whatever else
 //!    that language needs (a C header, Kotlin sources, …).

--- a/prebindgen-registry/src/prebindgen.rs
+++ b/prebindgen-registry/src/prebindgen.rs
@@ -5,10 +5,10 @@
 //! items they depend on (`prerequisites`), a cross-cutting rewrite
 //! (`post_process_item`) and two invariant checks.
 //!
-//! **Conversion is not here.** A generator builds those itself, against the
-//! demand `RegistryBuilder::crossings` hands it, and gives them back through
-//! `RegistryBuilder::convert_with` — so there is no `on_input_type`, no deferral, and no
-//! fixed-point loop retrying until it converges.
+//! **Conversion is not here.** A generator builds those itself, one per
+//! crossing, inside `RegistryBuilder::convert_with` — so there is no
+//! `on_input_type`, no deferral, and no fixed-point loop retrying until it
+//! converges.
 //!
 //! [`ConverterImpl::function`] is the **complete** Rust function for a
 //! converter — signature, body, attributes, lifetimes. The generator owns 100%
@@ -158,9 +158,8 @@ impl<M> ConverterImpl<M> {
 /// What used to be here and is not any more: which items to build, how
 /// composites decompose, and the wire form of each type. A generator states the
 /// first two into the builder (`RegistryBuilder::export`,
-/// `RegistryBuilder::decompose`)
-/// and answers the third by filling `RegistryBuilder::crossings` — so nothing in
-/// core calls back to ask. Moving emission out too is what would delete this
+/// `RegistryBuilder::decompose`) and answers the third inside
+/// `RegistryBuilder::convert_with` — so nothing in core calls back to ask. Moving emission out too is what would delete this
 /// trait entirely (prebindgen#251 phase E).
 ///
 /// Anything language-specific the rest of the pipeline must carry — a JNI

--- a/prebindgen-registry/src/recipe/compile.rs
+++ b/prebindgen-registry/src/recipe/compile.rs
@@ -464,10 +464,9 @@ impl<F> Compiled<F> {
     ///
     /// What an adapter emits from once it stops routing its conversions back
     /// through the converter table — handed to
-    /// [`write_rust`](crate::write::write_rust) as
-    /// [`Conversions::Compiled`](crate::write::Conversions::Compiled). The
-    /// order is by crossing key and then by row name, so a file written from
-    /// this is stable across runs.
+    /// [`write_rust`](crate::write::write_rust) directly. The order is by
+    /// crossing key and then by row name, so a file written from this is
+    /// stable across runs.
     pub fn fragments(&self) -> Vec<&F> {
         let mut keyed: Vec<(&FragmentKey, &Rc<F>)> = self.fragments.iter().collect();
         keyed.sort_by(|a, b| {

--- a/prebindgen-registry/src/registry/declare.rs
+++ b/prebindgen-registry/src/registry/declare.rs
@@ -30,7 +30,7 @@ pub struct RegistryBuilder<M> {
     /// Conversions handed over so far, applied at [`Self::build`].
     built: HashMap<Crossing, TypeEntry<M>>,
     /// The scan runs once, on demand: it needs every declaration, and
-    /// [`Self::crossings`] / [`Self::convert_with`] / [`Self::build`] each need
+    /// [`Self::convert_with`] and [`Self::build`] each need
     /// it to have run. `Some` holds the derived demand, in order.
     order: Option<Vec<Crossing>>,
 }

--- a/prebindgen-registry/src/registry/declare.rs
+++ b/prebindgen-registry/src/registry/declare.rs
@@ -173,7 +173,7 @@ impl<M> RegistryBuilder<M> {
 
     /// `from`'s conversion needs `on`'s to exist first.
     ///
-    /// [`Self::crossings`] derives its order from the type structure, which
+    /// [`Self::convert_with`] derives its order from the type structure, which
     /// covers almost everything: an `Option<T>` visibly contains a `T`. It
     /// cannot see a dependency the *declaration* creates — a `convert!` whose
     /// body chains through a helper function's parameter type, say, where
@@ -347,16 +347,6 @@ impl<M> RegistryBuilder<M> {
         Ok(self)
     }
 
-    /// Every crossing this binding needs a conversion for, **inner types
-    /// first** — see [`Self::crossings`] for what the order guarantees.
-    ///
-    /// Take this when you want to drive the loop yourself and hand the result
-    /// back through [`Self::conversions`]. [`Self::convert_with`] is the same
-    /// walk with the loop written for you.
-    pub fn crossings(&mut self) -> Result<Vec<Crossing>, WriteRustError> {
-        Ok(self.derive()?.to_vec())
-    }
-
     /// Build a conversion for each crossing, in dependency order.
     ///
     /// `f` is called once per crossing with the conversions already built, so
@@ -364,10 +354,9 @@ impl<M> RegistryBuilder<M> {
     /// `None` records a gap — whether that gap matters is decided by
     /// [`Self::build`], not here.
     ///
-    /// This is a convenience over [`Self::crossings`] + [`Self::conversions`],
-    /// not a second mechanism: it is the same list, walked in the same order.
-    /// Nothing about it lets the registry choose when to call back — the
-    /// closure is yours, and the walk is finished before this returns.
+    /// The one way to supply them. Nothing about it lets the registry choose
+    /// when to call back — the closure is yours, and the walk is finished
+    /// before this returns.
     pub fn convert_with<F>(mut self, mut f: F) -> Result<Self, WriteRustError>
     where
         F: FnMut(
@@ -390,16 +379,6 @@ impl<M> RegistryBuilder<M> {
             }
         }
         Ok(self)
-    }
-
-    /// Hand over conversions built elsewhere — the bulk peer of
-    /// [`Self::convert_with`], for a generator that walked
-    /// [`Self::crossings`] itself.
-    ///
-    /// Accumulates, so it composes with `convert_with` and with itself.
-    pub fn conversions(mut self, conversions: HashMap<Crossing, TypeEntry<M>>) -> Self {
-        self.built.extend(conversions);
-        self
     }
 
     /// The scanned registry, with no conversions applied and no completeness

--- a/prebindgen-registry/src/write.rs
+++ b/prebindgen-registry/src/write.rs
@@ -1,10 +1,13 @@
 //! Rust file emission for the resolved `Registry`.
 //!
-//! `write_rust` collects every resolved input/output converter (each entry
-//! already carries its full `ItemFn`), every per-item `on_<kind>` output,
-//! and every anonymous const; concatenates them; and hands them to
-//! `Destination::write` (which does prettyplease formatting and
-//! resolves the path against `OUT_DIR`).
+//! `write_rust` takes the conversions the adapter compiled, as a slice of
+//! `ItemFn`; adds every per-item `on_<kind>` output and every anonymous const;
+//! concatenates them; and hands them to `Destination::write` (which does
+//! prettyplease formatting and resolves the path against `OUT_DIR`).
+//!
+//! The conversions arrive from the adapter rather than being collected from the
+//! registry, which is what lets one crossing contribute more than one function
+//! — or one that occupies more than a single wire value.
 //!
 //! This module is `pub`, so **every `pub` item in it is public API of the
 //! crate**. That is meant to be exactly two — [`write_rust`] and

--- a/prebindgen-registry/src/write.rs
+++ b/prebindgen-registry/src/write.rs
@@ -22,26 +22,8 @@ use proc_macro2::TokenStream;
 use crate::{
     destination::Destination,
     prebindgen::Prebindgen,
-    registry::{Registry, TypeEntry, TypeKey},
+    registry::{Registry, TypeKey},
 };
-
-/// Where the generated conversions come from.
-///
-/// The converter table is the **lookup** index either way; this says only what
-/// reaches the file. An adapter that compiles its own fragments hands them over
-/// directly, and is then free to emit a conversion the table cannot hold —
-/// several functions for one crossing, or one occupying more than a single wire
-/// value, which is what a `ConverterImpl`'s single `destination` cannot name.
-pub enum Conversions<'a> {
-    /// What the adapter's compilation produced, in the order it produced it.
-    ///
-    /// Sorted and de-duplicated by function name here, so the order decides
-    /// which of two same-named functions wins and not where any of them lands.
-    Compiled(&'a [syn::ItemFn]),
-    /// Read them off the converter table, where they lived when a conversion
-    /// could only ever be one `ConverterImpl` per crossing.
-    Table,
-}
 
 /// Errors surfaced by the file-emission phase.
 ///
@@ -77,12 +59,19 @@ impl std::error::Error for WriteError {}
 
 /// Emit the resolved registry to a Rust file.
 ///
+/// `conversions` is what the adapter's compilation produced. It is sorted and
+/// de-duplicated by function name here, so the order decides which of two
+/// same-named functions wins and not where any of them lands. Handing them
+/// over directly is what frees an adapter to emit a conversion the converter
+/// table could not hold — several functions for one crossing, or one occupying
+/// more than a single wire value.
+///
 /// `out_path` may be relative (resolved against `OUT_DIR` by prebindgen) or
 /// absolute. Returns the path actually written.
 pub fn write_rust<P: AsRef<Path>, E: Prebindgen>(
     registry: &Registry<E::Metadata>,
     ext: &E,
-    conversions: Conversions<'_>,
+    conversions: &[syn::ItemFn],
     out_path: P,
 ) -> Result<PathBuf, WriteError> {
     // Validation already ran ONCE in the generator's `build` — a built generator
@@ -101,10 +90,7 @@ pub fn write_rust<P: AsRef<Path>, E: Prebindgen>(
     items.extend(ext.prerequisites(registry, &emit));
 
     // 1. Auto-generated converter wrappers (sorted by ident, deduped).
-    for (_, item_fn) in match conversions {
-        Conversions::Compiled(functions) => dedup_by_name(functions.to_vec()),
-        Conversions::Table => collect_converter_items(registry),
-    } {
+    for (_, item_fn) in dedup_by_name(conversions.to_vec()) {
         items.push(syn::Item::Fn(item_fn));
     }
 
@@ -187,57 +173,6 @@ pub fn write_rust<P: AsRef<Path>, E: Prebindgen>(
     Ok(dest.write(out_path))
 }
 
-/// Walk both type tables, dedupe each entry's stored `function` AND each
-/// of its [`crate::prebindgen::Stage`] functions by name, sort
-/// for determinism. Names are read directly off `function.sig.ident` —
-/// the adapter owns the naming.
-///
-/// Private: an internal step of [`write_rust`], not part of the
-/// adapter-facing surface this module exposes.
-/// Sort by name and keep the first of each, which is what the converter table
-/// does for the entries it holds — one function per name reaches the file
-/// however many crossings produced it.
-fn dedup_by_name(functions: Vec<syn::ItemFn>) -> Vec<(syn::Ident, syn::ItemFn)> {
-    let mut by_name: BTreeMap<String, (syn::Ident, syn::ItemFn)> = BTreeMap::new();
-    for function in functions {
-        let name = function.sig.ident.clone();
-        by_name.entry(name.to_string()).or_insert((name, function));
-    }
-    by_name.into_values().collect()
-}
-
-fn collect_converter_items<M>(registry: &Registry<M>) -> Vec<(syn::Ident, syn::ItemFn)> {
-    let mut by_name: BTreeMap<String, (syn::Ident, syn::ItemFn)> = BTreeMap::new();
-    let mut collect = |entry: &TypeEntry<M>| {
-        let name = entry.function.sig.ident.clone();
-        by_name
-            .entry(name.to_string())
-            .or_insert_with(|| (name, entry.function.clone()));
-        for stage in &entry.pre_stages {
-            let sname = stage.function.sig.ident.clone();
-            by_name
-                .entry(sname.to_string())
-                .or_insert_with(|| (sname, stage.function.clone()));
-        }
-    };
-    walk_resolved(&registry.input_types, |_, entry| collect(entry));
-    walk_resolved(&registry.output_types, |_, entry| collect(entry));
-    by_name.into_values().collect()
-}
-
-fn walk_resolved<M, F: FnMut(&TypeKey, &TypeEntry<M>)>(
-    table: &std::collections::HashMap<TypeKey, crate::registry::TypeCell<M>>,
-    mut f: F,
-) {
-    let mut keys: Vec<&TypeKey> = table.keys().collect();
-    keys.sort_by(|a, b| a.as_str().cmp(b.as_str()));
-    for key in keys {
-        if let Some(entry) = table.get(key).and_then(|c| c.entry.as_ref()) {
-            f(key, entry);
-        }
-    }
-}
-
 /// Name-sorted, because emission order is part of the generated file and the
 /// model is in source order. Was `sorted_items_by_ident` over the registry's
 /// maps; same ordering, read from the one index.
@@ -272,3 +207,14 @@ fn parse_items_from_tokens<I: IntoIterator<Item = TokenStream>>(
 
 #[cfg(test)]
 mod tests;
+
+/// Sort by name and keep the first of each: one function per name reaches the
+/// file however many crossings produced it.
+fn dedup_by_name(functions: Vec<syn::ItemFn>) -> Vec<(syn::Ident, syn::ItemFn)> {
+    let mut by_name: BTreeMap<String, (syn::Ident, syn::ItemFn)> = BTreeMap::new();
+    for function in functions {
+        let name = function.sig.ident.clone();
+        by_name.entry(name.to_string()).or_insert((name, function));
+    }
+    by_name.into_values().collect()
+}

--- a/prebindgen-registry/src/write/tests.rs
+++ b/prebindgen-registry/src/write/tests.rs
@@ -4,7 +4,7 @@ use prebindgen::SourceLocation;
 use proc_macro2::TokenStream;
 
 use super::*;
-use crate::registry::{Direction, RegistryBuilder};
+use crate::registry::RegistryBuilder;
 
 struct IdentityExt;
 
@@ -64,49 +64,24 @@ impl Prebindgen for IdentityExt {
 
 #[test]
 fn dedup_and_sort() {
-    let mut reg: Registry<()> = Registry::empty();
-    let ty_a: syn::Type = syn::parse_quote!(u64);
-    let ty_b: syn::Type = syn::parse_quote!(Sample);
-    let wire: syn::Type = syn::parse_quote!(i64);
-    let wire2: syn::Type = syn::parse_quote!(*const u8);
-
-    reg.insert_crossing(
-        Direction::Input,
-        &ty_a,
-        true,
-        Some(TypeEntry {
-            destination: wire.clone(),
-            function: syn::parse_quote!(
-                fn handle_to_u64_aaaa(v: i64) -> u64 {
-                    v as u64
-                }
-            ),
-            pre_stages: vec![],
-            subs: vec![],
-            niches: crate::niches::Niches::empty(),
-            metadata: (),
-        }),
+    // Two crossings can compile the same conversion, and an adapter hands over
+    // whatever its compilation produced. One function per name reaches the
+    // file, in name order — a generated file that reordered between runs would
+    // show up as a diff in `examples/regen-check.sh`.
+    let handle: syn::ItemFn = syn::parse_quote!(
+        fn handle_to_u64_aaaa(v: i64) -> u64 {
+            v as u64
+        }
     );
-    reg.insert_crossing(
-        Direction::Input,
-        &ty_b,
-        true,
-        Some(TypeEntry {
-            destination: wire2.clone(),
-            function: syn::parse_quote!(
-                fn Ptr_to_Sample_bbbb(v: *const u8) -> Sample {
-                    decode_sample(v)
-                }
-            ),
-            pre_stages: vec![],
-            subs: vec![],
-            niches: crate::niches::Niches::empty(),
-            metadata: (),
-        }),
+    let sample: syn::ItemFn = syn::parse_quote!(
+        fn Ptr_to_Sample_bbbb(v: *const u8) -> Sample {
+            decode_sample(v)
+        }
     );
 
-    let items = collect_converter_items(&reg);
-    assert_eq!(items.len(), 2);
+    let items = crate::write::dedup_by_name(vec![handle.clone(), sample.clone(), handle.clone()]);
+
+    assert_eq!(items.len(), 2, "the repeated conversion lands once");
     // Sorted ASCII: "Ptr_to_Sample_bbbb" < "handle_to_u64_aaaa"
     // (uppercase P < lowercase h).
     assert_eq!(items[0].0.to_string(), "Ptr_to_Sample_bbbb");
@@ -182,8 +157,7 @@ fn write_rust_sorts_declared_items_by_ident() {
         .expect("clock drift")
         .as_nanos();
     let path = std::env::temp_dir().join(format!("prebindgen-write-rust-{unique}.rs"));
-    let written = write_rust(&reg, &IdentityExt, crate::write::Conversions::Table, &path)
-        .expect("write_rust");
+    let written = write_rust(&reg, &IdentityExt, &[], &path).expect("write_rust");
     let content = std::fs::read_to_string(&written).expect("read generated file");
     let _ = std::fs::remove_file(&written);
 
@@ -306,13 +280,8 @@ fn guards_emit_ungated_and_in_stream_order() {
     let dir = crate::test_util::unique_test_dir("write_guards");
     std::fs::create_dir_all(&dir).unwrap();
     let registry = registry.resolve_gating(ConstGatingExt).expect("resolve");
-    let path = crate::write::write_rust(
-        &registry,
-        &ConstGatingExt,
-        crate::write::Conversions::Table,
-        dir.join("gen.rs"),
-    )
-    .expect("write_rust");
+    let path = crate::write::write_rust(&registry, &ConstGatingExt, &[], dir.join("gen.rs"))
+        .expect("write_rust");
     let src = std::fs::read_to_string(&path).unwrap();
 
     // The named const is gated out; both guards emit regardless.


### PR DESCRIPTION
Opens stage 2b of #472. Pure deletion: 160 lines out, 53 in, generated output byte-identical.

## What this removes

[#476](https://github.com/milyin/prebindgen/pull/476) took the last adapter
lookup off the converter table — the registry's index of one resolved
conversion per crossing. Nothing now asks the registry to hand a conversion
back, which strands four things:

- **`Conversions`**, the enum telling `write_rust` where generated
  conversions come from, had two variants and one live one. `write_rust`
  takes the adapter's compiled functions as `&[syn::ItemFn]` directly, and
  the enum is gone. `Conversions::Table` had two users, both registry tests,
  and neither asserted anything about a converter — they check const
  ordering and feature guards.
- **`collect_converter_items`** and **`walk_resolved`** existed to serve
  that variant.
- **`RegistryBuilder::conversions`**, documented as the bulk peer of
  `convert_with` for a generator that walks the crossings itself, had no
  caller at all.
- **`RegistryBuilder::crossings`** was the other half of that pair. It hands
  over the crossing list for a caller driving the loop itself — which, with
  `conversions` gone, has no way to hand a result back. `convert_with` is
  the one way to supply conversions now, and its doc comment says so instead
  of pointing at a second mechanism.

## The test

`dedup_and_sort` covered `collect_converter_items`, asserting that one
function per name reaches the file in name order. That property now lives in
`dedup_by_name`, so the test exercises it there — with the same two
conversions plus a repeat, which is what gives the de-duplication something
to do. It no longer needs to build a registry and stuff two `TypeEntry`s
into it to make the point.

## What is left for the rest of the stage

`convert_with` still takes back a whole `ConverterImpl`. What the registry
does with one is read `subs` — the dependency keys `propagate_required`
walks — and note that the crossing was answered. Narrowing it to that is the
next PR, and it reaches further than the table: strip a cell down to `subs`
and `M`, the metadata type parameter, goes unconstrained across the crate.

## Checks

- `cargo test --all` — green
- clippy and rustfmt on 1.85.0 and stable — clean
- `cargo doc` with `-D warnings` — clean
- `examples/regen-check.sh` — **byte-identical**
- `examples/smoke-asan.sh` — clean