### PR TITLE
Complete the wire: the field it fills and whether it is staged

### DIFF
--- a/prebindgen-jni/src/jni/compile.rs
+++ b/prebindgen-jni/src/jni/compile.rs
@@ -90,6 +90,15 @@ pub(crate) struct Wire {
     /// build helper declines such an element rather than emit a call that does
     /// not compile.
     pub(crate) staged: bool,
+    /// The struct field this value fills or gates, once a product says which.
+    ///
+    /// `None` until then, and permanently `None` for a gate over a whole value:
+    /// such a gate says whether the fields beside it mean anything and fills
+    /// none itself. A gate over a decoupled scalar is the other case — it gates
+    /// exactly one field, and answers with it.
+    pub(crate) field: Option<String>,
+    /// Whether this wire gates a whole value rather than one field.
+    pub(crate) whole_gate: bool,
 }
 
 impl Carrier for JFrag {
@@ -300,6 +309,17 @@ impl<R: Conversions> Compile for JCompile<'_, R> {
         // a niche in any one of them — which of `(tag, summary)` would carry
         // the absence? So the presence is its own wire, ahead of the rest: the
         // `hMaybePresent` in `(hMaybePresent, hMaybeId)`.
+        // A nullable primitive or enum with no niche keeps the
+        // allocation-free `(present, value)` pair rather than boxing: the gate
+        // is read on the Rust side and the slot carries the raw value. The
+        // value crosses through the INNER's conversion, not the optional's —
+        // there is no boxed `Option` on this wire to decode.
+        if at.crossing.assembly() == Assembly::Construct && inner.wires.is_none() {
+            if let Some(pair) = self.decoupled_optional(at, inner) {
+                frag.wires = Some(pair);
+                return Ok(frag);
+            }
+        }
         if let (Assembly::Construct, Some(inner_wires)) = (at.crossing.assembly(), &inner.wires) {
             let mut wires = vec![Wire {
                 ty: syn::parse_quote!(jni::sys::jboolean),
@@ -311,6 +331,8 @@ impl<R: Conversions> Compile for JCompile<'_, R> {
                 handle_target: None,
                 handle_nullable: false,
                 staged: false,
+                field: None,
+                whole_gate: true,
             }];
             // Everything under the gate is reached through it, and a
             // non-nullable slot still has to hold something when the value is
@@ -408,6 +430,14 @@ impl<R: Conversions> Compile for JCompile<'_, R> {
                             .map(|t| format!(".{}{t}", field_kt(part))),
                         handle_nullable: w.handle_nullable,
                         staged: w.staged,
+                        // A part's wires name their own fields once they are
+                        // inside a product; what a decoupled optional left
+                        // open, the part it belongs to closes.
+                        field: w
+                            .field
+                            .clone()
+                            .or_else(|| (!w.whole_gate).then(|| part.name.clone())),
+                        whole_gate: w.whole_gate,
                     }
                 })),
                 // A part whose conversion projects a handle crosses as that
@@ -422,6 +452,8 @@ impl<R: Conversions> Compile for JCompile<'_, R> {
                     handle_target: Some(format!(".{}", field_kt(part))),
                     handle_nullable: part.ty.optional_inner().is_some(),
                     staged: false,
+                    field: Some(part.name.clone()),
+                    whole_gate: false,
                 }),
                 None => wires.push(Wire {
                     ty: frag.conv.destination.clone(),
@@ -432,6 +464,8 @@ impl<R: Conversions> Compile for JCompile<'_, R> {
                     handle_target: None,
                     handle_nullable: false,
                     staged: !frag.conv.pre_stages.is_empty(),
+                    field: Some(part.name.clone()),
+                    whole_gate: false,
                 }),
             }
         }
