### PR TITLE
Take back reachability from convert_with, not the conversion

### DIFF
--- a/prebindgen-c/src/compile.rs
+++ b/prebindgen-c/src/compile.rs
@@ -66,7 +66,7 @@ impl Carrier for CFrag {
 
 impl CFrag {
     /// One of the adapter's existing converter builders, as a fragment.
-    fn from_converter(at: At<'_>, conv: ConverterImpl<()>) -> Self {
+    fn from_converter(at: At<'_>, conv: ConverterImpl) -> Self {
         let validity = validity_of(&conv, at.crossing.assembly());
         Self {
             destination: conv.destination,
@@ -83,7 +83,7 @@ impl CFrag {
     }
 
     /// What the registry that still emits converters expects back.
-    pub(crate) fn into_converter(self) -> ConverterImpl<()> {
+    pub(crate) fn into_converter(self) -> ConverterImpl {
         ConverterImpl {
             destination: self.destination,
             function: self.function,
@@ -101,7 +101,7 @@ impl CFrag {
 /// Reading the spelling is wrong in both directions: a conversion may clone or
 /// allocate out of a borrow, and — the case C actually has — a conversion may
 /// hand C a pointer *into* a Rust value from a crossing that looks owned.
-fn validity_of(conv: &ConverterImpl<()>, assembly: Assembly) -> Validity {
+fn validity_of(conv: &ConverterImpl, assembly: Assembly) -> Validity {
     match assembly {
         // Rust to C. A `*const T` is the zero-copy borrow: `out_borrow_or_result`
         // casts the Rust value's own address, and `repr_c_struct`'s reinterpret
@@ -194,14 +194,14 @@ fn refuse(at: At<'_>, why: &str) -> String {
     format!("Cbindgen: {} ({why})", at.crossing.key())
 }
 
-impl<R: Conversions<()>> CCompile<'_, R> {
-    fn wrap(&self, at: At<'_>, why: &str, conv: Option<ConverterImpl<()>>) -> Frag<Self> {
+impl<R: Conversions> CCompile<'_, R> {
+    fn wrap(&self, at: At<'_>, why: &str, conv: Option<ConverterImpl>) -> Frag<Self> {
         conv.map(|c| CFrag::from_converter(at, c))
             .ok_or_else(|| refuse(at, why))
     }
 }
 
-impl<R: Conversions<()>> Compile for CCompile<'_, R> {
+impl<R: Conversions> Compile for CCompile<'_, R> {
     type Fragment = CFrag;
     /// C keeps its own per-site emission for now: the exported signature, the
     /// call and the cleanup are built in `emit.rs` from the resolved registry.

--- a/prebindgen-c/src/convert.rs
+++ b/prebindgen-c/src/convert.rs
@@ -3,7 +3,7 @@ use prebindgen_registry::Conversions;
 use super::*;
 
 impl CbindgenBuilder {
-    pub(crate) fn prereq_domain_constants(&self, registry: &Registry<()>) -> Vec<syn::Item> {
+    pub(crate) fn prereq_domain_constants(&self, registry: &Registry) -> Vec<syn::Item> {
         let mut items = Vec::new();
         for decl in &self.convert_decls {
             let Some(domain) = decl.domain() else {
@@ -55,9 +55,9 @@ impl CbindgenBuilder {
     pub(crate) fn in_custom(
         &self,
         ty: &TypeRef,
-        registry: &impl Conversions<()>,
+        registry: &impl Conversions,
         emit: &prebindgen_registry::Emit,
-    ) -> Option<ConverterImpl<()>> {
+    ) -> Option<ConverterImpl> {
         let key = ty.key();
         let decl = self.convert_decls.iter().find(|d| *d.key() == key)?;
         let spec = decl.input_spec().as_ref()?;
@@ -123,9 +123,9 @@ impl CbindgenBuilder {
     pub(crate) fn out_custom(
         &self,
         ty: &TypeRef,
-        registry: &impl Conversions<()>,
+        registry: &impl Conversions,
         emit: &prebindgen_registry::Emit,
-    ) -> Option<ConverterImpl<()>> {
+    ) -> Option<ConverterImpl> {
         let key = ty.key();
         let decl = self.convert_decls.iter().find(|d| *d.key() == key)?;
         let spec = decl.output_spec().as_ref()?;
@@ -193,7 +193,7 @@ impl CbindgenBuilder {
         &self,
         decl: &ConvertDecl,
         spec: &ConvertSpec,
-        registry: &impl Conversions<()>,
+        registry: &impl Conversions,
         emit: &prebindgen_registry::Emit,
     ) -> (syn::Type, syn::Expr, bool) {
         let target = self.src_ty_of(&decl.rust_type().key());
@@ -240,7 +240,7 @@ impl CbindgenBuilder {
         &self,
         decl: &ConvertDecl,
         spec: &ConvertSpec,
-        registry: &impl Conversions<()>,
+        registry: &impl Conversions,
         emit: &prebindgen_registry::Emit,
     ) -> (syn::Type, syn::Expr, bool) {
         let target = self.src_ty_of(&decl.rust_type().key());
@@ -282,7 +282,7 @@ impl CbindgenBuilder {
     fn c_domain_niches(
         &self,
         decl: &ConvertDecl,
-        registry: &impl Conversions<()>,
+        registry: &impl Conversions,
         direction: Direction,
     ) -> Niches {
         let Some(domain) = decl.domain() else {
@@ -329,7 +329,7 @@ impl CbindgenBuilder {
         )
     }
 
-    fn conversion_fn_path(&self, registry: &impl Conversions<()>, ident: &syn::Ident) -> syn::Path {
+    fn conversion_fn_path(&self, registry: &impl Conversions, ident: &syn::Ident) -> syn::Path {
         let Some(mut module) = registry.origin_module(ident) else {
             return self.src_fn(ident);
         };

--- a/prebindgen-c/src/emit.rs
+++ b/prebindgen-c/src/emit.rs
@@ -6,7 +6,7 @@ impl CbindgenBuilder {
     /// Whether the generated layer hands `char*` data memory to C — a `String`
     /// return value, or a declared data struct that is produced as output and has
     /// a `String` field. When true, a `free_memory_function` must be declared.
-    pub(super) fn needs_free(&self, registry: &Registry<()>) -> bool {
+    pub(super) fn needs_free(&self, registry: &Registry) -> bool {
         let string_ty: syn::Type = syn::parse_quote!(String);
         // A `String` return hands out a `char*` — unless `String` is declared
         // `opaque_ptr` (then it crosses as `string_t *`, freed by `string_drop`).
@@ -65,7 +65,7 @@ impl CbindgenBuilder {
     /// path segment, and fetched the `syn::ItemEnum` to reach the same list.
     pub(super) fn enum_alternatives<'r>(
         &self,
-        registry: &'r Registry<()>,
+        registry: &'r Registry,
         key: &TypeKey,
     ) -> Option<&'r [prebindgen_registry::flat::Alternative]> {
         match registry.flat().declared_type(&key.ident()?)? {
@@ -284,7 +284,7 @@ impl CbindgenBuilder {
         &self,
         fty: &TypeRef,
         wire: &syn::Type,
-        registry: &Registry<()>,
+        registry: &Registry,
     ) -> bool {
         if matches!(wire, syn::Type::Ptr(_)) {
             return true;
@@ -297,7 +297,7 @@ impl CbindgenBuilder {
     pub(super) fn owning_data_struct_fields<'r>(
         &self,
         fty: &TypeRef,
-        registry: &'r Registry<()>,
+        registry: &'r Registry,
     ) -> Vec<(syn::Ident, &'r TypeRef)> {
         if !self.data.contains_key(&fty.key()) {
             return Vec::new();
@@ -313,7 +313,7 @@ impl CbindgenBuilder {
     /// is a pointer (`String` → `char *`), or it is a declared
     /// [`CbindgenBuilder::tagged_union`] with an owning arm — which crosses by value,
     /// so the pointer it owns is one level further down.
-    fn data_field_owns(&self, fty: &TypeRef, registry: &Registry<()>) -> bool {
+    fn data_field_owns(&self, fty: &TypeRef, registry: &Registry) -> bool {
         if matches!(self.data_field_wire(fty), Some(syn::Type::Ptr(_))) {
             return true;
         }
@@ -328,7 +328,7 @@ impl CbindgenBuilder {
     /// containing struct has to call it, so a union nested inside a payload
     /// cannot be freed through a symbol that was never emitted. `false` for
     /// anything that is not a declared tagged union.
-    pub(super) fn tagged_union_has_drop(&self, fty: &TypeRef, registry: &Registry<()>) -> bool {
+    pub(super) fn tagged_union_has_drop(&self, fty: &TypeRef, registry: &Registry) -> bool {
         if !self.tagged_unions.contains_key(&fty.key()) || self.out_frag(fty).is_none() {
             return false;
         }
@@ -352,7 +352,7 @@ impl CbindgenBuilder {
     /// it crosses as. [`sequence_elem`](prebindgen_registry::flat::TypeRef::sequence_elem)
     /// answers all three, which is why the two spellings this used to test
     /// separately need no arms of their own.
-    pub(super) fn produces_array(&self, registry: &Registry<()>) -> bool {
+    pub(super) fn produces_array(&self, registry: &Registry) -> bool {
         self.functions.keys().any(|orig| {
             registry
                 .flat()
@@ -369,7 +369,7 @@ impl CbindgenBuilder {
     /// struct.
     pub(super) fn struct_fields<'r>(
         &self,
-        registry: &'r impl Conversions<()>,
+        registry: &'r impl Conversions,
         key: &TypeKey,
     ) -> Option<Vec<(syn::Ident, &'r TypeRef)>> {
         // The element, not its item. A `Struct` holds the field list the
@@ -449,7 +449,7 @@ impl CbindgenBuilder {
     /// declaration order. Empty ⇒ the whole mirror is safe to reinterpret.
     pub(super) fn restricted_validity_fields(
         &self,
-        registry: &Registry<()>,
+        registry: &Registry,
         key: &TypeKey,
     ) -> Vec<(syn::Ident, &'static str)> {
         self.struct_fields(registry, key)
@@ -481,7 +481,7 @@ impl CbindgenBuilder {
     pub(super) fn emit_function_wrapper(
         &self,
         f: &prebindgen_registry::flat::Function,
-        registry: &Registry<()>,
+        registry: &Registry,
         emit: &prebindgen_registry::Emit,
     ) -> TokenStream {
         let orig = &f.name;
@@ -702,7 +702,7 @@ impl CbindgenBuilder {
     /// available for enclosing `Option`/`Result` layers. Mirrors the
     /// niche-stacking model in `core::niches`.
     #[allow(clippy::only_used_in_recursion)]
-    pub(super) fn lower_shape(&self, ty: &TypeRef, registry: &impl Conversions<()>) -> ValueShape {
+    pub(super) fn lower_shape(&self, ty: &TypeRef, registry: &impl Conversions) -> ValueShape {
         if matches!(ty.kind(), TypeKind::Unit) {
             return ValueShape {
                 fields: vec![],
@@ -838,7 +838,7 @@ impl CbindgenBuilder {
         ty: &TypeRef,
         val: TokenStream,
         targets: &[TokenStream],
-        registry: &impl Conversions<()>,
+        registry: &impl Conversions,
         route: &ErrRoute,
     ) -> TokenStream {
         if matches!(ty.kind(), TypeKind::Unit) {
@@ -1086,7 +1086,7 @@ impl CbindgenBuilder {
         &self,
         orig: &syn::Ident,
         f: &prebindgen_registry::flat::Function,
-        registry: &Registry<()>,
+        registry: &Registry,
         route: &ErrRoute,
         emit: &prebindgen_registry::Emit,
     ) -> (Vec<TokenStream>, Vec<TokenStream>, Vec<TokenStream>) {

--- a/prebindgen-c/src/lib.rs
+++ b/prebindgen-c/src/lib.rs
@@ -334,7 +334,7 @@ impl AliasAccess {
 /// emission over a complete registry.
 pub struct Cbindgen {
     pub(crate) gen: CbindgenBuilder,
-    pub(crate) registry: prebindgen_registry::Registry<()>,
+    pub(crate) registry: prebindgen_registry::Registry,
 }
 
 // Opaque — exists so `Result<Cbindgen, _>::expect_err` works in tests.
@@ -365,7 +365,7 @@ impl Cbindgen {
     }
 
     /// The resolved registry — conversions, decompositions, and the model.
-    pub fn registry(&self) -> &prebindgen_registry::Registry<()> {
+    pub fn registry(&self) -> &prebindgen_registry::Registry {
         &self.registry
     }
 
@@ -524,7 +524,7 @@ fn type_short(key: &TypeKey) -> String {
 /// `enum_shape` over a `syn::ItemEnum` to re-derive what the first had thrown
 /// away.
 fn payload_enum<'r>(
-    registry: &'r impl Conversions<()>,
+    registry: &'r impl Conversions,
     key: &TypeKey,
 ) -> Option<&'r prebindgen_registry::flat::Variant> {
     match registry.flat().declared_type(&key.ident()?)? {
@@ -551,7 +551,7 @@ fn payload_enum<'r>(
 /// was `enum_item` + `assert_unit_enum`, the second running `enum_shape` over a
 /// `syn::ItemEnum` to re-derive what the first had already thrown away.
 fn unit_enum<'r>(
-    registry: &'r impl Conversions<()>,
+    registry: &'r impl Conversions,
     key: &TypeKey,
 ) -> Option<&'r prebindgen_registry::flat::Enum> {
     match registry.flat().declared_type(&key.ident()?)? {

--- a/prebindgen-c/src/test_util.rs
+++ b/prebindgen-c/src/test_util.rs
@@ -15,9 +15,7 @@ use prebindgen_registry::{Registry, RegistryBuilder};
 ///
 /// Test-only sugar: the two steps are one line each in a build script, but they
 /// appear in dozens of fixtures here.
-pub(crate) fn reg_from_items<M, I>(
-    items: I,
-) -> Result<RegistryBuilder<M>, prebindgen_registry::ScanError>
+pub(crate) fn reg_from_items<I>(items: I) -> Result<RegistryBuilder, prebindgen_registry::ScanError>
 where
     I: IntoIterator<Item = (syn::Item, prebindgen::SourceLocation)>,
 {

--- a/prebindgen-c/src/tests/lowering.rs
+++ b/prebindgen-c/src/tests/lowering.rs
@@ -152,8 +152,7 @@ fn custom_conversion_without_domain_stays_infallible() {
 #[test]
 fn empty_adapter_writes_empty_file() {
     let cbindgen = CbindgenBuilder::new();
-    let registry: RegistryBuilder<()> =
-        crate::test_util::reg_from_items(Vec::new()).expect("empty");
+    let registry: RegistryBuilder = crate::test_util::reg_from_items(Vec::new()).expect("empty");
     let src = write(cbindgen, registry, "empty");
     assert!(src.trim().is_empty(), "expected empty output, got:\n{src}");
 }

--- a/prebindgen-c/src/tests/mod.rs
+++ b/prebindgen-c/src/tests/mod.rs
@@ -17,7 +17,7 @@ mod rows;
 mod structs;
 mod tagged_unions;
 
-fn write(cbindgen: CbindgenBuilder, registry: RegistryBuilder<()>, tag: &str) -> String {
+fn write(cbindgen: CbindgenBuilder, registry: RegistryBuilder, tag: &str) -> String {
     let dir = unique_test_dir(&format!("cbindgen_{tag}"));
     std::fs::create_dir_all(&dir).unwrap();
     let out = dir.join(format!("{tag}.rs"));

--- a/prebindgen-c/src/trait_impl.rs
+++ b/prebindgen-c/src/trait_impl.rs
@@ -41,7 +41,7 @@ impl CbindgenBuilder {
 impl CbindgenBuilder {
     /// Opaque handle, by-value consume: `*Box::from_raw(v)` — fallible (null
     /// handle → message). The wire is the bare handle pointer `*mut #c_struct`.
-    pub(crate) fn in_opaque_handle(&self, ty: &TypeRef) -> Option<ConverterImpl<()>> {
+    pub(crate) fn in_opaque_handle(&self, ty: &TypeRef) -> Option<ConverterImpl> {
         let key = ty.key();
         if !self.opaque.contains_key(&key) {
             return None;
@@ -82,7 +82,7 @@ impl CbindgenBuilder {
     /// invalid `Box`) forces the full `gravestone()` write.
     fn nullable_owned_ptr_fields(
         &self,
-        registry: &impl Conversions<()>,
+        registry: &impl Conversions,
         key: &TypeKey,
     ) -> Option<Vec<syn::Ident>> {
         let cfg = self.value_opaque.get(key)?;
@@ -112,7 +112,7 @@ impl CbindgenBuilder {
     /// declared `kind` (its fields are an opaque blob the generator can't introspect).
     fn value_opaque_writeback(
         &self,
-        registry: &impl Conversions<()>,
+        registry: &impl Conversions,
         key: &TypeKey,
         slot: &syn::Ident,
     ) -> Option<TokenStream> {
@@ -145,7 +145,7 @@ impl CbindgenBuilder {
     /// has a bare `Box<T>` owned-pointer field (a null `Box` is invalid). Nullable
     /// (`Option<Box<T>>`) mirrors null in place and need no `Gravestone`/`Default`;
     /// non-mirror owned types get their `Gravestone` impl from the consumer.
-    fn mirror_needs_gravestone_impl(&self, registry: &Registry<()>, key: &TypeKey) -> bool {
+    fn mirror_needs_gravestone_impl(&self, registry: &Registry, key: &TypeKey) -> bool {
         match self.value_opaque.get(key) {
             Some(cfg) if cfg.generate_mirror => {
                 self.nullable_owned_ptr_fields(registry, key).is_none()
@@ -174,8 +174,8 @@ impl CbindgenBuilder {
     pub(crate) fn in_value_opaque(
         &self,
         ty: &TypeRef,
-        registry: &impl Conversions<()>,
-    ) -> Option<ConverterImpl<()>> {
+        registry: &impl Conversions,
+    ) -> Option<ConverterImpl> {
         let opaque = self.value_opaque_ty_of(&ty.key())?.clone();
         let name = Self::in_name_of(&ty.key());
         let src = self.src_ty_of(&ty.key());
@@ -230,11 +230,7 @@ impl CbindgenBuilder {
     /// no generator-side evaluation. An unmatched value is a binding error
     /// through the wrapper's error channel; no Rust enum is ever constructed
     /// from it.
-    pub(crate) fn in_enum(
-        &self,
-        ty: &TypeRef,
-        r: &impl Conversions<()>,
-    ) -> Option<ConverterImpl<()>> {
+    pub(crate) fn in_enum(&self, ty: &TypeRef, r: &impl Conversions) -> Option<ConverterImpl> {
         let key = ty.key();
         if !self.enums.contains_key(&key) {
             return None;
@@ -290,7 +286,7 @@ impl CbindgenBuilder {
     }
 
     /// `String` input: `*const c_char` → owned `String` — fallible.
-    pub(crate) fn in_string(&self, ty: &TypeRef) -> Option<ConverterImpl<()>> {
+    pub(crate) fn in_string(&self, ty: &TypeRef) -> Option<ConverterImpl> {
         if !r_is_string(ty) {
             return None;
         }
@@ -329,7 +325,7 @@ impl CbindgenBuilder {
 
     /// Bare `str` never crosses the C ABI directly, but resolving `&str`
     /// inputs requires its inner node to have a filled rank-0 cell.
-    pub(crate) fn in_str(&self, ty: &TypeRef) -> Option<ConverterImpl<()>> {
+    pub(crate) fn in_str(&self, ty: &TypeRef) -> Option<ConverterImpl> {
         if !r_is_str(ty) {
             return None;
         }
@@ -354,7 +350,7 @@ impl CbindgenBuilder {
     /// Rust `bool` may hold, so it crosses as [`bool_wire`] and is normalised
     /// by [`bool_in_expr`] before a `bool` exists. The C prototype is
     /// unchanged — cbindgen simplifies `MaybeUninit<T>` to `T`.
-    pub(crate) fn in_bool(&self, ty: &TypeRef) -> Option<ConverterImpl<()>> {
+    pub(crate) fn in_bool(&self, ty: &TypeRef) -> Option<ConverterImpl> {
         if !r_is_bool(ty) {
             return None;
         }
@@ -398,9 +394,9 @@ impl CbindgenBuilder {
         &'v self,
         compiler: &mut prebindgen_registry::recipe::Compiler<
             '_,
-            crate::compile::CCompile<'v, Registry<()>>,
+            crate::compile::CCompile<'v, Registry>,
         >,
-        registry: &'v Registry<()>,
+        registry: &'v Registry,
     ) -> Result<(), String> {
         use prebindgen_registry::recipe::{Assembly, Crossing, Role, Site};
 
@@ -461,7 +457,7 @@ impl CbindgenBuilder {
     pub(crate) fn union_arm_name(
         &self,
         key: &TypeKey,
-        registry: &impl Conversions<()>,
+        registry: &impl Conversions,
         parts: &[(
             prebindgen_registry::recipe::Part<'_>,
             &crate::compile::CFrag,
@@ -492,7 +488,7 @@ impl CbindgenBuilder {
     /// back after being dropped arrives here NULL — and is reported, never
     /// materialised. An `Option<Box<T>>` reads NULL as `None` instead, which is
     /// the representation it has room for.
-    pub(crate) fn in_boxed_payload(&self, fty: &TypeRef) -> Option<ConverterImpl<()>> {
+    pub(crate) fn in_boxed_payload(&self, fty: &TypeRef) -> Option<ConverterImpl> {
         let name = format_ident!("{}_payload", Self::in_name_of(&fty.key()));
         let optional = fty.optional_inner().is_some();
         let (wire, src_inner, owned, short) =
@@ -563,7 +559,7 @@ impl CbindgenBuilder {
 
     /// The peer of [`Self::in_boxed_payload`]: an owned value the C side must
     /// later release, boxed here rather than having arrived boxed.
-    pub(crate) fn out_boxed_payload(&self, fty: &TypeRef) -> Option<ConverterImpl<()>> {
+    pub(crate) fn out_boxed_payload(&self, fty: &TypeRef) -> Option<ConverterImpl> {
         let name = format_ident!("{}_payload", Self::out_name_of(&fty.key()));
         let optional = fty.optional_inner().is_some();
         let src = self.src_ty_of(&fty.key());
@@ -622,7 +618,7 @@ impl CbindgenBuilder {
     /// Lossy on invalid UTF-8 for the same reason. This is the reading the
     /// hand-written field walk had; stating it as a row is what makes it
     /// visible rather than buried.
-    pub(crate) fn in_string_field(&self, ty: &TypeRef) -> Option<ConverterImpl<()>> {
+    pub(crate) fn in_string_field(&self, ty: &TypeRef) -> Option<ConverterImpl> {
         if !r_is_string(ty) {
             return None;
         }
@@ -657,7 +653,7 @@ impl CbindgenBuilder {
     /// `bool` **return** is always already one of two values and crosses as
     /// itself, while a field shares one mirror with the decode that has to
     /// normalise it.
-    pub(crate) fn out_bool_field(&self, ty: &TypeRef) -> Option<ConverterImpl<()>> {
+    pub(crate) fn out_bool_field(&self, ty: &TypeRef) -> Option<ConverterImpl> {
         if !r_is_bool(ty) {
             return None;
         }
@@ -682,7 +678,7 @@ impl CbindgenBuilder {
 
     /// FFI-safe scalar (integers, floats): identity pass-through. `bool` is
     /// claimed earlier by [`Self::in_bool`] and never reaches here.
-    pub(crate) fn in_scalar(&self, ty: &TypeRef) -> Option<ConverterImpl<()>> {
+    pub(crate) fn in_scalar(&self, ty: &TypeRef) -> Option<ConverterImpl> {
         if !r_is_scalar(ty) || r_is_bool(ty) {
             return None;
         }
@@ -713,7 +709,7 @@ impl CbindgenBuilder {
     /// C allocator extern + raw C-string allocator + the universal memory freer.
     /// Emitted when the layer hands `char*`/array memory to C. Panics if such
     /// memory is produced but no `.free_memory_function` is declared.
-    fn prereq_alloc_free(&self, registry: &Registry<()>, produces_array: bool) -> Vec<syn::Item> {
+    fn prereq_alloc_free(&self, registry: &Registry, produces_array: bool) -> Vec<syn::Item> {
         let mut items: Vec<syn::Item> = Vec::new();
         if !(self.needs_free(registry) || produces_array) {
             return items;
@@ -793,7 +789,7 @@ impl CbindgenBuilder {
 
     /// Opaque handles: bare-pointer C type (`z_*_t*` = `Box::into_raw`) + typed
     /// `_drop`. The C type is an opaque/incomplete struct.
-    fn prereq_opaque_handles(&self, registry: &Registry<()>) -> Vec<syn::Item> {
+    fn prereq_opaque_handles(&self, registry: &Registry) -> Vec<syn::Item> {
         let mut items: Vec<syn::Item> = Vec::new();
         for (key, _cfg) in sorted_by_key(&self.opaque) {
             // Keyed directly: this used to spell the key into tokens purely so
@@ -832,7 +828,7 @@ impl CbindgenBuilder {
     /// Data structs: `#[repr(C)]` mirror only. Heap (`String`) fields are
     /// `char*` raw blocks the C user releases individually via the
     /// `free_memory_function` — no per-struct destructor.
-    fn prereq_data_structs(&self, registry: &Registry<()>) -> Vec<syn::Item> {
+    fn prereq_data_structs(&self, registry: &Registry) -> Vec<syn::Item> {
         let mut items: Vec<syn::Item> = Vec::new();
         for (key, _cfg) in sorted_by_key(&self.data) {
             let Some(reading) = registry.reading(key) else {
@@ -873,7 +869,7 @@ impl CbindgenBuilder {
     /// the fail-closed size+align equality asserts and the typed `_drop` (drops
     /// the live Rust value in place; NULL/gravestone ⇒ no-op), plus a `_take`
     /// for types delivered as takeable callback params.
-    fn prereq_value_opaque(&self, registry: &Registry<()>) -> Vec<syn::Item> {
+    fn prereq_value_opaque(&self, registry: &Registry) -> Vec<syn::Item> {
         let mut items: Vec<syn::Item> = Vec::new();
         let takeable_keys = self.takeable_type_keys();
         let mut vo: Vec<(&TypeKey, &ValueOpaqueCfg)> = self.value_opaque.iter().collect();
@@ -1080,7 +1076,7 @@ impl CbindgenBuilder {
     /// need from it — a number versus a spelling.
     fn prereq_enums(
         &self,
-        registry: &Registry<()>,
+        registry: &Registry,
         emit: &prebindgen_registry::Emit,
     ) -> Vec<syn::Item> {
         let mut items: Vec<syn::Item> = Vec::new();
@@ -1130,7 +1126,7 @@ impl CbindgenBuilder {
     /// and gets no drop.
     fn prereq_tagged_unions(
         &self,
-        registry: &Registry<()>,
+        registry: &Registry,
         emit: &prebindgen_registry::Emit,
     ) -> Vec<syn::Item> {
         let mut items: Vec<syn::Item> = Vec::new();
@@ -1272,7 +1268,7 @@ impl CbindgenBuilder {
         &self,
         fty: &TypeRef,
         binding: &syn::Ident,
-        registry: &Registry<()>,
+        registry: &Registry,
     ) -> TokenStream {
         if r_is_string(fty) {
             return quote!(
@@ -1369,7 +1365,7 @@ impl CbindgenBuilder {
     /// resolved). `call` takes each arg's output wire (the owned handle the
     /// C callback must drop) plus the `void *context`; `drop` releases the
     /// context. Deterministic order by emitted name.
-    fn prereq_callback_structs(&self, registry: &Registry<()>) -> Vec<syn::Item> {
+    fn prereq_callback_structs(&self, registry: &Registry) -> Vec<syn::Item> {
         let mut items: Vec<syn::Item> = Vec::new();
         // The declaration's own argument types. `CallbackKey` is a list of
         // identities — what the map is keyed by — and the arguments it was
@@ -1501,7 +1497,7 @@ impl CbindgenBuilder {
     /// [`Self::build`] over a registry described elsewhere — the test seam.
     pub(crate) fn build_with(
         mut self,
-        registry: prebindgen_registry::RegistryBuilder<()>,
+        registry: prebindgen_registry::RegistryBuilder,
     ) -> Result<Cbindgen, prebindgen_registry::WriteRustError> {
         let declared = self.declare_into(registry)?.validate_with(&self)?;
         // A second holding of the model: `convert_with` consumes the builder,
@@ -1541,7 +1537,10 @@ impl CbindgenBuilder {
                 );
                 let conv = self.compile_crossing(&mut compiler, crossing, built);
                 *self.compiled.borrow_mut() = compiler.finish();
-                conv
+                // The conversion stays here; what the registry gets back is
+                // which other crossings this one delegates to, which is what
+                // its reachability walk needs.
+                conv.map(|c| prebindgen_registry::Answer::over(c.subs))
             })?
             .build()?;
         // Every site of every exported function, compiled. Nothing consumes
@@ -1583,12 +1582,12 @@ impl CbindgenBuilder {
     /// `None` records a gap, exactly as the chain of guesses this replaced did:
     /// whether the gap matters is the registry's call, and its report names the
     /// crossing.
-    fn compile_crossing<'v, R: Conversions<()>>(
+    fn compile_crossing<'v, R: Conversions>(
         &'v self,
         compiler: &mut prebindgen_registry::recipe::Compiler<'_, crate::compile::CCompile<'v, R>>,
         crossing: &Crossing,
         built: &'v R,
-    ) -> Option<ConverterImpl<()>> {
+    ) -> Option<ConverterImpl> {
         let (dir, key) = crossing;
         // The reading the scan already took for this crossing, fetched by the
         // key the crossing IS.
@@ -1608,8 +1607,8 @@ impl CbindgenBuilder {
 
     pub fn declare_into(
         &self,
-        mut registry: RegistryBuilder<()>,
-    ) -> Result<RegistryBuilder<()>, prebindgen_registry::ScanError> {
+        mut registry: RegistryBuilder,
+    ) -> Result<RegistryBuilder, prebindgen_registry::ScanError> {
         for (item_fn, origin) in self.collect_local_functions() {
             registry = registry.local_function(item_fn, origin)?;
         }
@@ -1630,8 +1629,8 @@ impl CbindgenBuilder {
     pub(crate) fn dispatch_fn_input(
         &self,
         args: &[TypeRef],
-        registry: &impl Conversions<()>,
-    ) -> Option<ConverterImpl<()>> {
+        registry: &impl Conversions,
+    ) -> Option<ConverterImpl> {
         let key: CallbackKey = args.iter().map(|a| a.key()).collect();
         if !self.callbacks.contains_key(&key) {
             // Undeclared callback signature: leave unresolved so the registry
@@ -1848,7 +1847,7 @@ impl Prebindgen for CbindgenBuilder {
     ///
     /// `consts: None` — cbindgen has no const declaration mechanism, so every
     /// captured const is re-emitted verbatim and none is ever a skip.
-    fn validate(&self, binding: &Building<'_, Self::Metadata>) -> Result<(), String> {
+    fn validate(&self, binding: &Building<'_>) -> Result<(), String> {
         let mut functions = self.declared_functions();
         functions.extend(self.helper_functions());
         prebindgen_registry::warn_unclaimed(
@@ -1868,8 +1867,6 @@ impl Prebindgen for CbindgenBuilder {
         Ok(())
     }
 
-    type Metadata = ();
-
     // Consts have no declaration mechanism here (`declared_consts` stays
     // `None`), so every indexed const re-emits through the default
     // `on_const` — a path-alias against this source module, keeping consts
@@ -1887,7 +1884,7 @@ impl Prebindgen for CbindgenBuilder {
 
     fn prerequisites(
         &self,
-        registry: &Registry<()>,
+        registry: &Registry,
         emit: &prebindgen_registry::Emit,
     ) -> Vec<syn::Item> {
         // C-string data memory (string returns + `String` fields of data structs)
@@ -1915,7 +1912,7 @@ impl Prebindgen for CbindgenBuilder {
     fn on_function(
         &self,
         f: &prebindgen_registry::flat::Function,
-        registry: &Registry<()>,
+        registry: &Registry,
         emit: &prebindgen_registry::Emit,
     ) -> TokenStream {
         self.emit_function_wrapper(f, registry, emit)
@@ -1924,7 +1921,7 @@ impl Prebindgen for CbindgenBuilder {
     fn on_struct(
         &self,
         _s: &prebindgen_registry::flat::Struct,
-        _registry: &Registry<()>,
+        _registry: &Registry,
         _emit: &prebindgen_registry::Emit,
     ) -> TokenStream {
         // The `#[repr(C)]` mirror + converters come from prerequisites /
@@ -1935,7 +1932,7 @@ impl Prebindgen for CbindgenBuilder {
     fn on_variant(
         &self,
         _v: &prebindgen_registry::flat::Variant,
-        _registry: &Registry<()>,
+        _registry: &Registry,
         _emit: &prebindgen_registry::Emit,
     ) -> TokenStream {
         TokenStream::new()
@@ -1944,7 +1941,7 @@ impl Prebindgen for CbindgenBuilder {
     fn on_enum(
         &self,
         _e: &prebindgen_registry::flat::Enum,
-        _registry: &Registry<()>,
+        _registry: &Registry,
         _emit: &prebindgen_registry::Emit,
     ) -> TokenStream {
         TokenStream::new()
@@ -1957,9 +1954,9 @@ impl CbindgenBuilder {
     pub(crate) fn out_terminal(
         &self,
         ty: &TypeRef,
-        _r: &impl Conversions<()>,
+        _r: &impl Conversions,
         _emit: &prebindgen_registry::Emit,
-    ) -> Option<ConverterImpl<()>> {
+    ) -> Option<ConverterImpl> {
         // Unit return: trivial converter so `()` (and `Result<(), _>`) resolves.
         // Never actually called — void-returning wrappers ignore it, and
         // `emit_fallible_wrapper` special-cases `Result<(), E>` to drop the
@@ -2134,7 +2131,7 @@ impl CbindgenBuilder {
         &self,
         inner: &TypeRef,
         entry: &crate::compile::CFrag,
-    ) -> Option<ConverterImpl<()>> {
+    ) -> Option<ConverterImpl> {
         {
             let inner_wire = entry.destination.clone();
             let inner_conv = entry.function.sig.ident.clone();
@@ -2253,7 +2250,7 @@ impl CbindgenBuilder {
 
     /// `&[E]` slice **input**: marker only — the two-param (`*const E_wire`,
     /// `usize`) lowering is done structurally in `emit_inputs`.
-    pub(crate) fn in_slice(&self, ty: &TypeRef) -> Option<ConverterImpl<()>> {
+    pub(crate) fn in_slice(&self, ty: &TypeRef) -> Option<ConverterImpl> {
         let e = r_shared_slice_elem(ty)?;
         // #170, the slice instance. The two-param lowering builds the
         // `&[E]` zero-copy from C's own block, so there is nowhere to
@@ -2294,7 +2291,7 @@ impl CbindgenBuilder {
 
     /// `&str`, `&mut T` and `&T` **input** shapes: a borrow reached through the
     /// pointer the C caller supplied.
-    pub(crate) fn in_borrow(&self, ty: &TypeRef) -> Option<ConverterImpl<()>> {
+    pub(crate) fn in_borrow(&self, ty: &TypeRef) -> Option<ConverterImpl> {
         // `mutable` off the `Ref` itself, NOT `is_exclusive_borrow`: that
         // reading deliberately answers `false` for `&mut MaybeUninit<_>` — an
         // out-param slot is not an exclusive borrow OF A VALUE — and these arms
@@ -2450,7 +2447,7 @@ impl CbindgenBuilder {
     /// Carries a `()` destination: the real lowering is structural in
     /// `emit_function_wrapper`, and this exists so the shape resolves and its
     /// inner is marked reachable.
-    pub(crate) fn out_arity_marker(&self, kind: &str, inner: &TypeRef) -> ConverterImpl<()> {
+    pub(crate) fn out_arity_marker(&self, kind: &str, inner: &TypeRef) -> ConverterImpl {
         let name = format_ident!("__cbg_outmark_{}_{}", kind, sanitize(&inner.key()));
         let function: syn::ItemFn = syn::parse_quote!(
             #[allow(non_snake_case, dead_code, unused)]
@@ -2472,7 +2469,7 @@ impl CbindgenBuilder {
     /// `call` parameter is structural in `prereq_callback_structs` /
     /// `dispatch_fn_input`; `subs: [E]` forces E's output so the closure wire
     /// element type exists.
-    pub(crate) fn out_slice_marker(&self, ty: &TypeRef) -> Option<ConverterImpl<()>> {
+    pub(crate) fn out_slice_marker(&self, ty: &TypeRef) -> Option<ConverterImpl> {
         let elem = self
             .r_value_opaque_slice_elem(ty)
             .or_else(|| r_scalar_slice_elem(ty))?;
@@ -2493,7 +2490,7 @@ impl CbindgenBuilder {
 
     /// The `&T` shared borrow and the `Result<T, E>` marker — the two **output**
     /// shapes that are neither terminal nor a run.
-    pub(crate) fn out_borrow_or_result(&self, ty: &TypeRef) -> Option<ConverterImpl<()>> {
+    pub(crate) fn out_borrow_or_result(&self, ty: &TypeRef) -> Option<ConverterImpl> {
         // `&T` shared borrow of an opaque/value-opaque type → non-owning `*const`.
         if let TypeKind::Ref { mutable, inner, .. } = ty.kind() {
             if !*mutable {

--- a/prebindgen-jni/src/jni/builder.rs
+++ b/prebindgen-jni/src/jni/builder.rs
@@ -83,11 +83,7 @@ impl Declarations {
     /// stream's `SourceLocation` stamp (multi-source bindings — helper
     /// crates layered on the flat crate), else the registry's default
     /// module (first-seen stream origin), else `crate`.
-    pub(crate) fn fn_module(
-        &self,
-        registry: &impl Conversions<KotlinMeta>,
-        ident: &syn::Ident,
-    ) -> syn::Path {
+    pub(crate) fn fn_module(&self, registry: &impl Conversions, ident: &syn::Ident) -> syn::Path {
         registry
             .origin_module(ident)
             .or_else(|| registry.default_module())
@@ -97,7 +93,7 @@ impl Declarations {
     /// The module for source references with no per-item origin (declared
     /// types with no `#[prebindgen]` item, glob imports): the registry's
     /// default module (first source), `crate` for an origin-less registry.
-    pub(crate) fn default_module(&self, registry: &Registry<KotlinMeta>) -> syn::Path {
+    pub(crate) fn default_module(&self, registry: &Registry) -> syn::Path {
         registry
             .default_module()
             .unwrap_or_else(|| syn::parse_quote!(crate))
@@ -845,7 +841,7 @@ impl Declarations {
     /// once, on the member), else the camel-cased Rust name.
     fn lower_fields(
         &self,
-        registry: &impl Conversions<KotlinMeta>,
+        registry: &impl Conversions,
         key: &TypeKey,
         fields: &[LocalField],
     ) -> Vec<prebindgen_registry::unfold::DeconRecord> {
@@ -902,7 +898,7 @@ impl Declarations {
     /// a field renamed upstream must not silently lose its adjustment.
     fn lower_value_form(
         &self,
-        registry: &impl Conversions<KotlinMeta>,
+        registry: &impl Conversions,
         key: &TypeKey,
         decl: &FieldsDecl,
     ) -> Vec<prebindgen_registry::unfold::FieldRecord> {
@@ -980,7 +976,7 @@ impl Declarations {
     #[allow(clippy::too_many_arguments)]
     fn walk_value_form(
         &self,
-        registry: &impl Conversions<KotlinMeta>,
+        registry: &impl Conversions,
         key: &TypeKey,
         decl: &FieldsDecl,
         st: &flat::Struct,
@@ -1157,7 +1153,7 @@ impl Declarations {
     /// output-flattened.
     pub(crate) fn build_deconstructors(
         &self,
-        registry: &impl Conversions<KotlinMeta>,
+        registry: &impl Conversions,
     ) -> prebindgen_registry::unfold::Deconstructors {
         use prebindgen_registry::unfold::{
             DeconSel, DeconTarget, DeconstructorDecl, Deconstructors, Delivery, OutputDecl,
@@ -1496,7 +1492,7 @@ impl Declarations {
     pub(crate) fn convert_input_body(
         &self,
         key: &TypeKey,
-        registry: &impl Conversions<KotlinMeta>,
+        registry: &impl Conversions,
         emit: &prebindgen_registry::Emit,
     ) -> Option<(syn::Type, Option<syn::Type>, syn::Expr)> {
         let decl = self.convert_decls.iter().find(|d| d.key() == key)?;
@@ -1567,7 +1563,7 @@ impl Declarations {
     pub(crate) fn convert_output_body(
         &self,
         key: &TypeKey,
-        registry: &impl Conversions<KotlinMeta>,
+        registry: &impl Conversions,
         emit: &prebindgen_registry::Emit,
     ) -> Option<(syn::Type, Option<syn::Type>, syn::Expr)> {
         let decl = self.convert_decls.iter().find(|d| d.key() == key)?;
@@ -1781,7 +1777,7 @@ impl Declarations {
     fn conversion_domain_niches(
         &self,
         key: &TypeKey,
-        registry: &impl Conversions<KotlinMeta>,
+        registry: &impl Conversions,
         direction: Direction,
         wire: &syn::Type,
     ) -> (Niches, Vec<String>) {
@@ -1887,7 +1883,7 @@ impl Declarations {
     pub(crate) fn convert_target(
         &self,
         key: &TypeKey,
-        registry: &impl Conversions<KotlinMeta>,
+        registry: &impl Conversions,
         dir: Direction,
     ) -> Option<syn::Type> {
         let decl = self.convert_decls.iter().find(|d| d.key() == key)?;
@@ -1914,7 +1910,7 @@ impl Declarations {
     pub(crate) fn lookup_input(
         &self,
         outer: &prebindgen_registry::flat::TypeRef,
-        registry: &impl Conversions<KotlinMeta>,
+        registry: &impl Conversions,
         emit: &prebindgen_registry::Emit,
     ) -> Option<ConverterImpl<KotlinMeta>> {
         // A `convert!`-declared conversion is the only thing that answers here.
@@ -2025,7 +2021,7 @@ impl Declarations {
     pub(crate) fn lookup_output(
         &self,
         outer: &prebindgen_registry::flat::TypeRef,
-        registry: &impl Conversions<KotlinMeta>,
+        registry: &impl Conversions,
         emit: &prebindgen_registry::Emit,
     ) -> Option<ConverterImpl<KotlinMeta>> {
         let key = outer.key();
@@ -2045,7 +2041,7 @@ impl Declarations {
         outer: &prebindgen_registry::flat::TypeRef,
         ok: &syn::Type,
         err: &syn::Type,
-        registry: &impl Conversions<KotlinMeta>,
+        registry: &impl Conversions,
         emit: &prebindgen_registry::Emit,
     ) -> Option<ConverterImpl<KotlinMeta>> {
         self.build_output_converter(
@@ -2072,7 +2068,7 @@ impl Declarations {
         ty: syn::Type,
         exc_ty: Option<syn::Type>,
         body: syn::Expr,
-        registry: &impl Conversions<KotlinMeta>,
+        registry: &impl Conversions,
         emit: &prebindgen_registry::Emit,
     ) -> Option<ConverterImpl<KotlinMeta>> {
         let key = outer.key();

--- a/prebindgen-jni/src/jni/classify.rs
+++ b/prebindgen-jni/src/jni/classify.rs
@@ -54,7 +54,7 @@ impl Declarations {
     /// wrapper folding is the resolver's business, not this table's.
     pub(crate) fn type_kind<'r, 'c>(
         &'c self,
-        registry: &'r impl Conversions<KotlinMeta>,
+        registry: &'r impl Conversions,
         bare: &TypeKey,
     ) -> TypeKind<'r, 'c> {
         let cfg = self.types.get(bare);

--- a/prebindgen-jni/src/jni/compile.rs
+++ b/prebindgen-jni/src/jni/compile.rs
@@ -108,7 +108,7 @@ fn refuse(at: At<'_>, why: &str) -> String {
     format!("JniGen: {} ({why})", at.crossing.key())
 }
 
-impl<R: Conversions<KotlinMeta>> JCompile<'_, R> {
+impl<R: Conversions> JCompile<'_, R> {
     fn wrap(&self, at: At<'_>, why: &str, conv: Option<ConverterImpl<KotlinMeta>>) -> Frag<Self> {
         conv.map(|c| JFrag::new(at, c))
             .ok_or_else(|| refuse(at, why))
@@ -171,7 +171,7 @@ impl<R: Conversions<KotlinMeta>> JCompile<'_, R> {
     }
 }
 
-impl<R: Conversions<KotlinMeta>> Compile for JCompile<'_, R> {
+impl<R: Conversions> Compile for JCompile<'_, R> {
     type Fragment = JFrag;
     /// JniGen keeps its own per-site emission for now: the exported signature,
     /// the call and the cleanup are built from the resolved registry.

--- a/prebindgen-jni/src/jni/emit/callback.rs
+++ b/prebindgen-jni/src/jni/emit/callback.rs
@@ -23,7 +23,7 @@ use super::*;
 pub(crate) fn callback_input(
     ext: &Declarations,
     args: &[prebindgen_registry::flat::TypeRef],
-    registry: &impl Conversions<KotlinMeta>,
+    registry: &impl Conversions,
     emit: &prebindgen_registry::Emit,
 ) -> Option<(syn::Type, syn::Expr)> {
     // Human-readable tag for attach/log messages.

--- a/prebindgen-jni/src/jni/emit/convert.rs
+++ b/prebindgen-jni/src/jni/emit/convert.rs
@@ -410,7 +410,7 @@ pub(crate) fn default_niches_for_wire(wire: &syn::Type) -> Niches {
 /// `use` statements. Pairs with output body below.
 pub(crate) fn enum_input_body(
     ext: &Declarations,
-    registry: &impl Conversions<KotlinMeta>,
+    registry: &impl Conversions,
     e: &prebindgen_registry::flat::Enum,
 ) -> (syn::Type, syn::Expr) {
     let ident = &e.name;

--- a/prebindgen-jni/src/jni/emit/delivery.rs
+++ b/prebindgen-jni/src/jni/emit/delivery.rs
@@ -32,7 +32,7 @@ use super::*;
 /// [`UnfoldShape::Optional`]: prebindgen_registry::unfold::UnfoldShape::Optional
 pub(crate) fn emit_unfold_delivery(
     ext: &Declarations,
-    registry: &Registry<KotlinMeta>,
+    registry: &Registry,
     plan: &prebindgen_registry::unfold::UnfoldPlan,
     iface: Option<&IfaceSpec>,
     call_expr: &TokenStream,
@@ -859,7 +859,7 @@ fn reach_leaf(
 /// `signal_error` with default ze values).
 pub(crate) fn encode_plan_leaves(
     ext: &Declarations,
-    registry: &impl Conversions<KotlinMeta>,
+    registry: &impl Conversions,
     plan: &prebindgen_registry::unfold::UnfoldPlan,
     obj_idents: &[syn::Ident],
     value: &TokenStream,

--- a/prebindgen-jni/src/jni/emit/flat_input.rs
+++ b/prebindgen-jni/src/jni/emit/flat_input.rs
@@ -19,7 +19,7 @@ use crate::jni::trait_impl::{build_through_erased_wrappers, build_through_wrappe
 pub(crate) fn struct_input_body(
     ext: &Declarations,
     s: &flat::Struct,
-    registry: &impl Conversions<KotlinMeta>,
+    registry: &impl Conversions,
     emit: &prebindgen_registry::Emit,
 ) -> Option<(syn::Type, syn::Expr)> {
     let struct_name = s.name.to_string();
@@ -321,7 +321,7 @@ pub(crate) fn struct_input_body(
 pub(crate) fn sum_input_body(
     ext: &Declarations,
     v: &flat::Variant,
-    registry: &impl Conversions<KotlinMeta>,
+    registry: &impl Conversions,
     emit: &prebindgen_registry::Emit,
 ) -> Option<(syn::Type, syn::Expr)> {
     let key = TypeKey::from_ident(&v.name);
@@ -598,7 +598,7 @@ fn read_kotlin_property(
 ///
 /// The mirror of [`ConvChain::call`](super::super::struct_plan::ConvChain) on
 /// the output side, and of the structural wrappers' own chain composition:
-/// stopping at [`TypeEntry::converter_ident`] would bind the *representation*
+/// stopping at [`ConverterImpl::converter_ident`] would bind the *representation*
 /// (`u64`) where the Rust value (`Duration`) is required, which does not
 /// compile.
 ///
@@ -1047,7 +1047,7 @@ fn wire_kotlin_type(entry: &prebindgen_registry::ConverterImpl<KotlinMeta>) -> S
 #[allow(clippy::too_many_arguments)]
 fn build_flat_sum_field(
     ext: &Declarations,
-    registry: &Registry<KotlinMeta>,
+    registry: &Registry,
     sum_reading: &TypeRef,
     field: syn::Ident,
     optional: bool,
@@ -1303,7 +1303,7 @@ fn push_handle_leaf(
 /// plan or a validation error — never a silent object fallback.
 pub(crate) fn build_flat_input_plan(
     ext: &Declarations,
-    registry: &Registry<KotlinMeta>,
+    registry: &Registry,
     param_name: &syn::Ident,
     arg: &TypeRef,
 ) -> Result<Option<FlatInputPlan>, FlatInputError> {
@@ -1412,7 +1412,7 @@ pub(crate) fn build_flat_input_plan(
 /// before the rebuild did.
 fn build_flat_struct_node(
     ext: &Declarations,
-    registry: &Registry<KotlinMeta>,
+    registry: &Registry,
     st: &flat::Struct,
     optional: bool,
     native_prefix: &str,

--- a/prebindgen-jni/src/jni/emit/struct_out.rs
+++ b/prebindgen-jni/src/jni/emit/struct_out.rs
@@ -83,7 +83,7 @@ pub(crate) fn primitive_default_for_descriptor(sig: &str) -> TokenStream {
 /// output converter table (not yet built at this stage).
 pub(crate) fn synth_value_struct_leaves(
     ext: &Declarations,
-    registry: &impl Conversions<KotlinMeta>,
+    registry: &impl Conversions,
     s: &prebindgen_registry::flat::Struct,
     path_prefix: &[prebindgen_registry::unfold::PathStep],
     name_prefix: &str,
@@ -174,7 +174,7 @@ pub(crate) fn synth_value_struct_leaves(
 /// order and JVM descriptors agree by construction.
 pub(crate) fn flatten_struct_encode(
     ext: &Declarations,
-    registry: &impl Conversions<KotlinMeta>,
+    registry: &impl Conversions,
     s: &prebindgen_registry::flat::Struct,
     access: &TokenStream,
     prefix: &str,
@@ -591,7 +591,7 @@ fn encode_field(
 pub(crate) fn struct_output_body(
     ext: &Declarations,
     s: &prebindgen_registry::flat::Struct,
-    registry: &impl Conversions<KotlinMeta>,
+    registry: &impl Conversions,
 ) -> Option<(syn::Type, syn::Expr)> {
     let struct_name = s.name.to_string();
     // Prefer the registered Kotlin FQN (`io.zenoh.jni.JniSample`) so the
@@ -652,7 +652,7 @@ pub(crate) fn struct_output_body(
 
 pub(crate) fn struct_module_path(
     ext: &Declarations,
-    registry: &impl Conversions<KotlinMeta>,
+    registry: &impl Conversions,
     name: &syn::Ident,
 ) -> syn::Path {
     // The module the struct is reachable under from the generated file: its

--- a/prebindgen-jni/src/jni/emit/sum_out.rs
+++ b/prebindgen-jni/src/jni/emit/sum_out.rs
@@ -164,7 +164,7 @@ pub(crate) fn is_sum_leaves(leaves: &[prebindgen_registry::unfold::UnfoldLeaf]) 
 /// every arm and only one arm computes it.
 pub(crate) fn encode_sum_group(
     ext: &Declarations,
-    registry: &impl Conversions<KotlinMeta>,
+    registry: &impl Conversions,
     leaves: &[prebindgen_registry::unfold::UnfoldLeaf],
     obj_idents: &[syn::Ident],
     matched: TokenStream,

--- a/prebindgen-jni/src/jni/emit/vec_build.rs
+++ b/prebindgen-jni/src/jni/emit/vec_build.rs
@@ -53,7 +53,7 @@ pub(crate) struct VecBuildElem {
 /// four sites agree on which params take the handle path.
 pub(crate) fn vec_build_elem(
     ext: &Declarations,
-    registry: &Registry<KotlinMeta>,
+    registry: &Registry,
     arg: &TypeRef,
 ) -> Option<VecBuildElem> {
     // The run and its element off the MODEL. `&mut [T]` is still refused —
@@ -182,7 +182,7 @@ pub(crate) fn vec_build_elem(
 /// the name `payloadVec` (#296).
 pub(crate) fn collect_vec_build_elem_types(
     ext: &Declarations,
-    registry: &Registry<KotlinMeta>,
+    registry: &Registry,
 ) -> Vec<TypeRef> {
     let declared = ext.declared_functions();
     let mut seen: std::collections::BTreeMap<String, TypeRef> = std::collections::BTreeMap::new();
@@ -217,7 +217,7 @@ pub(crate) struct VecBuildHelpers {
 /// the generated methods read naturally (`Payload` → `payloadVec`).
 pub(crate) fn vec_build_helpers(
     ext: &Declarations,
-    registry: &Registry<KotlinMeta>,
+    registry: &Registry,
     elem: &TypeRef,
 ) -> Option<VecBuildHelpers> {
     let plan = build_flat_input_plan(ext, registry, &format_ident!("e"), elem)
@@ -282,7 +282,7 @@ fn vec_helper_symbol(ext: &Declarations, base: &str, suffix: &str) -> String {
 /// push loop free of a per-element failure check.
 pub(crate) fn build_vec_build_helper_items(
     ext: &Declarations,
-    registry: &Registry<KotlinMeta>,
+    registry: &Registry,
     emit: &prebindgen_registry::Emit,
 ) -> Vec<syn::Item> {
     let mut named: Vec<(String, syn::Item)> = Vec::new();

--- a/prebindgen-jni/src/jni/emit/wrapper.rs
+++ b/prebindgen-jni/src/jni/emit/wrapper.rs
@@ -11,7 +11,7 @@ use crate::jni::trait_impl::{
 pub(crate) fn emit_jni_function_wrapper(
     ext: &Declarations,
     f: &prebindgen_registry::flat::Function,
-    registry: &Registry<KotlinMeta>,
+    registry: &Registry,
     emit: &prebindgen_registry::Emit,
 ) -> TokenStream {
     emit_jni_function_wrapper_with_callee(ext, f, registry, None, emit)
@@ -128,7 +128,7 @@ pub(crate) fn validate_constant_fn(ext: &Declarations, f: &prebindgen_registry::
 pub(crate) fn const_expr_getter_fn(
     kotlin_name: &str,
     ty: &syn::Type,
-    registry: &impl Conversions<KotlinMeta>,
+    registry: &impl Conversions,
 ) -> prebindgen_registry::flat::Function {
     let ident = format_ident!("const_get_{}", kotlin_name.to_lowercase());
     // The one lookup this path needs: the type is named by a build script, so
@@ -182,7 +182,7 @@ pub(crate) fn validate_constant_expr(ext: &Declarations, kotlin_name: &str, ty: 
 pub(crate) fn emit_jni_function_wrapper_with_callee(
     ext: &Declarations,
     f: &prebindgen_registry::flat::Function,
-    registry: &Registry<KotlinMeta>,
+    registry: &Registry,
     callee: Option<syn::Expr>,
     emit: &prebindgen_registry::Emit,
 ) -> TokenStream {
@@ -520,7 +520,7 @@ fn unfold_builder_param(iterable_fold: bool) -> TokenStream {
 #[allow(clippy::type_complexity)]
 fn emit_input_param(
     ext: &Declarations,
-    registry: &Registry<KotlinMeta>,
+    registry: &Registry,
     original_ident: &syn::Ident,
     param: &PlanParam,
     on_err: &TokenStream,
@@ -877,7 +877,7 @@ fn emit_plain_decode(
 /// argument is the built value (`&value` when the original parameter was `&T`).
 pub(crate) fn emit_expanded_param(
     ext: &Declarations,
-    registry: &Registry<KotlinMeta>,
+    registry: &Registry,
     plan: &prebindgen_registry::expand::FoldPlan,
     leaves: &[PlanLeaf],
     orig_param: &syn::Ident,

--- a/prebindgen-jni/src/jni/fn_plan.rs
+++ b/prebindgen-jni/src/jni/fn_plan.rs
@@ -352,10 +352,7 @@ impl PlanError {
 /// missing.
 ///
 /// [`Prebindgen::validate_resolved`]: prebindgen_registry::Prebindgen::validate_resolved
-pub(crate) fn validate_bindings(
-    ext: &Declarations,
-    registry: &Registry<KotlinMeta>,
-) -> Result<(), String> {
+pub(crate) fn validate_bindings(ext: &Declarations, registry: &Registry) -> Result<(), String> {
     let mut errors: Vec<String> = Vec::new();
 
     if let Err(e) = ext.validate_split_declarations(registry) {
@@ -471,7 +468,7 @@ impl Declarations {
     /// regen check (a plan change alters generated code).
     pub(crate) fn fn_plan(
         &self,
-        registry: &Registry<KotlinMeta>,
+        registry: &Registry,
         f: &prebindgen_registry::flat::Function,
     ) -> Result<std::rc::Rc<JniFunctionPlan>, PlanError> {
         if let Some(hit) = self.fn_plans.borrow().get(&f.name).cloned() {
@@ -491,7 +488,7 @@ impl JniFunctionPlan {
     /// built ONCE per function and shared; this is the underlying derivation.
     pub fn build(
         ext: &Declarations,
-        registry: &Registry<KotlinMeta>,
+        registry: &Registry,
         f: &prebindgen_registry::flat::Function,
     ) -> Result<Self, PlanError> {
         let jni_method = ext.mangle_jni_method(&kt_snake_to_camel(&f.name.to_string()));
@@ -556,7 +553,7 @@ impl JniFunctionPlan {
     fn jvm_parameter_slots(
         &self,
         ext: &Declarations,
-        registry: &Registry<KotlinMeta>,
+        registry: &Registry,
         f: &prebindgen_registry::flat::Function,
     ) -> usize {
         // `JNINative` is a Kotlin object, so its external methods are instance
@@ -607,7 +604,7 @@ fn kotlin_jvm_slots(ty: &str) -> usize {
 /// expansions and reuse the same Rust/Kotlin lowering as ordinary parameters.
 fn classify_leaf(
     ext: &Declarations,
-    registry: &Registry<KotlinMeta>,
+    registry: &Registry,
     ident: &syn::Ident,
     reading: &TypeRef,
     expanded: bool,
@@ -719,7 +716,7 @@ fn classify_leaf(
 /// (render_extern_decl's `ret_decl` reconstruction).
 fn build_output(
     ext: &Declarations,
-    registry: &Registry<KotlinMeta>,
+    registry: &Registry,
     f: &prebindgen_registry::flat::Function,
 ) -> Result<FnOutputPlan, PlanError> {
     use prebindgen_registry::unfold::{Delivery, UnfoldShape};

--- a/prebindgen-jni/src/jni/fold.rs
+++ b/prebindgen-jni/src/jni/fold.rs
@@ -190,7 +190,7 @@ pub(crate) type StructFactory = (Vec<(String, KtType)>, String, bool);
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn flatten_struct_factory(
     ext: &Declarations,
-    registry: &Registry<KotlinMeta>,
+    registry: &Registry,
     s: &prebindgen_registry::flat::Struct,
     prefix: &str,
     class_name: &str,

--- a/prebindgen-jni/src/jni/iface.rs
+++ b/prebindgen-jni/src/jni/iface.rs
@@ -180,7 +180,7 @@ impl IfaceParam {
     pub fn conversion(
         &self,
         ext: &crate::jni::Declarations,
-        registry: &impl Conversions<KotlinMeta>,
+        registry: &impl Conversions,
         imports: &mut std::collections::BTreeSet<String>,
     ) -> String {
         // A key the registry no longer knows is not a layer question — it is a
@@ -577,7 +577,7 @@ impl IfaceSpec {
     pub fn to_as_raw_fun(
         &self,
         ext: &crate::jni::Declarations,
-        registry: &impl Conversions<KotlinMeta>,
+        registry: &impl Conversions,
         imports: &mut std::collections::BTreeSet<String>,
     ) -> KtFun {
         let bare_generics: Vec<String> = self
@@ -1169,9 +1169,7 @@ impl SpecKey {
 /// so it is computed per `DeconId` over all plans, shared by the memo
 /// derivation ([`SpecKey::Folder`]'s typed groups) and the declaration
 /// emitter (the hoisted `fromParts`/appender singletons).
-pub(crate) fn fixed_decon_ids(
-    registry: &impl Conversions<KotlinMeta>,
-) -> std::collections::HashSet<DeconId> {
+pub(crate) fn fixed_decon_ids(registry: &impl Conversions) -> std::collections::HashSet<DeconId> {
     let fixed: std::collections::HashSet<DeconId> = registry
         .unfold_plans()
         .values()
@@ -1207,9 +1205,7 @@ pub(crate) fn fixed_decon_ids(
 /// Element type keys whose whole-element fold is fixed (a synthesized
 /// single-leaf `Vec<T>` fold) — the leaf dual of [`fixed_decon_ids`], used
 /// by the declaration emitter for the hoisted appender singleton.
-pub(crate) fn fixed_leaf_element_keys(
-    registry: &Registry<KotlinMeta>,
-) -> std::collections::HashSet<TypeKey> {
+pub(crate) fn fixed_leaf_element_keys(registry: &Registry) -> std::collections::HashSet<TypeKey> {
     registry
         .unfold_plans()
         .values()
@@ -1228,7 +1224,7 @@ pub(crate) fn fixed_leaf_element_keys(
 /// typed-group view in per `DeconId` (see [`fixed_decon_ids`]).
 fn derive_iface_spec(
     ext: &Declarations,
-    registry: &impl Conversions<KotlinMeta>,
+    registry: &impl Conversions,
     key: &SpecKey,
 ) -> Option<IfaceSpec> {
     match key {
@@ -1281,7 +1277,7 @@ impl Declarations {
     /// instead of shipping descriptor drift.
     pub(crate) fn iface_spec(
         &self,
-        registry: &impl Conversions<KotlinMeta>,
+        registry: &impl Conversions,
         key: &SpecKey,
     ) -> Option<std::sync::Arc<IfaceSpec>> {
         let hit = self.iface_specs.borrow().get(key).cloned();
@@ -1316,7 +1312,7 @@ impl Declarations {
 /// `when` over the tag that a sum-typed struct field gets.
 fn fixed_reassembly(
     ext: &Declarations,
-    registry: &impl Conversions<KotlinMeta>,
+    registry: &impl Conversions,
     source: &TypeKey,
     leaves: &[prebindgen_registry::unfold::UnfoldLeaf],
     class_fqn: &str,
@@ -1341,7 +1337,7 @@ fn fixed_reassembly(
 /// placed in the first arg type's package (root for `Fn()`).
 pub(crate) fn callback_iface_spec(
     ext: &Declarations,
-    registry: &impl Conversions<KotlinMeta>,
+    registry: &impl Conversions,
     cb_args: &[prebindgen_registry::flat::TypeRef],
 ) -> Option<IfaceSpec> {
     // Per-arg grouping over the flat raw leaves. A **fixed-builder** (by-value
@@ -1587,7 +1583,7 @@ pub(crate) fn callback_iface_spec(
 /// type's package.
 pub(crate) fn builder_iface_spec(
     ext: &Declarations,
-    registry: &impl Conversions<KotlinMeta>,
+    registry: &impl Conversions,
     decon: &DeconId,
 ) -> Option<IfaceSpec> {
     let spec = registry.decon_plans().get(decon)?;
@@ -1613,7 +1609,7 @@ pub(crate) fn builder_iface_spec(
 /// placed in the element type's package.
 pub(crate) fn folder_iface_spec(
     ext: &Declarations,
-    registry: &impl Conversions<KotlinMeta>,
+    registry: &impl Conversions,
     decon: &DeconId,
 ) -> Option<IfaceSpec> {
     let spec = registry.decon_plans().get(decon)?;
@@ -1671,7 +1667,7 @@ pub(crate) fn whole_folder_iface_spec(
 /// against), not per this plan's own `fixed_builder` flag.
 pub(crate) fn folder_iface_for_plan(
     ext: &Declarations,
-    registry: &impl Conversions<KotlinMeta>,
+    registry: &impl Conversions,
     plan: &UnfoldPlan,
 ) -> Option<std::sync::Arc<IfaceSpec>> {
     debug_assert!(
@@ -1696,7 +1692,7 @@ pub(crate) fn folder_iface_for_plan(
 /// two stay in lockstep.
 pub(crate) fn fixed_folder_typed_groups(
     ext: &Declarations,
-    registry: &impl Conversions<KotlinMeta>,
+    registry: &impl Conversions,
     decon: &DeconId,
 ) -> Option<Vec<TypedGroup>> {
     let spec = registry.decon_plans().get(decon)?;
@@ -1746,7 +1742,7 @@ pub(crate) fn fixed_folder_typed_groups(
 /// `<decl-base>Handler`, placed in the error type's package.
 pub(crate) fn error_handler_iface_spec(
     ext: &Declarations,
-    registry: &impl Conversions<KotlinMeta>,
+    registry: &impl Conversions,
     decon: &DeconId,
 ) -> Option<IfaceSpec> {
     let spec = registry.decon_plans().get(decon)?;
@@ -1828,7 +1824,7 @@ pub(crate) struct ErrorIfaces {
 /// alone always derives.
 pub(crate) fn onerror_iface_spec(
     ext: &Declarations,
-    registry: &Registry<KotlinMeta>,
+    registry: &Registry,
     fn_ident: &syn::Ident,
 ) -> Option<ErrorIfaces> {
     let binding = ext.iface_spec(registry, &SpecKey::JniErrorHandler)?;

--- a/prebindgen-jni/src/jni/kotlin_emit.rs
+++ b/prebindgen-jni/src/jni/kotlin_emit.rs
@@ -82,7 +82,7 @@ impl Declarations {
     /// was resolved first.
     pub(crate) fn write_kotlin(
         &self,
-        registry: &Registry<KotlinMeta>,
+        registry: &Registry,
         kotlin_root: &Path,
     ) -> Result<Vec<PathBuf>, WriteKotlinError> {
         // Validation already ran once in `RegistryBuilder::build` — this emitter
@@ -536,7 +536,7 @@ impl Declarations {
     /// uniform.
     pub(crate) fn write_enum_classes(
         &self,
-        registry: &Registry<KotlinMeta>,
+        registry: &Registry,
     ) -> Result<Vec<KtFile>, WriteKotlinError> {
         let mut written = Vec::new();
         // Deterministic order by canonical Rust type-key.
@@ -595,7 +595,7 @@ impl Declarations {
     /// and each declarator rejects the other's.
     pub(crate) fn write_sealed_classes(
         &self,
-        registry: &Registry<KotlinMeta>,
+        registry: &Registry,
     ) -> Result<Vec<KtFile>, WriteKotlinError> {
         let mut written = Vec::new();
         // Deterministic order by canonical Rust type-key.
@@ -667,7 +667,7 @@ impl Declarations {
     /// identically.
     fn build_sealed_class(
         &self,
-        registry: &Registry<KotlinMeta>,
+        registry: &Registry,
         class_name: &str,
         sum: &prebindgen_registry::flat::Variant,
         sum_cfg: &SumConfig,
@@ -997,7 +997,7 @@ impl Declarations {
     /// types, so wrappers and data-class declarations stay in sync. A
     /// compatibility-alias fragment is appended when any data class is
     /// renamed relative to its Rust ident.
-    pub(crate) fn write_data_classes(&self, registry: &Registry<KotlinMeta>) -> Vec<KtFile> {
+    pub(crate) fn write_data_classes(&self, registry: &Registry) -> Vec<KtFile> {
         let mut written = Vec::new();
         let mut aliases: Vec<(String, String)> = Vec::new();
         let mut keys: Vec<&TypeKey> = self.types.keys().collect();
@@ -1136,7 +1136,7 @@ impl Declarations {
     /// from the declaration's representative plan (`registry.decon_plans`) —
     /// the same source the native emitters read, so all sites agree by
     /// construction (no dedup, no signature reconciliation).
-    pub(crate) fn write_callback_ifaces(&self, registry: &Registry<KotlinMeta>) -> Vec<KtFile> {
+    pub(crate) fn write_callback_ifaces(&self, registry: &Registry) -> Vec<KtFile> {
         use prebindgen_registry::unfold::{DeconId, Delivery};
 
         // Distinct interface identities in use — [`SpecKey`] (`Ord`, so
@@ -1362,7 +1362,7 @@ impl Declarations {
     /// positionally with `fromParts`.
     fn value_struct_builder_singleton(
         &self,
-        registry: &Registry<KotlinMeta>,
+        registry: &Registry,
         spec: &crate::jni::IfaceSpec,
         decon: &prebindgen_registry::unfold::DeconId,
     ) -> KtDecl {
@@ -1409,7 +1409,7 @@ impl Declarations {
     /// `[acc, leaf0, …]`; `fromParts` takes the element leaves (all but `acc`).
     fn value_struct_folder_singleton(
         &self,
-        registry: &Registry<KotlinMeta>,
+        registry: &Registry,
         spec: &crate::jni::IfaceSpec,
         decon: &prebindgen_registry::unfold::DeconId,
     ) -> KtDecl {
@@ -1469,7 +1469,7 @@ impl Declarations {
     /// `factory_field`, so it is emitted here directly.
     fn sum_builder_singleton(
         &self,
-        registry: &Registry<KotlinMeta>,
+        registry: &Registry,
         spec: &crate::jni::IfaceSpec,
         decon: &prebindgen_registry::unfold::DeconId,
     ) -> KtDecl {
@@ -1512,7 +1512,7 @@ impl Declarations {
     /// `[acc, tag, group-slots…]`, so the reassembly reads all but `acc`.
     fn sum_folder_singleton(
         &self,
-        registry: &Registry<KotlinMeta>,
+        registry: &Registry,
         spec: &crate::jni::IfaceSpec,
         decon: &prebindgen_registry::unfold::DeconId,
     ) -> KtDecl {
@@ -1560,7 +1560,7 @@ impl Declarations {
     /// its variant-constructor argument by [`Self::sum_ctor_arg`].
     pub(crate) fn sum_reconstruct(
         &self,
-        registry: &impl Conversions<KotlinMeta>,
+        registry: &impl Conversions,
         // The sum's **identity**: every use of `source` here was
         // `TypeKey::from_type` or `bare_path_ident`, and a key that is one
         // identifier IS the ident — the same reduction `type_kind` made.
@@ -1785,7 +1785,7 @@ impl Declarations {
 
     pub(crate) fn write_jni_package(
         &self,
-        registry: &Registry<KotlinMeta>,
+        registry: &Registry,
         subpackage: &str,
         pkg_cfg: &crate::jni::PackageConfig,
     ) -> KtFile {
@@ -1900,7 +1900,7 @@ impl Declarations {
     /// inside an `init { … }` block here (e.g. a reference to the consumer's
     /// own loader object). Unset, the holder stays free of any loading logic
     /// and the wrapper layer is responsible for loading.
-    pub(crate) fn write_jni_native(&self, registry: &Registry<KotlinMeta>) -> KtFile {
+    pub(crate) fn write_jni_native(&self, registry: &Registry) -> KtFile {
         let class_name = self.jni_native_class_name();
         let declared = self.declared_functions();
 
@@ -2044,7 +2044,7 @@ impl Declarations {
     /// promoted method's signature).
     pub(crate) fn write_typed_handles(
         &self,
-        registry: &Registry<KotlinMeta>,
+        registry: &Registry,
         handles: &[TypedHandle<'_>],
     ) -> Vec<KtFile> {
         let mut written = Vec::new();

--- a/prebindgen-jni/src/jni/metadata.rs
+++ b/prebindgen-jni/src/jni/metadata.rs
@@ -1,4 +1,4 @@
-//! JNI adapter metadata propagated through `TypeEntry`.
+//! JNI adapter metadata, carried on this adapter's own conversions.
 
 use kotlin_codegen::KtType;
 
@@ -82,10 +82,10 @@ pub struct Projection {
 
 /// Per-converter language-specific extras carried by every converter this
 /// adapter produces. Filled by the same handler that builds the wire/body,
-/// propagated by the resolver into
-/// [`prebindgen_registry::TypeEntry::metadata`], and read directly by
-/// the Kotlin emitter — so cross-language facts flow through the existing
-/// wrapper machinery rather than a parallel side channel.
+/// carried in [`prebindgen_registry::ConverterImpl::metadata`], and read
+/// directly by the Kotlin emitter off the fragment that conversion belongs to
+/// — so cross-language facts flow through the existing wrapper machinery
+/// rather than a parallel side channel.
 #[derive(Clone, Debug, Default)]
 pub struct KotlinMeta {
     /// Value-context Kotlin type, structured ([`KtType`]). `Long` for

--- a/prebindgen-jni/src/jni/mod.rs
+++ b/prebindgen-jni/src/jni/mod.rs
@@ -448,7 +448,7 @@ pub struct JniGen {
     /// would be a comment rather than a type.
     decls: Declarations,
     /// Every crossing this binding needs, each with its conversion.
-    registry: prebindgen_registry::Registry<KotlinMeta>,
+    registry: prebindgen_registry::Registry,
 }
 
 // Opaque — exists so `Result<JniGen, _>::expect_err` works in tests.
@@ -484,7 +484,7 @@ impl JniGen {
     }
 
     /// The resolved registry — conversions, decompositions, and the model.
-    pub fn registry(&self) -> &prebindgen_registry::Registry<KotlinMeta> {
+    pub fn registry(&self) -> &prebindgen_registry::Registry {
         &self.registry
     }
 

--- a/prebindgen-jni/src/jni/overloads.rs
+++ b/prebindgen-jni/src/jni/overloads.rs
@@ -50,10 +50,7 @@ impl Declarations {
     /// artifact is written).
     ///
     /// [`validate_resolved`]: prebindgen_registry::Prebindgen::validate_resolved
-    pub(crate) fn validate_split_declarations(
-        &self,
-        registry: &Registry<KotlinMeta>,
-    ) -> Result<(), String> {
+    pub(crate) fn validate_split_declarations(&self, registry: &Registry) -> Result<(), String> {
         let type_level = self
             .param_expand_decls
             .iter()
@@ -113,7 +110,7 @@ impl Declarations {
 /// ambiguity check and the whole-artifact overload table agree on erasure.
 fn arm_erased_sig(
     ext: &Declarations,
-    registry: &Registry<KotlinMeta>,
+    registry: &Registry,
     target: &TypeKey,
     ctor: Option<&syn::Ident>,
 ) -> Vec<ErasedJvmType> {
@@ -246,7 +243,7 @@ fn non_null(mut ty: KtType) -> KtType {
 /// for an `Option<…>` parameter `null` encodes absence (nullable-arm rule).
 /// Returns `None` if any input is not a flat leaf.
 fn variant_typed_params(
-    registry: &impl Conversions<KotlinMeta>,
+    registry: &impl Conversions,
     variant: &prebindgen_registry::expand::FoldVariant,
     origin: &syn::Ident,
     block: &[KtParam],
@@ -315,7 +312,7 @@ fn find_block(params: &[KtParam], leaf_names: &[String]) -> Option<usize> {
 /// validating the parameter is expandable, multi-variant, and in-scope (all
 /// hard errors — the user explicitly asked to split it).
 fn resolve_split<'a>(
-    registry: &'a Registry<KotlinMeta>,
+    registry: &'a Registry,
     f: &prebindgen_registry::flat::Function,
     sel_fun: &KtFun,
     param_name: &str,
@@ -405,7 +402,7 @@ fn resolve_split<'a>(
 pub(crate) fn render_param_overloads(
     ext: &Declarations,
     f: &prebindgen_registry::flat::Function,
-    registry: &Registry<KotlinMeta>,
+    registry: &Registry,
     sel_fun: &KtFun,
 ) -> Vec<KtFun> {
     // Requested split params for this function, in signature order.

--- a/prebindgen-jni/src/jni/render.rs
+++ b/prebindgen-jni/src/jni/render.rs
@@ -88,7 +88,7 @@ pub(crate) fn build_data_class(
     ext: &Declarations,
     class_name: &str,
     item_struct: &prebindgen_registry::flat::Struct,
-    registry: &Registry<KotlinMeta>,
+    registry: &Registry,
 ) -> KtClass {
     // A tuple struct is an `Extern` in the model, never a `Struct`, so every
     // field here is named by construction.
@@ -279,7 +279,7 @@ pub(crate) fn build_data_class(
 /// extern on the Rust side (the auto-generated destructor).
 pub(crate) fn build_typed_handle(
     ext: &Declarations,
-    registry: &Registry<KotlinMeta>,
+    registry: &Registry,
     class_name: &str,
     rust_doc_name: &str,
     key: &TypeKey,
@@ -513,7 +513,7 @@ pub(crate) fn is_iterable_fold(shape: &prebindgen_registry::unfold::UnfoldShape)
 pub(crate) fn render_extern_decl(
     ext: &Declarations,
     f: &prebindgen_registry::flat::Function,
-    registry: &Registry<KotlinMeta>,
+    registry: &Registry,
 ) -> Option<KtFun> {
     // The name and wire params come straight off the lowered plan — the
     // same classification the Rust extern and the Kotlin call site consume,
@@ -828,7 +828,7 @@ fn nullable_recovery_type(declared: KtType, generics: &[String]) -> KtType {
 pub(crate) fn build_wrapper_surface(
     ext: &Declarations,
     f: &prebindgen_registry::flat::Function,
-    registry: &Registry<KotlinMeta>,
+    registry: &Registry,
     kotlin_name_override: Option<&str>,
     receiver_key: Option<&TypeKey>,
 ) -> Option<WrapperSurface> {
@@ -845,7 +845,7 @@ pub(crate) fn build_wrapper_surface(
 fn build_wrapper_surface_with_recovery(
     ext: &Declarations,
     f: &prebindgen_registry::flat::Function,
-    registry: &Registry<KotlinMeta>,
+    registry: &Registry,
     kotlin_name_override: Option<&str>,
     receiver_key: Option<&TypeKey>,
     recovery: RecoveryReturn,
@@ -922,7 +922,7 @@ fn build_wrapper_surface_with_recovery(
 pub(crate) fn render_wrapper_fn(
     ext: &Declarations,
     f: &prebindgen_registry::flat::Function,
-    registry: &Registry<KotlinMeta>,
+    registry: &Registry,
     kotlin_name_override: Option<&str>,
     receiver_key: Option<&TypeKey>,
 ) -> Option<KtFun> {
@@ -939,7 +939,7 @@ pub(crate) fn render_wrapper_fn(
 fn render_wrapper_fn_with_recovery(
     ext: &Declarations,
     f: &prebindgen_registry::flat::Function,
-    registry: &Registry<KotlinMeta>,
+    registry: &Registry,
     kotlin_name_override: Option<&str>,
     receiver_key: Option<&TypeKey>,
     recovery: RecoveryReturn,
@@ -1005,7 +1005,7 @@ pub(crate) fn render_const_val(
     ext: &Declarations,
     package: &str,
     c: &prebindgen_registry::flat::Constant,
-    registry: &Registry<KotlinMeta>,
+    registry: &Registry,
     imports: &mut BTreeSet<String>,
     kotlin_name_override: Option<&str>,
 ) -> Option<(KtFun, KtProperty)> {
@@ -1044,7 +1044,7 @@ pub(crate) fn render_constant_fn_val(
     ext: &Declarations,
     package: &str,
     f: &prebindgen_registry::flat::Function,
-    registry: &Registry<KotlinMeta>,
+    registry: &Registry,
     imports: &mut BTreeSet<String>,
     kotlin_name_override: Option<&str>,
 ) -> Option<(KtFun, KtProperty)> {
@@ -1082,7 +1082,7 @@ pub(crate) fn render_const_expr_val(
     ext: &Declarations,
     package: &str,
     decl: &crate::jni::decl::ConstExprDecl,
-    registry: &Registry<KotlinMeta>,
+    registry: &Registry,
     imports: &mut BTreeSet<String>,
 ) -> Option<(KtFun, KtProperty)> {
     let getter = const_expr_getter_fn(&decl.kotlin_name, &decl.ty, registry);
@@ -1120,7 +1120,7 @@ pub(crate) fn render_const_expr_val(
 /// not fire one JNI call per `val` at class-load (issue #58).
 fn render_val_over_helper(
     ext: &Declarations,
-    registry: &Registry<KotlinMeta>,
+    registry: &Registry,
     mut helper: KtFun,
     val_name: String,
     kdoc: String,
@@ -1211,7 +1211,7 @@ struct DomainSink {
 fn classify_params(
     ext: &Declarations,
     fplan: &JniFunctionPlan,
-    registry: &Registry<KotlinMeta>,
+    registry: &Registry,
     imports: &mut BTreeSet<String>,
     receiver_key: Option<&TypeKey>,
 ) -> Option<(Vec<Param>, Option<usize>)> {
@@ -1407,7 +1407,7 @@ fn classify_output(
     ext: &Declarations,
     f: &prebindgen_registry::flat::Function,
     fplan: &JniFunctionPlan,
-    registry: &Registry<KotlinMeta>,
+    registry: &Registry,
     imports: &mut BTreeSet<String>,
 ) -> Option<OutputPlan> {
     let unfold = registry.unfold_plans().get(&f.name);
@@ -1754,7 +1754,7 @@ fn collect_opaques(params: &[Param]) -> Vec<Opaque> {
 fn error_sink_parts(
     f: &prebindgen_registry::flat::Function,
     fplan: &JniFunctionPlan,
-    registry: &Registry<KotlinMeta>,
+    registry: &Registry,
     imports: &mut BTreeSet<String>,
     r_ty: &KtType,
 ) -> Option<ErrorSink> {
@@ -2361,10 +2361,7 @@ pub(crate) fn kt_param_name(rust_ident: &str) -> String {
 /// documenting the REAL prototype after all expansions — one note per
 /// position a plan reshaped, phrased for the caller. `None` for an
 /// undocumented, unshaped fn.
-fn wrapper_kdoc(
-    f: &prebindgen_registry::flat::Function,
-    registry: &Registry<KotlinMeta>,
-) -> Option<String> {
+fn wrapper_kdoc(f: &prebindgen_registry::flat::Function, registry: &Registry) -> Option<String> {
     let prose = f.docs();
     let notes = shape_notes(f, registry);
     match (prose, notes) {
@@ -2380,10 +2377,7 @@ fn wrapper_kdoc(
 /// returns (what the builder/fold receives), and error decompositions
 /// (what `onError` receives). Reads the same resolved plan maps the C7
 /// report uses.
-fn shape_notes(
-    f: &prebindgen_registry::flat::Function,
-    registry: &Registry<KotlinMeta>,
-) -> Option<String> {
+fn shape_notes(f: &prebindgen_registry::flat::Function, registry: &Registry) -> Option<String> {
     let fn_ident = &f.name;
     let mut notes: Vec<String> = Vec::new();
 
@@ -2470,7 +2464,7 @@ fn shape_notes(
 
 /// The `///` doc of the `#[prebindgen]` struct/enum behind a declared type
 /// key, when the item is indexed (a re-exported foreign type has none).
-pub(crate) fn source_item_doc<M>(registry: &Registry<M>, key: &TypeKey) -> Option<String> {
+pub(crate) fn source_item_doc(registry: &Registry, key: &TypeKey) -> Option<String> {
     // Whichever of the three shapes the name declares — the docs are the
     // element's answer, so there is no `attrs` slice to unify across them.
     match registry.flat().declared_type(&key.ident()?)? {

--- a/prebindgen-jni/src/jni/selector.rs
+++ b/prebindgen-jni/src/jni/selector.rs
@@ -126,7 +126,7 @@ impl Declarations {
     pub(crate) fn result_shape(
         &self,
         ty: &prebindgen_registry::flat::TypeRef,
-        registry: &impl Conversions<KotlinMeta>,
+        registry: &impl Conversions,
         emit: &prebindgen_registry::Emit,
     ) -> Option<ConverterImpl<KotlinMeta>> {
         let (ok, err) = fallible_parts(ty, emit)?;

--- a/prebindgen-jni/src/jni/struct_plan.rs
+++ b/prebindgen-jni/src/jni/struct_plan.rs
@@ -48,7 +48,7 @@ pub(crate) enum LeafForm {
 /// followed by the wire-facing converter (`u64 → jlong`).
 ///
 /// A leaf must carry the whole chain, not just
-/// [`TypeEntry::converter_ident`](prebindgen_registry::TypeEntry::converter_ident):
+/// [`converter_ident`](prebindgen_registry::ConverterImpl::converter_ident):
 /// calling only the wire-facing function would hand it the *semantic* value
 /// (a `Duration`) where it expects the *representation* (a `u64`), which does
 /// not compile. Structural wrappers (`Option<_>`, `Vec<_>`) already compose
@@ -186,7 +186,7 @@ pub(crate) struct SumPlanField {
 /// could silently diverge on such edge cases.
 pub(crate) fn build_struct_plan(
     ext: &Declarations,
-    registry: &impl Conversions<KotlinMeta>,
+    registry: &impl Conversions,
     s: &prebindgen_registry::flat::Struct,
     depth: usize,
 ) -> Option<StructPlan> {
@@ -250,7 +250,7 @@ fn kind_mints_handle(kind: &PlanFieldKind) -> bool {
 /// `Reading::Exact.v0`).
 pub(crate) fn classify_field(
     ext: &Declarations,
-    registry: &impl Conversions<KotlinMeta>,
+    registry: &impl Conversions,
     reading: &prebindgen_registry::flat::TypeRef,
     owner: &str,
     depth: usize,
@@ -626,7 +626,7 @@ fn whole_value_close(optional: bool, sequence: bool) -> FoldStrategy {
 /// leak direction — for a shape nobody can compile anyway.
 pub(crate) fn type_close_strategy(
     ext: &Declarations,
-    registry: &impl Conversions<KotlinMeta>,
+    registry: &impl Conversions,
     ty: &prebindgen_registry::flat::TypeRef,
     depth: usize,
 ) -> Option<FoldStrategy> {
@@ -697,7 +697,7 @@ pub(crate) fn type_close_strategy(
 /// was first attempted.
 fn sum_plan_kind(
     ext: &Declarations,
-    registry: &impl Conversions<KotlinMeta>,
+    registry: &impl Conversions,
     ty: &prebindgen_registry::flat::TypeRef,
     owner: &str,
     optional: bool,

--- a/prebindgen-jni/src/jni/symbols.rs
+++ b/prebindgen-jni/src/jni/symbols.rs
@@ -40,7 +40,7 @@ use super::*;
 ///   names colliding in one package, including a collision the mangler
 ///   created.
 /// * **Warnings** — where the default mangler sanitized a Rust-derived name.
-pub(crate) fn validate_symbols(ext: &Declarations, registry: &Registry<KotlinMeta>) -> Vec<String> {
+pub(crate) fn validate_symbols(ext: &Declarations, registry: &Registry) -> Vec<String> {
     let mut errors: Vec<String> = Vec::new();
     // (package, name) → origin, for top-level-unique Kotlin declarations.
     let mut top_level: BTreeMap<(String, String), String> = BTreeMap::new();
@@ -264,7 +264,7 @@ fn check_ident(name: &str, origin: &str, errors: &mut Vec<String>) {
 
 /// Emit a `cargo:warning` for each Rust struct field (data-class property) or
 /// enum variant whose Kotlin name the default mangler had to change.
-fn warn_derived_name_changes(ext: &Declarations, registry: &Registry<KotlinMeta>) {
+fn warn_derived_name_changes(ext: &Declarations, registry: &Registry) {
     let warn = |raw: &str, mangled: &str, what: &str, owner: &str| {
         if raw != mangled {
             println!(
@@ -318,7 +318,7 @@ fn warn_derived_name_changes(ext: &Declarations, registry: &Registry<KotlinMeta>
 /// `syn::ItemEnum`; the model states them as two elements, and both carry the
 /// names this asks for. `None` when `ident` names neither.
 fn declared_member_names(
-    registry: &impl prebindgen_registry::Conversions<KotlinMeta>,
+    registry: &impl prebindgen_registry::Conversions,
     ident: &syn::Ident,
 ) -> Option<Vec<syn::Ident>> {
     use prebindgen_registry::flat::Type;

--- a/prebindgen-jni/src/jni/tests/flatten.rs
+++ b/prebindgen-jni/src/jni/tests/flatten.rs
@@ -1403,7 +1403,7 @@ fn gc_managed_handle_lifecycle() {
 /// #52 shared fixture: a `ZSummary` ptr class, its `(count, total)` builder, a
 /// splittable 2-variant type-level `expand_param!`, and functions taking one or
 /// two `ZSummary` params. `extra` fns are appended before indexing.
-fn split_fixture(extra: &[&str]) -> RegistryBuilder<KotlinMeta> {
+fn split_fixture(extra: &[&str]) -> RegistryBuilder {
     let loc = myflat_loc();
     let base: &[&str] = &[
         "pub fn z_summary_new(count: i64, total: f64) -> ZSummary { unimplemented!() }",

--- a/prebindgen-jni/src/jni/tests/mod.rs
+++ b/prebindgen-jni/src/jni/tests/mod.rs
@@ -1,6 +1,5 @@
-// Only `entry` (below, gated off with the `niches` module) needs `TypeEntry`.
 pub(crate) use prebindgen::SourceLocation;
-use prebindgen_registry::TypeEntry;
+use prebindgen_registry::{Answer, ConverterImpl};
 use quote::ToTokens;
 
 use super::*;
@@ -37,10 +36,10 @@ mod symbols;
 mod value_form;
 mod values;
 
-/// Build a `TypeEntry` for use in tests. The function body is not
-/// inspected by `option_input` / `option_output`; only the ident,
-/// destination, and niches matter, so we use a stub `ItemFn`.
-fn entry(wire: syn::Type, conv_name: &str, niches: Niches) -> TypeEntry<KotlinMeta> {
+/// Build a conversion for use in tests. The function body is not inspected by
+/// `option_input` / `option_output`; only the ident, destination, and niches
+/// matter, so we use a stub `ItemFn`.
+fn entry(wire: syn::Type, conv_name: &str, niches: Niches) -> ConverterImpl<KotlinMeta> {
     let ident = syn::Ident::new(conv_name, proc_macro2::Span::call_site());
     let func: syn::ItemFn = syn::parse_quote!(
         unsafe fn #ident<'env, 'v>(
@@ -50,7 +49,7 @@ fn entry(wire: syn::Type, conv_name: &str, niches: Niches) -> TypeEntry<KotlinMe
             Ok(())
         }
     );
-    TypeEntry {
+    ConverterImpl {
         destination: wire,
         function: func,
         pre_stages: vec![],
@@ -66,11 +65,11 @@ fn entry(wire: syn::Type, conv_name: &str, niches: Niches) -> TypeEntry<KotlinMe
 /// find it: in the registry the test builds, and in `decls` as the fragment a
 /// compiled binding would have filed. Helpers under test read the second.
 fn install(
-    reg: &mut Registry<KotlinMeta>,
+    reg: &mut Registry,
     decls: &Declarations,
     direction: Direction,
     ty_str: &str,
-    e: TypeEntry<KotlinMeta>,
+    e: ConverterImpl<KotlinMeta>,
 ) {
     let ty: syn::Type = syn::parse_str(ty_str).expect("test type");
     let key = TypeKey::from_type(&ty);
@@ -82,25 +81,25 @@ fn install(
         key.clone(),
         assembly,
         prebindgen_registry::recipe::RecipeId::new("whole"),
-        crate::jni::compile::JFrag::by_hand(key, e.as_converter()),
+        crate::jni::compile::JFrag::by_hand(key, e.clone()),
     );
-    reg.insert_crossing(direction, &ty, true, Some(e));
+    reg.insert_crossing(direction, &ty, true, Some(Answer::over(e.subs)));
 }
 
 fn install_input(
-    reg: &mut Registry<KotlinMeta>,
+    reg: &mut Registry,
     decls: &Declarations,
     ty_str: &str,
-    e: TypeEntry<KotlinMeta>,
+    e: ConverterImpl<KotlinMeta>,
 ) {
     install(reg, decls, Direction::Input, ty_str, e);
 }
 
 fn install_output(
-    reg: &mut Registry<KotlinMeta>,
+    reg: &mut Registry,
     decls: &Declarations,
     ty_str: &str,
-    e: TypeEntry<KotlinMeta>,
+    e: ConverterImpl<KotlinMeta>,
 ) {
     install(reg, decls, Direction::Output, ty_str, e);
 }

--- a/prebindgen-jni/src/jni/tests/sealed.rs
+++ b/prebindgen-jni/src/jni/tests/sealed.rs
@@ -291,7 +291,7 @@ fn reopened_ptr_class_keeps_gc_managed() {
         )]
     };
     let gc_managed_of = |first: crate::PtrClassDecl, second: crate::PtrClassDecl| {
-        let registry: RegistryBuilder<KotlinMeta> =
+        let registry: RegistryBuilder =
             crate::test_util::reg_from_items(declare_referenced(items())).expect("index items");
         let jni = JniGenBuilder::new()
             .set_package_prefix("io.test.jni")
@@ -349,7 +349,7 @@ fn a_type_gets_one_class_declarator() {
         ]
     };
     let declare = |first: crate::ClassDecl, second: crate::ClassDecl| {
-        let registry: RegistryBuilder<KotlinMeta> =
+        let registry: RegistryBuilder =
             crate::test_util::reg_from_items(declare_referenced(items())).expect("index items");
         let _ = JniGenBuilder::new()
             .set_package_prefix("io.test.jni")

--- a/prebindgen-jni/src/jni/tests/symbols.rs
+++ b/prebindgen-jni/src/jni/tests/symbols.rs
@@ -11,11 +11,7 @@ use super::*;
 /// `validate_symbols`) now runs inside `resolve`, so an invalid binding fails
 /// here and no `JniGen` is produced (nothing can be written). On success,
 /// a real `write_rust` confirms the valid binding also emits.
-fn resolve_result(
-    tag: &str,
-    registry: RegistryBuilder<KotlinMeta>,
-    jni: JniGenBuilder,
-) -> Result<(), String> {
+fn resolve_result(tag: &str, registry: RegistryBuilder, jni: JniGenBuilder) -> Result<(), String> {
     match jni.build_with(registry) {
         Ok(gen) => {
             let dir = unique_test_dir(tag);
@@ -29,7 +25,7 @@ fn resolve_result(
     }
 }
 
-fn one_fn(src: &str) -> RegistryBuilder<KotlinMeta> {
+fn one_fn(src: &str) -> RegistryBuilder {
     let f: syn::ItemFn = syn::parse_str(src).unwrap();
     crate::test_util::reg_from_items(declare_referenced(vec![(syn::Item::Fn(f), myflat_loc())]))
         .expect("index")

--- a/prebindgen-jni/src/jni/trait_impl.rs
+++ b/prebindgen-jni/src/jni/trait_impl.rs
@@ -1820,13 +1820,6 @@ impl Declarations {
 }
 
 impl Prebindgen for Declarations {
-    /// Cross-language extras every JNI converter carries — currently the
-    /// Kotlin value-context type name. Filled by the rank-N handlers at the
-    /// same point they build the wire/body, carried in
-    /// [`prebindgen_registry::ConverterImpl::metadata`], and read back by the
-    /// Kotlin emitter to drive every wrapper / typed-handle / `JNIWrappers`
-    /// signature.
-
     // ── Structural type resolution ──────────────────────────────────────
     // Try the terminal categories, then the `Result` peel, then the built-in
     // wrapper shapes — peel

--- a/prebindgen-jni/src/jni/trait_impl.rs
+++ b/prebindgen-jni/src/jni/trait_impl.rs
@@ -422,7 +422,7 @@ impl Declarations {
 
     fn emitted_source_type_names(
         &self,
-        registry: &Registry<KotlinMeta>,
+        registry: &Registry,
     ) -> std::collections::HashMap<String, syn::Path> {
         let mut names = std::collections::HashMap::new();
         let mut add = |key: &TypeKey| {
@@ -467,7 +467,7 @@ impl Declarations {
     /// time via [`Prebindgen::post_process_item`] so converter bodies,
     /// type ascriptions, and casts all stay in sync without each emit
     /// site having to remember to qualify.
-    fn qualify_item(&self, item: &mut syn::Item, registry: &Registry<KotlinMeta>) {
+    fn qualify_item(&self, item: &mut syn::Item, registry: &Registry) {
         let source_names = self.emitted_source_type_names(registry);
         // Names reachable from an array LENGTH (`[u8; MAX]`, `[u8; Holder::N]`).
         //
@@ -633,7 +633,7 @@ pub(crate) fn build_signal_domain_error_item() -> syn::Item {
 /// producing destructors that reference types not in scope.
 pub(crate) fn build_handle_destructor_items(
     ext: &Declarations,
-    registry: &Registry<KotlinMeta>,
+    registry: &Registry,
     emit: &prebindgen_registry::Emit,
 ) -> Vec<syn::Item> {
     let mut named: Vec<(String, syn::Item)> = Vec::new();
@@ -1407,7 +1407,7 @@ impl JniGenBuilder {
     /// route to a `JniGenBuilder` at all.
     pub(crate) fn build_with(
         self,
-        registry: prebindgen_registry::RegistryBuilder<KotlinMeta>,
+        registry: prebindgen_registry::RegistryBuilder,
     ) -> Result<JniGen, prebindgen_registry::WriteRustError> {
         let mut decls = self.decls;
         let declared = decls.declare_into(registry)?.validate_with(&decls)?;
@@ -1464,7 +1464,10 @@ impl JniGenBuilder {
                         crate::jni::compile::JFrag::by_hand(key.clone(), c.clone()),
                     );
                 }
-                conv
+                // The conversion stays here; what the registry gets back is
+                // which other crossings this one delegates to, which is what
+                // its reachability walk needs.
+                conv.map(|c| prebindgen_registry::Answer::over(c.subs))
             })?
             .build()?;
         // What the compilation produced, kept for emission. The converter table
@@ -1502,11 +1505,7 @@ impl Declarations {
     /// so everything this could compose from is already in `built`.
     /// Whether this crossing is the callback shape `compile_crossing` answers
     /// without the compiler.
-    fn is_callback_crossing<R: Conversions<KotlinMeta>>(
-        &self,
-        crossing: &Crossing,
-        built: &R,
-    ) -> bool {
+    fn is_callback_crossing<R: Conversions>(&self, crossing: &Crossing, built: &R) -> bool {
         let (dir, key) = crossing;
         matches!(dir, Direction::Input)
             && built.reading(key).is_some_and(|r| {
@@ -1517,7 +1516,7 @@ impl Declarations {
             })
     }
 
-    fn compile_crossing<'v, R: Conversions<KotlinMeta>>(
+    fn compile_crossing<'v, R: Conversions>(
         &'v self,
         compiler: &mut prebindgen_registry::recipe::Compiler<
             '_,
@@ -1561,8 +1560,8 @@ impl Declarations {
 
     pub fn declare_into(
         &self,
-        mut registry: RegistryBuilder<KotlinMeta>,
-    ) -> Result<RegistryBuilder<KotlinMeta>, prebindgen_registry::ScanError> {
+        mut registry: RegistryBuilder,
+    ) -> Result<RegistryBuilder, prebindgen_registry::ScanError> {
         // Binding-local fns first: they become model, and everything below may
         // name one.
         for (item_fn, origin) in self.collect_local_functions() {
@@ -1640,7 +1639,7 @@ impl Declarations {
 impl Declarations {
     pub(crate) fn build_value_struct_decons(
         &self,
-        registry: &impl Conversions<KotlinMeta>,
+        registry: &impl Conversions,
     ) -> Vec<prebindgen_registry::unfold::ValueDecon> {
         let mut out = Vec::new();
         for item_struct in registry.flat().types().filter_map(|t| match t {
@@ -1677,7 +1676,7 @@ impl Declarations {
 
     pub(crate) fn build_sum_decons(
         &self,
-        registry: &impl Conversions<KotlinMeta>,
+        registry: &impl Conversions,
     ) -> Vec<prebindgen_registry::unfold::SumDecon> {
         let mut keys: Vec<&TypeKey> = self.types.keys().collect();
         keys.sort_by(|a, b| a.as_str().cmp(b.as_str()));
@@ -1712,10 +1711,7 @@ impl Declarations {
         out
     }
 
-    pub(crate) fn build_leaf_vec_fold_elements(
-        &self,
-        registry: &impl Conversions<KotlinMeta>,
-    ) -> Vec<TypeKey> {
+    pub(crate) fn build_leaf_vec_fold_elements(&self, registry: &impl Conversions) -> Vec<TypeKey> {
         let mut seen = std::collections::HashSet::new();
         let mut out = Vec::new();
         let mut consider = |bare: &prebindgen_registry::flat::TypeRef| {
@@ -1774,7 +1770,7 @@ fn peel_one_borrow(t: &prebindgen_registry::flat::TypeRef) -> &prebindgen_regist
 /// classification the model makes once, at parse time, and expresses as two
 /// different elements.
 fn flat_unit_enum<'r>(
-    registry: &'r impl Conversions<KotlinMeta>,
+    registry: &'r impl Conversions,
     name: &syn::Ident,
     declarator: &str,
 ) -> Option<&'r prebindgen_registry::flat::Enum> {
@@ -1802,7 +1798,7 @@ impl Declarations {
     pub(crate) fn dispatch_fn_input(
         &self,
         args: &[prebindgen_registry::flat::TypeRef],
-        registry: &impl Conversions<KotlinMeta>,
+        registry: &impl Conversions,
         emit: &prebindgen_registry::Emit,
     ) -> Option<ConverterImpl<KotlinMeta>> {
         let outer_ty = build_fn_type(args, emit);
@@ -1824,13 +1820,12 @@ impl Declarations {
 }
 
 impl Prebindgen for Declarations {
-    /// Cross-language extras every JNI converter carries — currently
-    /// the Kotlin value-context type name. Filled by the rank-N
-    /// handlers at the same point they build the wire/body; the
-    /// resolver propagates it into [`prebindgen_registry::TypeEntry::metadata`];
-    /// the Kotlin emitter reads it back to drive every wrapper /
-    /// typed-handle / `JNIWrappers` signature.
-    type Metadata = KotlinMeta;
+    /// Cross-language extras every JNI converter carries — currently the
+    /// Kotlin value-context type name. Filled by the rank-N handlers at the
+    /// same point they build the wire/body, carried in
+    /// [`prebindgen_registry::ConverterImpl::metadata`], and read back by the
+    /// Kotlin emitter to drive every wrapper / typed-handle / `JNIWrappers`
+    /// signature.
 
     // ── Structural type resolution ──────────────────────────────────────
     // Try the terminal categories, then the `Result` peel, then the built-in
@@ -1842,7 +1837,7 @@ impl Prebindgen for Declarations {
     /// the earliest possible moment. Without this, a receiver-less `.method()`
     /// member would silently emit a method that ignores `this`, and a
     /// wrong-return `.constructor()` a factory of the wrong type.
-    fn validate(&self, binding: &Building<'_, Self::Metadata>) -> Result<(), String> {
+    fn validate(&self, binding: &Building<'_>) -> Result<(), String> {
         // Report what this binding left unclaimed. Here because it is the
         // earliest generator-owned hook that sees the model, and it runs
         // exactly where the binding used to print these itself. Moves into
@@ -2030,7 +2025,7 @@ impl Prebindgen for Declarations {
     /// The post-resolve validation boundary (issue #90): every bound
     /// function's lowered plan must build, and the split declarations must
     /// be unambiguous, before ANY artifact writer touches disk.
-    fn validate_resolved(&self, registry: &Registry<KotlinMeta>) -> Result<(), String> {
+    fn validate_resolved(&self, registry: &Registry) -> Result<(), String> {
         validate_bindings(self, registry)
     }
 
@@ -2048,7 +2043,7 @@ impl Prebindgen for Declarations {
     /// crate's source tree.
     fn prerequisites(
         &self,
-        registry: &Registry<KotlinMeta>,
+        registry: &Registry,
         emit: &prebindgen_registry::Emit,
     ) -> Vec<syn::Item> {
         // `__JniErr` is the **framework** error type alias — always the
@@ -2114,7 +2109,7 @@ impl Prebindgen for Declarations {
     fn post_process_item(
         &self,
         item: &mut syn::Item,
-        registry: &Registry<KotlinMeta>,
+        registry: &Registry,
         _emit: &prebindgen_registry::Emit,
     ) {
         self.qualify_item(item, registry);
@@ -2125,7 +2120,7 @@ impl Prebindgen for Declarations {
     fn on_function(
         &self,
         f: &prebindgen_registry::flat::Function,
-        registry: &Registry<KotlinMeta>,
+        registry: &Registry,
         emit: &prebindgen_registry::Emit,
     ) -> TokenStream {
         emit_jni_function_wrapper(self, f, registry, emit)
@@ -2134,7 +2129,7 @@ impl Prebindgen for Declarations {
     fn on_struct(
         &self,
         _s: &prebindgen_registry::flat::Struct,
-        _registry: &Registry<KotlinMeta>,
+        _registry: &Registry,
         _emit: &prebindgen_registry::Emit,
     ) -> TokenStream {
         // Struct converter bodies are emitted by the resolver via
@@ -2146,7 +2141,7 @@ impl Prebindgen for Declarations {
     fn on_variant(
         &self,
         _v: &prebindgen_registry::flat::Variant,
-        _registry: &Registry<KotlinMeta>,
+        _registry: &Registry,
         _emit: &prebindgen_registry::Emit,
     ) -> TokenStream {
         TokenStream::new()
@@ -2155,7 +2150,7 @@ impl Prebindgen for Declarations {
     fn on_enum(
         &self,
         _e: &prebindgen_registry::flat::Enum,
-        _registry: &Registry<KotlinMeta>,
+        _registry: &Registry,
         _emit: &prebindgen_registry::Emit,
     ) -> TokenStream {
         TokenStream::new()
@@ -2171,7 +2166,7 @@ impl Prebindgen for Declarations {
     fn on_const(
         &self,
         c: &prebindgen_registry::flat::Constant,
-        registry: &Registry<KotlinMeta>,
+        registry: &Registry,
         emit: &prebindgen_registry::Emit,
     ) -> TokenStream {
         reject_handle_const(self, c);
@@ -2201,7 +2196,7 @@ impl Declarations {
     pub(crate) fn input_terminal(
         &self,
         reading: &prebindgen_registry::flat::TypeRef,
-        registry: &impl Conversions<KotlinMeta>,
+        registry: &impl Conversions,
         emit: &prebindgen_registry::Emit,
     ) -> Option<ConverterImpl<KotlinMeta>> {
         // Classify off `kind`, spell with `spell()`: the arms below that ask what
@@ -2433,7 +2428,7 @@ impl Declarations {
     pub(crate) fn output_transparent_bridge(
         &self,
         reading: &prebindgen_registry::flat::TypeRef,
-        registry: &impl Conversions<KotlinMeta>,
+        registry: &impl Conversions,
         emit: &prebindgen_registry::Emit,
     ) -> Option<ConverterImpl<KotlinMeta>> {
         if reading.erased_wrappers().is_empty() {
@@ -2507,7 +2502,7 @@ impl Declarations {
     pub(crate) fn input_transparent_bridge(
         &self,
         reading: &prebindgen_registry::flat::TypeRef,
-        registry: &impl Conversions<KotlinMeta>,
+        registry: &impl Conversions,
         emit: &prebindgen_registry::Emit,
     ) -> Option<ConverterImpl<KotlinMeta>> {
         if reading.erased_wrappers().is_empty() {
@@ -2595,7 +2590,7 @@ impl Declarations {
     pub(crate) fn output_terminal(
         &self,
         reading: &prebindgen_registry::flat::TypeRef,
-        registry: &impl Conversions<KotlinMeta>,
+        registry: &impl Conversions,
         emit: &prebindgen_registry::Emit,
     ) -> Option<ConverterImpl<KotlinMeta>> {
         // Classify off `kind`, spell with `spell()` — see `input_terminal`.

--- a/prebindgen-jni/src/test_util.rs
+++ b/prebindgen-jni/src/test_util.rs
@@ -15,9 +15,7 @@ use prebindgen_registry::{Registry, RegistryBuilder};
 ///
 /// Test-only sugar: the two steps are one line each in a build script, but they
 /// appear in dozens of fixtures here.
-pub(crate) fn reg_from_items<M, I>(
-    items: I,
-) -> Result<RegistryBuilder<M>, prebindgen_registry::ScanError>
+pub(crate) fn reg_from_items<I>(items: I) -> Result<RegistryBuilder, prebindgen_registry::ScanError>
 where
     I: IntoIterator<Item = (syn::Item, prebindgen::SourceLocation)>,
 {

--- a/prebindgen-registry/src/expand.rs
+++ b/prebindgen-registry/src/expand.rs
@@ -171,8 +171,8 @@ fn validate_declarations(exp: &Expansions) -> Result<(), ExpandError> {
 ///
 /// Runs inside the builder's scan, before any conversion is built, so
 /// leaf converters resolve through the normal rank machinery.
-pub(crate) fn apply<M>(
-    registry: &mut Registry<M>,
+pub(crate) fn apply(
+    registry: &mut Registry,
     exp: &Expansions,
     declared_fns: &std::collections::HashSet<syn::Ident>,
     accessor_fns: &std::collections::HashSet<syn::Ident>,
@@ -272,8 +272,8 @@ pub(crate) fn apply<M>(
 /// `spell()` and digging the parameter out of `sig.inputs` — what these
 /// three sites used to do — re-derives a fact the model was already handing over,
 /// which is `origin` used for reasoning rather than for emission.
-fn param_reading<M>(
-    registry: &Registry<M>,
+fn param_reading(
+    registry: &Registry,
     func: &syn::Ident,
     param: &syn::Ident,
 ) -> Result<prebindgen_flat::flat::TypeRef, ExpandError> {
@@ -289,8 +289,8 @@ fn param_reading<M>(
 }
 
 /// Build + store the fold plan for one `.construct` declaration.
-fn process_expand<M>(
-    registry: &mut Registry<M>,
+fn process_expand(
+    registry: &mut Registry,
     exp: &Expansions,
     ed: &ExpandDecl,
 ) -> Result<(), ExpandError> {
@@ -326,9 +326,9 @@ fn process_expand<M>(
 /// Pick the constructor (its variants) for one `.expand`/`.expand_with`
 /// declaration. A constructor is keyed by its declared `target`; `TopLevel`
 /// requires it to be unique for the parameter's target type.
-fn resolve_constructor<M>(
+fn resolve_constructor(
     exp: &Expansions,
-    _registry: &Registry<M>,
+    _registry: &Registry,
     target_key: &TypeKey,
     ed: &ExpandDecl,
 ) -> Result<Vec<Variant>, ExpandError> {
@@ -359,8 +359,8 @@ fn resolve_constructor<M>(
 /// supposed to build, so the check cannot be the thing a new declarator forgets
 /// (#223). The comparison is [`check_declared_target`], shared with the output
 /// side's accessor lookup.
-fn ctor_signature<M>(
-    registry: &Registry<M>,
+fn ctor_signature(
+    registry: &Registry,
     func: &syn::Ident,
     expected: &TypeKey,
 ) -> Result<CtorSig, ExpandError> {
@@ -399,9 +399,9 @@ struct CtorSig {
 /// selector-dispatched — so a "single" constructor and a 1-variant combined emit
 /// identical code.
 #[allow(clippy::too_many_arguments)]
-fn build_plan<M>(
+fn build_plan(
     exp: &Expansions,
-    registry: &Registry<M>,
+    registry: &Registry,
     ed: &ExpandDecl,
     optional: bool,
     by_ref: bool,
@@ -549,9 +549,9 @@ fn build_plan<M>(
 /// [`FoldArg::Build`] (recursive input). Used by both the top-level [`build_plan`]
 /// and each nested build. `prefix` disambiguates leaf names across the tree.
 #[allow(clippy::too_many_arguments)]
-fn build_core<M>(
+fn build_core(
     exp: &Expansions,
-    registry: &Registry<M>,
+    registry: &Registry,
     ed: &ExpandDecl,
     target: &prebindgen_flat::flat::TypeRef,
     variants: &[Variant],
@@ -647,9 +647,9 @@ fn build_core<M>(
 /// its own default constructor, recurse into a nested [`FoldArg::Build`]
 /// (recursive input); otherwise it is a flat wire [`FoldArg::Leaf`].
 #[allow(clippy::too_many_arguments)]
-fn build_arg<M>(
+fn build_arg(
     exp: &Expansions,
-    registry: &Registry<M>,
+    registry: &Registry,
     ed: &ExpandDecl,
     pty: &prebindgen_flat::flat::TypeRef,
     name: syn::Ident,

--- a/prebindgen-registry/src/expand/tests.rs
+++ b/prebindgen-registry/src/expand/tests.rs
@@ -26,7 +26,7 @@ fn src_qualify(id: &syn::Ident) -> syn::Path {
 
 #[test]
 fn single_constructor_plan_and_fold() {
-    let mut reg: Registry<()> = reg_with(&[
+    let mut reg: Registry = reg_with(&[
         "fn z_keyexpr_try_from(s: String) -> Result<ZKeyExpr, Error> { todo!() }",
         "fn z_keyexpr_intersects(a: &ZKeyExpr, b: &ZKeyExpr) -> bool { todo!() }",
     ]);
@@ -68,7 +68,7 @@ fn single_constructor_plan_and_fold() {
 
 #[test]
 fn constructor_plan_and_fold() {
-    let mut reg: Registry<()> = reg_with(&[
+    let mut reg: Registry = reg_with(&[
         "fn z_keyexpr_try_from(s: String) -> Result<ZKeyExpr, Error> { todo!() }",
         "fn z_keyexpr_intersects(a: &ZKeyExpr, b: &ZKeyExpr) -> bool { todo!() }",
     ]);
@@ -131,7 +131,7 @@ fn constructor_plan_and_fold() {
 #[test]
 fn optional_byvalue_single_ctor() {
     // `attachment: Option<ZZBytes>` with single `z_zbytes_from_vec(Vec<u8>)`.
-    let mut reg: Registry<()> = reg_with(&[
+    let mut reg: Registry = reg_with(&[
         "fn z_zbytes_from_vec(bytes: Vec<u8>) -> ZZBytes { todo!() }",
         "fn z_session_delete(s: &ZSession, attachment: Option<ZZBytes>) -> bool { todo!() }",
     ]);
@@ -184,7 +184,7 @@ fn optional_byvalue_single_ctor() {
 fn optional_byref_single_ctor() {
     // `encoding: Option<&ZEncoding>` with single, infallible
     // `z_encoding_from_string(String) -> ZEncoding`.
-    let mut reg: Registry<()> = reg_with(&[
+    let mut reg: Registry = reg_with(&[
         "fn z_encoding_from_string(s: String) -> ZEncoding { todo!() }",
         "fn z_session_put(s: &ZSession, encoding: Option<&ZEncoding>) -> bool { todo!() }",
     ]);
@@ -227,7 +227,7 @@ fn optional_byref_multi_arg_ctor() {
     // `encoding: Option<&ZEncoding>` built from a TWO-arg, infallible
     // `z_encoding_from_id(i32, Option<String>) -> ZEncoding`: an explicit
     // `present: bool` flag + two plain (non-`Option`-wrapped) arg leaves.
-    let mut reg: Registry<()> = reg_with(&[
+    let mut reg: Registry = reg_with(&[
         "fn z_encoding_from_id(id: i32, schema: Option<String>) -> ZEncoding { todo!() }",
         "fn z_session_put(s: &ZSession, encoding: Option<&ZEncoding>) -> bool { todo!() }",
     ]);
@@ -296,7 +296,7 @@ fn optional_combined_selector_encodes_absence() {
     // absence (`-1` = `None`). The ctor's own `Option<String>` arg is a
     // PASSTHROUGH leaf (kept as `Option<String>`, not double-wrapped —
     // `None` is a legitimate value for the taken arm).
-    let mut reg: Registry<()> = reg_with(&[
+    let mut reg: Registry = reg_with(&[
         "fn z_encoding_from_id(id: i32, schema: Option<String>) -> ZEncoding { todo!() }",
         "fn z_session_put(s: &ZSession, encoding: Option<&ZEncoding>) -> bool { todo!() }",
     ]);
@@ -420,7 +420,7 @@ fn iterable_emit_shape() {
 fn default_constructor_auto_applies_and_skips() {
     // A `.default()` ZKeyExpr constructor auto-`construct`s every matching
     // param of every declared fn — except where `.skip_default_construct`'d.
-    let mut reg: Registry<()> = reg_with(&[
+    let mut reg: Registry = reg_with(&[
         "fn z_keyexpr_try_from(s: String) -> Result<ZKeyExpr, Error> { todo!() }",
         "fn z_keyexpr_intersects(a: &ZKeyExpr, b: &ZKeyExpr) -> bool { todo!() }",
         "fn z_session_undeclare(s: &ZSession, k: ZKeyExpr) -> bool { todo!() }",
@@ -464,7 +464,7 @@ fn default_constructor_auto_applies_and_skips() {
 
 #[test]
 fn default_constructor_skips_accessor_and_explicit_construct_errors() {
-    let mut reg: Registry<()> = reg_with(&[
+    let mut reg: Registry = reg_with(&[
         "fn z_keyexpr_try_from(s: String) -> Result<ZKeyExpr, Error> { todo!() }",
         "fn z_keyexpr_intersects(a: &ZKeyExpr, b: &ZKeyExpr) -> bool { todo!() }",
         "fn z_keyexpr_clone(ke: &ZKeyExpr) -> ZKeyExpr { todo!() }",
@@ -493,7 +493,7 @@ fn default_constructor_skips_accessor_and_explicit_construct_errors() {
         .contains_key(&(ident("z_keyexpr_clone"), ident("ke"))));
 
     // An explicit per-fn input flatten on an accessor is a build error.
-    let mut reg2: Registry<()> = reg_with(&[
+    let mut reg2: Registry = reg_with(&[
         "fn z_keyexpr_try_from(s: String) -> Result<ZKeyExpr, Error> { todo!() }",
         "fn z_keyexpr_clone(ke: &ZKeyExpr) -> ZKeyExpr { todo!() }",
     ]);
@@ -514,7 +514,7 @@ fn recursive_input_nests_param_constructors() {
     // by z_reply_sample(sample: ZSample). ZSample's default input expands
     // the `sample` param into z_sample_new's params, each of which (ZKeyExpr,
     // ZZBytes) recursively expands per ITS default input.
-    let mut reg: Registry<()> = reg_with(&[
+    let mut reg: Registry = reg_with(&[
         "fn z_sample_new(key_expr: ZKeyExpr, payload: ZZBytes) -> ZSample { todo!() }",
         "fn z_keyexpr_try_from(s: String) -> ZKeyExpr { todo!() }",
         "fn z_zbytes_from_vec(b: Vec<u8>) -> ZZBytes { todo!() }",
@@ -604,7 +604,7 @@ fn recursive_input_nests_param_constructors() {
 #[test]
 fn recursive_input_cycle_errors() {
     // A → B → A constructor cycle is a build error (not an infinite expansion).
-    let mut reg: Registry<()> = reg_with(&[
+    let mut reg: Registry = reg_with(&[
         "fn make_a(b: B) -> A { todo!() }",
         "fn make_b(a: A) -> B { todo!() }",
         "fn consume_a(a: A) -> bool { todo!() }",
@@ -642,7 +642,7 @@ fn recursive_input_cycle_errors() {
 #[test]
 fn unknown_constructor_errors() {
     use prebindgen_flat::types_util::ident;
-    let mut reg: Registry<()> =
+    let mut reg: Registry =
         reg_with(&["fn z_keyexpr_intersects(a: &ZKeyExpr, b: &ZKeyExpr) -> bool { todo!() }"]);
     let mut exp = Expansions::default();
     exp.expands.push(ExpandDecl {
@@ -671,7 +671,7 @@ fn unknown_constructor_errors() {
 #[test]
 fn constructor_target_mismatch_errors() {
     use prebindgen_flat::types_util::ident;
-    let mut reg: Registry<()> = reg_with(&[
+    let mut reg: Registry = reg_with(&[
         "fn z_sample_new(s: String) -> ZSample { todo!() }",
         "fn z_keyexpr_intersects(a: &ZKeyExpr, b: &ZKeyExpr) -> bool { todo!() }",
     ]);
@@ -699,7 +699,7 @@ fn constructor_target_mismatch_errors() {
 #[test]
 fn invalid_declarations_collected() {
     use prebindgen_flat::types_util::ident;
-    let mut reg: Registry<()> = reg_with(&[
+    let mut reg: Registry = reg_with(&[
         "fn z_keyexpr_try_from(s: String) -> Result<ZKeyExpr, Error> { todo!() }",
         "fn z_session_get(s: &ZSession, k: &ZKeyExpr) -> bool { todo!() }",
     ]);
@@ -776,7 +776,7 @@ fn invalid_declarations_collected() {
 /// parameter whose element is constructible. That is what this fixture is.
 #[test]
 fn a_vec_param_does_not_match_its_elements_constructor() {
-    let mut reg: Registry<()> = reg_with(&[
+    let mut reg: Registry = reg_with(&[
         "fn z_keyexpr_try_from(s: String) -> Result<ZKeyExpr, Error> { todo!() }",
         "fn z_keyexpr_join_all(parts: Vec<ZKeyExpr>) -> bool { todo!() }",
     ]);

--- a/prebindgen-registry/src/lib.rs
+++ b/prebindgen-registry/src/lib.rs
@@ -25,12 +25,11 @@
 //!   `on_function` / `on_struct` / `on_enum` / `on_const` on the
 //!   [`Prebindgen`] trait.
 //!
-//! Everything language-specific that must travel through the pipeline rides in
-//! the back-end's chosen [`Metadata`](Prebindgen::Metadata) type (a JNI
-//! back-end's Kotlin class names and exception info, a C back-end's header
-//! names, …). It is set on each converter, propagated into the registry's
-//! [`TypeEntry`], and read back by the back-end's own emitter — no side
-//! channels. Back-ends needing no extras leave it at the default `()`.
+//! Everything language-specific that must travel through the pipeline rides on
+//! the adapter's own conversions — a JNI back-end's Kotlin class names and
+//! exception info in [`ConverterImpl::metadata`], a C back-end's header names.
+//! The registry does not carry it: an adapter keeps its own conversions, sets
+//! the extras where it builds them, and reads them back in its own emitter.
 //!
 //! # Flow
 //!
@@ -132,9 +131,9 @@ pub use self::{
     niches::{NicheSlot, Niches},
     prebindgen::{ConverterImpl, NamePredicate, Prebindgen, Stage},
     registry::{
-        Building, Conversions, Crossing, Decompositions, Direction, DuplicateNameError,
-        NotExpressibleEntry, Registry, RegistryBuilder, ScanError, TypeEntry, TypeKey,
-        TypeKeyParseError, WriteRustError,
+        Answer, Building, Conversions, Crossing, Decompositions, Direction, DuplicateNameError,
+        NotExpressibleEntry, Registry, RegistryBuilder, ScanError, TypeKey, TypeKeyParseError,
+        WriteRustError,
     },
 };
 

--- a/prebindgen-registry/src/prebindgen.rs
+++ b/prebindgen-registry/src/prebindgen.rs
@@ -40,14 +40,12 @@ pub struct Stage<M = ()> {
     /// [`ConverterImpl::function`] but typed for this stage's own `In →
     /// Out` and own error type.
     pub function: syn::ItemFn,
-    /// Adapter-specific extras for this stage — same [`Metadata`] type as
-    /// the owning converter ([`ConverterImpl::metadata`]). The core never
+    /// Adapter-specific extras for this stage — the same type as the owning
+    /// converter's ([`ConverterImpl::metadata`]). The core never
     /// inspects this; the adapter's emitter reads it to decide how the
     /// stage's `Err` arm is surfaced (e.g. a JNI adapter stores the JVM
     /// exception class and `throw_*` fn to call here; a C adapter might
     /// store the error-code sentinel). Defaults to `()`.
-    ///
-    /// [`Metadata`]: Prebindgen::Metadata
     pub metadata: M,
 }
 
@@ -93,32 +91,30 @@ pub struct ConverterImpl<M = ()> {
     /// Default is empty (no niche optimisation).
     pub niches: Niches,
     /// Adapter-specific extras carried alongside the converter. Filled by
-    /// the same handler that produces `destination` / `function` /
-    /// `niches`, copied through into `TypeEntry::metadata` by the resolver,
-    /// and read by the adapter's language-side emitters. Set this where you
-    /// build the converter, not in a side channel.
+    /// the same handler that produces `destination` / `function` / `niches`,
+    /// and read by the adapter's language-side emitters off the fragment this
+    /// conversion belongs to. Set this where you build the converter, not in a
+    /// side channel.
     pub metadata: M,
-    /// Inner types this converter composed from — the types whose
-    /// `input_entry`/`output_entry` the adapter looked up to build a wrapper
-    /// (`Option<X>` → `[X]`, `Result<T,E>` → `[T, E]`, `&T` → `[&T]`). Empty
-    /// for a terminal converter (scalar, opaque handle, string) and for
-    /// a callback's own converter (callback args are cross-direction — their
-    /// required-ness flows through the registry's type-graph edges, not here). The
-    /// resolver copies these into `TypeEntry::subs`, which `propagate_required`
-    /// walks to mark reachable types required.
+    /// Inner crossings this converter composed from — the ones the adapter
+    /// looked up to build a wrapper (`Option<X>` → `[X]`, `Result<T,E>` →
+    /// `[T, E]`, `&T` → `[&T]`). Empty for a terminal converter (scalar, opaque
+    /// handle, string) and for a callback's own converter (callback args are
+    /// cross-direction — their required-ness flows through the registry's
+    /// type-graph edges, not here).
+    ///
+    /// This is what an adapter reports back as an
+    /// [`Answer`](crate::Answer), and what `propagate_required` walks to mark
+    /// reachable crossings required.
     ///
     /// **Identities, not spellings.** They are looked up and walked, never
-    /// emitted — [`TypeEntry::subs`](crate::registry::TypeEntry::subs)
-    /// was already `Vec<TypeKey>` and the resolver keyed these on arrival, so
-    /// the spelling existed only to be converted. An adapter that composed the
-    /// inner type keys it (`TypeKey::from_type`); one that read it off the model
-    /// asks the reading (`TypeRef::key`), and names no escape to do it.
+    /// emitted. An adapter that composed the inner type keys it
+    /// (`TypeKey::from_type`); one that read it off the model asks the reading
+    /// (`TypeRef::key`), and names no escape to do it.
     pub subs: Vec<crate::registry::TypeKey>,
 }
 
-/// The same reads [`TypeEntry`](crate::TypeEntry) offers, on the conversion an
-/// adapter built. A `TypeEntry` is this type with its inners keyed, so an
-/// emitter reading a compiled fragment asks it the same questions.
+/// What an emitter asks of a conversion it holds.
 impl<M> ConverterImpl<M> {
     /// Identifier of the wire-facing converter function.
     pub fn converter_ident(&self) -> &syn::Ident {
@@ -163,11 +159,10 @@ impl<M> ConverterImpl<M> {
 /// trait entirely (prebindgen#251 phase E).
 ///
 /// Anything language-specific the rest of the pipeline must carry — a JNI
-/// adapter's Kotlin class names and exception info, a C adapter's header
-/// names, etc. — rides in [`Self::Metadata`], an opaque type the adapter
-/// chooses. It is set in each `ConverterImpl::metadata`, propagated by the
-/// resolver into `TypeEntry::metadata`, and read back by the adapter's own
-/// emitter. Adapters that need no extras leave it at the default `()`.
+/// adapter's Kotlin class names and exception info, a C adapter's header names,
+/// etc. — rides in [`ConverterImpl::metadata`], and is read back by the
+/// adapter's own emitter off the fragment that conversion belongs to. The
+/// registry neither stores it nor names its type.
 ///
 /// # The rule an adapter must obey
 ///
@@ -206,12 +201,6 @@ impl<M> ConverterImpl<M> {
 /// Reusing a mirror's spelling test in a converted position is how the rule
 /// gets broken (prebindgen#230, #292).
 pub trait Prebindgen {
-    /// Adapter-specific extras every resolved converter carries. The
-    /// resolver copies this from each `ConverterImpl` it accepts into
-    /// the matching `TypeEntry`, so emitter code reads metadata off
-    /// the registry rather than through a parallel side channel.
-    type Metadata: Clone + Default;
-
     /// Rust items the adapter's emitted converters depend on (helper
     /// structs, type aliases, runtime-support code). Emitted at the top
     /// of the destination file, before all auto-generated converters.
@@ -222,11 +211,7 @@ pub trait Prebindgen {
     /// (feature-aware) scan actually contains — e.g. emitting a
     /// per-opaque-handle item only for handles a scanned `#[prebindgen]`
     /// fn references.
-    fn prerequisites(
-        &self,
-        _registry: &Registry<Self::Metadata>,
-        _emit: &crate::Emit,
-    ) -> Vec<syn::Item> {
+    fn prerequisites(&self, _registry: &Registry, _emit: &crate::Emit) -> Vec<syn::Item> {
         Vec::new()
     }
 
@@ -241,13 +226,7 @@ pub trait Prebindgen {
     /// converter bodies compile in the binding crate's scope. Walks the
     /// entire AST, not just signatures, so type ascriptions and casts
     /// inside function bodies are covered.
-    fn post_process_item(
-        &self,
-        _item: &mut syn::Item,
-        _registry: &Registry<Self::Metadata>,
-        _emit: &crate::Emit,
-    ) {
-    }
+    fn post_process_item(&self, _item: &mut syn::Item, _registry: &Registry, _emit: &crate::Emit) {}
 
     /// Adapter-invariant checks that need registry **signatures** — the
     /// earliest they can run (decl objects are built before any source is
@@ -259,10 +238,7 @@ pub trait Prebindgen {
     /// receiver parameter of the class type.
     ///
     /// Default: no checks.
-    fn validate(
-        &self,
-        _binding: &crate::registry::Building<'_, Self::Metadata>,
-    ) -> Result<(), String> {
+    fn validate(&self, _binding: &crate::registry::Building<'_>) -> Result<(), String> {
         Ok(())
     }
 
@@ -276,7 +252,7 @@ pub trait Prebindgen {
     /// order-independent.
     ///
     /// Default: no checks.
-    fn validate_resolved(&self, _registry: &Registry<Self::Metadata>) -> Result<(), String> {
+    fn validate_resolved(&self, _registry: &Registry) -> Result<(), String> {
         Ok(())
     }
 
@@ -306,7 +282,7 @@ pub trait Prebindgen {
     fn on_function(
         &self,
         f: &prebindgen_flat::flat::Function,
-        registry: &Registry<Self::Metadata>,
+        registry: &Registry,
         emit: &crate::Emit,
     ) -> TokenStream;
 
@@ -315,7 +291,7 @@ pub trait Prebindgen {
     fn on_struct(
         &self,
         s: &prebindgen_flat::flat::Struct,
-        registry: &Registry<Self::Metadata>,
+        registry: &Registry,
         emit: &crate::Emit,
     ) -> TokenStream;
 
@@ -328,7 +304,7 @@ pub trait Prebindgen {
     fn on_variant(
         &self,
         v: &prebindgen_flat::flat::Variant,
-        registry: &Registry<Self::Metadata>,
+        registry: &Registry,
         emit: &crate::Emit,
     ) -> TokenStream;
 
@@ -336,7 +312,7 @@ pub trait Prebindgen {
     fn on_enum(
         &self,
         e: &prebindgen_flat::flat::Enum,
-        registry: &Registry<Self::Metadata>,
+        registry: &Registry,
         emit: &crate::Emit,
     ) -> TokenStream;
 
@@ -352,7 +328,7 @@ pub trait Prebindgen {
     fn on_const(
         &self,
         c: &prebindgen_flat::flat::Constant,
-        _registry: &Registry<Self::Metadata>,
+        _registry: &Registry,
         emit: &crate::Emit,
     ) -> TokenStream {
         match self.source_module() {

--- a/prebindgen-registry/src/registry/cell.rs
+++ b/prebindgen-registry/src/registry/cell.rs
@@ -4,7 +4,7 @@
 use super::*;
 
 /// One type-table cell: what the key names, and the adapter's answer for it.
-pub(crate) struct TypeCell<M = ()> {
+pub(crate) struct TypeCell {
     /// The frontend's reading of this type, reused whole — so its classification
     /// and its origin are already here rather than re-derived per consumer.
     ///
@@ -19,8 +19,8 @@ pub(crate) struct TypeCell<M = ()> {
     /// less than its neighbours.
     pub subject: Box<prebindgen_flat::flat::TypeRef>,
     /// The binding asks for this cell **directly** — a declared fn's signature, a
-    /// declared type, an `unfold` leaf — as opposed to reaching it through some
-    /// converter's [`TypeEntry::subs`].
+    /// declared type, an `unfold` leaf — as opposed to reaching it through
+    /// another crossing's [`Answer::subs`].
     ///
     /// A scan fact. Whether a converter is *needed* here is reachability from
     /// these roots, which [`crate::resolve`] derives rather than
@@ -28,108 +28,38 @@ pub(crate) struct TypeCell<M = ()> {
     /// position, every struct in both directions), so the roots are what say
     /// which of it has to work.
     pub root: bool,
-    /// The adapter's converter, once resolved.
-    pub entry: Option<TypeEntry<M>>,
+    /// What the adapter said about this crossing, once it answered.
+    ///
+    /// `Some` means the adapter has a conversion for it. The conversion itself
+    /// stays in the adapter, which is the only thing that reads one; what the
+    /// registry keeps is in [`Answer`].
+    pub entry: Option<Answer>,
 }
 
-/// Per-cell registry entry.
-#[derive(Clone)]
-pub struct TypeEntry<M = ()> {
-    /// Wire/destination type — the form the value takes on the wire as
-    /// chosen by the adapter (e.g. an `i64` handle for a JNI adapter, or
-    /// a `*const T` raw pointer for a C adapter). Other converters that
-    /// ask "what's the wire form of this rust type?" read this.
-    pub destination: syn::Type,
-    /// Complete generated function for the **wire-facing** stage of the
-    /// converter (signature, body, attributes, lifetimes). The adapter
-    /// owns the shape. Callers compute this stage's name via
-    /// `function.sig.ident`.
-    pub function: syn::ItemFn,
-    /// **Rust-side** stages that compose with [`Self::function`] to form
-    /// the full chain — copied verbatim from the resolving
-    /// [`crate::prebindgen::ConverterImpl::pre_stages`]. See
-    /// that field's docs for the chain-order semantics.
-    pub pre_stages: Vec<Stage<M>>,
-    /// Inner types whose function delegates to their converters. Empty for
-    /// terminal converters; populated by wrapper converters. Used by the
-    /// post-resolution propagation pass.
+/// What the registry keeps of an adapter's answer for one crossing.
+///
+/// Not the conversion. An adapter emits from its own fragments and looks up its
+/// own answers, so generated Rust never travels through here. What the registry
+/// does with an answer is walk it: the resolver follows `subs` to decide which
+/// crossings a binding actually has to be able to make.
+#[derive(Clone, Default, Debug)]
+pub struct Answer {
+    /// The crossings this one is built out of — an `Option<T>` conversion names
+    /// `T`, a `Result<T, E>` names both. Empty for a terminal conversion.
+    ///
+    /// **Identities, not spellings**, so `T`, `&T` and `Box<T>` reach one cell.
     pub subs: Vec<TypeKey>,
-    /// Wire bit-patterns this converter never produces / always rejects.
-    /// Wrappers (`Option<_>`, sum-typed enums) carve from this set for
-    /// their own discriminants. See [`Niches`] for the cascade model.
-    pub niches: Niches,
-    /// Adapter-specific extras carried in by the
-    /// [`crate::prebindgen::ConverterImpl`] that filled this
-    /// slot. Emitter code reads this directly — the registry is the
-    /// single source of truth for cross-language facts (C header names,
-    /// JVM class names, etc.). Defaults to `()` for adapters that don't
-    /// need any.
-    pub metadata: M,
 }
 
-impl<M> TypeEntry<M> {
-    /// The resolved form of what a generator built.
-    ///
-    /// The only difference is `subs`: a generator names its inners as types,
-    /// and the table keys them.
-    pub fn from_converter(c: crate::ConverterImpl<M>) -> Self {
-        Self {
-            destination: c.destination,
-            function: c.function,
-            pre_stages: c.pre_stages,
-            subs: c.subs.clone(),
-            niches: c.niches,
-            metadata: c.metadata,
-        }
+impl Answer {
+    /// An answer that delegates to no other crossing.
+    pub fn terminal() -> Self {
+        Self::default()
     }
 
-    /// This entry as the conversion an adapter built.
-    ///
-    /// The two types carry the same six fields — an entry is what the resolver
-    /// stored, a conversion is what the adapter handed it. An emitter reading a
-    /// compiled fragment gets a [`ConverterImpl`](crate::ConverterImpl), so a
-    /// helper it shares with a caller that still holds a table entry speaks
-    /// that type, and the entry converts.
-    pub fn as_converter(&self) -> crate::ConverterImpl<M>
-    where
-        M: Clone,
-    {
-        crate::ConverterImpl {
-            destination: self.destination.clone(),
-            function: self.function.clone(),
-            pre_stages: self.pre_stages.clone(),
-            niches: self.niches.clone(),
-            metadata: self.metadata.clone(),
-            subs: self.subs.clone(),
-        }
-    }
-
-    /// Identifier of the wire-facing converter function.
-    pub fn converter_ident(&self) -> &syn::Ident {
-        &self.function.sig.ident
-    }
-
-    /// Wire/destination type carried by this converter on success.
-    pub fn wire_type(&self) -> &syn::Type {
-        &self.destination
-    }
-
-    /// Rust-side stages in input execution order, after the wire-facing
-    /// converter has decoded the wire value.
-    pub fn input_stage_order(&self) -> impl Iterator<Item = (usize, &Stage<M>)> {
-        self.pre_stages.iter().enumerate().rev()
-    }
-
-    /// Rust-side stages in output execution order, before the wire-facing
-    /// converter encodes the final wire value.
-    pub fn output_stage_order(&self) -> impl Iterator<Item = (usize, &Stage<M>)> {
-        self.pre_stages.iter().enumerate()
-    }
-
-    /// Immediate converter dependencies recorded by the adapter when this entry
-    /// resolved.
-    pub fn dependency_keys(&self) -> &[TypeKey] {
-        &self.subs
+    /// An answer built out of the crossings `subs` names.
+    pub fn over(subs: Vec<TypeKey>) -> Self {
+        Self { subs }
     }
 }
 

--- a/prebindgen-registry/src/registry/declare.rs
+++ b/prebindgen-registry/src/registry/declare.rs
@@ -27,7 +27,8 @@ use super::*;
 /// than a phase you have to be careful about.
 pub struct RegistryBuilder {
     registry: Registry,
-    /// Conversions handed over so far, applied at [`Self::build`].
+    /// What has been answered so far, applied at [`Self::build`]. Not the
+    /// conversions — those stay with the adapter; see [`Answer`].
     built: HashMap<Crossing, Answer>,
     /// The scan runs once, on demand: it needs every declaration, and
     /// [`Self::convert_with`] and [`Self::build`] each need

--- a/prebindgen-registry/src/registry/declare.rs
+++ b/prebindgen-registry/src/registry/declare.rs
@@ -25,17 +25,17 @@ use super::*;
 /// The result is read-only. Nothing can add a crossing to a `Registry`, which
 /// is what makes "every crossing has a conversion" a fact about the type rather
 /// than a phase you have to be careful about.
-pub struct RegistryBuilder<M> {
-    registry: Registry<M>,
+pub struct RegistryBuilder {
+    registry: Registry,
     /// Conversions handed over so far, applied at [`Self::build`].
-    built: HashMap<Crossing, TypeEntry<M>>,
+    built: HashMap<Crossing, Answer>,
     /// The scan runs once, on demand: it needs every declaration, and
     /// [`Self::convert_with`] and [`Self::build`] each need
     /// it to have run. `Some` holds the derived demand, in order.
     order: Option<Vec<Crossing>>,
 }
 
-impl<M> Registry<M> {
+impl Registry {
     /// Start describing a binding over this model.
     ///
     /// A `Flat` is what a registry projects, and reading captured prebindgen
@@ -50,7 +50,7 @@ impl<M> Registry<M> {
     /// let flat = Flat::builder().source("source_ffi").build()?;
     /// // Annotated only because nothing here resolves: in a build script `M` is
     /// // fixed by the adapter passed to `resolve`, so no call site names it.
-    /// let registry: Registry<()> = Registry::builder(flat)?.build()?;
+    /// let registry: Registry = Registry::builder(flat)?.build()?;
     /// assert!(registry.flat().function("test_function").is_some());
     /// # Ok::<_, Box<dyn std::error::Error>>(())
     /// ```
@@ -70,7 +70,7 @@ impl<M> Registry<M> {
     /// a source crate that needs migrating sees one list instead of one rebuild
     /// per item. This is independent of what any binding declares: an
     /// inexpressible item is a hard error whether or not it is ever named.
-    pub fn builder(flat: prebindgen_flat::flat::Flat) -> Result<RegistryBuilder<M>, ScanError> {
+    pub fn builder(flat: prebindgen_flat::flat::Flat) -> Result<RegistryBuilder, ScanError> {
         let entries: Vec<NotExpressibleEntry> = flat
             .unsupported()
             .map(|u| NotExpressibleEntry {
@@ -93,7 +93,7 @@ impl<M> Registry<M> {
     }
 }
 
-impl<M> RegistryBuilder<M> {
+impl RegistryBuilder {
     // ── configure: what this binding builds ───────────────────────────
     //
     // Pushed in by the generator before `resolve`. The registry never asks —
@@ -263,7 +263,7 @@ impl<M> RegistryBuilder<M> {
     }
 }
 
-impl<M> RegistryBuilder<M> {
+impl RegistryBuilder {
     /// The model being described. Complete from the first call: everything that
     /// adds to it ([`Self::local_function`]) is a declaration, not a derivation.
     pub fn flat(&self) -> &prebindgen_flat::flat::Flat {
@@ -322,13 +322,9 @@ impl<M> RegistryBuilder<M> {
     }
 
     /// What a conversion — or a validation — is written against right now: the
-    /// model, the full crossing population, and whatever has been built so far.
-    fn view(&self) -> Building<'_, M> {
-        Building::new(
-            &self.registry,
-            &self.built,
-            self.order.as_deref().unwrap_or_default(),
-        )
+    /// model and the full crossing population.
+    fn view(&self) -> Building<'_> {
+        Building::new(&self.registry, self.order.as_deref().unwrap_or_default())
     }
 
     /// Check this binding against a generator's own invariants, now that the
@@ -336,10 +332,7 @@ impl<M> RegistryBuilder<M> {
     ///
     /// Earliest it can run: a missing declaration has already hard-errored, so
     /// a check here sees only items that exist.
-    pub fn validate_with<E>(mut self, adapter: &E) -> Result<Self, WriteRustError>
-    where
-        E: Prebindgen<Metadata = M>,
-    {
+    pub fn validate_with<E: Prebindgen>(mut self, adapter: &E) -> Result<Self, WriteRustError> {
         self.derive()?;
         adapter
             .validate(&self.view())
@@ -349,21 +342,21 @@ impl<M> RegistryBuilder<M> {
 
     /// Build a conversion for each crossing, in dependency order.
     ///
-    /// `f` is called once per crossing with the conversions already built, so
-    /// by the time it sees `Option<Handle>` it can look up `Handle`. Returning
-    /// `None` records a gap — whether that gap matters is decided by
-    /// [`Self::build`], not here.
+    /// `f` is called once per crossing, and answers with an [`Answer`] rather
+    /// than the conversion itself: the conversion belongs to the adapter, which
+    /// emits from it and looks it up, and what the registry needs back is which
+    /// other crossings this one is built out of. Returning `None` records a gap
+    /// — whether that gap matters is decided by [`Self::build`], not here.
+    ///
+    /// The walk is inner types first, so by the time `f` sees `Option<Handle>`
+    /// it has already answered `Handle`.
     ///
     /// The one way to supply them. Nothing about it lets the registry choose
     /// when to call back — the closure is yours, and the walk is finished
     /// before this returns.
     pub fn convert_with<F>(mut self, mut f: F) -> Result<Self, WriteRustError>
     where
-        F: FnMut(
-            &Crossing,
-            &Building<'_, M>,
-            &crate::Emit,
-        ) -> Option<crate::prebindgen::ConverterImpl<M>>,
+        F: FnMut(&Crossing, &Building<'_>, &crate::Emit) -> Option<Answer>,
     {
         // A converter IS generated Rust — `ConverterImpl::function` is a
         // complete `syn::ItemFn` the adapter writes — so this closure is an
@@ -372,10 +365,8 @@ impl<M> RegistryBuilder<M> {
         let emit = crate::Emit::new();
         let order = self.derive()?.to_vec();
         for crossing in &order {
-            let conv = f(crossing, &self.view(), &emit);
-            if let Some(c) = conv {
-                self.built
-                    .insert(crossing.clone(), TypeEntry::from_converter(c));
+            if let Some(answer) = f(crossing, &self.view(), &emit) {
+                self.built.insert(crossing.clone(), answer);
             }
         }
         Ok(self)
@@ -388,7 +379,7 @@ impl<M> RegistryBuilder<M> {
     /// "answerable", which is exactly what the split exists to keep out of
     /// everyone else's hands.
     #[cfg(test)]
-    pub(crate) fn scanned(mut self) -> Result<Registry<M>, ScanError> {
+    pub(crate) fn scanned(mut self) -> Result<Registry, ScanError> {
         // Narrower than `build`'s error on purpose: the scan is the only phase
         // this runs, so a test matching on `ScanError` says what it means.
         match self.derive() {
@@ -404,7 +395,7 @@ impl<M> RegistryBuilder<M> {
     /// A crossing with no conversion is not itself a failure — the scan
     /// over-approximates on purpose. What fails is a crossing *reachable from
     /// an export* with none, and the error names every one at once.
-    pub fn build(mut self) -> Result<Registry<M>, WriteRustError> {
+    pub fn build(mut self) -> Result<Registry, WriteRustError> {
         self.derive()?;
         for ((dir, key), entry) in self.built {
             if let Some(cell) = self.registry.type_table_mut(dir).get_mut(&key) {
@@ -416,28 +407,17 @@ impl<M> RegistryBuilder<M> {
     }
 }
 
-/// A builder answers the same questions a finished registry does — with one
-/// difference that is the whole point of the split: [`conversion`] sees only
-/// what has been handed over *so far*.
-///
-/// That is what a generator writing a conversion needs (its inners, already
-/// built) and it is all it should be able to see. Everything else — the model,
-/// the decompositions — is complete from the moment it is declared.
-///
-/// [`conversion`]: Conversions::conversion
-impl<M> Conversions<M> for RegistryBuilder<M> {
+/// A builder answers the same questions a finished registry does. It used to
+/// answer one fewer — it lent out conversions handed over *so far*, so a
+/// generator writing one could see its inners and nothing else. An adapter
+/// keeps its own conversions now, so that read is gone and the rest — the
+/// model, the decompositions — is complete from the moment it is declared.
+impl Conversions for RegistryBuilder {
     fn reading(&self, key: &TypeKey) -> Option<prebindgen_flat::flat::TypeRef> {
         self.registry.reading(key)
     }
     fn flat(&self) -> &prebindgen_flat::flat::Flat {
         &self.registry.flat
-    }
-    fn conversion(
-        &self,
-        dir: Direction,
-        reading: &prebindgen_flat::flat::TypeRef,
-    ) -> Option<&TypeEntry<M>> {
-        self.built.get(&(dir, reading.key()))
     }
     fn crossing_keys(&self, dir: Direction) -> Vec<TypeKey> {
         self.order

--- a/prebindgen-registry/src/registry/mod.rs
+++ b/prebindgen-registry/src/registry/mod.rs
@@ -25,10 +25,9 @@
 //!
 //! # What a conversion is
 //!
-//! A [`TypeEntry`]: a `destination` (the wire type), a wire-facing `function`,
-//! and `pre_stages` — the Rust-side stages that compose with it. **A chain, not a
-//! function**, which is how composition works: `Option<Handle>`'s chain embeds
-//! `Handle`'s.
+//! The adapter's business. It keeps the conversion itself; what it hands back
+//! is an [`Answer`], naming the crossings this one delegates to. That is what
+//! reachability walks, and it is all the registry needs to know.
 //!
 //! A composite need not cross whole. `Option<T>` may cross as a `T` carrying a
 //! niche value, as a `(bool, T)` pair, or as leaves delivered separately — which,
@@ -162,10 +161,7 @@ use std::collections::{HashMap, HashSet};
 use prebindgen::SourceLocation;
 use prebindgen_flat::{flat::Origin, types_util::bare_path_ident};
 
-use crate::{
-    niches::Niches,
-    prebindgen::{Prebindgen, Stage},
-};
+use crate::prebindgen::Prebindgen;
 
 mod cell;
 pub(crate) use self::cell::TypeCell;
@@ -182,7 +178,7 @@ mod view;
 pub use prebindgen_flat::flat::{TypeKey, TypeKeyParseError};
 
 pub use self::{
-    cell::{Direction, TypeEntry},
+    cell::{Answer, Direction},
     declare::RegistryBuilder,
     error::{DuplicateNameError, NotExpressibleEntry, ScanError, WriteRustError},
     view::{Building, Conversions, Crossing},
@@ -190,13 +186,11 @@ pub use self::{
 
 /// Single owner of everything parsed from the prebindgen source stream.
 ///
-/// The metadata parameter `M` is the language adapter's per-converter
-/// extra type, supplied via
-/// [`crate::prebindgen::Prebindgen::Metadata`]. Each
-/// [`TypeEntry`] carries one `M` copied in by the resolver from the
-/// [`crate::prebindgen::ConverterImpl`] that produced it.
-/// Adapters that don't carry extras leave `M = ()`.
-pub struct Registry<M = ()> {
+/// Carries no adapter metadata. It used to be generic over one, so a converter's
+/// language-specific extras could be stored beside it and read back; an adapter
+/// keeps its own conversions now, so both the storage and the parameter are
+/// gone.
+pub struct Registry {
     /// The parsed model these maps project. Held rather than discarded, so a
     /// later stage can ask it what a name means through the registry it already
     /// has — see [`Self::flat`].
@@ -217,8 +211,8 @@ pub struct Registry<M = ()> {
     /// [`Conversions::conversion`] — which is what makes direction a parameter
     /// rather than half of a field name, and what stops anyone observing a cell
     /// before `RegistryBuilder::build` has graded it.
-    pub(crate) input_types: HashMap<TypeKey, TypeCell<M>>,
-    pub(crate) output_types: HashMap<TypeKey, TypeCell<M>>,
+    pub(crate) input_types: HashMap<TypeKey, TypeCell>,
+    pub(crate) output_types: HashMap<TypeKey, TypeCell>,
 
     /// Resolved constructor-expansion plans, keyed by `(function, parameter)`.
     /// Filled by [`crate::expand::apply`] before resolution; read
@@ -259,13 +253,13 @@ pub struct Registry<M = ()> {
 
 // Opaque — exists so `Result<Registry, _>::expect_err` works in tests, the way
 // `Generation`'s did before the generators took ownership of the built object.
-impl<M> std::fmt::Debug for Registry<M> {
+impl std::fmt::Debug for Registry {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.write_str("Registry(..)")
     }
 }
 
-impl<M> Registry<M> {
+impl Registry {
     /// An empty registry: no model, no items, no types.
     ///
     /// **Not public.** A `Registry` is a projection of a [`Flat`](prebindgen_flat::Flat), and one built
@@ -293,11 +287,11 @@ impl<M> Registry<M> {
         self.type_table(dir).get(key).map(|cell| cell.root)
     }
 
-    /// Whether `key`'s cell in `dir` has a resolved converter.
+    /// Whether `key`'s cell in `dir` has been answered.
     ///
-    /// Test support, `testing`-gated. The public [`Self::input_entry`] /
-    /// [`Self::output_entry`] answer this from a reading; a fixture that built
-    /// the type itself holds only its identity.
+    /// Test support, `testing`-gated: a fixture that built the type itself
+    /// holds only its identity, and this is the one question about a cell that
+    /// does not need a reading.
     #[cfg(any(test, feature = "testing"))]
     pub fn has_entry_for_test(&self, dir: Direction, key: &TypeKey) -> Option<bool> {
         self.type_table(dir)

--- a/prebindgen-registry/src/registry/model.rs
+++ b/prebindgen-registry/src/registry/model.rs
@@ -7,7 +7,7 @@ use super::{
     *,
 };
 
-impl<M> Registry<M> {
+impl Registry {
     /// The parameter-side fold for each `(function, parameter)` position.
     ///
     /// Inherent rather than on [`Conversions`]: a fold is read when a wrapper's

--- a/prebindgen-registry/src/registry/order.rs
+++ b/prebindgen-registry/src/registry/order.rs
@@ -1,8 +1,9 @@
 //! Hand the demand over, and grade the answers.
 //!
 //! The two halves of the exchange with a generator: [`Registry::crossings`]
-//! sorts the derived set inner-first, `RegistryBuilder::build` takes every
-//! conversion back at once and names whatever is missing.
+//! sorts the derived set inner-first, and `RegistryBuilder::build` grades what
+//! came back — every crossing answered, or a report naming the ones that were
+//! not.
 
 use std::collections::HashSet;
 

--- a/prebindgen-registry/src/registry/order.rs
+++ b/prebindgen-registry/src/registry/order.rs
@@ -8,7 +8,7 @@ use std::collections::HashSet;
 
 use super::*;
 
-impl<M> Registry<M> {
+impl Registry {
     /// Every crossing this binding needs a conversion for, **inner types
     /// first**.
     ///

--- a/prebindgen-registry/src/registry/run.rs
+++ b/prebindgen-registry/src/registry/run.rs
@@ -2,7 +2,7 @@
 
 use super::*;
 
-impl<M> Registry<M> {
+impl Registry {
     pub(super) fn apply_adapter_plans(
         &mut self,
         declared: &mut Declared,

--- a/prebindgen-registry/src/registry/scan.rs
+++ b/prebindgen-registry/src/registry/scan.rs
@@ -23,7 +23,7 @@ fn canonical_of(declared_ty: &prebindgen_flat::flat::Origin<syn::Type>) -> syn::
         .expect("a `TypeKey` is a normalized `syn::Type`, so it re-parses")
 }
 
-impl<M> Registry<M> {
+impl Registry {
     pub(super) fn scan_declared_items(&mut self, declared: &Declared) -> Result<(), ScanError> {
         // Source-qualified declared types are a hard error (issue #95). The
         // key's own normalization already reduced `crate::`/`self::` and std
@@ -589,7 +589,7 @@ impl<M> Registry<M> {
         dir: Direction,
         ty: &syn::Type,
         root: bool,
-        entry: Option<TypeEntry<M>>,
+        entry: Option<Answer>,
     ) {
         self.intern(dir, ty, root).unwrap_or_else(|e| {
             panic!(
@@ -698,7 +698,7 @@ impl<M> Registry<M> {
     }
 
     /// Direction-indexed read access to the type-resolution tables.
-    pub(crate) fn type_table(&self, dir: Direction) -> &HashMap<TypeKey, TypeCell<M>> {
+    pub(crate) fn type_table(&self, dir: Direction) -> &HashMap<TypeKey, TypeCell> {
         match dir {
             Direction::Input => &self.input_types,
             Direction::Output => &self.output_types,
@@ -719,38 +719,10 @@ impl<M> Registry<M> {
     }
 
     /// Direction-indexed mutable access to the type-resolution tables.
-    pub(crate) fn type_table_mut(&mut self, dir: Direction) -> &mut HashMap<TypeKey, TypeCell<M>> {
+    pub(crate) fn type_table_mut(&mut self, dir: Direction) -> &mut HashMap<TypeKey, TypeCell> {
         match dir {
             Direction::Input => &mut self.input_types,
             Direction::Output => &mut self.output_types,
         }
-    }
-
-    /// Look up the resolved input entry for `reading`, returning `None` if it
-    /// was never registered or is still unresolved. The returned entry's
-    /// `function.sig.ident` is the converter's call name; `destination` is
-    /// its wire form.
-    ///
-    /// Takes a `TypeRef` for the reason the trait methods do (#284) — and this
-    /// pair matters more than they do, because an **inherent** method wins over
-    /// a trait method on a concrete `Registry`. While these took a spelling they
-    /// were a second door into the table that the trait's signature could not
-    /// close, and every caller with a `Registry` in hand silently used it. The
-    /// same "second door inside the room" that hid `classify` behind
-    /// `Registry::reading` until #267.
-    pub fn input_entry(&self, reading: &prebindgen_flat::flat::TypeRef) -> Option<&TypeEntry<M>> {
-        self.type_table(Direction::Input)
-            .get(&reading.key())?
-            .entry
-            .as_ref()
-    }
-
-    /// Look up the resolved output entry for `reading`. See
-    /// [`Self::input_entry`].
-    pub fn output_entry(&self, reading: &prebindgen_flat::flat::TypeRef) -> Option<&TypeEntry<M>> {
-        self.type_table(Direction::Output)
-            .get(&reading.key())?
-            .entry
-            .as_ref()
     }
 }

--- a/prebindgen-registry/src/registry/tests.rs
+++ b/prebindgen-registry/src/registry/tests.rs
@@ -14,16 +14,16 @@ use crate::{
 /// Push-then-resolve, the way a real generator's `resolve` does. Test-only:
 /// production generators own this pairing themselves (`JniGenBuilder::resolve`).
 trait DeclareAndResolve<M> {
-    fn declare_and_resolve<E>(self, ext: E) -> Result<Registry<()>, WriteRustError>
+    fn declare_and_resolve<E>(self, ext: E) -> Result<Registry, WriteRustError>
     where
-        E: Prebindgen<Metadata = M> + AsStub;
+        E: Prebindgen + AsStub;
 }
 
 /// How a test stub states what it declares, and what it can convert.
 trait AsStub {
     fn stub(&self) -> &StubExt;
     /// Default: converts nothing, so every required crossing is a gap.
-    fn converter(&self, _ty: &syn::Type) -> Option<ConverterImpl<()>> {
+    fn converter(&self, _ty: &syn::Type) -> Option<ConverterImpl> {
         None
     }
 }
@@ -33,10 +33,10 @@ impl AsStub for StubExt {
     }
 }
 
-impl DeclareAndResolve<()> for RegistryBuilder<()> {
-    fn declare_and_resolve<E>(self, ext: E) -> Result<Registry<()>, WriteRustError>
+impl DeclareAndResolve<()> for RegistryBuilder {
+    fn declare_and_resolve<E>(self, ext: E) -> Result<Registry, WriteRustError>
     where
-        E: Prebindgen<Metadata = ()> + AsStub,
+        E: Prebindgen + AsStub,
     {
         let registry = ext
             .stub()
@@ -45,7 +45,8 @@ impl DeclareAndResolve<()> for RegistryBuilder<()> {
             // The reading, not a spelling re-derived from the key: this is the
             // route a real generator takes, so the stub takes it too (#291).
             .convert_with(|crossing, built, emit| {
-                ext.converter(&emit.spell_ty(&built.reading(&crossing.1)?))
+                let conv = ext.converter(&emit.spell_ty(&built.reading(&crossing.1)?))?;
+                Some(Answer::over(conv.subs))
             })?
             .build()?;
         ext.validate_resolved(&registry)
@@ -71,10 +72,7 @@ struct StubExt {
 impl StubExt {
     /// Push what this stub declares, the way a real generator does. Generic
     /// over `M` so a stub can configure any adapter's registry.
-    fn declare_into_any<M>(
-        &self,
-        mut reg: RegistryBuilder<M>,
-    ) -> Result<RegistryBuilder<M>, ScanError> {
+    fn declare_into_any(&self, mut reg: RegistryBuilder) -> Result<RegistryBuilder, ScanError> {
         for (item_fn, origin) in self.local_fns.clone() {
             reg = reg.local_function(item_fn, origin)?;
         }
@@ -98,12 +96,10 @@ impl StubExt {
 }
 
 impl Prebindgen for StubExt {
-    type Metadata = ();
-
     fn on_function(
         &self,
         _f: &prebindgen_flat::flat::Function,
-        _registry: &Registry<()>,
+        _registry: &Registry,
         _emit: &crate::Emit,
     ) -> TokenStream {
         TokenStream::new()
@@ -111,7 +107,7 @@ impl Prebindgen for StubExt {
     fn on_struct(
         &self,
         _s: &prebindgen_flat::flat::Struct,
-        _registry: &Registry<()>,
+        _registry: &Registry,
         _emit: &crate::Emit,
     ) -> TokenStream {
         TokenStream::new()
@@ -119,7 +115,7 @@ impl Prebindgen for StubExt {
     fn on_variant(
         &self,
         _v: &prebindgen_flat::flat::Variant,
-        _registry: &Registry<()>,
+        _registry: &Registry,
         _emit: &crate::Emit,
     ) -> TokenStream {
         TokenStream::new()
@@ -127,7 +123,7 @@ impl Prebindgen for StubExt {
     fn on_enum(
         &self,
         _e: &prebindgen_flat::flat::Enum,
-        _registry: &Registry<()>,
+        _registry: &Registry,
         _emit: &crate::Emit,
     ) -> TokenStream {
         TokenStream::new()
@@ -148,7 +144,7 @@ fn fn_item(src: &str) -> (syn::Item, SourceLocation) {
 #[test]
 fn scan_declared_empty_ext_marks_nothing_required() {
     let items = vec![fn_item("fn good(x: u64) -> u64 { x }")];
-    let reg: RegistryBuilder<()> = crate::test_util::reg_from_items(items).unwrap();
+    let reg: RegistryBuilder = crate::test_util::reg_from_items(items).unwrap();
     let ext = StubExt::default();
     let reg = ext
         .declare_into_any(reg)
@@ -165,7 +161,7 @@ fn scan_declared_marks_types_required_only_for_declared_fns() {
         fn_item("fn a(x: u64) -> u64 { x }"),
         fn_item("fn b(x: u32) -> u32 { x }"),
     ];
-    let reg: RegistryBuilder<()> = crate::test_util::reg_from_items(items).unwrap();
+    let reg: RegistryBuilder = crate::test_util::reg_from_items(items).unwrap();
     let mut ext = StubExt::default();
     ext.functions.insert(syn::parse_str("a").unwrap());
     let reg = ext
@@ -173,7 +169,7 @@ fn scan_declared_marks_types_required_only_for_declared_fns() {
         .expect("declare")
         .scanned()
         .unwrap();
-    let is_root = |t: &HashMap<TypeKey, TypeCell<()>>, k: &str| {
+    let is_root = |t: &HashMap<TypeKey, TypeCell>, k: &str| {
         t.get(&TypeKey::parse(k).expect("test type"))
             .is_some_and(|c| c.root)
     };
@@ -188,7 +184,7 @@ fn scan_declared_marks_types_required_only_for_declared_fns() {
 #[test]
 fn scan_declared_missing_function_is_hard_error() {
     let items = vec![fn_item("fn good(x: u64) -> u64 { x }")];
-    let reg: RegistryBuilder<()> = crate::test_util::reg_from_items(items).unwrap();
+    let reg: RegistryBuilder = crate::test_util::reg_from_items(items).unwrap();
     let mut ext = StubExt::default();
     ext.functions.insert(syn::parse_str("good").unwrap());
     ext.functions.insert(syn::parse_str("typo_fn").unwrap());
@@ -206,7 +202,7 @@ fn scan_declared_missing_function_is_hard_error() {
 #[test]
 fn scan_declared_collects_all_missing_kinds_in_one_error() {
     let items = vec![fn_item("fn good(x: u64) -> u64 { x }")];
-    let reg: RegistryBuilder<()> = crate::test_util::reg_from_items(items).unwrap();
+    let reg: RegistryBuilder = crate::test_util::reg_from_items(items).unwrap();
     let mut ext = StubExt::default();
     ext.functions.insert(syn::parse_str("typo_fn").unwrap());
     ext.helper_functions
@@ -232,8 +228,8 @@ fn scan_declared_collects_all_missing_kinds_in_one_error() {
 }
 
 #[test]
-fn type_entry_helpers_expose_converter_chain_contract() {
-    let entry = TypeEntry {
+fn conversion_helpers_expose_converter_chain_contract() {
+    let entry = crate::ConverterImpl {
         destination: syn::parse_quote!(jni::sys::jlong),
         function: syn::parse_quote!(
             fn __wire(v: Owned) -> jni::sys::jlong {
@@ -241,7 +237,7 @@ fn type_entry_helpers_expose_converter_chain_contract() {
             }
         ),
         pre_stages: vec![
-            Stage {
+            crate::Stage {
                 function: syn::parse_quote!(
                     fn __stage_rust(v: Rust) -> Result<Mid, Err> {
                         todo!()
@@ -249,7 +245,7 @@ fn type_entry_helpers_expose_converter_chain_contract() {
                 ),
                 metadata: (),
             },
-            Stage {
+            crate::Stage {
                 function: syn::parse_quote!(
                     fn __stage_wire(v: Mid) -> Result<Owned, Err> {
                         todo!()
@@ -286,11 +282,7 @@ fn type_entry_helpers_expose_converter_chain_contract() {
         vec!["__stage_wire", "__stage_rust"]
     );
     assert_eq!(
-        entry
-            .dependency_keys()
-            .iter()
-            .map(TypeKey::as_str)
-            .collect::<Vec<_>>(),
+        entry.subs.iter().map(TypeKey::as_str).collect::<Vec<_>>(),
         vec!["Rust", "Mid"]
     );
 }
@@ -309,7 +301,7 @@ fn type_entry_helpers_expose_converter_chain_contract() {
 /// judgement now, and its diagnosis is richer: it names the parameter.
 #[test]
 fn from_items_rejects_what_the_language_cannot_express() {
-    let err = match crate::test_util::reg_from_items::<(), _>(vec![
+    let err = match crate::test_util::reg_from_items::<_>(vec![
         fn_item("fn bogus(x: u64) -> impl std::fmt::Debug { 0u64 }"),
         fn_item("fn worse(self) -> u64 { 0 }"),
     ]) {
@@ -354,7 +346,7 @@ fn duplicate_name_across_sources_names_both_crates() {
 
     let a = make_source("first-crate");
     let b = make_source("second-crate");
-    let msg = match crate::test_util::reg_from_items::<(), _>(a.items_all().chain(b.items_all())) {
+    let msg = match crate::test_util::reg_from_items::<_>(a.items_all().chain(b.items_all())) {
         Ok(_) => panic!("collision must fail"),
         Err(e) => e.to_string(),
     };
@@ -378,8 +370,7 @@ fn from_items_records_origins_from_location_stamps() {
     let f_b: syn::ItemFn = syn::parse_str("fn from_helper(x: u64) -> u64 { x }").unwrap();
     let a = vec![(syn::Item::Fn(f_a), loc("flat-crate"))];
     let b = vec![(syn::Item::Fn(f_b), loc("helper-crate"))];
-    let reg: RegistryBuilder<()> =
-        crate::test_util::reg_from_items(a.into_iter().chain(b)).unwrap();
+    let reg: RegistryBuilder = crate::test_util::reg_from_items(a.into_iter().chain(b)).unwrap();
 
     let path = |p: syn::Path| p.to_token_stream().to_string();
     assert_eq!(
@@ -418,14 +409,13 @@ fn resolve_surfaces_adapter_invariant_errors() {
         }
     }
     impl Prebindgen for FailingExt {
-        type Metadata = ();
-        fn validate(&self, _binding: &Building<'_, ()>) -> Result<(), String> {
+        fn validate(&self, _binding: &Building<'_>) -> Result<(), String> {
             Err("member fun `f` has no receiver".to_string())
         }
         fn on_function(
             &self,
             f: &prebindgen_flat::flat::Function,
-            r: &Registry<()>,
+            r: &Registry,
             _emit: &crate::Emit,
         ) -> TokenStream {
             self.0.on_function(f, r, _emit)
@@ -433,7 +423,7 @@ fn resolve_surfaces_adapter_invariant_errors() {
         fn on_struct(
             &self,
             s: &prebindgen_flat::flat::Struct,
-            r: &Registry<()>,
+            r: &Registry,
             _emit: &crate::Emit,
         ) -> TokenStream {
             self.0.on_struct(s, r, _emit)
@@ -441,7 +431,7 @@ fn resolve_surfaces_adapter_invariant_errors() {
         fn on_variant(
             &self,
             v: &prebindgen_flat::flat::Variant,
-            r: &Registry<()>,
+            r: &Registry,
             _emit: &crate::Emit,
         ) -> TokenStream {
             self.0.on_variant(v, r, _emit)
@@ -449,14 +439,14 @@ fn resolve_surfaces_adapter_invariant_errors() {
         fn on_enum(
             &self,
             e: &prebindgen_flat::flat::Enum,
-            r: &Registry<()>,
+            r: &Registry,
             _emit: &crate::Emit,
         ) -> TokenStream {
             self.0.on_enum(e, r, _emit)
         }
     }
     let items = vec![fn_item("fn good(x: u64) -> u64 { x }")];
-    let reg: RegistryBuilder<()> = crate::test_util::reg_from_items(items).unwrap();
+    let reg: RegistryBuilder = crate::test_util::reg_from_items(items).unwrap();
     let err = reg
         .declare_and_resolve(FailingExt(StubExt::default()))
         .expect_err("validate Err must abort resolve");
@@ -529,7 +519,7 @@ fn qualified_signature_matches_bare_declaration() {
         (syn::Item::Struct(s), crate_loc("myflat")),
         (syn::Item::Fn(f), crate_loc("myflat")),
     ];
-    let reg: RegistryBuilder<()> = crate::test_util::reg_from_items(items).unwrap();
+    let reg: RegistryBuilder = crate::test_util::reg_from_items(items).unwrap();
     let mut ext = StubExt::default();
     ext.functions.insert(syn::parse_str("get").unwrap());
     ext.types.push(syn::parse_str("Thing").expect("test type"));
@@ -541,8 +531,7 @@ fn qualified_signature_matches_bare_declaration() {
     assert!(reg.input_types[&TypeKey::parse("&Thing").expect("test type")].root);
     assert!(reg.output_types[&TypeKey::parse("Vec<Thing>").expect("test type")].root);
     // No spelling-variant duplicate cells survive anywhere.
-    let no_paths =
-        |t: &HashMap<TypeKey, TypeCell<()>>| !t.keys().any(|k| k.as_str().contains("::"));
+    let no_paths = |t: &HashMap<TypeKey, TypeCell>| !t.keys().any(|k| k.as_str().contains("::"));
     assert!(no_paths(&reg.input_types));
     assert!(no_paths(&reg.output_types));
 }
@@ -562,7 +551,7 @@ fn multi_source_rename_cross_reference_normalizes() {
         (syn::Item::Struct(b_ty), crate_loc("cov-helpers")),
         (syn::Item::Struct(a_ty), crate_loc("srca")),
     ];
-    let reg: RegistryBuilder<()> = crate::test_util::reg_from_items(items).unwrap();
+    let reg: RegistryBuilder = crate::test_util::reg_from_items(items).unwrap();
     let mut ext = StubExt::default();
     ext.functions.insert(syn::parse_str("use_a").unwrap());
     ext.types.push(syn::parse_str("TypeA").expect("test type"));
@@ -583,7 +572,7 @@ fn qualified_declared_type_is_hard_error() {
     // a collected hard error with the bare fix-it, not a silent miss.
     let s: syn::ItemStruct = syn::parse_str("pub struct Thing { pub v: u64 }").unwrap();
     let items = vec![(syn::Item::Struct(s), crate_loc("myflat"))];
-    let reg: RegistryBuilder<()> = crate::test_util::reg_from_items(items).unwrap();
+    let reg: RegistryBuilder = crate::test_util::reg_from_items(items).unwrap();
     let mut ext = StubExt::default();
     ext.types
         .push(syn::parse_str("myflat::Thing").expect("test type"));
@@ -606,7 +595,7 @@ fn foreign_qualified_declared_type_stays_supported() {
     // module, so the declaration passes through verbatim and is marked
     // required under its own spelling (the no-indexed-body arm).
     let items = vec![fn_item("fn touch(x: u64) -> u64 { x }")];
-    let reg: RegistryBuilder<()> = crate::test_util::reg_from_items(items).unwrap();
+    let reg: RegistryBuilder = crate::test_util::reg_from_items(items).unwrap();
     let mut ext = StubExt::default();
     let foreign_ty: syn::Type = syn::parse_str("zenoh::KeyExpr<'static>").expect("test type");
     let foreign = TypeKey::from_type(&foreign_ty);
@@ -658,7 +647,7 @@ fn fn_ident(name: &str) -> syn::Ident {
 #[test]
 fn builder_reads_a_source_directory() {
     let dir = write_source_dir("plain", "flat-crate", "marked_fn");
-    let registry: RegistryBuilder<()> =
+    let registry: RegistryBuilder =
         Registry::builder(Flat::builder().source(&dir).build().expect("parses")).expect("indexes");
 
     assert!(registry
@@ -684,14 +673,14 @@ fn builder_source_named_overrides_the_captured_crate() {
     let dir = write_source_dir("renamed", "real-package-name", "helper_fn");
 
     // Without the override, the registry believes the package name.
-    let plain: RegistryBuilder<()> =
+    let plain: RegistryBuilder =
         Registry::builder(Flat::builder().source(&dir).build().expect("parses")).expect("indexes");
     assert_eq!(
         plain.origin_module(&fn_ident("helper_fn")).map(module),
         Some("real_package_name".to_string())
     );
 
-    let renamed: RegistryBuilder<()> = Registry::builder(
+    let renamed: RegistryBuilder = Registry::builder(
         Flat::builder()
             .source_named(&dir, "as_renamed")
             .build()
@@ -716,7 +705,7 @@ fn builder_composes_directories_and_streams() {
     let flat = write_source_dir("multi_flat", "flat-crate", "flat_fn");
     let helper = write_source_dir("multi_helper", "real-helper-name", "helper_fn");
 
-    let registry: RegistryBuilder<()> = Registry::builder(
+    let registry: RegistryBuilder = Registry::builder(
         Flat::builder()
             .source(&flat)
             .source_named(&helper, "renamed_helper")
@@ -773,9 +762,9 @@ fn builder_composes_directories_and_streams() {
 fn builder_and_from_items_agree() {
     let dir = write_source_dir("agree", "flat-crate", "marked_fn");
 
-    let built: RegistryBuilder<()> =
+    let built: RegistryBuilder =
         Registry::builder(Flat::builder().source(&dir).build().expect("parses")).expect("indexes");
-    let streamed: RegistryBuilder<()> =
+    let streamed: RegistryBuilder =
         crate::test_util::reg_from_items(prebindgen::Source::new(&dir).items_all())
             .expect("indexes");
 
@@ -809,7 +798,7 @@ fn a_source_type_cell_carries_the_models_typeref() {
         crate_name: Some("myflat".into()),
     };
     let item: syn::Item = syn::parse_str("pub fn f(v: Option<u64>) -> u64 { v.unwrap() }").unwrap();
-    let reg: RegistryBuilder<()> = crate::test_util::reg_from_items([(item, loc.clone())]).unwrap();
+    let reg: RegistryBuilder = crate::test_util::reg_from_items([(item, loc.clone())]).unwrap();
 
     let mut ext = StubExt::default();
     ext.functions.insert(syn::parse_str("f").unwrap());
@@ -876,7 +865,7 @@ fn a_composed_reading_reaches_the_cell_unchanged() {
             loc.clone(),
         ),
     ];
-    let reg: RegistryBuilder<()> = crate::test_util::reg_from_items(items).unwrap();
+    let reg: RegistryBuilder = crate::test_util::reg_from_items(items).unwrap();
     let mut ext = StubExt::default();
     ext.functions.insert(syn::parse_str("f").unwrap());
     ext.types.push(syn::parse_str("Thing").unwrap());
@@ -927,7 +916,7 @@ fn a_composed_reading_reaches_the_cell_unchanged() {
 #[test]
 fn reading_is_a_lookup_not_a_classification() {
     let items = vec![fn_item("fn f(x: u64) -> u64 { x }")];
-    let reg: RegistryBuilder<()> = crate::test_util::reg_from_items(items).unwrap();
+    let reg: RegistryBuilder = crate::test_util::reg_from_items(items).unwrap();
     let mut ext = StubExt::default();
     ext.functions.insert(syn::parse_str("f").unwrap());
     let reg = ext
@@ -969,7 +958,7 @@ fn an_adapter_authored_type_cell_is_classified_but_placeless() {
     use prebindgen_flat::flat::TypeKind;
 
     let items = vec![fn_item("fn f(x: u64) -> u64 { x }")];
-    let reg: RegistryBuilder<()> = crate::test_util::reg_from_items(items).unwrap();
+    let reg: RegistryBuilder = crate::test_util::reg_from_items(items).unwrap();
 
     let mut ext = StubExt::default();
     ext.types
@@ -1078,7 +1067,7 @@ fn from_flat_projects_each_element_kind() {
         .items(items)
         .build()
         .expect("parse");
-    let reg: RegistryBuilder<()> = Registry::builder(flat).expect("project");
+    let reg: RegistryBuilder = Registry::builder(flat).expect("project");
 
     let id = |n: &str| syn::parse_str::<syn::Ident>(n).unwrap();
     let is_enum = |name: &str| {
@@ -1150,7 +1139,7 @@ fn not_expressible_report_names_the_crate_of_each_offender() {
             at("helpers"),
         ),
     ];
-    let Err(err) = crate::test_util::reg_from_items::<(), _>(items) else {
+    let Err(err) = crate::test_util::reg_from_items::<_>(items) else {
         panic!("both items are inexpressible")
     };
     let msg = err.to_string();
@@ -1187,7 +1176,7 @@ fn a_binding_local_fn_is_checked_against_the_grammar() {
         ("fn takes_impl(x: impl std::fmt::Debug) {}", "impl Trait"),
         ("async fn is_async() {}", "async"),
     ] {
-        let reg: RegistryBuilder<()> =
+        let reg: RegistryBuilder =
             crate::test_util::reg_from_items(vec![fn_item("fn good(x: u64) -> u64 { x }")])
                 .unwrap();
         let ext = StubExt {
@@ -1214,7 +1203,7 @@ fn a_binding_local_fn_is_checked_against_the_grammar() {
 /// declared, which a binding-local fn legitimately may not be.
 #[test]
 fn a_well_formed_binding_local_fn_passes() {
-    let reg: RegistryBuilder<()> =
+    let reg: RegistryBuilder =
         crate::test_util::reg_from_items(vec![fn_item("fn good(x: u64) -> u64 { x }")]).unwrap();
     let ext = StubExt {
         local_fns: vec![(
@@ -1259,7 +1248,7 @@ fn a_guard_never_reaches_the_const_surface() {
             loc.clone(),
         ),
     ];
-    let reg: RegistryBuilder<()> = crate::test_util::reg_from_items(items).unwrap();
+    let reg: RegistryBuilder = crate::test_util::reg_from_items(items).unwrap();
 
     assert_eq!(reg.flat().guards().count(), 2);
     assert_eq!(reg.flat().constants().count(), 1);
@@ -1287,7 +1276,7 @@ fn a_guard_never_reaches_the_const_surface() {
 /// one would move generated output. This is the assertion that keeps the filter.
 #[test]
 fn named_item_idents_omits_aliases() {
-    let reg: RegistryBuilder<()> = crate::test_util::reg_with(&[
+    let reg: RegistryBuilder = crate::test_util::reg_with(&[
         "pub fn f(x: u64) -> u64 { x }",
         "pub struct S { pub a: u64 }",
         "pub enum E { A }",
@@ -1315,7 +1304,7 @@ fn a_binding_local_fn_joins_the_index_but_not_the_source_modules() {
         crate_name: Some("myflat".into()),
         ..SourceLocation::default()
     };
-    let reg: RegistryBuilder<()> = crate::test_util::reg_from_items(vec![(
+    let reg: RegistryBuilder = crate::test_util::reg_from_items(vec![(
         syn::parse_quote!(
             pub fn captured(x: u64) -> u64 {
                 x
@@ -1356,7 +1345,7 @@ fn a_binding_local_fn_joins_the_index_but_not_the_source_modules() {
 /// Both enum shapes remain distinct and directly usable through the flat model.
 #[test]
 fn both_enum_shapes_are_available_from_the_model() {
-    let reg: RegistryBuilder<()> = crate::test_util::reg_with(&[
+    let reg: RegistryBuilder = crate::test_util::reg_with(&[
         "pub enum Sum { A(u64), B }",
         "pub enum Flags { X = 1, Y = 2 }",
         "pub struct S { pub a: u64 }",
@@ -1389,7 +1378,7 @@ fn both_enum_shapes_are_available_from_the_model() {
 /// captured item" about it is simply false.
 #[test]
 fn every_declared_type_counts_including_an_alias() {
-    let reg: RegistryBuilder<()> = crate::test_util::reg_with(&[
+    let reg: RegistryBuilder = crate::test_util::reg_with(&[
         "pub struct S { pub a: u64 }",
         "pub enum Sum { A(u64), B }",
         "pub enum Flags { X = 1 }",
@@ -1424,7 +1413,7 @@ fn every_declared_type_counts_including_an_alias() {
 /// `core::diagnostics::ignoring_an_alias_is_not_stale`.
 #[test]
 fn a_qualified_alias_warns_rather_than_failing() {
-    let reg: RegistryBuilder<()> = crate::test_util::reg_with(&[
+    let reg: RegistryBuilder = crate::test_util::reg_with(&[
         "pub type Handle = other::Inner;",
         "pub fn f(x: u64) -> u64 { x }",
     ]);
@@ -1457,12 +1446,12 @@ fn a_type_only_a_local_fn_writes_still_has_a_reading() {
         fn stub(&self) -> &StubExt {
             &self.0
         }
-        fn converter(&self, ty: &syn::Type) -> Option<ConverterImpl<()>> {
+        fn converter(&self, ty: &syn::Type) -> Option<ConverterImpl> {
             Self::converter(ty)
         }
     }
     impl AnyConverterExt {
-        fn converter(ty: &syn::Type) -> Option<ConverterImpl<()>> {
+        fn converter(ty: &syn::Type) -> Option<ConverterImpl> {
             Some(ConverterImpl {
                 destination: ty.clone(),
                 function: syn::parse_quote!(
@@ -1476,11 +1465,10 @@ fn a_type_only_a_local_fn_writes_still_has_a_reading() {
         }
     }
     impl Prebindgen for AnyConverterExt {
-        type Metadata = ();
         fn on_function(
             &self,
             f: &prebindgen_flat::flat::Function,
-            r: &Registry<()>,
+            r: &Registry,
             _emit: &crate::Emit,
         ) -> TokenStream {
             self.0.on_function(f, r, _emit)
@@ -1488,7 +1476,7 @@ fn a_type_only_a_local_fn_writes_still_has_a_reading() {
         fn on_struct(
             &self,
             st: &prebindgen_flat::flat::Struct,
-            r: &Registry<()>,
+            r: &Registry,
             _emit: &crate::Emit,
         ) -> TokenStream {
             self.0.on_struct(st, r, _emit)
@@ -1496,7 +1484,7 @@ fn a_type_only_a_local_fn_writes_still_has_a_reading() {
         fn on_variant(
             &self,
             v: &prebindgen_flat::flat::Variant,
-            r: &Registry<()>,
+            r: &Registry,
             _emit: &crate::Emit,
         ) -> TokenStream {
             self.0.on_variant(v, r, _emit)
@@ -1504,7 +1492,7 @@ fn a_type_only_a_local_fn_writes_still_has_a_reading() {
         fn on_enum(
             &self,
             e: &prebindgen_flat::flat::Enum,
-            r: &Registry<()>,
+            r: &Registry,
             _emit: &crate::Emit,
         ) -> TokenStream {
             self.0.on_enum(e, r, _emit)
@@ -1512,7 +1500,7 @@ fn a_type_only_a_local_fn_writes_still_has_a_reading() {
     }
 
     // `Option<u64>` appears nowhere in the captured stream.
-    let reg: RegistryBuilder<()> =
+    let reg: RegistryBuilder =
         crate::test_util::reg_from_items(vec![fn_item("fn captured(x: u64) -> u64 { x }")])
             .unwrap();
     assert!(
@@ -1563,7 +1551,7 @@ fn a_type_only_a_local_fn_writes_still_has_a_reading() {
 /// the location has a position at all, which is the only thing that now gates it.
 #[test]
 fn an_unresolved_type_without_a_position_reports_none() {
-    let reg: RegistryBuilder<()> =
+    let reg: RegistryBuilder =
         crate::test_util::reg_from_items(vec![fn_item("fn captured(x: u64) -> u64 { x }")])
             .unwrap();
     let ext = StubExt {
@@ -1594,7 +1582,7 @@ fn an_unresolved_type_without_a_position_reports_none() {
     );
 
     // A captured item that DOES have a position still reports it.
-    let located: RegistryBuilder<()> = crate::test_util::reg_from_items(vec![(
+    let located: RegistryBuilder = crate::test_util::reg_from_items(vec![(
         syn::parse_quote!(
             pub fn f(x: u64) -> u64 {
                 x
@@ -1630,7 +1618,7 @@ fn an_unresolved_type_without_a_position_reports_none() {
 /// binding author reaches for and the source language refuses.
 #[test]
 fn a_declared_crossing_the_grammar_refuses_is_not_called_a_prebindgen_item() {
-    let reg: RegistryBuilder<()> =
+    let reg: RegistryBuilder =
         crate::test_util::reg_from_items(vec![fn_item("fn f(x: u64) -> u64 { x }")]).unwrap();
 
     let mut ext = StubExt::default();
@@ -1719,7 +1707,7 @@ fn a_not_expressible_report_omits_a_position_it_does_not_have() {
 fn a_recursive_type_is_handed_out_once_and_terminates() {
     use std::collections::HashSet as Set;
 
-    let reg: RegistryBuilder<()> = crate::test_util::reg_with(&[
+    let reg: RegistryBuilder = crate::test_util::reg_with(&[
         "pub struct Node { pub next: Option<Box<Node>>, pub value: u64 }",
         "pub fn walk(n: &Node) -> u64 { n.value }",
     ]);

--- a/prebindgen-registry/src/registry/view.rs
+++ b/prebindgen-registry/src/registry/view.rs
@@ -22,8 +22,8 @@ pub type Crossing = (Direction, TypeKey);
 /// [`Building`] is the partial view a generator sees while it is still
 /// producing conversions; [`Registry`] is the total one everything else sees.
 /// A helper that serves both — reading a signature off the model, say — takes
-/// `&impl Conversions<M>` and works either side of the boundary.
-pub trait Conversions<M> {
+/// `&impl Conversions` and works either side of the boundary.
+pub trait Conversions {
     /// The model.
     fn flat(&self) -> &Flat;
 
@@ -45,15 +45,6 @@ pub trait Conversions<M> {
     /// rest take one precisely because this exists to hand them one (#284).
     fn reading(&self, key: &TypeKey) -> Option<TypeRef>;
 
-    /// The conversion for `reading` in `dir`, if there is one.
-    ///
-    /// Takes the **reading**, not a spelling. A caller that has to ask what a
-    /// type converts to has already established what the type *is*; asking with
-    /// tokens instead let a spelling nobody classified reach the table, and cost
-    /// a `TypeKey::from_type` on every call for an identity the reading already
-    /// carries.
-    fn conversion(&self, dir: Direction, reading: &TypeRef) -> Option<&TypeEntry<M>>;
-
     /// The reading for a **spelling** — identify, then look up.
     ///
     /// The door for a caller holding tokens it peeled or composed itself, which
@@ -67,16 +58,6 @@ pub trait Conversions<M> {
     /// tokens is a visible step with a `None` to handle.
     fn reading_of(&self, ty: &syn::Type) -> Option<TypeRef> {
         self.reading(&TypeKey::from_type(ty))
-    }
-
-    /// Wire → rust.
-    fn input_entry(&self, reading: &TypeRef) -> Option<&TypeEntry<M>> {
-        self.conversion(Direction::Input, reading)
-    }
-
-    /// Rust → wire.
-    fn output_entry(&self, reading: &TypeRef) -> Option<&TypeEntry<M>> {
-        self.conversion(Direction::Output, reading)
     }
 
     /// The decomposition of a callback argument type, if it has one.
@@ -116,15 +97,12 @@ pub trait Conversions<M> {
     }
 }
 
-impl<M> Conversions<M> for Building<'_, M> {
+impl Conversions for Building<'_> {
     fn flat(&self) -> &Flat {
         &self.registry.flat
     }
     fn reading(&self, key: &TypeKey) -> Option<TypeRef> {
         self.registry.reading(key)
-    }
-    fn conversion(&self, dir: Direction, reading: &TypeRef) -> Option<&TypeEntry<M>> {
-        self.built.get(&(dir, reading.key()))
     }
     fn callback_arg_plan(&self, key: &TypeKey) -> Option<&UnfoldPlan> {
         self.registry.callback_arg_plans.get(key)
@@ -150,15 +128,12 @@ impl<M> Conversions<M> for Building<'_, M> {
     }
 }
 
-impl<M> Conversions<M> for Registry<M> {
+impl Conversions for Registry {
     fn flat(&self) -> &Flat {
         &self.flat
     }
     fn reading(&self, key: &TypeKey) -> Option<TypeRef> {
         Registry::reading(self, key)
-    }
-    fn conversion(&self, dir: Direction, reading: &TypeRef) -> Option<&TypeEntry<M>> {
-        self.type_table(dir).get(&reading.key())?.entry.as_ref()
     }
     fn callback_arg_plan(&self, key: &TypeKey) -> Option<&UnfoldPlan> {
         self.callback_arg_plans.get(key)
@@ -182,36 +157,28 @@ impl<M> Conversions<M> for Registry<M> {
 
 /// The registry mid-fill: the model, plus the conversions supplied so far.
 ///
-/// What a generator builds a conversion *against*. It sees every crossing it
-/// can compose from — `RegistryBuilder::crossings` hands them out inner-first, so by
-/// the time `Option<Handle>` is asked for, `Handle` is already in here.
+/// What a generator builds a conversion *against*: the model, the
+/// decompositions, and the full crossing population.
 ///
 /// It exposes exactly the reads a conversion needs, which is what keeps the
 /// half-filled state from leaking anywhere else: the resolved [`Registry`] is
 /// what the emitters get, and it is total.
-pub struct Building<'a, M> {
-    /// The prepared registry: model, decompositions and the full crossing
-    /// population. Its conversion cells are still empty — [`Self::conversion`]
-    /// deliberately reads [`Self::built`] instead, so a generator can only see
-    /// what it has actually produced.
-    registry: &'a Registry<M>,
-    built: &'a HashMap<Crossing, TypeEntry<M>>,
+///
+/// It no longer lends out conversions built so far. An adapter composes from
+/// its own fragments, which it keeps itself, so what the registry could offer
+/// here — one `ConverterImpl` per crossing — was both less than the adapter
+/// already had and less than a multi-wire crossing needs.
+pub struct Building<'a> {
+    /// The prepared registry. Its cells are still empty at this point.
+    registry: &'a Registry,
     /// Every crossing in the binding, resolved or not — the niche allocator
     /// reads the population, not just what is built so far.
     all_keys: &'a [Crossing],
 }
 
-impl<'a, M> Building<'a, M> {
-    pub(crate) fn new(
-        registry: &'a Registry<M>,
-        built: &'a HashMap<Crossing, TypeEntry<M>>,
-        all_keys: &'a [Crossing],
-    ) -> Self {
-        Self {
-            registry,
-            built,
-            all_keys,
-        }
+impl<'a> Building<'a> {
+    pub(crate) fn new(registry: &'a Registry, all_keys: &'a [Crossing]) -> Self {
+        Self { registry, all_keys }
     }
 }
 

--- a/prebindgen-registry/src/resolve.rs
+++ b/prebindgen-registry/src/resolve.rs
@@ -80,7 +80,7 @@ impl std::error::Error for ResolveError {}
 /// Derived, never stored. Needing a converter is a property of the graph, and the
 /// graph is not complete until resolution has run — so computing it once here
 /// beats maintaining a flag that every edge discovery has to write back.
-fn required_set<M>(registry: &Registry<M>) -> HashSet<(Direction, TypeKey)> {
+fn required_set(registry: &Registry) -> HashSet<(Direction, TypeKey)> {
     let mut required: HashSet<(Direction, TypeKey)> = HashSet::new();
     let mut queue: VecDeque<(Direction, TypeKey)> = VecDeque::new();
     for dir in [Direction::Input, Direction::Output] {
@@ -117,8 +117,8 @@ fn required_set<M>(registry: &Registry<M>) -> HashSet<(Direction, TypeKey)> {
 /// `subs` were already walked by `required_set`, so traversing through
 /// them risks reporting dependents the resolved converter doesn't actually
 /// need.
-fn collect_unresolved_descendants<M>(
-    registry: &Registry<M>,
+fn collect_unresolved_descendants(
+    registry: &Registry,
     seeds: &[(Direction, TypeKey)],
     seen: &mut std::collections::HashSet<(Direction, TypeKey)>,
     out: &mut Vec<UnresolvedEntry>,
@@ -169,7 +169,7 @@ fn collect_unresolved_descendants<M>(
     }
 }
 
-pub(crate) fn check_complete<M>(registry: &Registry<M>) -> Result<(), ResolveError> {
+pub(crate) fn check_complete(registry: &Registry) -> Result<(), ResolveError> {
     let required = required_set(registry);
     let mut entries: Vec<UnresolvedEntry> = Vec::new();
     let mut unresolved_required_roots: Vec<(Direction, TypeKey)> = Vec::new();

--- a/prebindgen-registry/src/resolve.rs
+++ b/prebindgen-registry/src/resolve.rs
@@ -1,12 +1,12 @@
 //! Completeness: which conversions a binding actually needs, and whether it has
 //! them.
 //!
-//! What survives here is the completeness check. The generator fills the cells
-//! itself (`RegistryBuilder::crossings` → `convert_with`); this decides whether the
-//! set it produced covers everything reachable from an exported root.
+//! What survives here is the completeness check. The generator answers the
+//! crossings itself, in `RegistryBuilder::convert_with`; this decides whether
+//! the set it answered covers everything reachable from an exported root.
 //!
-//! There is no loop. `Registry::crossings` hands the demand out inner-first, so
-//! a generator answers each crossing once, with everything it composes from
+//! There is no loop. `convert_with` hands the demand out inner-first, so a
+//! generator answers each crossing once, with everything it composes from
 //! already built — including across the `impl Fn` seam, whose args cross in the
 //! opposite direction.
 //!

--- a/prebindgen-registry/src/resolve/tests.rs
+++ b/prebindgen-registry/src/resolve/tests.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::registry::TypeEntry;
+use crate::registry::Answer;
 
 /// Regression: when a required type is itself unresolved AND has fields
 /// that are also unresolved, the diagnostic must list both. Previously
@@ -15,7 +15,7 @@ fn final_invariant_reports_unresolved_field_of_unresolved_struct() {
     // gets a cell that is NOT a root — exactly the case the BFS is here to
     // catch. Driven through the real scan rather than simulated, so the state
     // under test is one the pipeline can actually produce.
-    let mut reg: Registry<()> =
+    let mut reg: Registry =
         crate::test_util::scanned_with(&["pub struct Outer { pub inner: ZKeyExpr }"]);
     let outer = reg
         .intern(
@@ -51,11 +51,11 @@ fn final_invariant_reports_unresolved_field_of_unresolved_struct() {
 /// that the resolved converter doesn't actually depend on.
 #[test]
 fn final_invariant_stops_at_resolved_nodes() {
-    use crate::registry::{Direction, Registry, TypeEntry};
+    use crate::registry::{Answer, Direction, Registry};
 
     // Through the real scan, so the state under test is one the pipeline can
     // actually produce: `Unrelated` is a field type nothing declares.
-    let mut reg: Registry<()> = crate::test_util::scanned_with(&[
+    let mut reg: Registry = crate::test_util::scanned_with(&[
         "pub struct Outer { pub inner: Inner }",
         "pub struct Inner { pub unused: Unrelated }",
     ]);
@@ -72,16 +72,7 @@ fn final_invariant_stops_at_resolved_nodes() {
         Direction::Input,
         &inner_ty,
         false,
-        Some(TypeEntry {
-            destination: syn::parse_quote!(i64),
-            function: syn::parse_quote!(
-                fn __dummy() {}
-            ),
-            pre_stages: vec![],
-            subs: vec![],
-            niches: crate::niches::Niches::empty(),
-            metadata: (),
-        }),
+        Some(Answer::over(vec![])),
     );
 
     reg.insert_crossing(Direction::Input, &unrelated_ty, false, None);
@@ -112,7 +103,7 @@ fn final_invariant_stops_at_resolved_nodes() {
 fn a_type_reachable_only_through_subs_must_still_resolve() {
     use crate::registry::{Registry, TypeKey};
 
-    let mut reg: Registry<()> = Registry::empty();
+    let mut reg: Registry = Registry::empty();
     let outer: syn::Type = syn::parse_quote!(Outer);
     let mid: syn::Type = syn::parse_quote!(Mid);
 
@@ -122,16 +113,7 @@ fn a_type_reachable_only_through_subs_must_still_resolve() {
         Direction::Input,
         &outer,
         true,
-        Some(TypeEntry {
-            destination: syn::parse_quote!(i64),
-            function: syn::parse_quote!(
-                fn __outer() {}
-            ),
-            pre_stages: vec![],
-            subs: vec![TypeKey::from_type(&mid)],
-            niches: crate::niches::Niches::empty(),
-            metadata: (),
-        }),
+        Some(Answer::over(vec![TypeKey::from_type(&mid)])),
     );
     // `Mid` is present, unresolved, and NOT a root.
     reg.insert_crossing(Direction::Input, &mid, false, None);

--- a/prebindgen-registry/src/test_util.rs
+++ b/prebindgen-registry/src/test_util.rs
@@ -16,7 +16,7 @@ use crate::registry::{Registry, RegistryBuilder};
 /// Whatever it does *not* declare is supplied by [`declare_referenced`], because
 /// these fixtures exist to exercise plan shapes and a handle declaration is noise
 /// in them.
-pub(crate) fn reg_with<M>(sources: &[&str]) -> RegistryBuilder<M> {
+pub(crate) fn reg_with(sources: &[&str]) -> RegistryBuilder {
     let items = sources
         .iter()
         .map(|src| {
@@ -30,7 +30,7 @@ pub(crate) fn reg_with<M>(sources: &[&str]) -> RegistryBuilder<M> {
 /// A **scanned** registry from item sources — for tests that drive `expand` /
 /// `unfold` directly and need the type tables populated, without going through
 /// a generator's conversion loop.
-pub(crate) fn scanned_with<M>(sources: &[&str]) -> Registry<M> {
+pub(crate) fn scanned_with(sources: &[&str]) -> Registry {
     reg_with(sources).scanned().expect("scan")
 }
 
@@ -47,7 +47,7 @@ pub(crate) fn declared_origin(ty: syn::Type) -> prebindgen_flat::flat::Origin<sy
 ///
 /// Test-only sugar: the two steps are one line each in a build script, but they
 /// appear in dozens of fixtures here.
-pub(crate) fn reg_from_items<M, I>(items: I) -> Result<RegistryBuilder<M>, crate::ScanError>
+pub(crate) fn reg_from_items<I>(items: I) -> Result<RegistryBuilder, crate::ScanError>
 where
     I: IntoIterator<Item = (syn::Item, SourceLocation)>,
 {

--- a/prebindgen-registry/src/unfold.rs
+++ b/prebindgen-registry/src/unfold.rs
@@ -279,8 +279,8 @@ fn validate_declarations(acc: &Deconstructors) -> Result<(), UnfoldError> {
 ///
 /// Runs inside `write_rust` after `expand::apply` and before `resolve`, so leaf
 /// converters resolve through the normal rank machinery.
-pub(crate) fn apply<M>(
-    registry: &mut Registry<M>,
+pub(crate) fn apply(
+    registry: &mut Registry,
     acc: &Deconstructors,
     declared_fns: &std::collections::HashSet<syn::Ident>,
     accessor_fns: &std::collections::HashSet<syn::Ident>,
@@ -502,8 +502,8 @@ pub struct ValueDecon {
 /// stays non-generic.
 ///
 /// Runs in `write_rust` right after [`apply`] and before `resolve`.
-pub(crate) fn apply_value_structs<M>(
-    registry: &mut Registry<M>,
+pub(crate) fn apply_value_structs(
+    registry: &mut Registry,
     decons: Vec<ValueDecon>,
     declared_fns: &std::collections::HashSet<syn::Ident>,
 ) -> Result<(), UnfoldError> {
@@ -577,7 +577,7 @@ pub struct SumDecon {
 /// true for jnigen via `export_type`, and not true at all for a registry
 /// assembled without declarations. The invariant holds by construction now
 /// rather than by declaration order.
-fn register_leaves<M>(registry: &mut crate::registry::Registry<M>, leaves: &[UnfoldLeaf]) {
+fn register_leaves(registry: &mut crate::registry::Registry, leaves: &[UnfoldLeaf]) {
     for leaf in leaves {
         if leaf.has_converter() {
             registry.require_output(&leaf.out_ty);
@@ -588,8 +588,8 @@ fn register_leaves<M>(registry: &mut crate::registry::Registry<M>, leaves: &[Unf
 }
 
 /// Runs in `write_rust` right after [`apply_value_structs`] and before `resolve`.
-pub(crate) fn apply_sum_returns<M>(
-    registry: &mut Registry<M>,
+pub(crate) fn apply_sum_returns(
+    registry: &mut Registry,
     decons: Vec<SumDecon>,
     declared_fns: &std::collections::HashSet<syn::Ident>,
 ) -> Result<(), UnfoldError> {
@@ -608,8 +608,8 @@ pub(crate) fn apply_sum_returns<M>(
 
 /// Register the declaration-canonical [`DeconSpec`] of a synthesized
 /// decomposition (first writer wins) and return its identity.
-fn wire_fixed_decon<M>(
-    registry: &mut Registry<M>,
+fn wire_fixed_decon(
+    registry: &mut Registry,
     key: &TypeKey,
     source: &prebindgen_flat::flat::TypeRef,
     leaves: &[UnfoldLeaf],
@@ -631,8 +631,8 @@ fn wire_fixed_decon<M>(
 /// marks a type that has no whole-value converter at all (a sum), so the
 /// declared return's scan-time output requirement is dropped as the plan
 /// replaces it.
-fn wire_fixed_returns<M>(
-    registry: &mut Registry<M>,
+fn wire_fixed_returns(
+    registry: &mut Registry,
     vd: &ValueDecon,
     decon: &DeconId,
     declared_fns: &std::collections::HashSet<syn::Ident>,
@@ -696,8 +696,8 @@ fn wire_fixed_returns<M>(
 /// instead of a whole value built on the Rust side. Separate from the
 /// output-position wiring so the callback path (which needs the foreign-side
 /// group-reassembly adapter) can be enabled on its own.
-fn wire_fixed_callbacks<M>(
-    registry: &mut Registry<M>,
+fn wire_fixed_callbacks(
+    registry: &mut Registry,
     vd: &ValueDecon,
     decon: &DeconId,
     declared_fns: &std::collections::HashSet<syn::Ident>,
@@ -772,8 +772,8 @@ fn wire_fixed_callbacks<M>(
 /// Runs right after [`apply_value_structs`]; skips any function/arg that already
 /// carries a plan (an explicit `.deconstruct_output`, a `data_class` fold, …) so
 /// declared decompositions and value-struct folds win.
-pub(crate) fn apply_leaf_vec_folds<M>(
-    registry: &mut Registry<M>,
+pub(crate) fn apply_leaf_vec_folds(
+    registry: &mut Registry,
     elements: Vec<TypeKey>,
     declared_fns: &std::collections::HashSet<syn::Ident>,
 ) -> Result<(), UnfoldError> {
@@ -980,8 +980,8 @@ fn returns_type(ret: &prebindgen_flat::flat::TypeRef, key: &TypeKey) -> bool {
 }
 
 /// Build one output/error plan for `ed` and store it in the right registry map.
-fn process_decl<M>(
-    registry: &mut Registry<M>,
+fn process_decl(
+    registry: &mut Registry,
     acc: &Deconstructors,
     ed: &OutputDecl,
 ) -> Result<(), UnfoldError> {
@@ -1175,8 +1175,8 @@ fn decl_id(type_key: &TypeKey, _decl: &DeconstructorDecl) -> DeconId {
 /// already present): re-flatten the records with normalized inputs —
 /// borrowed identity, no outer shape — so the stored spec is independent of
 /// the using function's return shape and of processing order.
-fn register_decon_spec<M>(
-    registry: &mut Registry<M>,
+fn register_decon_spec(
+    registry: &mut Registry,
     acc: &Deconstructors,
     decon: &DeconId,
     records: &[DeconRecord],
@@ -1251,9 +1251,9 @@ fn find_deconstructor_by_type<'a>(
 /// recursively flattened ([`flatten`]) — nested accessors contribute
 /// their leaves with the access path prefixed.
 #[allow(clippy::too_many_arguments)]
-fn build_plan<M>(
+fn build_plan(
     acc: &Deconstructors,
-    registry: &Registry<M>,
+    registry: &Registry,
     ed: &OutputDecl,
     by_ref: bool,
     source: &prebindgen_flat::flat::TypeRef,
@@ -1340,9 +1340,9 @@ fn require_root_identity_last(
 /// * `visited` — type keys on the current nesting chain (cycle guard; entries
 ///   are removed after each nested recursion so sibling records may reuse a type).
 #[allow(clippy::too_many_arguments)]
-fn flatten<M>(
+fn flatten(
     acc: &Deconstructors,
-    registry: &Registry<M>,
+    registry: &Registry,
     records: &[DeconRecord],
     source: &prebindgen_flat::flat::TypeRef,
     path_prefix: &[PathStep],
@@ -1744,8 +1744,8 @@ pub fn dedup_names(names: &mut [String]) {
 /// to be about, so the check cannot be the thing a new declarator forgets
 /// (#223). The comparison is [`check_declared_target`], shared with the input
 /// side's constructor lookup.
-fn accessor_signature<M>(
-    registry: &Registry<M>,
+fn accessor_signature(
+    registry: &Registry,
     func: &syn::Ident,
     expected: &TypeKey,
 ) -> Result<prebindgen_flat::flat::TypeRef, UnfoldError> {
@@ -1797,7 +1797,7 @@ fn place_is_owned(hoists: &[Hoist], path_prefix: &[PathStep], by_ref: bool) -> b
 /// Asked separately because [`accessor_signature`] peels the `&` in order to
 /// compare target types, so `f(v: T)` and `f(v: &T)` are indistinguishable
 /// there by design.
-fn accessor_consumes<M>(registry: &Registry<M>, func: &syn::Ident) -> bool {
+fn accessor_consumes(registry: &Registry, func: &syn::Ident) -> bool {
     registry
         .flat()
         .function(&func)

--- a/prebindgen-registry/src/unfold/tests.rs
+++ b/prebindgen-registry/src/unfold/tests.rs
@@ -79,7 +79,7 @@ fn accessor_optional_primitive() {
     // M2: `z_sample_timestamp(&ZSample) -> Option<&ZTimestamp>` decomposed
     // into a single primitive leaf `z_timestamp_ntp64(&ZTimestamp) -> i64`
     // (no identity). Outer shape is `Optional(Decompose)`.
-    let mut reg: Registry<()> = reg_with(&[
+    let mut reg: Registry = reg_with(&[
         "fn z_sample_timestamp(s: &ZSample) -> Option<&ZTimestamp> { todo!() }",
         "fn z_timestamp_ntp64(t: &ZTimestamp) -> i64 { todo!() }",
     ]);
@@ -130,7 +130,7 @@ fn accessor_optional_primitive() {
 fn accessor_plan_byref() {
     // `z_sample_key_expr(&ZSample) -> &ZKeyExpr` decomposed into the keyexpr
     // handle (identity) + its string form (`z_keyexpr_as_str`).
-    let mut reg: Registry<()> = reg_with(&[
+    let mut reg: Registry = reg_with(&[
         "fn z_sample_key_expr(s: &ZSample) -> &ZKeyExpr { todo!() }",
         "fn z_keyexpr_as_str(ke: &ZKeyExpr) -> &str { todo!() }",
     ]);
@@ -194,7 +194,7 @@ fn root_identity_before_nested_identity_errors() {
     // Owned return: the root `.field_self()` MOVES the value, a nested
     // identity (spliced ZKeyExpr handle) borrows it — id-first is the
     // order that would generate non-compiling Rust, caught at apply time.
-    let mut reg: Registry<()> = reg_with(&[
+    let mut reg: Registry = reg_with(&[
         "fn z_take_query(q: &ZQuery) -> ZQuery { todo!() }",
         "fn z_query_key_expr(q: &ZQuery) -> &ZKeyExpr { todo!() }",
     ]);
@@ -228,7 +228,7 @@ fn root_identity_before_nested_identity_errors() {
     assert!(matches!(err, UnfoldError::RootIdentityBeforeNested { .. }));
 
     // Root identity LAST (the zenoh `Query` shape) is accepted.
-    let mut reg2: Registry<()> = reg_with(&[
+    let mut reg2: Registry = reg_with(&[
         "fn z_take_query(q: &ZQuery) -> ZQuery { todo!() }",
         "fn z_query_key_expr(q: &ZQuery) -> &ZKeyExpr { todo!() }",
     ]);
@@ -261,7 +261,7 @@ fn root_identity_before_nested_identity_errors() {
 #[test]
 fn accessor_target_mismatch_errors() {
     // Accessor takes a different type than the accessor's target.
-    let mut reg: Registry<()> = reg_with(&[
+    let mut reg: Registry = reg_with(&[
         "fn z_foo() -> ZKeyExpr { todo!() }",
         "fn wrong(x: &ZSample) -> &str { todo!() }",
     ]);
@@ -286,7 +286,7 @@ fn accessor_target_mismatch_errors() {
 
 #[test]
 fn multiple_identity_errors() {
-    let mut reg: Registry<()> = reg_with(&["fn z_foo() -> ZKeyExpr { todo!() }"]);
+    let mut reg: Registry = reg_with(&["fn z_foo() -> ZKeyExpr { todo!() }"]);
     let mut acc = Deconstructors::default();
     acc.deconstructors.push(DeconstructorDecl {
         target: key("ZKeyExpr"),
@@ -307,7 +307,7 @@ fn multiple_identity_errors() {
 #[test]
 fn record_must_be_fun_accessor() {
     // A deconstructor record referencing a non-`.fun_accessor` fn errors.
-    let mut reg: Registry<()> = reg_with(&[
+    let mut reg: Registry = reg_with(&[
         "fn z_foo(s: &ZSample) -> &ZKeyExpr { todo!() }",
         "fn z_keyexpr_as_str(ke: &ZKeyExpr) -> &str { todo!() }",
     ]);
@@ -346,7 +346,7 @@ fn record_must_be_fun_accessor() {
 fn duplicate_leaf_name_errors() {
     // Two records of one deconstructor given the same literal name ⇒ hard
     // error (names are emitted verbatim; never auto-disambiguated).
-    let mut reg: Registry<()> = reg_with(&[
+    let mut reg: Registry = reg_with(&[
         "fn z_foo() -> ZSample { todo!() }",
         "fn z_sample_key_expr(s: &ZSample) -> &str { todo!() }",
         "fn z_sample_payload(s: &ZSample) -> Vec<u8> { todo!() }",
@@ -383,7 +383,7 @@ fn duplicate_leaf_name_errors() {
 #[test]
 fn reserved_separator_in_name_errors() {
     // A record name containing the reserved `"__"` chain separator ⇒ error.
-    let mut reg: Registry<()> = reg_with(&[
+    let mut reg: Registry = reg_with(&[
         "fn z_foo() -> ZSample { todo!() }",
         "fn z_sample_key_expr(s: &ZSample) -> &str { todo!() }",
     ]);
@@ -420,7 +420,7 @@ fn nested_accessor_flatten() {
     // accessor nests ZKeyExpr (handle+string), ZZBytes (bytes), and a
     // nullable ZTimestamp (Option<&ZTimestamp> → ntp64), plus a direct enum
     // leaf. Verifies path prefixes + nullable propagation.
-    let mut reg: Registry<()> = reg_with(&[
+    let mut reg: Registry = reg_with(&[
         "fn z_reply_sample(r: &ZReply) -> Option<&ZSample> { todo!() }",
         "fn z_sample_key_expr(s: &ZSample) -> &ZKeyExpr { todo!() }",
         "fn z_sample_payload(s: &ZSample) -> &ZZBytes { todo!() }",
@@ -545,7 +545,7 @@ fn reply_product_double_option_flatten() {
     // `Option<ZZenohId>` Acc record with NO default child, which keeps
     // the full `Option<…>` as its leaf `out_ty` (its own `Option` is the
     // converter's business, not a nesting step ⇒ NOT nullable).
-    let mut reg: Registry<()> = reg_with(&[
+    let mut reg: Registry = reg_with(&[
         "fn z_recv_reply(q: &ZQuery) -> ZReply { todo!() }",
         "fn z_reply_replier_zid(r: &ZReply) -> Option<ZZenohId> { todo!() }",
         "fn z_reply_is_ok(r: &ZReply) -> bool { todo!() }",
@@ -694,7 +694,7 @@ fn reply_product_double_option_flatten() {
 #[test]
 fn nested_cycle_errors() {
     // A → B → A nesting is rejected.
-    let mut reg: Registry<()> = reg_with(&[
+    let mut reg: Registry = reg_with(&[
         "fn z_foo() -> ZA { todo!() }",
         "fn a_to_b(a: &ZA) -> &ZB { todo!() }",
         "fn b_to_a(b: &ZB) -> &ZA { todo!() }",
@@ -736,7 +736,7 @@ fn iterable_whole_element_plan() {
     // each element delivered WHOLE (no accessor, no leaves): a per-fn
     // flatten with an empty record list on an element type that has no
     // deconstructor of its own.
-    let mut reg: Registry<()> =
+    let mut reg: Registry =
         reg_with(&["fn z_session_peers_zid(s: &ZSession) -> Vec<ZZenohId> { todo!() }"]);
     let mut acc = Deconstructors::default();
     acc.outputs.push(OutputDecl {
@@ -784,7 +784,7 @@ fn iterable_decomposed_plan() {
     // accessor → Iterable with per-element leaves: the string form + the
     // value itself via `record_id` (an identity leaf, owned at the
     // root since `Vec<ZZenohId>` owns its elements).
-    let mut reg: Registry<()> = reg_with(&[
+    let mut reg: Registry = reg_with(&[
         "fn z_session_peers_zid(s: &ZSession) -> Vec<ZZenohId> { todo!() }",
         "fn z_zenoh_id_to_string(z: &ZZenohId) -> String { todo!() }",
     ]);
@@ -837,7 +837,7 @@ fn convert_output_single_value() {
     // `.converter(ZTimestamp, z_timestamp_ntp64)` + `.convert_output()` on
     // `z_sample_timestamp -> Option<&ZTimestamp>` ⇒ Return delivery, single
     // leaf, convert_out_ty = Option<i64>.
-    let mut reg: Registry<()> = reg_with(&[
+    let mut reg: Registry = reg_with(&[
         "fn z_sample_timestamp(s: &ZSample) -> Option<&ZTimestamp> { todo!() }",
         "fn z_timestamp_ntp64(t: &ZTimestamp) -> i64 { todo!() }",
     ]);
@@ -878,7 +878,7 @@ fn convert_output_single_value() {
 #[test]
 fn multi_leaf_output_is_callback() {
     // A two-record deconstructor (handle + string) ⇒ Callback delivery (>1 leaf).
-    let mut reg: Registry<()> = reg_with(&[
+    let mut reg: Registry = reg_with(&[
         "fn z_sample_key_expr(s: &ZSample) -> &ZKeyExpr { todo!() }",
         "fn z_keyexpr_as_str(ke: &ZKeyExpr) -> &str { todo!() }",
     ]);
@@ -914,7 +914,7 @@ fn multi_leaf_output_is_callback() {
 #[test]
 fn vec_output_is_iterable_callback() {
     // A `Vec` return ⇒ Iterable + Callback (a fold), never a single Return.
-    let mut reg: Registry<()> = reg_with(&[
+    let mut reg: Registry = reg_with(&[
         "fn z_session_peers_zid(s: &ZSession) -> Vec<ZZenohId> { todo!() }",
         "fn z_zenoh_id_to_string(z: &ZZenohId) -> String { todo!() }",
     ]);
@@ -962,7 +962,7 @@ fn option_vec_output_is_optional_iterable_callback() {
     // a RECORD-BUILT `Optional(Iterable)` fold (issue #105): the auto-apply
     // peels the `Option` before probing the `Vec`, the elements decompose
     // into leaves (M5), and `None` skips the fold to deliver a null result.
-    let mut reg: Registry<()> = reg_with(&[
+    let mut reg: Registry = reg_with(&[
         "fn z_routers_zid(s: &ZSession) -> Option<Vec<ZZenohId>> { todo!() }",
         "fn z_zenoh_id_to_string(z: &ZZenohId) -> String { todo!() }",
     ]);
@@ -1005,7 +1005,7 @@ fn option_vec_single_leaf_stays_callback() {
     // single-Return reclassification is gated on "no Iterable at any layer",
     // not just a top-level `Iterable` (an `Option<Vec<T>>` fold has no single
     // value to return through `convert_out_ty`).
-    let mut reg: Registry<()> = reg_with(&[
+    let mut reg: Registry = reg_with(&[
         "fn z_routers_zid(s: &ZSession) -> Option<Vec<ZZenohId>> { todo!() }",
         "fn z_zenoh_id_to_string(z: &ZZenohId) -> String { todo!() }",
     ]);
@@ -1036,7 +1036,7 @@ fn option_vec_whole_element_plan() {
     // M4 dual of the decomposed case: an `Option<Vec<T>>` return with an
     // inline EMPTY record list delivers each element whole through its own
     // output converter, wrapped in the `Optional` layer.
-    let mut reg: Registry<()> =
+    let mut reg: Registry =
         reg_with(&["fn z_routers_zid(s: &ZSession) -> Option<Vec<ZZenohId>> { todo!() }"]);
     let mut acc = Deconstructors::default();
     acc.outputs.push(OutputDecl {
@@ -1077,7 +1077,7 @@ fn value_struct_vec_is_fixed_iterable_fold() {
     // an Optional layer: the field leaves cross raw per element and the
     // foreign folder rebuilds + appends them (no Java object is built on the
     // Rust side); `None` ⇒ a null list. Closes the data_class→Vec milestone.
-    let mut reg: Registry<()> =
+    let mut reg: Registry =
         reg_with(&["fn storage_get_vec(s: &Storage) -> Option<Vec<Payload>> { todo!() }"]);
     let leaf = |name: &str, ty: syn::Type| UnfoldLeaf {
         name: name.to_string(),
@@ -1129,7 +1129,7 @@ fn value_struct_slice_callback_is_fixed_iterable_fold() {
     // `callback_arg_plans` entry keyed by the `&[Payload]` arg: the
     // trampoline folds each element's field leaves into a foreign list, the
     // user callback still sees the whole `List<Payload>`.
-    let mut reg: Registry<()> = reg_with(&[
+    let mut reg: Registry = reg_with(&[
         "fn storage_callback_vec(f: impl Fn(&[Payload]) + Send + Sync + 'static) { todo!() }",
     ]);
     let leaf = |name: &str, ty: syn::Type| UnfoldLeaf {
@@ -1169,7 +1169,7 @@ fn value_struct_slice_callback_is_fixed_iterable_fold() {
     assert_eq!(plan.leaves.len(), 2);
     assert!(plan.leaves.iter().all(|l| l.source == LeafSource::Field));
     // A scalar `&Payload` callback arg must stay a Base fixed builder.
-    let mut reg2: Registry<()> = reg_with(&[
+    let mut reg2: Registry = reg_with(&[
         "fn storage_callback(f: impl Fn(&Payload) + Send + Sync + 'static) { todo!() }",
     ]);
     let vd2 = ValueDecon {
@@ -1192,7 +1192,7 @@ fn convert_error_decomposes_result_e() {
     // The ZError deconstructor (`z_error_message`) auto-applies to every fn
     // returning `Result<_, ZError>`, storing the plan in `error_plans`. Error
     // delivery is always Callback (its leaves are the `ze` callback args).
-    let mut reg: Registry<()> = reg_with(&[
+    let mut reg: Registry = reg_with(&[
         "fn z_keyexpr_try_from(s: String) -> Result<ZKeyExpr, ZError> { todo!() }",
         "fn z_error_message(e: &ZError) -> String { todo!() }",
         "fn z_infallible(s: &ZSample) -> bool { todo!() }",
@@ -1240,7 +1240,7 @@ fn default_output_applies_to_owned_and_borrow_returns() {
     // Default-everywhere: the ZKeyExpr deconstructor auto-applies to BOTH a
     // `&ZKeyExpr` (borrow) and an owned `ZKeyExpr` return. (`Result<…>` returns
     // are excluded — they keep a handle — and `fun_accessor`s are skipped.)
-    let mut reg: Registry<()> = reg_with(&[
+    let mut reg: Registry = reg_with(&[
         "fn z_borrow_keyexpr(s: &ZSession) -> &ZKeyExpr { todo!() }",
         "fn z_make_keyexpr(s: &ZSession) -> ZKeyExpr { todo!() }",
         "fn z_keyexpr_as_str(k: &ZKeyExpr) -> &str { todo!() }",
@@ -1285,7 +1285,7 @@ fn callback_arg_plan_derived() {
     // An `impl Fn(ZSample)` parameter of a declared fn gets a type-level
     // plan from ZSample's default deconstructor — same leaves a return of
     // ZSample would produce, but owned (`by_ref = false`).
-    let mut reg: Registry<()> = reg_with(&[
+    let mut reg: Registry = reg_with(&[
         "fn z_declare_sub(cb: impl Fn(ZSample) + Send + Sync + 'static) { todo!() }",
         "fn z_sample_key_expr(s: &ZSample) -> &ZKeyExpr { todo!() }",
         "fn z_sample_kind(s: &ZSample) -> SampleKind { todo!() }",
@@ -1362,7 +1362,7 @@ fn callback_arg_borrowed_decomposed() {
     // deconstructor as the by-value case, but with `by_ref = true` (leaves
     // read through the reference) and keyed under the actual `&ZSample` arg
     // type — so `callback_input`/`callback_iface_spec` find it.
-    let mut reg: Registry<()> = reg_with(&[
+    let mut reg: Registry = reg_with(&[
         "fn z_declare_sub(cb: impl Fn(&ZSample) + Send + Sync + 'static) { todo!() }",
         "fn z_sample_key_expr(s: &ZSample) -> &ZKeyExpr { todo!() }",
         "fn z_sample_kind(s: &ZSample) -> SampleKind { todo!() }",
@@ -1426,7 +1426,7 @@ fn callback_arg_borrowed_decomposed() {
 #[test]
 fn callback_arg_identity_fallback() {
     // No deconstructor for ZQuery ⇒ no plan: the arg is delivered whole.
-    let mut reg: Registry<()> = reg_with(&[
+    let mut reg: Registry = reg_with(&[
         "fn z_declare_queryable(cb: impl Fn(ZQuery) + Send + Sync + 'static) { todo!() }",
     ]);
     let acc = Deconstructors::default();
@@ -1438,7 +1438,7 @@ fn callback_arg_identity_fallback() {
 
 #[test]
 fn callback_zero_arg_no_plan() {
-    let mut reg: Registry<()> =
+    let mut reg: Registry =
         reg_with(&["fn z_with_close(on_close: impl Fn() + Send + Sync + 'static) { todo!() }"]);
     let acc = Deconstructors::default();
     let declared: std::collections::HashSet<syn::Ident> =
@@ -1451,7 +1451,7 @@ fn callback_zero_arg_no_plan() {
 fn callback_arg_nonbare_skipped() {
     // `impl Fn(Vec<ZSample>)`: the arg type key (`Vec<ZSample>`) matches no
     // deconstructor target ⇒ whole-value fallback, no plan.
-    let mut reg: Registry<()> = reg_with(&[
+    let mut reg: Registry = reg_with(&[
         "fn z_batched(cb: impl Fn(Vec<ZSample>) + Send + Sync + 'static) { todo!() }",
         "fn z_sample_kind(s: &ZSample) -> SampleKind { todo!() }",
     ]);
@@ -1490,7 +1490,7 @@ fn leaf_vec_fold_synthesizes_whole_element_plans() {
     // `Vec<String>` / `Option<Vec<ZenohId>>` returns and an `impl Fn(&[String])`
     // callback arg synthesize FIXED **whole-element** folds (no decon, element
     // set, no leaves) — the single-leaf dual of the `data_class` Vec fold.
-    let mut reg: Registry<()> = reg_with(&[
+    let mut reg: Registry = reg_with(&[
         "fn hello_get_locators(h: &Hello) -> Vec<String> { todo!() }",
         "fn session_peers(s: &Session) -> Option<Vec<ZenohId>> { todo!() }",
         "fn on_strings(f: impl Fn(&[String]) + Send + Sync + 'static) { todo!() }",
@@ -1548,7 +1548,7 @@ fn leaf_vec_fold_synthesizes_whole_element_plans() {
 fn leaf_vec_fold_skips_unnominated_and_preexisting() {
     // An un-nominated element is left on the ArrayList path (no plan); a fn
     // that already has a plan is never overwritten.
-    let mut reg: Registry<()> = reg_with(&[
+    let mut reg: Registry = reg_with(&[
         "fn other(x: &X) -> Vec<NotNominated> { todo!() }",
         "fn strings() -> Vec<String> { todo!() }",
     ]);
@@ -1588,7 +1588,7 @@ fn leaf_vec_fold_skips_unnominated_and_preexisting() {
 /// that stands on its own for any adapter.)
 #[test]
 fn unknown_accessor_errors() {
-    let mut reg: Registry<()> = reg_with(&["fn z_foo() -> ZKeyExpr { todo!() }"]);
+    let mut reg: Registry = reg_with(&["fn z_foo() -> ZKeyExpr { todo!() }"]);
     let mut acc = Deconstructors::default();
     acc.deconstructors.push(DeconstructorDecl {
         target: key("ZKeyExpr"),
@@ -1614,7 +1614,7 @@ fn unknown_accessor_errors() {
 /// delivery form.)
 #[test]
 fn duplicate_declarations_collected() {
-    let mut reg: Registry<()> = reg_with(&[
+    let mut reg: Registry = reg_with(&[
         "fn z_keyexpr_as_str(ke: &ZKeyExpr) -> &str { todo!() }",
         "fn z_session_key(s: &ZSession) -> ZKeyExpr { todo!() }",
     ]);
@@ -1707,7 +1707,7 @@ fn reading_sum_decon() -> SumDecon {
 /// would fail the resolve on a converter that must not exist.
 #[test]
 fn sum_return_is_a_fixed_builder_plan() {
-    let mut reg: Registry<()> = reg_with(&["fn read_one(which: i32) -> Reading { todo!() }"]);
+    let mut reg: Registry = reg_with(&["fn read_one(which: i32) -> Reading { todo!() }"]);
     let declared: std::collections::HashSet<syn::Ident> =
         ["read_one"].iter().map(|s| ident(s)).collect();
     apply_sum_returns(&mut reg, vec![reading_sum_decon()], &declared).expect("apply_sum_returns");
@@ -1760,7 +1760,7 @@ fn sum_return_is_a_fixed_builder_plan() {
 /// dropped along with the bare type's.
 #[test]
 fn sum_return_layers_ride_the_shape_fold() {
-    let mut reg: Registry<()> = reg_with(&[
+    let mut reg: Registry = reg_with(&[
         "fn read_maybe(w: i32) -> Option<Reading> { todo!() }",
         "fn read_all(n: i32) -> Vec<Reading> { todo!() }",
     ]);
@@ -1802,7 +1802,7 @@ fn sum_return_layers_ride_the_shape_fold() {
 /// unrequire exists for.
 #[test]
 fn a_vec_only_sum_return_drops_the_bare_requirement() {
-    let mut reg: Registry<()> = reg_with(&["fn read_all(n: i32) -> Vec<Reading> { todo!() }"]);
+    let mut reg: Registry = reg_with(&["fn read_all(n: i32) -> Vec<Reading> { todo!() }"]);
     let bare: syn::Type = syn::parse_quote!(Reading);
     let bare_reading = reg
         .intern(crate::registry::Direction::Output, &bare, true)
@@ -1834,7 +1834,7 @@ fn a_vec_only_sum_return_drops_the_bare_requirement() {
 /// groups instead of a whole value built on the Rust side.
 #[test]
 fn sum_callback_arg_is_a_fixed_builder_plan() {
-    let mut reg: Registry<()> = reg_with(&[
+    let mut reg: Registry = reg_with(&[
         "fn read_each(n: i32, f: impl Fn(Reading) + Send + Sync + 'static) { todo!() }",
     ]);
     let declared: std::collections::HashSet<syn::Ident> =
@@ -1865,7 +1865,7 @@ fn sum_callback_arg_is_a_fixed_builder_plan() {
 /// verified by sabotage, not assumed.
 #[test]
 fn a_vec_of_optionals_installs_no_fixed_fold() {
-    let mut reg: Registry<()> =
+    let mut reg: Registry =
         reg_with(&["fn storage_get_vec(s: &Storage) -> Vec<Option<Payload>> { todo!() }"]);
     let leaf = |name: &str, ty: syn::Type| UnfoldLeaf {
         name: name.to_string(),

--- a/prebindgen-registry/src/write.rs
+++ b/prebindgen-registry/src/write.rs
@@ -72,7 +72,7 @@ impl std::error::Error for WriteError {}
 /// `out_path` may be relative (resolved against `OUT_DIR` by prebindgen) or
 /// absolute. Returns the path actually written.
 pub fn write_rust<P: AsRef<Path>, E: Prebindgen>(
-    registry: &Registry<E::Metadata>,
+    registry: &Registry,
     ext: &E,
     conversions: &[syn::ItemFn],
     out_path: P,

--- a/prebindgen-registry/src/write/tests.rs
+++ b/prebindgen-registry/src/write/tests.rs
@@ -9,7 +9,7 @@ use crate::registry::RegistryBuilder;
 struct IdentityExt;
 
 impl IdentityExt {
-    fn declare_into(&self, mut reg: RegistryBuilder<()>) -> RegistryBuilder<()> {
+    fn declare_into(&self, mut reg: RegistryBuilder) -> RegistryBuilder {
         for f in [syn::parse_quote!(a_fn), syn::parse_quote!(b_fn)] {
             reg = reg.export(&f);
         }
@@ -23,12 +23,10 @@ impl IdentityExt {
 }
 
 impl Prebindgen for IdentityExt {
-    type Metadata = ();
-
     fn on_function(
         &self,
         f: &prebindgen_flat::flat::Function,
-        _registry: &Registry<Self::Metadata>,
+        _registry: &Registry,
         emit: &crate::Emit,
     ) -> TokenStream {
         emit.verbatim_fn(f)
@@ -37,7 +35,7 @@ impl Prebindgen for IdentityExt {
     fn on_struct(
         &self,
         s: &prebindgen_flat::flat::Struct,
-        _registry: &Registry<Self::Metadata>,
+        _registry: &Registry,
         emit: &crate::Emit,
     ) -> TokenStream {
         emit.verbatim_struct(s)
@@ -46,7 +44,7 @@ impl Prebindgen for IdentityExt {
     fn on_variant(
         &self,
         v: &prebindgen_flat::flat::Variant,
-        _registry: &Registry<Self::Metadata>,
+        _registry: &Registry,
         emit: &crate::Emit,
     ) -> TokenStream {
         emit.verbatim_variant(v)
@@ -55,7 +53,7 @@ impl Prebindgen for IdentityExt {
     fn on_enum(
         &self,
         e: &prebindgen_flat::flat::Enum,
-        _registry: &Registry<Self::Metadata>,
+        _registry: &Registry,
         emit: &crate::Emit,
     ) -> TokenStream {
         emit.verbatim_enum(e)
@@ -147,7 +145,7 @@ fn write_rust_sorts_declared_items_by_ident() {
             loc,
         ),
     ];
-    let reg: Registry<()> = IdentityExt
+    let reg: Registry = IdentityExt
         .declare_into(crate::test_util::reg_from_items(items).expect("index"))
         .scanned()
         .expect("scan");
@@ -196,14 +194,10 @@ fn guards_emit_ungated_and_in_stream_order() {
     struct ConstGatingExt;
 
     trait ResolveGating {
-        fn resolve_gating(self, ext: ConstGatingExt)
-            -> Result<Registry<()>, crate::WriteRustError>;
+        fn resolve_gating(self, ext: ConstGatingExt) -> Result<Registry, crate::WriteRustError>;
     }
-    impl ResolveGating for RegistryBuilder<()> {
-        fn resolve_gating(
-            self,
-            ext: ConstGatingExt,
-        ) -> Result<Registry<()>, crate::WriteRustError> {
+    impl ResolveGating for RegistryBuilder {
+        fn resolve_gating(self, ext: ConstGatingExt) -> Result<Registry, crate::WriteRustError> {
             let registry = self.declares_consts().build()?;
             let _ = &ext;
             Ok(registry)
@@ -211,12 +205,10 @@ fn guards_emit_ungated_and_in_stream_order() {
     }
 
     impl Prebindgen for ConstGatingExt {
-        type Metadata = ();
-
         fn on_function(
             &self,
             f: &prebindgen_flat::flat::Function,
-            _r: &Registry<()>,
+            _r: &Registry,
             _emit: &crate::Emit,
         ) -> TokenStream {
             _emit.verbatim_fn(f)
@@ -224,7 +216,7 @@ fn guards_emit_ungated_and_in_stream_order() {
         fn on_struct(
             &self,
             s: &prebindgen_flat::flat::Struct,
-            _r: &Registry<()>,
+            _r: &Registry,
             _emit: &crate::Emit,
         ) -> TokenStream {
             _emit.verbatim_struct(s)
@@ -232,7 +224,7 @@ fn guards_emit_ungated_and_in_stream_order() {
         fn on_variant(
             &self,
             v: &prebindgen_flat::flat::Variant,
-            _r: &Registry<()>,
+            _r: &Registry,
             _emit: &crate::Emit,
         ) -> TokenStream {
             _emit.verbatim_variant(v)
@@ -240,7 +232,7 @@ fn guards_emit_ungated_and_in_stream_order() {
         fn on_enum(
             &self,
             e: &prebindgen_flat::flat::Enum,
-            _r: &Registry<()>,
+            _r: &Registry,
             _emit: &crate::Emit,
         ) -> TokenStream {
             _emit.verbatim_enum(e)
@@ -274,7 +266,7 @@ fn guards_emit_ungated_and_in_stream_order() {
             loc.clone(),
         ),
     ];
-    let registry: RegistryBuilder<()> = crate::test_util::reg_from_items(items).expect("index");
+    let registry: RegistryBuilder = crate::test_util::reg_from_items(items).expect("index");
     assert_eq!(registry.flat().guards().count(), 2);
 
     let dir = crate::test_util::unique_test_dir("write_guards");


### PR DESCRIPTION
Completes stage 2 of #472 — **the gate**. Stacked on [#477](https://github.com/milyin/prebindgen/pull/477); merge that first.

849 lines out, 591 in, generated output byte-identical.

## What the registry was holding, and why it stopped

The registry stored a whole `ConverterImpl` per crossing — a `TypeEntry` —
so an adapter could look one up. After
[#476](https://github.com/milyin/prebindgen/pull/476) neither adapter does.

What the registry itself reads of a stored entry is `subs`: the crossings
this one delegates to, which `propagate_required` walks to decide what a
binding actually has to be able to make. Plus whether the crossing was
answered at all.

So `convert_with` takes back an `Answer` carrying exactly that. The
conversion stays in the adapter, which emits from it and looks it up.

`TypeEntry` is gone. It held six fields, all but `subs` for readers that no
longer exist, and — as Copilot's review of #475 established — it was
structurally identical to the `ConverterImpl` it was built from.

## Why the diff is this big

Strip a cell down to `subs` and the compiler says where the rest of it
reached: **`M` is unconstrained across `prebindgen-registry`**. The metadata
parameter existed to carry a `KotlinMeta` or a `()` through the converter
table, and an adapter reads its metadata off its own fragment now.

So `Registry<M>`, `RegistryBuilder<M>`, `Conversions<M>`, `Building<'_, M>`
and the `Prebindgen::Metadata` that fed them all lose the parameter.
`ConverterImpl<M>` keeps it — it is what an adapter's fragment carries, and
where `KotlinMeta` still lives.

Most of the diff is deleting a type argument. The load-bearing part is
`Answer`, `convert_with`'s signature, and the deletions below.

## Also gone

- **`Conversions::conversion`**, with `input_entry` and `output_entry` on
  top of it, and the inherent pair on `Registry` that shadowed them.
- **`Building::built`** — `conversion` was its only reader. `Building` no
  longer lends out conversions built so far; one `ConverterImpl` per
  crossing was both less than an adapter already holds and less than a
  multi-wire crossing can be described by.

## Tests

Two changed rather than moved:

- `type_entry_helpers_expose_converter_chain_contract` asserted
  `converter_ident` / `wire_type` / `input_stage_order` /
  `output_stage_order` / `dependency_keys`. Those reads moved to
  `ConverterImpl` in #475, so the test follows them there.
- The fixtures that built a `TypeEntry` purely to put one in a registry
  were saying "this crossing is answered, and delegates to these". They say
  it directly now — `Answer::over(vec![…])` — which is both shorter and the
  thing those tests were ever about.

`jni/tests/niches.rs`'s `install` helper files a `ConverterImpl` as the
adapter's fragment and an `Answer` in the registry, which is the split this
PR makes everywhere.

## Checks

- `cargo test --all` — green
- clippy and rustfmt on 1.85.0 and stable — clean
- `cargo doc` with `-D warnings` — clean, including the prose that described
  the deleted type rather than only the links that broke
- `examples/regen-check.sh` — **byte-identical**
- `examples/smoke-asan.sh` — clean