### PR TITLE
A wire says where the Rust side reaches it (#472 §6)

### DIFF
--- a/prebindgen-jni/src/jni/compile.rs
+++ b/prebindgen-jni/src/jni/compile.rs
@@ -271,6 +271,13 @@ pub(crate) struct OutWire {
     pub(crate) group: Option<i32>,
     /// How the Rust side reaches it.
     pub(crate) from: OutFrom,
+    /// Whether this value is the whole crossed object rather than a part of it
+    /// — the move-or-clone handle a decomposition delivers beside its fields.
+    ///
+    /// Never true in a composition: a row states what a value is **made of**,
+    /// and the value itself is not one of its own parts. A declaration is what
+    /// asks for one, through `.field_self()`.
+    pub(crate) identity: bool,
     /// Whether the value may be absent, so the wire boxes rather than carrying
     /// a raw primitive.
     ///
@@ -299,11 +306,13 @@ impl OutWire {
                     variant: Some(variant.clone()),
                     member: member.clone(),
                 },
-                // An accessor chain and a field chain are one thing to a wire:
-                // where the Rust side reaches the value. Which of the two it
-                // was is the plan's, and nothing the sum emitters read.
-                _ => OutFrom::Field { path: Vec::new() },
+                // Every other leaf is reached off the value, and the steps say
+                // how — an accessor chain, a field chain, or the two mixed.
+                _ => OutFrom::Reach {
+                    path: leaf.path.clone(),
+                },
             },
+            identity: leaf.identity,
             nullable: leaf.nullable,
         }
     }
@@ -311,6 +320,28 @@ impl OutWire {
     /// A whole plan's leaves in the row's vocabulary.
     pub(crate) fn from_leaves(leaves: &[prebindgen_registry::unfold::UnfoldLeaf]) -> Vec<Self> {
         leaves.iter().map(Self::from_leaf).collect()
+    }
+
+    /// The steps from the crossed value down to this one, or empty for a value
+    /// no reach describes — the selector, or a payload its arm's pattern binds.
+    pub(crate) fn reach(&self) -> &[prebindgen_registry::unfold::PathStep] {
+        match &self.from {
+            OutFrom::Reach { path } => path,
+            _ => &[],
+        }
+    }
+
+    /// Whether this value is **read off** a place rather than produced by a
+    /// call — so it is cloned out of the value that holds it.
+    ///
+    /// The last step being a field read is the whole question, and it is what
+    /// `LeafSource::Field` meant: a value form's field leaf reads a field off
+    /// what the accessor returned, and an accessor leaf ends at the call.
+    pub(crate) fn is_field_read(&self) -> bool {
+        matches!(
+            self.reach().last(),
+            Some(prebindgen_registry::unfold::PathStep::Field { .. })
+        )
     }
 
     /// Whether this value is the synthesized selector.
@@ -325,15 +356,21 @@ pub(crate) enum OutFrom {
     /// The synthesized selector, which is not read off the value at all: the
     /// emitter assigns the alternative's number in each arm of its `match`.
     Tag,
-    /// A field of the value, reached by field access and cloned — the chain of
-    /// idents from the value itself.
+    /// Reached off the value, by field access or by calling an accessor.
     ///
-    /// Nested where a `data_class` field is itself one: its fields cross as
-    /// decoupled values under the parent's chain, and the foreign side
-    /// reassembles the whole graph in one call.
-    Field {
-        /// The field idents from the value down to this one.
-        path: Vec<syn::Ident>,
+    /// The **steps** rather than a chain of idents, because the two kinds mix:
+    /// a value form calls an accessor and then reads fields off what it
+    /// returned, and a nested `data_class` reads fields all the way down. A
+    /// step also says whether it may find nothing, which is what puts every
+    /// value below it in doubt.
+    ///
+    /// Spelled in the plans' own vocabulary rather than a second one. A reach
+    /// **is** a path, and inventing a parallel spelling for it would leave two
+    /// things to keep in step for no gain — the mistake `Access` and
+    /// `handle_target` avoided on the constructing side by being one type.
+    Reach {
+        /// The steps from the value down to this one.
+        path: Vec<prebindgen_registry::unfold::PathStep>,
     },
     /// A payload of one alternative, bound by that arm's pattern.
     Payload {
@@ -1269,6 +1306,7 @@ impl<R: Conversions> JCompile<'_, R> {
                         member: part_member(part)?,
                     },
                     nullable: false,
+                    identity: false,
                 })
             })
             .collect();
@@ -1365,8 +1403,11 @@ impl<R: Conversions> JCompile<'_, R> {
                 // The chain starts at the accessor's result, which the emitter
                 // binds once. The call itself is the site's to make, so what a
                 // wire states is the field read off it.
