### PR TITLE
Compose every wire a JNI data class parameter occupies (#472 §3)

### DIFF
--- a/prebindgen-jni/src/jni/compile.rs
+++ b/prebindgen-jni/src/jni/compile.rs
@@ -47,36 +47,60 @@ pub(crate) struct JFrag {
     pub(crate) composed_only: bool,
 }
 
+/// One step of the walk from the object a site names to a wire's value.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct Nav {
+    /// The Kotlin property read.
+    pub(crate) field: String,
+    /// Whether the value it is read **off** may be null, which makes the read a
+    /// safe call.
+    ///
+    /// Set by every gate above the step, not only the nearest: once a chain
+    /// passes through one `?.` every read after it is on a nullable value, so a
+    /// gate marks the whole chain below it rather than its first step.
+    pub(crate) gated: bool,
+}
+
 /// How Kotlin reaches one wire value, relative to the object the site names.
 ///
-/// Three forms rather than one string, because two of them put the base in the
-/// **middle**: a sum's tag reads `when (<base>.f) { … }` and a sum's payload
-/// slot reads `(<base>.f as? I.V)?.v0`. A suffix cannot say that, and a raw
-/// prefix/suffix pair cannot be composed — an optional layer has to know
-/// whether it is adding a `?.` navigation or a `null ->` arm, and only a named
-/// form tells it which.
+/// The walk is kept as steps rather than as one string, and that is what makes
+/// a gate composable: an optional is applied **after** the fields under it have
+/// composed, so it has to reach back and make every step below it a safe call.
+/// A string cannot say which of its dots are property reads — the `0.0` a
+/// non-nullable slot falls back to has one too.
+///
+/// Three forms, because two of them put the base in the **middle**: a sum's tag
+/// reads `when (<base>.f) { … }` and a sum's payload slot reads
+/// `(<base>.f as? I.V)?.v0`.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) enum Access {
-    /// `<base><tail>` — the ordinary read, including a presence comparison.
-    Read(String),
-    /// `when (<base><tail>) { … }` — which alternative of a sum is live, as the
+    /// `<base><walk><tail>` — the ordinary read. `tail` is whatever follows the
+    /// property chain: a presence comparison, an elvis default, a Kotlin enum's
+    /// `?.value`, or nothing.
+    Read {
+        /// The property chain from the base.
+        walk: Vec<Nav>,
+        /// What follows it.
+        tail: String,
+    },
+    /// `when (<base><walk>) { … }` — which alternative of a sum is live, as the
     /// `jint` tag the arms below are numbered by.
     Select {
-        /// What reaches the sum value from the base.
-        tail: String,
+        /// The property chain reaching the sum value.
+        walk: Vec<Nav>,
         /// One arm per alternative, in declaration order, without the `null`
-        /// one — an optional ancestor adds that by setting `nullable`.
+        /// one — a gate above adds that by setting `nullable`.
         arms: Vec<String>,
         /// Whether the value reached can be null, which is its own arm.
         nullable: bool,
     },
