### PR TITLE
A JNI parameter is planned through Compile::plan (#472 §5)

### DIFF
--- a/prebindgen-jni/src/jni/builder.rs
+++ b/prebindgen-jni/src/jni/builder.rs
@@ -144,6 +144,7 @@ impl Default for Declarations {
     fn default() -> Self {
         Self {
             compiled_fns: Vec::new(),
+            tables: None,
             compiled: Default::default(),
             package: String::new(),
             fun_name_mangle: None,

--- a/prebindgen-jni/src/jni/compile.rs
+++ b/prebindgen-jni/src/jni/compile.rs
@@ -400,10 +400,57 @@ fn produces_borrow(ty: &syn::Type) -> bool {
 pub(crate) struct JCompile<'a, R> {
     pub(crate) decls: &'a Declarations,
     pub(crate) registry: &'a R,
+    /// Which site is being planned, when one is.
+    ///
+    /// `None` while compiling a row: a row answers for a crossing wherever it
+    /// appears, so nothing about a site may reach it. Set only for the one hook
+    /// the registry calls per site.
+    pub(crate) site: Option<PlanSite>,
 }
 
-fn refuse(at: At<'_>, why: &str) -> String {
-    format!("JniGen: {} ({why})", at.crossing.key())
+/// What [`Compile::plan`] needs about a site that the crossing does not say.
+pub(crate) struct PlanSite {
+    /// The parameter ident the wrapper binds this value to.
+    pub(crate) ident: syn::Ident,
+    /// Whether this leaf is one of a constructor expansion's arguments rather
+    /// than a parameter the signature names.
+    ///
+    /// The one fact a plan needs that the crossing cannot say: a `Vec`
+    /// parameter builds through a collection helper where the site is a real
+    /// parameter, and crosses as one value where it is an expansion's leaf.
+    pub(crate) expanded: bool,
+}
+
+/// What this adapter reports when it cannot answer.
+///
+/// Two kinds, because two readers act on them differently. A **refusal** names
+/// a crossing this adapter has no representation for, and the driver turns it
+/// into an adapter invariant. A **plan failure** is `fn_plan`'s own typed
+/// error, whose readers choose their diagnostic from which failure it is — so
+/// it travels whole rather than as the string it would print to.
+#[derive(Debug)]
+pub(crate) enum JErr {
+    /// No JNI representation for this crossing.
+    Refused(String),
+    /// One site could not be planned.
+    ///
+    /// Boxed for the reason `PlanError` boxes its own readings: a `Result` is
+    /// sized by its largest variant, and the success side of every hook on this
+    /// path is the one that always happens.
+    Plan(Box<crate::jni::fn_plan::PlanError>),
+}
+
+impl std::fmt::Display for JErr {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            JErr::Refused(why) => f.write_str(why),
+            JErr::Plan(e) => write!(f, "{e:?}"),
+        }
+    }
+}
+
+fn refuse(at: At<'_>, why: &str) -> JErr {
+    JErr::Refused(format!("JniGen: {} ({why})", at.crossing.key()))
 }
 
 impl<R: Conversions> JCompile<'_, R> {
@@ -471,10 +518,9 @@ impl<R: Conversions> JCompile<'_, R> {
 
 impl<R: Conversions> Compile for JCompile<'_, R> {
     type Fragment = JFrag;
-    /// JniGen keeps its own per-site emission for now: the exported signature,
-    /// the call and the cleanup are built from the resolved registry.
-    type Plan = ();
-    type Error = String;
+    /// One parameter of one exported function, classified.
+    type Plan = crate::jni::fn_plan::PlanLeaf;
+    type Error = JErr;
 
     fn atomic(&mut self, cx: &mut Cx<'_>, at: At<'_>) -> Frag<Self> {
         let ty = at.crossing.spelled();
@@ -763,8 +809,93 @@ impl<R: Conversions> Compile for JCompile<'_, R> {
         self.wrap(at, "undeclared callback signature", conv)
     }
 
-    fn plan(&mut self, _cx: &mut Cx<'_>, _bound: &Bound, _root: &JFrag) -> Result<(), String> {
-        Ok(())
+    /// One site: which of the seven wire layouts this parameter takes, and the
+    /// names the three coordinated emitters give it.
+    ///
+    /// The only hook the registry calls once per **site**; every hook above it
+    /// answers once per crossing, however many sites reuse the answer. What
+    /// makes this one per-site is not the type — that is the fragment's — but
+    /// what wraps it: a `Vec` parameter builds through a collection helper only
+    /// where the site is a real parameter and not a constructor expansion's
+    /// leaf, and the diagnostic for an unresolved leaf names the parameter that
+    /// expanded.
+    fn plan(&mut self, _cx: &mut Cx<'_>, bound: &Bound, root: &JFrag) -> Result<PlanLeaf, JErr> {
+        use crate::jni::fn_plan::{plan_error, InputKind, PlanLeaf};
+        let site = self
+            .site
+            .as_ref()
+            .ok_or_else(|| JErr::Refused("JniGen: a site compiled with no site context".into()))?;
+        let (ident, expanded) = (&site.ident, site.expanded);
+        let reading = bound.crossing.spelled();
+        let registry = self.registry;
+        let ext = self.decls;
+
+        // Every question below is the model's — the local spelling this
+        // function opened with has no users left.
+        let optional = reading.optional_inner().is_some();
+        // The enum probe off the reading: the layers it peels are the model's
+        // own (`&`, `Option`), so there is nothing to re-spell and nothing to
+        // look up.
+        let as_enum_value = ext.is_kotlin_enum_reading(reading);
+        let kt_name = crate::jni::kt_param_name(&ident.to_string());
+
+        // The site's own conversion, which the registry built before calling
+        // this. What used to be a lookup by type is the fragment it is handed.
+        let entry = &root.conv;
+
+        let flat_plan = crate::jni::emit::build_flat_input_plan(ext, registry, ident, reading)
+            .map_err(|e| plan_error(crate::jni::fn_plan::PlanError::UnflattenableDataClass(e)))?;
+        let kind = if let Some(v) = (!expanded)
+            .then(|| crate::jni::emit::vec_build_elem(ext, registry, reading))
+            .flatten()
+        {
+            InputKind::VecBuild {
+                elem: v.elem,
+                by_ref: v.by_ref,
+                elem_wrappers: v.elem_wrappers,
+            }
+        } else if let Some(sp) =
+            crate::jni::emit::build_option_scalar_input_plan(ext, ident, reading)
+        {
+            InputKind::OptionScalar(sp)
+        } else if let Some(plan) = flat_plan {
+            InputKind::FlattenStruct(plan)
+        } else {
+            match entry.metadata.projection.as_ref().map(|p| p.kind.clone()) {
+                Some(ProjectionKind::Handle) => InputKind::Handle {
+                    direct: entry.metadata.is_direct_handle(),
+                },
+                Some(ProjectionKind::Unsigned64) => InputKind::Unsigned64 {
+                    niche: entry.metadata.projection.as_ref().and_then(|p| {
+                        reading
+                            .optional_inner()
+                            .is_some()
+                            .then(|| p.niche_sentinels.first().cloned())
+                            .flatten()
+                    }),
+                },
+                None => InputKind::Plain,
+            }
+        };
+
+        // Typed surface: handle/value projections show their Kotlin class (from
+        // the projection's leaf key); everything else the conversion's resolved
+        // name.
+        let kt_meta = entry.metadata.kotlin_name.clone();
+        let kt_public = match entry.metadata.projection.as_ref() {
+            Some(p) => crate::jni::projection_leaf_kt(ext, p),
+            None => kt_meta.clone(),
+        };
+
+        Ok(PlanLeaf {
+            reading: reading.clone(),
+            kt_name,
+            kt_public,
+            kt_meta,
+            optional,
+            as_enum_value,
+            kind,
+        })
     }
 }
 

--- a/prebindgen-jni/src/jni/emit/flat_input.rs
+++ b/prebindgen-jni/src/jni/emit/flat_input.rs
@@ -1059,7 +1059,7 @@ pub(crate) fn wire_kotlin_type(entry: &prebindgen_registry::ConverterImpl<Kotlin
 #[allow(clippy::too_many_arguments)]
 fn build_flat_sum_field(
     ext: &Declarations,
-    registry: &Registry,
+    registry: &impl Conversions,
     sum_reading: &TypeRef,
     field: syn::Ident,
     optional: bool,
@@ -1152,7 +1152,7 @@ impl Leaves<'_> {
 
 pub(crate) fn build_flat_input_plan(
     ext: &Declarations,
-    registry: &Registry,
+    registry: &impl Conversions,
     param_name: &syn::Ident,
     arg: &TypeRef,
 ) -> Result<Option<FlatInputPlan>, FlatInputError> {
@@ -1272,7 +1272,7 @@ pub(crate) fn build_flat_input_plan(
 #[allow(clippy::too_many_arguments)]
 fn build_flat_struct_node(
     ext: &Declarations,
-    registry: &Registry,
+    registry: &impl Conversions,
     st: &flat::Struct,
     optional: bool,
     native_prefix: &str,

--- a/prebindgen-jni/src/jni/emit/vec_build.rs
+++ b/prebindgen-jni/src/jni/emit/vec_build.rs
@@ -53,7 +53,7 @@ pub(crate) struct VecBuildElem {
 /// four sites agree on which params take the handle path.
 pub(crate) fn vec_build_elem(
     ext: &Declarations,
-    registry: &Registry,
+    registry: &impl prebindgen_registry::Conversions,
     arg: &TypeRef,
 ) -> Option<VecBuildElem> {
     // The run and its element off the MODEL. `&mut [T]` is still refused —

--- a/prebindgen-jni/src/jni/fn_plan.rs
+++ b/prebindgen-jni/src/jni/fn_plan.rs
@@ -274,6 +274,11 @@ pub(crate) enum PlanError {
     JvmParameterLimit { slots: usize },
 }
 
+/// A plan failure, as the adapter's own error carries it.
+pub(crate) fn plan_error(e: PlanError) -> crate::jni::compile::JErr {
+    crate::jni::compile::JErr::Plan(Box::new(e))
+}
+
 impl PlanError {
     /// Where the offending type was written, when a file wrote it — the
     /// suffix [`Self::message`] appends.
@@ -610,42 +615,71 @@ fn classify_leaf(
     expanded: bool,
     source_param: &syn::Ident,
 ) -> Result<PlanLeaf, PlanError> {
-    // Every question below is the model's now — the local spelling this function
-    // opened with has no users left.
-    let optional = reading.optional_inner().is_some();
-    // The enum probe off the reading — the layers it peels are the model's own
-    // (`&`, `Option`), so there is nothing to re-spell and nothing to look up.
-    let as_enum_value = ext.is_kotlin_enum_reading(reading);
-    let kt_name = kt_param_name(&ident.to_string());
-
-    // `impl Fn(args)` first: typed entirely from the interface spec — the
-    // erased entry exists but its metadata carries no surface type.
+    use prebindgen_registry::recipe::{Assembly, Compiler, Crossing, Role, Site};
+    // `impl Fn(args)` never reaches the compiler, for the reason
+    // `JniGen::compile_crossing` gives: a callback is answered whole, because a
+    // JniGen callback ARGUMENT does not always have a conversion of its own —
+    // a sealed class reaches the JVM as a selector plus the live arm's slots.
+    // Driving the derived callback row here would ask for the one conversion
+    // that does not exist. This carve-out goes when the arms are rows a
+    // callback can be composed from.
     if let Some(args) = reading.callback_args() {
         // `SpecKey` is a memo key and holds `TypeKey`s, so the args reach it as
         // each arg reading's own identity.
-        // `a_callback_identity_is_the_same_from_the_reading_or_the_syntax`
-        // pins that this is the same identity the signature-derived key gives.
         let iface = ext.iface_spec(registry, &SpecKey::callback(args));
         return Ok(PlanLeaf {
             reading: reading.clone(),
-            kt_name,
+            kt_name: kt_param_name(&ident.to_string()),
             kt_public: None,
             kt_meta: ext
                 .in_frag(reading)
                 .and_then(|e| e.metadata.kotlin_name.clone()),
-            optional,
-            as_enum_value,
+            optional: reading.optional_inner().is_some(),
+            as_enum_value: ext.is_kotlin_enum_reading(reading),
             kind: InputKind::Callback { iface },
         });
     }
-
-    // Every non-callback leaf requires a resolved input entry — the same
-    // hard boundary the Rust emitter has always enforced.
-    let Some(entry) = ext.in_frag(reading) else {
-        // The reading itself, so the diagnostic can say where the type was
-        // written. Reaching here means the type IS classified and merely has no
-        // converter, which is why there is something to carry.
-        return Err(if expanded {
+    // The compiler, resumed over what the build already compiled. Every
+    // fragment this site's row needs is in that store, so `site` finds them
+    // rather than building them again — and the plan it wraps them in is the
+    // one hook the registry calls per site rather than per crossing.
+    let mut compiler = Compiler::resume(
+        registry.flat(),
+        ext.recipe_table(),
+        ext.site_bindings(),
+        ext.compiled.borrow().clone(),
+    );
+    let mut adapter = crate::jni::compile::JCompile {
+        decls: ext,
+        registry,
+        site: Some(crate::jni::compile::PlanSite {
+            ident: ident.clone(),
+            expanded,
+        }),
+    };
+    // The site names the parameter it is, and the position is the source
+    // parameter's rather than a running count: a constructor expansion
+    // contributes leaves the signature does not name, and they all belong to
+    // the one parameter that expanded.
+    let site = Site {
+        owner: source_param.clone(),
+        role: Role::Param { index: 0 },
+    };
+    let crossing = Crossing::new(reading.clone(), Assembly::Construct);
+    let planned = compiler.site(&mut adapter, site, crossing);
+    *ext.compiled.borrow_mut() = compiler.finish();
+    match planned {
+        Ok(Some(leaf)) => Ok(leaf),
+        // A site the bindings omitted, which JniGen never declares.
+        Ok(None) => Err(PlanError::Unresolved {
+            ty: Box::new(reading.clone()),
+        }),
+        Err(prebindgen_registry::recipe::CompileError::Adapter(
+            crate::jni::compile::JErr::Plan(e),
+        )) => Err(*e),
+        // A refusal or a table disagreement, which reach this path only for a
+        // type with no conversion — the same failure the entry lookup reported.
+        Err(_) => Err(if expanded {
             PlanError::UnresolvedLeaf {
                 ty: Box::new(reading.clone()),
                 param: source_param.clone(),
@@ -654,59 +688,8 @@ fn classify_leaf(
             PlanError::Unresolved {
                 ty: Box::new(reading.clone()),
             }
-        });
-    };
-
-    let flat_plan = build_flat_input_plan(ext, registry, ident, reading)
-        .map_err(PlanError::UnflattenableDataClass)?;
-    let kind = if let Some(v) = (!expanded)
-        .then(|| vec_build_elem(ext, registry, reading))
-        .flatten()
-    {
-        InputKind::VecBuild {
-            elem: v.elem,
-            by_ref: v.by_ref,
-            elem_wrappers: v.elem_wrappers,
-        }
-    } else if let Some(sp) = build_option_scalar_input_plan(ext, ident, reading) {
-        InputKind::OptionScalar(sp)
-    } else if let Some(plan) = flat_plan {
-        InputKind::FlattenStruct(plan)
-    } else {
-        match entry.metadata.projection.as_ref().map(|p| p.kind.clone()) {
-            Some(ProjectionKind::Handle) => InputKind::Handle {
-                direct: entry.metadata.is_direct_handle(),
-            },
-            Some(ProjectionKind::Unsigned64) => InputKind::Unsigned64 {
-                niche: entry.metadata.projection.as_ref().and_then(|p| {
-                    reading
-                        .optional_inner()
-                        .is_some()
-                        .then(|| p.niche_sentinels.first().cloned())
-                        .flatten()
-                }),
-            },
-            None => InputKind::Plain,
-        }
-    };
-
-    // Typed surface: handle/value projections show their Kotlin class (from
-    // the projection's leaf key); everything else the entry's resolved name.
-    let kt_meta = entry.metadata.kotlin_name.clone();
-    let kt_public = match entry.metadata.projection.as_ref() {
-        Some(p) => projection_leaf_kt(ext, p),
-        None => kt_meta.clone(),
-    };
-
-    Ok(PlanLeaf {
-        reading: reading.clone(),
-        kt_name,
-        kt_public,
-        kt_meta,
-        optional,
-        as_enum_value,
-        kind,
-    })
+        }),
+    }
 }
 
 /// Lower the output side. Mirrors the historical derivations exactly:

--- a/prebindgen-jni/src/jni/mod.rs
+++ b/prebindgen-jni/src/jni/mod.rs
@@ -231,6 +231,13 @@ pub(crate) enum DeclaredKind {
     Data,
 }
 
+/// What compiling a site needs beyond the model: which rows exist, and which
+/// row each site takes.
+pub(crate) struct Tables {
+    pub(crate) recipes: prebindgen_registry::recipe::Recipes,
+    pub(crate) bindings: prebindgen_registry::recipe::Bindings,
+}
+
 /// All configuration the structured builder accumulates for one
 /// canonical Rust type key. The declared kind is mandatory (an entry exists
 /// only because some declarator created it); the remaining, cross-kind
@@ -795,6 +802,18 @@ pub struct Declarations {
     pub(crate) compiled: std::rc::Rc<
         std::cell::RefCell<prebindgen_registry::recipe::Compiled<crate::jni::compile::JFrag>>,
     >,
+    /// The row table and the site bindings this binding was built against.
+    ///
+    /// Kept beside the fragment store for the same reason it is: a plan is
+    /// compiled per **site**, and the sites are `fn_plan`'s to enumerate — a
+    /// constructor expansion contributes leaves no signature names. So the
+    /// compiler has to be resumable after `build_with` has returned, and these
+    /// are the two things `Compiler::resume` needs that the model does not
+    /// already carry.
+    ///
+    /// `None` only before the build fills them, which is before anything can
+    /// ask.
+    pub(crate) tables: Option<std::rc::Rc<Tables>>,
 
     /// When `true` (default), generated wrappers wrap each call that
     /// touches an opaque handle in the per-call `withSortedHandleLocks`

--- a/prebindgen-jni/src/jni/trait_impl.rs
+++ b/prebindgen-jni/src/jni/trait_impl.rs
@@ -1434,6 +1434,10 @@ impl JniGenBuilder {
                     .join("; "),
             }
         })?;
+        // Both tables go on `decls`, because compiling a **site** happens after
+        // this function has returned: the sites are `fn_plan`'s to enumerate,
+        // and `Compiler::resume` needs these two beside the model.
+        decls.tables = Some(std::rc::Rc::new(crate::jni::Tables { recipes, bindings }));
         // The driver's state lives on `decls` rather than here, because the
         // adapter reads it **while** it compiles: a conversion for one type is
         // built out of the conversions for its inners, which are compiled
@@ -1452,8 +1456,8 @@ impl JniGenBuilder {
             .convert_with(|crossing, built, emit| {
                 let mut compiler = prebindgen_registry::recipe::Compiler::resume(
                     &model,
-                    &recipes,
-                    &bindings,
+                    decls.recipe_table(),
+                    decls.site_bindings(),
                     decls.compiled.borrow().clone(),
                 );
                 let conv =
@@ -1568,13 +1572,14 @@ impl JniGenBuilder {
             );
             let mut compiler = prebindgen_registry::recipe::Compiler::resume(
                 &model,
-                &recipes,
-                &bindings,
+                decls.recipe_table(),
+                decls.site_bindings(),
                 decls.compiled.borrow().clone(),
             );
             let mut adapter = crate::jni::compile::JCompile {
                 decls: &decls,
                 registry: &registry,
+                site: None,
             };
             if let Err(e) = compiler.row_of(&mut adapter, &crossing, &crate::jni::rows::parts()) {
                 refusals.push(format!(
@@ -1650,6 +1655,7 @@ impl Declarations {
         let mut adapter = crate::jni::compile::JCompile {
             decls: self,
             registry: built,
+            site: None,
         };
         let crossing = prebindgen_registry::recipe::Crossing::new(reading, assembly);
         let fragment = compiler.crossing(&mut adapter, &crossing).ok()?;
@@ -3260,6 +3266,16 @@ impl Declarations {
             .map(|(k, c)| (k.clone(), c.rust_type.clone()))
             .collect()
     }
+    /// The row table this binding was built against.
+    pub(crate) fn recipe_table(&self) -> &prebindgen_registry::recipe::Recipes {
+        &self.tables.as_ref().expect("built").recipes
+    }
+
+    /// Which row each site takes.
+    pub(crate) fn site_bindings(&self) -> &prebindgen_registry::recipe::Bindings {
+        &self.tables.as_ref().expect("built").bindings
+    }
+
     /// Every type that states what it hands out — `sealed_class!` and
     /// `data_class!` — in a stable order.
     ///


### PR DESCRIPTION
The first step of stage 5. `Compiler::site` is the entry point that calls `Compile::plan`, and until now nothing called it: both adapters drove `Compiler::crossing` and did their own per-site wrapping.

`fn_plan::classify_leaf` **was** that wrapping for a JNI parameter — which of the seven wire layouts it takes, and the names the Rust wrapper, the `JNINative` extern declaration and the Kotlin call site give it — and it is now the hook's body. `JCompile::Plan` is a `PlanLeaf`.

Byte-identical: `examples/regen-check.sh` passes, 273 lib tests.

## Why the move was small

`classify_leaf` had already stopped looking anything up. Since #476 it reads the crossing's own fragment rather than the converter table, and a fragment is exactly what the registry hands a plan — so the `ext.in_frag(reading)` the function opened with is the `root` parameter now, and nothing else in the body changed.

What is genuinely per-**site** rather than per-crossing turns out to be one fact: whether the leaf is a constructor expansion's argument rather than a parameter the signature names. A `Vec` parameter builds through a collection helper in the first case and crosses as one value in the second. That rides on the adapter for the length of the call, where a row can never see it.

## Two things had to move with it

**The compiler has to be resumable after `build_with` returns.** Which sites to compile is `fn_plan`'s answer and not the model's — an expansion contributes leaves no signature names — so the drive belongs where that enumeration already is. `Declarations` keeps the `Recipes` and the `Bindings` beside the fragment store it already kept, which is what `Compiler::resume` needs that the model does not carry.

**`Compile::Error` had to widen.** `classify_leaf` returns a typed `PlanError` whose readers choose their diagnostic from which failure it is, so it travels whole rather than as the string it would print to. `JErr` is that: a refusal naming a crossing with no JNI representation, or a plan failure carried intact.

`build_flat_input_plan` and `vec_build_elem` take the conversions view rather than the concrete `Registry`, because a hook is generic over it. Neither used anything else.

## One carve-out stays where it was

An `impl Fn(args)` parameter never reaches the compiler, for the reason `JniGen::compile_crossing` already gives: a JniGen callback **argument** does not always have a conversion of its own — a sealed class reaches the JVM as a selector plus the live arm's slots — so driving the derived callback row would ask for the one conversion that does not exist.

It is the same carve-out, now in two places rather than one, and it goes when the arms are rows a callback can be composed from. That is stage 4's switch, which #489 and #490 have already composed the rows for.