### PR TITLE
Ask whether a decomposition is a sum of the row (#472 §4d)

### DIFF
--- a/prebindgen-jni/src/jni/emit/sum_out.rs
+++ b/prebindgen-jni/src/jni/emit/sum_out.rs
@@ -116,11 +116,11 @@ pub(crate) fn leaf_slot(ext: &Declarations, leaf: &crate::jni::compile::OutWire)
     }
 }
 
-/// True when `plan` decomposes a sum — it carries the synthesized selector.
-/// The one place that question is asked, so every consumer agrees on it.
-pub(crate) fn is_sum_leaves(leaves: &[prebindgen_registry::unfold::UnfoldLeaf]) -> bool {
-    use prebindgen_registry::unfold::LeafSource;
-    leaves.iter().any(|l| l.source == LeafSource::SumTag)
+/// True when these values decompose a sum — they carry the synthesized
+/// selector. The one place that question is asked, so every consumer agrees on
+/// it.
+pub(crate) fn is_sum_row(leaves: &[crate::jni::compile::OutWire]) -> bool {
+    leaves.iter().any(|l| l.is_tag())
 }
 
 /// Emit the Rust-side encode of a decomposed sum: ONE `match` over the value

--- a/prebindgen-jni/src/jni/iface.rs
+++ b/prebindgen-jni/src/jni/iface.rs
@@ -1317,14 +1317,14 @@ fn fixed_reassembly(
     class_fqn: &str,
 ) -> (String, Vec<String>) {
     let slots: Vec<String> = (0..leaves.len()).map(|i| format!("${i}")).collect();
-    if !is_sum_leaves(leaves) {
+    let wires = crate::jni::compile::OutWire::from_leaves(leaves);
+    if !is_sum_row(&wires) {
         let class_short = class_fqn.rsplit('.').next().unwrap_or(class_fqn);
         return (
             format!("{class_short}.fromParts({})", slots.join(", ")),
             Vec::new(),
         );
     }
-    let wires = crate::jni::compile::OutWire::from_leaves(leaves);
     let params = plan_leaf_params(ext, &wires).unwrap_or_default();
     let mut imports: BTreeSet<String> = BTreeSet::new();
     let (_, when) = ext.sum_reconstruct(registry, source, &wires, &params, &slots, &mut imports);

--- a/prebindgen-jni/src/jni/kotlin_emit.rs
+++ b/prebindgen-jni/src/jni/kotlin_emit.rs
@@ -1162,7 +1162,7 @@ impl Declarations {
             registry
                 .decon_plans()
                 .get(d)
-                .is_some_and(|p| is_sum_leaves(&p.leaves))
+                .is_some_and(|p| is_sum_row(&crate::jni::compile::OutWire::from_leaves(&p.leaves)))
         };
 
         // Fixedness sets shared with the memo derivation (`iface.rs`): a


### PR DESCRIPTION
`is_sum_leaves` becomes `is_sum_row`, over `OutWire`s. It is the one place that question is asked — so every consumer agrees on it — and the answer is a wire fact: whether the values carry the synthesized selector.

Byte-identical: `examples/regen-check.sh` passes, 273 lib tests.

## Where stage 4d's vocabulary switch stops

What still reads `UnfoldLeaf` in `prebindgen-jni` is the **encode** side, and it is there for a reason rather than by omission.

`reach_leaf_flat` and `encode_plan_leaves` read a leaf's **path**: the accessor chain that reaches the value, the hoist it sits under, the rebase a splice applies, and the gate a conditional value form puts over it. A wire says which values cross and in what order; *where the Rust side reaches one* is the plan's business.

So moving those needs `Compile::plan` on the return side rather than another vocabulary change — the site wrapping a fragment, which is what the hook exists for. That is the shape #472's stage 5b describes, and 4d's remainder is the same piece of work seen from the other end.