-    /// `(<base><tail> as? <class>)?.<read>[ ?: <zero>]` — one payload slot of
-    /// one alternative. Every alternative's slots cross on every call; the
-    /// cast yields null for the ones that are not live, and `zero` is what a
+    /// `(<base><walk> as? <class>)?.<read>[ ?: <zero>]` — one payload slot of
+    /// one alternative. Every alternative's slots cross on every call; the cast
+    /// yields null for the ones that are not live, and `zero` is what a
     /// non-nullable wire carries instead.
     Slot {
-        /// What reaches the sum value from the base.
-        tail: String,
+        /// The property chain reaching the sum value.
+        walk: Vec<Nav>,
         /// The Kotlin class of the alternative this slot belongs to. Empty
         /// until [`Compile::choice`] names it — the arm's own composition
         /// cannot, because a product hook is not told which alternative it is.
@@ -91,16 +115,29 @@ pub(crate) enum Access {
 }
 
 impl Access {
+    /// An ordinary read of the base itself, with nothing walked.
+    fn read(tail: impl Into<String>) -> Self {
+        Access::Read {
+            walk: Vec::new(),
+            tail: tail.into(),
+        }
+    }
+
     /// The Kotlin expression, rooted at the object this site destructures.
     ///
     /// Only the equivalence check calls it until the emitters take the row —
     /// the same `#[cfg(test)]` the wire's other readers carry.
     #[cfg(test)]
     pub(crate) fn render(&self, base: &str) -> String {
+        let reached = |walk: &[Nav]| {
+            walk.iter()
+                .map(|n| format!("{}{}", if n.gated { "?." } else { "." }, n.field))
+                .collect::<String>()
+        };
         match self {
-            Access::Read(tail) => format!("{base}{tail}"),
+            Access::Read { walk, tail } => format!("{base}{}{tail}", reached(walk)),
             Access::Select {
-                tail,
+                walk,
                 arms,
                 nullable,
             } => {
@@ -110,10 +147,10 @@ impl Access {
                     .chain(arms.iter().cloned())
                     .collect::<Vec<_>>()
                     .join("; ");
-                format!("when ({base}{tail}) {{ {arms} }}")
+                format!("when ({base}{}) {{ {arms} }}", reached(walk))
             }
             Access::Slot {
-                tail,
+                walk,
                 class,
                 read,
                 zero,
@@ -122,23 +159,29 @@ impl Access {
                     .as_ref()
                     .map(|z| format!(" ?: {z}"))
                     .unwrap_or_default();
-                format!("({base}{tail} as? {class})?.{read}{zero}")
+                format!("({base}{} as? {class})?.{read}{zero}", reached(walk))
             }
         }
     }
 
-    /// What reaches this value from the base — the part a container prepends
-    /// its own field to, whichever form the access takes.
-    fn tail_mut(&mut self) -> &mut String {
+    /// The property chain, whichever form the access takes.
+    fn walk_mut(&mut self) -> &mut Vec<Nav> {
         match self {
-            Access::Read(tail) | Access::Select { tail, .. } | Access::Slot { tail, .. } => tail,
+            Access::Read { walk, .. } | Access::Select { walk, .. } | Access::Slot { walk, .. } => {
+                walk
+            }
         }
     }
 
     /// This access read from one field in, rather than from the object itself.
     fn under(mut self, field: &str) -> Self {
-        let tail = self.tail_mut();
-        *tail = format!(".{field}{tail}");
+        self.walk_mut().insert(
+            0,
+            Nav {
+                field: field.to_string(),
+                gated: false,
+            },
+        );
         self
     }
 }
@@ -429,7 +472,7 @@ impl<R: Conversions> Compile for JCompile<'_, R> {
                 kt_ty: "Boolean".to_string(),
                 path: "present".to_string(),
                 // The gate reads the object itself, not through it.
-                access: Access::Read(" != null".to_string()),
+                access: Access::read(" != null"),
                 conv: None,
                 handle_target: None,
                 handle_nullable: false,
@@ -554,7 +597,7 @@ impl<R: Conversions> Compile for JCompile<'_, R> {
                     ty: syn::parse_quote!(jni::sys::jlong),
                     kt_ty: "Long".to_string(),
                     path: part.name.clone(),
-                    access: Access::Read(format!(".{}", field_kt(part))),
+                    access: Access::read("").under(&field_kt(part)),
                     conv: None,
                     handle_target: Some(format!(".{}", field_kt(part))),
                     handle_nullable: part.ty.optional_inner().is_some(),
@@ -566,7 +609,7 @@ impl<R: Conversions> Compile for JCompile<'_, R> {
                     ty: frag.conv.destination.clone(),
                     kt_ty: crate::jni::emit::wire_kotlin_type(&frag.conv),
                     path: part.name.clone(),
-                    access: Access::Read(format!(".{}", field_kt(part))),
+                    access: Access::read("").under(&field_kt(part)),
                     conv: Some(frag.conv.function.sig.ident.clone()),
                     handle_target: None,
                     handle_nullable: false,
@@ -798,7 +841,7 @@ impl<R: Conversions> JCompile<'_, R> {
             kt_ty,
             path: prop,
             access: Access::Slot {
-                tail: String::new(),
+                walk: Vec::new(),
                 // Named by `choice`, the only hook told which alternative this
                 // payload belongs to.
                 class: String::new(),
@@ -838,7 +881,7 @@ impl<R: Conversions> JCompile<'_, R> {
             kt_ty: "Int".to_string(),
             path: "_tag".to_string(),
             access: Access::Select {
-                tail: String::new(),
+                walk: Vec::new(),
                 arms: arms
                     .iter()
                     .zip(&classes)
@@ -864,7 +907,7 @@ impl<R: Conversions> JCompile<'_, R> {
                 wires.push(Wire {
                     path: crate::jni::struct_plan::sum_slot_fragment(short, &w.path),
                     access: Access::Slot {
-                        tail: String::new(),
+                        walk: Vec::new(),
                         class: class.clone(),
                         read: read.clone(),
                         zero: zero.clone(),
@@ -906,7 +949,7 @@ impl<R: Conversions> JCompile<'_, R> {
                 ty: syn::parse_quote!(jni::sys::jboolean),
                 kt_ty: "Boolean".to_string(),
                 path: "present".to_string(),
-                access: Access::Read(" != null".to_string()),
+                access: Access::read(" != null"),
                 conv: None,
                 handle_target: None,
                 handle_nullable: false,
@@ -918,7 +961,7 @@ impl<R: Conversions> JCompile<'_, R> {
                 ty: c.destination.clone(),
                 kt_ty: crate::jni::emit::wire_kotlin_type(c),
                 path: "value".to_string(),
-                access: Access::Read(value_access),
+                access: Access::read(value_access),
                 conv: Some(c.function.sig.ident.clone()),
                 handle_target: None,
                 handle_nullable: false,
@@ -994,15 +1037,18 @@ fn absent_default(w: &Wire, tail: &str) -> String {
 /// `null` arm instead, and a sum's `as?` slot needs neither — a cast over a
 /// null subject is already null.
 fn gated(access: &Access, w: &Wire) -> Access {
-    match access {
-        Access::Read(tail) => Access::Read(format!("?{tail}{}", absent_default(w, tail))),
-        Access::Select { tail, arms, .. } => Access::Select {
-            tail: tail.clone(),
-            arms: arms.clone(),
-            nullable: true,
-        },
-        slot @ Access::Slot { .. } => slot.clone(),
+    let mut gated = access.clone();
+    // Every step below the gate, not only the first: after one safe call the
+    // chain is on a nullable value and stays there.
+    for nav in gated.walk_mut() {
+        nav.gated = true;
     }
+    match &mut gated {
+        Access::Read { tail, .. } => *tail = format!("{tail}{}", absent_default(w, tail)),
+        Access::Select { nullable, .. } => *nullable = true,
+        Access::Slot { .. } => {}
+    }
+    gated
 }
 
 /// Whether this fragment states a sum taken apart into a tag and its arms'

--- a/prebindgen-jni/src/jni/compile.rs
+++ b/prebindgen-jni/src/jni/compile.rs
@@ -114,6 +114,19 @@ pub(crate) enum Access {
     },
 }
 
+/// The Kotlin property chain, rooted at the object a site destructures.
+///
+/// Only the equivalence check calls it until the emitters take the row.
+#[cfg(test)]
+pub(crate) fn reached(base: &str, walk: &[Nav]) -> String {
+    let mut out = base.to_string();
+    for nav in walk {
+        out.push_str(if nav.gated { "?." } else { "." });
+        out.push_str(&nav.field);
+    }
+    out
+}
+
 impl Access {
     /// An ordinary read of the base itself, with nothing walked.
     fn read(tail: impl Into<String>) -> Self {
@@ -129,13 +142,8 @@ impl Access {
     /// the same `#[cfg(test)]` the wire's other readers carry.
     #[cfg(test)]
     pub(crate) fn render(&self, base: &str) -> String {
-        let reached = |walk: &[Nav]| {
-            walk.iter()
-                .map(|n| format!("{}{}", if n.gated { "?." } else { "." }, n.field))
-                .collect::<String>()
-        };
         match self {
-            Access::Read { walk, tail } => format!("{base}{}{tail}", reached(walk)),
+            Access::Read { walk, tail } => format!("{}{tail}", reached(base, walk)),
             Access::Select {
                 walk,
                 arms,
@@ -147,7 +155,7 @@ impl Access {
                     .chain(arms.iter().cloned())
                     .collect::<Vec<_>>()
                     .join("; ");
-                format!("when ({base}{}) {{ {arms} }}", reached(walk))
+                format!("when ({}) {{ {arms} }}", reached(base, walk))
             }
             Access::Slot {
                 walk,
@@ -159,7 +167,7 @@ impl Access {
                     .as_ref()
                     .map(|z| format!(" ?: {z}"))
                     .unwrap_or_default();
-                format!("({base}{} as? {class})?.{read}{zero}", reached(walk))
+                format!("({} as? {class})?.{read}{zero}", reached(base, walk))
             }
         }
     }
@@ -187,7 +195,10 @@ impl Access {
 }
 
 /// One wire value of a crossing that occupies several.
-#[derive(Clone, Debug, PartialEq, Eq)]
+///
+/// `Clone` alone: a wire carries the whole conversion its value crosses
+/// through, and a `syn::ItemFn` is neither comparable nor cheap to print.
+#[derive(Clone)]
 pub(crate) struct Wire {
     /// The JNI type this value crosses as.
     pub(crate) ty: syn::Type,
@@ -208,27 +219,36 @@ pub(crate) struct Wire {
     /// next.
     pub(crate) access: Access,
     /// The conversion this value crosses through, or `None` for a presence flag
-    /// — which is read on the Rust side and converts nothing.
-    pub(crate) conv: Option<syn::Ident>,
+    /// or a tag — both of which are read on the Rust side and convert nothing.
+    ///
+    /// The whole conversion rather than its name: the Rust side that rebuilds
+    /// the value calls it through its wire-facing function **and** whatever
+    /// Rust-side stages follow, and a name says nothing about those.
+    pub(crate) entry: Option<ConverterImpl<KotlinMeta>>,
     /// For a nested owned handle: where Kotlin finds the handle **object**, as
     /// against the `Long` this wire carries.
     ///
     /// A nested handle crosses under the same lock-and-consume scaffold as a
     /// top-level one, and that scaffold needs the object, not its pointer. The
     /// wire itself is filled from a local the scaffold binds.
-    pub(crate) handle_target: Option<String>,
+    ///
+    /// A walk rather than a string, and for the reason [`Access`] is one: a gate
+    /// above has to make every read in it a safe call, and the scaffold locks
+    /// what this reaches — so a chain that ignored the gate would lock and
+    /// consume the wrong expression.
+    pub(crate) handle_target: Option<Vec<Nav>>,
     /// Whether that handle access can be null — the field is optional, or an
     /// optional ancestor gates it.
     pub(crate) handle_nullable: bool,
-    /// Whether the conversion carries Rust-side stages beyond its wire-facing
-    /// function — a `convert!` with a semantic step, say `jlong -> u64 ->
-    /// Duration`.
+    /// The Kotlin literal this wire carries while a gate above it is closed,
+    /// or `None` for one that rides a JVM `null` or already substitutes its
+    /// own.
     ///
-    /// Read where a caller may only call the wire-facing function and would
-    /// otherwise bind the representation where the value is wanted: the `Vec`
-    /// build helper declines such an element rather than emit a call that does
-    /// not compile.
-    pub(crate) staged: bool,
+    /// Stated where the wire is built rather than derived where the gate is
+    /// applied, because only the former knows what the value is: an unsigned
+    /// projection substitutes its niche sentinel, and a decoupled pair has
+    /// already put its zero in the access.
+    pub(crate) absent: Option<String>,
     /// The struct field this value fills or gates, once a product says which.
     ///
     /// `None` until then, and permanently `None` for a gate over a whole value:
@@ -454,7 +474,7 @@ impl<R: Conversions> Compile for JCompile<'_, R> {
         // value crosses through the INNER's conversion, not the optional's —
         // there is no boxed `Option` on this wire to decode.
         if at.crossing.assembly() == Assembly::Construct && inner.wires.is_none() {
-            if let Some(pair) = self.decoupled_optional(at, inner) {
+            if let Some(pair) = self.decoupled_optional(at, inner, &frag.conv) {
                 frag.wires = Some(pair);
                 return Ok(frag);
             }
@@ -473,23 +493,17 @@ impl<R: Conversions> Compile for JCompile<'_, R> {
                 path: "present".to_string(),
                 // The gate reads the object itself, not through it.
                 access: Access::read(" != null"),
-                conv: None,
+                entry: None,
                 handle_target: None,
                 handle_nullable: false,
-                staged: false,
+                absent: None,
                 field: None,
                 whole_gate: !sum,
             }];
             // Everything under the gate is reached through it, and a
             // non-nullable slot still has to hold something when the value is
             // absent — the flag is what tells Rust to ignore it.
-            wires.extend(inner_wires.iter().map(|w| Wire {
-                access: gated(&w.access, w),
-                // Anything under the gate can be absent, however the field
-                // itself was spelled.
-                handle_nullable: w.handle_target.is_some() || w.handle_nullable,
-                ..w.clone()
-            }));
+            wires.extend(inner_wires.iter().map(gated));
             frag.wires = Some(wires);
         }
         Ok(frag)
@@ -573,13 +587,17 @@ impl<R: Conversions> Compile for JCompile<'_, R> {
                         // The field this part reads, then however the part's own
                         // wire reaches on from there.
                         access: w.access.clone().under(&field_kt(part)),
-                        conv: w.conv.clone(),
-                        handle_target: w
-                            .handle_target
-                            .as_ref()
-                            .map(|t| format!(".{}{t}", field_kt(part))),
+                        entry: w.entry.clone(),
+                        handle_target: w.handle_target.as_ref().map(|t| {
+                            std::iter::once(Nav {
+                                field: field_kt(part),
+                                gated: false,
+                            })
+                            .chain(t.iter().cloned())
+                            .collect()
+                        }),
                         handle_nullable: w.handle_nullable,
-                        staged: w.staged,
+                        absent: w.absent.clone(),
                         // A part's wires name their own fields once they are
                         // inside a product; what a decoupled optional left
                         // open, the part it belongs to closes.
@@ -598,25 +616,17 @@ impl<R: Conversions> Compile for JCompile<'_, R> {
                     kt_ty: "Long".to_string(),
                     path: part.name.clone(),
                     access: Access::read("").under(&field_kt(part)),
-                    conv: None,
-                    handle_target: Some(format!(".{}", field_kt(part))),
+                    entry: None,
+                    handle_target: Some(vec![Nav {
+                        field: field_kt(part),
+                        gated: false,
+                    }]),
                     handle_nullable: part.ty.optional_inner().is_some(),
-                    staged: false,
+                    absent: None,
                     field: Some(part.name.clone()),
                     whole_gate: false,
                 }),
-                None => wires.push(Wire {
-                    ty: frag.conv.destination.clone(),
-                    kt_ty: crate::jni::emit::wire_kotlin_type(&frag.conv),
-                    path: part.name.clone(),
-                    access: Access::read("").under(&field_kt(part)),
-                    conv: Some(frag.conv.function.sig.ident.clone()),
-                    handle_target: None,
-                    handle_nullable: false,
-                    staged: !frag.conv.pre_stages.is_empty(),
-                    field: Some(part.name.clone()),
-                    whole_gate: false,
-                }),
+                None => wires.push(self.field_wire(part, frag)),
             }
         }
         // Only the wire list is composed here. The conversion that reads these
@@ -742,6 +752,30 @@ impl std::ops::Deref for Conv {
 /// the `parts` row. Only the equivalence check calls them until then.
 #[cfg(test)]
 impl Wire {
+    /// The wire-facing function this value crosses through.
+    pub(crate) fn conv(&self) -> Option<&syn::Ident> {
+        self.entry.as_ref().map(|e| &e.function.sig.ident)
+    }
+
+    /// Whether the conversion carries Rust-side stages beyond its wire-facing
+    /// function — a `convert!` with a semantic step, say `jlong -> u64 ->
+    /// Duration`.
+    ///
+    /// Read where a caller may only call the wire-facing function and would
+    /// otherwise bind the representation where the value is wanted: the `Vec`
+    /// build helper declines such an element rather than emit a call that does
+    /// not compile.
+    pub(crate) fn staged(&self) -> bool {
+        self.entry
+            .as_ref()
+            .is_some_and(|e| !e.pre_stages.is_empty())
+    }
+}
+
+/// Facts a wire states about itself, which the emitters read once they take
+/// the `parts` row. Only the equivalence check calls them until then.
+#[cfg(test)]
+impl Wire {
     /// The struct field this value fills, which the Rust-side rebuild binds by
     /// name.
     ///
@@ -812,6 +846,67 @@ impl<R: Conversions> JCompile<'_, R> {
         frag
     }
 
+    /// One field that crosses as a single value of its own conversion.
+    ///
+    /// Three reads the value itself asks for, each because the Kotlin property
+    /// holds something other than the wire: an `enum_class` property is the
+    /// enum object and the wire is its discriminant, an unsigned projection's
+    /// property is a `ULong` and the wire is the `Long` under it, and an
+    /// optional whose wire is a JVM object rides a `null` rather than a
+    /// literal.
+    fn field_wire(&self, part: &Part<'_>, frag: &JFrag) -> Wire {
+        let optional = part.ty.optional_inner().is_some();
+        let mut walk = vec![Nav {
+            field: field_kt(part),
+            gated: false,
+        }];
+        let mut kt_ty = crate::jni::emit::wire_kotlin_type(&frag.conv);
+        let projection = frag.conv.metadata.projection.as_ref();
+        let mut absent = None;
+        if projection.map(|p| &p.kind) == Some(&ProjectionKind::Unsigned64) {
+            walk.push(Nav {
+                field: "toLong()".to_string(),
+                gated: optional,
+            });
+            // An unsigned projection carves its absent value out of the
+            // representation's own range, so a closed gate substitutes that
+            // rather than the wire's zero.
+            absent = Some(
+                projection
+                    .and_then(|p| p.niche_sentinels.first().cloned())
+                    .unwrap_or_else(|| "0L".to_string()),
+            );
+        } else if self.decls.is_kotlin_enum_reading(&part.ty) {
+            walk.push(Nav {
+                field: "value".to_string(),
+                gated: optional,
+            });
+        }
+        if optional && crate::jni::emit::is_jobject_shaped_wire(&frag.conv.destination) {
+            if !kt_ty.ends_with('?') {
+                kt_ty.push('?');
+            }
+        } else if absent.is_none() {
+            absent = crate::jni::wire_access::jni_field_access(&frag.conv.destination)
+                .and_then(|(sig, _, _)| crate::jni::emit::kt_leaf_default(sig, false));
+        }
+        Wire {
+            ty: frag.conv.destination.clone(),
+            kt_ty,
+            path: part.name.clone(),
+            access: Access::Read {
+                walk,
+                tail: String::new(),
+            },
+            entry: Some(frag.conv.clone()),
+            handle_target: None,
+            handle_nullable: false,
+            absent,
+            field: Some(part.name.clone()),
+            whole_gate: false,
+        }
+    }
+
     /// One payload of one alternative, or `None` if it has no slot form.
     fn slot(&self, part: &Part<'_>, frag: &JFrag) -> Option<Wire> {
         if frag.wires.is_some() || frag.conv.metadata.projection.is_some() {
@@ -848,10 +943,10 @@ impl<R: Conversions> JCompile<'_, R> {
                 read,
                 zero: prim.map(|p| p.kotlin_zero().to_string()),
             },
-            conv: Some(frag.conv.function.sig.ident.clone()),
+            entry: Some(frag.conv.clone()),
             handle_target: None,
             handle_nullable: false,
-            staged: !frag.conv.pre_stages.is_empty(),
+            absent: None,
             field: None,
             whole_gate: false,
         })
@@ -891,10 +986,10 @@ impl<R: Conversions> JCompile<'_, R> {
                     .collect(),
                 nullable: false,
             },
-            conv: None,
+            entry: None,
             handle_target: None,
             handle_nullable: false,
-            staged: false,
+            absent: None,
             field: None,
             whole_gate: false,
         }];
@@ -925,24 +1020,57 @@ impl<R: Conversions> JCompile<'_, R> {
     /// The conditions are the ones the walk applies: the inner is not a borrow,
     /// its wire is a JNI primitive, and it has nothing that would already carry
     /// the absence — no carved niche, no projection, no Rust-side stages.
-    fn decoupled_optional(&self, at: At<'_>, inner: &JFrag) -> Option<Vec<Wire>> {
+    fn decoupled_optional(
+        &self,
+        at: At<'_>,
+        inner: &JFrag,
+        outer: &ConverterImpl<KotlinMeta>,
+    ) -> Option<Vec<Wire>> {
         let inner_reading = at.crossing.value().optional_inner()?;
         if inner_reading.borrow_target().is_some() {
             return None;
         }
         let c = &inner.conv;
         let prim = crate::jni::JniPrim::from_wire(&c.destination)?;
-        if c.niches.clone().carve().is_some()
-            || c.metadata.projection.is_some()
-            || !c.pre_stages.is_empty()
-        {
+        if c.niches.clone().carve().is_some() || !c.pre_stages.is_empty() {
             return None;
         }
-        // A Kotlin enum's slot is its `value`, reached through the same gate.
-        let value_access = if self.decls.is_kotlin_enum_reading(inner_reading) {
-            format!("?.value ?: {}", prim.kotlin_zero())
+        // An unsigned representation is the one projection that still takes the
+        // pair. Its Kotlin property is a `ULong?`, which boxes, and its wire is
+        // the `Long` under it — so the gate is worth the same here as it is over
+        // a signed primitive. Only where the optional has no primitive wire of
+        // its own: a bounded representation whose range leaves a niche already
+        // crosses as one value and keeps doing so.
+        let unsigned = match c.metadata.projection.as_ref().map(|p| &p.kind) {
+            None => false,
+            Some(ProjectionKind::Unsigned64)
+                if crate::jni::JniPrim::from_wire(&outer.destination).is_none() =>
+            {
+                true
+            }
+            Some(_) => return None,
+        };
+        // A Kotlin enum's slot is its `value`, reached through the same gate —
+        // what this pair was decoupled from is optional, so that read is a safe
+        // call however the wire above it is composed.
+        let step = if unsigned {
+            // The `ULong` property's own representation, which is the wire.
+            Some("toLong()")
+        } else if self.decls.is_kotlin_enum_reading(inner_reading) {
+            Some("value")
         } else {
-            format!(" ?: {}", prim.kotlin_zero())
+            None
+        };
+        let value_access = Access::Read {
+            walk: step
+                .map(|field| {
+                    vec![Nav {
+                        field: field.to_string(),
+                        gated: true,
+                    }]
+                })
+                .unwrap_or_default(),
+            tail: format!(" ?: {}", prim.kotlin_zero()),
         };
         Some(vec![
             Wire {
@@ -950,10 +1078,10 @@ impl<R: Conversions> JCompile<'_, R> {
                 kt_ty: "Boolean".to_string(),
                 path: "present".to_string(),
                 access: Access::read(" != null"),
-                conv: None,
+                entry: None,
                 handle_target: None,
                 handle_nullable: false,
-                staged: false,
+                absent: None,
                 field: None,
                 whole_gate: false,
             },
@@ -961,11 +1089,11 @@ impl<R: Conversions> JCompile<'_, R> {
                 ty: c.destination.clone(),
                 kt_ty: crate::jni::emit::wire_kotlin_type(c),
                 path: "value".to_string(),
-                access: Access::read(value_access),
-                conv: Some(c.function.sig.ident.clone()),
+                access: value_access,
+                entry: Some(c.clone()),
                 handle_target: None,
                 handle_nullable: false,
-                staged: false,
+                absent: None,
                 field: None,
                 whole_gate: false,
             },
@@ -1006,48 +1134,49 @@ fn is_handle(frag: &JFrag) -> bool {
         .is_some_and(|p| p.kind == crate::jni::ProjectionKind::Handle)
 }
 
-/// What a non-nullable slot holds while its gate is closed, as an elvis tail.
+/// One wire, read through a gate above it that may find nothing.
 ///
-/// Empty for the two cases that need none. A **presence flag** is a `!= null`
-/// comparison: it is already non-null, and a Kotlin elvis on a non-null operand
-/// does not compile. A wire that **already carries one** got it from a gate
-/// further in — the expression yields a value from there on, so an outer gate
-/// has nothing left to substitute for.
-fn absent_default(w: &Wire, tail: &str) -> String {
-    if w.conv.is_none() && w.handle_target.is_none() {
-        return String::new();
-    }
-    if tail.contains(" ?: ") {
-        return String::new();
-    }
-    crate::jni::emit::kt_leaf_default(
-        crate::jni::wire_access::jni_field_access(&w.ty)
-            .map(|(sig, _, _)| sig)
-            .unwrap_or(""),
-        w.kt_ty.ends_with('?'),
-    )
-    .map(|d| format!(" ?: {d}"))
-    .unwrap_or_default()
-}
-
-/// One wire's access, read through a gate that may find nothing.
+/// Every step below the gate becomes a safe call — not only the first: after
+/// one `?.` the chain is on a nullable value and stays there. What each form
+/// then needs is its own. An ordinary read carries the literal it stated for
+/// exactly this case; a sum's `when` gains the `null` arm; a sum's `as?` slot
+/// needs neither, a cast over a null subject being already null.
 ///
-/// Only an ordinary read navigates: it gains the `?` that stops at a null and
-/// the literal a non-nullable slot then carries. A sum's `when` gains the
-/// `null` arm instead, and a sum's `as?` slot needs neither — a cast over a
-/// null subject is already null.
-fn gated(access: &Access, w: &Wire) -> Access {
-    let mut gated = access.clone();
-    // Every step below the gate, not only the first: after one safe call the
-    // chain is on a nullable value and stays there.
-    for nav in gated.walk_mut() {
+/// A wire whose value is a JVM object rides that `null` instead of a literal,
+/// and its Kotlin type says so. Read **after** the literal rather than before,
+/// because a `String` slot does both: it falls back to `""` when its own field
+/// is present under a closed ancestor, and it is typed `String?`.
+fn gated(w: &Wire) -> Wire {
+    let mut gated = w.clone();
+    for nav in gated
+        .access
+        .walk_mut()
+        .iter_mut()
+        .chain(gated.handle_target.iter_mut().flatten())
+    {
         nav.gated = true;
     }
-    match &mut gated {
-        Access::Read { tail, .. } => *tail = format!("{tail}{}", absent_default(w, tail)),
+    match &mut gated.access {
+        Access::Read { tail, .. } => {
+            if let Some(absent) = gated.absent.take() {
+                if !tail.contains(" ?: ") {
+                    *tail = format!("{tail} ?: {absent}");
+                }
+            }
+        }
         Access::Select { nullable, .. } => *nullable = true,
         Access::Slot { .. } => {}
     }
+    if gated.entry.is_some()
+        && matches!(gated.access, Access::Read { .. })
+        && crate::jni::emit::is_jobject_shaped_wire(&gated.ty)
+        && !gated.kt_ty.ends_with('?')
+    {
+        gated.kt_ty.push('?');
+    }
+    // Anything under the gate can be absent, however the field itself was
+    // spelled.
+    gated.handle_nullable = gated.handle_target.is_some() || gated.handle_nullable;
     gated
 }
 

--- a/prebindgen-jni/src/jni/compile.rs
+++ b/prebindgen-jni/src/jni/compile.rs
@@ -47,6 +47,102 @@ pub(crate) struct JFrag {
     pub(crate) composed_only: bool,
 }
 
+/// How Kotlin reaches one wire value, relative to the object the site names.
+///
+/// Three forms rather than one string, because two of them put the base in the
+/// **middle**: a sum's tag reads `when (<base>.f) { … }` and a sum's payload
+/// slot reads `(<base>.f as? I.V)?.v0`. A suffix cannot say that, and a raw
+/// prefix/suffix pair cannot be composed — an optional layer has to know
+/// whether it is adding a `?.` navigation or a `null ->` arm, and only a named
+/// form tells it which.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) enum Access {
+    /// `<base><tail>` — the ordinary read, including a presence comparison.
+    Read(String),
+    /// `when (<base><tail>) { … }` — which alternative of a sum is live, as the
+    /// `jint` tag the arms below are numbered by.
+    Select {
+        /// What reaches the sum value from the base.
+        tail: String,
+        /// One arm per alternative, in declaration order, without the `null`
+        /// one — an optional ancestor adds that by setting `nullable`.
+        arms: Vec<String>,
+        /// Whether the value reached can be null, which is its own arm.
+        nullable: bool,
+    },
+    /// `(<base><tail> as? <class>)?.<read>[ ?: <zero>]` — one payload slot of
+    /// one alternative. Every alternative's slots cross on every call; the
+    /// cast yields null for the ones that are not live, and `zero` is what a
+    /// non-nullable wire carries instead.
+    Slot {
+        /// What reaches the sum value from the base.
+        tail: String,
+        /// The Kotlin class of the alternative this slot belongs to. Empty
+        /// until [`Compile::choice`] names it — the arm's own composition
+        /// cannot, because a product hook is not told which alternative it is.
+        class: String,
+        /// What reads the payload off the cast alternative — `v0`, or
+        /// `v1?.value` for a Kotlin enum payload.
+        read: String,
+        /// What an inert slot carries, or `None` for a wire that rides a JVM
+        /// `null`.
+        zero: Option<String>,
+    },
+}
+
+impl Access {
+    /// The Kotlin expression, rooted at the object this site destructures.
+    ///
+    /// Only the equivalence check calls it until the emitters take the row —
+    /// the same `#[cfg(test)]` the wire's other readers carry.
+    #[cfg(test)]
+    pub(crate) fn render(&self, base: &str) -> String {
+        match self {
+            Access::Read(tail) => format!("{base}{tail}"),
+            Access::Select {
+                tail,
+                arms,
+                nullable,
+            } => {
+                let arms = nullable
+                    .then(|| "null -> 0".to_string())
+                    .into_iter()
+                    .chain(arms.iter().cloned())
+                    .collect::<Vec<_>>()
+                    .join("; ");
+                format!("when ({base}{tail}) {{ {arms} }}")
+            }
+            Access::Slot {
+                tail,
+                class,
+                read,
+                zero,
+            } => {
+                let zero = zero
+                    .as_ref()
+                    .map(|z| format!(" ?: {z}"))
+                    .unwrap_or_default();
+                format!("({base}{tail} as? {class})?.{read}{zero}")
+            }
+        }
+    }
+
+    /// What reaches this value from the base — the part a container prepends
+    /// its own field to, whichever form the access takes.
+    fn tail_mut(&mut self) -> &mut String {
+        match self {
+            Access::Read(tail) | Access::Select { tail, .. } | Access::Slot { tail, .. } => tail,
+        }
+    }
+
+    /// This access read from one field in, rather than from the object itself.
+    fn under(mut self, field: &str) -> Self {
+        let tail = self.tail_mut();
+        *tail = format!(".{field}{tail}");
+        self
+    }
+}
+
 /// One wire value of a crossing that occupies several.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) struct Wire {
@@ -67,7 +163,7 @@ pub(crate) struct Wire {
     /// Relative for the same reason `path` is: the site supplies the base, so
     /// the same wire reads `h.flat.id` in one call and `this.flat.id` in the
     /// next.
-    pub(crate) access: String,
+    pub(crate) access: Access,
     /// The conversion this value crosses through, or `None` for a presence flag
     /// — which is read on the Rust side and converts nothing.
     pub(crate) conv: Option<syn::Ident>,
@@ -321,24 +417,31 @@ impl<R: Conversions> Compile for JCompile<'_, R> {
             }
         }
         if let (Assembly::Construct, Some(inner_wires)) = (at.crossing.assembly(), &inner.wires) {
+            // A sum reached through the gate needs no navigation added: every
+            // one of its wires already reads the value through a `when` or an
+            // `as?`, both of which take a null subject. What the gate does add
+            // is the `null` arm — and the flag it prepends gates one field
+            // rather than a whole value, because the value under it IS the
+            // field.
+            let sum = is_choice(inner);
             let mut wires = vec![Wire {
                 ty: syn::parse_quote!(jni::sys::jboolean),
                 kt_ty: "Boolean".to_string(),
                 path: "present".to_string(),
                 // The gate reads the object itself, not through it.
-                access: " != null".to_string(),
+                access: Access::Read(" != null".to_string()),
                 conv: None,
                 handle_target: None,
                 handle_nullable: false,
                 staged: false,
                 field: None,
-                whole_gate: true,
+                whole_gate: !sum,
             }];
             // Everything under the gate is reached through it, and a
             // non-nullable slot still has to hold something when the value is
             // absent — the flag is what tells Rust to ignore it.
             wires.extend(inner_wires.iter().map(|w| Wire {
-                access: format!("?{}{}", w.access, absent_default(w)),
+                access: gated(&w.access, w),
                 // Anything under the gate can be absent, however the field
                 // itself was spelled.
                 handle_nullable: w.handle_target.is_some() || w.handle_nullable,
@@ -398,12 +501,20 @@ impl<R: Conversions> Compile for JCompile<'_, R> {
         Err(refuse(at, "JniGen states no value-form rows yet"))
     }
 
-    fn fields(&mut self, _cx: &mut Cx<'_>, at: At<'_>, parts: Parts<'_, Self>) -> Frag<Self> {
+    fn fields(&mut self, cx: &mut Cx<'_>, at: At<'_>, parts: Parts<'_, Self>) -> Frag<Self> {
         if at.crossing.assembly() != Assembly::Construct {
             return Err(refuse(
                 at,
                 "JniGen states no deconstructing product rows yet",
             ));
+        }
+        // A product whose own type is a sum is one **alternative's** payload:
+        // the registry composes every arm through this hook and hands the lot
+        // to `choice`. Its parts are read off a cast rather than off the value,
+        // so they take the slot form — and which alternative to cast to is
+        // `choice`'s to fill in, being the only hook told.
+        if self.is_sum(cx, at) {
+            return Ok(self.arm(at, parts));
         }
         // A `data_class` crosses as its fields, and a field that is itself one
         // contributes its own several — which is the recursion, stated once
@@ -418,7 +529,7 @@ impl<R: Conversions> Compile for JCompile<'_, R> {
                         path: format!("{}.{}", part.name, w.path),
                         // The field this part reads, then however the part's own
                         // wire reaches on from there.
-                        access: format!(".{}{}", field_kt(part), w.access),
+                        access: w.access.clone().under(&field_kt(part)),
                         conv: w.conv.clone(),
                         handle_target: w
                             .handle_target
@@ -443,7 +554,7 @@ impl<R: Conversions> Compile for JCompile<'_, R> {
                     ty: syn::parse_quote!(jni::sys::jlong),
                     kt_ty: "Long".to_string(),
                     path: part.name.clone(),
-                    access: format!(".{}", field_kt(part)),
+                    access: Access::Read(format!(".{}", field_kt(part))),
                     conv: None,
                     handle_target: Some(format!(".{}", field_kt(part))),
                     handle_nullable: part.ty.optional_inner().is_some(),
@@ -455,7 +566,7 @@ impl<R: Conversions> Compile for JCompile<'_, R> {
                     ty: frag.conv.destination.clone(),
                     kt_ty: crate::jni::emit::wire_kotlin_type(&frag.conv),
                     path: part.name.clone(),
-                    access: format!(".{}", field_kt(part)),
+                    access: Access::Read(format!(".{}", field_kt(part))),
                     conv: Some(frag.conv.function.sig.ident.clone()),
                     handle_target: None,
                     handle_nullable: false,
@@ -474,17 +585,7 @@ impl<R: Conversions> Compile for JCompile<'_, R> {
         // their own.
         let mut frag = JFrag::new(
             at,
-            ConverterImpl {
-                destination: syn::parse_quote!(()),
-                function: syn::parse_quote!(
-                    #[allow(dead_code)]
-                    fn __jni_parts() {}
-                ),
-                pre_stages: Vec::new(),
-                niches: Niches::empty(),
-                metadata: KotlinMeta::default(),
-                subs: parts.iter().map(|(p, _)| p.ty.key()).collect(),
-            },
+            self.parts_marker(parts.iter().map(|(p, _)| p.ty.key()).collect()),
         );
         frag.wires = Some(wires);
         frag.composed_only = true;
@@ -495,9 +596,38 @@ impl<R: Conversions> Compile for JCompile<'_, R> {
         &mut self,
         _cx: &mut Cx<'_>,
         at: At<'_>,
-        _arms: &[(&Alternative, &JFrag)],
+        arms: &[(&Alternative, &JFrag)],
     ) -> Frag<Self> {
-        Err(refuse(at, "JniGen states no choice rows yet"))
+        if at.crossing.assembly() != Assembly::Construct {
+            return Err(refuse(
+                at,
+                "JniGen states no deconstructing choice rows yet",
+            ));
+        }
+        // Which alternative is live crosses as its own `jint`, and every
+        // alternative's slots cross on every call — the inert ones carrying the
+        // literal their wire takes when the cast finds nothing. The N-way form
+        // of the presence flag an optional already uses.
+        match self.selected(at, arms) {
+            Some(wires) => {
+                let mut frag = JFrag::new(at, self.parts_marker(parts_subs(arms)));
+                frag.wires = Some(wires);
+                frag.composed_only = true;
+                Ok(frag)
+            }
+            // A payload this adapter has no slot for — a nested object, a
+            // handle — leaves the whole sum object-shaped, which is the row it
+            // already had. Stated as a fragment with no wires rather than as a
+            // refusal: the site that asked composes it as one value, exactly as
+            // it did before a `parts` row existed.
+            None => {
+                let conv = self
+                    .decls
+                    .in_frag(at.crossing.spelled())
+                    .ok_or_else(|| refuse(at, "no JNI representation for this sum"))?;
+                Ok(JFrag::new(at, (*conv).clone()))
+            }
+        }
     }
 
     fn callback(
@@ -582,6 +712,170 @@ impl Wire {
 }
 
 impl<R: Conversions> JCompile<'_, R> {
+    /// The conversion a composed-only row carries: none.
+    ///
+    /// The `parts` and arm rows state what a value is made of and nothing
+    /// about how it is rebuilt, so there is no function to name. `subs` is
+    /// still real — it is what the registry walks for reachability.
+    /// `prebindgen-c` does the same for a union arm, and for the same reason.
+    fn parts_marker(&self, subs: Vec<TypeKey>) -> ConverterImpl<KotlinMeta> {
+        ConverterImpl {
+            destination: syn::parse_quote!(()),
+            function: syn::parse_quote!(
+                #[allow(dead_code)]
+                fn __jni_parts() {}
+            ),
+            pre_stages: Vec::new(),
+            niches: Niches::empty(),
+            metadata: KotlinMeta::default(),
+            subs,
+        }
+    }
+
+    /// Whether the crossing being composed is a data-carrying enum, which is
+    /// what makes a product hook an **arm** rather than a struct.
+    fn is_sum(&self, cx: &Cx<'_>, at: At<'_>) -> bool {
+        let TypeKind::Named { id, .. } = at.crossing.value().unwrapped().kind() else {
+            return false;
+        };
+        id.ident().is_some_and(|ident| {
+            matches!(
+                cx.model().declared_type(&ident),
+                Some(prebindgen_registry::flat::Type::Variant(_))
+            )
+        })
+    }
+
+    /// One alternative's payload, as the slots it crosses in.
+    ///
+    /// A fragment with **no** wires is this adapter declining: a payload it has
+    /// no slot for — one that is itself several values, an opaque handle, or a
+    /// wire that is neither a JNI primitive nor a string — keeps the whole sum
+    /// object-shaped. See [`Compile::choice`]'s `None` arm for what that costs.
+    fn arm(&self, at: At<'_>, parts: Parts<'_, Self>) -> JFrag {
+        let mut wires = Vec::new();
+        for (part, frag) in parts {
+            let Some(wire) = self.slot(part, frag) else {
+                return JFrag::new(at, self.parts_marker(Vec::new()));
+            };
+            wires.push(wire);
+        }
+        let mut frag = JFrag::new(
+            at,
+            self.parts_marker(parts.iter().map(|(p, _)| p.ty.key()).collect()),
+        );
+        frag.wires = Some(wires);
+        frag.composed_only = true;
+        frag
+    }
+
+    /// One payload of one alternative, or `None` if it has no slot form.
+    fn slot(&self, part: &Part<'_>, frag: &JFrag) -> Option<Wire> {
+        if frag.wires.is_some() || frag.conv.metadata.projection.is_some() {
+            return None;
+        }
+        let prim = crate::jni::JniPrim::from_wire(&frag.conv.destination);
+        let string_like = matches!(&frag.conv.destination, syn::Type::Path(tp)
+            if tp.path.segments.last().is_some_and(|s| s.ident == "JString"));
+        if prim.is_none() && !string_like {
+            return None;
+        }
+        let prop = crate::jni::struct_plan::sum_field_prop_name(&part_member(part)?);
+        // An `enum_class` payload is a Kotlin enum object whose wire is the
+        // `jint` discriminant, so the slot reads `.value` — without it the wire
+        // would carry a `Priority?` where it wants an `Int`.
+        let read = if self.decls.is_kotlin_enum_reading(&part.ty) {
+            format!("{prop}?.value")
+        } else {
+            prop.clone()
+        };
+        let mut kt_ty = crate::jni::emit::wire_kotlin_type(&frag.conv);
+        if prim.is_none() && !kt_ty.ends_with('?') {
+            kt_ty.push('?');
+        }
+        Some(Wire {
+            ty: frag.conv.destination.clone(),
+            kt_ty,
+            path: prop,
+            access: Access::Slot {
+                tail: String::new(),
+                // Named by `choice`, the only hook told which alternative this
+                // payload belongs to.
+                class: String::new(),
+                read,
+                zero: prim.map(|p| p.kotlin_zero().to_string()),
+            },
+            conv: Some(frag.conv.function.sig.ident.clone()),
+            handle_target: None,
+            handle_nullable: false,
+            staged: !frag.conv.pre_stages.is_empty(),
+            field: None,
+            whole_gate: false,
+        })
+    }
+
+    /// The tag, then every alternative's slots — or `None` if any alternative
+    /// declined, since a sum crosses whole or not at all.
+    fn selected(&self, at: At<'_>, arms: &[(&Alternative, &JFrag)]) -> Option<Vec<Wire>> {
+        let TypeKind::Named { id, .. } = at.crossing.value().unwrapped().kind() else {
+            return None;
+        };
+        let cfg = self.decls.types.get(&TypeKey::from_ident(&id.ident()?))?;
+        let sum_cfg = cfg.sum()?;
+        let iface = cfg.name_spec.as_ref().map(|s| self.decls.fqn_of(s))?;
+
+        let classes: Vec<String> = arms
+            .iter()
+            .map(|(alt, _)| {
+                format!(
+                    "{iface}.{}",
+                    self.decls.sum_variant_class_name(sum_cfg, &alt.name)
+                )
+            })
+            .collect();
+        let mut wires = vec![Wire {
+            ty: syn::parse_quote!(jni::sys::jint),
+            kt_ty: "Int".to_string(),
+            path: "_tag".to_string(),
+            access: Access::Select {
+                tail: String::new(),
+                arms: arms
+                    .iter()
+                    .zip(&classes)
+                    .map(|((alt, _), class)| {
+                        format!("is {class} -> {}", crate::jni::struct_plan::sum_tag(alt))
+                    })
+                    .collect(),
+                nullable: false,
+            },
+            conv: None,
+            handle_target: None,
+            handle_nullable: false,
+            staged: false,
+            field: None,
+            whole_gate: false,
+        }];
+        for ((_, frag), class) in arms.iter().zip(&classes) {
+            let short = class.rsplit('.').next().unwrap_or(class);
+            for w in frag.wires.as_ref()? {
+                let Access::Slot { read, zero, .. } = &w.access else {
+                    return None;
+                };
+                wires.push(Wire {
+                    path: crate::jni::struct_plan::sum_slot_fragment(short, &w.path),
+                    access: Access::Slot {
+                        tail: String::new(),
+                        class: class.clone(),
+                        read: read.clone(),
+                        zero: zero.clone(),
+                    },
+                    ..w.clone()
+                });
+            }
+        }
+        Some(wires)
+    }
+
     /// The `(present, value)` pair a nullable primitive or enum crosses as, or
     /// `None` if this optional boxes instead.
     ///
@@ -612,7 +906,7 @@ impl<R: Conversions> JCompile<'_, R> {
                 ty: syn::parse_quote!(jni::sys::jboolean),
                 kt_ty: "Boolean".to_string(),
                 path: "present".to_string(),
-                access: " != null".to_string(),
+                access: Access::Read(" != null".to_string()),
                 conv: None,
                 handle_target: None,
                 handle_nullable: false,
@@ -624,7 +918,7 @@ impl<R: Conversions> JCompile<'_, R> {
                 ty: c.destination.clone(),
                 kt_ty: crate::jni::emit::wire_kotlin_type(c),
                 path: "value".to_string(),
-                access: value_access,
+                access: Access::Read(value_access),
                 conv: Some(c.function.sig.ident.clone()),
                 handle_target: None,
                 handle_nullable: false,
@@ -634,6 +928,21 @@ impl<R: Conversions> JCompile<'_, R> {
             },
         ])
     }
+}
+
+/// The model field one part reads, which a sum payload names its slot after.
+fn part_member(part: &Part<'_>) -> Option<syn::Member> {
+    match part.from {
+        prebindgen_registry::recipe::PartSource::Field { field, .. } => Some(field.member()),
+        _ => None,
+    }
+}
+
+/// Every crossing a sum's arms delegate to, which is what reachability walks.
+fn parts_subs(arms: &[(&Alternative, &JFrag)]) -> Vec<TypeKey> {
+    arms.iter()
+        .flat_map(|(_, f)| f.conv.subs.iter().cloned())
+        .collect()
 }
 
 /// The Kotlin property name for one part of a product, sanitized — `object` is
@@ -661,11 +970,11 @@ fn is_handle(frag: &JFrag) -> bool {
 /// does not compile. A wire that **already carries one** got it from a gate
 /// further in — the expression yields a value from there on, so an outer gate
 /// has nothing left to substitute for.
-fn absent_default(w: &Wire) -> String {
+fn absent_default(w: &Wire, tail: &str) -> String {
     if w.conv.is_none() && w.handle_target.is_none() {
         return String::new();
     }
-    if w.access.contains(" ?: ") {
+    if tail.contains(" ?: ") {
         return String::new();
     }
     crate::jni::emit::kt_leaf_default(
@@ -676,4 +985,31 @@ fn absent_default(w: &Wire) -> String {
     )
     .map(|d| format!(" ?: {d}"))
     .unwrap_or_default()
+}
+
+/// One wire's access, read through a gate that may find nothing.
+///
+/// Only an ordinary read navigates: it gains the `?` that stops at a null and
+/// the literal a non-nullable slot then carries. A sum's `when` gains the
+/// `null` arm instead, and a sum's `as?` slot needs neither — a cast over a
+/// null subject is already null.
+fn gated(access: &Access, w: &Wire) -> Access {
+    match access {
+        Access::Read(tail) => Access::Read(format!("?{tail}{}", absent_default(w, tail))),
+        Access::Select { tail, arms, .. } => Access::Select {
+            tail: tail.clone(),
+            arms: arms.clone(),
+            nullable: true,
+        },
+        slot @ Access::Slot { .. } => slot.clone(),
+    }
+}
+
+/// Whether this fragment states a sum taken apart into a tag and its arms'
+/// slots, rather than a product taken apart into its fields.
+fn is_choice(frag: &JFrag) -> bool {
+    frag.wires
+        .as_ref()
+        .and_then(|w| w.first())
+        .is_some_and(|w| matches!(w.access, Access::Select { .. }))
 }

--- a/prebindgen-jni/src/jni/mod.rs
+++ b/prebindgen-jni/src/jni/mod.rs
@@ -492,10 +492,12 @@ impl JniGen {
                     name,
                     w.kt_ty.clone(),
                     w.access.render(param),
-                    w.conv.as_ref().map(|c| c.to_string()),
-                    w.handle_target.as_ref().map(|t| format!("{param}{t}")),
+                    w.conv().map(|c| c.to_string()),
+                    w.handle_target
+                        .as_ref()
+                        .map(|t| crate::jni::compile::reached(param, t)),
                     w.handle_nullable,
-                    w.staged,
+                    w.staged(),
                     w.field().map(str::to_string),
                 )
             })

--- a/prebindgen-jni/src/jni/mod.rs
+++ b/prebindgen-jni/src/jni/mod.rs
@@ -491,7 +491,7 @@ impl JniGen {
                 (
                     name,
                     w.kt_ty.clone(),
-                    format!("{param}{}", w.access),
+                    w.access.render(param),
                     w.conv.as_ref().map(|c| c.to_string()),
                     w.handle_target.as_ref().map(|t| format!("{param}{t}")),
                     w.handle_nullable,

--- a/prebindgen-jni/src/jni/mod.rs
+++ b/prebindgen-jni/src/jni/mod.rs
@@ -479,10 +479,10 @@ impl JniGen {
     /// asserting a hand-written expectation.
     pub(crate) fn parts_vs_walk_for_test(
         &self,
-        short: &str,
+        spelling: &str,
         param: &str,
     ) -> Option<(Vec<NamedWire>, Vec<NamedWire>)> {
-        let wires = self.parts_wires_for_test(short)?;
+        let wires = self.parts_wires_for_test(spelling)?;
         let composed = wires
             .iter()
             .map(|w| {
@@ -501,8 +501,7 @@ impl JniGen {
             })
             .collect();
 
-        let ident = syn::Ident::new(short, proc_macro2::Span::call_site());
-        let ty: syn::Type = syn::parse_quote!(#ident);
+        let ty: syn::Type = syn::parse_str(spelling).ok()?;
         let arg = prebindgen_registry::Conversions::reading_of(&self.registry, &ty)?;
         let plan = crate::jni::emit::build_flat_input_plan(
             &self.decls,
@@ -537,25 +536,19 @@ impl JniGen {
     /// what it composed.
     pub(crate) fn parts_wires_for_test(
         &self,
-        short: &str,
+        spelling: &str,
     ) -> Option<Vec<crate::jni::compile::Wire>> {
-        let key = self
-            .decls
-            .compiled
-            .borrow()
-            .fragments()
-            .iter()
-            .find_map(|f| {
-                (f.wires.is_some() && f.yields.ty.as_str() == short).then(|| f.yields.ty.clone())
-            })?;
-        self.decls
-            .compiled
-            .borrow()
-            .row_fragment(
-                &key,
-                prebindgen_registry::recipe::Assembly::Construct,
-                &crate::jni::rows::parts(),
-            )?
+        use prebindgen_registry::recipe::Assembly;
+        let ty: syn::Type = syn::parse_str(spelling).ok()?;
+        let reading = prebindgen_registry::Conversions::reading_of(&self.registry, &ty)?;
+        let key = reading.key();
+        let compiled = self.decls.compiled.borrow();
+        // A declared class states its composition under `parts`; an optional
+        // over one has no row of its own and composes on the row the registry
+        // derived, which is the crossing's default.
+        compiled
+            .row_fragment(&key, Assembly::Construct, &crate::jni::rows::parts())
+            .or_else(|| compiled.fragment(&key, Assembly::Construct))?
             .wires
             .clone()
     }

--- a/prebindgen-jni/src/jni/rows.rs
+++ b/prebindgen-jni/src/jni/rows.rs
@@ -17,7 +17,7 @@ use std::collections::BTreeMap;
 
 use prebindgen_registry::{
     flat::{Flat, TypeRef},
-    recipe::{Construct, Constructing, Deconstructing, RecipeError, RecipeId, Recipes},
+    recipe::{Arm, Construct, Constructing, Deconstructing, RecipeError, RecipeId, Recipes},
 };
 
 use super::*;
@@ -44,6 +44,30 @@ fn element_types(element: &prebindgen_registry::Element) -> Vec<&TypeRef> {
         prebindgen_registry::Element::Constant(c) => vec![&c.ty],
         _ => Vec::new(),
     }
+}
+
+/// One arm per alternative of a declared sum, each assembled from its own
+/// payload fields.
+///
+/// Empty for anything the model does not hold as a data-carrying enum, which
+/// includes a `sealed_class!` declared over a type the scan dropped — the scan
+/// reports that, and a row over no arms would report it a second time.
+fn alternatives(model: &Flat, ty: &TypeRef) -> Vec<Arm<Construct>> {
+    let prebindgen_registry::flat::TypeKind::Named { id, .. } = ty.unwrapped().kind() else {
+        return Vec::new();
+    };
+    let Some(prebindgen_registry::flat::Type::Variant(v)) =
+        id.ident().and_then(|ident| model.declared_type(&ident))
+    else {
+        return Vec::new();
+    };
+    v.alternatives
+        .iter()
+        .map(|alt| Arm {
+            alternative: alt.index,
+            op: Construct::Fields,
+        })
+        .collect()
 }
 
 /// The row a type with no parts takes: the adapter emits the conversion itself.
@@ -108,14 +132,25 @@ impl Declarations {
             // A `data_class` also has a row that says what it is made of, so
             // its constructing side names which of the two a site takes by
             // default. See [`parts`] for why that is still `whole`.
-            if matches!(
-                self.types.get(&ty.key()).map(|c| &c.kind),
-                Some(DeclaredKind::Data)
-            ) {
-                rows.declare_default(ty.clone(), whole(), Constructing::Atomic)
-                    .declare(ty, parts(), Constructing::Product(Construct::Fields));
-            } else {
-                rows.declare(ty, whole(), Constructing::Atomic);
+            match self.types.get(&ty.key()).map(|c| &c.kind) {
+                Some(DeclaredKind::Data) => {
+                    rows.declare_default(ty.clone(), whole(), Constructing::Atomic)
+                        .declare(ty, parts(), Constructing::Product(Construct::Fields));
+                }
+                // A `sealed_class` has one too, and it is a choice rather than
+                // a product: exactly one alternative is live, every one of them
+                // still crosses, and the tag says which. The arms are the
+                // model's — a row states which parts, never what they are.
+                Some(DeclaredKind::Sealed(_)) => {
+                    let arms = alternatives(model, &ty);
+                    rows.declare_default(ty.clone(), whole(), Constructing::Atomic);
+                    if !arms.is_empty() {
+                        rows.declare(ty, parts(), Constructing::Choice { arms });
+                    }
+                }
+                _ => {
+                    rows.declare(ty, whole(), Constructing::Atomic);
+                }
             }
         }
 
@@ -165,7 +200,16 @@ impl Declarations {
     fn field_crosses_as_its_fields(&self, ty: &TypeRef) -> bool {
         self.types
             .get(&ty.stripped_key())
-            .is_some_and(|c| matches!(c.kind, DeclaredKind::Data) && !c.jobject_input)
+            .is_some_and(|c| match c.kind {
+                DeclaredKind::Data => !c.jobject_input,
+                // A `sealed_class` field crosses as a tag plus every alternative's
+                // slots. Whether it *can* is the adapter's answer at compile time,
+                // not a declaration: a payload with no slot form leaves the sum
+                // object-shaped, which is the fragment `Compile::choice` hands
+                // back. So the site asks, and the row answers.
+                DeclaredKind::Sealed(_) => true,
+                _ => false,
+            })
     }
 
     pub(crate) fn bindings(

--- a/prebindgen-jni/src/jni/rows.rs
+++ b/prebindgen-jni/src/jni/rows.rs
@@ -230,6 +230,45 @@ impl Declarations {
             .collect();
         declared.sort_by(|a, b| a.as_str().cmp(b.as_str()));
 
+        // Every optional over a flattenable value, wherever the model spells
+        // one: a parameter, a field, a callback argument. A `Site` keys a part
+        // by the crossing's **stripped** key, so `Option<Payload>` and
+        // `Box<Option<Payload>>` are one site and binding it once answers for
+        // both spellings.
+        //
+        // Enumerated from the model rather than from the declarations, for the
+        // same reason the array rows are: what has to be bound is what the
+        // model names, and a declaration says nothing about where its type is
+        // used.
+        let mut optionals: BTreeMap<TypeKey, (&TypeRef, &TypeRef)> = BTreeMap::new();
+        for ty in model
+            .elements()
+            .flat_map(element_types)
+            .flat_map(|t| t.walk())
+        {
+            let Some(inner) = ty.optional_inner() else {
+                continue;
+            };
+            if self.field_crosses_as_its_fields(inner) {
+                optionals.entry(ty.stripped_key()).or_insert((ty, inner));
+            }
+        }
+        for (outer, inner) in optionals.into_values() {
+            // The optional keeps the row the registry derived from its shape —
+            // it has no `parts` row of its own — and it is the value one layer
+            // in that crosses as its parts.
+            bound.bind(
+                Site::part(
+                    &Crossing::new(outer.clone(), Assembly::Construct),
+                    &RecipeId::derived(),
+                    0,
+                ),
+                Crossing::new(inner.clone(), Assembly::Construct),
+                Ask::Recipe(parts()),
+                Origin::Part,
+            );
+        }
+
         for key in declared {
             let Some(ident) = key.ident() else { continue };
             let Some(prebindgen_registry::flat::Type::Struct(s)) = model.declared_type(&ident)
@@ -248,29 +287,18 @@ impl Declarations {
                 if !self.field_crosses_as_its_fields(target) {
                     continue;
                 }
-                match field.ty.optional_inner() {
-                    // The field IS the class: its part takes the `parts` row.
-                    None => bound.bind(
+                // An `Option<D>` field reaches D through the optional's own
+                // part site, which the model-wide scan above already bound. What
+                // is left is the field that IS the class: its part takes the
+                // `parts` row.
+                if field.ty.optional_inner().is_none() {
+                    bound.bind(
                         Site::part(&of, &parts(), index),
                         Crossing::new(field.ty.clone(), Assembly::Construct),
                         Ask::Recipe(parts()),
                         Origin::Part,
-                    ),
-                    // The field is an `Option<D>`. That crossing keeps the row
-                    // the registry derived from its shape — it has no `parts`
-                    // row of its own — and it is D, one layer in, that takes
-                    // `parts`.
-                    Some(_) => bound.bind(
-                        Site::part(
-                            &Crossing::new(field.ty.clone(), Assembly::Construct),
-                            &RecipeId::derived(),
-                            0,
-                        ),
-                        Crossing::new(target.clone(), Assembly::Construct),
-                        Ask::Recipe(parts()),
-                        Origin::Part,
-                    ),
-                };
+                    );
+                }
             }
         }
         bound.build(recipes)

--- a/prebindgen-jni/src/jni/tests/flatten.rs
+++ b/prebindgen-jni/src/jni/tests/flatten.rs
@@ -2509,3 +2509,104 @@ fn every_spelling_the_walk_flattens_states_the_same_row() {
         .expect("optional row");
     assert_eq!(opt.len(), bare.len() + 1, "the gate is one more wire");
 }
+
+/// Every field shape the walk reads specially, held to the row.
+///
+/// A `data_class` field is not always one property read: an `enum_class`
+/// property holds the enum object where the wire holds its discriminant, an
+/// unsigned representation's property is a `ULong` over a `Long` wire, an
+/// optional primitive is decoupled into a presence flag and a raw slot rather
+/// than boxed, an optional whose wire is a JVM object rides a `null`, and a
+/// nested handle is locked through the object rather than the pointer it
+/// carries. Each of those is a place the composition and the walk could differ
+/// silently, so the fixture carries all of them at once — and again one layer
+/// down, where a closed gate above turns every read into a safe call and
+/// substitutes what a non-nullable slot carries meanwhile.
+#[test]
+fn every_field_shape_the_walk_reads_specially_states_the_same_row() {
+    let loc = myflat_loc();
+    let items: Vec<(syn::Item, SourceLocation)> = vec![
+        (
+            syn::Item::Enum(syn::parse_quote!(
+                pub enum Priority {
+                    Low = 0,
+                    High = 1,
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Struct(syn::parse_quote!(
+                pub struct Bits {
+                    pub pri: Priority,
+                    pub maybe_pri: Option<Priority>,
+                    pub big: u64,
+                    pub maybe_big: Option<u64>,
+                    pub name: String,
+                    pub maybe_name: Option<String>,
+                    pub flag: bool,
+                    pub maybe_flag: Option<bool>,
+                    pub bytes: [u8; 4],
+                    pub opaque: Opaque,
+                    pub maybe_opaque: Option<Opaque>,
+                    pub nested: Nested,
+                    pub maybe_nested: Option<Nested>,
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Struct(syn::parse_quote!(
+                pub struct Opaque {
+                    pub v: i64,
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Struct(syn::parse_quote!(
+                pub struct Nested {
+                    pub k: i64,
+                    pub s: String,
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn bits_use(b: Bits) -> i64 {
+                    unimplemented!()
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn bits_opt(b: Option<Bits>) -> i64 {
+                    unimplemented!()
+                }
+            )),
+            loc.clone(),
+        ),
+    ];
+    let registry =
+        crate::test_util::reg_from_items(declare_referenced(items)).expect("index items");
+    let jni = JniGenBuilder::new()
+        .set_package_prefix("io.test.jni")
+        .package(
+            crate::package!()
+                .class(crate::enum_class!(Priority))
+                .class(crate::ptr_class!(Opaque))
+                .class(crate::data_class!(Nested))
+                .class(crate::data_class!(Bits))
+                .fun(prebindgen_registry::fun!(bits_use))
+                .fun(prebindgen_registry::fun!(bits_opt)),
+        );
+    let gen = jni.build_with(registry).expect("resolve");
+    for spelling in ["Bits", "Option<Bits>"] {
+        let (composed, walked) = gen
+            .parts_vs_walk_for_test(spelling, "b")
+            .unwrap_or_else(|| panic!("{spelling}"));
+        assert_eq!(composed, walked, "disagree on {spelling}");
+    }
+}

--- a/prebindgen-jni/src/jni/tests/flatten.rs
+++ b/prebindgen-jni/src/jni/tests/flatten.rs
@@ -2289,3 +2289,108 @@ fn a_nullable_primitive_field_crosses_as_a_pair() {
     let (composed, walked) = gen.parts_vs_walk_for_test("Scal", "s").expect("plan");
     assert_eq!(composed, walked, "the row and the walk disagree");
 }
+
+/// A `sealed_class` field crosses as a tag plus every alternative's slots, and
+/// the row says so where the walk did.
+///
+/// The shape covertest carries: `Observation` holds a required `Reading` and an
+/// optional one, whose alternatives between them cover a scalar payload, a
+/// two-field payload, a string payload that rides a JVM `null`, and a Kotlin
+/// enum payload read through `.value`. Both fields go through the same
+/// composition, and the optional one takes the `null` arm and the presence flag
+/// on top of it.
+#[test]
+fn a_sealed_class_field_crosses_as_a_tag_and_every_arm_s_slots() {
+    let loc = myflat_loc();
+    let items: Vec<(syn::Item, SourceLocation)> = vec![
+        (
+            syn::Item::Enum(syn::parse_quote!(
+                pub enum Priority {
+                    Low = 0,
+                    High = 1,
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Enum(syn::parse_quote!(
+                pub enum Reading {
+                    Missing,
+                    Exact(i64),
+                    Range { low: i64, high: i64 },
+                    Tagged(String, Priority),
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Struct(syn::parse_quote!(
+                pub struct Observation {
+                    pub id: i64,
+                    pub reading: Reading,
+                    pub fallback: Option<Reading>,
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn observation_which(o: Observation) -> i32 {
+                    unimplemented!()
+                }
+            )),
+            loc.clone(),
+        ),
+    ];
+    let registry =
+        crate::test_util::reg_from_items(declare_referenced(items)).expect("index items");
+    let jni = JniGenBuilder::new()
+        .set_package_prefix("io.test.jni")
+        .package(
+            crate::package!()
+                .class(crate::enum_class!(Priority))
+                .class(crate::sealed_class!(Reading))
+                .class(crate::data_class!(Observation))
+                .fun(prebindgen_registry::fun!(observation_which)),
+        );
+    let gen = jni.build_with(registry).expect("resolve");
+
+    let (composed, walked) = gen
+        .parts_vs_walk_for_test("Observation", "o")
+        .expect("Observation states a parts row and the walk plans it");
+    assert_eq!(composed, walked, "the row and the walk disagree");
+
+    // What the two agree on, stated once so a change to both at the same time
+    // still has to be meant: the required field is a tag and six slots, the
+    // optional one adds a presence flag and a `null` arm.
+    let accesses: Vec<String> = composed.iter().map(|w| w.2.clone()).collect();
+    assert!(
+        accesses.contains(&"(o.reading as? io.test.jni.Reading.Exact)?.v0 ?: 0L".to_string()),
+        "{accesses:#?}"
+    );
+    assert!(
+        accesses
+            .contains(&"(o.reading as? io.test.jni.Reading.Tagged)?.v1?.value ?: 0".to_string()),
+        "a Kotlin enum payload is read through its discriminant: {accesses:#?}"
+    );
+    assert!(
+        accesses.contains(&"(o.reading as? io.test.jni.Reading.Tagged)?.v0".to_string()),
+        "a string payload rides a JVM null rather than a literal: {accesses:#?}"
+    );
+    assert!(
+        accesses.contains(&"o.fallback != null".to_string()),
+        "{accesses:#?}"
+    );
+    assert!(
+        accesses
+            .iter()
+            .any(|a| a.starts_with("when (o.fallback) { null -> 0;")),
+        "an optional sum gates on null in its own arm: {accesses:#?}"
+    );
+    assert!(
+        accesses
+            .iter()
+            .any(|a| a.starts_with("when (o.reading) { is io.test.jni.Reading.Missing -> 0;")),
+        "a required sum has no null arm: {accesses:#?}"
+    );
+}

--- a/prebindgen-jni/src/jni/tests/flatten.rs
+++ b/prebindgen-jni/src/jni/tests/flatten.rs
@@ -2394,3 +2394,118 @@ fn a_sealed_class_field_crosses_as_a_tag_and_every_arm_s_slots() {
         "a required sum has no null arm: {accesses:#?}"
     );
 }
+
+/// Every spelling the walk flattens states the same row.
+///
+/// `build_flat_input_plan` accepts a `data_class` parameter through five
+/// spellings — bare, `&`, `Option`, `Box`, and `Box<Option<…>>` — and all five
+/// appear in `covertest-kotlin` or `perftest-kotlin`. A borrow and a transparent
+/// wrapper find the class's own `parts` row, because a crossing is keyed by the
+/// value that crosses; an optional has no such row and composes on the one the
+/// registry derives for it, which is why `Declarations::bindings` binds its
+/// part.
+#[test]
+fn every_spelling_the_walk_flattens_states_the_same_row() {
+    let loc = myflat_loc();
+    let items: Vec<(syn::Item, SourceLocation)> = vec![
+        (
+            syn::Item::Struct(syn::parse_quote!(
+                pub struct Summary {
+                    pub count: i64,
+                    pub total: f64,
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Struct(syn::parse_quote!(
+                pub struct Holder {
+                    pub tag: i64,
+                    pub summary: Summary,
+                    pub note: Option<i64>,
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn bare(h: Holder) -> i64 {
+                    unimplemented!()
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn borrowed(h: &Holder) -> i64 {
+                    unimplemented!()
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn optional(h: Option<Holder>) -> i64 {
+                    unimplemented!()
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn boxed(h: Box<Holder>) -> i64 {
+                    unimplemented!()
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn boxed_optional(h: Box<Option<Holder>>) -> i64 {
+                    unimplemented!()
+                }
+            )),
+            loc.clone(),
+        ),
+    ];
+    let registry =
+        crate::test_util::reg_from_items(declare_referenced(items)).expect("index items");
+    let jni = JniGenBuilder::new()
+        .set_package_prefix("io.test.jni")
+        .package(
+            crate::package!()
+                .class(crate::data_class!(Summary))
+                .class(crate::data_class!(Holder))
+                .fun(prebindgen_registry::fun!(bare))
+                .fun(prebindgen_registry::fun!(borrowed))
+                .fun(prebindgen_registry::fun!(optional))
+                .fun(prebindgen_registry::fun!(boxed))
+                .fun(prebindgen_registry::fun!(boxed_optional)),
+        );
+    let gen = jni.build_with(registry).expect("resolve");
+
+    for spelling in [
+        "Holder",
+        "&Holder",
+        "Option<Holder>",
+        "Box<Holder>",
+        "Box<Option<Holder>>",
+    ] {
+        let (composed, walked) = gen
+            .parts_vs_walk_for_test(spelling, "h")
+            .unwrap_or_else(|| panic!("{spelling} states a row and the walk plans it"));
+        assert_eq!(
+            composed, walked,
+            "the row and the walk disagree on {spelling}"
+        );
+    }
+
+    // The optional spellings carry a presence flag the bare ones do not, so
+    // "they all agree with the walk" is not the same claim as "they are all
+    // the same list".
+    let bare = gen.parts_wires_for_test("Holder").expect("bare row");
+    let opt = gen
+        .parts_wires_for_test("Option<Holder>")
+        .expect("optional row");
+    assert_eq!(opt.len(), bare.len() + 1, "the gate is one more wire");
+}

--- a/prebindgen-jni/src/jni/tests/sealed.rs
+++ b/prebindgen-jni/src/jni/tests/sealed.rs
@@ -868,9 +868,13 @@ fn recursive_sum_shapes_fail_deterministically() {
         }
     };
 
-    // `Vec<Node>` — variable arity, rejected with the intended message.
+    // `Vec<Node>` — the row saying what `Node` is made of reaches `Node`
+    // again, and the table refuses it by name before anything is compiled.
+    // The same refusal the emitter used to phrase as "variable arity", now
+    // stating which crossings close the loop.
     let msg = attempt(quote::quote!(Branch(Vec<Node>)), "rec_vec").expect_err("must fail");
-    assert!(msg.contains("variable arity"), "{msg}");
+    assert!(msg.contains("reaches its own crossing"), "{msg}");
+    assert!(msg.contains("Node"), "{msg}");
 
     // `Box<Node>` — not a bare ident, so it never classifies as a sum; it
     // fails as an unresolvable payload rather than recursing.

--- a/prebindgen-jni/src/jni/trait_impl.rs
+++ b/prebindgen-jni/src/jni/trait_impl.rs
@@ -1587,9 +1587,14 @@ impl Declarations {
         // crate builds rather than to one fixture. Nothing reads the result
         // yet: `whole` is still the row every site takes, so a failure here is
         // a failure to compose parts that already cross individually.
+        // The **stripped** key, so `Box<Payload>` and `&Payload` compile the
+        // row too: all three spellings find one row and each gets its own
+        // fragment, which is what a site taking a wrapped spelling reads.
         if assembly == prebindgen_registry::recipe::Assembly::Construct
             && matches!(
-                self.types.get(&crossing.value().key()).map(|c| &c.kind),
+                self.types
+                    .get(&crossing.value().stripped_key())
+                    .map(|c| &c.kind),
                 Some(DeclaredKind::Data)
             )
         {


### PR DESCRIPTION
The composition half of stage 3. Nothing takes the row yet, so the generated output is unchanged — `examples/regen-check.sh` is byte-identical — and what lands here is the row saying exactly what `build_flat_input_plan` says, for every shape that walk plans.

That equality is the whole point. `JniGen::parts_vs_walk_for_test` puts the composed wire list and the walk's leaves side by side, and the fixtures below assert they agree. Once they do everywhere, pointing the emitters at the fragment is a move rather than a rewrite — which is the next PR.

## What did not compose before

Three gaps, each found by holding the row to the walk rather than by reading the code.

**A `sealed_class` field contributed one wire.** A sum had no row saying what it is made of, so `Observation { reading: Reading, fallback: Option<Reading> }` — a shape both `covertest-kotlin` and zenoh-flat-jni carry — composed two values where the walk plans a tag and every alternative's slots. `Declarations::recipes` now declares a `parts` row for every declared `sealed_class`: `Constructing::Choice`, one arm per alternative, each assembled from its own payload fields. `Compile::fields` answers an arm and `Compile::choice` puts the tag ahead of the arms' slots.

A payload this adapter has no slot form for — one that is itself several values, an opaque handle, a wire that is neither a JNI primitive nor a string — leaves the whole sum object-shaped. Stated as a fragment with no wires rather than as a refusal, so the site that asked composes it as one value exactly as it did before the row existed. Which is what makes the binding unconditional: whether a sum *can* cross as its parts is the adapter's answer at compile time, not a declaration.

**Four of the five spellings had no row at all.** `build_flat_input_plan` accepts a `data_class` parameter as `Payload`, `&Payload`, `Option<Payload>`, `Box<Payload>` and `Box<Option<Payload>>`, and the two example bindings use all five. A crossing is keyed by the value that crosses, so the borrow and the transparent wrapper only had to be asked — `JniGen::compile_crossing` was reading `key()` where it wanted `stripped_key()`. An optional has no `parts` row of its own and composes on the row the registry derives for it, so `Declarations::bindings` now binds the part of **every** optional the model spells over a flattenable value, rather than only the ones that are fields of a `data_class`.

**A field is not always one property read.** Five more disagreements, each a place the two could have differed silently:

- an `enum_class` property holds the enum object where the wire holds its discriminant — `.pri.value`;
- an unsigned representation's property is a `ULong` over a `Long` wire — `.big.toLong()` — and what it carries under a closed gate is the projection's own niche sentinel, not the wire's zero;
- an `Option<u64>` keeps the allocation-free `(present, value)` pair like every other nullable primitive, its ordinary conversion being the boxing that pair exists to avoid;
- an optional whose wire is a JVM object rides that `null`, so its Kotlin type carries the `?`;
- a nested handle is locked through the handle **object**, and that access went unchanged under a gate — a gated field would have locked and consumed `b.opaque` where the value is at `b?.opaque`.

## What the wire had to become

**`Access` holds the walk as steps, not as a string.** Two of its three forms put the base in the middle — `when (<base>.f) { … }` for a tag, `(<base>.f as? I.V)?.v0` for a slot — and a prefix/suffix pair cannot be composed either, because a gate has to know whether it is adding a `?.` navigation or a `null ->` arm.

More than that: a gate is applied **after** the fields under it have composed, so it must reach back and make every read below it a safe call — `h?.summary?.count`, not `h?.summary.count`, which does not compile. A string cannot say which of its dots are property reads: the `0.0` an absent `f64` slot falls back to has one too. So the chain is a list of steps, each knowing whether the value it reads off may be null, and `Wire::handle_target` is one for the same reason.

**A wire carries its conversion, not the name of one**, because the Rust side that rebuilds a value calls it through its wire-facing function *and* whatever Rust-side stages follow. It also states what it carries while a gate above it is closed, at the point that knows: only the site building the wire knows whether that is the wire's zero, a projection's sentinel, or nothing at all.

## One diagnostic changes

A sum that reaches its own type through a `Vec` is now refused by `Recipes::build`, which names the crossings that close the loop, rather than by the emitter as "variable arity". Both refuse the same shape; the row states the reason earlier and more precisely.

## Checks

`examples/regen-check.sh` byte-identical, 270 lib tests, clippy and fmt clean. Three new fixtures, each asserting the row and the walk agree: a sealed-class field required and optional, all five parameter spellings, and every field shape the walk reads specially — bare and again one layer down, where a closed gate turns each read into a safe call.