### PR TITLE
One sum composition, on both sides of resolve (#472 §4d)

### DIFF
--- a/prebindgen-jni/src/jni/builder.rs
+++ b/prebindgen-jni/src/jni/builder.rs
@@ -1122,14 +1122,25 @@ impl Declarations {
                     else {
                         panic!("TypeKind::Sum implies a payload-carrying enum")
                     };
-                    let sum_cfg = self.types[&probe.key()]
-                        .sum()
-                        .expect("TypeKind::Sum implies a sealed-class config");
+                    // The declaration has to exist for the composition below
+                    // to name the alternatives' classes, and `TypeKind::Sum`
+                    // means it does — asserted here rather than trusted,
+                    // because the composition answers `None` for a missing one
+                    // and an empty leaf list would silently drop the field.
+                    assert!(
+                        self.types[&probe.key()].sum().is_some(),
+                        "TypeKind::Sum implies a sealed-class config",
+                    );
                     out.push(FieldRecord {
                         members: member_path,
                         name,
                         ty: field.ty.clone(),
-                        decon: FieldDecon::Leaves(crate::jni::synth_sum_leaves(self, sum_cfg, sum)),
+                        decon: FieldDecon::Leaves(crate::jni::synth_sum_leaves(
+                            self,
+                            registry,
+                            &id.ident().expect("a sum type is one identifier"),
+                            sum,
+                        )),
                     });
                     continue;
                 }

--- a/prebindgen-jni/src/jni/compile.rs
+++ b/prebindgen-jni/src/jni/compile.rs
@@ -1343,45 +1343,18 @@ impl<R: Conversions> JCompile<'_, R> {
         let TypeKind::Named { id, .. } = at.crossing.value().unwrapped().kind() else {
             return Err(refuse(at, "a choice row over a type that is not named"));
         };
-        let sum_cfg = id
+        let ident = id
             .ident()
-            .and_then(|ident| self.decls.types.get(&TypeKey::from_ident(&ident)))
-            .and_then(|cfg| cfg.sum())
+            .ok_or_else(|| refuse(at, "a choice row over a type that is not one identifier"))?;
+        // The composition is the declaration's and the model's, so the same
+        // answer serves the leaf synthesis that runs before `resolve`. The arm
+        // fragments the driver built are not read at all — a sum hands its
+        // payloads out through their own conversions, and which those are is
+        // the emitter's question rather than this row's.
+        let wires = self
+            .decls
+            .sum_out_wires(self.registry, &ident, at.crossing.value())
             .ok_or_else(|| refuse(at, "a choice row over an undeclared sum"))?;
-
-        // The selector rides ahead of the groups it chooses between, and
-        // carries **which sum** it selects over — nothing converts it, so
-        // naming the sum is the only use its type has, and it is the one an
-        // emitter needs to find the enum to match.
-        let mut wires = vec![OutWire {
-            name: crate::jni::emit::SUM_TAG_LEAF.to_string(),
-            out_ty: at.crossing.value().clone(),
-            group: None,
-            from: OutFrom::Tag,
-            nullable: false,
-        }];
-        for (alt, frag) in arms {
-            let kotlin = self.decls.sum_variant_class_name(sum_cfg, &alt.name);
-            let group = Some(crate::jni::struct_plan::sum_tag(alt));
-            for w in frag.out_wires.as_ref().into_iter().flatten() {
-                let OutFrom::Payload { member, .. } = &w.from else {
-                    return Err(refuse(
-                        at,
-                        "an arm that states something other than payloads",
-                    ));
-                };
-                wires.push(OutWire {
-                    name: crate::jni::struct_plan::sum_slot_fragment(&kotlin, &w.name),
-                    out_ty: w.out_ty.clone(),
-                    group,
-                    from: OutFrom::Payload {
-                        variant: Some(alt.name.clone()),
-                        member: member.clone(),
-                    },
-                    nullable: w.nullable,
-                });
-            }
-        }
         let mut frag = JFrag::new(at, self.parts_marker(parts_subs(arms)));
         frag.out_wires = Some(wires);
         frag.composed_only = true;
@@ -1579,6 +1552,63 @@ impl<R: Conversions> JCompile<'_, R> {
                 whole_gate: false,
             },
         ])
