### PR TITLE
The reach is every value's, not one kind's (#472 §6)

### DIFF
--- a/prebindgen-jni/src/jni/compile.rs
+++ b/prebindgen-jni/src/jni/compile.rs
@@ -271,6 +271,24 @@ pub(crate) struct OutWire {
     pub(crate) group: Option<i32>,
     /// How the Rust side reaches it.
     pub(crate) from: OutFrom,
+    /// The steps from the crossed value down to this one.
+    ///
+    /// **Steps** rather than a chain of idents, because the two kinds mix: a
+    /// value form calls an accessor and then reads fields off what it returned,
+    /// while a nested `data_class` reads fields all the way down. A step also
+    /// says whether it may find nothing, which is what puts every value below
+    /// it in doubt.
+    ///
+    /// Spelled in the plans' own vocabulary rather than a second one. A reach
+    /// **is** a path, and inventing a parallel spelling would leave two things
+    /// to keep in step for no gain — the mistake the constructing side avoided
+    /// by making `Access` and `handle_target` one type.
+    ///
+    /// Independent of [`Self::from`], because every kind of value has one: a
+    /// selector spliced into a value form reaches the sum it selects over, and
+    /// a payload reaches the sum whose arm binds it. Empty means the value the
+    /// site names, which is the common case.
+    pub(crate) reach: Vec<prebindgen_registry::unfold::PathStep>,
     /// Whether this value is the whole crossed object rather than a part of it
     /// — the move-or-clone handle a decomposition delivers beside its fields.
     ///
@@ -306,12 +324,10 @@ impl OutWire {
                     variant: Some(variant.clone()),
                     member: member.clone(),
                 },
-                // Every other leaf is reached off the value, and the steps say
-                // how — an accessor chain, a field chain, or the two mixed.
-                _ => OutFrom::Reach {
-                    path: leaf.path.clone(),
-                },
+                // Every other leaf is read off the place its reach names.
+                _ => OutFrom::Place,
             },
+            reach: leaf.path.clone(),
             identity: leaf.identity,
             nullable: leaf.nullable,
         }
@@ -325,10 +341,7 @@ impl OutWire {
     /// The steps from the crossed value down to this one, or empty for a value
     /// no reach describes — the selector, or a payload its arm's pattern binds.
     pub(crate) fn reach(&self) -> &[prebindgen_registry::unfold::PathStep] {
-        match &self.from {
-            OutFrom::Reach { path } => path,
-            _ => &[],
-        }
+        &self.reach
     }
 
     /// Whether this value is **read off** a place rather than produced by a
@@ -339,7 +352,7 @@ impl OutWire {
     /// what the accessor returned, and an accessor leaf ends at the call.
     pub(crate) fn is_field_read(&self) -> bool {
         matches!(
-            self.reach().last(),
+            self.reach.last(),
             Some(prebindgen_registry::unfold::PathStep::Field { .. })
         )
     }
@@ -356,22 +369,9 @@ pub(crate) enum OutFrom {
     /// The synthesized selector, which is not read off the value at all: the
     /// emitter assigns the alternative's number in each arm of its `match`.
     Tag,
-    /// Reached off the value, by field access or by calling an accessor.
-    ///
-    /// The **steps** rather than a chain of idents, because the two kinds mix:
-    /// a value form calls an accessor and then reads fields off what it
-    /// returned, and a nested `data_class` reads fields all the way down. A
-    /// step also says whether it may find nothing, which is what puts every
-    /// value below it in doubt.
-    ///
-    /// Spelled in the plans' own vocabulary rather than a second one. A reach
-    /// **is** a path, and inventing a parallel spelling for it would leave two
-    /// things to keep in step for no gain — the mistake `Access` and
-    /// `handle_target` avoided on the constructing side by being one type.
-    Reach {
-        /// The steps from the value down to this one.
-        path: Vec<prebindgen_registry::unfold::PathStep>,
-    },
+    /// Read off the place [`OutWire::reach`] names — a field access, or the
+    /// result of the accessor the reach ends in.
+    Place,
     /// A payload of one alternative, bound by that arm's pattern.
     Payload {
         /// The alternative's ident as the source enum declares it. Empty until
@@ -1307,6 +1307,7 @@ impl<R: Conversions> JCompile<'_, R> {
                     },
                     nullable: false,
                     identity: false,
+                    reach: Vec::new(),
                 })
             })
             .collect();
