### PR TITLE
One data-class composition, on both sides of resolve (#472 §4d)

### DIFF
--- a/prebindgen-jni/src/jni/compile.rs
+++ b/prebindgen-jni/src/jni/compile.rs
@@ -1197,85 +1197,28 @@ impl<R: Conversions> JCompile<'_, R> {
         frag
     }
 
-    /// The values a `data_class` hands out: its fields, and a field that is
-    /// itself one contributes its own.
+    /// The values a `data_class` hands out, composed by
+    /// [`Declarations::struct_out_wires`].
     ///
-    /// A fragment with **no** out-wires is this adapter declining, and it
-    /// declines for the whole value rather than per field. A handle, an
-    /// `enum_class`, a sum or a `data_class` behind an `Option` or a `Vec` is
-    /// delivered with a transform the decoupled form does not carry, and one
-    /// such field sends the whole object down the whole-value `fromParts` path
-    /// — so a row that decomposed the rest of it would describe a shape nothing
-    /// emits.
+    /// The part fragments are not read. Whether a field nests is the model's
+    /// answer and the declaration's, which is what lets the same composition
+    /// run before `resolve` — see that method for why that matters.
     fn out_product(&self, at: At<'_>, parts: Parts<'_, Self>) -> JFrag {
-        let declined = JFrag::new(at, self.parts_marker(Vec::new()));
-        let mut wires = Vec::new();
-        for (part, frag) in parts {
-            let Some(field) = part_field(part) else {
-                return declined;
-            };
-            let ident = match &field.name {
-                Some(name) => name.clone(),
-                None => return declined,
-            };
-            // The same name the leaf synthesis gives it: the Kotlin property,
-            // and nested names joined by the reserved `__` separator.
-            let name =
-                crate::jni::mangle_kotlin_ident(&crate::jni::kt_snake_to_camel(&ident.to_string()));
-            // The layer questions off the field's own reading — `Optional` to
-            // look through, `Vec` to decline — never a last path segment.
-            let probe = part.ty.optional_inner().unwrap_or(&part.ty);
-            if matches!(
-                self.decls.type_kind(self.registry, &probe.key()),
-                crate::jni::classify::TypeKind::Handle
-                    | crate::jni::classify::TypeKind::Enum
-                    | crate::jni::classify::TypeKind::Sum
-            ) {
-                return declined;
+        match self
+            .decls
+            .struct_out_wires(self.registry, at.crossing.value())
+        {
+            Some(wires) => {
+                let mut frag = JFrag::new(
+                    at,
+                    self.parts_marker(parts.iter().map(|(p, _)| p.ty.key()).collect()),
+                );
+                frag.out_wires = Some(wires);
+                frag.composed_only = true;
+                frag
             }
-            match &frag.out_wires {
-                // A nested `data_class`, which contributes its own values under
-                // this field's name and chain. Only unwrapped: behind an
-                // `Option` or a `Vec` there is no chain to reach through.
-                Some(inner) => {
-                    if part.ty.optional_inner().is_some()
-                        || matches!(part.ty.kind(), TypeKind::Vec(_))
-                    {
-                        return declined;
-                    }
-                    for w in inner {
-                        let OutFrom::Field { path } = &w.from else {
-                            return declined;
-                        };
-                        wires.push(OutWire {
-                            name: format!("{name}__{}", w.name),
-                            out_ty: w.out_ty.clone(),
-                            group: None,
-                            from: OutFrom::Field {
-                                path: std::iter::once(ident.clone())
-                                    .chain(path.iter().cloned())
-                                    .collect(),
-                            },
-                            nullable: false,
-                        });
-                    }
-                }
-                None => wires.push(OutWire {
-                    name,
-                    out_ty: part.ty.clone(),
-                    group: None,
-                    from: OutFrom::Field { path: vec![ident] },
-                    nullable: false,
-                }),
-            }
+            None => JFrag::new(at, self.parts_marker(Vec::new())),
         }
-        let mut frag = JFrag::new(
-            at,
-            self.parts_marker(parts.iter().map(|(p, _)| p.ty.key()).collect()),
-        );
-        frag.out_wires = Some(wires);
-        frag.composed_only = true;
-        frag
     }
 
     /// The values a **value form** hands out: call the accessor once, then read
@@ -1556,6 +1499,123 @@ impl<R: Conversions> JCompile<'_, R> {
 }
 
 impl Declarations {
+    /// The values a `data_class` hands out: its fields, and a field that is
+    /// itself one contributes its own under the parent's name and chain.
+    ///
+    /// Model and declaration only, like [`Self::sum_out_wires`] — so the same
+    /// answer serves the leaf synthesis that runs before `resolve` and the row
+    /// that composes after it.
+    ///
+    /// `None` is this adapter declining, and it declines for the **whole**
+    /// value rather than per field. A handle, an `enum_class`, a sum, or a
+    /// `data_class` behind an `Option` or a `Vec` is delivered with a transform
+    /// the decoupled form does not carry, and one such field sends the whole
+    /// object down the whole-value `fromParts` path — so a row that decomposed
+    /// the rest of it would describe a shape nothing emits.
+    pub(crate) fn struct_out_wires(
+        &self,
+        registry: &impl Conversions,
+        ty: &TypeRef,
+    ) -> Option<Vec<OutWire>> {
+        let TypeKind::Named { id, .. } = ty.unwrapped().kind() else {
+            return None;
+        };
+        self.struct_out_wires_at(registry, &id.ident()?, &[], "", 0)
+    }
+
+    /// One level of [`Self::struct_out_wires`]'s walk. `path` and `name_prefix`
+    /// accumulate through inlined nested classes, whose names join with the
+    /// reserved `__` separator.
+    /// [`Self::struct_out_wires`] by the struct's own name, for a caller that
+    /// has the element rather than a reading of it.
+    pub(crate) fn struct_out_wires_of(
+        &self,
+        registry: &impl Conversions,
+        ident: &syn::Ident,
+    ) -> Option<Vec<OutWire>> {
+        self.struct_out_wires_at(registry, ident, &[], "", 0)
+    }
+
+    fn struct_out_wires_at(
+        &self,
+        registry: &impl Conversions,
+        ident: &syn::Ident,
+        path: &[syn::Ident],
+        name_prefix: &str,
+        depth: usize,
+    ) -> Option<Vec<OutWire>> {
+        if depth > 16 {
+            return None;
+        }
+        let prebindgen_registry::flat::Type::Struct(st) = registry.flat().declared_type(ident)?
+        else {
+            return None;
+        };
+        let mut wires = Vec::new();
+        for field in &st.fields {
+            // Named by construction — a tuple struct is an `Extern`, not a
+            // `Struct` — so a positional field means the model and this walk
+            // disagree, and declining is the safe answer.
+            let fname = field.name.as_ref()?;
+            let name =
+                crate::jni::mangle_kotlin_ident(&crate::jni::kt_snake_to_camel(&fname.to_string()));
+            let name = match name_prefix.is_empty() {
+                true => name,
+                false => format!("{name_prefix}__{name}"),
+            };
+            let mut field_path = path.to_vec();
+            field_path.push(fname.clone());
+
+            // The layer questions off the field's own reading — `Optional` to
+            // look through, `Vec` to decline — never a last path segment.
+            let probe = field.ty.optional_inner().unwrap_or(&field.ty);
+            match self.type_kind(registry, &probe.key()) {
+                crate::jni::classify::TypeKind::Handle
+                | crate::jni::classify::TypeKind::Enum
+                | crate::jni::classify::TypeKind::Sum => return None,
+                // A nested `data_class` inlines when it is reached directly.
+                // Behind an `Option` or a `Vec` there is no chain to reach
+                // through, so the whole value stays object-shaped.
+                crate::jni::classify::TypeKind::DataStruct {
+                    st: _,
+                    cfg: Some(_),
+                } => {
+                    if field.ty.optional_inner().is_some()
+                        || matches!(field.ty.kind(), TypeKind::Vec(_))
+                    {
+                        return None;
+                    }
+                    let child = match probe.unwrapped().kind() {
+                        TypeKind::Named { id, .. } => id.ident()?,
+                        _ => return None,
+                    };
+                    wires.extend(self.struct_out_wires_at(
+                        registry,
+                        &child,
+                        &field_path,
+                        &name,
+                        depth + 1,
+                    )?);
+                    continue;
+                }
+                _ => {}
+            }
+
+            // A simple value: the field's own output conversion encodes it, and
+            // the foreign `fromParts` forwards it verbatim. Nullability rides
+            // that conversion — `Option<Box<String>>` is a `String?` — so the
+            // value itself is not path-nullable.
+            wires.push(OutWire {
+                name,
+                out_ty: field.ty.clone(),
+                group: None,
+                from: OutFrom::Field { path: field_path },
+                nullable: false,
+            });
+        }
+        Some(wires)
+    }
+
     /// The values a `sealed_class` hands out: the selector, then one group of
     /// slots per alternative, laid beside the others.
     ///

--- a/prebindgen-jni/src/jni/emit/struct_out.rs
+++ b/prebindgen-jni/src/jni/emit/struct_out.rs
@@ -64,100 +64,50 @@ pub(crate) fn primitive_default_for_descriptor(sig: &str) -> TokenStream {
     }
 }
 
-/// Synthesize the [`LeafSource::Field`](prebindgen_registry::unfold::LeafSource)
-/// leaves of a by-value `data_class` for the fixed-builder output/callback path
-/// — the pre-resolve analog of [`flatten_struct_encode`] (which runs at emit
-/// time). Each named field becomes one field-access leaf
-/// (`name`, `path = [..field idents]`, `out_ty = <field type>`); a non-optional
-/// nested data-class field recurses (inlined), so the whole graph crosses as
-/// decoupled leaves the foreign side reassembles.
+/// The [`LeafSource::Field`](prebindgen_registry::unfold::LeafSource) leaves of
+/// a by-value `data_class`, as the fixed-builder output and callback paths want
+/// them.
 ///
-/// Returns `None` (⇒ the type keeps the whole-value `fromParts` path) when a
-/// field needs a transform this fixed builder can't yet forward verbatim — a
-/// **projection** (opaque handle), an **enum**, or a nested
-/// data-class behind `Option` / `Vec`. (Those are handled by the slower
-/// [`struct_output_body`] until the synthesizer is widened to wrap them.)
+/// The list is [`Declarations::struct_out_wires`]', mapped. Runs BEFORE
+/// `resolve`, which is exactly why it shares that composition rather than
+/// walking the struct a second time: the leaf names reach the foreign
+/// `fromParts` parameters and the row identically, and two walks agreeing was a
+/// property nothing checked.
 ///
-/// Classification reads only `ext.types` (`opaque`/`enum_cfg`) and the parsed
-/// model (`registry.flat()`) — both populated before `resolve` — never the
-/// output converter table (not yet built at this stage).
+/// `None` — the type keeps the whole-value `fromParts` path — when a field needs
+/// a transform this fixed builder cannot forward verbatim. See
+/// [`Declarations::struct_out_wires`] for which fields those are and why one of
+/// them declines the whole value.
 pub(crate) fn synth_value_struct_leaves(
     ext: &Declarations,
     registry: &impl Conversions,
     s: &prebindgen_registry::flat::Struct,
-    path_prefix: &[prebindgen_registry::unfold::PathStep],
-    name_prefix: &str,
-    depth: usize,
 ) -> Option<Vec<prebindgen_registry::unfold::UnfoldLeaf>> {
     use prebindgen_registry::unfold::{LeafSource, PathStep, UnfoldLeaf};
-    if depth > 16 {
-        return None;
-    }
-    // Named by construction — a tuple struct is an `Extern`, not a `Struct`.
-    let mut leaves: Vec<UnfoldLeaf> = Vec::new();
-    for field in &s.fields {
-        let fname = field.name.as_ref()?.clone();
-        let camel = mangle_kotlin_ident(&kt_snake_to_camel(&fname.to_string()));
-        let leaf_name = if name_prefix.is_empty() {
-            camel
-        } else {
-            format!("{name_prefix}__{camel}")
-        };
-        let mut path = path_prefix.to_vec();
-        // The synthesizer declines `Option`-wrapped nesting below, so an
-        // intermediate step is never optional; a TERMINAL `Option` field is not
-        // a nesting step either (its own converter carries the nullability).
-        path.push(PathStep::field(fname, false));
-
-        // A projection field (opaque handle) or an enum field
-        // is delivered with a transform the fixed builder can't forward yet.
-        // A nested data-class field (a *declared* plain struct) inlines when
-        // non-optional (recurse); `Option`/`Vec`-wrapped nesting is deferred
-        // to the whole-value path.
-        // Both layer questions off the field's own reading: `Optional` to look
-        // through, `Vec` to defer — the kinds, not a last path segment.
-        let probe = field.ty.optional_inner().unwrap_or(&field.ty);
-        let nested = match ext.type_kind(registry, &probe.key()) {
-            // A sum joins the kinds this fixed builder cannot forward: it has
-            // no single leaf and no converter of its own — it crosses as a tag
-            // plus one group per variant, which only the whole-value
-            // `fromParts` path (`PlanFieldKind::Sum`) can lay out. Falling
-            // through to the simple-leaf arm below would silently synthesize a
-            // leaf whose `out_ty` is the sum and then REQUIRE an output
-            // converter for it, failing the resolve with the sum named rather
-            // than the unsupported position.
-            TypeKind::Handle | TypeKind::Enum | TypeKind::Sum => return None,
-            TypeKind::DataStruct { st, cfg: Some(_) } => Some(st.clone()),
-            _ => None,
-        };
-        if let Some(child) = nested {
-            if field.ty.optional_inner().is_some()
-                || matches!(field.ty.kind(), prebindgen_registry::flat::TypeKind::Vec(_))
-            {
-                return None;
-            }
-            let child_leaves =
-                synth_value_struct_leaves(ext, registry, &child, &path, &leaf_name, depth + 1)?;
-            leaves.extend(child_leaves);
-            continue;
-        }
-
-        // Simple leaf: scalar / String / Option<Box<String>> / ByteArray / Vec.
-        // The field's own output converter (resolved later) encodes it; the
-        // foreign `fromParts` forwards it verbatim. Nullability is carried by
-        // the converter (e.g. `Option<Box<String>>` → `String?`), so the leaf
-        // itself isn't path-nullable.
-        leaves.push(UnfoldLeaf {
-            name: leaf_name,
-            path,
-            out_ty: field.ty.clone(),
-            identity: false,
-            nullable: false,
-            source: LeafSource::Field,
-            group: None,
-        });
-    }
-    Some(leaves)
+    Some(
+        ext.struct_out_wires_of(registry, &s.name)?
+            .into_iter()
+            .map(|w| UnfoldLeaf {
+                name: w.name,
+                // The synthesizer declines `Option`-wrapped nesting, so an
+                // intermediate step is never optional; a TERMINAL `Option`
+                // field is not a nesting step either, its own converter
+                // carrying the nullability.
+                path: match w.from {
+                    crate::jni::compile::OutFrom::Field { path } => path
+                        .into_iter()
+                        .map(|ident| PathStep::field(ident, false))
+                        .collect(),
+                    _ => Vec::new(),
+                },
+                out_ty: w.out_ty,
+                identity: false,
+                nullable: w.nullable,
+                source: LeafSource::Field,
+                group: w.group,
+            })
+            .collect(),
+    )
 }
 
 /// Recursively flatten a struct's output encode into a list of leaf wire

--- a/prebindgen-jni/src/jni/mod.rs
+++ b/prebindgen-jni/src/jni/mod.rs
@@ -573,7 +573,7 @@ impl JniGen {
                 crate::jni::synth_sum_leaves(&self.decls, &self.registry, &ident, sum)
             }
             prebindgen_registry::flat::Type::Struct(s) => {
-                crate::jni::synth_value_struct_leaves(&self.decls, &self.registry, s, &[], "", 0)?
+                crate::jni::synth_value_struct_leaves(&self.decls, &self.registry, s)?
             }
             _ => return None,
         };

