### PR TITLE
Hold the composed row to what the walk it replaces says

### DIFF
--- a/prebindgen-jni/src/jni/compile.rs
+++ b/prebindgen-jni/src/jni/compile.rs
@@ -43,9 +43,14 @@ pub(crate) struct JFrag {
 pub(crate) struct Wire {
     /// The JNI type this value crosses as.
     pub(crate) ty: syn::Type,
-    /// The path through the value that reached it — `tag`, `summary.count` —
-    /// which is what a JNI parameter name and a Kotlin accessor are both
-    /// mangled from.
+    /// The Kotlin type of the same value, as an `external fun` writes it.
+    pub(crate) kt_ty: String,
+    /// The path through the value that reached it — `tag`, `summary.count`.
+    ///
+    /// **Relative**, because a fragment answers for a crossing and a name
+    /// belongs to a site: the same `Holder` is `hTag` in one signature and
+    /// `otherTag` in the next, so the parameter it hangs off is the caller's to
+    /// prepend.
     pub(crate) path: String,
 }
 
@@ -321,10 +326,12 @@ impl<R: Conversions> Compile for JCompile<'_, R> {
             match &frag.wires {
                 Some(inner) => wires.extend(inner.iter().map(|w| Wire {
                     ty: w.ty.clone(),
+                    kt_ty: w.kt_ty.clone(),
                     path: format!("{}.{}", part.name, w.path),
                 })),
                 None => wires.push(Wire {
                     ty: frag.conv.destination.clone(),
+                    kt_ty: crate::jni::emit::wire_kotlin_type(&frag.conv),
                     path: part.name.clone(),
                 }),
             }

--- a/prebindgen-jni/src/jni/compile.rs
+++ b/prebindgen-jni/src/jni/compile.rs
@@ -36,6 +36,15 @@ pub(crate) struct JFrag {
     /// makes a nested `data_class` field contribute its own several rather than
     /// one.
     pub(crate) wires: Option<Vec<Wire>>,
+    /// This fragment states a wire list and nothing else — no conversion of its
+    /// own, so nothing of it reaches the generated file.
+    ///
+    /// Only the `parts` row is this. A crossing may legitimately carry **both**
+    /// a wire list and a real conversion: an `Option<data_class>` composes a
+    /// presence flag ahead of the inner's wires and still has the optional's
+    /// own conversion to emit, so "has wires" is the wrong test for what to
+    /// leave out of the file.
+    pub(crate) composed_only: bool,
 }
 
 /// One wire value of a crossing that occupies several.
@@ -73,6 +82,7 @@ impl JFrag {
         Self {
             conv,
             wires: None,
+            composed_only: false,
             yields: Yield {
                 ty,
                 mode: Mode::Owned,
@@ -86,6 +96,7 @@ impl JFrag {
         Self {
             conv,
             wires: None,
+            composed_only: false,
             yields: Yield {
                 ty: at.crossing.value().stripped_key(),
                 mode: at.crossing.mode(),
@@ -239,7 +250,7 @@ impl<R: Conversions> Compile for JCompile<'_, R> {
         self.wrap(at, "no JNI representation for this type", conv)
     }
 
-    fn optional(&mut self, cx: &mut Cx<'_>, at: At<'_>, _inner: &JFrag) -> Frag<Self> {
+    fn optional(&mut self, cx: &mut Cx<'_>, at: At<'_>, inner: &JFrag) -> Frag<Self> {
         let ty = at.crossing.spelled();
         let emit = cx.emit();
         // A declared terminal outranks the arity the registry derived, exactly
@@ -255,7 +266,21 @@ impl<R: Conversions> Compile for JCompile<'_, R> {
                 .output_terminal(ty, self.registry, emit)
                 .or_else(|| self.decls.output_optional(ty, emit)),
         };
-        self.wrap(at, "no JNI representation for this optional", conv)
+        let mut frag = self.wrap(at, "no JNI representation for this optional", conv)?;
+        // An optional over something that crosses as several values cannot ride
+        // a niche in any one of them — which of `(tag, summary)` would carry
+        // the absence? So the presence is its own wire, ahead of the rest: the
+        // `hMaybePresent` in `(hMaybePresent, hMaybeId)`.
+        if let (Assembly::Construct, Some(inner_wires)) = (at.crossing.assembly(), &inner.wires) {
+            let mut wires = vec![Wire {
+                ty: syn::parse_quote!(jni::sys::jboolean),
+                kt_ty: "Boolean".to_string(),
+                path: "present".to_string(),
+            }];
+            wires.extend(inner_wires.iter().cloned());
+            frag.wires = Some(wires);
+        }
+        Ok(frag)
     }
 
     fn sequence(
@@ -358,6 +383,7 @@ impl<R: Conversions> Compile for JCompile<'_, R> {
             },
         );
         frag.wires = Some(wires);
+        frag.composed_only = true;
         Ok(frag)
     }
 

--- a/prebindgen-jni/src/jni/emit/flat_input.rs
+++ b/prebindgen-jni/src/jni/emit/flat_input.rs
@@ -1000,7 +1000,7 @@ fn flat_error(root: &TypeKey, path: &str, reason: impl Into<String>) -> FlatInpu
     }
 }
 
-fn wire_kotlin_type(entry: &prebindgen_registry::ConverterImpl<KotlinMeta>) -> String {
+pub(crate) fn wire_kotlin_type(entry: &prebindgen_registry::ConverterImpl<KotlinMeta>) -> String {
     if let Some(p) = JniPrim::from_wire(&entry.destination) {
         return p.kotlin_type().to_string();
     }

--- a/prebindgen-jni/src/jni/mod.rs
+++ b/prebindgen-jni/src/jni/mod.rs
@@ -451,8 +451,52 @@ pub struct JniGen {
     registry: prebindgen_registry::Registry,
 }
 
+/// One JNI parameter as a signature writes it: its name and its Kotlin type.
+#[cfg(test)]
+pub(crate) type NamedWire = (String, String);
+
 #[cfg(test)]
 impl JniGen {
+    /// The composed wires and the walk's leaves for one `data_class`, named
+    /// the way a parameter would name them.
+    ///
+    /// Test support, and the check that lets the emitter switch happen: the
+    /// `parts` row is meant to say exactly what `build_flat_input_plan` says,
+    /// so this puts the two side by side for a real binding rather than
+    /// asserting a hand-written expectation.
+    pub(crate) fn parts_vs_walk_for_test(
+        &self,
+        short: &str,
+        param: &str,
+    ) -> Option<(Vec<NamedWire>, Vec<NamedWire>)> {
+        let wires = self.parts_wires_for_test(short)?;
+        let composed = wires
+            .iter()
+            .map(|w| {
+                let name =
+                    crate::util::snake_to_camel(&format!("{param}_{}", w.path.replace('.', "_")));
+                (name, w.kt_ty.clone())
+            })
+            .collect();
+
+        let ident = syn::Ident::new(short, proc_macro2::Span::call_site());
+        let ty: syn::Type = syn::parse_quote!(#ident);
+        let arg = prebindgen_registry::Conversions::reading_of(&self.registry, &ty)?;
+        let plan = crate::jni::emit::build_flat_input_plan(
+            &self.decls,
+            &self.registry,
+            &syn::Ident::new(param, proc_macro2::Span::call_site()),
+            &arg,
+        )
+        .ok()??;
+        let walked = plan
+            .leaves
+            .iter()
+            .map(|l| (l.kt_name.clone(), l.kt_wire_ty.clone()))
+            .collect();
+        Some((composed, walked))
+    }
+
     /// The wires a `data_class` composes into, by short type name.
     ///
     /// Test support: the `parts` row is compiled for every declared

--- a/prebindgen-jni/src/jni/rows.rs
+++ b/prebindgen-jni/src/jni/rows.rs
@@ -157,12 +157,25 @@ impl Declarations {
     ///
     /// Without it a nested class contributes a single wire and the flattening
     /// stops one layer down.
+    /// Whether a `data_class` field is itself flattened, or stays one value.
+    ///
+    /// A `data_class` declared `.jobject_input()` crosses Kotlin → Rust as a
+    /// single `JObject` — that is the whole point of the opt-in — so binding
+    /// its parts would flatten a boundary the declaration drew.
+    fn field_crosses_as_its_fields(&self, ty: &TypeRef) -> bool {
+        self.types
+            .get(&ty.stripped_key())
+            .is_some_and(|c| matches!(c.kind, DeclaredKind::Data) && !c.jobject_input)
+    }
+
     pub(crate) fn bindings(
         &self,
         model: &Flat,
         recipes: &prebindgen_registry::recipe::Recipes,
     ) -> Result<prebindgen_registry::recipe::Bindings, Vec<RecipeError>> {
-        use prebindgen_registry::recipe::{Ask, Assembly, Bindings, Crossing, Origin, Site};
+        use prebindgen_registry::recipe::{
+            Ask, Assembly, Bindings, Crossing, Origin, RecipeId, Site,
+        };
 
         let mut bound = Bindings::builder();
         let mut declared: Vec<TypeKey> = self
@@ -184,18 +197,36 @@ impl Declarations {
             };
             let of = Crossing::new(ty, Assembly::Construct);
             for (index, field) in s.fields.iter().enumerate() {
-                if !matches!(
-                    self.types.get(&field.ty.stripped_key()).map(|c| &c.kind),
-                    Some(DeclaredKind::Data)
-                ) {
+                // An `Option<D>` field reaches D through the optional's own
+                // row, so the part bound here is the optional and the inner is
+                // bound below.
+                let target = field.ty.optional_inner().unwrap_or(&field.ty);
+                if !self.field_crosses_as_its_fields(target) {
                     continue;
                 }
-                bound.bind(
-                    Site::part(&of, &parts(), index),
-                    Crossing::new(field.ty.clone(), Assembly::Construct),
-                    Ask::Recipe(parts()),
-                    Origin::Part,
-                );
+                match field.ty.optional_inner() {
+                    // The field IS the class: its part takes the `parts` row.
+                    None => bound.bind(
+                        Site::part(&of, &parts(), index),
+                        Crossing::new(field.ty.clone(), Assembly::Construct),
+                        Ask::Recipe(parts()),
+                        Origin::Part,
+                    ),
+                    // The field is an `Option<D>`. That crossing keeps the row
+                    // the registry derived from its shape — it has no `parts`
+                    // row of its own — and it is D, one layer in, that takes
+                    // `parts`.
+                    Some(_) => bound.bind(
+                        Site::part(
+                            &Crossing::new(field.ty.clone(), Assembly::Construct),
+                            &RecipeId::derived(),
+                            0,
+                        ),
+                        Crossing::new(target.clone(), Assembly::Construct),
+                        Ask::Recipe(parts()),
+                        Origin::Part,
+                    ),
+                };
             }
         }
         bound.build(recipes)

--- a/prebindgen-jni/src/jni/tests/flatten.rs
+++ b/prebindgen-jni/src/jni/tests/flatten.rs
@@ -2154,6 +2154,14 @@ fn a_data_class_crosses_as_its_fields_and_a_nested_one_as_its_own() {
         );
     let gen = jni.build_with(registry).expect("resolve");
 
+    let (composed, walked) = gen
+        .parts_vs_walk_for_test("Holder", "h")
+        .expect("Holder states a parts row and the walk plans it");
+    // The row says exactly what the walk it will replace says — names, types
+    // and order — which is what makes pointing the emitters at the fragment a
+    // move rather than a rewrite.
+    assert_eq!(composed, walked, "the row and the walk disagree");
+
     let wires = gen
         .parts_wires_for_test("Holder")
         .expect("Holder states a parts row");

--- a/prebindgen-jni/src/jni/tests/values.rs
+++ b/prebindgen-jni/src/jni/tests/values.rs
@@ -1025,6 +1025,16 @@ fn jobject_input_is_an_explicit_hybrid_leaf_escape_hatch() {
     let _ = std::fs::remove_dir_all(&dir);
     std::fs::create_dir_all(&dir).unwrap();
     let generation = jni.build_with(registry).expect("resolve");
+    // The `parts` row has to agree with the walk on the two boundaries this
+    // fixture draws, not just on plain fields: `object` is declared
+    // `.jobject_input()` and stays ONE value, and `maybe` is an
+    // `Option<data_class>`, which is a presence flag plus the inner's wires.
+    // Composing either wrongly is invisible until an emitter reads the row,
+    // which is why it is asserted here rather than after the switch.
+    let (composed, walked) = generation
+        .parts_vs_walk_for_test("Hybrid", "h")
+        .expect("Hybrid states a parts row and the walk plans it");
+    assert_eq!(composed, walked, "the row and the walk disagree");
     let rust = std::fs::read_to_string(generation.write_rust(dir.join("gen.rs")).unwrap()).unwrap();
     let kotlin = generation
         .write_kotlin(&dir.join("kotlin"))

--- a/prebindgen-jni/src/jni/trait_impl.rs
+++ b/prebindgen-jni/src/jni/trait_impl.rs
@@ -1496,12 +1496,13 @@ impl JniGenBuilder {
             .borrow()
             .fragments()
             .into_iter()
-            // A fragment that carries only a wire list has no conversion to
-            // emit: the `parts` row states what a `data_class` is made of, and
-            // the function that reads those several values and rebuilds the
-            // struct is what the emitter switch brings. Its marker would
-            // otherwise reach the file.
-            .filter(|f| f.wires.is_none())
+            // A composed-only fragment has no conversion to emit: the `parts`
+            // row states what a `data_class` is made of, and the function that
+            // reads those several values and rebuilds the struct is what the
+            // emitter switch brings. Its marker would otherwise reach the file.
+            // Deliberately not "has wires" — an `Option<data_class>` has both a
+            // wire list and a conversion of its own.
+            .filter(|f| !f.composed_only)
             // A JNI conversion already emits more than one function: a
             // `convert!` with a fallible or binding-local step carries it as a
             // pre-stage, and every one of them has to reach the file. This is


### PR DESCRIPTION
Continues stage 3 of #472, after [#479](https://github.com/milyin/prebindgen/pull/479). Byte-identical.

## What this establishes

#479 composed a `data_class` into a wire list but only checked its shape
against a hand-written expectation. The row is meant to state **exactly** what
`build_flat_input_plan` — the 2,148-line walk in `emit/flat_input.rs` — states,
and asserting that is what turns the emitter switch from a rewrite into a move.

So `Wire` now carries the Kotlin type beside the JNI one, and a test puts the
row and the walk side by side for a real binding:

```
[("hTag", "Long"), ("hSummaryCount", "Long"), ("hSummaryTotal", "Double")]
```

That is `Holder { tag: i64, summary: Summary }` — a scalar and a nested
`data_class` — composed and walked, equal. The nested class contributing
`hSummaryCount` and `hSummaryTotal` rather than one value is the recursion the
switch depends on.

## A wire's path is relative, on purpose

The `h` in `hTag` belongs to the **parameter**, not to `Holder`: the same
struct is `hTag` in one signature and `otherTag` in the next. A fragment
answers for a crossing, so it carries `tag` and `summary.count`, and the site
prepends. That keeps naming out of the fragment and leaves it where
`Compile::plan` will want it, without this PR needing plans.

## What is deliberately not here

An `Option<data_class>` adds a presence flag — the `hPresent` in
`holderTagOr(hPresent, hTag, hSummary, …)`. Composing it belongs to the
optional's row, and reaching it needs the optional's **inner** bound to `parts`
too. I tried that: it makes the optional's fragment carry both a wire list and
a real conversion, at which point "a fragment holding only wires emits nothing"
— the rule that keeps #479's marker out of the generated file — stops holding,
and two externs lost their Kotlin declarations.

That rule is the emitter switch's to restate, since it is what decides which
fragments produce functions at all. So the presence flag goes with the switch
rather than ahead of it.

## Checks

- `cargo test --all` — green
- clippy and rustfmt on 1.85.0 and stable — clean
- `cargo doc` with `-D warnings` — clean
- `examples/regen-check.sh` — **byte-identical**
- `examples/smoke-asan.sh` — clean