@@ -1403,9 +1404,8 @@ impl<R: Conversions> JCompile<'_, R> {
                 // The chain starts at the accessor's result, which the emitter
                 // binds once. The call itself is the site's to make, so what a
                 // wire states is the field read off it.
-                from: OutFrom::Reach {
-                    path: vec![field_step(&ident)],
-                },
+                from: OutFrom::Place,
+                reach: vec![field_step(&ident)],
                 nullable: false,
                 identity: false,
             });
@@ -1757,9 +1757,8 @@ impl Declarations {
                 name,
                 out_ty: field.ty.clone(),
                 group: None,
-                from: OutFrom::Reach {
-                    path: field_path.iter().map(field_step).collect(),
-                },
+                from: OutFrom::Place,
+                reach: field_path.iter().map(field_step).collect(),
                 nullable: false,
                 identity: false,
             });
@@ -1800,6 +1799,7 @@ impl Declarations {
             from: OutFrom::Tag,
             nullable: false,
             identity: false,
+            reach: Vec::new(),
         }];
         for alt in &sum.alternatives {
             let kotlin = self.sum_variant_class_name(cfg, &alt.name);
@@ -1818,6 +1818,7 @@ impl Declarations {
                     },
                     nullable: false,
                     identity: false,
+                    reach: Vec::new(),
                 });
             }
         }

