### PR TITLE
Carry what Kotlin reads and what the value converts through

### DIFF
--- a/prebindgen-jni/src/jni/compile.rs
+++ b/prebindgen-jni/src/jni/compile.rs
@@ -306,18 +306,7 @@ impl<R: Conversions> Compile for JCompile<'_, R> {
             // non-nullable slot still has to hold something when the value is
             // absent — the flag is what tells Rust to ignore it.
             wires.extend(inner_wires.iter().map(|w| Wire {
-                access: format!(
-                    "?{}{}",
-                    w.access,
-                    crate::jni::emit::kt_leaf_default(
-                        crate::jni::wire_access::jni_field_access(&w.ty)
-                            .map(|(sig, _, _)| sig)
-                            .unwrap_or(""),
-                        w.kt_ty.ends_with('?'),
-                    )
-                    .map(|d| format!(" ?: {d}"))
-                    .unwrap_or_default()
-                ),
+                access: format!("?{}{}", w.access, absent_default(w)),
                 // Anything under the gate can be absent, however the field
                 // itself was spelled.
                 handle_nullable: w.handle_target.is_some() || w.handle_nullable,
@@ -549,4 +538,28 @@ fn is_handle(frag: &JFrag) -> bool {
         .projection
         .as_ref()
         .is_some_and(|p| p.kind == crate::jni::ProjectionKind::Handle)
+}
+
+/// What a non-nullable slot holds while its gate is closed, as an elvis tail.
+///
+/// Empty for the two cases that need none. A **presence flag** is a `!= null`
+/// comparison: it is already non-null, and a Kotlin elvis on a non-null operand
+/// does not compile. A wire that **already carries one** got it from a gate
+/// further in — the expression yields a value from there on, so an outer gate
+/// has nothing left to substitute for.
+fn absent_default(w: &Wire) -> String {
+    if w.conv.is_none() && w.handle_target.is_none() {
+        return String::new();
+    }
+    if w.access.contains(" ?: ") {
+        return String::new();
+    }
+    crate::jni::emit::kt_leaf_default(
+        crate::jni::wire_access::jni_field_access(&w.ty)
+            .map(|(sig, _, _)| sig)
+            .unwrap_or(""),
+        w.kt_ty.ends_with('?'),
+    )
+    .map(|d| format!(" ?: {d}"))
+    .unwrap_or_default()
 }

--- a/prebindgen-jni/src/jni/compile.rs
+++ b/prebindgen-jni/src/jni/compile.rs
@@ -8,7 +8,7 @@
 
 use prebindgen_registry::{
     flat::{Alternative, Function, TypeKind, TypeRef},
-    recipe::{Assembly, At, Bound, Carrier, Compile, Cx, Frag, Mode, Parts, Validity, Yield},
+    recipe::{Assembly, At, Bound, Carrier, Compile, Cx, Frag, Mode, Part, Parts, Validity, Yield},
     Conversions,
 };
 
@@ -71,6 +71,16 @@ pub(crate) struct Wire {
     /// The conversion this value crosses through, or `None` for a presence flag
     /// — which is read on the Rust side and converts nothing.
     pub(crate) conv: Option<syn::Ident>,
+    /// For a nested owned handle: where Kotlin finds the handle **object**, as
+    /// against the `Long` this wire carries.
+    ///
+    /// A nested handle crosses under the same lock-and-consume scaffold as a
+    /// top-level one, and that scaffold needs the object, not its pointer. The
+    /// wire itself is filled from a local the scaffold binds.
+    pub(crate) handle_target: Option<String>,
+    /// Whether that handle access can be null — the field is optional, or an
+    /// optional ancestor gates it.
+    pub(crate) handle_nullable: bool,
 }
 
 impl Carrier for JFrag {
@@ -289,6 +299,8 @@ impl<R: Conversions> Compile for JCompile<'_, R> {
                 // The gate reads the object itself, not through it.
                 access: " != null".to_string(),
                 conv: None,
+                handle_target: None,
+                handle_nullable: false,
             }];
             // Everything under the gate is reached through it, and a
             // non-nullable slot still has to hold something when the value is
@@ -306,6 +318,9 @@ impl<R: Conversions> Compile for JCompile<'_, R> {
                     .map(|d| format!(" ?: {d}"))
                     .unwrap_or_default()
                 ),
+                // Anything under the gate can be absent, however the field
+                // itself was spelled.
+                handle_nullable: w.handle_target.is_some() || w.handle_nullable,
                 ..w.clone()
             }));
             frag.wires = Some(wires);
