### PR TITLE
Refuse a row asked for by a name the crossing lacks (#472, review)

### DIFF
--- a/prebindgen-jni/src/jni/mod.rs
+++ b/prebindgen-jni/src/jni/mod.rs
@@ -676,6 +676,30 @@ impl JniGen {
         )
     }
 
+    /// Whether a declared type states a `parts` row at all, in the given
+    /// direction — asked of the compiled fragments the way an emitter asks.
+    ///
+    /// Test support. A type with nothing to be made of declares no such row,
+    /// and `Compiled::row_fragment` must then answer `None` rather than hand
+    /// back whatever the crossing compiled by default.
+    pub(crate) fn has_parts_row_for_test(&self, short: &str, out: bool) -> bool {
+        use prebindgen_registry::recipe::Assembly;
+        let ident = syn::Ident::new(short, proc_macro2::Span::call_site());
+        let assembly = match out {
+            true => Assembly::Deconstruct,
+            false => Assembly::Construct,
+        };
+        self.decls
+            .compiled
+            .borrow()
+            .row_fragment(
+                &TypeKey::from_ident(&ident),
+                assembly,
+                &crate::jni::rows::parts(),
+            )
+            .is_some()
+    }
+
     /// The wires a crossing composes into, by spelling.
     pub(crate) fn parts_wires_for_test(
         &self,

--- a/prebindgen-jni/src/jni/rows.rs
+++ b/prebindgen-jni/src/jni/rows.rs
@@ -223,15 +223,19 @@ impl Declarations {
 /// `data_class!` over a type the scan dropped — the scan reports that, and a
 /// row over no fields would report it a second time.
 fn out_fields(model: &Flat, ty: &TypeRef) -> Vec<Reach> {
+    (0..fields_of(model, ty).len()).map(Reach::Field).collect()
+}
+
+/// The fields of a declared struct, or none for anything the model does not
+/// hold as one.
+fn fields_of<'a>(model: &'a Flat, ty: &TypeRef) -> &'a [prebindgen_registry::flat::Field] {
     let prebindgen_registry::flat::TypeKind::Named { id, .. } = ty.unwrapped().kind() else {
-        return Vec::new();
+        return &[];
     };
-    let Some(prebindgen_registry::flat::Type::Struct(s)) =
-        id.ident().and_then(|ident| model.declared_type(&ident))
-    else {
-        return Vec::new();
-    };
-    (0..s.fields.len()).map(Reach::Field).collect()
+    match id.ident().and_then(|ident| model.declared_type(&ident)) {
+        Some(prebindgen_registry::flat::Type::Struct(s)) => &s.fields,
+        _ => &[],
+    }
 }
 
 /// The row a type with no parts takes: the adapter emits the conversion itself.
