### PR TITLE
The sum emitters speak the row's vocabulary (#472 §4d)

### DIFF
--- a/prebindgen-jni/src/jni/compile.rs
+++ b/prebindgen-jni/src/jni/compile.rs
@@ -223,6 +223,47 @@ pub(crate) struct OutWire {
     pub(crate) group: Option<i32>,
     /// How the Rust side reaches it.
     pub(crate) from: OutFrom,
+    /// Whether the value may be absent, so the wire boxes rather than carrying
+    /// a raw primitive.
+    ///
+    /// Always false in a composition: a decomposition of its own is reached
+    /// unconditionally. It is a **splice** that makes one nullable — a value
+    /// form reached through an `Option` puts every value under it in doubt —
+    /// and the site that splices is what sets it.
+    pub(crate) nullable: bool,
+}
+
+impl OutWire {
+    /// One leaf of an expansion plan, in the row's vocabulary.
+    ///
+    /// The shim that lets the sum emitters speak rows before every plan is one:
+    /// what they read of a leaf is exactly what a wire states, so the switch is
+    /// per call site rather than all at once.
+    pub(crate) fn from_leaf(leaf: &prebindgen_registry::unfold::UnfoldLeaf) -> Self {
+        use prebindgen_registry::unfold::LeafSource;
+        Self {
+            name: leaf.name.clone(),
+            out_ty: leaf.out_ty.clone(),
+            group: leaf.group,
+            from: match &leaf.source {
+                LeafSource::SumTag => OutFrom::Tag,
+                LeafSource::VariantField { variant, member } => OutFrom::Payload {
+                    variant: Some(variant.clone()),
+                    member: member.clone(),
+                },
+                // An accessor chain and a field chain are one thing to a wire:
+                // where the Rust side reaches the value. Which of the two it
+                // was is the plan's, and nothing the sum emitters read.
+                _ => OutFrom::Field { path: Vec::new() },
+            },
+            nullable: leaf.nullable,
+        }
+    }
+
+    /// Whether this value is the synthesized selector.
+    pub(crate) fn is_tag(&self) -> bool {
+        matches!(self.from, OutFrom::Tag)
+    }
 }
 
 /// Where an outgoing value comes from.
@@ -1143,6 +1184,7 @@ impl<R: Conversions> JCompile<'_, R> {
                         variant: None,
                         member: part_member(part)?,
                     },
+                    nullable: false,
                 })
             })
             .collect();
@@ -1214,6 +1256,7 @@ impl<R: Conversions> JCompile<'_, R> {
                                     .chain(path.iter().cloned())
                                     .collect(),
                             },
+                            nullable: false,
                         });
                     }
                 }
@@ -1222,6 +1265,7 @@ impl<R: Conversions> JCompile<'_, R> {
                     out_ty: part.ty.clone(),
                     group: None,
                     from: OutFrom::Field { path: vec![ident] },
+                    nullable: false,
                 }),
             }
         }
@@ -1272,6 +1316,7 @@ impl<R: Conversions> JCompile<'_, R> {
                 // binds once. The call itself is the site's to make, so what a
                 // wire states is the field read off it.
                 from: OutFrom::Field { path: vec![ident] },
+                nullable: false,
             });
         }
         let mut frag = JFrag::new(
@@ -1313,6 +1358,7 @@ impl<R: Conversions> JCompile<'_, R> {
             out_ty: at.crossing.value().clone(),
             group: None,
             from: OutFrom::Tag,
+            nullable: false,
         }];
         for (alt, frag) in arms {
             let kotlin = self.decls.sum_variant_class_name(sum_cfg, &alt.name);
@@ -1332,6 +1378,7 @@ impl<R: Conversions> JCompile<'_, R> {
                         variant: Some(alt.name.clone()),
                         member: member.clone(),
                     },
+                    nullable: w.nullable,
                 });
             }
         }