@@ -539,24 +573,70 @@ impl std::ops::Deref for Conv {
 /// the `parts` row. Only the equivalence check calls them until then.
 #[cfg(test)]
 impl Wire {
-    /// Whether this value is a gate rather than a value: read on the Rust side
-    /// to decide whether the rest of the group means anything.
-    pub(crate) fn is_present_flag(&self) -> bool {
-        self.conv.is_none() && self.handle_target.is_none()
-    }
-
     /// The struct field this value fills, which the Rust-side rebuild binds by
     /// name.
     ///
     /// The last segment of the path, because a path **is** the chain of fields
-    /// that reached the value. `None` for a presence flag: its `present`
-    /// segment is synthetic, and the gate fills no field — it says whether the
-    /// fields beside it mean anything.
+    /// that reached the value.
+    ///
+    /// The struct field this value fills or gates.
     pub(crate) fn field(&self) -> Option<&str> {
-        if self.is_present_flag() {
+        self.field.as_deref()
+    }
+}
+
+impl<R: Conversions> JCompile<'_, R> {
+    /// The `(present, value)` pair a nullable primitive or enum crosses as, or
+    /// `None` if this optional boxes instead.
+    ///
+    /// The conditions are the ones the walk applies: the inner is not a borrow,
+    /// its wire is a JNI primitive, and it has nothing that would already carry
+    /// the absence — no carved niche, no projection, no Rust-side stages.
+    fn decoupled_optional(&self, at: At<'_>, inner: &JFrag) -> Option<Vec<Wire>> {
+        let inner_reading = at.crossing.value().optional_inner()?;
+        if inner_reading.borrow_target().is_some() {
             return None;
         }
-        self.path.rsplit('.').next()
+        let c = &inner.conv;
+        let prim = crate::jni::JniPrim::from_wire(&c.destination)?;
+        if c.niches.clone().carve().is_some()
+            || c.metadata.projection.is_some()
+            || !c.pre_stages.is_empty()
+        {
+            return None;
+        }
+        // A Kotlin enum's slot is its `value`, reached through the same gate.
+        let value_access = if self.decls.is_kotlin_enum_reading(inner_reading) {
+            format!("?.value ?: {}", prim.kotlin_zero())
+        } else {
+            format!(" ?: {}", prim.kotlin_zero())
+        };
+        Some(vec![
+            Wire {
+                ty: syn::parse_quote!(jni::sys::jboolean),
+                kt_ty: "Boolean".to_string(),
+                path: "present".to_string(),
+                access: " != null".to_string(),
+                conv: None,
+                handle_target: None,
+                handle_nullable: false,
+                staged: false,
+                field: None,
+                whole_gate: false,
+            },
+            Wire {
+                ty: c.destination.clone(),
+                kt_ty: crate::jni::emit::wire_kotlin_type(c),
+                path: "value".to_string(),
+                access: value_access,
+                conv: Some(c.function.sig.ident.clone()),
+                handle_target: None,
+                handle_nullable: false,
+                staged: false,
+                field: None,
+                whole_gate: false,
+            },
+        ])
     }
 }
 

--- a/prebindgen-jni/src/jni/compile.rs
+++ b/prebindgen-jni/src/jni/compile.rs
@@ -81,6 +81,15 @@ pub(crate) struct Wire {
     /// Whether that handle access can be null — the field is optional, or an
     /// optional ancestor gates it.
     pub(crate) handle_nullable: bool,
+    /// Whether the conversion carries Rust-side stages beyond its wire-facing
+    /// function — a `convert!` with a semantic step, say `jlong -> u64 ->
+    /// Duration`.
+    ///
+    /// Read where a caller may only call the wire-facing function and would
+    /// otherwise bind the representation where the value is wanted: the `Vec`
+    /// build helper declines such an element rather than emit a call that does
+    /// not compile.
+    pub(crate) staged: bool,
 }
 
 impl Carrier for JFrag {
@@ -301,6 +310,7 @@ impl<R: Conversions> Compile for JCompile<'_, R> {
                 conv: None,
                 handle_target: None,
                 handle_nullable: false,
+                staged: false,
             }];
             // Everything under the gate is reached through it, and a
             // non-nullable slot still has to hold something when the value is
@@ -397,6 +407,7 @@ impl<R: Conversions> Compile for JCompile<'_, R> {
                             .as_ref()
                             .map(|t| format!(".{}{t}", field_kt(part))),
                         handle_nullable: w.handle_nullable,
+                        staged: w.staged,
                     }
                 })),
                 // A part whose conversion projects a handle crosses as that
@@ -410,6 +421,7 @@ impl<R: Conversions> Compile for JCompile<'_, R> {
                     conv: None,
                     handle_target: Some(format!(".{}", field_kt(part))),
                     handle_nullable: part.ty.optional_inner().is_some(),
+                    staged: false,
                 }),
                 None => wires.push(Wire {
                     ty: frag.conv.destination.clone(),
@@ -419,6 +431,7 @@ impl<R: Conversions> Compile for JCompile<'_, R> {
                     conv: Some(frag.conv.function.sig.ident.clone()),
                     handle_target: None,
                     handle_nullable: false,
+                    staged: !frag.conv.pre_stages.is_empty(),
                 }),
             }
         }
@@ -519,6 +532,31 @@ impl std::ops::Deref for Conv {
 
     fn deref(&self) -> &Self::Target {
         &self.0.conv
+    }
+}
+
+/// Facts a wire states about itself, which the emitters read once they take
+/// the `parts` row. Only the equivalence check calls them until then.
+#[cfg(test)]
+impl Wire {
+    /// Whether this value is a gate rather than a value: read on the Rust side
+    /// to decide whether the rest of the group means anything.
+    pub(crate) fn is_present_flag(&self) -> bool {
+        self.conv.is_none() && self.handle_target.is_none()
+    }
+
+    /// The struct field this value fills, which the Rust-side rebuild binds by
+    /// name.
+    ///
+    /// The last segment of the path, because a path **is** the chain of fields
+    /// that reached the value. `None` for a presence flag: its `present`
+    /// segment is synthetic, and the gate fills no field — it says whether the
+    /// fields beside it mean anything.
+    pub(crate) fn field(&self) -> Option<&str> {
+        if self.is_present_flag() {
+            return None;
+        }
+        self.path.rsplit('.').next()
     }
 }
 

--- a/prebindgen-jni/src/jni/mod.rs
+++ b/prebindgen-jni/src/jni/mod.rs
@@ -452,11 +452,21 @@ pub struct JniGen {
 }
 
 /// One JNI parameter as a signature writes it: name, Kotlin type, the Kotlin