--- a/prebindgen-jni/src/jni/trait_impl.rs
+++ b/prebindgen-jni/src/jni/trait_impl.rs
@@ -1793,8 +1793,7 @@ impl Declarations {
             if !is_data_class {
                 continue;
             }
-            if let Some(leaves) =
-                crate::jni::synth_value_struct_leaves(self, registry, item_struct, &[], "", 0)
+            if let Some(leaves) = crate::jni::synth_value_struct_leaves(self, registry, item_struct)
             {
                 if !leaves.is_empty() {
                     out.push(prebindgen_registry::unfold::ValueDecon {


### PR DESCRIPTION
The same move #493 made for a `sealed_class`, for the other pre-`resolve` synthesis.

`Declarations::struct_out_wires` is the single statement of what a `data_class` hands out — its fields, and a field that is itself one contributing its own under the parent's name and chain — and `synth_value_struct_leaves` maps it into the `UnfoldLeaf`s the fixed-builder output and callback paths want.

Byte-identical: `examples/regen-check.sh` passes, 273 lib tests.

## Why this one shares too

The composition reads no conversions, only the model and the declaration. `Compile::fields` was already reading its part fragments for exactly one thing — whether a field nests — and that is the model's answer, so nothing is lost by not being handed them.

## The refusal rule, stated once

A handle, an `enum_class`, a sum, or a `data_class` behind an `Option` or a `Vec` is delivered with a transform the decoupled form does not carry, and one such field sends the **whole** object down the whole-value `fromParts` path. Both readers now get that from one place, rather than from a comment in one of them saying the other follows the same rule.

That comment was accurate. It was also the only thing keeping the two in step.