@@ -379,34 +394,42 @@ impl<R: Conversions> Compile for JCompile<'_, R> {
         let mut wires: Vec<Wire> = Vec::new();
         for (part, frag) in parts {
             match &frag.wires {
-                Some(inner) => wires.extend(inner.iter().map(|w| Wire {
-                    ty: w.ty.clone(),
-                    kt_ty: w.kt_ty.clone(),
-                    path: format!("{}.{}", part.name, w.path),
-                    // The field this part reads, then however the part's own
-                    // wire reaches on from there.
-                    access: format!(
-                        ".{}{}",
-                        crate::jni::render::kotlin_property_name(&syn::Ident::new(
-                            &part.name,
-                            proc_macro2::Span::call_site(),
-                        )),
-                        w.access
-                    ),
-                    conv: w.conv.clone(),
+                Some(inner) => wires.extend(inner.iter().map(|w| {
+                    Wire {
+                        ty: w.ty.clone(),
+                        kt_ty: w.kt_ty.clone(),
+                        path: format!("{}.{}", part.name, w.path),
+                        // The field this part reads, then however the part's own
+                        // wire reaches on from there.
+                        access: format!(".{}{}", field_kt(part), w.access),
+                        conv: w.conv.clone(),
+                        handle_target: w
+                            .handle_target
+                            .as_ref()
+                            .map(|t| format!(".{}{t}", field_kt(part))),
+                        handle_nullable: w.handle_nullable,
+                    }
                 })),
+                // A part whose conversion projects a handle crosses as that
+                // handle's `Long`, and Kotlin reaches the object it has to lock
+                // through the same access.
+                None if is_handle(frag) => wires.push(Wire {
+                    ty: syn::parse_quote!(jni::sys::jlong),
+                    kt_ty: "Long".to_string(),
+                    path: part.name.clone(),
+                    access: format!(".{}", field_kt(part)),
+                    conv: None,
+                    handle_target: Some(format!(".{}", field_kt(part))),
+                    handle_nullable: part.ty.optional_inner().is_some(),
+                }),
                 None => wires.push(Wire {
                     ty: frag.conv.destination.clone(),
                     kt_ty: crate::jni::emit::wire_kotlin_type(&frag.conv),
                     path: part.name.clone(),
-                    access: format!(
-                        ".{}",
-                        crate::jni::render::kotlin_property_name(&syn::Ident::new(
-                            &part.name,
-                            proc_macro2::Span::call_site(),
-                        ))
-                    ),
+                    access: format!(".{}", field_kt(part)),
                     conv: Some(frag.conv.function.sig.ident.clone()),
+                    handle_target: None,
+                    handle_nullable: false,
                 }),
             }
         }
@@ -508,4 +531,22 @@ impl std::ops::Deref for Conv {
     fn deref(&self) -> &Self::Target {
         &self.0.conv
     }
+}
+
+/// The Kotlin property name for one part of a product, sanitized — `object` is
+/// a keyword, and only the emitter's own mangler knows that.
+fn field_kt(part: &Part<'_>) -> String {
+    crate::jni::render::kotlin_property_name(&syn::Ident::new(
+        &part.name,
+        proc_macro2::Span::call_site(),
+    ))
+}
+
+/// Whether this conversion delivers a Kotlin typed handle rather than a value.
+fn is_handle(frag: &JFrag) -> bool {
+    frag.conv
+        .metadata
+        .projection
+        .as_ref()
+        .is_some_and(|p| p.kind == crate::jni::ProjectionKind::Handle)
 }

--- a/prebindgen-jni/src/jni/compile.rs
+++ b/prebindgen-jni/src/jni/compile.rs
@@ -61,6 +61,16 @@ pub(crate) struct Wire {
     /// `otherTag` in the next, so the parameter it hangs off is the caller's to
     /// prepend.
     pub(crate) path: String,
+    /// How Kotlin reaches this value from the object it is destructuring,
+    /// relative to that object — `.flat.id`, `.maybe?.id ?: 0L`, ` != null`.
+    ///
+    /// Relative for the same reason `path` is: the site supplies the base, so
+    /// the same wire reads `h.flat.id` in one call and `this.flat.id` in the
+    /// next.
+    pub(crate) access: String,
+    /// The conversion this value crosses through, or `None` for a presence flag
+    /// — which is read on the Rust side and converts nothing.
+    pub(crate) conv: Option<syn::Ident>,
 }
 
 impl Carrier for JFrag {
@@ -276,8 +286,28 @@ impl<R: Conversions> Compile for JCompile<'_, R> {
                 ty: syn::parse_quote!(jni::sys::jboolean),
                 kt_ty: "Boolean".to_string(),
                 path: "present".to_string(),
+                // The gate reads the object itself, not through it.
+                access: " != null".to_string(),
+                conv: None,
             }];
-            wires.extend(inner_wires.iter().cloned());
+            // Everything under the gate is reached through it, and a
+            // non-nullable slot still has to hold something when the value is
+            // absent — the flag is what tells Rust to ignore it.
+            wires.extend(inner_wires.iter().map(|w| Wire {
+                access: format!(
+                    "?{}{}",
+                    w.access,
+                    crate::jni::emit::kt_leaf_default(
+                        crate::jni::wire_access::jni_field_access(&w.ty)
+                            .map(|(sig, _, _)| sig)
+                            .unwrap_or(""),
+                        w.kt_ty.ends_with('?'),
+                    )
+                    .map(|d| format!(" ?: {d}"))
+                    .unwrap_or_default()
+                ),
+                ..w.clone()
+            }));
             frag.wires = Some(wires);
         }
         Ok(frag)
@@ -353,11 +383,30 @@ impl<R: Conversions> Compile for JCompile<'_, R> {
                     ty: w.ty.clone(),
                     kt_ty: w.kt_ty.clone(),
                     path: format!("{}.{}", part.name, w.path),
+                    // The field this part reads, then however the part's own
+                    // wire reaches on from there.
+                    access: format!(
+                        ".{}{}",
+                        crate::jni::render::kotlin_property_name(&syn::Ident::new(
+                            &part.name,
+                            proc_macro2::Span::call_site(),
+                        )),
+                        w.access
+                    ),
+                    conv: w.conv.clone(),
                 })),
                 None => wires.push(Wire {
                     ty: frag.conv.destination.clone(),
                     kt_ty: crate::jni::emit::wire_kotlin_type(&frag.conv),
                     path: part.name.clone(),
+                    access: format!(
+                        ".{}",
+                        crate::jni::render::kotlin_property_name(&syn::Ident::new(
+                            &part.name,
+                            proc_macro2::Span::call_site(),
+                        ))
+                    ),
+                    conv: Some(frag.conv.function.sig.ident.clone()),
                 }),
             }
         }