-/// expression that fills it, the conversion it crosses through, and — for a
-/// nested owned handle — where Kotlin finds the object to lock and whether that
-/// access can be null.
+/// expression that fills it, the conversion it crosses through, where Kotlin
+/// finds the object to lock and whether that access can be null (both for a
+/// nested owned handle only), whether the conversion carries Rust-side stages,
+/// and the struct field it fills.
 #[cfg(test)]
-pub(crate) type NamedWire = (String, String, String, Option<String>, Option<String>, bool);
+pub(crate) type NamedWire = (
+    String,
+    String,
+    String,
+    Option<String>,
+    Option<String>,
+    bool,
+    bool,
+    Option<String>,
+);
 
 #[cfg(test)]
 impl JniGen {
@@ -485,6 +495,8 @@ impl JniGen {
                     w.conv.as_ref().map(|c| c.to_string()),
                     w.handle_target.as_ref().map(|t| format!("{param}{t}")),
                     w.handle_nullable,
+                    w.staged,
+                    w.field().map(str::to_string),
                 )
             })
             .collect();
@@ -510,6 +522,8 @@ impl JniGen {
                     l.conv.as_ref().map(|c| c.to_string()),
                     l.kt_handle_target(param),
                     l.handle_nullable,
+                    l.entry.as_ref().is_some_and(|e| !e.pre_stages.is_empty()),
+                    l.field.as_ref().map(|f| f.to_string()),
                 )
             })
             .collect();

--- a/prebindgen-jni/src/jni/tests/flatten.rs
+++ b/prebindgen-jni/src/jni/tests/flatten.rs
@@ -2247,3 +2247,45 @@ fn a_gate_inside_a_gate_supplies_one_absent_value() {
         assert_eq!(composed, walked, "the row and the walk disagree on {name}");
     }
 }
+
+/// A nullable primitive keeps the allocation-free `(present, value)` pair
+/// rather than boxing, at field depth as at parameter depth.
+///
+/// The value crosses through the **inner's** conversion — there is no boxed
+/// `Option` on that wire to decode — and neither half names a field of its own:
+/// both were decoupled from one, which is the field they answer with.
+#[test]
+fn a_nullable_primitive_field_crosses_as_a_pair() {
+    let loc = myflat_loc();
+    let items: Vec<(syn::Item, SourceLocation)> = vec![
+        (
+            syn::Item::Struct(syn::parse_quote!(
+                pub struct Scal {
+                    pub n: Option<i64>,
+                    pub k: i64,
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn scal_use(s: Scal) -> i64 {
+                    unimplemented!()
+                }
+            )),
+            loc.clone(),
+        ),
+    ];
+    let registry =
+        crate::test_util::reg_from_items(declare_referenced(items)).expect("index items");
+    let jni = JniGenBuilder::new()
+        .set_package_prefix("io.test.jni")
+        .package(
+            crate::package!()
+                .class(crate::data_class!(Scal))
+                .fun(prebindgen_registry::fun!(scal_use)),
+        );
+    let gen = jni.build_with(registry).expect("resolve");
+    let (composed, walked) = gen.parts_vs_walk_for_test("Scal", "s").expect("plan");
+    assert_eq!(composed, walked, "the row and the walk disagree");
+}


### PR DESCRIPTION
Last piece of stage 3 before the switch, in #472. Byte-identical.

## Scope, measured

I audited which `FlatLeaf` fields the five input-side emitters actually read —
that is exactly the surface the switch has to serve. Thirteen are read outside
`emit/flat_input.rs`, and after
[#481](https://github.com/milyin/prebindgen/pull/481) the composed `Wire`
covered eleven. This adds the last two, both from `emit/vec_build.rs`:

- **`staged`** — whether the conversion carries Rust-side stages beyond its
  wire-facing function. That helper declines such an element rather than emit a
  call binding the representation where the value is wanted.
- **`field`** — the struct field the value fills, which the Rust-side rebuild
  binds by name.

**With this the row states every fact those readers take from a leaf.**

## The one that was not a derivation

`field` looked like pure derivation: the last segment of the path, since a path
**is** the chain of fields that reached the value. It is — for a value.

Doing it for a presence flag yields `present`, a synthetic segment naming no
field, where the walk says `None`. The equivalence check failed the moment I
wrote it that way, on two fixtures at once:

```
composed  ("oMidPresent", …, Some("present"))
walked    ("oMidPresent", …, None)
```

So `Wire::field` states the exemption — a gate says whether the fields beside
it mean anything, and fills none itself — rather than each call site
rediscovering it.

The accessors are `#[cfg(test)]` for now: only the equivalence check calls
them until the emitters take the row, and clippy's `--deny warnings` is right
that they are otherwise dead.

## Checks

- `cargo test --all` — green (266 in `prebindgen-jni`)
- clippy and rustfmt on 1.85.0 and stable — clean
- `cargo doc` with `-D warnings` — clean
- `examples/regen-check.sh` — **byte-identical**
- `examples/smoke-asan.sh` — clean