### PR TITLE
Compose what a JNI value form hands out (#472 §4c)

### DIFF
--- a/prebindgen-jni/src/jni/builder.rs
+++ b/prebindgen-jni/src/jni/builder.rs
@@ -896,7 +896,7 @@ impl Declarations {
     /// **Rust field ident**, and both are checked against the struct: naming a
     /// field the value form doesn't have is a hard error, which is the point —
     /// a field renamed upstream must not silently lose its adjustment.
-    fn lower_value_form(
+    pub(crate) fn lower_value_form(
         &self,
         registry: &impl Conversions,
         key: &TypeKey,

--- a/prebindgen-jni/src/jni/compile.rs
+++ b/prebindgen-jni/src/jni/compile.rs
@@ -612,10 +612,16 @@ impl<R: Conversions> Compile for JCompile<'_, R> {
         &mut self,
         _cx: &mut Cx<'_>,
         at: At<'_>,
-        _func: &Function,
-        _parts: Parts<'_, Self>,
+        func: &Function,
+        parts: Parts<'_, Self>,
     ) -> Frag<Self> {
-        Err(refuse(at, "JniGen states no value-form rows yet"))
+        if at.crossing.assembly() != Assembly::Construct {
+            return Ok(self.out_value_form(at, func, parts));
+        }
+        Err(refuse(
+            at,
+            "JniGen states no constructing value-form rows yet",
+        ))
     }
 
     fn fields(&mut self, cx: &mut Cx<'_>, at: At<'_>, parts: Parts<'_, Self>) -> Frag<Self> {
@@ -1091,6 +1097,59 @@ impl<R: Conversions> JCompile<'_, R> {
         let mut frag = JFrag::new(
             at,
             self.parts_marker(parts.iter().map(|(p, _)| p.ty.key()).collect()),
+        );
+        frag.out_wires = Some(wires);
+        frag.composed_only = true;
+        frag
+    }
+
+    /// The values a **value form** hands out: call the accessor once, then read
+    /// the fields of what it returned.
+    ///
+    /// Every field is one value here, where a by-value `data_class` inlines a
+    /// nested one — the difference is the declaration, not the type. A value
+    /// form states its own field list, and what it does not state, it does not
+    /// decompose.
+    ///
+    /// The names are the declaration's: a `.name(..)` rename carries through,
+    /// which is why the record list is asked for again rather than the Kotlin
+    /// property being derived a second time here.
+    fn out_value_form(&self, at: At<'_>, func: &Function, parts: Parts<'_, Self>) -> JFrag {
+        let declined = JFrag::new(at, self.parts_marker(Vec::new()));
+        let Some(names) = self
+            .decls
+            .value_form_names(self.registry, at.crossing.value())
+        else {
+            return declined;
+        };
+        let mut wires = Vec::new();
+        for (part, _) in parts {
+            let Some(field) = part_field(part) else {
+                return declined;
+            };
+            let Some(ident) = field.name.clone() else {
+                return declined;
+            };
+            let Some(name) = names.get(&ident.to_string()).cloned() else {
+                return declined;
+            };
+            wires.push(OutWire {
+                name,
+                out_ty: part.ty.clone(),
+                group: None,
+                // The chain starts at the accessor's result, which the emitter
+                // binds once. The call itself is the site's to make, so what a
+                // wire states is the field read off it.
+                from: OutFrom::Field { path: vec![ident] },
+            });
+        }
+        let mut frag = JFrag::new(
+            at,
+            self.parts_marker(
+                std::iter::once(TypeKey::from_ident(&func.name))
+                    .chain(parts.iter().map(|(p, _)| p.ty.key()))
+                    .collect(),
+            ),
         );
         frag.out_wires = Some(wires);
         frag.composed_only = true;

--- a/prebindgen-jni/src/jni/mod.rs
+++ b/prebindgen-jni/src/jni/mod.rs
@@ -598,6 +598,37 @@ impl JniGen {
         )
     }
 
+    /// The leaves the registry's own expansion plans for one function, in the
+    /// form [`Self::out_lines_for_test`] renders a row in.
+    ///
+    /// The walk side of a value form: its leaves come from `unfold::flatten`
+    /// rather than from a JniGen-side synthesis, so the comparison goes through
+    /// a plan rather than through a leaf list.
+    pub(crate) fn plan_lines_for_test(&self, func: &str) -> Option<Vec<String>> {
+        use prebindgen_registry::unfold::PathStep;
+        let ident = syn::Ident::new(func, proc_macro2::Span::call_site());
+        let plan = prebindgen_registry::Conversions::unfold_plans(&self.registry).get(&ident)?;
+        Some(
+            plan.leaves
+                .iter()
+                .map(|l| {
+                    // The accessor call every leaf hangs off is the site's, not
+                    // the wire's, so it is dropped to line the two up.
+                    let from = l
+                        .path
+                        .iter()
+                        .filter_map(|step| match step {
+                            PathStep::Field { ident, .. } => Some(ident.to_string()),
+                            PathStep::Call { .. } => None,
+                        })
+                        .collect::<Vec<_>>()
+                        .join(".");
+                    format!("{}: {} <- {from} @{:?}", l.name, l.out_ty.key(), l.group)
+                })
+                .collect(),
+        )
+    }
+
     /// The wires a crossing composes into, by spelling.
     pub(crate) fn parts_wires_for_test(
         &self,

--- a/prebindgen-jni/src/jni/rows.rs
+++ b/prebindgen-jni/src/jni/rows.rs
@@ -99,6 +99,99 @@ fn out_alternatives(model: &Flat, ty: &TypeRef) -> Vec<Arm<Deconstruct>> {
         .collect()
 }
 
+impl Declarations {
+    /// The accessor a type's value form names, and one reach per field of the
+    /// struct it returns.
+    ///
+    /// `None` unless the declaration is exactly one `.fields(fields!(f))` whose
+    /// every field is a plain leaf. A record that states its own decomposition
+    /// — a per-field `expand_return!` override, an inlined nested class, a sum
+    /// laid out as a selector and its groups — is a shape this row does not
+    /// state yet, and stating half of one would describe a boundary nothing
+    /// emits.
+    fn value_form_of(
+        &self,
+        model: &Flat,
+        registry: &impl prebindgen_registry::Conversions,
+        ty: &TypeRef,
+    ) -> Option<(syn::Ident, Vec<Reach>)> {
+        use prebindgen_registry::unfold::{FieldDecon, FieldRecord};
+        let decl = self
+            .return_expand_decls
+            .iter()
+            .find(|d| *d.key() == ty.stripped_key())?;
+        let [crate::jni::LocalField::Fields(fields)] = decl.field_list() else {
+            return None;
+        };
+        let records: Vec<FieldRecord> = self.lower_value_form(registry, decl.key(), fields);
+        let ret = model.function(fields.func())?.ret.clone();
+        let ret = ret.borrow_target().unwrap_or(&ret);
+        let prebindgen_registry::flat::TypeKind::Named { id, .. } = ret.unwrapped().kind() else {
+            return None;
+        };
+        let prebindgen_registry::flat::Type::Struct(st) =
+            id.ident().and_then(|i| model.declared_type(&i))?
+        else {
+            return None;
+        };
+        let mut reaches = Vec::new();
+        for record in &records {
+            if !matches!(record.decon, FieldDecon::Default) {
+                return None;
+            }
+            let [member] = record.members.as_slice() else {
+                return None;
+            };
+            let index = st
+                .fields
+                .iter()
+                .position(|f| f.name.as_ref() == Some(member))?;
+            // A field that reaches the type being taken apart. The leaf
+            // synthesis treats `Box<T>` as a spelling of its own and stops
+            // there; a recipe keys a crossing by the value that crosses, so
+            // `Box<ZSample>` inside `ZSample`'s own value form is that row
+            // reaching itself. Refused here rather than by `Recipes::build`,
+            // which would refuse the whole binding over a shape the leaf
+            // synthesis handles.
+            if st.fields[index].ty.stripped_key() == ty.stripped_key() {
+                return None;
+            }
+            reaches.push(Reach::Field(index));
+        }
+        Some((fields.func().clone(), reaches))
+    }
+}
+
+impl Declarations {
+    /// What a value form calls each of its fields, by the Rust field ident.
+    ///
+    /// The declaration's answer, so a `.name(..)` rename carries through to the
+    /// builder parameter. `None` for a type with no value form, or one whose
+    /// records this row does not state — the same test [`Self::value_form_of`]
+    /// makes when it declares the row.
+    pub(crate) fn value_form_names(
+        &self,
+        registry: &impl prebindgen_registry::Conversions,
+        ty: &TypeRef,
+    ) -> Option<std::collections::HashMap<String, String>> {
+        use prebindgen_registry::unfold::FieldDecon;
+        let decl = self
+            .return_expand_decls
+            .iter()
+            .find(|d| *d.key() == ty.stripped_key())?;
+        let [crate::jni::LocalField::Fields(fields)] = decl.field_list() else {
+            return None;
+        };
+        self.lower_value_form(registry, decl.key(), fields)
+            .into_iter()
+            .map(|r| match (r.members.as_slice(), &r.decon) {
+                ([member], FieldDecon::Default) => Some((member.to_string(), r.name)),
+                _ => None,
+            })
+            .collect()
+    }
+}
+
 /// One reach per field of a declared struct, in the model's order.
 ///
 /// Empty for anything the model does not hold as a struct, which includes a
@@ -137,7 +230,11 @@ impl Declarations {
     /// A type declared but absent from the model is skipped rather than
     /// refused: the scan already reports it, and reporting it twice in
     /// different words helps nobody.
-    pub(crate) fn recipes(&self, model: &Flat) -> Result<Recipes, Vec<RecipeError>> {
+    pub(crate) fn recipes(
+        &self,
+        model: &Flat,
+        registry: &impl prebindgen_registry::Conversions,
+    ) -> Result<Recipes, Vec<RecipeError>> {
         let mut rows = Recipes::builder();
         // Every Kotlin class declaration, and every `convert!`-declared
         // conversion. The second matters as much as the first: a conversion may
@@ -202,8 +299,22 @@ impl Declarations {
                     }
                 }
                 _ => {
-                    rows.declare(ty.clone(), whole(), Deconstructing::Atomic);
+                    rows.declare_default(ty.clone(), whole(), Deconstructing::Atomic);
                 }
+            }
+            // A value form: `expand_return!(T).fields(fields!(f))` calls `f`
+            // once and hands out the fields of the struct it returns. The one
+            // declaration shape that names its own accessor, and the reason
+            // `Deconstruct::ValueForm` exists.
+            if let Some((func, reaches)) = self.value_form_of(model, registry, &ty) {
+                rows.declare(
+                    ty.clone(),
+                    parts(),
+                    Deconstructing::Product(Deconstruct::ValueForm {
+                        func,
+                        parts: reaches,
+                    }),
+                );
             }
             // A `data_class` also has a row that says what it is made of, so
             // its constructing side names which of the two a site takes by

--- a/prebindgen-jni/src/jni/tests/value_form.rs
+++ b/prebindgen-jni/src/jni/tests/value_form.rs
@@ -3335,3 +3335,76 @@ fn nullability_ignores_how_rust_spells_the_optional() {
         "a transparent wrapper must not change the Kotlin surface"
     );
 }
+
+/// A value form states a row saying what it hands out, and it says what the
+/// expansion plan it will replace says.
+///
+/// `expand_return!(Vault).fields(fields!(vault_to_struct))` calls the accessor
+/// once and hands out the fields of the struct it returns, named as the
+/// declaration names them — a `.name(..)` rename included, which is why the row
+/// asks the declaration rather than deriving a Kotlin property a second time.
+#[test]
+fn a_value_form_states_what_it_hands_out() {
+    let loc = myflat_loc();
+    let items: Vec<(syn::Item, SourceLocation)> = vec![
+        (
+            syn::Item::Struct(syn::parse_quote!(
+                pub struct Vault {
+                    pub inner: i64,
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Struct(syn::parse_quote!(
+                pub struct VaultStruct {
+                    pub seq: i64,
+                    pub label: String,
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn vault_to_struct(v: &Vault) -> VaultStruct {
+                    unimplemented!()
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn vault_new() -> Vault {
+                    unimplemented!()
+                }
+            )),
+            loc.clone(),
+        ),
+    ];
+    let registry =
+        crate::test_util::reg_from_items(declare_referenced(items)).expect("index items");
+    let jni = JniGenBuilder::new()
+        .set_package_prefix("io.test.jni")
+        .expand(
+            prebindgen_registry::expand_return!(Vault)
+                .fields(prebindgen_registry::fields!(vault_to_struct).name("label", "tag")),
+        )
+        .package(
+            crate::package!()
+                .class(crate::ptr_class!(Vault))
+                .fun(prebindgen_registry::fun!(vault_new)),
+        );
+    let gen = jni.build_with(registry).expect("resolve");
+
+    assert_eq!(
+        gen.out_lines_for_test("Vault")
+            .expect("Vault states a value-form row"),
+        vec!["seq: i64 <- seq @None", "tag: String <- label @None"],
+        "the row hands out the value form's fields, named as declared",
+    );
+    assert_eq!(
+        gen.out_lines_for_test("Vault"),
+        gen.plan_lines_for_test("vault_new"),
+        "the row and the expansion plan disagree",
+    );
+}

--- a/prebindgen-jni/src/jni/trait_impl.rs
+++ b/prebindgen-jni/src/jni/trait_impl.rs
@@ -1414,7 +1414,7 @@ impl JniGenBuilder {
         // A second holding of the model: `convert_with` consumes the builder,
         // and the table outlives that call.
         let model = declared.flat().clone();
-        let recipes = decls.recipes(&model).map_err(|errors| {
+        let recipes = decls.recipes(&model, &declared).map_err(|errors| {
             prebindgen_registry::ScanError::AdapterInvariant {
                 message: errors
                     .iter()
@@ -1553,6 +1553,10 @@ impl JniGenBuilder {
                     Some(prebindgen_registry::flat::Type::Struct(s)) => {
                         s.fields.iter().map(|f| &f.ty).collect()
                     }
+                    // A value form's parts belong to the struct its accessor
+                    // returns, not to this type — so there is nothing to
+                    // pre-check here, and the compiler's own deferral answers.
+                    _ if decls.value_form_names(&registry, &ty).is_some() => Vec::new(),
                     _ => continue,
                 };
             if part_types.iter().any(|ty| decls.out_frag(ty).is_none()) {
@@ -3267,8 +3271,13 @@ impl Declarations {
             .iter()
             .filter(|(_, c)| matches!(c.kind, DeclaredKind::Sealed(_) | DeclaredKind::Data))
             .map(|(k, _)| k.clone())
+            // And every type whose value form says what it hands out, whatever
+            // kind of class it is — `expand_return!` is declared over a
+            // `ptr_class` as readily as over anything else.
+            .chain(self.return_expand_decls.iter().map(|d| d.key().clone()))
             .collect();
         keys.sort_by(|a, b| a.as_str().cmp(b.as_str()));
+        keys.dedup();
         keys
     }
 


### PR DESCRIPTION
Follows #489, which composes what a sealed class and a data class hand out. This is the third deconstructing shape and the last one stage 4's composition needs: `Deconstruct::ValueForm`.

`expand_return!(T).fields(fields!(f))` calls the accessor `f` once and hands out the fields of the struct it returns. That is what the recipe vocabulary's `ValueForm` has always meant, and until now no adapter said it — `Compile::value_form` refused.

Byte-identical: `examples/regen-check.sh` passes, and the row is declared but taken by nobody.

## What a value form is, against what a data class is

Every field of a value form is **one** value, where a by-value `data_class` inlines a nested one. The difference is the declaration rather than the type: a value form states its own field list, and what it does not state, it does not decompose.

The names are the declaration's too — a `.name(..)` rename carries through to the builder parameter — which is why the row asks `lower_value_form` for the record list again instead of deriving a Kotlin property a second time. `Declarations::recipes` takes the conversions view alongside the model so it can.

## What the row does not state yet

It is declared only for a declaration that is exactly one `.fields(fields!(f))` whose every record is a plain leaf at the top level. A record carrying its own decomposition — a per-field `expand_return!` override, an inlined nested class, a sum laid out as a selector and its groups — is a shape this row does not state, and stating half of one would describe a boundary nothing emits.

Those are not gaps in the vocabulary but in this row: an inlined nested class needs the nested type to be read *as inlined* rather than as the by-value decomposition #489 gave it, which is a second row for one crossing — "one crossing read two ways is two rows", the rule #465 established.

## One refusal that belongs to the row rather than to the table

A field reaching the type being taken apart — `Box<ZSample>` inside `ZSample`'s own value form, which `covertest`'s wrapper fixture carries — is a **cycle** to a recipe, because a recipe keys a crossing by the value that crosses and `Box<T>` is a spelling of `T`. The leaf synthesis it is held to treats `Box<T>` as a spelling of its own and stops there, producing a plain leaf.

So the row declines rather than letting `Recipes::build` refuse the whole binding over a shape the synthesis handles. Refusing there would be correct about recipes and wrong about the binding.

## Checks

Held to the expansion plan the registry builds for a function returning the type. The walk side of a value form is `unfold::flatten` rather than a JniGen-side synthesis, so the comparison goes through an `UnfoldPlan` rather than through a leaf list — the accessor call every leaf hangs off is the site's, not the wire's, and is dropped to line the two up.

`examples/regen-check.sh` byte-identical, 273 lib tests, clippy and fmt clean.