### PR TITLE
A JNI return is planned through Compile::plan (#472 §5b)

### DIFF
--- a/prebindgen-jni/src/jni/compile.rs
+++ b/prebindgen-jni/src/jni/compile.rs
@@ -17,6 +17,37 @@ use super::{
     *,
 };
 
+/// The JNI adapter's answer for one site.
+///
+/// Both variants are boxed. A `PlanLeaf` embeds whole sub-plans and runs to
+/// ~856 bytes, a `ValueOutputPlan` to ~608, and every site pays the larger of
+/// the two — the same reason `FnOutputPlan::Value` boxes its own payload.
+pub(crate) enum JPlan {
+    /// One parameter, in the seven-way wire layout the emitters branch on.
+    Param(Box<crate::jni::fn_plan::PlanLeaf>),
+    /// A return that crosses as one value: what it converts through, and what
+    /// the Kotlin surface declares.
+    Return(Box<crate::jni::fn_plan::ValueOutputPlan>),
+}
+
+impl JPlan {
+    /// This plan as a parameter's, or `None` if it is a return's.
+    pub(crate) fn param(self) -> Option<crate::jni::fn_plan::PlanLeaf> {
+        match self {
+            JPlan::Param(leaf) => Some(*leaf),
+            JPlan::Return(_) => None,
+        }
+    }
+
+    /// This plan as a return's, or `None` if it is a parameter's.
+    pub(crate) fn returned(self) -> Option<crate::jni::fn_plan::ValueOutputPlan> {
+        match self {
+            JPlan::Return(plan) => Some(*plan),
+            JPlan::Param(_) => None,
+        }
+    }
+}
+
 /// The JNI adapter's answer for one crossing.
 ///
 /// What a `ConverterImpl` was, minus the bookkeeping the table now does.
@@ -446,6 +477,13 @@ fn produces_borrow(ty: &syn::Type) -> bool {
 pub(crate) struct JCompile<'a, R> {
     pub(crate) decls: &'a Declarations,
     pub(crate) registry: &'a R,
+    /// The return as the signature declares it, when that differs from the
+    /// crossing being compiled.
+    ///
+    /// A `Return`-delivery convert crosses the value its decomposition
+    /// produced, while the Kotlin surface is classified over what the function
+    /// says it returns. `None` when the two are the same.
+    pub(crate) declared_return: Option<TypeRef>,
     /// Which site is being planned, when one is.
     ///
     /// `None` while compiling a row: a row answers for a crossing wherever it
@@ -455,7 +493,18 @@ pub(crate) struct JCompile<'a, R> {
 }
 
 /// What [`Compile::plan`] needs about a site that the crossing does not say.
-pub(crate) struct PlanSite {
+pub(crate) enum PlanSite {
+    /// One parameter of an exported function.
+    Param(ParamSite),
+    /// What the function returns, as one value.
+    ///
+    /// A **decomposed** return is not this: it has no single crossing, which is
+    /// what decomposing it means, so it never reaches `Compiler::site` at all.
+    Return,
+}
+
+/// What planning a parameter needs beyond its crossing.
+pub(crate) struct ParamSite {
     /// The parameter ident the wrapper binds this value to.
     pub(crate) ident: syn::Ident,
     /// Whether this leaf is one of a constructor expansion's arguments rather
@@ -564,8 +613,8 @@ impl<R: Conversions> JCompile<'_, R> {
 
 impl<R: Conversions> Compile for JCompile<'_, R> {
     type Fragment = JFrag;
-    /// One parameter of one exported function, classified.
-    type Plan = crate::jni::fn_plan::PlanLeaf;
+    /// One site of one exported function, classified.
+    type Plan = JPlan;
     type Error = JErr;
 
     fn atomic(&mut self, cx: &mut Cx<'_>, at: At<'_>) -> Frag<Self> {
@@ -865,12 +914,16 @@ impl<R: Conversions> Compile for JCompile<'_, R> {
     /// where the site is a real parameter and not a constructor expansion's
     /// leaf, and the diagnostic for an unresolved leaf names the parameter that
     /// expanded.
-    fn plan(&mut self, _cx: &mut Cx<'_>, bound: &Bound, root: &JFrag) -> Result<PlanLeaf, JErr> {
+    fn plan(&mut self, _cx: &mut Cx<'_>, bound: &Bound, root: &JFrag) -> Result<JPlan, JErr> {
         use crate::jni::fn_plan::{plan_error, InputKind, PlanLeaf};
         let site = self
             .site
             .as_ref()
             .ok_or_else(|| JErr::Refused("JniGen: a site compiled with no site context".into()))?;
+        let site = match site {
+            PlanSite::Return => return Ok(JPlan::Return(Box::new(self.return_plan(bound, root)))),
+            PlanSite::Param(site) => site,
+        };
         let (ident, expanded) = (&site.ident, site.expanded);
         let reading = bound.crossing.spelled();
         let registry = self.registry;
@@ -933,7 +986,7 @@ impl<R: Conversions> Compile for JCompile<'_, R> {
             None => kt_meta.clone(),
         };
 
-        Ok(PlanLeaf {
+        Ok(JPlan::Param(Box::new(PlanLeaf {
             reading: reading.clone(),
             kt_name,
             kt_public,
@@ -941,7 +994,7 @@ impl<R: Conversions> Compile for JCompile<'_, R> {
             optional,
             as_enum_value,
             kind,
-        })
+        })))
     }
 }
 
@@ -1200,6 +1253,29 @@ impl<R: Conversions> JCompile<'_, R> {
         frag.out_wires = Some(wires);
         frag.composed_only = true;
         frag
+    }
+
+    /// A return that crosses as one value.
+    ///
+    /// The site's own fragment is the conversion — the registry built it before
+    /// calling this, which is the whole point of the hook. What the plan adds
+    /// is the Kotlin surface, which is classified over the **declared** return
+    /// rather than over the crossing: an error peel rides the conversion's
+    /// `value_rust_type`, so the full `Result<T, E>` is what the surface reads.
+    fn return_plan(&self, bound: &Bound, root: &JFrag) -> crate::jni::fn_plan::ValueOutputPlan {
+        let declared = self
+            .declared_return
+            .as_ref()
+            .unwrap_or_else(|| bound.crossing.spelled());
+        let (surface, enums) = crate::jni::fn_plan::ReturnSurface::classify(self.decls, declared);
+        crate::jni::fn_plan::ValueOutputPlan {
+            is_convert: self.declared_return.is_some(),
+            target_ty: bound.crossing.spelled().clone(),
+            wire_ty: root.conv.destination.clone(),
+            surface,
+            is_enum: enums.is_enum,
+            is_option_enum: enums.is_option_enum,
+        }
     }
 
     /// The values a `data_class` hands out, composed by

--- a/prebindgen-jni/src/jni/fn_plan.rs
+++ b/prebindgen-jni/src/jni/fn_plan.rs
@@ -652,10 +652,13 @@ fn classify_leaf(
     let mut adapter = crate::jni::compile::JCompile {
         decls: ext,
         registry,
-        site: Some(crate::jni::compile::PlanSite {
-            ident: ident.clone(),
-            expanded,
-        }),
+        declared_return: None,
+        site: Some(crate::jni::compile::PlanSite::Param(
+            crate::jni::compile::ParamSite {
+                ident: ident.clone(),
+                expanded,
+            },
+        )),
     };
     // The site names the parameter it is, and the position is the source
     // parameter's rather than a running count: a constructor expansion
@@ -669,7 +672,9 @@ fn classify_leaf(
     let planned = compiler.site(&mut adapter, site, crossing);
     *ext.compiled.borrow_mut() = compiler.finish();
     match planned {
-        Ok(Some(leaf)) => Ok(leaf),
+        Ok(Some(plan)) => plan.param().ok_or_else(|| PlanError::Unresolved {
+            ty: Box::new(reading.clone()),
+        }),
         // A site the bindings omitted, which JniGen never declares.
         Ok(None) => Err(PlanError::Unresolved {
             ty: Box::new(reading.clone()),
@@ -690,6 +695,41 @@ fn classify_leaf(
             }
         }),
     }
+}
+
+/// Compile the return of `func` as one site.
+///
+/// `declared` is what the signature says the function returns, when that
+/// differs from the value that crosses — a `Return`-delivery convert crosses
+/// what its decomposition produced. `None` when the two are the same.
+fn return_site(
+    ext: &Declarations,
+    registry: &Registry,
+    func: &syn::Ident,
+    target: &TypeRef,
+    declared: Option<TypeRef>,
+) -> Option<ValueOutputPlan> {
+    use prebindgen_registry::recipe::{Assembly, Compiler, Crossing, Role, Site};
+    let mut compiler = Compiler::resume(
+        registry.flat(),
+        ext.recipe_table(),
+        ext.site_bindings(),
+        ext.compiled.borrow().clone(),
+    );
+    let mut adapter = crate::jni::compile::JCompile {
+        decls: ext,
+        registry,
+        declared_return: declared,
+        site: Some(crate::jni::compile::PlanSite::Return),
+    };
+    let site = Site {
+        owner: func.clone(),
+        role: Role::Return,
+    };
+    let crossing = Crossing::new(target.clone(), Assembly::Deconstruct);
+    let planned = compiler.site(&mut adapter, site, crossing);
+    *ext.compiled.borrow_mut() = compiler.finish();
+    planned.ok().flatten().and_then(|p| p.returned())
 }
 
 /// Lower the output side. Mirrors the historical derivations exactly:
@@ -774,24 +814,34 @@ fn build_output(
             ty: target_ty.key(),
         });
     };
-    let Some(entry) = ext.out_frag(&target) else {
-        return Err(PlanError::UnresolvedOutput {
-            ty: Box::new(target),
-        });
-    };
-    let wire_ty = entry.destination.clone();
-
-    // The Kotlin surface classifies the DECLARED return — `convert_out_ty`
-    // for a convert, else the signature's own output. (Not `target_ty`: the
-    // Kotlin error peel rides the entry's `value_rust_type`, so the full
-    // `Result<T, E>` type is looked up as written.)
-    let ret_decl = if is_convert { target_ty } else { &f.ret };
-    let (surface, enums) = ReturnSurface::classify(ext, ret_decl);
-    let EnumSurface {
+    // The site's own row, compiled through the hook. `Compiler::site` is what
+    // makes this a site rather than a lookup: it picks the row, builds the
+    // fragment, checks the value's validity against what a return tolerates —
+    // the JVM keeps what it is given, so a borrowed one is refused here rather
+    // than emitted — and hands the fragment to `Compile::plan`.
+    //
+    // The Kotlin surface classifies the DECLARED return: `convert_out_ty` for a
+    // convert, else the signature's own output. Not `target_ty` — the Kotlin
+    // error peel rides the conversion's `value_rust_type`, so the full
+    // `Result<T, E>` is what the surface reads, and that is the one fact the
+    // crossing cannot carry.
+    let plan = return_site(
+        ext,
+        registry,
+        ident,
+        &target,
+        is_convert.then(|| target_ty.clone()),
+    )
+    .ok_or_else(|| PlanError::UnresolvedOutput {
+        ty: Box::new(target.clone()),
+    })?;
+    let ValueOutputPlan {
+        wire_ty,
+        surface,
         is_enum,
         is_option_enum,
-    } = enums;
-
+        ..
+    } = plan;
     Ok(FnOutputPlan::Value(Box::new(ValueOutputPlan {
         is_convert,
         target_ty: target_ty.clone(),

--- a/prebindgen-jni/src/jni/trait_impl.rs
+++ b/prebindgen-jni/src/jni/trait_impl.rs
@@ -1579,6 +1579,7 @@ impl JniGenBuilder {
             let mut adapter = crate::jni::compile::JCompile {
                 decls: &decls,
                 registry: &registry,
+                declared_return: None,
                 site: None,
             };
             if let Err(e) = compiler.row_of(&mut adapter, &crossing, &crate::jni::rows::parts()) {
@@ -1655,6 +1656,7 @@ impl Declarations {
         let mut adapter = crate::jni::compile::JCompile {
             decls: self,
             registry: built,
+            declared_return: None,
             site: None,
         };
         let crossing = prebindgen_registry::recipe::Crossing::new(reading, assembly);


### PR DESCRIPTION
The output half of #491. `build_output`'s value path resolves the target type, then goes through `Compiler::site` for the rest — which picks the row, builds the fragment, checks the value's validity, and hands the fragment to `Compile::plan`.

Byte-identical: `examples/regen-check.sh` passes, 273 lib tests.

## What the site check adds

`Compiler::site` asks `Compile::tolerates` what a return accepts. The JVM keeps what it is given, so the answer is `SelfSufficient`, and a conversion yielding a borrow is refused **at the site** rather than emitted.

JniGen never produced one — its `&T` outputs clone into a fresh handle, which is why `validity_of` reports self-sufficient for them — so nothing changes today. What changes is who holds the invariant: it was this adapter's to maintain by construction, and it is the registry's to check now.

## One fact travels beside the crossing

A `Return`-delivery convert crosses the value its decomposition produced, while the Kotlin surface is classified over what the **signature** says the function returns — the error peel rides the conversion's `value_rust_type`, so the full `Result<T, E>` is what the surface reads.

A crossing cannot carry that, so `JCompile` does, for the length of the call. Same shape as the `expanded` flag #491 introduced for parameters: the small residue of what is genuinely per-site.

## `Compile::Plan` becomes two-way

`JPlan` is a parameter's plan or a return's, because one hook answers both. Two associated types would say a plan is per-kind-of-site, and it is not — it is per site. Both variants box, for the reason `FnOutputPlan::Value` already boxes its own payload: a `PlanLeaf` embeds whole sub-plans and every site would otherwise pay its ~856 bytes.

## What still does not come through here

A **decomposed** return. It has no single crossing — that is what decomposing it means — so it never reaches `Compiler::site` at all. That remains `UnfoldPlan`'s, and it is what 4d's encode side (`reach_leaf_flat`, `encode_plan_leaves`) still reads: the accessor chain, the hoist, the rebase a splice applies.