### PR TITLE
LeafSource::Accessor and ::Field were one thing (#472 §6)

### DIFF
--- a/prebindgen-jni/src/jni/compile.rs
+++ b/prebindgen-jni/src/jni/compile.rs
@@ -348,7 +348,7 @@ impl OutWire {
     /// call — so it is cloned out of the value that holds it.
     ///
     /// The last step being a field read is the whole question, and it is what
-    /// `LeafSource::Field` meant: a value form's field leaf reads a field off
+    /// `LeafSource::Reach` meant: a value form's field leaf reads a field off
     /// what the accessor returned, and an accessor leaf ends at the call.
     pub(crate) fn is_field_read(&self) -> bool {
         matches!(

--- a/prebindgen-jni/src/jni/emit/delivery.rs
+++ b/prebindgen-jni/src/jni/emit/delivery.rs
@@ -1573,7 +1573,7 @@ mod tests {
                 syn::parse_quote!(Owned),
                 path.clone(),
                 true,
-                LeafSource::Accessor,
+                LeafSource::Reach,
             );
             let got = reach_leaf_flat(
                 &qualify,
@@ -1600,7 +1600,7 @@ mod tests {
             syn::parse_quote!(&Owned),
             path.clone(),
             true,
-            LeafSource::Accessor,
+            LeafSource::Reach,
         );
         let got = reach_leaf_flat(
             &qualify,
@@ -1632,7 +1632,7 @@ mod tests {
             syn::parse_quote!(Owned),
             path.clone(),
             false,
-            LeafSource::Field,
+            LeafSource::Reach,
         );
         let got = reach_leaf_flat(
             &qualify,
@@ -1662,7 +1662,7 @@ mod tests {
             PathStep::call(syn::parse_quote!(get_it), true, false),
             PathStep::field(syn::parse_quote!(a), false),
         ];
-        let l = leaf(syn::parse_quote!(Owned), full, false, LeafSource::Accessor);
+        let l = leaf(syn::parse_quote!(Owned), full, false, LeafSource::Reach);
         // The suffix a rebase would hand over — the optional call is gone from
         // it, and used to take the guard with it.
         let rest = vec![PathStep::field(syn::parse_quote!(a), false)];

--- a/prebindgen-jni/src/jni/emit/struct_out.rs
+++ b/prebindgen-jni/src/jni/emit/struct_out.rs
@@ -64,7 +64,7 @@ pub(crate) fn primitive_default_for_descriptor(sig: &str) -> TokenStream {
     }
 }
 
-/// The [`LeafSource::Field`](prebindgen_registry::unfold::LeafSource) leaves of
+/// The [`LeafSource::Reach`](prebindgen_registry::unfold::LeafSource) leaves of
 /// a by-value `data_class`, as the fixed-builder output and callback paths want
 /// them.
 ///
@@ -93,7 +93,7 @@ pub(crate) fn synth_value_struct_leaves(
                 out_ty: w.out_ty,
                 identity: false,
                 nullable: w.nullable,
-                source: LeafSource::Field,
+                source: LeafSource::Reach,
                 group: w.group,
             })
             .collect(),

--- a/prebindgen-jni/src/jni/emit/sum_out.rs
+++ b/prebindgen-jni/src/jni/emit/sum_out.rs
@@ -63,7 +63,7 @@ pub(crate) fn synth_sum_leaves(
                         member,
                     }
                 }
-                crate::jni::compile::OutFrom::Place => LeafSource::Field,
+                crate::jni::compile::OutFrom::Place => LeafSource::Reach,
             },
             group: w.group,
         })

--- a/prebindgen-registry/src/unfold.rs
+++ b/prebindgen-registry/src/unfold.rs
@@ -478,7 +478,7 @@ pub(crate) fn apply(
 /// classes) and handed over as
 /// [`Decompositions::value_structs`](crate::Decompositions::value_structs).
 /// Its [`leaves`](Self::leaves)
-/// are [`LeafSource::Field`] leaves: each crosses the boundary as its own field
+/// are [`LeafSource::Reach`] leaves: each crosses the boundary as its own field
 /// value and the foreign side reassembles the object (no Java object is built
 /// on the Rust side).
 pub struct ValueDecon {
@@ -1403,7 +1403,7 @@ fn flatten(
                     out_ty,
                     identity: true,
                     nullable,
-                    source: LeafSource::Accessor,
+                    source: LeafSource::Reach,
                     group: None,
                 });
             }
@@ -1586,7 +1586,7 @@ fn flatten(
                             out_ty: fr.ty.clone(),
                             identity: false,
                             nullable,
-                            source: LeafSource::Field,
+                            source: LeafSource::Reach,
                             group: None,
                         });
                     }
@@ -1687,7 +1687,7 @@ fn flatten(
                         out_ty,
                         identity,
                         nullable,
-                        source: LeafSource::Accessor,
+                        source: LeafSource::Reach,
                         group: None,
                     });
                 }

