### PR TITLE
Compose what a JNI sealed class and a data class hand out (#472 §4)

### DIFF
--- a/prebindgen-jni/src/jni/compile.rs
+++ b/prebindgen-jni/src/jni/compile.rs
@@ -36,6 +36,15 @@ pub(crate) struct JFrag {
     /// makes a nested `data_class` field contribute its own several rather than
     /// one.
     pub(crate) wires: Option<Vec<Wire>>,
+    /// The values this crossing hands **out**, when it hands out more than one.
+    ///
+    /// The deconstructing twin of [`Self::wires`], and a different shape rather
+    /// than the same one read backwards: an outgoing value is not filled from a
+    /// Kotlin expression, it is produced by the Rust side and named for the
+    /// builder parameter it lands in. Never set at the same time as
+    /// [`Self::wires`] — a fragment answers one crossing, and a crossing does
+    /// one job.
+    pub(crate) out_wires: Option<Vec<OutWire>>,
     /// This fragment states a wire list and nothing else — no conversion of its
     /// own, so nothing of it reaches the generated file.
     ///
@@ -187,6 +196,52 @@ impl Access {
     }
 }
 
+/// One value a crossing hands out, when it hands out several.
+///
+/// What a JVM builder call receives: a name, the Rust value behind it, and —
+/// for a sum — which alternative produces it. There is no access expression
+/// and no Kotlin type, because the foreign side does not reach for this value;
+/// the Rust side pushes it.
+#[derive(Clone)]
+pub(crate) struct OutWire {
+    /// The builder parameter this value fills, used literally.
+    pub(crate) name: String,
+    /// The reading whose output conversion encodes it.
+    ///
+    /// For the tag it is **the sum**, not the `jint` the tag crosses as: what
+    /// the tag carries is which alternative is live, and naming the sum is how
+    /// an emitter finds the enum to match over.
+    pub(crate) out_ty: TypeRef,
+    /// Which alternative produces this value, or `None` for one every call
+    /// produces — including the tag, which selects between the groups rather
+    /// than joining one.
+    ///
+    /// Composed and checked but not yet read outside the equivalence fixture:
+    /// grouping is what turns the list into a `match`, and the emitter that
+    /// writes that `match` still reads it off the leaf synthesis.
+    #[cfg_attr(not(test), allow(dead_code))]
+    pub(crate) group: Option<i32>,
+    /// How the Rust side reaches it.
+    pub(crate) from: OutFrom,
+}
+
+/// Where an outgoing value comes from.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) enum OutFrom {
+    /// The synthesized selector, which is not read off the value at all: the
+    /// emitter assigns the alternative's number in each arm of its `match`.
+    Tag,
+    /// A payload of one alternative, bound by that arm's pattern.
+    Payload {
+        /// The alternative's ident as the source enum declares it. Empty until
+        /// [`Compile::choice`] names it — an arm's own composition cannot,
+        /// because a product hook is not told which alternative it is.
+        variant: Option<syn::Ident>,
+        /// How the payload is addressed in the arm's pattern.
+        member: syn::Member,
+    },
+}
+
 /// One wire value of a crossing that occupies several.
 ///
 /// `Clone` alone: a wire carries the whole conversion its value crosses
