### PR TITLE
Compose what a JNI data class is made of

### DIFF
--- a/prebindgen-jni/src/jni/compile.rs
+++ b/prebindgen-jni/src/jni/compile.rs
@@ -24,6 +24,29 @@ use super::{
 pub(crate) struct JFrag {
     pub(crate) conv: ConverterImpl<KotlinMeta>,
     pub(crate) yields: Yield,
+    /// The wire values this crossing occupies, when it occupies more than the
+    /// one `conv.destination` names.
+    ///
+    /// A JniGen `data_class` parameter arrives as **several** JNI parameters —
+    /// `Option<Holder>` is `(hPresent, hTag, hSummary)` — so a single
+    /// destination cannot say what it costs. `None` is the ordinary case: one
+    /// wire, and `conv.destination` is it.
+    ///
+    /// Composed by [`Compile::fields`] from the parts' own wires, which is what
+    /// makes a nested `data_class` field contribute its own several rather than
+    /// one.
+    pub(crate) wires: Option<Vec<Wire>>,
+}
+
+/// One wire value of a crossing that occupies several.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct Wire {
+    /// The JNI type this value crosses as.
+    pub(crate) ty: syn::Type,
+    /// The path through the value that reached it — `tag`, `summary.count` —
+    /// which is what a JNI parameter name and a Kotlin accessor are both
+    /// mangled from.
+    pub(crate) path: String,
 }
 
 impl Carrier for JFrag {
@@ -44,6 +67,7 @@ impl JFrag {
     pub(crate) fn by_hand(ty: TypeKey, conv: ConverterImpl<KotlinMeta>) -> Self {
         Self {
             conv,
+            wires: None,
             yields: Yield {
                 ty,
                 mode: Mode::Owned,
@@ -56,6 +80,7 @@ impl JFrag {
         let validity = validity_of(&conv, at.crossing.assembly());
         Self {
             conv,
+            wires: None,
             yields: Yield {
                 ty: at.crossing.value().stripped_key(),
                 mode: at.crossing.mode(),
@@ -281,8 +306,52 @@ impl<R: Conversions> Compile for JCompile<'_, R> {
         Err(refuse(at, "JniGen states no value-form rows yet"))
     }
 
-    fn fields(&mut self, _cx: &mut Cx<'_>, at: At<'_>, _parts: Parts<'_, Self>) -> Frag<Self> {
-        Err(refuse(at, "JniGen states no product rows yet"))
+    fn fields(&mut self, _cx: &mut Cx<'_>, at: At<'_>, parts: Parts<'_, Self>) -> Frag<Self> {
+        if at.crossing.assembly() != Assembly::Construct {
+            return Err(refuse(
+                at,
+                "JniGen states no deconstructing product rows yet",
+            ));
+        }
+        // A `data_class` crosses as its fields, and a field that is itself one
+        // contributes its own several — which is the recursion, stated once
+        // here rather than walked by hand.
+        let mut wires: Vec<Wire> = Vec::new();
+        for (part, frag) in parts {
+            match &frag.wires {
+                Some(inner) => wires.extend(inner.iter().map(|w| Wire {
+                    ty: w.ty.clone(),
+                    path: format!("{}.{}", part.name, w.path),
+                })),
+                None => wires.push(Wire {
+                    ty: frag.conv.destination.clone(),
+                    path: part.name.clone(),
+                }),
+            }
+        }
+        // Only the wire list is composed here. The conversion that reads these
+        // several values and rebuilds the struct is what the emitter switch
+        // brings; until then this row is compiled but never taken, so it
+        // carries a marker rather than a conversion it would have to invent.
+        // `prebindgen-c` does the same for a union arm, and for the same
+        // reason: a product's parts do not always assemble into a function of
+        // their own.
+        let mut frag = JFrag::new(
+            at,
+            ConverterImpl {
+                destination: syn::parse_quote!(()),
+                function: syn::parse_quote!(
+                    #[allow(dead_code)]
+                    fn __jni_parts() {}
+                ),
+                pre_stages: Vec::new(),
+                niches: Niches::empty(),
+                metadata: KotlinMeta::default(),
+                subs: parts.iter().map(|(p, _)| p.ty.key()).collect(),
+            },
+        );
+        frag.wires = Some(wires);
+        Ok(frag)
     }
 
     fn choice(

--- a/prebindgen-jni/src/jni/mod.rs
+++ b/prebindgen-jni/src/jni/mod.rs
@@ -451,6 +451,39 @@ pub struct JniGen {
     registry: prebindgen_registry::Registry,
 }
 
+#[cfg(test)]
+impl JniGen {
+    /// The wires a `data_class` composes into, by short type name.
+    ///
+    /// Test support: the `parts` row is compiled for every declared
+    /// `data_class` but taken by no site yet, so this is the only way to see
+    /// what it composed.
+    pub(crate) fn parts_wires_for_test(
+        &self,
+        short: &str,
+    ) -> Option<Vec<crate::jni::compile::Wire>> {
+        let key = self
+            .decls
+            .compiled
+            .borrow()
+            .fragments()
+            .iter()
+            .find_map(|f| {
+                (f.wires.is_some() && f.yields.ty.as_str() == short).then(|| f.yields.ty.clone())
+            })?;
+        self.decls
+            .compiled
+            .borrow()
+            .row_fragment(
+                &key,
+                prebindgen_registry::recipe::Assembly::Construct,
+                &crate::jni::rows::parts(),
+            )?
+            .wires
+            .clone()
+    }
+}
+
 // Opaque — exists so `Result<JniGen, _>::expect_err` works in tests.
 impl std::fmt::Debug for JniGen {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {

--- a/prebindgen-jni/src/jni/rows.rs
+++ b/prebindgen-jni/src/jni/rows.rs
@@ -17,7 +17,7 @@ use std::collections::BTreeMap;
 
 use prebindgen_registry::{
     flat::{Flat, TypeRef},
-    recipe::{Constructing, Deconstructing, RecipeError, RecipeId, Recipes},
+    recipe::{Construct, Constructing, Deconstructing, RecipeError, RecipeId, Recipes},
 };
 
 use super::*;
@@ -49,6 +49,16 @@ fn element_types(element: &prebindgen_registry::Element) -> Vec<&TypeRef> {
 /// The row a type with no parts takes: the adapter emits the conversion itself.
 fn whole() -> RecipeId {
     RecipeId::new("whole")
+}
+
+/// The row a `data_class` takes when it crosses **as its fields**.
+///
+/// Not the default yet. `whole()` still answers for every site, and this one is
+/// compiled only where something asks for it by name — which is what lets the
+/// composed wire list be checked against the walk it will replace before
+/// anything depends on it.
+pub(crate) fn parts() -> RecipeId {
+    RecipeId::new("parts")
 }
 
 impl Declarations {
@@ -94,8 +104,19 @@ impl Declarations {
             // the adapter emits the conversion itself, and how many wire values
             // that costs is its own business — so it describes the adapter as it
             // stands rather than as it will be.
-            rows.declare(ty.clone(), whole(), Deconstructing::Atomic)
-                .declare(ty, whole(), Constructing::Atomic);
+            rows.declare(ty.clone(), whole(), Deconstructing::Atomic);
+            // A `data_class` also has a row that says what it is made of, so
+            // its constructing side names which of the two a site takes by
+            // default. See [`parts`] for why that is still `whole`.
+            if matches!(
+                self.types.get(&ty.key()).map(|c| &c.kind),
+                Some(DeclaredKind::Data)
+            ) {
+                rows.declare_default(ty.clone(), whole(), Constructing::Atomic)
+                    .declare(ty, parts(), Constructing::Product(Construct::Fields));
+            } else {
+                rows.declare(ty, whole(), Constructing::Atomic);
+            }
         }
 
         // A fixed-size array of JNI primitives is one Kotlin `ByteArray` or
@@ -123,5 +144,60 @@ impl Declarations {
         }
 
         rows.build(model)
+    }
+}
+
+impl Declarations {
+    /// Which row each part of a `data_class` takes.
+    ///
+    /// A field that is itself a `data_class` crosses as **its** fields too, so
+    /// the part site asks for [`parts`] rather than letting the field take its
+    /// own default. That is the one thing a site can say that a row cannot: the
+    /// same crossing is read one way on its own and another inside a product.
+    ///
+    /// Without it a nested class contributes a single wire and the flattening
+    /// stops one layer down.
+    pub(crate) fn bindings(
+        &self,
+        model: &Flat,
+        recipes: &prebindgen_registry::recipe::Recipes,
+    ) -> Result<prebindgen_registry::recipe::Bindings, Vec<RecipeError>> {
+        use prebindgen_registry::recipe::{Ask, Assembly, Bindings, Crossing, Origin, Site};
+
+        let mut bound = Bindings::builder();
+        let mut declared: Vec<TypeKey> = self
+            .types
+            .iter()
+            .filter(|(_, c)| matches!(c.kind, DeclaredKind::Data))
+            .map(|(k, _)| k.clone())
+            .collect();
+        declared.sort_by(|a, b| a.as_str().cmp(b.as_str()));
+
+        for key in declared {
+            let Some(ident) = key.ident() else { continue };
+            let Some(prebindgen_registry::flat::Type::Struct(s)) = model.declared_type(&ident)
+            else {
+                continue;
+            };
+            let Ok(ty) = model.classify(&syn::parse_quote!(#ident)) else {
+                continue;
+            };
+            let of = Crossing::new(ty, Assembly::Construct);
+            for (index, field) in s.fields.iter().enumerate() {
+                if !matches!(
+                    self.types.get(&field.ty.stripped_key()).map(|c| &c.kind),
+                    Some(DeclaredKind::Data)
+                ) {
+                    continue;
+                }
+                bound.bind(
+                    Site::part(&of, &parts(), index),
+                    Crossing::new(field.ty.clone(), Assembly::Construct),
+                    Ask::Recipe(parts()),
+                    Origin::Part,
+                );
+            }
+        }
+        bound.build(recipes)
     }
 }

--- a/prebindgen-jni/src/jni/tests/flatten.rs
+++ b/prebindgen-jni/src/jni/tests/flatten.rs
@@ -2103,3 +2103,74 @@ fn qualified_signature_spelling_matches_bare_ptr_class() {
         "{all}"
     );
 }
+
+/// A `data_class` states a row saying what it is made of, and a field that is
+/// itself one contributes its own wires rather than a single value.
+///
+/// The composition every binding compiles (see `JniGen::compile_crossing`),
+/// asserted here on the shape that makes the recursion visible: `Holder` is a
+/// scalar plus a nested `Summary`, so it crosses as three JNI values and not
+/// as two.
+#[test]
+fn a_data_class_crosses_as_its_fields_and_a_nested_one_as_its_own() {
+    let loc = myflat_loc();
+    let items: Vec<(syn::Item, SourceLocation)> = vec![
+        (
+            syn::Item::Struct(syn::parse_quote!(
+                pub struct Summary {
+                    pub count: i64,
+                    pub total: f64,
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Struct(syn::parse_quote!(
+                pub struct Holder {
+                    pub tag: i64,
+                    pub summary: Summary,
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn holder_tag(h: Holder) -> i64 {
+                    unimplemented!()
+                }
+            )),
+            loc.clone(),
+        ),
+    ];
+    let registry =
+        crate::test_util::reg_from_items(declare_referenced(items)).expect("index items");
+    let jni = JniGenBuilder::new()
+        .set_package_prefix("io.test.jni")
+        .package(
+            crate::package!()
+                .class(crate::data_class!(Summary))
+                .class(crate::data_class!(Holder))
+                .fun(prebindgen_registry::fun!(holder_tag)),
+        );
+    let gen = jni.build_with(registry).expect("resolve");
+
+    let wires = gen
+        .parts_wires_for_test("Holder")
+        .expect("Holder states a parts row");
+    let described: Vec<String> = wires
+        .iter()
+        .map(|w| {
+            let ty = &w.ty;
+            format!("{}: {}", w.path, quote::quote!(#ty))
+        })
+        .collect();
+    assert_eq!(
+        described,
+        vec![
+            "tag: jni :: sys :: jlong",
+            "summary.count: jni :: sys :: jlong",
+            "summary.total: jni :: sys :: jdouble",
+        ],
+        "a nested data class contributes its own wires, under its field's path"
+    );
+}

--- a/prebindgen-jni/src/jni/trait_impl.rs
+++ b/prebindgen-jni/src/jni/trait_impl.rs
@@ -1445,6 +1445,9 @@ impl JniGenBuilder {
         // than papered over: this list empties when the derived callback row
         // takes over.
         let mut uncompiled: Vec<syn::ItemFn> = Vec::new();
+        // Compositions that refused. See `compile_crossing`: these are adapter
+        // invariants, reported together once the walk is done.
+        let mut refusals: Vec<String> = Vec::new();
         let registry = declared
             .convert_with(|crossing, built, emit| {
                 let mut compiler = prebindgen_registry::recipe::Compiler::resume(
@@ -1453,7 +1456,8 @@ impl JniGenBuilder {
                     &bindings,
                     decls.compiled.borrow().clone(),
                 );
-                let conv = decls.compile_crossing(&mut compiler, crossing, built, emit);
+                let conv =
+                    decls.compile_crossing(&mut compiler, crossing, built, emit, &mut refusals);
                 *decls.compiled.borrow_mut() = compiler.finish();
                 if let (Some(c), true) =
                     (conv.as_ref(), decls.is_callback_crossing(crossing, built))
@@ -1479,6 +1483,12 @@ impl JniGenBuilder {
                 conv.map(|c| prebindgen_registry::Answer::over(c.subs))
             })?
             .build()?;
+        if !refusals.is_empty() {
+            return Err(prebindgen_registry::ScanError::AdapterInvariant {
+                message: refusals.join("; "),
+            }
+            .into());
+        }
         // What the compilation produced, kept for emission. The converter table
         // stays the lookup index; this is what reaches the file.
         decls.compiled_fns = decls
@@ -1540,6 +1550,7 @@ impl Declarations {
         crossing: &Crossing,
         built: &'v R,
         emit: &prebindgen_registry::Emit,
+        refusals: &mut Vec<String>,
     ) -> Option<ConverterImpl<KotlinMeta>> {
         let (dir, key) = crossing;
         // The reading the scan already took for this crossing, fetched by the
@@ -1583,17 +1594,17 @@ impl Declarations {
         {
             // A refusal is a bug in the composition, not a gap in the binding:
             // every part of a `data_class` is a crossing that already resolved
-            // on its own, so there is nothing here that can legitimately be
-            // missing. Panicking says so where returning `None` would report an
-            // unresolved crossing and blame the declaration.
-            compiler
-                .row_of(&mut adapter, &crossing, &crate::jni::rows::parts())
-                .unwrap_or_else(|e| {
-                    panic!(
-                        "JniGen: `{}` crosses as its fields, but composing them failed: {e:?}",
-                        crossing.spelled().key()
-                    )
-                });
+            // on its own, so nothing here can legitimately be missing.
+            // Returning `None` would report an unresolved crossing and blame
+            // the declaration, so the reason is collected and surfaced as an
+            // adapter invariant — beside whatever else the walk found, and
+            // through the same `Result` every other refusal takes.
+            if let Err(e) = compiler.row_of(&mut adapter, &crossing, &crate::jni::rows::parts()) {
+                refusals.push(format!(
+                    "`{}` crosses as its fields, but composing them failed: {e:?}",
+                    crossing.spelled().key()
+                ));
+            }
         }
         Some((*fragment).clone().conv)
     }

--- a/prebindgen-jni/src/jni/trait_impl.rs
+++ b/prebindgen-jni/src/jni/trait_impl.rs
@@ -1423,8 +1423,17 @@ impl JniGenBuilder {
                     .join("; "),
             }
         })?;
-        // JniGen overrides no site yet: every crossing takes its type's own row.
-        let bindings = prebindgen_registry::recipe::Bindings::default();
+        // A `data_class` field that is itself one takes the `parts` row rather
+        // than its own default — see `Declarations::bindings`.
+        let bindings = decls.bindings(&model, &recipes).map_err(|errors| {
+            prebindgen_registry::ScanError::AdapterInvariant {
+                message: errors
+                    .iter()
+                    .map(|e| e.to_string())
+                    .collect::<Vec<_>>()
+                    .join("; "),
+            }
+        })?;
         // The driver's state lives on `decls` rather than here, because the
         // adapter reads it **while** it compiles: a conversion for one type is
         // built out of the conversions for its inners, which are compiled
@@ -1477,6 +1486,12 @@ impl JniGenBuilder {
             .borrow()
             .fragments()
             .into_iter()
+            // A fragment that carries only a wire list has no conversion to
+            // emit: the `parts` row states what a `data_class` is made of, and
+            // the function that reads those several values and rebuilds the
+            // struct is what the emitter switch brings. Its marker would
+            // otherwise reach the file.
+            .filter(|f| f.wires.is_none())
             // A JNI conversion already emits more than one function: a
             // `convert!` with a fallible or binding-local step carries it as a
             // pre-stage, and every one of them has to reach the file. This is
@@ -1555,6 +1570,31 @@ impl Declarations {
         };
         let crossing = prebindgen_registry::recipe::Crossing::new(reading, assembly);
         let fragment = compiler.crossing(&mut adapter, &crossing).ok()?;
+        // A `data_class` also states a row that says what it is made of, and
+        // compiling it here is what holds the composition to every binding this
+        // crate builds rather than to one fixture. Nothing reads the result
+        // yet: `whole` is still the row every site takes, so a failure here is
+        // a failure to compose parts that already cross individually.
+        if assembly == prebindgen_registry::recipe::Assembly::Construct
+            && matches!(
+                self.types.get(&crossing.value().key()).map(|c| &c.kind),
+                Some(DeclaredKind::Data)
+            )
+        {
+            // A refusal is a bug in the composition, not a gap in the binding:
+            // every part of a `data_class` is a crossing that already resolved
+            // on its own, so there is nothing here that can legitimately be
+            // missing. Panicking says so where returning `None` would report an
+            // unresolved crossing and blame the declaration.
+            compiler
+                .row_of(&mut adapter, &crossing, &crate::jni::rows::parts())
+                .unwrap_or_else(|e| {
+                    panic!(
+                        "JniGen: `{}` crosses as its fields, but composing them failed: {e:?}",
+                        crossing.spelled().key()
+                    )
+                });
+        }
         Some((*fragment).clone().conv)
     }
 

--- a/prebindgen-registry/src/recipe/compile.rs
+++ b/prebindgen-registry/src/recipe/compile.rs
@@ -578,6 +578,23 @@ impl<'a, C: Compile> Compiler<'a, C> {
         Ok(fragment)
     }
 
+    /// The fragment for one crossing under a **named** row, rather than the one
+    /// the crossing defaults to.
+    ///
+    /// For an adapter that states more than one row for a type and wants both:
+    /// the default answers every site, and this compiles the other so it can be
+    /// checked, or read through
+    /// [`Compiled::row_fragment`](Compiled::row_fragment), before any site
+    /// takes it.
+    pub fn row_of(
+        &mut self,
+        adapter: &mut C,
+        crossing: &Crossing,
+        recipe: &RecipeId,
+    ) -> Result<Rc<C::Fragment>, CompileError<C::Error>> {
+        self.row(adapter, crossing, recipe)
+    }
+
     /// The fragment for one row, built once and reused.
     fn row(&mut self, adapter: &mut C, crossing: &Crossing, recipe: &RecipeId) -> Built<C> {
         // Keyed by the spelling, not by the row's identity: one row can answer


### PR DESCRIPTION
First half of stage 3 in #472. Byte-identical: nothing takes the new row yet.

## The thing being moved

A JniGen `data_class` parameter arrives as **several** JNI parameters. In the
covertest goldens, `holderTagOr` takes an `Option<Holder>` and its extern is

```kotlin
external fun holderTagOr(
    hPresent: Boolean, hTag: Long, hSummary: Long, fallback: Long, errorSink: Any,
): Long
```

Today `render.rs` builds that by walking `FlatInputPlan::leaves` — a
hand-written descent in `emit/flat_input.rs`, 2,148 lines. This PR states the
same thing as a row and composes it from the parts.

## What composes

`JFrag` gains a **wire list**, for a crossing that occupies more than the one
`conv.destination` can name. `Compile::fields` fills it by concatenating its
parts' own wires, so a field that is itself a `data_class` contributes its
several rather than one. That is the recursion, stated once instead of walked.

## The site has to speak, not just the row

The first attempt composed `Holder { tag: i64, summary: Summary }` into **two**
wires, not three. A part is compiled under its **own default row**, and a
nested `data_class`'s default is `whole` — so the flattening stopped one layer
down.

`Declarations::bindings` binds each data-class field of a `data_class` to the
`parts` row. That is the "one crossing read two ways is two rows, with the site
picking" mechanism `prebindgen-c` already uses for union payloads, and it is the
one thing a site can say that a row cannot.

## Why this is still byte-identical

- `whole` stays the default row every site takes; `parts` is declared but
  chosen by nobody.
- The `parts` fragment carries a **marker** rather than a conversion. The
  function that reads several values and rebuilds the struct is what the
  emitter switch brings; inventing one here would be inventing the half this
  PR is not doing. `prebindgen-c` does the same for a union arm.
- A fragment holding only wires emits nothing, so the marker does not reach
  the generated file.

## How the composition is checked before anything depends on it

`JniGen::compile_crossing` compiles the `parts` row for **every** declared
`data_class`, so all 264 lib tests exercise it rather than one fixture. A
refusal panics naming the type: every part of a `data_class` is a crossing that
already resolved on its own, so nothing there can legitimately be missing, and
returning `None` would report an unresolved crossing and blame the declaration.

One test asserts the shape that makes the recursion visible — `Holder` is a
scalar plus a nested `Summary`, so it crosses as `tag`, `summary.count`,
`summary.total` and not as two values.

`Compiler::row_of` is what compiles a named row; the read side,
`Compiled::row_fragment`, was already public.

## What is left for the second half

Point `render.rs` and the emitters at the fragment, give the row a real
conversion, and delete `emit/flat_input.rs`. That one changes generated output.

## Checks

- `cargo test --all` — green
- clippy and rustfmt on 1.85.0 and stable — clean
- `cargo doc` with `-D warnings` — clean
- `examples/regen-check.sh` — **byte-identical**
- `examples/smoke-asan.sh` — clean