--- a/prebindgen-jni/src/jni/mod.rs
+++ b/prebindgen-jni/src/jni/mod.rs
@@ -452,9 +452,11 @@ pub struct JniGen {
 }
 
 /// One JNI parameter as a signature writes it: name, Kotlin type, the Kotlin
-/// expression that fills it, and the conversion it crosses through.
+/// expression that fills it, the conversion it crosses through, and — for a
+/// nested owned handle — where Kotlin finds the object to lock and whether that
+/// access can be null.
 #[cfg(test)]
-pub(crate) type NamedWire = (String, String, String, Option<String>);
+pub(crate) type NamedWire = (String, String, String, Option<String>, Option<String>, bool);
 
 #[cfg(test)]
 impl JniGen {
@@ -481,6 +483,8 @@ impl JniGen {
                     w.kt_ty.clone(),
                     format!("{param}{}", w.access),
                     w.conv.as_ref().map(|c| c.to_string()),
+                    w.handle_target.as_ref().map(|t| format!("{param}{t}")),
+                    w.handle_nullable,
                 )
             })
             .collect();
@@ -504,6 +508,8 @@ impl JniGen {
                     l.kt_wire_ty.clone(),
                     l.kt_access(param),
                     l.conv.as_ref().map(|c| c.to_string()),
+                    l.kt_handle_target(param),
+                    l.handle_nullable,
                 )
             })
             .collect();