@@ -272,6 +327,7 @@ impl JFrag {
         Self {
             conv,
             wires: None,
+            out_wires: None,
             composed_only: false,
             yields: Yield {
                 ty,
@@ -286,6 +342,7 @@ impl JFrag {
         Self {
             conv,
             wires: None,
+            out_wires: None,
             composed_only: false,
             yields: Yield {
                 ty: at.crossing.value().stripped_key(),
@@ -552,18 +609,23 @@ impl<R: Conversions> Compile for JCompile<'_, R> {
     }
 
     fn fields(&mut self, cx: &mut Cx<'_>, at: At<'_>, parts: Parts<'_, Self>) -> Frag<Self> {
-        if at.crossing.assembly() != Assembly::Construct {
-            return Err(refuse(
-                at,
-                "JniGen states no deconstructing product rows yet",
-            ));
-        }
         // A product whose own type is a sum is one **alternative's** payload:
         // the registry composes every arm through this hook and hands the lot
-        // to `choice`. Its parts are read off a cast rather than off the value,
-        // so they take the slot form — and which alternative to cast to is
-        // `choice`'s to fill in, being the only hook told.
-        if self.is_sum(cx, at) {
+        // to `choice`. Which alternative that is stays `choice`'s to fill in,
+        // being the only hook told — so both directions leave a hole here.
+        let sum = self.is_sum(cx, at);
+        if at.crossing.assembly() != Assembly::Construct {
+            return match sum {
+                true => Ok(self.out_arm(at, parts)),
+                false => Err(refuse(
+                    at,
+                    "JniGen states no deconstructing product rows yet",
+                )),
+            };
+        }
+        if sum {
+            // Its parts are read off a cast rather than off the value, so they
+            // take the slot form.
             return Ok(self.arm(at, parts));
         }
         // A `data_class` crosses as its fields, and a field that is itself one
@@ -645,10 +707,7 @@ impl<R: Conversions> Compile for JCompile<'_, R> {
         arms: &[(&Alternative, &JFrag)],
     ) -> Frag<Self> {
         if at.crossing.assembly() != Assembly::Construct {
-            return Err(refuse(
-                at,
-                "JniGen states no deconstructing choice rows yet",
-            ));
+            return self.selected_out(at, arms);
         }
         // Which alternative is live crosses as its own `jint`, and every
         // alternative's slots cross on every call — the inert ones carrying the
@@ -916,6 +975,94 @@ impl<R: Conversions> JCompile<'_, R> {
             field: Some(part.name.clone()),
             whole_gate: false,
         }
+    }
+
+    /// One alternative's payloads, as the values it hands out.
+    ///
+    /// Every payload contributes, unconditionally: a sum's alternatives are
+    /// laid side by side on the wire and the tag says which group is live, so
+    /// there is nothing for an arm to decline. That is the asymmetry with the
+    /// constructing side, where a payload with no slot form leaves the whole
+    /// sum object-shaped — going the other way the Rust side produces the
+    /// value and its own output conversion is what encodes it.
+    fn out_arm(&self, at: At<'_>, parts: Parts<'_, Self>) -> JFrag {
+        let wires = parts
+            .iter()
+            .filter_map(|(part, _)| {
+                Some(OutWire {
+                    // Named by `choice`, which knows the alternative the name
+                    // is built from.
+                    name: crate::jni::struct_plan::sum_field_prop_name(&part_member(part)?),
+                    out_ty: part.ty.clone(),
+                    group: None,
+                    from: OutFrom::Payload {
+                        variant: None,
+                        member: part_member(part)?,
+                    },
+                })
+            })
+            .collect();
+        let mut frag = JFrag::new(
+            at,
+            self.parts_marker(parts.iter().map(|(p, _)| p.ty.key()).collect()),
+        );
+        frag.out_wires = Some(wires);
+        frag.composed_only = true;
+        frag
+    }
+
+    /// The tag, then every alternative's payloads.
+    ///
+    /// The deconstructing shape of a `sealed_class`: one `jint` naming which
+    /// alternative is live, and one group of values per alternative laid
+    /// beside the others. Exactly one group is live per value and the rest
+    /// carry their wire defaults, which is what makes the whole thing one
+    /// `match` on the Rust side rather than N conditionals.
+    fn selected_out(&self, at: At<'_>, arms: &[(&Alternative, &JFrag)]) -> Frag<Self> {
+        let TypeKind::Named { id, .. } = at.crossing.value().unwrapped().kind() else {
+            return Err(refuse(at, "a choice row over a type that is not named"));
+        };
+        let sum_cfg = id
+            .ident()
+            .and_then(|ident| self.decls.types.get(&TypeKey::from_ident(&ident)))
+            .and_then(|cfg| cfg.sum())
+            .ok_or_else(|| refuse(at, "a choice row over an undeclared sum"))?;
+
+        // The selector rides ahead of the groups it chooses between, and
+        // carries **which sum** it selects over — nothing converts it, so
+        // naming the sum is the only use its type has, and it is the one an
+        // emitter needs to find the enum to match.
+        let mut wires = vec![OutWire {
+            name: crate::jni::emit::SUM_TAG_LEAF.to_string(),
+            out_ty: at.crossing.value().clone(),
+            group: None,
+            from: OutFrom::Tag,
+        }];
+        for (alt, frag) in arms {
+            let kotlin = self.decls.sum_variant_class_name(sum_cfg, &alt.name);
+            let group = Some(crate::jni::struct_plan::sum_tag(alt));
+            for w in frag.out_wires.as_ref().into_iter().flatten() {
+                let OutFrom::Payload { member, .. } = &w.from else {
+                    return Err(refuse(
+                        at,
+                        "an arm that states something other than payloads",
+                    ));
+                };
+                wires.push(OutWire {
+                    name: crate::jni::struct_plan::sum_slot_fragment(&kotlin, &w.name),
+                    out_ty: w.out_ty.clone(),
+                    group,
+                    from: OutFrom::Payload {
+                        variant: Some(alt.name.clone()),
+                        member: member.clone(),
+                    },
+                });
+            }
+        }
+        let mut frag = JFrag::new(at, self.parts_marker(parts_subs(arms)));
+        frag.out_wires = Some(wires);
+        frag.composed_only = true;
+        Ok(frag)
     }
 
     /// One payload of one alternative, or `None` if it has no slot form.

--- a/prebindgen-jni/src/jni/compile.rs
+++ b/prebindgen-jni/src/jni/compile.rs
@@ -231,6 +231,16 @@ pub(crate) enum OutFrom {
     /// The synthesized selector, which is not read off the value at all: the
     /// emitter assigns the alternative's number in each arm of its `match`.
     Tag,
+    /// A field of the value, reached by field access and cloned — the chain of
+    /// idents from the value itself.
+    ///
+    /// Nested where a `data_class` field is itself one: its fields cross as
+    /// decoupled values under the parent's chain, and the foreign side
+    /// reassembles the whole graph in one call.
+    Field {
+        /// The field idents from the value down to this one.
+        path: Vec<syn::Ident>,
+    },
     /// A payload of one alternative, bound by that arm's pattern.
     Payload {
         /// The alternative's ident as the source enum declares it. Empty until
@@ -617,10 +627,7 @@ impl<R: Conversions> Compile for JCompile<'_, R> {
         if at.crossing.assembly() != Assembly::Construct {
             return match sum {
                 true => Ok(self.out_arm(at, parts)),
-                false => Err(refuse(
-                    at,
-                    "JniGen states no deconstructing product rows yet",
-                )),
+                false => Ok(self.out_product(at, parts)),
             };
         }
         if sum {
@@ -1011,6 +1018,85 @@ impl<R: Conversions> JCompile<'_, R> {
         frag
     }
 
+    /// The values a `data_class` hands out: its fields, and a field that is
+    /// itself one contributes its own.
+    ///
+    /// A fragment with **no** out-wires is this adapter declining, and it
+    /// declines for the whole value rather than per field. A handle, an
+    /// `enum_class`, a sum or a `data_class` behind an `Option` or a `Vec` is
+    /// delivered with a transform the decoupled form does not carry, and one
+    /// such field sends the whole object down the whole-value `fromParts` path
+    /// — so a row that decomposed the rest of it would describe a shape nothing
+    /// emits.
+    fn out_product(&self, at: At<'_>, parts: Parts<'_, Self>) -> JFrag {
+        let declined = JFrag::new(at, self.parts_marker(Vec::new()));
+        let mut wires = Vec::new();
+        for (part, frag) in parts {
+            let Some(field) = part_field(part) else {
+                return declined;
+            };
+            let ident = match &field.name {
+                Some(name) => name.clone(),
+                None => return declined,
+            };
+            // The same name the leaf synthesis gives it: the Kotlin property,
+            // and nested names joined by the reserved `__` separator.
+            let name =
+                crate::jni::mangle_kotlin_ident(&crate::jni::kt_snake_to_camel(&ident.to_string()));
+            // The layer questions off the field's own reading — `Optional` to
+            // look through, `Vec` to decline — never a last path segment.
+            let probe = part.ty.optional_inner().unwrap_or(&part.ty);
+            if matches!(
+                self.decls.type_kind(self.registry, &probe.key()),
+                crate::jni::classify::TypeKind::Handle
+                    | crate::jni::classify::TypeKind::Enum
+                    | crate::jni::classify::TypeKind::Sum
+            ) {
+                return declined;
+            }
+            match &frag.out_wires {
+                // A nested `data_class`, which contributes its own values under
+                // this field's name and chain. Only unwrapped: behind an
+                // `Option` or a `Vec` there is no chain to reach through.
+                Some(inner) => {
+                    if part.ty.optional_inner().is_some()
+                        || matches!(part.ty.kind(), TypeKind::Vec(_))
+                    {
+                        return declined;
+                    }
+                    for w in inner {
+                        let OutFrom::Field { path } = &w.from else {
+                            return declined;
+                        };
+                        wires.push(OutWire {
+                            name: format!("{name}__{}", w.name),
+                            out_ty: w.out_ty.clone(),
+                            group: None,
+                            from: OutFrom::Field {
+                                path: std::iter::once(ident.clone())
+                                    .chain(path.iter().cloned())
+                                    .collect(),
+                            },
+                        });
+                    }
+                }
+                None => wires.push(OutWire {
+                    name,
+                    out_ty: part.ty.clone(),
+                    group: None,
+                    from: OutFrom::Field { path: vec![ident] },
+                }),
+            }
+        }
+        let mut frag = JFrag::new(
+            at,
+            self.parts_marker(parts.iter().map(|(p, _)| p.ty.key()).collect()),
+        );
+        frag.out_wires = Some(wires);
+        frag.composed_only = true;
+        frag
+    }
+
     /// The tag, then every alternative's payloads.
     ///
     /// The deconstructing shape of a `sealed_class`: one `jint` naming which
@@ -1259,12 +1345,17 @@ impl<R: Conversions> JCompile<'_, R> {
     }
 }
 
-/// The model field one part reads, which a sum payload names its slot after.
-fn part_member(part: &Part<'_>) -> Option<syn::Member> {
+/// The model field one part reads, or `None` for a part that is not a field.
+fn part_field<'a>(part: &Part<'a>) -> Option<&'a prebindgen_registry::flat::Field> {
     match part.from {
-        prebindgen_registry::recipe::PartSource::Field { field, .. } => Some(field.member()),
+        prebindgen_registry::recipe::PartSource::Field { field, .. } => Some(field),
         _ => None,
     }
+}
+
+/// The model field one part reads, which a sum payload names its slot after.
+fn part_member(part: &Part<'_>) -> Option<syn::Member> {
+    part_field(part).map(|f| f.member())
 }
 
 /// Every crossing a sum's arms delegate to, which is what reachability walks.

--- a/prebindgen-jni/src/jni/mod.rs
+++ b/prebindgen-jni/src/jni/mod.rs
@@ -508,6 +508,77 @@ impl JniGen {
         )
     }
 
+    /// What a `sealed_class` hands out, as the row states it: one line per
+    /// value, naming it, the alternative it belongs to, and how the Rust side
+    /// reaches it.
+    ///
+    /// Test support. The same list `synth_sum_leaves` produces, in the form
+    /// that compares — a `TypeRef` has no equality and a `syn::Member` prints
+    /// differently by variant, so both sides go through the same rendering.
+    pub(crate) fn sum_out_lines_for_test(&self, short: &str) -> Option<Vec<String>> {
+        use prebindgen_registry::recipe::Assembly;
+        let ident = syn::Ident::new(short, proc_macro2::Span::call_site());
+        let ty: syn::Type = syn::parse_quote!(#ident);
+        let reading = prebindgen_registry::Conversions::reading_of(&self.registry, &ty)?;
+        let compiled = self.decls.compiled.borrow();
+        let wires = compiled
+            .row_fragment(
+                &reading.key(),
+                Assembly::Deconstruct,
+                &crate::jni::rows::parts(),
+            )?
+            .out_wires
+            .clone()?;
+        Some(
+            wires
+                .iter()
+                .map(|w| {
+                    let from = match &w.from {
+                        crate::jni::compile::OutFrom::Tag => "tag".to_string(),
+                        crate::jni::compile::OutFrom::Payload { variant, member } => format!(
+                            "{}.{}",
+                            variant
+                                .as_ref()
+                                .map(|v| v.to_string())
+                                .unwrap_or_else(|| "?".to_string()),
+                            crate::jni::struct_plan::sum_field_prop_name(member)
+                        ),
+                    };
+                    format!("{}: {} <- {from} @{:?}", w.name, w.out_ty.key(), w.group)
+                })
+                .collect(),
+        )
+    }
+
+    /// The same list, taken from the leaf synthesis the row is meant to
+    /// replace.
+    pub(crate) fn sum_walk_lines_for_test(&self, short: &str) -> Option<Vec<String>> {
+        use prebindgen_registry::unfold::LeafSource;
+        let ident = syn::Ident::new(short, proc_macro2::Span::call_site());
+        let cfg = self.decls.types.get(&TypeKey::from_ident(&ident))?;
+        let prebindgen_registry::flat::Type::Variant(sum) =
+            self.registry.flat().declared_type(&ident)?
+        else {
+            return None;
+        };
+        Some(
+            crate::jni::synth_sum_leaves(&self.decls, cfg.sum()?, sum)
+                .iter()
+                .map(|l| {
+                    let from = match &l.source {
+                        LeafSource::SumTag => "tag".to_string(),
+                        LeafSource::VariantField { variant, member } => format!(
+                            "{variant}.{}",
+                            crate::jni::struct_plan::sum_field_prop_name(member)
+                        ),
+                        other => format!("{other:?}"),
+                    };
+                    format!("{}: {} <- {from} @{:?}", l.name, l.out_ty.key(), l.group)
+                })
+                .collect(),
+        )
+    }
+
     /// The wires a crossing composes into, by spelling.
     pub(crate) fn parts_wires_for_test(
         &self,

--- a/prebindgen-jni/src/jni/mod.rs
+++ b/prebindgen-jni/src/jni/mod.rs
@@ -508,14 +508,14 @@ impl JniGen {
         )
     }
 
-    /// What a `sealed_class` hands out, as the row states it: one line per
+    /// What a declared type hands out, as the row states it: one line per
     /// value, naming it, the alternative it belongs to, and how the Rust side
     /// reaches it.
     ///
     /// Test support. The same list `synth_sum_leaves` produces, in the form
     /// that compares — a `TypeRef` has no equality and a `syn::Member` prints
     /// differently by variant, so both sides go through the same rendering.
-    pub(crate) fn sum_out_lines_for_test(&self, short: &str) -> Option<Vec<String>> {
+    pub(crate) fn out_lines_for_test(&self, short: &str) -> Option<Vec<String>> {
         use prebindgen_registry::recipe::Assembly;
         let ident = syn::Ident::new(short, proc_macro2::Span::call_site());
         let ty: syn::Type = syn::parse_quote!(#ident);
@@ -535,6 +535,11 @@ impl JniGen {
                 .map(|w| {
                     let from = match &w.from {
                         crate::jni::compile::OutFrom::Tag => "tag".to_string(),
+                        crate::jni::compile::OutFrom::Field { path } => path
+                            .iter()
+                            .map(|p| p.to_string())
+                            .collect::<Vec<_>>()
+                            .join("."),
                         crate::jni::compile::OutFrom::Payload { variant, member } => format!(
                             "{}.{}",
                             variant
@@ -551,18 +556,23 @@ impl JniGen {
     }
 
     /// The same list, taken from the leaf synthesis the row is meant to
-    /// replace.
-    pub(crate) fn sum_walk_lines_for_test(&self, short: &str) -> Option<Vec<String>> {
-        use prebindgen_registry::unfold::LeafSource;
+    /// replace — `synth_sum_leaves` for a `sealed_class`,
+    /// `synth_value_struct_leaves` for a `data_class`.
+    pub(crate) fn walk_lines_for_test(&self, short: &str) -> Option<Vec<String>> {
+        use prebindgen_registry::unfold::{LeafSource, PathStep};
         let ident = syn::Ident::new(short, proc_macro2::Span::call_site());
         let cfg = self.decls.types.get(&TypeKey::from_ident(&ident))?;
-        let prebindgen_registry::flat::Type::Variant(sum) =
-            self.registry.flat().declared_type(&ident)?
-        else {
-            return None;
+        let leaves = match self.registry.flat().declared_type(&ident)? {
+            prebindgen_registry::flat::Type::Variant(sum) => {
+                crate::jni::synth_sum_leaves(&self.decls, cfg.sum()?, sum)
+            }
+            prebindgen_registry::flat::Type::Struct(s) => {
+                crate::jni::synth_value_struct_leaves(&self.decls, &self.registry, s, &[], "", 0)?
+            }
+            _ => return None,
         };
         Some(
-            crate::jni::synth_sum_leaves(&self.decls, cfg.sum()?, sum)
+            leaves
                 .iter()
                 .map(|l| {
                     let from = match &l.source {
@@ -571,6 +581,15 @@ impl JniGen {
                             "{variant}.{}",
                             crate::jni::struct_plan::sum_field_prop_name(member)
                         ),
+                        LeafSource::Field => l
+                            .path
+                            .iter()
+                            .map(|step| match step {
+                                PathStep::Field { ident, .. } => ident.to_string(),
+                                other => format!("{other:?}"),
+                            })
+                            .collect::<Vec<_>>()
+                            .join("."),
                         other => format!("{other:?}"),
                     };
                     format!("{}: {} <- {from} @{:?}", l.name, l.out_ty.key(), l.group)

--- a/prebindgen-jni/src/jni/rows.rs
+++ b/prebindgen-jni/src/jni/rows.rs
@@ -99,6 +99,23 @@ fn out_alternatives(model: &Flat, ty: &TypeRef) -> Vec<Arm<Deconstruct>> {
         .collect()
 }
 
+/// One reach per field of a declared struct, in the model's order.
+///
+/// Empty for anything the model does not hold as a struct, which includes a
+/// `data_class!` over a type the scan dropped — the scan reports that, and a
+/// row over no fields would report it a second time.
+fn out_fields(model: &Flat, ty: &TypeRef) -> Vec<Reach> {
+    let prebindgen_registry::flat::TypeKind::Named { id, .. } = ty.unwrapped().kind() else {
+        return Vec::new();
+    };
+    let Some(prebindgen_registry::flat::Type::Struct(s)) =
+        id.ident().and_then(|ident| model.declared_type(&ident))
+    else {
+        return Vec::new();
+    };
+    (0..s.fields.len()).map(Reach::Field).collect()
+}
+
 /// The row a type with no parts takes: the adapter emits the conversion itself.
 fn whole() -> RecipeId {
     RecipeId::new("whole")
@@ -168,6 +185,20 @@ impl Declarations {
                     rows.declare_default(ty.clone(), whole(), Deconstructing::Atomic);
                     if !arms.is_empty() {
                         rows.declare(ty.clone(), parts(), Deconstructing::Choice { arms });
+                    }
+                }
+                // A `data_class` hands its value out as its fields too, so the
+                // foreign side reassembles the object and nothing builds one on
+                // the Rust side.
+                Some(DeclaredKind::Data) => {
+                    let reaches = out_fields(model, &ty);
+                    rows.declare_default(ty.clone(), whole(), Deconstructing::Atomic);
+                    if !reaches.is_empty() {
+                        rows.declare(
+                            ty.clone(),
+                            parts(),
+                            Deconstructing::Product(Deconstruct::Fields(reaches)),
+                        );
                     }
                 }
                 _ => {
@@ -325,7 +356,8 @@ impl Declarations {
             let Ok(ty) = model.classify(&syn::parse_quote!(#ident)) else {
                 continue;
             };
-            let of = Crossing::new(ty, Assembly::Construct);
+            let building = Crossing::new(ty.clone(), Assembly::Construct);
+            let handing_out = Crossing::new(ty, Assembly::Deconstruct);
             for (index, field) in s.fields.iter().enumerate() {
                 // An `Option<D>` field reaches D through the optional's own
                 // row, so the part bound here is the optional and the inner is
@@ -337,14 +369,19 @@ impl Declarations {
                 // An `Option<D>` field reaches D through the optional's own
                 // part site, which the model-wide scan above already bound. What
                 // is left is the field that IS the class: its part takes the
-                // `parts` row.
+                // `parts` row, in both directions.
                 if field.ty.optional_inner().is_none() {
-                    bound.bind(
-                        Site::part(&of, &parts(), index),
-                        Crossing::new(field.ty.clone(), Assembly::Construct),
-                        Ask::Recipe(parts()),
-                        Origin::Part,
-                    );
+                    for (of, assembly) in [
+                        (&building, Assembly::Construct),
+                        (&handing_out, Assembly::Deconstruct),
+                    ] {
+                        bound.bind(
+                            Site::part(of, &parts(), index),
+                            Crossing::new(field.ty.clone(), assembly),
+                            Ask::Recipe(parts()),
+                            Origin::Part,
+                        );
+                    }
                 }
             }
         }

--- a/prebindgen-jni/src/jni/rows.rs
+++ b/prebindgen-jni/src/jni/rows.rs
@@ -17,7 +17,10 @@ use std::collections::BTreeMap;
 
 use prebindgen_registry::{
     flat::{Flat, TypeRef},
-    recipe::{Arm, Construct, Constructing, Deconstructing, RecipeError, RecipeId, Recipes},
+    recipe::{
+        Arm, Construct, Constructing, Deconstruct, Deconstructing, Reach, RecipeError, RecipeId,
+        Recipes,
+    },
 };
 
 use super::*;
@@ -66,6 +69,32 @@ fn alternatives(model: &Flat, ty: &TypeRef) -> Vec<Arm<Construct>> {
         .map(|alt| Arm {
             alternative: alt.index,
             op: Construct::Fields,
+        })
+        .collect()
+}
+
+/// One arm per alternative of a declared sum, each taken apart into its own
+/// payload fields.
+///
+/// The deconstructing twin of [`alternatives`]. Separate because the two jobs
+/// name different operations — building an alternative is `Construct::Fields`,
+/// reading one is `Deconstruct::Fields` over the reaches that get there — and
+/// a shared helper would have to be generic over an operation neither side
+/// chooses.
+fn out_alternatives(model: &Flat, ty: &TypeRef) -> Vec<Arm<Deconstruct>> {
+    let prebindgen_registry::flat::TypeKind::Named { id, .. } = ty.unwrapped().kind() else {
+        return Vec::new();
+    };
+    let Some(prebindgen_registry::flat::Type::Variant(v)) =
+        id.ident().and_then(|ident| model.declared_type(&ident))
+    else {
+        return Vec::new();
+    };
+    v.alternatives
+        .iter()
+        .map(|alt| Arm {
+            alternative: alt.index,
+            op: Deconstruct::Fields((0..alt.fields.len()).map(Reach::Field).collect()),
         })
         .collect()
 }
@@ -128,7 +157,23 @@ impl Declarations {
             // the adapter emits the conversion itself, and how many wire values
             // that costs is its own business — so it describes the adapter as it
             // stands rather than as it will be.
-            rows.declare(ty.clone(), whole(), Deconstructing::Atomic);
+            // A `sealed_class` hands its value out as a tag plus every
+            // alternative's payloads, laid side by side — the deconstructing
+            // twin of the constructing row below, and the direction that
+            // actually has no alternative: a sum has no whole-value output
+            // conversion, because a tag plus groups is not one wire.
+            match self.types.get(&ty.key()).map(|c| &c.kind) {
+                Some(DeclaredKind::Sealed(_)) => {
+                    let arms = out_alternatives(model, &ty);
+                    rows.declare_default(ty.clone(), whole(), Deconstructing::Atomic);
+                    if !arms.is_empty() {
+                        rows.declare(ty.clone(), parts(), Deconstructing::Choice { arms });
+                    }
+                }
+                _ => {
+                    rows.declare(ty.clone(), whole(), Deconstructing::Atomic);
+                }
+            }
             // A `data_class` also has a row that says what it is made of, so
             // its constructing side names which of the two a site takes by
             // default. See [`parts`] for why that is still `whole`.

--- a/prebindgen-jni/src/jni/tests/sealed.rs
+++ b/prebindgen-jni/src/jni/tests/sealed.rs
@@ -2388,3 +2388,80 @@ fn a_types_close_answer_matches_its_plans() {
         "the fixture must cover reaching a handle four ways AND not reaching one"
     );
 }
+
+/// A `sealed_class` states a row saying what it hands out, and it says exactly
+/// what the leaf synthesis it will replace says.
+///
+/// One `jint` naming which alternative is live, then one group of values per
+/// alternative laid beside the others — names, types, groups and the pattern
+/// binding each is reached through. The fixture carries a unit alternative
+/// (which contributes nothing), a positional payload, a two-field payload and a
+/// named-field payload, so the slot naming is exercised in every form it takes.
+#[test]
+fn a_sealed_class_states_what_it_hands_out() {
+    let loc = myflat_loc();
+    let items: Vec<(syn::Item, SourceLocation)> = vec![
+        (
+            syn::Item::Enum(syn::parse_quote!(
+                pub enum Priority {
+                    Low = 0,
+                    High = 1,
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Enum(syn::parse_quote!(
+                pub enum Reading {
+                    Missing,
+                    Exact(i64),
+                    Range { low: i64, high: i64 },
+                    Tagged(String, Priority),
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn read_one(which: i32) -> Reading {
+                    unimplemented!()
+                }
+            )),
+            loc.clone(),
+        ),
+    ];
+    let registry =
+        crate::test_util::reg_from_items(declare_referenced(items)).expect("index items");
+    let jni = JniGenBuilder::new()
+        .set_package_prefix("io.test.jni")
+        .package(
+            crate::package!()
+                .class(crate::enum_class!(Priority))
+                .class(crate::sealed_class!(Reading))
+                .fun(prebindgen_registry::fun!(read_one)),
+        );
+    let gen = jni.build_with(registry).expect("resolve");
+
+    let composed = gen
+        .sum_out_lines_for_test("Reading")
+        .expect("Reading states a deconstructing parts row");
+    assert_eq!(
+        composed,
+        vec![
+            "tag: Reading <- tag @None",
+            "exact_v0: i64 <- Exact.v0 @Some(1)",
+            "range_low: i64 <- Range.low @Some(2)",
+            "range_high: i64 <- Range.high @Some(2)",
+            "tagged_v0: String <- Tagged.v0 @Some(3)",
+            "tagged_v1: Priority <- Tagged.v1 @Some(3)",
+        ],
+        "the row states the tag, then one group per alternative",
+    );
+    // And it is the same list the synthesis it replaces produces, which is what
+    // makes pointing the emitters at the fragment a move rather than a rewrite.
+    assert_eq!(
+        composed,
+        gen.sum_walk_lines_for_test("Reading").expect("the walk"),
+        "the row and the leaf synthesis disagree",
+    );
+}

--- a/prebindgen-jni/src/jni/tests/sealed.rs
+++ b/prebindgen-jni/src/jni/tests/sealed.rs
@@ -2443,7 +2443,7 @@ fn a_sealed_class_states_what_it_hands_out() {
     let gen = jni.build_with(registry).expect("resolve");
 
     let composed = gen
-        .sum_out_lines_for_test("Reading")
+        .out_lines_for_test("Reading")
         .expect("Reading states a deconstructing parts row");
     assert_eq!(
         composed,
@@ -2461,7 +2461,113 @@ fn a_sealed_class_states_what_it_hands_out() {
     // makes pointing the emitters at the fragment a move rather than a rewrite.
     assert_eq!(
         composed,
-        gen.sum_walk_lines_for_test("Reading").expect("the walk"),
+        gen.walk_lines_for_test("Reading").expect("the walk"),
         "the row and the leaf synthesis disagree",
+    );
+}
+
+/// A `data_class` states a row saying what it hands out, and a field that is
+/// itself one contributes its own values under the parent's name and chain.
+///
+/// The row declines for the **whole** value rather than per field, because the
+/// emitter it feeds does: a handle, an `enum_class`, a sum, or a `data_class`
+/// behind an `Option` or a `Vec` is delivered with a transform the decoupled
+/// form does not carry, and one such field sends the whole object down the
+/// whole-value `fromParts` path. So `Wrapped` composes and `Opaque`-bearing
+/// `Guarded` does not, and both agree with the synthesis they will replace.
+#[test]
+fn a_data_class_states_what_it_hands_out() {
+    let loc = myflat_loc();
+    let items: Vec<(syn::Item, SourceLocation)> = vec![
+        (
+            syn::Item::Struct(syn::parse_quote!(
+                pub struct Inner {
+                    pub count: i64,
+                    pub label: String,
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Struct(syn::parse_quote!(
+                pub struct Wrapped {
+                    pub id: i64,
+                    pub inner: Inner,
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Struct(syn::parse_quote!(
+                pub struct Opaque {
+                    pub v: i64,
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Struct(syn::parse_quote!(
+                pub struct Guarded {
+                    pub id: i64,
+                    pub held: Opaque,
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn wrapped_new() -> Wrapped {
+                    unimplemented!()
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn guarded_new() -> Guarded {
+                    unimplemented!()
+                }
+            )),
+            loc.clone(),
+        ),
+    ];
+    let registry =
+        crate::test_util::reg_from_items(declare_referenced(items)).expect("index items");
+    let jni = JniGenBuilder::new()
+        .set_package_prefix("io.test.jni")
+        .package(
+            crate::package!()
+                .class(crate::data_class!(Inner))
+                .class(crate::data_class!(Wrapped))
+                .class(crate::ptr_class!(Opaque))
+                .class(crate::data_class!(Guarded))
+                .fun(prebindgen_registry::fun!(wrapped_new))
+                .fun(prebindgen_registry::fun!(guarded_new)),
+        );
+    let gen = jni.build_with(registry).expect("resolve");
+
+    assert_eq!(
+        gen.out_lines_for_test("Wrapped")
+            .expect("Wrapped states a deconstructing parts row"),
+        vec![
+            "id: i64 <- id @None",
+            "inner__count: i64 <- inner.count @None",
+            "inner__label: String <- inner.label @None",
+        ],
+        "a nested data class contributes its own values, under its field's name",
+    );
+    // Compared as options, because declining is one of the two answers: a row
+    // that states nothing and a synthesis that returns nothing are the same
+    // claim, and `Guarded` makes it.
+    for short in ["Wrapped", "Inner", "Guarded"] {
+        assert_eq!(
+            gen.out_lines_for_test(short),
+            gen.walk_lines_for_test(short),
+            "the row and the leaf synthesis disagree on {short}",
+        );
+    }
+    assert!(
+        gen.out_lines_for_test("Guarded").is_none(),
+        "a handle field sends the whole object down the whole-value path",
     );
 }

--- a/prebindgen-jni/src/jni/trait_impl.rs
+++ b/prebindgen-jni/src/jni/trait_impl.rs
@@ -1519,19 +1519,20 @@ impl JniGenBuilder {
         decls
             .validate_resolved(&registry)
             .map_err(|message| prebindgen_registry::ScanError::AdapterInvariant { message })?;
-        // A `sealed_class`'s deconstructing composition, last of all.
+        // What each declared class hands out, composed last of all.
         //
-        // After `validate_resolved`, so a binding whose payload simply has no
-        // output conversion gets the diagnostic that names the payload rather
-        // than this one, which can only say that composing failed. What is left
-        // for this to catch is a composition that fails over parts which did
-        // resolve — a bug here rather than a gap in the binding.
-        // Driven here rather than from `compile_crossing`
-        // because a sum has **no** deconstructing crossing to be driven from: it
-        // is boundary-only, so nothing ever asks for its whole-value output
-        // conversion and the walk never reaches it. Nothing reads the result
-        // yet; compiling it is what holds the composition to every binding this
-        // crate builds rather than to one fixture.
+        // Driven here rather than from `compile_crossing` because a
+        // `sealed_class` has **no** deconstructing crossing to be driven from:
+        // it is boundary-only, so nothing ever asks for its whole-value output
+        // conversion and the converter walk never reaches it. A `data_class`
+        // does have one, and goes through the same loop so that both sides of
+        // the same question are answered in one place.
+        //
+        // After `validate_resolved`, so a binding whose part simply has no
+        // output conversion gets the diagnostic that names the part rather than
+        // this one, which could only say that composing failed. Nothing reads
+        // the result yet; compiling it is what holds the composition to every
+        // binding this crate builds rather than to one fixture.
         for key in decls.declared_decompositions() {
             let Some(ident) = key.ident() else { continue };
             let Ok(ty) = model.classify(&syn::parse_quote!(#ident)) else {
@@ -1541,20 +1542,20 @@ impl JniGenBuilder {
             // not is a gap in the binding, and the writers report it against
             // the part — `Reading.Exact.v0 has no OUTPUT converter` — where
             // this could only say that composing failed.
-            let parts: Vec<&prebindgen_registry::flat::TypeRef> = match model.declared_type(&ident)
-            {
-                Some(prebindgen_registry::flat::Type::Variant(sum)) => sum
-                    .alternatives
-                    .iter()
-                    .flat_map(|alt| &alt.fields)
-                    .map(|f| &f.ty)
-                    .collect(),
-                Some(prebindgen_registry::flat::Type::Struct(s)) => {
-                    s.fields.iter().map(|f| &f.ty).collect()
-                }
-                _ => continue,
-            };
-            if parts.iter().any(|ty| decls.out_frag(ty).is_none()) {
+            let part_types: Vec<&prebindgen_registry::flat::TypeRef> =
+                match model.declared_type(&ident) {
+                    Some(prebindgen_registry::flat::Type::Variant(sum)) => sum
+                        .alternatives
+                        .iter()
+                        .flat_map(|alt| &alt.fields)
+                        .map(|f| &f.ty)
+                        .collect(),
+                    Some(prebindgen_registry::flat::Type::Struct(s)) => {
+                        s.fields.iter().map(|f| &f.ty).collect()
+                    }
+                    _ => continue,
+                };
+            if part_types.iter().any(|ty| decls.out_frag(ty).is_none()) {
                 continue;
             }
             let crossing = prebindgen_registry::recipe::Crossing::new(
@@ -1576,8 +1577,8 @@ impl JniGenBuilder {
                     "`{key}` hands out its parts, but composing them failed: {e:?}"
                 ));
             }
-            let done = compiler.finish();
-            *decls.compiled.borrow_mut() = done;
+            let compiled = compiler.finish();
+            *decls.compiled.borrow_mut() = compiled;
         }
         if !refusals.is_empty() {
             return Err(prebindgen_registry::ScanError::AdapterInvariant {

--- a/prebindgen-jni/src/jni/trait_impl.rs
+++ b/prebindgen-jni/src/jni/trait_impl.rs
@@ -1532,25 +1532,29 @@ impl JniGenBuilder {
         // conversion and the walk never reaches it. Nothing reads the result
         // yet; compiling it is what holds the composition to every binding this
         // crate builds rather than to one fixture.
-        for key in decls.declared_sums() {
+        for key in decls.declared_decompositions() {
             let Some(ident) = key.ident() else { continue };
             let Ok(ty) = model.classify(&syn::parse_quote!(#ident)) else {
                 continue;
             };
-            // Only a sum every payload of which already crosses. One that does
+            // Only a type every part of which already crosses. One that does
             // not is a gap in the binding, and the writers report it against
-            // the payload — `Reading.Exact.v0 has no OUTPUT converter` — where
+            // the part — `Reading.Exact.v0 has no OUTPUT converter` — where
             // this could only say that composing failed.
-            let Some(prebindgen_registry::flat::Type::Variant(sum)) = model.declared_type(&ident)
-            else {
-                continue;
-            };
-            if sum
-                .alternatives
-                .iter()
-                .flat_map(|alt| &alt.fields)
-                .any(|f| decls.out_frag(&f.ty).is_none())
+            let parts: Vec<&prebindgen_registry::flat::TypeRef> = match model.declared_type(&ident)
             {
+                Some(prebindgen_registry::flat::Type::Variant(sum)) => sum
+                    .alternatives
+                    .iter()
+                    .flat_map(|alt| &alt.fields)
+                    .map(|f| &f.ty)
+                    .collect(),
+                Some(prebindgen_registry::flat::Type::Struct(s)) => {
+                    s.fields.iter().map(|f| &f.ty).collect()
+                }
+                _ => continue,
+            };
+            if parts.iter().any(|ty| decls.out_frag(ty).is_none()) {
                 continue;
             }
             let crossing = prebindgen_registry::recipe::Crossing::new(
@@ -1569,7 +1573,7 @@ impl JniGenBuilder {
             };
             if let Err(e) = compiler.row_of(&mut adapter, &crossing, &crate::jni::rows::parts()) {
                 refusals.push(format!(
-                    "`{key}` hands out its alternatives, but composing them failed: {e:?}"
+                    "`{key}` hands out its parts, but composing them failed: {e:?}"
                 ));
             }
             let done = compiler.finish();
@@ -3251,15 +3255,16 @@ impl Declarations {
             .map(|(k, c)| (k.clone(), c.rust_type.clone()))
             .collect()
     }
-    /// Every type declared `sealed_class!`, in a stable order.
+    /// Every type that states what it hands out — `sealed_class!` and
+    /// `data_class!` — in a stable order.
     ///
     /// Sorted, because what reads it drives compilation and a refusal has to
     /// name the same type run to run.
-    pub(crate) fn declared_sums(&self) -> Vec<TypeKey> {
+    pub(crate) fn declared_decompositions(&self) -> Vec<TypeKey> {
         let mut keys: Vec<TypeKey> = self
             .types
             .iter()
-            .filter(|(_, c)| matches!(c.kind, DeclaredKind::Sealed(_)))
+            .filter(|(_, c)| matches!(c.kind, DeclaredKind::Sealed(_) | DeclaredKind::Data))
             .map(|(k, _)| k.clone())
             .collect();
         keys.sort_by(|a, b| a.as_str().cmp(b.as_str()));

--- a/prebindgen-jni/src/jni/trait_impl.rs
+++ b/prebindgen-jni/src/jni/trait_impl.rs
@@ -1519,6 +1519,68 @@ impl JniGenBuilder {
         decls
             .validate_resolved(&registry)
             .map_err(|message| prebindgen_registry::ScanError::AdapterInvariant { message })?;
+        // A `sealed_class`'s deconstructing composition, last of all.
+        //
+        // After `validate_resolved`, so a binding whose payload simply has no
+        // output conversion gets the diagnostic that names the payload rather
+        // than this one, which can only say that composing failed. What is left
+        // for this to catch is a composition that fails over parts which did
+        // resolve — a bug here rather than a gap in the binding.
+        // Driven here rather than from `compile_crossing`
+        // because a sum has **no** deconstructing crossing to be driven from: it
+        // is boundary-only, so nothing ever asks for its whole-value output
+        // conversion and the walk never reaches it. Nothing reads the result
+        // yet; compiling it is what holds the composition to every binding this
+        // crate builds rather than to one fixture.
+        for key in decls.declared_sums() {
+            let Some(ident) = key.ident() else { continue };
+            let Ok(ty) = model.classify(&syn::parse_quote!(#ident)) else {
+                continue;
+            };
+            // Only a sum every payload of which already crosses. One that does
+            // not is a gap in the binding, and the writers report it against
+            // the payload — `Reading.Exact.v0 has no OUTPUT converter` — where
+            // this could only say that composing failed.
+            let Some(prebindgen_registry::flat::Type::Variant(sum)) = model.declared_type(&ident)
+            else {
+                continue;
+            };
+            if sum
+                .alternatives
+                .iter()
+                .flat_map(|alt| &alt.fields)
+                .any(|f| decls.out_frag(&f.ty).is_none())
+            {
+                continue;
+            }
+            let crossing = prebindgen_registry::recipe::Crossing::new(
+                ty,
+                prebindgen_registry::recipe::Assembly::Deconstruct,
+            );
+            let mut compiler = prebindgen_registry::recipe::Compiler::resume(
+                &model,
+                &recipes,
+                &bindings,
+                decls.compiled.borrow().clone(),
+            );
+            let mut adapter = crate::jni::compile::JCompile {
+                decls: &decls,
+                registry: &registry,
+            };
+            if let Err(e) = compiler.row_of(&mut adapter, &crossing, &crate::jni::rows::parts()) {
+                refusals.push(format!(
+                    "`{key}` hands out its alternatives, but composing them failed: {e:?}"
+                ));
+            }
+            let done = compiler.finish();
+            *decls.compiled.borrow_mut() = done;
+        }
+        if !refusals.is_empty() {
+            return Err(prebindgen_registry::ScanError::AdapterInvariant {
+                message: refusals.join("; "),
+            }
+            .into());
+        }
         Ok(JniGen { decls, registry })
     }
 }
@@ -3189,6 +3251,21 @@ impl Declarations {
             .map(|(k, c)| (k.clone(), c.rust_type.clone()))
             .collect()
     }
+    /// Every type declared `sealed_class!`, in a stable order.
+    ///
+    /// Sorted, because what reads it drives compilation and a refusal has to
+    /// name the same type run to run.
+    pub(crate) fn declared_sums(&self) -> Vec<TypeKey> {
+        let mut keys: Vec<TypeKey> = self
+            .types
+            .iter()
+            .filter(|(_, c)| matches!(c.kind, DeclaredKind::Sealed(_)))
+            .map(|(k, _)| k.clone())
+            .collect();
+        keys.sort_by(|a, b| a.as_str().cmp(b.as_str()));
+        keys
+    }
+
     /// Types acknowledged-but-undeclared via [`JniGenBuilder::ignore`].
     pub(crate) fn ignored_types(&self) -> std::collections::HashSet<TypeKey> {
         self.ignored_class_types.clone()


### PR DESCRIPTION
The composition half of stage 4, and the deconstructing twin of #486. Nothing takes the row yet, so `examples/regen-check.sh` is byte-identical; what lands here is the row saying exactly what `synth_sum_leaves` says.

This is the direction with no alternative. A sum has **no** whole-value output conversion, because a tag plus one group of values per alternative is not one wire — where a `data_class` parameter could always have crossed as a single `JObject`, a sum returned to the JVM has only ever crossed decomposed.

## The row

`Declarations::recipes` declares a `parts` row for every `sealed_class` on the deconstructing side: `Deconstructing::Choice`, one arm per alternative, each taken apart into its own payload fields. `Compile::fields` answers an arm, `Compile::choice` puts the selector ahead of the groups it chooses between.

**Every payload of an alternative contributes, unconditionally.** That is the asymmetry with the constructing side, where a payload this adapter has no slot form for leaves the whole sum object-shaped. Going the other way the Rust side produces the value and the payload's own output conversion is what encodes it, so there is nothing for an arm to decline.

## What an outgoing value is

`JFrag` gains a second wire list rather than reading the first one backwards, because an outgoing value is a different shape. It is not filled from a Kotlin expression — it is produced by the Rust side and pushed — so what it carries is the builder parameter it lands in, the reading whose output conversion encodes it, the alternative that produces it, and the pattern binding it is reached through. A fragment answers one crossing and a crossing does one job, so the two lists are never both set.

The tag's type is **the sum**, not the `jint` it crosses as. Nothing converts a tag — the emitter assigns the alternative's number in each arm of its `match` — so naming the sum is the only use that type has, and it is exactly the use an emitter has for it: which enum to match over.

## Where it is driven from

`build_with`, not `compile_crossing`. A sum has no deconstructing crossing to be driven from: nothing ever asks for its whole-value output conversion, so the converter walk never reaches it.

It runs last, after `validate_resolved`, and only over sums every payload of which already resolved. A sum with an unresolved payload is a gap in the binding, and the writers report that against the payload — `Reading.Exact.v0 has no OUTPUT converter` — where this could only say that composing failed. What is left for it to catch is a composition that fails over parts which did resolve, which is a bug here rather than a gap there.

## The product beside the choice

A `data_class` states a deconstructing row too: it hands its value out as its fields, so the foreign side reassembles the object in one call and nothing builds one on the Rust side. A field that is itself a `data_class` contributes its own values under the parent's name and chain, which is why `OutFrom` carries a field chain at all — a sum's payload needs none, being bound by its arm's pattern.

That row declines for the **whole** value rather than per field, because the emitter it feeds does. A handle, an `enum_class`, a sum, or a `data_class` behind an `Option` or a `Vec` is delivered with a transform the decoupled form does not carry, and one such field sends the whole object down the whole-value `fromParts` path. A row that decomposed the rest of it would describe a shape nothing emits.

`Declarations::bindings` binds a nested `data_class` field's part in both directions now rather than only in the constructing one. Without it the nested field states one value and the flattening stops a layer down — the same failure the constructing side had before #479.

## Checks

The sum row is held to `synth_sum_leaves` on a fixture carrying a unit alternative (which contributes nothing), a positional payload, a two-field payload and a named-field payload, so the slot naming is exercised in every form it takes. The two agree on names, types, groups and pattern bindings.

The product row is held to `synth_value_struct_leaves` on a fixture with a nested class and a handle-bearing sibling, compared as options — declining is one of the two answers, and a row that states nothing and a synthesis that returns nothing are the same claim.

`examples/regen-check.sh` byte-identical, 272 lib tests, clippy and fmt clean.