-                from: OutFrom::Field { path: vec![ident] },
+                from: OutFrom::Reach {
+                    path: vec![field_step(&ident)],
+                },
                 nullable: false,
+                identity: false,
             });
         }
         let mut frag = JFrag::new(
@@ -1716,8 +1757,11 @@ impl Declarations {
                 name,
                 out_ty: field.ty.clone(),
                 group: None,
-                from: OutFrom::Field { path: field_path },
+                from: OutFrom::Reach {
+                    path: field_path.iter().map(field_step).collect(),
+                },
                 nullable: false,
+                identity: false,
             });
         }
         Some(wires)
@@ -1755,6 +1799,7 @@ impl Declarations {
             group: None,
             from: OutFrom::Tag,
             nullable: false,
+            identity: false,
         }];
         for alt in &sum.alternatives {
             let kotlin = self.sum_variant_class_name(cfg, &alt.name);
@@ -1772,11 +1817,21 @@ impl Declarations {
                         member,
                     },
                     nullable: false,
+                    identity: false,
                 });
             }
         }
         Some(wires)
     }
+}
+
+/// One step of a reach that reads a struct field.
+///
+/// Never optional: a composition looks through an `Option` rather than stopping
+/// at one — a terminal optional rides its own conversion, and an intermediate
+/// one is a shape the compositions decline.
+fn field_step(ident: &syn::Ident) -> prebindgen_registry::unfold::PathStep {
+    prebindgen_registry::unfold::PathStep::field(ident.clone(), false)
 }
 
 /// The model field one part reads, or `None` for a part that is not a field.

