### PR TITLE
The interface and Kotlin emitters speak the row's vocabulary (#472 §4d)

### DIFF
--- a/prebindgen-jni/src/jni/compile.rs
+++ b/prebindgen-jni/src/jni/compile.rs
@@ -260,6 +260,11 @@ impl OutWire {
         }
     }
 
+    /// A whole plan's leaves in the row's vocabulary.
+    pub(crate) fn from_leaves(leaves: &[prebindgen_registry::unfold::UnfoldLeaf]) -> Vec<Self> {
+        leaves.iter().map(Self::from_leaf).collect()
+    }
+
     /// Whether this value is the synthesized selector.
     pub(crate) fn is_tag(&self) -> bool {
         matches!(self.from, OutFrom::Tag)

--- a/prebindgen-jni/src/jni/iface.rs
+++ b/prebindgen-jni/src/jni/iface.rs
@@ -890,7 +890,7 @@ fn subject_package(ext: &Declarations, subject: &prebindgen_registry::flat::Type
 /// [`plan_leaf_names`], typed + raw views per leaf.
 fn plan_leaf_params(
     ext: &Declarations,
-    leaves: &[prebindgen_registry::unfold::UnfoldLeaf],
+    leaves: &[crate::jni::compile::OutWire],
 ) -> Option<Vec<IfaceParam>> {
     // Decomposition leaf names are author-supplied, literal, and unique by
     // construction (enforced in `core::unfold`) — no dedup/casing here.
@@ -910,14 +910,13 @@ fn plan_leaf_params(
 fn plan_leaf_param(
     ext: &Declarations,
     name: String,
-    leaf: &prebindgen_registry::unfold::UnfoldLeaf,
+    leaf: &crate::jni::compile::OutWire,
 ) -> Option<IfaceParam> {
-    use prebindgen_registry::unfold::LeafSource;
     // The sum selector has no converter behind it — it is a plain `Int` the
     // emitter assigns per `match` arm. Nullable when the sum sits under a
     // conditional value form: null is the absent case, which the tag's own
     // variants cannot express.
-    if leaf.source == LeafSource::SumTag {
+    if leaf.is_tag() {
         let ty = KtType::int();
         let ty = if leaf.nullable { ty.nullable() } else { ty };
         return Some(IfaceParam::same(name, ty));
@@ -1325,9 +1324,10 @@ fn fixed_reassembly(
             Vec::new(),
         );
     }
-    let params = plan_leaf_params(ext, leaves).unwrap_or_default();
+    let wires = crate::jni::compile::OutWire::from_leaves(leaves);
+    let params = plan_leaf_params(ext, &wires).unwrap_or_default();
     let mut imports: BTreeSet<String> = BTreeSet::new();
-    let (_, when) = ext.sum_reconstruct(registry, source, leaves, &params, &slots, &mut imports);
+    let (_, when) = ext.sum_reconstruct(registry, source, &wires, &params, &slots, &mut imports);
     (when, imports.into_iter().collect())
 }
 
@@ -1397,7 +1397,8 @@ pub(crate) fn callback_iface_spec(
             .get(&t.key())
             .filter(|p| !super::render::is_iterable_fold(&p.shape));
         if let Some(plan) = plan {
-            let leaf_names = plan_leaf_names(&plan.leaves);
+            let leaf_names =
+                plan_leaf_names(&crate::jni::compile::OutWire::from_leaves(&plan.leaves));
             for (n, l) in leaf_names.iter().zip(plan.leaves.iter()) {
                 leaf_tys.push(LeafDesc::Plan(n.clone(), l.clone()));
             }
@@ -1516,7 +1517,9 @@ pub(crate) fn callback_iface_spec(
     for (k, desc) in leaf_tys.iter().enumerate() {
         let name = names[k].clone();
         let param = match desc {
-            LeafDesc::Plan(_, leaf) => plan_leaf_param(ext, name, leaf)?,
+            LeafDesc::Plan(_, leaf) => {
+                plan_leaf_param(ext, name, &crate::jni::compile::OutWire::from_leaf(leaf))?
+            }
             LeafDesc::Whole {
                 ty,
                 nullable,
@@ -1587,7 +1590,10 @@ pub(crate) fn builder_iface_spec(
     decon: &DeconId,
 ) -> Option<IfaceSpec> {
     let spec = registry.decon_plans().get(decon)?;
-    let params = plan_leaf_params(ext, &spec.leaves)?;
+    let params = plan_leaf_params(
+        ext,
+        &crate::jni::compile::OutWire::from_leaves(&spec.leaves),
+    )?;
     let name = format!(
         "{}Builder",
         decon_base_name(&subject_short(&spec.source), Some(decon))
@@ -1614,7 +1620,10 @@ pub(crate) fn folder_iface_spec(
 ) -> Option<IfaceSpec> {
     let spec = registry.decon_plans().get(decon)?;
     let mut params: Vec<IfaceParam> = vec![IfaceParam::same("acc".to_string(), KtType::var_("A"))];
-    params.extend(plan_leaf_params(ext, &spec.leaves)?);
+    params.extend(plan_leaf_params(
+        ext,
+        &crate::jni::compile::OutWire::from_leaves(&spec.leaves),
+    )?);
     let name = format!(
         "{}Folder",
         decon_base_name(&subject_short(&spec.source), Some(decon))
@@ -1746,7 +1755,10 @@ pub(crate) fn error_handler_iface_spec(
     decon: &DeconId,
 ) -> Option<IfaceSpec> {
     let spec = registry.decon_plans().get(decon)?;
-    let params: Vec<IfaceParam> = plan_leaf_params(ext, &spec.leaves)?;
+    let params: Vec<IfaceParam> = plan_leaf_params(
+        ext,
+        &crate::jni::compile::OutWire::from_leaves(&spec.leaves),
+    )?;
     let name = format!(
         "{}Handler",
         decon_base_name(&subject_short(&spec.source), Some(decon))

--- a/prebindgen-jni/src/jni/kotlin_emit.rs
+++ b/prebindgen-jni/src/jni/kotlin_emit.rs
@@ -1479,7 +1479,7 @@ impl Declarations {
         let (iface_short, when) = self.sum_reconstruct(
             registry,
             &plan.source.key(),
-            &plan.leaves,
+            &crate::jni::compile::OutWire::from_leaves(&plan.leaves),
             &spec.params,
             &names,
             &mut imports,
@@ -1522,7 +1522,7 @@ impl Declarations {
         let (iface_short, when) = self.sum_reconstruct(
             registry,
             &plan.source.key(),
-            &plan.leaves,
+            &crate::jni::compile::OutWire::from_leaves(&plan.leaves),
             &spec.params[1..],
             &names[1..],
             &mut imports,
@@ -1565,7 +1565,7 @@ impl Declarations {
         // `TypeKey::from_type` or `bare_path_ident`, and a key that is one
         // identifier IS the ident — the same reduction `type_kind` made.
         key: &TypeKey,
-        leaves: &[prebindgen_registry::unfold::UnfoldLeaf],
+        leaves: &[crate::jni::compile::OutWire],
         params: &[crate::jni::IfaceParam],
         names: &[String],
         imports: &mut BTreeSet<String>,
@@ -1640,7 +1640,7 @@ impl Declarations {
     /// `!!` would turn a legitimately absent value into an exception.
     fn sum_ctor_arg(
         &self,
-        leaf: &prebindgen_registry::unfold::UnfoldLeaf,
+        leaf: &crate::jni::compile::OutWire,
         param: &crate::jni::IfaceParam,
         name: &str,
         imports: &mut BTreeSet<String>,

--- a/prebindgen-jni/src/jni/render.rs
+++ b/prebindgen-jni/src/jni/render.rs
@@ -2209,7 +2209,7 @@ pub(crate) fn unfold_leaf_kt(
 /// `core::unfold`).
 ///
 /// [`UnfoldLeaf::name`]: prebindgen_registry::unfold::UnfoldLeaf::name
-pub(crate) fn plan_leaf_names(leaves: &[prebindgen_registry::unfold::UnfoldLeaf]) -> Vec<String> {
+pub(crate) fn plan_leaf_names(leaves: &[crate::jni::compile::OutWire]) -> Vec<String> {
     leaves.iter().map(|leaf| leaf.name.clone()).collect()
 }
 


### PR DESCRIPTION
The same move #492 made for `sum_out.rs`, for the two emitters that decide what a delivered value looks like on the JVM side.

- `plan_leaf_param` classifies **one delivered value** for every builder, folder, handler and callback signature — it is the single entry point that keeps those four agreeing about the selector slot and the inert-group nullability rule.
- `sum_reconstruct` writes the `when` that rebuilds a sealed class from its selector and its slots.

Both now take `OutWire`s; the expansion plans that still feed them arrive through `OutWire::from_leaves`.

Byte-identical: `examples/regen-check.sh` passes, 273 lib tests.

## Why they move without their source moving

They read only what a wire states. `plan_leaf_param` asks whether a value is the selector, whether it may be absent, and which alternative it belongs to. `sum_reconstruct` asks those three and the reading whose conversion encodes the value.

Nothing about *where the Rust side reaches it* — the accessor chain, the hoist, the rebase — reaches either of them. That is `delivery.rs`'s business and it is what remains.

After this, `UnfoldLeaf` survives in `prebindgen-jni` at 18 mentions: six in `sum_out.rs` and five in `delivery.rs` are the encode side, three in `struct_out.rs` are its own synthesis, and the four in `render.rs` and `iface.rs` are doc links and one enum payload.