--- a/prebindgen-jni/src/jni/emit/delivery.rs
+++ b/prebindgen-jni/src/jni/emit/delivery.rs
@@ -898,16 +898,16 @@ pub(crate) fn encode_plan_leaves(
     // A leaf under a CONDITIONAL value form reaches off the name that form's
     // `Some` arm binds — a borrow of the struct, so nothing moves out of it —
     // and its statements are collected into that arm rather than emitted here.
-    let rebase =
-        |leaf: &prebindgen_registry::unfold::UnfoldLeaf| -> (TokenStream, bool, Vec<PathStep>, bool) {
-            if let Some((i, _, bind, rest)) = hoisted.conditional(&leaf.path) {
-                return (quote!(#bind), false, rest, hoisted.consumed(i));
-            }
-            match hoisted.rebase(&leaf.path) {
-                Some((local, rest, consuming)) => (quote!(#local), false, rest, consuming),
-                None => (value.clone(), by_ref, leaf.path.clone(), false),
-            }
-        };
+    let rebase = |leaf: &crate::jni::compile::OutWire| -> (TokenStream, bool, Vec<PathStep>, bool) {
+        let path = leaf.reach();
+        if let Some((i, _, bind, rest)) = hoisted.conditional(path) {
+            return (quote!(#bind), false, rest, hoisted.consumed(i));
+        }
+        match hoisted.rebase(path) {
+            Some((local, rest, consuming)) => (quote!(#local), false, rest, consuming),
+            None => (value.clone(), by_ref, path.to_vec(), false),
+        }
+    };
 
     // A decomposed **sum** is the one shape whose leaves are not independent:
     // only one group is live per value, so its whole segment — the selector
@@ -915,8 +915,9 @@ pub(crate) fn encode_plan_leaves(
     // instead of per-leaf expressions. A plan may carry several: a sum that IS
     // the returned value is the degenerate case of one segment covering
     // everything, while a value form contributes one per sum-typed field.
+    let wires = crate::jni::compile::OutWire::from_leaves(&plan.leaves);
     let sum_segments: Vec<std::ops::Range<usize>> = (0..n)
-        .filter(|&i| plan.leaves[i].source == prebindgen_registry::unfold::LeafSource::SumTag)
+        .filter(|&i| wires[i].is_tag())
         .map(|start| {
             let end = (start + 1..n)
                 .take_while(|&i| plan.leaves[i].group.is_some())
@@ -946,7 +947,7 @@ pub(crate) fn encode_plan_leaves(
         .collect();
 
     for seg in &sum_segments {
-        let leaf = &plan.leaves[seg.start];
+        let leaf = &wires[seg.start];
         let (base, base_is_ref, path, _) = rebase(leaf);
         // The value to `match` on. The selector's own path reaches the sum
         // (empty when the sum IS the value), and a step on it MAY be optional:
@@ -1066,7 +1067,7 @@ pub(crate) fn encode_plan_leaves(
         };
         // The whole segment — its slot declarations and its `match` — is
         // routed like any other leaf under the same form.
-        match hoisted.conditional(&leaf.path) {
+        match hoisted.conditional(leaf.reach()) {
             Some((i, ..)) => cond_stmts
                 .get_mut(&i)
                 .expect("a conditional leaf's hoist has a bucket")
@@ -1094,7 +1095,8 @@ pub(crate) fn encode_plan_leaves(
             Some((i, ..)) => cond_stmts.get_mut(&i).expect("collected above"),
             None => &mut stmts,
         };
-        let (value, by_ref, path, consuming) = rebase(leaf);
+        let (value, by_ref, path, consuming) =
+            rebase(&crate::jni::compile::OutWire::from_leaf(leaf));
         let value = &value;
         let out_entry = ext.out_frag(&leaf.out_ty).unwrap_or_else(|| {
             panic!(

--- a/prebindgen-jni/src/jni/emit/struct_out.rs
+++ b/prebindgen-jni/src/jni/emit/struct_out.rs
@@ -89,10 +89,7 @@ pub(crate) fn synth_value_struct_leaves(
             .into_iter()
             .map(|w| UnfoldLeaf {
                 name: w.name,
-                path: match w.from {
-                    crate::jni::compile::OutFrom::Reach { path } => path,
-                    _ => Vec::new(),
-                },
+                path: w.reach,
                 out_ty: w.out_ty,
                 identity: false,
                 nullable: w.nullable,

--- a/prebindgen-jni/src/jni/emit/sum_out.rs
+++ b/prebindgen-jni/src/jni/emit/sum_out.rs
@@ -63,7 +63,7 @@ pub(crate) fn synth_sum_leaves(
                         member,
                     }
                 }
-                crate::jni::compile::OutFrom::Reach { .. } => LeafSource::Field,
+                crate::jni::compile::OutFrom::Place => LeafSource::Field,
             },
             group: w.group,
         })

--- a/prebindgen-jni/src/jni/mod.rs
+++ b/prebindgen-jni/src/jni/mod.rs
@@ -572,7 +572,7 @@ impl JniGen {
                 .map(|w| {
                     let from = match &w.from {
                         crate::jni::compile::OutFrom::Tag => "tag".to_string(),
-                        crate::jni::compile::OutFrom::Reach { path } => reach_of(path),
+                        crate::jni::compile::OutFrom::Place => reach_of(&w.reach),
                         crate::jni::compile::OutFrom::Payload { variant, member } => format!(
                             "{}.{}",
                             variant
@@ -635,7 +635,7 @@ impl JniGen {
                 .map(|w| {
                     let from = match &w.from {
                         crate::jni::compile::OutFrom::Tag => "tag".to_string(),
-                        crate::jni::compile::OutFrom::Reach { path } => reach_of(path),
+                        crate::jni::compile::OutFrom::Place => reach_of(&w.reach),
                         crate::jni::compile::OutFrom::Payload { variant, member } => format!(
                             "{}.{}",
                             variant


### PR DESCRIPTION
Follows #499, and corrects its shape.

#499 put the reach inside `OutFrom::Reach`, which said only a field-or-accessor value has one. Two value-form tests said otherwise the moment `encode_plan_leaves` started reading wires: a **selector** spliced into a value form reaches the sum it selects over, and routing its whole segment under the right hoist needs that reach. Under #499's shape the selector's was empty, and the segment landed outside the arm.

Byte-identical: `examples/regen-check.sh` passes, 274 lib tests.

## The correction

The reach is its own field. Every kind of value has one:

- a **field** reaches the field,
- a **payload** reaches the sum whose arm binds it,
- a **selector** reaches the sum it selects over.

Empty means the value the site names, which is the common case. `OutFrom` goes back to saying what *kind* of value it is rather than doubling as where it comes from — the two are orthogonal, and #499 conflated them.

## What moved onto wires with it

`encode_plan_leaves`'s rebase closure, and its sum-segment scan. Which values form a segment is `is_tag`; where each one sits is the reach the hoists are matched against.

What is still the plan's is the **hoists** themselves — `bind_hoists`, `Hoisted::rebase`, `Hoisted::conditional`. Those are about evaluating a value form once and binding it to a local, which is a per-site concern rather than a per-value one, so they follow the plan hook rather than the wire.