### PR TITLE
A decomposed return is a site asking for the parts row (#472 §5c)

### DIFF
--- a/prebindgen-jni/src/jni/compile.rs
+++ b/prebindgen-jni/src/jni/compile.rs
@@ -28,6 +28,14 @@ pub(crate) enum JPlan {
     /// A return that crosses as one value: what it converts through, and what
     /// the Kotlin surface declares.
     Return(Box<crate::jni::fn_plan::ValueOutputPlan>),
+    /// A return the binding takes apart: the values it hands out, in the order
+    /// the builder receives them.
+    ///
+    /// Read only by the equivalence fixture until the encode side takes it —
+    /// `reach_leaf_flat` and `encode_plan_leaves` still read the plan, because
+    /// where the Rust side reaches a value is the plan's and not the wire's.
+    #[cfg_attr(not(test), allow(dead_code))]
+    Decomposed(Vec<OutWire>),
 }
 
 impl JPlan {
@@ -35,7 +43,7 @@ impl JPlan {
     pub(crate) fn param(self) -> Option<crate::jni::fn_plan::PlanLeaf> {
         match self {
             JPlan::Param(leaf) => Some(*leaf),
-            JPlan::Return(_) => None,
+            _ => None,
         }
     }
 
@@ -43,7 +51,16 @@ impl JPlan {
     pub(crate) fn returned(self) -> Option<crate::jni::fn_plan::ValueOutputPlan> {
         match self {
             JPlan::Return(plan) => Some(*plan),
-            JPlan::Param(_) => None,
+            _ => None,
+        }
+    }
+
+    /// The values a decomposed return hands out, or `None` if it is not one.
+    #[cfg(test)]
+    pub(crate) fn decomposed(self) -> Option<Vec<OutWire>> {
+        match self {
+            JPlan::Decomposed(wires) => Some(wires),
+            _ => None,
         }
     }
 }
@@ -921,7 +938,16 @@ impl<R: Conversions> Compile for JCompile<'_, R> {
             .as_ref()
             .ok_or_else(|| JErr::Refused("JniGen: a site compiled with no site context".into()))?;
         let site = match site {
-            PlanSite::Return => return Ok(JPlan::Return(Box::new(self.return_plan(bound, root)))),
+            PlanSite::Return => {
+                // A fragment that occupies several wires IS the decomposed
+                // return: the site asked for the `parts` row and got what that
+                // row states. Nothing else distinguishes the two cases, and
+                // nothing needs to.
+                return Ok(match &root.out_wires {
+                    Some(wires) => JPlan::Decomposed(wires.clone()),
+                    None => JPlan::Return(Box::new(self.return_plan(bound, root))),
+                });
+            }
             PlanSite::Param(site) => site,
         };
         let (ident, expanded) = (&site.ident, site.expanded);

--- a/prebindgen-jni/src/jni/fn_plan.rs
+++ b/prebindgen-jni/src/jni/fn_plan.rs
@@ -708,7 +708,7 @@ fn return_site(
     func: &syn::Ident,
     target: &TypeRef,
     declared: Option<TypeRef>,
-) -> Option<ValueOutputPlan> {
+) -> Option<crate::jni::compile::JPlan> {
     use prebindgen_registry::recipe::{Assembly, Compiler, Crossing, Role, Site};
     let mut compiler = Compiler::resume(
         registry.flat(),
@@ -729,7 +729,27 @@ fn return_site(
     let crossing = Crossing::new(target.clone(), Assembly::Deconstruct);
     let planned = compiler.site(&mut adapter, site, crossing);
     *ext.compiled.borrow_mut() = compiler.finish();
-    planned.ok().flatten().and_then(|p| p.returned())
+    planned.ok().flatten()
+}
+
+/// The values one function's decomposed return hands out, compiled through
+/// `Compiler::site`.
+///
+/// Test support until the encode side takes it: this is the whole of what a
+/// decomposed return site produces, and holding it to the expansion plan is
+/// what says the two agree before anything depends on it.
+#[cfg(test)]
+pub(crate) fn decomposed_return_for_test(
+    ext: &Declarations,
+    registry: &Registry,
+    func: &syn::Ident,
+) -> Option<Vec<crate::jni::compile::OutWire>> {
+    let f = registry.flat().function(func)?;
+    let ret = f.ret.borrow_target().unwrap_or(&f.ret);
+    let ret = ret.optional_inner().unwrap_or(ret);
+    let ret = ret.sequence_elem().unwrap_or(ret);
+    let ret = ret.borrow_target().unwrap_or(ret);
+    return_site(ext, registry, func, ret, None).and_then(|p| p.decomposed())
 }
 
 /// Lower the output side. Mirrors the historical derivations exactly:
@@ -832,6 +852,7 @@ fn build_output(
         &target,
         is_convert.then(|| target_ty.clone()),
     )
+    .and_then(|p| p.returned())
     .ok_or_else(|| PlanError::UnresolvedOutput {
         ty: Box::new(target.clone()),
     })?;

--- a/prebindgen-jni/src/jni/mod.rs
+++ b/prebindgen-jni/src/jni/mod.rs
@@ -475,6 +475,30 @@ pub(crate) type NamedWire = (
     Option<String>,
 );
 
+/// How the Rust side reaches one plan leaf, in the form a wire renders it —
+/// the accessor call every leaf hangs off is the site's, not the value's, so it
+/// is dropped to line the two up.
+#[cfg(test)]
+fn leaf_reach(leaf: &prebindgen_registry::unfold::UnfoldLeaf) -> String {
+    use prebindgen_registry::unfold::{LeafSource, PathStep};
+    match &leaf.source {
+        LeafSource::SumTag => "tag".to_string(),
+        LeafSource::VariantField { variant, member } => format!(
+            "{variant}.{}",
+            crate::jni::struct_plan::sum_field_prop_name(member)
+        ),
+        _ => leaf
+            .path
+            .iter()
+            .filter_map(|step| match step {
+                PathStep::Field { ident, .. } => Some(ident.to_string()),
+                PathStep::Call { .. } => None,
+            })
+            .collect::<Vec<_>>()
+            .join("."),
+    }
+}
+
 #[cfg(test)]
 impl JniGen {
     /// What one crossing occupies on the wire, named the way a parameter
@@ -566,7 +590,6 @@ impl JniGen {
     /// replace — `synth_sum_leaves` for a `sealed_class`,
     /// `synth_value_struct_leaves` for a `data_class`.
     pub(crate) fn walk_lines_for_test(&self, short: &str) -> Option<Vec<String>> {
-        use prebindgen_registry::unfold::{LeafSource, PathStep};
         let ident = syn::Ident::new(short, proc_macro2::Span::call_site());
         let leaves = match self.registry.flat().declared_type(&ident)? {
             prebindgen_registry::flat::Type::Variant(sum) => {
@@ -581,24 +604,50 @@ impl JniGen {
             leaves
                 .iter()
                 .map(|l| {
-                    let from = match &l.source {
-                        LeafSource::SumTag => "tag".to_string(),
-                        LeafSource::VariantField { variant, member } => format!(
-                            "{variant}.{}",
-                            crate::jni::struct_plan::sum_field_prop_name(member)
-                        ),
-                        LeafSource::Field => l
-                            .path
+                    format!(
+                        "{}: {} <- {} @{:?}",
+                        l.name,
+                        l.out_ty.key(),
+                        leaf_reach(l),
+                        l.group
+                    )
+                })
+                .collect(),
+        )
+    }
+
+    /// What the return **site** of one function composes to, as the row states
+    /// it — rendered exactly as [`Self::out_lines_for_test`] renders a type's
+    /// row, so a site and a type can be compared.
+    ///
+    /// The decomposed-return path through `Compiler::site`: the site asks for
+    /// the `parts` row of its return type and gets the several values that row
+    /// states.
+    pub(crate) fn return_site_lines_for_test(&self, func: &str) -> Option<Vec<String>> {
+        let ident = syn::Ident::new(func, proc_macro2::Span::call_site());
+        let wires =
+            crate::jni::fn_plan::decomposed_return_for_test(&self.decls, &self.registry, &ident)?;
+        Some(
+            wires
+                .iter()
+                .map(|w| {
+                    let from = match &w.from {
+                        crate::jni::compile::OutFrom::Tag => "tag".to_string(),
+                        crate::jni::compile::OutFrom::Field { path } => path
                             .iter()
-                            .map(|step| match step {
-                                PathStep::Field { ident, .. } => ident.to_string(),
-                                other => format!("{other:?}"),
-                            })
+                            .map(|p| p.to_string())
                             .collect::<Vec<_>>()
                             .join("."),
-                        other => format!("{other:?}"),
+                        crate::jni::compile::OutFrom::Payload { variant, member } => format!(
+                            "{}.{}",
+                            variant
+                                .as_ref()
+                                .map(|v| v.to_string())
+                                .unwrap_or_else(|| "?".to_string()),
+                            crate::jni::struct_plan::sum_field_prop_name(member)
+                        ),
                     };
-                    format!("{}: {} <- {from} @{:?}", l.name, l.out_ty.key(), l.group)
+                    format!("{}: {} <- {from} @{:?}", w.name, w.out_ty.key(), w.group)
                 })
                 .collect(),
         )
@@ -611,25 +660,19 @@ impl JniGen {
     /// rather than from a JniGen-side synthesis, so the comparison goes through
     /// a plan rather than through a leaf list.
     pub(crate) fn plan_lines_for_test(&self, func: &str) -> Option<Vec<String>> {
-        use prebindgen_registry::unfold::PathStep;
         let ident = syn::Ident::new(func, proc_macro2::Span::call_site());
         let plan = prebindgen_registry::Conversions::unfold_plans(&self.registry).get(&ident)?;
         Some(
             plan.leaves
                 .iter()
                 .map(|l| {
-                    // The accessor call every leaf hangs off is the site's, not
-                    // the wire's, so it is dropped to line the two up.
-                    let from = l
-                        .path
-                        .iter()
-                        .filter_map(|step| match step {
-                            PathStep::Field { ident, .. } => Some(ident.to_string()),
-                            PathStep::Call { .. } => None,
-                        })
-                        .collect::<Vec<_>>()
-                        .join(".");
-                    format!("{}: {} <- {from} @{:?}", l.name, l.out_ty.key(), l.group)
+                    format!(
+                        "{}: {} <- {} @{:?}",
+                        l.name,
+                        l.out_ty.key(),
+                        leaf_reach(l),
+                        l.group
+                    )
                 })
                 .collect(),
         )

--- a/prebindgen-jni/src/jni/rows.rs
+++ b/prebindgen-jni/src/jni/rows.rs
@@ -100,6 +100,31 @@ fn out_alternatives(model: &Flat, ty: &TypeRef) -> Vec<Arm<Deconstruct>> {
 }
 
 impl Declarations {
+    /// How many values this type hands out, or 0 if it hands out none.
+    ///
+    /// Model and declaration only, like the compositions it asks — so a
+    /// declaration-time caller may ask it, which is what binding a return site
+    /// needs.
+    fn out_wire_count(
+        &self,
+        registry: &impl prebindgen_registry::Conversions,
+        ty: &TypeRef,
+    ) -> usize {
+        let prebindgen_registry::flat::TypeKind::Named { id, .. } = ty.unwrapped().kind() else {
+            return 0;
+        };
+        let Some(ident) = id.ident() else { return 0 };
+        match registry.flat().declared_type(&ident) {
+            Some(prebindgen_registry::flat::Type::Variant(_)) => self
+                .sum_out_wires(registry, &ident, ty)
+                .map_or(0, |w| w.len()),
+            Some(prebindgen_registry::flat::Type::Struct(_)) => {
+                self.struct_out_wires(registry, ty).map_or(0, |w| w.len())
+            }
+            _ => 0,
+        }
+    }
+
     /// The accessor a type's value form names, and one reach per field of the
     /// struct it returns.
     ///
@@ -404,6 +429,7 @@ impl Declarations {
     pub(crate) fn bindings(
         &self,
         model: &Flat,
+        registry: &impl prebindgen_registry::Conversions,
         recipes: &prebindgen_registry::recipe::Recipes,
     ) -> Result<prebindgen_registry::recipe::Bindings, Vec<RecipeError>> {
         use prebindgen_registry::recipe::{
@@ -496,6 +522,49 @@ impl Declarations {
                 }
             }
         }
+        // Every function whose return the binding takes apart, bound to the
+        // `parts` row of its return type.
+        //
+        // This is what a site naming several values is: `Ask::Recipe` already
+        // lets a site pick a row, and a `parts` fragment already occupies
+        // several wires — the two facts stages 3 and 4 established, meeting.
+        // The registry needs nothing new to express a decomposed return.
+        for f in model.functions() {
+            // The value that crosses, through the layers a decomposition looks
+            // through: a `&T` return decomposes T, and so does an `Option<T>`
+            // or a `Vec<T>` — the shape rides the delivery, not the row.
+            let ret = f.ret.borrow_target().unwrap_or(&f.ret);
+            let ret = ret.optional_inner().unwrap_or(ret);
+            let ret = ret.sequence_elem().unwrap_or(ret);
+            let ret = ret.borrow_target().unwrap_or(ret);
+            let crossing = Crossing::new(ret.clone(), Assembly::Deconstruct);
+            // Only where the type states one. A `sealed_class` always does; a
+            // `data_class` states one unless a field of it declines, and a
+            // return whose type states none crosses whole.
+            if recipes.get(&crossing.key(), &parts()).is_none() {
+                continue;
+            }
+            // And only where it is genuinely several. A decomposition that
+            // yields ONE value takes `Delivery::Return`: the wrapper hands that
+            // value back through its own conversion rather than through a
+            // builder, so the return site's crossing is the value's, not this
+            // type's. Asked of the composition, which is model and declaration
+            // only and so answerable here — the same property that let one
+            // composition serve both sides of `resolve`.
+            if self.out_wire_count(registry, ret) < 2 {
+                continue;
+            }
+            bound.bind(
+                Site {
+                    owner: f.name.clone(),
+                    role: prebindgen_registry::recipe::Role::Return,
+                },
+                crossing,
+                Ask::Recipe(parts()),
+                Origin::Adapter,
+            );
+        }
+
         bound.build(recipes)
     }
 }

--- a/prebindgen-jni/src/jni/tests/sealed.rs
+++ b/prebindgen-jni/src/jni/tests/sealed.rs
@@ -2571,3 +2571,82 @@ fn a_data_class_states_what_it_hands_out() {
         "a handle field sends the whole object down the whole-value path",
     );
 }
+
+/// A decomposed return is a **site** asking for its type's `parts` row, and it
+/// composes to what the expansion plan delivers.
+///
+/// The registry needed nothing new to express this: `Ask::Recipe` already lets
+/// a site name a row, and a `parts` fragment already occupies several wires.
+/// The two facts stages 3 and 4 established, meeting.
+#[test]
+fn a_decomposed_return_is_a_site_asking_for_the_parts_row() {
+    let loc = myflat_loc();
+    let items: Vec<(syn::Item, SourceLocation)> = vec![
+        (
+            syn::Item::Enum(syn::parse_quote!(
+                pub enum Reading {
+                    Missing,
+                    Exact(i64),
+                    Range { low: i64, high: i64 },
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn read_one(which: i32) -> Reading {
+                    unimplemented!()
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn read_maybe(which: i32) -> Option<Reading> {
+                    unimplemented!()
+                }
+            )),
+            loc.clone(),
+        ),
+    ];
+    let registry =
+        crate::test_util::reg_from_items(declare_referenced(items)).expect("index items");
+    let jni = JniGenBuilder::new()
+        .set_package_prefix("io.test.jni")
+        .package(
+            crate::package!()
+                .class(crate::sealed_class!(Reading))
+                .fun(prebindgen_registry::fun!(read_one))
+                .fun(prebindgen_registry::fun!(read_maybe)),
+        );
+    let gen = jni.build_with(registry).expect("resolve");
+
+    let expected = vec![
+        "tag: Reading <- tag @None",
+        "exact_v0: i64 <- Exact.v0 @Some(1)",
+        "range_low: i64 <- Range.low @Some(2)",
+        "range_high: i64 <- Range.high @Some(2)",
+    ];
+    assert_eq!(
+        gen.return_site_lines_for_test("read_one")
+            .expect("read_one's return is a site"),
+        expected,
+        "the site composes the sum's parts",
+    );
+    // The shape rides the delivery, not the row: an `Option<Reading>` return
+    // hands out the same values, and the optional is what the builder's
+    // nullability says.
+    assert_eq!(
+        gen.return_site_lines_for_test("read_maybe")
+            .expect("read_maybe's return is a site"),
+        expected,
+        "an optional return decomposes the same type",
+    );
+    // And it is what the expansion plan delivers, which is what the emitters
+    // read today.
+    assert_eq!(
+        gen.return_site_lines_for_test("read_one"),
+        gen.plan_lines_for_test("read_one"),
+        "the site and the expansion plan disagree",
+    );
+}

--- a/prebindgen-jni/src/jni/trait_impl.rs
+++ b/prebindgen-jni/src/jni/trait_impl.rs
@@ -1425,15 +1425,15 @@ impl JniGenBuilder {
         })?;
         // A `data_class` field that is itself one takes the `parts` row rather
         // than its own default — see `Declarations::bindings`.
-        let bindings = decls.bindings(&model, &recipes).map_err(|errors| {
-            prebindgen_registry::ScanError::AdapterInvariant {
+        let bindings = decls
+            .bindings(&model, &declared, &recipes)
+            .map_err(|errors| prebindgen_registry::ScanError::AdapterInvariant {
                 message: errors
                     .iter()
                     .map(|e| e.to_string())
                     .collect::<Vec<_>>()
                     .join("; "),
-            }
-        })?;
+            })?;
         // Both tables go on `decls`, because compiling a **site** happens after
         // this function has returned: the sites are `fn_plan`'s to enumerate,
         // and `Compiler::resume` needs these two beside the model.


### PR DESCRIPTION
The remainder of both stage 4d and stage 5b, and it turned out to need nothing new from the registry.

`Ask::Recipe` already lets a site name a row. A `parts` fragment already occupies several wires. Those are the two facts stages 3 and 4 established, and a decomposed return is them meeting: the site asks for its return type's `parts` row and gets the several values that row states.

An earlier note on #472 claimed this needed a change to what `prebindgen-registry` accepts as input. It does not. The note is corrected in the umbrella body.

Byte-identical: `examples/regen-check.sh` passes, 274 lib tests.

## How the two return cases are told apart

They are not. `Compile::plan` looks at whether the fragment it was handed occupies several wires, and answers `JPlan::Decomposed` if it does. What a fragment occupies **is** the answer, and nothing else distinguishes the cases.

## Two conditions on the binding, both measured

**A type that states no `parts` row crosses whole.** A `data_class` one of whose fields declines is that case — it keeps the whole-value `fromParts` path, and #494 is where that refusal is stated.

**A decomposition yielding one value takes `Delivery::Return`.** The wrapper hands that value back through its own conversion rather than through a builder, so the return site's crossing is the **value's**, not the type's. Binding the type there made the two collide on one `Site`, which three value-form tests caught immediately:

> `z_one_make`'s return value was bound as `ZOne (deconstruct)` and is being resolved as `String (deconstruct)`

The count comes from the composition, which is model and declaration only and so answerable at declaration time — the same property #493 and #494 turned on.

## What rides the delivery rather than the row

The shape. `T`, `&T`, `Option<T>` and `Vec<T>` returns all decompose T; which of them it was is what the builder's nullability and the fold surface say, not what the row says. The fixture asserts a bare and an `Option`-wrapped return compose identically.

## What still reads the plan

The encode side. `reach_leaf_flat` and `encode_plan_leaves` read a leaf's path — the accessor chain, the hoist, the splice prefixes — and that is genuinely the plan's: a wire says which values cross and in what order, never where the Rust side reaches one. `JPlan::Decomposed` is read by the equivalence fixture until stage 6 moves that.