--- a/prebindgen-registry/src/unfold/plan.rs
+++ b/prebindgen-registry/src/unfold/plan.rs
@@ -176,19 +176,17 @@ pub fn steps_are_movable(steps: &[PathStep]) -> bool {
 /// How a leaf's [`UnfoldLeaf::path`] is reached from the decomposed value.
 #[derive(Clone, PartialEq, Eq, Debug, Default)]
 pub enum LeafSource {
-    /// The path is a chain of `#[prebindgen]` **accessor functions**:
-    /// `source_module::f(&value)`, composing nested accessors. Nesting steps
-    /// that return `Option` make the leaf nullable. This is the form produced
-    /// by `.deconstructor_record*` / `.fun_accessor` declarations.
+    /// The value is **reached off** the decomposed value: an accessor chain, a
+    /// field chain, or the two mixed, which is what
+    /// [`UnfoldLeaf::path`] spells.
+    ///
+    /// One variant rather than two. `Accessor` and `Field` were separate while
+    /// an adapter branched on which it was; none does — the difference is
+    /// whether the path ENDS in a field read, which the path itself says. Two
+    /// spellings of one fact are two things to keep in step, and this is the
+    /// one that had no reader left.
     #[default]
-    Accessor,
-    /// The path is a chain of **struct field idents** reached by field access
-    /// and cloned: `value.a.b.clone()`. Produced by the synthesized
-    /// decomposition of a by-value `data_class` (see
-    /// [`ValueDecon`](crate::unfold::ValueDecon)); the value's own
-    /// fields cross as decoupled leaves and the foreign side reassembles the
-    /// object (so no Java object is built on the Rust side).
-    Field,
+    Reach,
     /// The **synthesized selector** of a decomposed sum: an `i32` naming which
     /// alternative is live. It is not read off the value at all — the emitter
     /// assigns it per `match` arm — so it has no path. Emitted once, ahead of
@@ -205,14 +203,14 @@ pub enum LeafSource {
     /// — never from an adapter composing one out of a name.
     SumTag,
     /// A payload field of ONE alternative of a decomposed sum, reached through
-    /// a **variant pattern** rather than an accessor chain or a field chain:
-    /// the emitter binds `member` inside `variant`'s `match` arm. The leaf is
-    /// live only when [`UnfoldLeaf::group`] equals the value's tag; in every
-    /// other arm its slot carries the wire default.
+    /// a **variant pattern** rather than a path: the emitter binds `member`
+    /// inside `variant`'s `match` arm. The leaf is live only when
+    /// [`UnfoldLeaf::group`] equals the value's tag; in every other arm its
+    /// slot carries the wire default.
     ///
-    /// This is the selector [`Accessor`](Self::Accessor) and
-    /// [`Field`](Self::Field) deliberately lack — both are deterministic
-    /// products, every record contributing unconditionally.
+    /// This is the selector [`Reach`](Self::Reach) deliberately lacks — a
+    /// reached value is a deterministic product, every one of them
+    /// contributing unconditionally.
     VariantField {
         /// The variant's ident as declared in the source enum.
         variant: syn::Ident,

--- a/prebindgen-registry/src/unfold/tests.rs
+++ b/prebindgen-registry/src/unfold/tests.rs
@@ -1085,7 +1085,7 @@ fn value_struct_vec_is_fixed_iterable_fold() {
         out_ty: tref(ty),
         identity: false,
         nullable: false,
-        source: LeafSource::Field,
+        source: LeafSource::Reach,
         group: None,
     };
     let vd = ValueDecon {
@@ -1118,7 +1118,7 @@ fn value_struct_vec_is_fixed_iterable_fold() {
         "decomposed-leaf fold, not whole-element"
     );
     assert_eq!(plan.leaves.len(), 2, "field leaves cross raw per element");
-    assert!(plan.leaves.iter().all(|l| l.source == LeafSource::Field));
+    assert!(plan.leaves.iter().all(|l| l.source == LeafSource::Reach));
     assert!(!plan.by_ref, "owned Vec<Payload> elements");
 }
 
@@ -1138,7 +1138,7 @@ fn value_struct_slice_callback_is_fixed_iterable_fold() {
         out_ty: tref(ty),
         identity: false,
         nullable: false,
-        source: LeafSource::Field,
+        source: LeafSource::Reach,
         group: None,
     };
     let vd = ValueDecon {
@@ -1167,7 +1167,7 @@ fn value_struct_slice_callback_is_fixed_iterable_fold() {
     assert!(plan.decon.is_some(), "carries the field decon");
     assert!(plan.element.is_none(), "decomposed-leaf fold");
     assert_eq!(plan.leaves.len(), 2);
-    assert!(plan.leaves.iter().all(|l| l.source == LeafSource::Field));
+    assert!(plan.leaves.iter().all(|l| l.source == LeafSource::Reach));
     // A scalar `&Payload` callback arg must stay a Base fixed builder.
     let mut reg2: Registry = reg_with(&[
         "fn storage_callback(f: impl Fn(&Payload) + Send + Sync + 'static) { todo!() }",
@@ -1873,7 +1873,7 @@ fn a_vec_of_optionals_installs_no_fixed_fold() {
         out_ty: tref(ty),
         identity: false,
         nullable: false,
-        source: LeafSource::Field,
+        source: LeafSource::Reach,
         group: None,
     };
     let vd = ValueDecon {


### PR DESCRIPTION
The first deletion stage 6 can actually make, and it fell out of the reading work rather than needing a migration.

Nothing branches on which of the two a leaf is:

- `prebindgen-jni` stopped in #502 — the difference is whether the path **ends in a field read**, which `OutWire::is_field_read` asks of the path itself.
- The registry never did. Its one reader is `has_converter`, which asks only whether a leaf is the selector.

So they merge into `LeafSource::Reach`, and what remains says the three things a reader actually distinguishes: reached off the value, the synthesized selector, or a payload an arm's pattern binds.

Two spellings of one fact are two things to keep in step, and this is the pair that had no reader left to keep them honest.

Byte-identical: `examples/regen-check.sh` passes, 28 test binaries green.