--- a/prebindgen-jni/src/jni/mod.rs
+++ b/prebindgen-jni/src/jni/mod.rs
@@ -451,9 +451,10 @@ pub struct JniGen {
     registry: prebindgen_registry::Registry,
 }
 
-/// One JNI parameter as a signature writes it: its name and its Kotlin type.
+/// One JNI parameter as a signature writes it: name, Kotlin type, the Kotlin
+/// expression that fills it, and the conversion it crosses through.
 #[cfg(test)]
-pub(crate) type NamedWire = (String, String);
+pub(crate) type NamedWire = (String, String, String, Option<String>);
 
 #[cfg(test)]
 impl JniGen {
@@ -475,7 +476,12 @@ impl JniGen {
             .map(|w| {
                 let name =
                     crate::util::snake_to_camel(&format!("{param}_{}", w.path.replace('.', "_")));
-                (name, w.kt_ty.clone())
+                (
+                    name,
+                    w.kt_ty.clone(),
+                    format!("{param}{}", w.access),
+                    w.conv.as_ref().map(|c| c.to_string()),
+                )
             })
             .collect();
 
@@ -492,7 +498,14 @@ impl JniGen {
         let walked = plan
             .leaves
             .iter()
-            .map(|l| (l.kt_name.clone(), l.kt_wire_ty.clone()))
+            .map(|l| {
+                (
+                    l.kt_name.clone(),
+                    l.kt_wire_ty.clone(),
+                    l.kt_access(param),
+                    l.conv.as_ref().map(|c| c.to_string()),
+                )
+            })
             .collect();
         Some((composed, walked))
     }

--- a/prebindgen-jni/src/jni/tests/flatten.rs
+++ b/prebindgen-jni/src/jni/tests/flatten.rs
@@ -2182,3 +2182,68 @@ fn a_data_class_crosses_as_its_fields_and_a_nested_one_as_its_own() {
         "a nested data class contributes its own wires, under its field's path"
     );
 }
+
+/// Two gates deep, the inner one supplies the absent value and the outer one
+/// must not supply a second.
+///
+/// `Outer { mid: Option<Mid> }` where `Mid { inner: Option<Leaf> }`: reaching
+/// `Leaf.id` passes through both. The value slot reads
+/// `o.mid?.inner?.id ?: 0L` — one elvis, from the innermost gate — and the
+/// presence flags read as plain comparisons, which are already non-null and
+/// which Kotlin refuses to elvis at all.
+#[test]
+fn a_gate_inside_a_gate_supplies_one_absent_value() {
+    let loc = myflat_loc();
+    let items: Vec<(syn::Item, SourceLocation)> = vec![
+        (
+            syn::Item::Struct(syn::parse_quote!(
+                pub struct Leaf {
+                    pub id: i64,
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Struct(syn::parse_quote!(
+                pub struct Mid {
+                    pub inner: Option<Leaf>,
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Struct(syn::parse_quote!(
+                pub struct Outer {
+                    pub mid: Option<Mid>,
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn outer_use(o: Option<Outer>) -> i64 {
+                    unimplemented!()
+                }
+            )),
+            loc.clone(),
+        ),
+    ];
+    let registry =
+        crate::test_util::reg_from_items(declare_referenced(items)).expect("index items");
+    let jni = JniGenBuilder::new()
+        .set_package_prefix("io.test.jni")
+        .package(
+            crate::package!()
+                .class(crate::data_class!(Leaf))
+                .class(crate::data_class!(Mid))
+                .class(crate::data_class!(Outer))
+                .fun(prebindgen_registry::fun!(outer_use)),
+        );
+    let gen = jni.build_with(registry).expect("resolve");
+    for (name, param) in [("Outer", "o"), ("Mid", "m")] {
+        let (composed, walked) = gen
+            .parts_vs_walk_for_test(name, param)
+            .unwrap_or_else(|| panic!("{name} states a parts row and the walk plans it"));
+        assert_eq!(composed, walked, "the row and the walk disagree on {name}");
+    }
+}

--- a/prebindgen-jni/src/jni/tests/values.rs
+++ b/prebindgen-jni/src/jni/tests/values.rs
@@ -1860,6 +1860,15 @@ fn an_optional_handle_field_mints_through_the_factory() {
     let _ = std::fs::remove_dir_all(&dir);
     std::fs::create_dir_all(&dir).unwrap();
     let generation = jni.build_with(registry).expect("resolve");
+    // A nested owned handle crosses as a `Long` and is locked through the
+    // handle OBJECT, so the row has to carry both — the facts the Kotlin
+    // lock-and-consume scaffold reads. Asserted here because `Bag`'s field is
+    // an `Option<Handle>`, where the access is nullable and the pointer still
+    // is not.
+    let (composed, walked) = generation
+        .parts_vs_walk_for_test("Bag", "b")
+        .expect("Bag states a parts row and the walk plans it");
+    assert_eq!(composed, walked, "the row and the walk disagree");
     let kotlin = generation
         .write_kotlin(&dir.join("kotlin"))
         .unwrap()


### PR DESCRIPTION
Continues stage 3 of #472, after [#480](https://github.com/milyin/prebindgen/pull/480). Byte-identical; still nothing switched.

## What a wire was missing

A `Wire` said what it is (JNI type, Kotlin type) and where it sits (path). To
point an emitter at it, two more facts have to come from the same place: the
Kotlin expression that **fills** it, and the conversion it **crosses through**.
Both are now composed the way the type and path already were.

The access is relative, for the same reason the path is: a wire reads
`.flat.id`, and the site turns that into `h.flat.id` in one call and
`this.flat.id` in the next.

- `fields` prefixes the field a part reads, then whatever the part's own wire
  reaches on from there.
- `optional` chains through its gate and supplies the literal a non-nullable
  slot holds while the value is absent — the presence flag is what tells the
  Rust side to ignore it.

## The check this buys

For the `Hybrid` fixture — a flat child, an `Option<data_class>` child, and a
`.jobject_input()` child — the row now reproduces the walk **exactly**:

```
hFlatId        h.flat.id           jlong_to_i64_…
hMaybePresent  h.maybe != null     —
hMaybeId       h.maybe?.id ?: 0L   jlong_to_i64_…
hObject        h.object_           JObject_to_ObjectChild_…
```

So the equivalence assertion now covers names, types, accesses **and**
conversions, where before it covered the first two. That is what makes the
emitter switch a move.

`h.object_` is why the composition calls the walk's own helpers rather than
reimplementing them: `object` is a Kotlin keyword, and only
`kotlin_property_name` knows that. The same applies to `kt_leaf_default` and
`jni_field_access` for the absent-slot literal.

## The handle facts, added in the second commit

A `data_class` field that is an opaque handle crosses as that handle's `Long`,
but the Kotlin scaffold that locks and consumes it needs the handle **object**.
So a wire carries both, and `fields` states the `jlong` itself for such a part
rather than taking the conversion's destination.

Asserted on `Bag { handle: Option<Handle> }`:

```
[("bHandle", "Long", "b.handle", None, Some("b.handle"), true)]
```

— row and walk equal, including that a handle wire has no converter of its own
and that an optional field's access is nullable while its pointer is not.

**With this the row states everything `FlatLeaf` does that a caller reads.**

## What is left before the switch

Pointing `render.rs`, `fn_plan.rs`, `emit/wrapper.rs`, `emit/callback.rs` and
`emit/vec_build.rs` at the fragment, then deleting `emit/flat_input.rs`.

## Checks

- `cargo test --all` — green
- clippy and rustfmt on 1.85.0 and stable — clean
- `cargo doc` with `-D warnings` — clean
- `examples/regen-check.sh` — **byte-identical**
- `examples/smoke-asan.sh` — clean