--- a/prebindgen-jni/src/jni/emit/delivery.rs
+++ b/prebindgen-jni/src/jni/emit/delivery.rs
@@ -447,13 +447,12 @@ fn project_leading_fields(
 /// [`Delivery::Return`]: prebindgen_registry::unfold::Delivery::Return
 pub(crate) fn reach_leaf_flat(
     qualify: &dyn Fn(&syn::Ident) -> syn::Path,
-    leaf: &prebindgen_registry::unfold::UnfoldLeaf,
+    leaf: &crate::jni::compile::OutWire,
     path: &[PathStep],
     base: TokenStream,
     base_is_ref: bool,
     consuming: bool,
 ) -> TokenStream {
-    use prebindgen_registry::unfold::LeafSource;
     // An optional step BEFORE the last one needs a `match` whose `None` arm has
     // somewhere to go. This derivation has none — it yields a plain Rust value,
     // not a `JObject` that could be null — so the shape is refused here rather
@@ -466,8 +465,9 @@ pub(crate) fn reach_leaf_flat(
     // conditional one, which is the case that cannot compose (an `Option<T>`
     // local with a field read hung off it). The full path is what the shape
     // question is about.
+    let own_path = leaf.reach();
     assert!(
-        !leaf.path.iter().rev().skip(1).any(PathStep::is_optional),
+        !own_path.iter().rev().skip(1).any(PathStep::is_optional),
         "jnigen unfold: leaf `{}` reaches through an optional step but is \
          delivered as a single return value, which has no `None` arm — this \
          shape needs callback delivery",
@@ -508,7 +508,7 @@ pub(crate) fn reach_leaf_flat(
     }
     let (e, lead) = project_leading_fields(&base, base_is_ref, path);
     let e = fold_steps(qualify, &path[lead..], e, false);
-    if leaf.source == LeafSource::Field {
+    if leaf.is_field_read() {
         quote!((#e).clone())
     } else {
         e
@@ -1592,7 +1592,15 @@ mod tests {
                 true,
                 LeafSource::Accessor,
             );
-            let got = reach_leaf_flat(&qualify, &l, &path, quote!(__src), false, false).to_string();
+            let got = reach_leaf_flat(
+                &qualify,
+                &crate::jni::compile::OutWire::from_leaf(&l),
+                &path,
+                quote!(__src),
+                false,
+                false,
+            )
+            .to_string();
             assert!(
                 !got.contains('&') && !got.contains("clone"),
                 "a movable place is moved, not borrowed or cloned — got `{got}`"
@@ -1611,7 +1619,15 @@ mod tests {
             true,
             LeafSource::Accessor,
         );
-        let got = reach_leaf_flat(&qualify, &l, &path, quote!(__src), false, false).to_string();
+        let got = reach_leaf_flat(
+            &qualify,
+            &crate::jni::compile::OutWire::from_leaf(&l),
+            &path,
+            quote!(__src),
+            false,
+            false,
+        )
+        .to_string();
         assert!(
             got.contains('&'),
             "a borrowed out_ty keeps its borrow — got `{got}`"
@@ -1635,7 +1651,15 @@ mod tests {
             false,
             LeafSource::Field,
         );
-        let got = reach_leaf_flat(&qualify, &l, &path, quote!(__src), false, false).to_string();
+        let got = reach_leaf_flat(
+            &qualify,
+            &crate::jni::compile::OutWire::from_leaf(&l),
+            &path,
+            quote!(__src),
+            false,
+            false,
+        )
+        .to_string();
         assert!(
             got.contains("clone"),
             "a non-consuming field leaf clones rather than moves — got `{got}`"
@@ -1659,6 +1683,13 @@ mod tests {
         // The suffix a rebase would hand over — the optional call is gone from
         // it, and used to take the guard with it.
         let rest = vec![PathStep::field(syn::parse_quote!(a), false)];
-        let _ = reach_leaf_flat(&qualify, &l, &rest, quote!(__vf0), false, false);
+        let _ = reach_leaf_flat(
+            &qualify,
+            &crate::jni::compile::OutWire::from_leaf(&l),
+            &rest,
+            quote!(__vf0),
+            false,
+            false,
+        );
     }
 }

--- a/prebindgen-jni/src/jni/emit/struct_out.rs
+++ b/prebindgen-jni/src/jni/emit/struct_out.rs
@@ -83,21 +83,14 @@ pub(crate) fn synth_value_struct_leaves(
     registry: &impl Conversions,
     s: &prebindgen_registry::flat::Struct,
 ) -> Option<Vec<prebindgen_registry::unfold::UnfoldLeaf>> {
-    use prebindgen_registry::unfold::{LeafSource, PathStep, UnfoldLeaf};
+    use prebindgen_registry::unfold::{LeafSource, UnfoldLeaf};
     Some(
         ext.struct_out_wires_of(registry, &s.name)?
             .into_iter()
             .map(|w| UnfoldLeaf {
                 name: w.name,
-                // The synthesizer declines `Option`-wrapped nesting, so an
-                // intermediate step is never optional; a TERMINAL `Option`
-                // field is not a nesting step either, its own converter
-                // carrying the nullability.
                 path: match w.from {
-                    crate::jni::compile::OutFrom::Field { path } => path
-                        .into_iter()
-                        .map(|ident| PathStep::field(ident, false))
-                        .collect(),
+                    crate::jni::compile::OutFrom::Reach { path } => path,
                     _ => Vec::new(),
                 },
                 out_ty: w.out_ty,

--- a/prebindgen-jni/src/jni/emit/sum_out.rs
+++ b/prebindgen-jni/src/jni/emit/sum_out.rs
@@ -63,7 +63,7 @@ pub(crate) fn synth_sum_leaves(
                         member,
                     }
                 }
-                crate::jni::compile::OutFrom::Field { .. } => LeafSource::Field,
+                crate::jni::compile::OutFrom::Reach { .. } => LeafSource::Field,
             },
             group: w.group,
         })

--- a/prebindgen-jni/src/jni/emit/wrapper.rs
+++ b/prebindgen-jni/src/jni/emit/wrapper.rs
@@ -283,12 +283,22 @@ pub(crate) fn emit_jni_function_wrapper_with_callee(
             let hoisted = bind_hoists(&qualify, &uplan.hoists, &base, base_is_ref);
             let stmts = &hoisted.stmts;
             let reached = match hoisted.rebase(&leaf.path) {
-                Some((local, rest, consuming)) => {
-                    reach_leaf_flat(&qualify, leaf, &rest, quote!(#local), false, consuming)
-                }
-                None => {
-                    reach_leaf_flat(&qualify, leaf, &leaf.path, base.clone(), base_is_ref, false)
-                }
+                Some((local, rest, consuming)) => reach_leaf_flat(
+                    &qualify,
+                    &crate::jni::compile::OutWire::from_leaf(leaf),
+                    &rest,
+                    quote!(#local),
+                    false,
+                    consuming,
+                ),
+                None => reach_leaf_flat(
+                    &qualify,
+                    &crate::jni::compile::OutWire::from_leaf(leaf),
+                    &leaf.path,
+                    base.clone(),
+                    base_is_ref,
+                    false,
+                ),
             };
             if stmts.is_empty() && reached.to_string() == base.to_string() {
                 return None;

--- a/prebindgen-jni/src/jni/mod.rs
+++ b/prebindgen-jni/src/jni/mod.rs
@@ -475,27 +475,33 @@ pub(crate) type NamedWire = (
     Option<String>,
 );
 
+/// How a reach renders: its field steps, joined — the accessor call every leaf
+/// hangs off is the site's, not the value's, so it is dropped.
+#[cfg(test)]
+fn reach_of(path: &[prebindgen_registry::unfold::PathStep]) -> String {
+    use prebindgen_registry::unfold::PathStep;
+    path.iter()
+        .filter_map(|step| match step {
+            PathStep::Field { ident, .. } => Some(ident.to_string()),
+            PathStep::Call { .. } => None,
+        })
+        .collect::<Vec<_>>()
+        .join(".")
+}
+
 /// How the Rust side reaches one plan leaf, in the form a wire renders it —
 /// the accessor call every leaf hangs off is the site's, not the value's, so it
 /// is dropped to line the two up.
 #[cfg(test)]
 fn leaf_reach(leaf: &prebindgen_registry::unfold::UnfoldLeaf) -> String {
-    use prebindgen_registry::unfold::{LeafSource, PathStep};
+    use prebindgen_registry::unfold::LeafSource;
     match &leaf.source {
         LeafSource::SumTag => "tag".to_string(),
         LeafSource::VariantField { variant, member } => format!(
             "{variant}.{}",
             crate::jni::struct_plan::sum_field_prop_name(member)
         ),
-        _ => leaf
-            .path
-            .iter()
-            .filter_map(|step| match step {
-                PathStep::Field { ident, .. } => Some(ident.to_string()),
-                PathStep::Call { .. } => None,
-            })
-            .collect::<Vec<_>>()
-            .join("."),
+        _ => reach_of(&leaf.path),
     }
 }
 
@@ -566,11 +572,7 @@ impl JniGen {
                 .map(|w| {
                     let from = match &w.from {
                         crate::jni::compile::OutFrom::Tag => "tag".to_string(),
-                        crate::jni::compile::OutFrom::Field { path } => path
-                            .iter()
-                            .map(|p| p.to_string())
-                            .collect::<Vec<_>>()
-                            .join("."),
+                        crate::jni::compile::OutFrom::Reach { path } => reach_of(path),
                         crate::jni::compile::OutFrom::Payload { variant, member } => format!(
                             "{}.{}",
                             variant
@@ -633,11 +635,7 @@ impl JniGen {
                 .map(|w| {
                     let from = match &w.from {
                         crate::jni::compile::OutFrom::Tag => "tag".to_string(),
-                        crate::jni::compile::OutFrom::Field { path } => path
-                            .iter()
-                            .map(|p| p.to_string())
-                            .collect::<Vec<_>>()
-                            .join("."),
+                        crate::jni::compile::OutFrom::Reach { path } => reach_of(path),
                         crate::jni::compile::OutFrom::Payload { variant, member } => format!(
                             "{}.{}",
                             variant


### PR DESCRIPTION
The fact stage 4d stopped at, and the one that keeps `unfold` load-bearing.

A wire said *which values cross and in what order*. Where the Rust side **reaches** one was the plan's alone — the accessor chain, the field chain, the step that may find nothing — and that is what kept `reach_leaf_flat` and `encode_plan_leaves` reading `UnfoldLeaf`.

Byte-identical: `examples/regen-check.sh` passes, 274 lib tests.

## Steps, not a chain of idents

`OutFrom::Field { path: Vec<syn::Ident> }` becomes `OutFrom::Reach { path: Vec<PathStep> }`, because the two kinds mix: a value form calls an accessor and then reads fields off what it returned, while a nested `data_class` reads fields all the way down. A step also says whether it may find nothing, which is what puts every value below it in doubt.

Spelled in the plans' own `PathStep` rather than a second vocabulary. A reach **is** a path, and inventing a parallel spelling for it would leave two things to keep in step for no gain — the mistake the constructing side avoided by making `Access` and `handle_target` one type rather than a string and a parallel walk.

## Two facts move with it

- **`identity`** — whether the value is the whole crossed object rather than a part of it, the move-or-clone handle a decomposition delivers beside its fields. Never true in a composition: a row states what a value is *made of*, and the value is not one of its own parts. A declaration asks for one, through `.field_self()`.
- **`LeafSource::Field`** becomes `OutWire::is_field_read`, and the question is simply whether the reach ends in a field read. That is what the variant meant: a value form's field leaf reads a field off what the accessor returned (`[Call(f), Field(x)]`), and an accessor leaf ends at the call.

## What this leaves for the rest of stage 6

`encode_plan_leaves` and the hoist machinery (`bind_hoists`, `Hoisted::rebase`, `Hoisted::conditional`). Those are about *evaluating a value form once and binding it*, which is a per-site concern rather than a per-value one — so they follow the plan hook rather than the wire, and `reach_leaf_flat` taking a wire is what lets them.