@@ -345,7 +349,11 @@ impl Declarations {
             // its constructing side names which of the two a site takes by
             // default. See [`parts`] for why that is still `whole`.
             match self.types.get(&ty.key()).map(|c| &c.kind) {
-                Some(DeclaredKind::Data) => {
+                // A struct with no fields is nothing to be made of, so it
+                // states no `parts` row — the same condition the deconstructing
+                // side applies, and the reason `row_of` may be asked for the
+                // row by name.
+                Some(DeclaredKind::Data) if !fields_of(model, &ty).is_empty() => {
                     rows.declare_default(ty.clone(), whole(), Constructing::Atomic)
                         .declare(ty, parts(), Constructing::Product(Construct::Fields));
                 }

--- a/prebindgen-jni/src/jni/tests/values.rs
+++ b/prebindgen-jni/src/jni/tests/values.rs
@@ -2896,3 +2896,67 @@ fn an_exclusive_borrow_parameter_crosses_only_over_a_handle() {
         );
     }
 }
+
+/// A declared type with nothing to be made of states no `parts` row, and no
+/// fragment is filed under that name.
+///
+/// `Declarations::recipes` declares `parts` only where there is something to
+/// decompose — an empty struct has no fields, so it gets the `whole` row and
+/// nothing else. The build then asks each declared type for `parts` by name,
+/// and `Compiler::row_of` refuses a name the crossing lacks rather than
+/// compiling the default and filing it under the asked-for name.
+///
+/// Without that refusal `row_fragment(.., parts)` answered with the whole-value
+/// fragment for a row nobody declared — an emitter reading it would take a
+/// single atomic conversion for a list of parts.
+#[test]
+fn a_type_with_no_parts_files_no_parts_row() {
+    let loc = myflat_loc();
+    let items = vec![
+        (
+            syn::Item::Struct(syn::parse_quote!(
+                pub struct EmptyNamed {}
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Struct(syn::parse_quote!(
+                pub struct HasOne {
+                    pub id: i64,
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn use_both(a: EmptyNamed, b: HasOne) -> i64 {
+                    unimplemented!()
+                }
+            )),
+            loc,
+        ),
+    ];
+    let registry =
+        crate::test_util::reg_from_items(declare_referenced(items)).expect("index items");
+    let gen = JniGenBuilder::new()
+        .set_package_prefix("io.test.jni")
+        .package(
+            crate::package!()
+                .class(crate::data_class!(EmptyNamed))
+                .class(crate::data_class!(HasOne))
+                .fun(prebindgen_registry::fun!(use_both)),
+        )
+        .build_with(registry)
+        .expect("resolve");
+
+    for out in [false, true] {
+        assert!(
+            !gen.has_parts_row_for_test("EmptyNamed", out),
+            "an empty struct states no parts row (out={out})",
+        );
+        assert!(
+            gen.has_parts_row_for_test("HasOne", out),
+            "a struct with a field states one (out={out})",
+        );
+    }
+}

--- a/prebindgen-jni/src/jni/trait_impl.rs
+++ b/prebindgen-jni/src/jni/trait_impl.rs
@@ -1570,6 +1570,17 @@ impl JniGenBuilder {
                 ty,
                 prebindgen_registry::recipe::Assembly::Deconstruct,
             );
+            // A type with nothing to hand out states no `parts` row — an empty
+            // struct, or an enum with no alternatives. Asking for one by name
+            // is refused now rather than answered with the default, so the
+            // condition that declared it is the condition asked here.
+            if decls
+                .recipe_table()
+                .get(&crossing.key(), &crate::jni::rows::parts())
+                .is_none()
+            {
+                continue;
+            }
             let mut compiler = prebindgen_registry::recipe::Compiler::resume(
                 &model,
                 decls.recipe_table(),
@@ -1669,6 +1680,11 @@ impl Declarations {
         // The **stripped** key, so `Box<Payload>` and `&Payload` compile the
         // row too: all three spellings find one row and each gets its own
         // fragment, which is what a site taking a wrapped spelling reads.
+        // A `data_class` with no fields states no `parts` row — there is
+        // nothing for it to be made of — so the row is asked for by name only
+        // where it was declared. `row_of` refuses an absent name rather than
+        // answering with the default, which is what makes that condition the
+        // one that has to match.
         if assembly == prebindgen_registry::recipe::Assembly::Construct
             && matches!(
                 self.types
@@ -1676,6 +1692,10 @@ impl Declarations {
                     .map(|c| &c.kind),
                 Some(DeclaredKind::Data)
             )
+            && compiler
+                .recipes()
+                .get(&crossing.key(), &crate::jni::rows::parts())
+                .is_some()
         {
             // A refusal is a bug in the composition, not a gap in the binding:
             // every part of a `data_class` is a crossing that already resolved

--- a/prebindgen-registry/src/recipe.rs
+++ b/prebindgen-registry/src/recipe.rs
@@ -1104,6 +1104,19 @@ pub enum RecipeError {
         /// The name the site asked for.
         recipe: RecipeId,
     },
+    /// A caller named a row the crossing does not have.
+    ///
+    /// Distinct from [`UnknownRow`](Self::UnknownRow), which is a **site**
+    /// asking for one. This is a caller compiling a named row directly through
+    /// [`Compiler::row_of`](crate::recipe::Compiler::row_of), where there is no
+    /// site to name — an adapter checking a row it declared conditionally, and
+    /// getting the condition wrong.
+    NoSuchRow {
+        /// The crossing that has no such row.
+        crossing: CrossingKey,
+        /// The name the caller asked for.
+        recipe: RecipeId,
+    },
     /// Two declarations of equal precedence bound one site to different rows.
     Rebound {
         /// The site both named.
@@ -1215,6 +1228,11 @@ impl fmt::Display for RecipeError {
             RecipeError::NotAProduct { row, recipe } => write!(
                 f,
                 "row `{recipe}` takes {row} apart, and the model gives that type no parts"
+            ),
+            RecipeError::NoSuchRow { crossing, recipe } => write!(
+                f,
+                "{crossing} has no row `{recipe}` — it was compiled by name, not \
+                 through a site"
             ),
             RecipeError::UnknownRow {
                 site,

--- a/prebindgen-registry/src/recipe/compile.rs
+++ b/prebindgen-registry/src/recipe/compile.rs
@@ -531,6 +531,15 @@ impl<'a, C: Compile> Compiler<'a, C> {
         Ok(fragment)
     }
 
+    /// The rows this compilation was built against.
+    ///
+    /// So a caller can ask whether a crossing has a row before compiling it by
+    /// name — the check [`Self::row_of`] enforces, available ahead of the
+    /// error rather than only through it.
+    pub fn recipes(&self) -> &Recipes {
+        self.recipes
+    }
+
     /// The fragment for one crossing under a **named** row, rather than the one
     /// the crossing defaults to.
     ///
@@ -539,12 +548,28 @@ impl<'a, C: Compile> Compiler<'a, C> {
     /// checked, or read through
     /// [`Compiled::row_fragment`](Compiled::row_fragment), before any site
     /// takes it.
+    ///
+    /// Refuses a name the crossing does not have. Compiling a row falls back to
+    /// the derived row when the lookup misses, which is right for the two
+    /// callers that pass a name they got **from** the table — a crossing's
+    /// default, or a site's binding — and wrong here, where the name is the
+    /// caller's own claim. Without the check a conditionally-declared row that was not
+    /// declared compiles the default instead and files it under the asked-for
+    /// name, leaving [`Compiled::row_fragment`] to answer for a row that does
+    /// not exist.
     pub fn row_of(
         &mut self,
         adapter: &mut C,
         crossing: &Crossing,
         recipe: &RecipeId,
     ) -> Result<Rc<C::Fragment>, CompileError<C::Error>> {
+        if self.recipes.get(&crossing.key(), recipe).is_none() {
+            return Err(RecipeError::NoSuchRow {
+                crossing: crossing.key(),
+                recipe: recipe.clone(),
+            }
+            .into());
+        }
         self.row(adapter, crossing, recipe)
     }
 

--- a/prebindgen-registry/src/recipe/tests.rs
+++ b/prebindgen-registry/src/recipe/tests.rs
@@ -2301,3 +2301,50 @@ fn an_emitter_asking_for_a_crossing_gets_the_row_the_crossing_defaults_to() {
     // The other direction was never crossed, so there is no answer to give.
     assert!(compiled.fragment(&key, Assembly::Construct).is_none());
 }
+
+/// Compiling a row **by name** refuses a name the crossing does not have,
+/// rather than answering with the row it would have derived.
+///
+/// The two callers that reach [`Compiler::row`] with a name they got *from* the
+/// table — a crossing's default, and a site's binding — rely on that fallback,
+/// and it is right for them. [`Compiler::row_of`] takes the caller's own claim,
+/// so the same fallback would compile the default and file it under the asked-for
+/// name, leaving [`Compiled::row_fragment`] to answer for a row nobody declared.
+///
+/// The shape that hits it is a conditionally-declared row: an adapter that
+/// declares `fields` only for a type that has some, then asks every declared
+/// type for `fields` anyway.
+#[test]
+fn compiling_a_row_by_name_refuses_a_name_the_crossing_lacks() {
+    let model = model(&[SAMPLE]);
+    let recipes = two_rows(&model);
+    let bindings = Bindings::default();
+    let crossing = Crossing::new(ty(&model, "Sample"), Assembly::Deconstruct);
+    let mut adapter = Recorder::default();
+    let mut compiler = Compiler::new(&model, &recipes, &bindings);
+
+    let err = compiler
+        .row_of(&mut adapter, &crossing, &id("nonesuch"))
+        .expect_err("`Sample` declares `whole` and `fields`, and nothing else");
+    let message = err.to_string();
+    assert!(message.contains("nonesuch"), "{message}");
+    assert!(message.contains("Sample"), "{message}");
+
+    // And nothing was filed under the name, so no emitter can read one back.
+    let compiled = compiler.finish();
+    assert!(compiled
+        .row_fragment(
+            &ty(&model, "Sample").key(),
+            Assembly::Deconstruct,
+            &id("nonesuch")
+        )
+        .is_none());
+
+    // The two rows that DO exist still compile by name.
+    let mut compiler = Compiler::new(&model, &recipes, &bindings);
+    for name in ["whole", "fields"] {
+        compiler
+            .row_of(&mut adapter, &crossing, &id(name))
+            .unwrap_or_else(|e| panic!("`{name}` is declared: {e}"));
+    }
+}


### PR DESCRIPTION
Addresses the P2 on [#472](https://github.com/milyin/prebindgen/pull/472).

`Compiler::row_of` compiles one **named** row. It delegated to the same lookup a site does, and that lookup falls back to the derived row when the name misses. The fallback is right for the two callers that pass a name they got *from* the table — a crossing's default, or a site's binding — and wrong for a caller stating the name itself.

## What it cost

A fragment filed under a name nobody declared. `Compiled::row_fragment(.., parts)` then answered with the whole-value conversion for a row that does not exist, and an emitter reading it would take one atomic conversion for a list of parts.

Reproduced before fixing, on an empty `data_class` — `row_fragment(parts)` returned a fragment in **both** directions for a type that declares `parts` in neither.

No generated output was affected: `wires_of` reads `.wires` off whatever it gets, the mislabelled fragment carries `None`, and the caller falls through to the same path the absent row would have taken. That is why the golden diff never saw it.

## The fix

`row_of` checks the table first and reports `RecipeError::NoSuchRow`. That is a distinct variant from `UnknownRow`, which is a **site** asking for a missing row and names the site; this one has no site to name — it is a caller compiling by name, having declared a row conditionally and got the condition wrong.

`Compiler::recipes` exposes the table, so a caller can ask ahead of the error rather than only through it. Both JniGen callers now do, so the error is a backstop and not a routine path.

## One inconsistency it exposed

`Declarations::recipes` declared the constructing `parts` row unconditionally while the deconstructing one was conditional. An empty struct therefore stated a row going in and not coming out. Both are conditional now, on the same question: a type with no fields is nothing to be made of.

## Tests

- `compiling_a_row_by_name_refuses_a_name_the_crossing_lacks` — the registry-side guard, plus that nothing is filed under the refused name, plus that the rows which do exist still compile by name.
- `a_type_with_no_parts_files_no_parts_row` — the shape that triggered it, checking both directions against a sibling struct that does have a field.

`examples/regen-check.sh` byte-identical, 28 test binaries green, clippy and rustdoc clean.