--- a/prebindgen-jni/src/jni/emit/delivery.rs
+++ b/prebindgen-jni/src/jni/emit/delivery.rs
@@ -880,7 +880,7 @@ pub(crate) fn encode_plan_leaves(
     let mut arg_exprs: Vec<TokenStream> = Vec::with_capacity(n);
     for (idx, leaf) in plan.leaves.iter().enumerate() {
         let obj_ident = &obj_idents[idx];
-        if leaf_is_prim(ext, leaf) {
+        if leaf_is_prim(ext, &crate::jni::compile::OutWire::from_leaf(leaf)) {
             arg_exprs.push(quote!(#obj_ident));
         } else {
             arg_exprs.push(quote!(jni::sys::jvalue { l: #obj_ident.as_raw() }));
@@ -1019,7 +1019,10 @@ pub(crate) fn encode_plan_leaves(
         let (group_stmts, group_args) = encode_sum_group(
             ext,
             registry,
-            &plan.leaves[seg.clone()],
+            &plan.leaves[seg.clone()]
+                .iter()
+                .map(crate::jni::compile::OutWire::from_leaf)
+                .collect::<Vec<_>>(),
             &obj_idents[seg.clone()],
             matched,
             fail,
@@ -1031,7 +1034,7 @@ pub(crate) fn encode_plan_leaves(
                 let ids: Vec<&syn::Ident> = obj_idents[seg.clone()].iter().collect();
                 let slots: Vec<Slot> = plan.leaves[seg.clone()]
                     .iter()
-                    .map(|l| leaf_slot(ext, l))
+                    .map(|l| leaf_slot(ext, &crate::jni::compile::OutWire::from_leaf(l)))
                     .collect();
                 let tys = slots.iter().map(|s| &s.ty);
                 let defaults = slots.iter().map(|s| &s.default);
@@ -1404,7 +1407,7 @@ pub(crate) fn encode_plan_leaves(
         // value with the leaf's output converter and casts to JObject.
         let wire = out_entry.destination.clone();
         let enc_ident = format_ident!("__enc{}", idx);
-        if leaf_is_prim(ext, leaf) {
+        if leaf_is_prim(ext, &crate::jni::compile::OutWire::from_leaf(leaf)) {
             let letter = jni_field_access(&wire)
                 .expect("leaf_is_prim guarantees a primitive wire")
                 .1;
@@ -1447,10 +1450,20 @@ pub(crate) fn encode_plan_leaves(
             })
             .collect();
         let ids: Vec<&syn::Ident> = idxs.iter().map(|&k| &obj_idents[k]).collect();
-        let tys = idxs.iter().map(|&k| leaf_slot(ext, &plan.leaves[k]).ty);
-        let defaults = idxs
-            .iter()
-            .map(|&k| leaf_slot(ext, &plan.leaves[k]).default);
+        let tys = idxs.iter().map(|&k| {
+            leaf_slot(
+                ext,
+                &crate::jni::compile::OutWire::from_leaf(&plan.leaves[k]),
+            )
+            .ty
+        });
+        let defaults = idxs.iter().map(|&k| {
+            leaf_slot(
+                ext,
+                &crate::jni::compile::OutWire::from_leaf(&plan.leaves[k]),
+            )
+            .default
+        });
         // Matched BY VALUE: the local is this arm's alone (every leaf under the
         // hoist is in it), so a consuming value form's fields move out here
         // exactly as they do at an unconditional one.
@@ -1469,10 +1482,7 @@ pub(crate) fn encode_plan_leaves(
 /// primitive JNI wire. Must agree with the descriptor chunk
 /// [`crate::jni::iface`] derives for the same leaf — a
 /// nullable primitive boxes (object chunk), object wires pass as objects.
-pub(crate) fn leaf_is_prim(
-    ext: &Declarations,
-    leaf: &prebindgen_registry::unfold::UnfoldLeaf,
-) -> bool {
+pub(crate) fn leaf_is_prim(ext: &Declarations, leaf: &crate::jni::compile::OutWire) -> bool {
     // The synthesized sum selector is a `jint` by definition — it is assigned,
     // never converted, so it has no output entry to read a wire from and must
     // not be made to depend on one resolving.
@@ -1481,7 +1491,7 @@ pub(crate) fn leaf_is_prim(
     // the absent case needs a representation the tag's own variants do not
     // provide. A raw `jint` has none — zero is a real variant — so the selector
     // boxes like any other nullable leaf and JVM null means "no value here".
-    if leaf.source == prebindgen_registry::unfold::LeafSource::SumTag {
+    if leaf.is_tag() {
         return !leaf.nullable;
     }
     if leaf.nullable {

--- a/prebindgen-jni/src/jni/emit/sum_out.rs
+++ b/prebindgen-jni/src/jni/emit/sum_out.rs
@@ -105,11 +105,7 @@ pub(crate) struct Slot {
     pub(crate) default: TokenStream,
 }
 
-pub(crate) fn leaf_slot(
-    ext: &Declarations,
-    leaf: &prebindgen_registry::unfold::UnfoldLeaf,
-) -> Slot {
-    use prebindgen_registry::unfold::LeafSource;
+pub(crate) fn leaf_slot(ext: &Declarations, leaf: &crate::jni::compile::OutWire) -> Slot {
     if !leaf_is_prim(ext, leaf) {
         return Slot {
             prim: false,
@@ -119,7 +115,7 @@ pub(crate) fn leaf_slot(
     }
     // The tag is synthesized, so it has no converter to read a wire from — it
     // is a `jint` by definition.
-    let (sig, letter) = if leaf.source == LeafSource::SumTag {
+    let (sig, letter) = if leaf.is_tag() {
         ("I", format_ident!("i"))
     } else {
         let wire = ext
@@ -165,20 +161,18 @@ pub(crate) fn is_sum_leaves(leaves: &[prebindgen_registry::unfold::UnfoldLeaf]) 
 pub(crate) fn encode_sum_group(
     ext: &Declarations,
     registry: &impl Conversions,
-    leaves: &[prebindgen_registry::unfold::UnfoldLeaf],
+    leaves: &[crate::jni::compile::OutWire],
     obj_idents: &[syn::Ident],
     matched: TokenStream,
     fail: &dyn Fn(TokenStream) -> TokenStream,
     emit: &prebindgen_registry::Emit,
 ) -> (TokenStream, Vec<TokenStream>) {
-    use prebindgen_registry::unfold::LeafSource;
-
     // Which sum this is comes from the selector leaf, not from the plan's
     // source: the plan's source is the *containing* value when the sum is a
     // field of a value form.
     let tag_leaf = leaves
         .iter()
-        .find(|l| l.source == LeafSource::SumTag)
+        .find(|l| l.is_tag())
         .expect("a sum segment carries its selector leaf");
     // The name off the reading — `TypeId` IS the name, so nothing takes a path
     // apart to re-derive one.
@@ -231,7 +225,7 @@ pub(crate) fn encode_sum_group(
     // its pattern binds them in.
     let tag_idx = leaves
         .iter()
-        .position(|l| l.source == LeafSource::SumTag)
+        .position(|l| l.is_tag())
         .expect("a sum plan carries its selector leaf");
     let tag_id = &obj_idents[tag_idx];
     // A unit variant contributes no leaf, so the arm list is driven by the
@@ -339,7 +333,7 @@ pub(crate) fn encode_sum_group(
 /// way.
 fn encode_group_leaf(
     ext: &Declarations,
-    leaf: &prebindgen_registry::unfold::UnfoldLeaf,
+    leaf: &crate::jni::compile::OutWire,
     obj_ident: &syn::Ident,
     prim: bool,
     bind: &syn::Ident,


### PR DESCRIPTION
The first step of stage 4's switch. `sum_out.rs` walked `UnfoldLeaf`s; it now walks `OutWire`s — the values a `sealed_class`'s deconstructing row states, composed in #489 — and the expansion plans that still feed it arrive through a shim.

Byte-identical: `examples/regen-check.sh` passes, 273 lib tests.

## Why a shim rather than the switch

What these emitters read of a leaf is **exactly** what a wire states: the name, the reading whose output conversion encodes it, the alternative it belongs to, whether it is the selector, and whether it may be absent. Nothing else. So the vocabulary can change ahead of the source, and a call site can be moved onto the composed row one at a time — with `OutWire::from_leaf` carrying the plan's leaves to the same code until it is.

Moving all five of `unfold`'s dependants at once would put the change and its blast radius in one diff, over emitters whose failure mode is generated Kotlin that compiles and misbehaves.

## What the wire had to gain

Nullability. A composition never produces a nullable value — a decomposition of its own is reached unconditionally — but a **splice** does: a value form reached through an `Option` puts everything under it in doubt. A sum's selector then boxes, because a raw `jint` has no spare value to mean absent when zero is a real alternative.

That fact belongs on the wire and not on the composer, which is why `Compile::choice` sets it false and the splicing site is what will set it true.

## One distinction deliberately dropped

An accessor chain and a field chain arrive as one thing. Where the Rust side reaches a value is the plan's business and nothing the sum emitters read, so the shim maps both to a field chain rather than inventing a wire form for a difference its readers cannot see.

## Where this was thought to be blocked

An earlier note on #472 claimed this stage waited on the declare/resolve ordering. It does not, and `registry/run.rs` is why: `apply_sum_returns` runs before `resolve` to **register** which output conversions the binding demands, and the plans it builds are only **read** at emission — which is after the rows are compiled. The note is corrected in the umbrella body.