+    }
+}
+
+impl Declarations {
+    /// The values a `sealed_class` hands out: the selector, then one group of
+    /// slots per alternative, laid beside the others.
+    ///
+    /// Model and declaration only — no conversion is read. That is what lets
+    /// one answer serve on both sides of `resolve`: the leaf synthesis feeding
+    /// `Decompositions` runs before it, the row composes after it, and a fact
+    /// derived twice is a fact that can differ.
+    ///
+    /// `None` for a type the model does not hold as a data-carrying enum, or
+    /// one no `sealed_class!` declares — neither has a decomposition to state.
+    pub(crate) fn sum_out_wires(
+        &self,
+        registry: &impl Conversions,
+        ident: &syn::Ident,
+        sum_ty: &TypeRef,
+    ) -> Option<Vec<OutWire>> {
+        let prebindgen_registry::flat::Type::Variant(sum) = registry.flat().declared_type(ident)?
+        else {
+            return None;
+        };
+        let cfg = self.types.get(&TypeKey::from_ident(ident))?.sum()?;
+
+        // The selector rides ahead of the groups it chooses between, and
+        // carries **which sum** it selects over — nothing converts it, so
+        // naming the sum is the only use its type has, and it is the one an
+        // emitter needs: which enum to match over.
+        let mut wires = vec![OutWire {
+            name: crate::jni::emit::SUM_TAG_LEAF.to_string(),
+            out_ty: sum_ty.clone(),
+            group: None,
+            from: OutFrom::Tag,
+            nullable: false,
+        }];
+        for alt in &sum.alternatives {
+            let kotlin = self.sum_variant_class_name(cfg, &alt.name);
+            for field in &alt.fields {
+                let member = field.member();
+                wires.push(OutWire {
+                    name: crate::jni::struct_plan::sum_slot_fragment(
+                        &kotlin,
+                        &crate::jni::struct_plan::sum_field_prop_name(&member),
+                    ),
+                    out_ty: field.ty.clone(),
+                    group: Some(crate::jni::struct_plan::sum_tag(alt)),
+                    from: OutFrom::Payload {
+                        variant: Some(alt.name.clone()),
+                        member,
+                    },
+                    nullable: false,
+                });
+            }
+        }
+        Some(wires)
     }
 }
 

--- a/prebindgen-jni/src/jni/emit/sum_out.rs
+++ b/prebindgen-jni/src/jni/emit/sum_out.rs
@@ -25,68 +25,49 @@ use super::*;
 /// variant fragment from its property.
 pub(crate) const SUM_TAG_LEAF: &str = "tag";
 
-/// Synthesize the leaves of one `sealed_class`-declared sum: the
-/// [`LeafSource::SumTag`] selector followed by one
+/// The leaves of one `sealed_class`-declared sum, as the expansion plans want
+/// them: the [`LeafSource::SumTag`] selector followed by one
 /// [`LeafSource::VariantField`] leaf per payload field, in tag order, each
 /// carrying its variant's tag as its [`group`](UnfoldLeaf::group).
 ///
-/// Runs BEFORE `resolve` (like
-/// [`synth_value_struct_leaves`](super::synth_value_struct_leaves)), so it may
-/// only read the declaration (`sum_cfg`) and the enum's syntax — never the
-/// converter tables. Every payload's own `out_ty` is registered as a required
-/// output by the core wiring, so a payload that cannot cross fails naming
-/// itself.
-///
-/// Slot names come from the same [`sum_slot_fragment`] / [`sum_field_prop_name`]
-/// pair the sealed-interface emitter and the struct-field bridge use, so a
-/// `variant!(V).name(...)` rename carries through to the builder's parameter
-/// names too.
+/// The list is `Declarations::sum_out_wires`', mapped. Runs BEFORE `resolve`,
+/// which is exactly why it shares that composition rather than walking the
+/// enum a second time: a `variant!(V).name(..)` rename and the slot naming have
+/// to reach the builder's parameter names and the row identically, and two
+/// walks agreeing was a property nothing checked.
 pub(crate) fn synth_sum_leaves(
     ext: &Declarations,
-    sum_cfg: &SumConfig,
+    registry: &impl Conversions,
+    ident: &syn::Ident,
     sum: &prebindgen_registry::flat::Variant,
 ) -> Vec<prebindgen_registry::unfold::UnfoldLeaf> {
     use prebindgen_registry::unfold::{LeafSource, UnfoldLeaf};
-
-    // The selector rides ahead of the groups it chooses between, and carries
-    // **which sum** it selects over as its `out_ty` — that is how the emitter
-    // finds the enum to `match` when the sum is a field rather than the whole
-    // returned value. Nothing looks up a converter for it (`has_converter()` is
-    // false for a `SumTag`): there is no value to convert, the emitter assigns
-    // the tag literal per arm. Its wire is a `jint` by definition.
-    let mut leaves = vec![UnfoldLeaf {
-        name: SUM_TAG_LEAF.to_string(),
-        path: Vec::new(),
-        // The tag names WHICH sum it selects over, and no source wrote that as
-        // a standalone type — so the DECLARATION answers, rather than this
-        // emitter minting a reading from the name. Nothing resolves a converter
-        // for it (`has_converter()` is false), but the emitter reads it back to
-        // find the enum to `match`.
-        out_ty: sum.type_ref().clone(),
-        identity: false,
-        nullable: false,
-        source: LeafSource::SumTag,
-        group: None,
-    }];
-    for alt in &sum.alternatives {
-        let kotlin_name = ext.sum_variant_class_name(sum_cfg, &alt.name);
-        for field in &alt.fields {
-            let prop = sum_field_prop_name(&field.member());
-            leaves.push(UnfoldLeaf {
-                name: sum_slot_fragment(&kotlin_name, &prop),
-                path: Vec::new(),
-                out_ty: field.ty.clone(),
-                identity: false,
-                nullable: false,
-                source: LeafSource::VariantField {
-                    variant: alt.name.clone(),
-                    member: field.member(),
-                },
-                group: Some(sum_tag(alt)),
-            });
-        }
-    }
-    leaves
+    ext.sum_out_wires(registry, ident, sum.type_ref())
+        .unwrap_or_default()
+        .into_iter()
+        .map(|w| UnfoldLeaf {
+            name: w.name,
+            path: Vec::new(),
+            out_ty: w.out_ty,
+            identity: false,
+            nullable: w.nullable,
+            source: match w.from {
+                // Nothing looks up a converter for the selector
+                // (`has_converter()` is false for a `SumTag`): there is no
+                // value to convert, the emitter assigns the tag literal per
+                // arm. Its wire is a `jint` by definition.
+                crate::jni::compile::OutFrom::Tag => LeafSource::SumTag,
+                crate::jni::compile::OutFrom::Payload { variant, member } => {
+                    LeafSource::VariantField {
+                        variant: variant.expect("a composed payload names its alternative"),
+                        member,
+                    }
+                }
+                crate::jni::compile::OutFrom::Field { .. } => LeafSource::Field,
+            },
+            group: w.group,
+        })
+        .collect()
 }
 
 /// The wire slot one leaf occupies when its value is only computed in SOME arm

