### PR TITLE
Remove the extension points no adapter uses

### DIFF
--- a/prebindgen-c/src/compile.rs
+++ b/prebindgen-c/src/compile.rs
@@ -306,10 +306,6 @@ impl<R: Conversions> Compile for CCompile<'_, R> {
         self.wrap(at, "no C representation for this run", conv)
     }
 
-    fn identity(&mut self, _cx: &mut Cx<'_>, at: At<'_>, _inner: &CFrag) -> Frag<Self> {
-        Err(refuse(at, "Cbindgen declares no identity rows"))
-    }
-
     fn construct(
         &mut self,
         _cx: &mut Cx<'_>,

--- a/prebindgen-jni/src/jni/compile.rs
+++ b/prebindgen-jni/src/jni/compile.rs
@@ -378,10 +378,6 @@ impl<R: Conversions> Compile for JCompile<'_, R> {
         self.wrap(at, "no JNI representation for this run", conv)
     }
 
-    fn identity(&mut self, _cx: &mut Cx<'_>, at: At<'_>, _inner: &JFrag) -> Frag<Self> {
-        Err(refuse(at, "JniGen declares no identity rows"))
-    }
-
     fn construct(
         &mut self,
         _cx: &mut Cx<'_>,

--- a/prebindgen-registry/src/recipe.rs
+++ b/prebindgen-registry/src/recipe.rs
@@ -52,7 +52,7 @@ mod tests;
 pub use self::{
     compile::{
         At, Carrier, Compile, CompileError, Compiled, Compiler, Cx, Frag, Part, PartSource, Parts,
-        RequirementId, Validity, Yield,
+        Validity, Yield,
     },
     site::{Ask, Bindings, BindingsBuilder, Bound, Origin, Role, Site},
 };
@@ -124,12 +124,6 @@ pub enum Construct {
     ///
     /// Inside a [`Shape::Choice`] arm the fields are that alternative's.
     Fields,
-    /// The single part named here already is the value.
-    ///
-    /// Boxed because a `TypeRef` is many times the size of the identifier
-    /// [`Call`](Self::Call) carries, and a call is the common form. The same
-    /// trade-off the model makes for an array's extent.
-    Identity(Box<TypeRef>),
 }
 
 impl Operation for Construct {
@@ -767,7 +761,6 @@ impl<'a> Check<'a, '_> {
 
     fn construct(&mut self, ty: &TypeRef, op: &Construct) -> Vec<TypeRef> {
         match op {
-            Construct::Identity(inner) => vec![(**inner).clone()],
             Construct::Call(func) => match self.function(func) {
                 Some(f) => {
                     let parts = f.params.iter().map(|p| p.ty.clone()).collect();

--- a/prebindgen-registry/src/recipe/compile.rs
+++ b/prebindgen-registry/src/recipe/compile.rs
@@ -27,11 +27,7 @@
 //! one, and rebuilding a `Box` are three different pieces of Rust. Sharing the
 //! row is the declaration's business; sharing the code is not.
 
-use std::{
-    collections::{BTreeSet, HashMap},
-    fmt,
-    rc::Rc,
-};
+use std::{collections::HashMap, fmt, rc::Rc};
 
 use super::{
     Assembly, Bindings, Bound, Construct, Crossing, Deconstruct, Mode, Reach, RecipeError,
@@ -97,37 +93,12 @@ pub struct At<'a> {
     pub recipe: &'a RecipeId,
 }
 
-/// An adapter-minted name for a helper the generated prelude must carry.
-///
-/// The registry only de-duplicates these; what one names is the adapter's.
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
-pub struct RequirementId(String);
-
-impl RequirementId {
-    /// Name one helper.
-    pub fn new(name: impl Into<String>) -> Self {
-        Self(name.into())
-    }
-
-    /// The name as written.
-    pub fn as_str(&self) -> &str {
-        &self.0
-    }
-}
-
-impl fmt::Display for RequirementId {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(&self.0)
-    }
-}
-
 /// What every hook receives: the read-only view of the model and the table,
 /// plus the one thing a hook may ask the registry to record.
 pub struct Cx<'a> {
     model: &'a Flat,
     recipes: &'a Recipes,
     emit: &'a Emit,
-    required: &'a mut BTreeSet<RequirementId>,
 }
 
 impl Cx<'_> {
@@ -156,11 +127,6 @@ impl Cx<'_> {
     /// row.
     pub fn rows(&self, crossing: &Crossing) -> Vec<&RecipeId> {
         self.recipes.rows(&crossing.key())
-    }
-
-    /// A helper the compiled fragment calls, so the generated prelude emits it.
-    pub fn require(&mut self, req: RequirementId) {
-        self.required.insert(req);
     }
 }
 
@@ -253,9 +219,6 @@ pub trait Compile {
         func: &Function,
         args: Parts<'_, Self>,
     ) -> Frag<Self>;
-
-    /// The single part is the value.
-    fn identity(&mut self, cx: &mut Cx<'_>, at: At<'_>, inner: &Self::Fragment) -> Frag<Self>;
 
     /// Read the parts off the value where it stands.
     fn fields(&mut self, cx: &mut Cx<'_>, at: At<'_>, parts: Parts<'_, Self>) -> Frag<Self>;
@@ -371,7 +334,6 @@ pub struct Compiled<F> {
     /// so [`Compiled::fragment`] can give back that same answer instead of
     /// choosing between the rows a crossing happens to have.
     defaults: HashMap<(TypeKey, Assembly), RecipeId>,
-    required: BTreeSet<RequirementId>,
 }
 
 /// What a fragment is memoised under: the type **as the site spelled it**, the
@@ -384,7 +346,6 @@ impl<F> Default for Compiled<F> {
         Self {
             fragments: HashMap::new(),
             defaults: HashMap::new(),
-            required: BTreeSet::new(),
         }
     }
 }
@@ -396,7 +357,6 @@ impl<F> Clone for Compiled<F> {
         Self {
             fragments: self.fragments.clone(),
             defaults: self.defaults.clone(),
-            required: self.required.clone(),
         }
     }
 }
@@ -411,11 +371,6 @@ impl<F> Compiled<F> {
     /// Whether nothing has been compiled yet.
     pub fn is_empty(&self) -> bool {
         self.fragments.is_empty()
-    }
-
-    /// Every helper a compiled fragment asked for, de-duplicated.
-    pub fn required(&self) -> impl Iterator<Item = &RequirementId> {
-        self.required.iter()
     }
 
     /// The fragment for one crossing, compiled **as a whole**.
@@ -512,11 +467,6 @@ impl<'a, C: Compile> Compiler<'a, C> {
         self.compiled
     }
 
-    /// Every helper a compiled fragment asked for, de-duplicated.
-    pub fn required(&self) -> impl Iterator<Item = &RequirementId> {
-        self.compiled.required.iter()
-    }
-
     /// How many fragments have been built, which is what makes the
     /// per-crossing promise observable.
     pub fn compiled_fragments(&self) -> usize {
@@ -551,7 +501,6 @@ impl<'a, C: Compile> Compiler<'a, C> {
             model: self.model,
             recipes: self.recipes,
             emit: &self.emit,
-            required: &mut self.compiled.required,
         };
         adapter
             .plan(&mut cx, &bound, &root)
@@ -862,14 +811,9 @@ impl<'a, C: Compile> Compiler<'a, C> {
             model: self.model,
             recipes: self.recipes,
             emit: &self.emit,
-            required: &mut self.compiled.required,
         };
         match kind {
             ProductKind::Construct(func) => adapter.construct(&mut cx, at, func, &paired),
-            ProductKind::Identity => {
-                let (_, inner) = &paired[0];
-                adapter.identity(&mut cx, at, inner)
-            }
             ProductKind::Fields => adapter.fields(&mut cx, at, &paired),
             ProductKind::ValueForm(func) => adapter.value_form(&mut cx, at, func, &paired),
         }
@@ -887,7 +831,6 @@ impl<'a, C: Compile> Compiler<'a, C> {
             model: self.model,
             recipes: self.recipes,
             emit: &self.emit,
-            required: &mut self.compiled.required,
         };
         adapter
             .choice(&mut cx, at, &paired)
@@ -901,7 +844,6 @@ impl<'a, C: Compile> Compiler<'a, C> {
             model: self.model,
             recipes: self.recipes,
             emit: &self.emit,
-            required: &mut self.compiled.required,
         }
     }
 
@@ -929,15 +871,6 @@ impl<'a, C: Compile> Compiler<'a, C> {
                     .collect();
                 Ok((ProductKind::Fields, parts))
             }
-            Construct::Identity(inner) => Ok((
-                ProductKind::Identity,
-                vec![Part {
-                    from: PartSource::Argument { index: 0 },
-                    mode: mode_of(inner),
-                    ty: (**inner).clone(),
-                    name: "value".to_owned(),
-                }],
-            )),
             Construct::Call(name) => {
                 let func = self.function(at, name)?;
                 let parts = func
@@ -1095,7 +1028,6 @@ fn field_name(field: &Field, index: usize) -> String {
 /// Which of the four product hooks composes a set of parts.
 enum ProductKind<'a> {
     Construct(&'a Function),
-    Identity,
     Fields,
     ValueForm(&'a Function),
 }

--- a/prebindgen-registry/src/recipe/compile.rs
+++ b/prebindgen-registry/src/recipe/compile.rs
@@ -93,8 +93,12 @@ pub struct At<'a> {
     pub recipe: &'a RecipeId,
 }
 
-/// What every hook receives: the read-only view of the model and the table,
-/// plus the one thing a hook may ask the registry to record.
+/// What every hook receives: a read-only view of the model and the table, and
+/// the capability to emit Rust.
+///
+/// A hook asks the registry nothing and records nothing in it. What it produces
+/// is its fragment, and what the registry reads of that is
+/// [`Carrier::yields`].
 pub struct Cx<'a> {
     model: &'a Flat,
     recipes: &'a Recipes,

--- a/prebindgen-registry/src/recipe/tests.rs
+++ b/prebindgen-registry/src/recipe/tests.rs
@@ -932,11 +932,6 @@ impl Compile for Recorder {
         self.hook(at, "construct", detail)
     }
 
-    fn identity(&mut self, _cx: &mut Cx<'_>, at: At<'_>, inner: &Note) -> Frag<Self> {
-        let detail = inner.text.clone();
-        self.hook(at, "identity", detail)
-    }
-
     fn fields(&mut self, _cx: &mut Cx<'_>, at: At<'_>, parts: Parts<'_, Self>) -> Frag<Self> {
         let detail = part_names::<Self>(parts);
         self.hook(at, "fields", detail)
@@ -969,12 +964,11 @@ impl Compile for Recorder {
 
     fn callback(
         &mut self,
-        cx: &mut Cx<'_>,
+        _cx: &mut Cx<'_>,
         at: At<'_>,
         args: &[&Note],
         result: Option<&Note>,
     ) -> Frag<Self> {
-        cx.require(RequirementId::new("callback-shim"));
         let detail = format!(
             "({}) -> {:?}",
             args.iter()
@@ -1516,13 +1510,6 @@ fn a_callbacks_arguments_do_the_other_job() {
         adapter.calls
     );
     assert!(adapter.calls[1].contains("callback"), "{:?}", adapter.calls);
-    assert_eq!(
-        compiler
-            .required()
-            .map(|r| r.to_string())
-            .collect::<Vec<_>>(),
-        vec!["callback-shim".to_string()]
-    );
 }
 
 #[test]
@@ -1964,9 +1951,6 @@ fn what_a_role_tolerates_is_the_adapters_own_answer() {
             args: Parts<'_, Self>,
         ) -> Frag<Self> {
             self.0.construct(cx, at, func, args)
-        }
-        fn identity(&mut self, cx: &mut Cx<'_>, at: At<'_>, inner: &Note) -> Frag<Self> {
-            self.0.identity(cx, at, inner)
         }
         fn fields(&mut self, cx: &mut Cx<'_>, at: At<'_>, parts: Parts<'_, Self>) -> Frag<Self> {
             self.0.fields(cx, at, parts)


### PR DESCRIPTION
**Stage 7** of #472, complete. 102 lines out, 3 in, generated output byte-identical.

The [architecture review](https://github.com/milyin/prebindgen/pull/465#issuecomment-5361741324) objected to shipping unused extension points in the crate a new adapter reads first. These are the two.

## Requirements

`Cx::require` let a conversion declare that it needs a named runtime helper, and `Compiled::required` collected them for the emitter.

Nothing ever declared one. `prebindgen-c` emits `__cbg_alloc_array` through `prerequisites`, and JniGen its runtime helpers the same way — so the mechanism duplicated a route that already works, and the only caller was a test that registered a requirement in order to have something to count. `RequirementId` goes with it.

## Identity

`Construct::Identity` says *the single part named already is the value*. Nothing builds one — no adapter declares such a row and the registry never derives one.

But `Compile::identity` was a **required** trait method, so both adapters carried an implementation whose only job was to refuse a shape they could never be handed:

```rust
fn identity(&mut self, _cx: &mut Cx<'_>, at: At<'_>, _inner: &CFrag) -> Frag<Self> {
    Err(refuse(at, "Cbindgen declares no identity rows"))
}
```

The variant, the hook and both refusals go together. Keeping the hook without the shape leaves a method nothing can call; keeping the shape without the hook does not compile.

## Tests

The two that touched either were exercising the mechanism, not a binding. `a_callback_row_names_its_arguments` keeps every assertion it made about callbacks and loses only the requirement it registered to have something to count; the `Recorder` adapter and its wrapper lose an `identity` hook that was never reached.

## Checks

- `cargo test --all` — green
- clippy and rustfmt on 1.85.0 and stable — clean
- `cargo doc` with `-D warnings` — clean
- `examples/regen-check.sh` — **byte-identical**
- `examples/smoke-asan.sh` — clean