--- a/prebindgen-jni/src/jni/mod.rs
+++ b/prebindgen-jni/src/jni/mod.rs
@@ -568,10 +568,9 @@ impl JniGen {
     pub(crate) fn walk_lines_for_test(&self, short: &str) -> Option<Vec<String>> {
         use prebindgen_registry::unfold::{LeafSource, PathStep};
         let ident = syn::Ident::new(short, proc_macro2::Span::call_site());
-        let cfg = self.decls.types.get(&TypeKey::from_ident(&ident))?;
         let leaves = match self.registry.flat().declared_type(&ident)? {
             prebindgen_registry::flat::Type::Variant(sum) => {
-                crate::jni::synth_sum_leaves(&self.decls, cfg.sum()?, sum)
+                crate::jni::synth_sum_leaves(&self.decls, &self.registry, &ident, sum)
             }
             prebindgen_registry::flat::Type::Struct(s) => {
                 crate::jni::synth_value_struct_leaves(&self.decls, &self.registry, s, &[], "", 0)?

--- a/prebindgen-jni/src/jni/trait_impl.rs
+++ b/prebindgen-jni/src/jni/trait_impl.rs
@@ -1816,9 +1816,9 @@ impl Declarations {
         keys.sort_by(|a, b| a.as_str().cmp(b.as_str()));
         let mut out = Vec::new();
         for key in keys {
-            let Some(sum_cfg) = self.types[key].sum() else {
+            if self.types[key].sum().is_none() {
                 continue;
-            };
+            }
             // The `sealed_class!` declaration's own IDENTITY. This runs during
             // the declare phase, where a `reading()` would legitimately answer
             // `None` for a type nothing has interned yet — the declaration is
@@ -1839,7 +1839,7 @@ impl Declarations {
                 // `Variant::type_ref` exists for exactly this, and it works in
                 // the declare phase where a `reading()` lookup could not.
                 source: sum.type_ref().clone(),
-                leaves: crate::jni::synth_sum_leaves(self, sum_cfg, sum),
+                leaves: crate::jni::synth_sum_leaves(self, registry, &ident, sum),
             });
         }
         out


### PR DESCRIPTION
Follows #492, which put the sum emitters on the row's vocabulary. This makes the row and the pre-`resolve` leaf synthesis **one composition** rather than two walks that agreed.

Byte-identical: `examples/regen-check.sh` passes, 273 lib tests.

## The two-answers problem

`synth_sum_leaves` walked a `sealed_class`'s alternatives to build the `UnfoldLeaf`s the expansion plans want. `Compile::choice` walked the same alternatives to compose the row. Both derive the same facts — the slot names, the tag order, which alternative each payload belongs to — and a `variant!(V).name(..)` rename has to reach the builder's parameter names and the row identically.

Two walks agreeing about that was a property nothing checked. #489's equivalence fixture checked it for one fixture, which is not the same claim.

`Declarations::sum_out_wires` is now the single statement, and `synth_sum_leaves` maps it. The fixture now asserts a tautology, deliberately: it is what catches the two coming apart again if anyone reintroduces a second walk.

## Why sharing is possible at all

The composition reads **no conversions** — only the model and the declaration. That is what lets one answer serve on both sides of `resolve`: before it, where no conversion exists yet, and after it, where the driver has built every part's fragment.

`Compile::choice` ignores the arm fragments the driver hands it for exactly that reason. A sum hands its payloads out through their own conversions, and which those are is the emitter's question rather than the row's — the row says *which* values cross and in what order, never how.

That property is also the answer to the ordering question the umbrella body raised: a composition that reads nothing conversion-shaped is not trapped on either side of `resolve`.