### PR TITLE
Separate recipe names from row identity

### DIFF
--- a/docs/model.md
+++ b/docs/model.md
@@ -148,11 +148,16 @@ callback type takes `Invoke`, and the registry accepts no other shape there.
 makes about how values cross. `Recipes` is the type. The adapter fills the
 table before any of it is walked; the registry reads it and never adds to it.
 
-**Recipe.** One entry of the table — one such decision. Three things make one:
+**Recipe.** One row of the table — one such decision. Three things make one:
 
 * the **crossing** it answers — a Rust type and a direction;
-* a **name**, chosen by the adapter, since a crossing may have several recipes;
+* a **recipe name**, chosen by the adapter and meaningful within that crossing;
 * a **shape**.
+
+Names such as `whole` and `parts` are policy vocabulary and are deliberately
+reused under many crossings. `RecipeName` represents that local selector.
+`RecipeKey` pairs it with the crossing key and is the globally unique identity
+of one table row.
 
 *Why the adapter declares recipes and the model does not.* The model already
 knows how a Rust type **can** be taken apart: `Sample`'s fields are in it, and
@@ -409,29 +414,35 @@ pub struct CrossingKey {
 }
 ```
 
-`Crossing` is what a site hands the compiler; `CrossingKey` is what the table
-and the fragment memo are keyed by. The narrowing is deliberate and one-way —
-`key()` exists, its inverse does not — because a key names a recipe and a
-recipe is shared by every way its type can be written.
+`Crossing` is what a site hands the compiler; `CrossingKey` is what groups rows
+in the table. The narrowing is deliberate and one-way — `key()` exists, its
+inverse does not — because rows are shared by every way their type can be
+written. The fragment memo adds the spelled type to `RecipeKey`, since applying
+one row to `T`, `&T` and `Box<T>` can require different Rust.
 
 ### The recipe's name
 
 ```rust
-/// Names one of several answers a crossing may have. Adapters mint these; the
-/// table attaches no meaning to any particular name.
-pub struct RecipeId(String);
+/// An adapter-chosen row name, reusable under different crossing keys.
+pub struct RecipeName(String);
 
-impl RecipeId {
+impl RecipeName {
     pub fn new(name: impl Into<String>) -> Self;
     /// The name the table gives the recipe it derives for an undeclared crossing.
     pub fn derived() -> Self;
     pub fn as_str(&self) -> &str;
 }
+
+/// The globally unique identity of one row in the recipe table.
+pub struct RecipeKey {
+    crossing: CrossingKey,
+    name: RecipeName,
+}
 ```
 
-A crossing is identified by `CrossingKey`; one of its recipes by `(CrossingKey,
-RecipeId)`. The names are the adapter's own — `prebindgen-c` uses `whole` for
-how a type crosses on its own and `in_field` / `parts` / `payload` for how the
-same type crosses inside a container — and the registry never reads one.
-`derived()` is the single reserved name, given to the recipe the table builds
-for a crossing nobody declared.
+A crossing is identified by `CrossingKey`; one table row by `RecipeKey`, whose
+value is the pair `(CrossingKey, RecipeName)`. The names are the adapter's own —
+`prebindgen-c` uses `whole` for how many types cross on their own and `field` /
+`parts` / `payload` for contextual alternatives — and the registry never
+interprets one. `derived()` is the single reserved name, given to a row the
+table derives for a crossing nobody declared.

--- a/prebindgen-c/src/compile.rs
+++ b/prebindgen-c/src/compile.rs
@@ -223,14 +223,14 @@ impl<R: Conversions> Compile for CCompile<'_, R> {
         // filed under `Crossing::key`, which strips `Box`, so `Box<Blob>` and
         // `Blob` share one recipe and could not be told apart there. A fragment is
         // keyed by the spelling, which is exactly the distinction needed.
-        if *at.recipe == crate::recipes::payload() {
+        if at.recipe.name() == &crate::recipes::payload() {
             let conv = match at.crossing.direction() {
                 Direction::Construct => self.gen.in_boxed_payload(ty),
                 Direction::Deconstruct => self.gen.out_boxed_payload(ty),
             };
             return self.wrap(at, "no payload reading for this handle", conv);
         }
-        if *at.recipe == crate::recipes::in_field() {
+        if at.recipe.name() == &crate::recipes::in_field() {
             let conv = match at.crossing.direction() {
                 Direction::Construct => self
                     .gen

--- a/prebindgen-c/src/recipes.rs
+++ b/prebindgen-c/src/recipes.rs
@@ -16,7 +16,7 @@ use prebindgen_registry::{
     flat::{Flat, Type, TypeRef},
     recipe::{
         Arm, Construct, Constructing, Deconstruct, Deconstructing, Direction, Reach, RecipeError,
-        RecipeKey, RecipeName, Recipes,
+        RecipeName, Recipes,
     },
 };
 
@@ -304,7 +304,7 @@ impl CbindgenBuilder {
                     };
                     for &direction in directions {
                         let of = Crossing::new(ty.clone(), direction);
-                        let row = RecipeKey::new(of.key(), parts());
+                        let row = of.row(parts());
                         bound.bind(
                             Site::arm_part(&row, Some(arm), index),
                             Crossing::new(field.ty.clone(), direction),
@@ -351,7 +351,7 @@ impl CbindgenBuilder {
                 };
                 for &direction in directions {
                     let of = Crossing::new(ty.clone(), direction);
-                    let row = RecipeKey::new(of.key(), parts());
+                    let row = of.row(parts());
                     bound.bind(
                         Site::part(&row, index),
                         Crossing::new(field.ty.clone(), direction),

--- a/prebindgen-c/src/recipes.rs
+++ b/prebindgen-c/src/recipes.rs
@@ -16,20 +16,20 @@ use prebindgen_registry::{
     flat::{Flat, Type, TypeRef},
     recipe::{
         Arm, Construct, Constructing, Deconstruct, Deconstructing, Direction, Reach, RecipeError,
-        RecipeId, Recipes,
+        RecipeKey, RecipeName, Recipes,
     },
 };
 
 use super::*;
 
 /// The recipe a type with no parts takes: the adapter emits the conversion itself.
-fn whole() -> RecipeId {
-    RecipeId::new("whole")
+fn whole() -> RecipeName {
+    RecipeName::new("whole")
 }
 
 /// The recipe a type crossing field by field takes.
-pub(crate) fn parts() -> RecipeId {
-    RecipeId::new("parts")
+pub(crate) fn parts() -> RecipeName {
+    RecipeName::new("parts")
 }
 
 /// The recipe a value takes as a **tagged union's payload**, where it rides
@@ -44,8 +44,8 @@ pub(crate) fn parts() -> RecipeId {
 /// `Box`: `Box<Blob>` and `Blob` share one crossing and are told apart by the
 /// site that picks between their recipes, and by the fragment, which is keyed by
 /// the spelling.
-pub(crate) fn payload() -> RecipeId {
-    RecipeId::new("payload")
+pub(crate) fn payload() -> RecipeName {
+    RecipeName::new("payload")
 }
 
 /// The recipe a value takes **inside a `data_struct`'s mirror**, where its wire
@@ -61,8 +61,8 @@ pub(crate) fn payload() -> RecipeId {
 /// `String`: a field decodes a null pointer to an empty string, where a
 /// `String` parameter refuses one. Both readings were in the hand-written field
 /// walk; the recipe is what makes the difference visible.
-pub(crate) fn in_field() -> RecipeId {
-    RecipeId::new("field")
+pub(crate) fn in_field() -> RecipeName {
+    RecipeName::new("field")
 }
 
 impl CbindgenBuilder {
@@ -252,7 +252,7 @@ impl CbindgenBuilder {
 
     /// `bool` and `String` read as they do inside a struct; a `Box`-over-handle
     /// needs [`payload`], the one reading neither of the other two covers.
-    fn payload_reading(&self, fty: &TypeRef) -> Option<(RecipeId, &'static [Direction])> {
+    fn payload_reading(&self, fty: &TypeRef) -> Option<(RecipeName, &'static [Direction])> {
         use prebindgen_registry::flat::{ScalarKind, TypeKind};
         if self.declared_opaque_payload_inner(fty).is_some() || r_boxed_inner(fty).is_some() {
             return Some((payload(), &[Direction::Construct, Direction::Deconstruct]));
@@ -304,8 +304,9 @@ impl CbindgenBuilder {
                     };
                     for &direction in directions {
                         let of = Crossing::new(ty.clone(), direction);
+                        let row = RecipeKey::new(of.key(), parts());
                         bound.bind(
-                            Site::arm_part(&of, &parts(), Some(arm), index),
+                            Site::arm_part(&row, Some(arm), index),
                             Crossing::new(field.ty.clone(), direction),
                             Ask::Recipe(recipe.clone()),
                             Asked::Part,
@@ -350,8 +351,9 @@ impl CbindgenBuilder {
                 };
                 for &direction in directions {
                     let of = Crossing::new(ty.clone(), direction);
+                    let row = RecipeKey::new(of.key(), parts());
                     bound.bind(
-                        Site::part(&of, &parts(), index),
+                        Site::part(&row, index),
                         Crossing::new(field.ty.clone(), direction),
                         Ask::Recipe(in_field()),
                         Asked::Part,

--- a/prebindgen-c/src/tests/recipes.rs
+++ b/prebindgen-c/src/tests/recipes.rs
@@ -61,8 +61,8 @@ fn recipes_of(gen: &CbindgenBuilder, model: &prebindgen_registry::Flat, spelling
         .into_iter()
         .map(|direction| {
             let crossing = Crossing::new(ty(model, spelling), direction);
-            let (id, recipe) = recipes.recipe(&crossing);
-            format!("{direction} {id}:{}", shape(&recipe))
+            let (key, recipe) = recipes.recipe(&crossing);
+            format!("{direction} {}:{}", key.name(), shape(&recipe))
         })
         .collect::<Vec<_>>()
         .join(", ")
@@ -140,7 +140,7 @@ fn a_value_read_two_ways_inside_a_struct_has_two_rows() {
     // The default is the whole-value reading in every case; the field reading
     // is reached only by a part that asks for it.
     let key = Crossing::new(ty(&model, "bool"), Direction::Construct).key();
-    assert_eq!(recipes.default_of(&key).unwrap().as_str(), "whole");
+    assert_eq!(recipes.default_of(&key).unwrap().name().as_str(), "whole");
 }
 
 #[test]

--- a/prebindgen-jni/src/jni/compile.rs
+++ b/prebindgen-jni/src/jni/compile.rs
@@ -1099,9 +1099,14 @@ impl crate::jni::Declarations {
     /// registry derived, which is that crossing's default.
     pub(crate) fn wires_of(&self, ty: &TypeRef) -> Option<Vec<Wire>> {
         let key = ty.key();
+        let crossing = prebindgen_registry::recipe::Crossing::new(ty.clone(), Direction::Construct);
+        let parts = self
+            .recipe_table()
+            .key_of(&crossing.key(), &crate::jni::recipes::parts())
+            .cloned();
         let compiled = self.compiled.borrow();
-        compiled
-            .recipe_fragment(&key, Direction::Construct, &crate::jni::recipes::parts())
+        parts
+            .and_then(|parts| compiled.recipe_fragment(&key, &parts))
             .or_else(|| compiled.fragment(&key, Direction::Construct))?
             .wires
             .clone()

--- a/prebindgen-jni/src/jni/mod.rs
+++ b/prebindgen-jni/src/jni/mod.rs
@@ -557,11 +557,9 @@ impl JniGen {
         let ident = syn::Ident::new(short, proc_macro2::Span::call_site());
         let ty: syn::Type = syn::parse_quote!(#ident);
         let reading = prebindgen_registry::Conversions::reading_of(&self.registry, &ty)?;
-        let row = prebindgen_registry::recipe::RecipeKey::new(
+        let row =
             prebindgen_registry::recipe::Crossing::new(reading.clone(), Direction::Deconstruct)
-                .key(),
-            crate::jni::recipes::parts(),
-        );
+                .row(crate::jni::recipes::parts());
         let compiled = self.decls.compiled.borrow();
         let wires = compiled
             .recipe_fragment(&reading.key(), &row)?
@@ -690,13 +688,11 @@ impl JniGen {
             true => Direction::Deconstruct,
             false => Direction::Construct,
         };
-        let row = prebindgen_registry::recipe::RecipeKey::new(
-            prebindgen_registry::recipe::CrossingKey {
-                ty: TypeKey::from_ident(&ident),
-                direction,
-            },
-            crate::jni::recipes::parts(),
-        );
+        let row = prebindgen_registry::recipe::CrossingKey {
+            ty: TypeKey::from_ident(&ident),
+            direction,
+        }
+        .row(crate::jni::recipes::parts());
         self.decls
             .compiled
             .borrow()
@@ -713,10 +709,8 @@ impl JniGen {
         let ty: syn::Type = syn::parse_str(spelling).ok()?;
         let reading = prebindgen_registry::Conversions::reading_of(&self.registry, &ty)?;
         let key = reading.key();
-        let row = prebindgen_registry::recipe::RecipeKey::new(
-            prebindgen_registry::recipe::Crossing::new(reading.clone(), Direction::Construct).key(),
-            crate::jni::recipes::parts(),
-        );
+        let row = prebindgen_registry::recipe::Crossing::new(reading.clone(), Direction::Construct)
+            .row(crate::jni::recipes::parts());
         let compiled = self.decls.compiled.borrow();
         // A declared class states its composition under `parts`; an optional
         // over one has no recipe of its own and composes on the recipe the registry

--- a/prebindgen-jni/src/jni/mod.rs
+++ b/prebindgen-jni/src/jni/mod.rs
@@ -557,13 +557,14 @@ impl JniGen {
         let ident = syn::Ident::new(short, proc_macro2::Span::call_site());
         let ty: syn::Type = syn::parse_quote!(#ident);
         let reading = prebindgen_registry::Conversions::reading_of(&self.registry, &ty)?;
+        let row = prebindgen_registry::recipe::RecipeKey::new(
+            prebindgen_registry::recipe::Crossing::new(reading.clone(), Direction::Deconstruct)
+                .key(),
+            crate::jni::recipes::parts(),
+        );
         let compiled = self.decls.compiled.borrow();
         let wires = compiled
-            .recipe_fragment(
-                &reading.key(),
-                Direction::Deconstruct,
-                &crate::jni::recipes::parts(),
-            )?
+            .recipe_fragment(&reading.key(), &row)?
             .out_wires
             .clone()?;
         Some(
@@ -689,14 +690,17 @@ impl JniGen {
             true => Direction::Deconstruct,
             false => Direction::Construct,
         };
+        let row = prebindgen_registry::recipe::RecipeKey::new(
+            prebindgen_registry::recipe::CrossingKey {
+                ty: TypeKey::from_ident(&ident),
+                direction,
+            },
+            crate::jni::recipes::parts(),
+        );
         self.decls
             .compiled
             .borrow()
-            .recipe_fragment(
-                &TypeKey::from_ident(&ident),
-                direction,
-                &crate::jni::recipes::parts(),
-            )
+            .recipe_fragment(&TypeKey::from_ident(&ident), &row)
             .is_some()
     }
 
@@ -709,12 +713,16 @@ impl JniGen {
         let ty: syn::Type = syn::parse_str(spelling).ok()?;
         let reading = prebindgen_registry::Conversions::reading_of(&self.registry, &ty)?;
         let key = reading.key();
+        let row = prebindgen_registry::recipe::RecipeKey::new(
+            prebindgen_registry::recipe::Crossing::new(reading.clone(), Direction::Construct).key(),
+            crate::jni::recipes::parts(),
+        );
         let compiled = self.decls.compiled.borrow();
         // A declared class states its composition under `parts`; an optional
         // over one has no recipe of its own and composes on the recipe the registry
         // derived, which is the crossing's default.
         compiled
-            .recipe_fragment(&key, Direction::Construct, &crate::jni::recipes::parts())
+            .recipe_fragment(&key, &row)
             .or_else(|| compiled.fragment(&key, Direction::Construct))?
             .wires
             .clone()

--- a/prebindgen-jni/src/jni/recipes.rs
+++ b/prebindgen-jni/src/jni/recipes.rs
@@ -19,8 +19,8 @@ use std::collections::BTreeMap;
 use prebindgen_registry::{
     flat::{Flat, TypeRef},
     recipe::{
-        Arm, Construct, Constructing, Deconstruct, Deconstructing, Reach, RecipeError, RecipeId,
-        Recipes,
+        Arm, Construct, Constructing, Deconstruct, Deconstructing, Reach, RecipeError, RecipeKey,
+        RecipeName, Recipes,
     },
 };
 
@@ -240,8 +240,8 @@ fn fields_of<'a>(model: &'a Flat, ty: &TypeRef) -> &'a [prebindgen_registry::fla
 }
 
 /// The recipe a type with no parts takes: the adapter emits the conversion itself.
-fn whole() -> RecipeId {
-    RecipeId::new("whole")
+fn whole() -> RecipeName {
+    RecipeName::new("whole")
 }
 
 /// The recipe a `data_class` takes when it crosses **as its fields**.
@@ -250,8 +250,8 @@ fn whole() -> RecipeId {
 /// compiled only where something asks for it by name — which is what lets the
 /// composed wire list be checked against the walk it will replace before
 /// anything depends on it.
-pub(crate) fn parts() -> RecipeId {
-    RecipeId::new("parts")
+pub(crate) fn parts() -> RecipeName {
+    RecipeName::new("parts")
 }
 
 impl Declarations {
@@ -444,7 +444,7 @@ impl Declarations {
         recipes: &prebindgen_registry::recipe::Recipes,
     ) -> Result<prebindgen_registry::recipe::Bindings, Vec<RecipeError>> {
         use prebindgen_registry::recipe::{
-            Ask, Bindings, Crossing, Direction, Origin, RecipeId, Site,
+            Ask, Bindings, Crossing, Direction, Origin, RecipeName, Site,
         };
 
         let mut bound = Bindings::builder();
@@ -483,12 +483,10 @@ impl Declarations {
             // The optional keeps the recipe the registry derived from its shape —
             // it has no `parts` recipe of its own — and it is the value one layer
             // in that crosses as its parts.
+            let outer = Crossing::new(outer.clone(), Direction::Construct);
+            let row = RecipeKey::new(outer.key(), RecipeName::derived());
             bound.bind(
-                Site::part(
-                    &Crossing::new(outer.clone(), Direction::Construct),
-                    &RecipeId::derived(),
-                    0,
-                ),
+                Site::part(&row, 0),
                 Crossing::new(inner.clone(), Direction::Construct),
                 Ask::Recipe(parts()),
                 Origin::Part,
@@ -523,8 +521,9 @@ impl Declarations {
                         (&building, Direction::Construct),
                         (&handing_out, Direction::Deconstruct),
                     ] {
+                        let row = RecipeKey::new(of.key(), parts());
                         bound.bind(
-                            Site::part(of, &parts(), index),
+                            Site::part(&row, index),
                             Crossing::new(field.ty.clone(), direction),
                             Ask::Recipe(parts()),
                             Origin::Part,
@@ -552,7 +551,7 @@ impl Declarations {
             // Only where the type states one. A `sealed_class` always does; a
             // `data_class` states one unless a field of it declines, and a
             // return whose type states none crosses whole.
-            if recipes.get(&crossing.key(), &parts()).is_none() {
+            if recipes.key_of(&crossing.key(), &parts()).is_none() {
                 continue;
             }
             // And only where it is genuinely several. A decomposition that

--- a/prebindgen-jni/src/jni/recipes.rs
+++ b/prebindgen-jni/src/jni/recipes.rs
@@ -19,8 +19,8 @@ use std::collections::BTreeMap;
 use prebindgen_registry::{
     flat::{Flat, TypeRef},
     recipe::{
-        Arm, Construct, Constructing, Deconstruct, Deconstructing, Reach, RecipeError, RecipeKey,
-        RecipeName, Recipes,
+        Arm, Construct, Constructing, Deconstruct, Deconstructing, Reach, RecipeError, RecipeName,
+        Recipes,
     },
 };
 
@@ -484,7 +484,7 @@ impl Declarations {
             // it has no `parts` recipe of its own — and it is the value one layer
             // in that crosses as its parts.
             let outer = Crossing::new(outer.clone(), Direction::Construct);
-            let row = RecipeKey::new(outer.key(), RecipeName::derived());
+            let row = outer.row(RecipeName::derived());
             bound.bind(
                 Site::part(&row, 0),
                 Crossing::new(inner.clone(), Direction::Construct),
@@ -521,7 +521,7 @@ impl Declarations {
                         (&building, Direction::Construct),
                         (&handing_out, Direction::Deconstruct),
                     ] {
-                        let row = RecipeKey::new(of.key(), parts());
+                        let row = of.row(parts());
                         bound.bind(
                             Site::part(&row, index),
                             Crossing::new(field.ty.clone(), direction),

--- a/prebindgen-jni/src/jni/tests/mod.rs
+++ b/prebindgen-jni/src/jni/tests/mod.rs
@@ -75,8 +75,13 @@ fn install(
     let key = TypeKey::from_type(&ty);
     decls.compiled.borrow_mut().record(
         key.clone(),
-        direction,
-        prebindgen_registry::recipe::RecipeId::new("whole"),
+        prebindgen_registry::recipe::RecipeKey::new(
+            prebindgen_registry::recipe::CrossingKey {
+                ty: key.clone(),
+                direction,
+            },
+            prebindgen_registry::recipe::RecipeName::new("whole"),
+        ),
         crate::jni::compile::JFrag::by_hand(key, e.clone()),
     );
     reg.insert_crossing(direction, &ty, true, Some(Answer::over(e.subs)));

--- a/prebindgen-jni/src/jni/tests/mod.rs
+++ b/prebindgen-jni/src/jni/tests/mod.rs
@@ -74,14 +74,11 @@ fn install(
     let ty: syn::Type = syn::parse_str(ty_str).expect("test type");
     let key = TypeKey::from_type(&ty);
     decls.compiled.borrow_mut().record(
-        key.clone(),
-        prebindgen_registry::recipe::RecipeKey::new(
-            prebindgen_registry::recipe::CrossingKey {
-                ty: key.clone(),
-                direction,
-            },
-            prebindgen_registry::recipe::RecipeName::new("whole"),
-        ),
+        prebindgen_registry::recipe::CrossingKey {
+            ty: key.clone(),
+            direction,
+        }
+        .row(prebindgen_registry::recipe::RecipeName::new("whole")),
         crate::jni::compile::JFrag::by_hand(key, e.clone()),
     );
     reg.insert_crossing(direction, &ty, true, Some(Answer::over(e.subs)));

--- a/prebindgen-jni/src/jni/trait_impl.rs
+++ b/prebindgen-jni/src/jni/trait_impl.rs
@@ -1472,14 +1472,11 @@ impl JniGenBuilder {
                     // fall-back for the one crossing kind the compiler skips.
                     let (dir, key) = crossing;
                     decls.compiled.borrow_mut().record(
-                        key.clone(),
-                        prebindgen_registry::recipe::RecipeKey::new(
-                            prebindgen_registry::recipe::CrossingKey {
-                                ty: key.clone(),
-                                direction: *dir,
-                            },
-                            prebindgen_registry::recipe::RecipeName::new("callback"),
-                        ),
+                        prebindgen_registry::recipe::CrossingKey {
+                            ty: key.clone(),
+                            direction: *dir,
+                        }
+                        .row(prebindgen_registry::recipe::RecipeName::new("callback")),
                         crate::jni::compile::JFrag::by_hand(key.clone(), c.clone()),
                     );
                 }

--- a/prebindgen-jni/src/jni/trait_impl.rs
+++ b/prebindgen-jni/src/jni/trait_impl.rs
@@ -1473,8 +1473,13 @@ impl JniGenBuilder {
                     let (dir, key) = crossing;
                     decls.compiled.borrow_mut().record(
                         key.clone(),
-                        *dir,
-                        prebindgen_registry::recipe::RecipeId::new("callback"),
+                        prebindgen_registry::recipe::RecipeKey::new(
+                            prebindgen_registry::recipe::CrossingKey {
+                                ty: key.clone(),
+                                direction: *dir,
+                            },
+                            prebindgen_registry::recipe::RecipeName::new("callback"),
+                        ),
                         crate::jni::compile::JFrag::by_hand(key.clone(), c.clone()),
                     );
                 }
@@ -1573,7 +1578,7 @@ impl JniGenBuilder {
             // condition that declared it is the condition asked here.
             if decls
                 .recipe_table()
-                .get(&crossing.key(), &crate::jni::recipes::parts())
+                .key_of(&crossing.key(), &crate::jni::recipes::parts())
                 .is_none()
             {
                 continue;
@@ -1690,7 +1695,7 @@ impl Declarations {
             )
             && compiler
                 .recipes()
-                .get(&crossing.key(), &crate::jni::recipes::parts())
+                .key_of(&crossing.key(), &crate::jni::recipes::parts())
                 .is_some()
         {
             // A refusal is a bug in the composition, not a gap in the binding:

--- a/prebindgen-registry/src/recipe.rs
+++ b/prebindgen-registry/src/recipe.rs
@@ -356,10 +356,12 @@ impl fmt::Display for RecipeName {
     }
 }
 
-/// The globally unique identity of one row in a [`Recipes`] table.
+/// The globally unique position of one row in a [`Recipes`] table.
 ///
-/// A row name is meaningful only under the crossing key that owns it, so the
-/// table's primary key is the pair rather than an insertion-order surrogate.
+/// A [`RecipeKey`] identifies that position whether or not the table currently
+/// holds a row there. A row name is meaningful only under the crossing key that
+/// owns it, so the table's primary key is the pair rather than an
+/// insertion-order surrogate.
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct RecipeKey {
     crossing: CrossingKey,
@@ -1194,7 +1196,8 @@ pub enum RecipeError {
     },
     /// A constructor was named where what it returns is not the recipe type.
     ///
-    /// A `Result<T, E>` return counts as building a `T`, because that is where a
+    /// The constructing twin of [`NotAnAccessor`](Self::NotAnAccessor). A
+    /// `Result<T, E>` return counts as building a `T`, because that is where a
     /// construction's fallibility is read from.
     NotAConstructor {
         /// The row that named the function.
@@ -1222,6 +1225,9 @@ pub enum RecipeError {
     /// A shape was declared for a type that cannot take it: `Optional` on a
     /// type that is not an `Option`, `Sequence` on one that is not a run, or
     /// `Invoke` on one that is not a callback.
+    ///
+    /// The arity shapes read their inner type off the crossing rather than
+    /// stating it, so this is where a mismatch surfaces.
     WrongShape {
         /// The row whose shape is wrong.
         recipe: RecipeKey,
@@ -1247,7 +1253,8 @@ pub enum RecipeError {
     /// Distinct from [`UnknownRecipe`](Self::UnknownRecipe), which is a **site**
     /// asking for one. This is a caller compiling a named recipe directly through
     /// [`Compiler::recipe_of`](crate::recipe::Compiler::recipe_of), where there is no
-    /// site to name.
+    /// site to name — an adapter checking a recipe it declared conditionally, and
+    /// getting the condition wrong.
     NoSuchRecipe {
         /// The complete key the caller asked for.
         recipe: RecipeKey,

--- a/prebindgen-registry/src/recipe.rs
+++ b/prebindgen-registry/src/recipe.rs
@@ -15,6 +15,11 @@
 //! a recipe cannot contradict the Rust it describes. What is left is short: a
 //! whole product is one identifier.
 //!
+//! [`RecipeName`] is reusable adapter vocabulary such as `whole` or `parts`.
+//! [`RecipeKey`] pairs that name with a [`CrossingKey`] and uniquely identifies
+//! one row throughout the table. Resolved bindings and compiled fragments carry
+//! the full key rather than a context-dependent name.
+//!
 //! # What a crossing is keyed by
 //!
 //! A borrow is not part of the crossing. `Sample`, `&Sample` and `Box<Sample>`
@@ -309,14 +314,15 @@ impl fmt::Display for CrossingKey {
     }
 }
 
-/// Names one of several answers a crossing may have.
+/// The adapter-chosen name of a recipe row within one crossing key.
 ///
-/// Adapters mint these; the table attaches no meaning to any particular name.
+/// Names such as `whole` and `parts` are deliberately reusable across types and
+/// directions. Use [`RecipeKey`] where the identity of one table row is needed.
 #[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
-pub struct RecipeId(String);
+pub struct RecipeName(String);
 
-impl RecipeId {
-    /// The name of one answer.
+impl RecipeName {
+    /// A reusable row name.
     pub fn new(name: impl Into<String>) -> Self {
         Self(name.into())
     }
@@ -332,9 +338,46 @@ impl RecipeId {
     }
 }
 
-impl fmt::Display for RecipeId {
+impl fmt::Display for RecipeName {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(&self.0)
+    }
+}
+
+/// The globally unique identity of one row in a [`Recipes`] table.
+///
+/// A row name is meaningful only under the crossing key that owns it, so the
+/// table's primary key is the pair rather than an insertion-order surrogate.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct RecipeKey {
+    crossing: CrossingKey,
+    name: RecipeName,
+}
+
+impl RecipeKey {
+    /// Identify the row named `name` under `crossing`.
+    pub fn new(crossing: CrossingKey, name: RecipeName) -> Self {
+        Self { crossing, name }
+    }
+
+    /// The crossing key under which the row is filed.
+    pub fn crossing(&self) -> &CrossingKey {
+        &self.crossing
+    }
+
+    /// The adapter-chosen name within that crossing key.
+    pub fn name(&self) -> &RecipeName {
+        &self.name
+    }
+
+    fn derived(crossing: CrossingKey) -> Self {
+        Self::new(crossing, RecipeName::derived())
+    }
+}
+
+impl fmt::Display for RecipeKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "recipe `{}` of {}", self.name, self.crossing)
     }
 }
 
@@ -435,7 +478,7 @@ impl Recipe {
 
 #[derive(Clone, Debug)]
 struct Entry {
-    id: RecipeId,
+    key: RecipeKey,
     recipe: Recipe,
     /// The type as the declaration spelled it, which is what the checks read
     /// fields and alternatives off.
@@ -460,19 +503,28 @@ impl Recipes {
     ///
     /// Empty for a crossing nobody declared, which still has the recipe
     /// [`Self::recipe`] derives.
-    pub fn names_of(&self, key: &CrossingKey) -> Vec<&RecipeId> {
+    pub fn names_of(&self, key: &CrossingKey) -> Vec<&RecipeName> {
         self.recipes
             .get(key)
-            .map(|recipes| recipes.iter().map(|e| &e.id).collect())
+            .map(|recipes| recipes.iter().map(|e| e.key.name()).collect())
             .unwrap_or_default()
     }
 
-    /// One named recipe of a crossing, or `None` if it was never declared.
-    pub fn get(&self, key: &CrossingKey, id: &RecipeId) -> Option<&Recipe> {
+    /// The key of one named row under a crossing, or `None` if it was never declared.
+    pub fn key_of(&self, crossing: &CrossingKey, name: &RecipeName) -> Option<&RecipeKey> {
         self.recipes
-            .get(key)?
+            .get(crossing)?
             .iter()
-            .find(|e| &e.id == id)
+            .find(|e| e.key.name() == name)
+            .map(|e| &e.key)
+    }
+
+    /// One row by its globally unique key.
+    pub fn get(&self, key: &RecipeKey) -> Option<&Recipe> {
+        self.recipes
+            .get(key.crossing())?
+            .iter()
+            .find(|e| &e.key == key)
             .map(|e| &e.recipe)
     }
 
@@ -481,11 +533,11 @@ impl Recipes {
     /// With one declared recipe that recipe is the default; with several it is the
     /// one declared through [`RecipesBuilder::declare_default`]. `None` for a
     /// crossing nobody declared.
-    pub fn default_of(&self, key: &CrossingKey) -> Option<&RecipeId> {
+    pub fn default_of(&self, key: &CrossingKey) -> Option<&RecipeKey> {
         let recipes = self.recipes.get(key)?;
         match recipes.as_slice() {
-            [only] => Some(&only.id),
-            many => many.iter().find(|e| e.default).map(|e| &e.id),
+            [only] => Some(&only.key),
+            many => many.iter().find(|e| e.default).map(|e| &e.key),
         }
     }
 
@@ -495,17 +547,17 @@ impl Recipes {
     /// A callback type derives [`Shape::Invoke`], the only shape such a
     /// crossing takes, so an adapter reaches one here the same way it reaches
     /// every other recipe.
-    pub fn recipe(&self, crossing: &Crossing) -> (RecipeId, Cow<'_, Recipe>) {
+    pub fn recipe(&self, crossing: &Crossing) -> (RecipeKey, Cow<'_, Recipe>) {
         let key = crossing.key();
         match self.default_of(&key) {
-            Some(id) => {
-                let id = id.clone();
+            Some(recipe_key) => {
+                let recipe_key = recipe_key.clone();
                 let recipe = self
-                    .get(&key, &id)
+                    .get(&recipe_key)
                     .expect("default names a declared recipe");
-                (id, Cow::Borrowed(recipe))
+                (recipe_key, Cow::Borrowed(recipe))
             }
-            None => (RecipeId::derived(), Cow::Owned(derive(crossing))),
+            None => (RecipeKey::derived(key), Cow::Owned(derive(crossing))),
         }
     }
 }
@@ -567,7 +619,7 @@ pub struct RecipesBuilder {
     recipes: HashMap<CrossingKey, Vec<Entry>>,
     /// A recipe declared twice under one name, reported by [`Self::build`] rather
     /// than by overwriting silently.
-    duplicates: Vec<(CrossingKey, RecipeId)>,
+    duplicates: Vec<RecipeKey>,
 }
 
 impl RecipesBuilder {
@@ -581,10 +633,10 @@ impl RecipesBuilder {
     pub fn declare<OP: Operation>(
         &mut self,
         ty: TypeRef,
-        id: RecipeId,
+        name: RecipeName,
         shape: Shape<OP>,
     ) -> &mut Self {
-        self.insert(ty, id, OP::into_recipe(shape), false)
+        self.insert(ty, name, OP::into_recipe(shape), false)
     }
 
     /// Add one recipe and make it the recipe used where a site names none.
@@ -594,21 +646,28 @@ impl RecipesBuilder {
     pub fn declare_default<OP: Operation>(
         &mut self,
         ty: TypeRef,
-        id: RecipeId,
+        name: RecipeName,
         shape: Shape<OP>,
     ) -> &mut Self {
-        self.insert(ty, id, OP::into_recipe(shape), true)
+        self.insert(ty, name, OP::into_recipe(shape), true)
     }
 
-    fn insert(&mut self, ty: TypeRef, id: RecipeId, recipe: Recipe, default: bool) -> &mut Self {
-        let key = Crossing::new(ty.clone(), recipe.direction()).key();
-        let entries = self.recipes.entry(key.clone()).or_default();
-        if entries.iter().any(|e| e.id == id) {
-            self.duplicates.push((key, id));
+    fn insert(
+        &mut self,
+        ty: TypeRef,
+        name: RecipeName,
+        recipe: Recipe,
+        default: bool,
+    ) -> &mut Self {
+        let crossing = Crossing::new(ty.clone(), recipe.direction()).key();
+        let key = RecipeKey::new(crossing.clone(), name);
+        let entries = self.recipes.entry(crossing).or_default();
+        if entries.iter().any(|e| e.key == key) {
+            self.duplicates.push(key);
             return self;
         }
         entries.push(Entry {
-            id,
+            key,
             recipe,
             ty,
             default,
@@ -629,15 +688,18 @@ impl RecipesBuilder {
         let mut errors: Vec<RecipeError> = self
             .duplicates
             .into_iter()
-            .map(|(crossing, recipe)| RecipeError::Duplicate { crossing, recipe })
+            .map(|key| RecipeError::Duplicate {
+                crossing: key.crossing().clone(),
+                recipe: key.name().clone(),
+            })
             .collect();
 
         for (key, entries) in &table.recipes {
             if entries.len() > 1 {
-                let defaults: Vec<RecipeId> = entries
+                let defaults: Vec<RecipeName> = entries
                     .iter()
                     .filter(|e| e.default)
-                    .map(|e| e.id.clone())
+                    .map(|e| e.key.name().clone())
                     .collect();
                 if defaults.len() != 1 {
                     errors.push(RecipeError::NoDefault {
@@ -654,14 +716,14 @@ impl RecipesBuilder {
                 if crossing.value().callback_args().is_some() && !entry.recipe.is_invoke() {
                     errors.push(RecipeError::CallbackShape {
                         crossing: key.clone(),
-                        recipe: entry.id.clone(),
+                        recipe: entry.key.name().clone(),
                     });
                     continue;
                 }
                 let mut check = Check {
                     model,
                     crossing: key,
-                    recipe: &entry.id,
+                    recipe: entry.key.name(),
                     errors: &mut errors,
                     arm_fields: None,
                 };
@@ -684,7 +746,7 @@ impl RecipesBuilder {
 struct Check<'a, 'e> {
     model: &'a Flat,
     crossing: &'a CrossingKey,
-    recipe: &'a RecipeId,
+    recipe: &'a RecipeName,
     errors: &'e mut Vec<RecipeError>,
     /// The payload fields of the arm being checked, which is what a
     /// [`Reach::Field`] indexes inside a [`Shape::Choice`].
@@ -1071,13 +1133,13 @@ fn walk(
 /// cycle through the recipe nobody happens to default to is still a cycle.
 fn successors(model: &Flat, table: &Recipes, crossing: &Crossing) -> Vec<Crossing> {
     let key = crossing.key();
-    let recipes: Vec<(RecipeId, TypeRef, Recipe)> = match table.recipes.get(&key) {
+    let recipes: Vec<(RecipeName, TypeRef, Recipe)> = match table.recipes.get(&key) {
         Some(entries) => entries
             .iter()
-            .map(|e| (e.id.clone(), e.ty.clone(), e.recipe.clone()))
+            .map(|e| (e.key.name().clone(), e.ty.clone(), e.recipe.clone()))
             .collect(),
         None => vec![(
-            RecipeId::derived(),
+            RecipeName::derived(),
             crossing.spelled().clone(),
             derive(crossing),
         )],
@@ -1087,11 +1149,11 @@ fn successors(model: &Flat, table: &Recipes, crossing: &Crossing) -> Vec<Crossin
     let mut discarded = Vec::new();
     recipes
         .into_iter()
-        .flat_map(|(id, ty, recipe)| {
+        .flat_map(|(name, ty, recipe)| {
             let mut check = Check {
                 model,
                 crossing: &key,
-                recipe: &id,
+                recipe: &name,
                 errors: &mut discarded,
                 arm_fields: None,
             };
@@ -1119,21 +1181,21 @@ pub enum RecipeError {
         /// The crossing whose recipes disagree.
         crossing: CrossingKey,
         /// The recipes that claimed to be the default.
-        defaults: Vec<RecipeId>,
+        defaults: Vec<RecipeName>,
     },
     /// One name was declared twice for one crossing.
     Duplicate {
         /// The crossing declared twice.
         crossing: CrossingKey,
         /// The name used twice.
-        recipe: RecipeId,
+        recipe: RecipeName,
     },
     /// A recipe named a constructor or accessor the model does not have.
     UnknownFunction {
         /// The crossing the recipe answers.
         crossing: CrossingKey,
         /// Which of the crossing's recipes named it.
-        recipe: RecipeId,
+        recipe: RecipeName,
         /// The name that resolved to nothing.
         func: syn::Ident,
     },
@@ -1146,7 +1208,7 @@ pub enum RecipeError {
         /// The crossing the recipe answers.
         crossing: CrossingKey,
         /// Which of the crossing's recipes named it.
-        recipe: RecipeId,
+        recipe: RecipeName,
         /// The function whose return type does not match.
         func: syn::Ident,
     },
@@ -1155,7 +1217,7 @@ pub enum RecipeError {
         /// The crossing the recipe answers.
         crossing: CrossingKey,
         /// Which of the crossing's recipes named it.
-        recipe: RecipeId,
+        recipe: RecipeName,
         /// The function whose first parameter does not match.
         func: syn::Ident,
     },
@@ -1165,7 +1227,7 @@ pub enum RecipeError {
         /// The crossing the recipe answers.
         crossing: CrossingKey,
         /// Which of the crossing's recipes names the index.
-        recipe: RecipeId,
+        recipe: RecipeName,
         /// The index the recipe named.
         index: usize,
         /// How many the model holds.
@@ -1183,7 +1245,7 @@ pub enum RecipeError {
         /// The crossing the recipe answers.
         crossing: CrossingKey,
         /// Which of the crossing's recipes was declared.
-        recipe: RecipeId,
+        recipe: RecipeName,
         /// The shape as declared.
         shape: &'static str,
         /// What the type would have had to be.
@@ -1193,7 +1255,7 @@ pub enum RecipeError {
         /// The crossing the recipe answers.
         crossing: CrossingKey,
         /// Which of the crossing's recipes was declared.
-        recipe: RecipeId,
+        recipe: RecipeName,
     },
     /// A site asked for a recipe that was never declared.
     UnknownRecipe {
@@ -1202,7 +1264,7 @@ pub enum RecipeError {
         /// The crossing that has no such recipe.
         crossing: CrossingKey,
         /// The name the site asked for.
-        recipe: RecipeId,
+        recipe: RecipeName,
     },
     /// A caller named a recipe the crossing does not have.
     ///
@@ -1215,7 +1277,7 @@ pub enum RecipeError {
         /// The crossing that has no such recipe.
         crossing: CrossingKey,
         /// The name the caller asked for.
-        recipe: RecipeId,
+        recipe: RecipeName,
     },
     /// Two declarations of equal precedence bound one site to different recipes.
     Rebound {
@@ -1277,7 +1339,7 @@ pub enum RecipeError {
         /// The callback crossing.
         crossing: CrossingKey,
         /// The recipe declared for it.
-        recipe: RecipeId,
+        recipe: RecipeName,
     },
 }
 

--- a/prebindgen-registry/src/recipe.rs
+++ b/prebindgen-registry/src/recipe.rs
@@ -297,6 +297,11 @@ impl Crossing {
             direction: self.direction,
         }
     }
+
+    /// The row named `name` under this crossing's normalized key.
+    pub fn row(&self, name: RecipeName) -> RecipeKey {
+        self.key().row(name)
+    }
 }
 
 /// A crossing identified rather than described.
@@ -306,6 +311,13 @@ pub struct CrossingKey {
     pub ty: TypeKey,
     /// Which of the two directions.
     pub direction: Direction,
+}
+
+impl CrossingKey {
+    /// The row named `name` under this crossing key.
+    pub fn row(&self, name: RecipeName) -> RecipeKey {
+        RecipeKey::new(self.clone(), name)
+    }
 }
 
 impl fmt::Display for CrossingKey {
@@ -356,7 +368,7 @@ pub struct RecipeKey {
 
 impl RecipeKey {
     /// Identify the row named `name` under `crossing`.
-    pub fn new(crossing: CrossingKey, name: RecipeName) -> Self {
+    fn new(crossing: CrossingKey, name: RecipeName) -> Self {
         Self { crossing, name }
     }
 
@@ -499,7 +511,7 @@ impl Recipes {
         RecipesBuilder::default()
     }
 
-    /// Which recipes this crossing has, in declaration order.
+    /// Which recipe names this crossing has, in declaration order.
     ///
     /// Empty for a crossing nobody declared, which still has the recipe
     /// [`Self::recipe`] derives.
@@ -660,7 +672,7 @@ impl RecipesBuilder {
         default: bool,
     ) -> &mut Self {
         let crossing = Crossing::new(ty.clone(), recipe.direction()).key();
-        let key = RecipeKey::new(crossing.clone(), name);
+        let key = crossing.row(name);
         let entries = self.recipes.entry(crossing).or_default();
         if entries.iter().any(|e| e.key == key) {
             self.duplicates.push(key);
@@ -688,10 +700,7 @@ impl RecipesBuilder {
         let mut errors: Vec<RecipeError> = self
             .duplicates
             .into_iter()
-            .map(|key| RecipeError::Duplicate {
-                crossing: key.crossing().clone(),
-                recipe: key.name().clone(),
-            })
+            .map(|recipe| RecipeError::Duplicate { recipe })
             .collect();
 
         for (key, entries) in &table.recipes {
@@ -715,15 +724,13 @@ impl RecipesBuilder {
                 // is no second answer for such a crossing.
                 if crossing.value().callback_args().is_some() && !entry.recipe.is_invoke() {
                     errors.push(RecipeError::CallbackShape {
-                        crossing: key.clone(),
-                        recipe: entry.key.name().clone(),
+                        recipe: entry.key.clone(),
                     });
                     continue;
                 }
                 let mut check = Check {
                     model,
-                    crossing: key,
-                    recipe: entry.key.name(),
+                    recipe: &entry.key,
                     errors: &mut errors,
                     arm_fields: None,
                 };
@@ -745,8 +752,7 @@ impl RecipesBuilder {
 
 struct Check<'a, 'e> {
     model: &'a Flat,
-    crossing: &'a CrossingKey,
-    recipe: &'a RecipeName,
+    recipe: &'a RecipeKey,
     errors: &'e mut Vec<RecipeError>,
     /// The payload fields of the arm being checked, which is what a
     /// [`Reach::Field`] indexes inside a [`Shape::Choice`].
@@ -760,7 +766,6 @@ impl<'a> Check<'a, '_> {
 
     fn out_of_range(&mut self, index: usize, len: usize) {
         self.push(RecipeError::OutOfRange {
-            crossing: self.crossing.clone(),
             recipe: self.recipe.clone(),
             index,
             len,
@@ -769,14 +774,12 @@ impl<'a> Check<'a, '_> {
 
     fn not_a_product(&mut self) {
         self.push(RecipeError::NotAProduct {
-            crossing: self.crossing.clone(),
             recipe: self.recipe.clone(),
         });
     }
 
     fn not_a_callback(&mut self) {
         self.push(RecipeError::WrongShape {
-            crossing: self.crossing.clone(),
             recipe: self.recipe.clone(),
             shape: "Invoke",
             wanted: "a callback type",
@@ -790,7 +793,6 @@ impl<'a> Check<'a, '_> {
             ("Sequence", "a `Vec`, slice or array")
         };
         self.push(RecipeError::WrongShape {
-            crossing: self.crossing.clone(),
             recipe: self.recipe.clone(),
             shape,
             wanted,
@@ -911,7 +913,6 @@ impl<'a> Check<'a, '_> {
                     let parts = f.params.iter().map(|p| p.ty.clone()).collect();
                     if !constructor_of(f, ty) {
                         self.push(RecipeError::NotAConstructor {
-                            crossing: self.crossing.clone(),
                             recipe: self.recipe.clone(),
                             func: func.clone(),
                         });
@@ -940,7 +941,6 @@ impl<'a> Check<'a, '_> {
                 let bound = f.ret.clone();
                 if !accessor_of(f, ty) {
                     self.push(RecipeError::NotAnAccessor {
-                        crossing: self.crossing.clone(),
                         recipe: self.recipe.clone(),
                         func: func.clone(),
                     });
@@ -967,7 +967,6 @@ impl<'a> Check<'a, '_> {
                     let ret = f.ret.clone();
                     if !accessor_of(f, ty) {
                         self.push(RecipeError::NotAnAccessor {
-                            crossing: self.crossing.clone(),
                             recipe: self.recipe.clone(),
                             func: func.clone(),
                         });
@@ -994,7 +993,6 @@ impl<'a> Check<'a, '_> {
             Some(f) => Some(f),
             None => {
                 let error = RecipeError::UnknownFunction {
-                    crossing: self.crossing.clone(),
                     recipe: self.recipe.clone(),
                     func: name.clone(),
                 };
@@ -1133,13 +1131,13 @@ fn walk(
 /// cycle through the recipe nobody happens to default to is still a cycle.
 fn successors(model: &Flat, table: &Recipes, crossing: &Crossing) -> Vec<Crossing> {
     let key = crossing.key();
-    let recipes: Vec<(RecipeName, TypeRef, Recipe)> = match table.recipes.get(&key) {
+    let recipes: Vec<(RecipeKey, TypeRef, Recipe)> = match table.recipes.get(&key) {
         Some(entries) => entries
             .iter()
-            .map(|e| (e.key.name().clone(), e.ty.clone(), e.recipe.clone()))
+            .map(|e| (e.key.clone(), e.ty.clone(), e.recipe.clone()))
             .collect(),
         None => vec![(
-            RecipeName::derived(),
+            key.row(RecipeName::derived()),
             crossing.spelled().clone(),
             derive(crossing),
         )],
@@ -1149,11 +1147,10 @@ fn successors(model: &Flat, table: &Recipes, crossing: &Crossing) -> Vec<Crossin
     let mut discarded = Vec::new();
     recipes
         .into_iter()
-        .flat_map(|(name, ty, recipe)| {
+        .flat_map(|(recipe_key, ty, recipe)| {
             let mut check = Check {
                 model,
-                crossing: &key,
-                recipe: &name,
+                recipe: &recipe_key,
                 errors: &mut discarded,
                 arm_fields: None,
             };
@@ -1183,101 +1180,77 @@ pub enum RecipeError {
         /// The recipes that claimed to be the default.
         defaults: Vec<RecipeName>,
     },
-    /// One name was declared twice for one crossing.
+    /// One row was declared twice.
     Duplicate {
-        /// The crossing declared twice.
-        crossing: CrossingKey,
-        /// The name used twice.
-        recipe: RecipeName,
+        /// The row declared twice.
+        recipe: RecipeKey,
     },
     /// A recipe named a constructor or accessor the model does not have.
     UnknownFunction {
-        /// The crossing the recipe answers.
-        crossing: CrossingKey,
-        /// Which of the crossing's recipes named it.
-        recipe: RecipeName,
+        /// The row that named it.
+        recipe: RecipeKey,
         /// The name that resolved to nothing.
         func: syn::Ident,
     },
-    /// A constructor was named where what it returns is not the recipe's type.
+    /// A constructor was named where what it returns is not the recipe type.
     ///
-    /// The constructing twin of [`NotAnAccessor`](Self::NotAnAccessor). A
-    /// `Result<T, E>` return counts as building a `T`, because that is where a
+    /// A `Result<T, E>` return counts as building a `T`, because that is where a
     /// construction's fallibility is read from.
     NotAConstructor {
-        /// The crossing the recipe answers.
-        crossing: CrossingKey,
-        /// Which of the crossing's recipes named it.
-        recipe: RecipeName,
+        /// The row that named the function.
+        recipe: RecipeKey,
         /// The function whose return type does not match.
         func: syn::Ident,
     },
-    /// An accessor was named where its first parameter is not the recipe's type.
+    /// An accessor was named where its first parameter is not the recipe type.
     NotAnAccessor {
-        /// The crossing the recipe answers.
-        crossing: CrossingKey,
-        /// Which of the crossing's recipes named it.
-        recipe: RecipeName,
+        /// The row that named the function.
+        recipe: RecipeKey,
         /// The function whose first parameter does not match.
         func: syn::Ident,
     },
     /// A [`Reach::Field`] or an [`Arm::alternative`] is past the end of what the
     /// model holds for that type.
     OutOfRange {
-        /// The crossing the recipe answers.
-        crossing: CrossingKey,
-        /// Which of the crossing's recipes names the index.
-        recipe: RecipeName,
+        /// The row that names the index.
+        recipe: RecipeKey,
         /// The index the recipe named.
         index: usize,
         /// How many the model holds.
         len: usize,
     },
-    /// A product or choice recipe was declared for a type the model gives no
-    /// parts.
     /// A shape was declared for a type that cannot take it: `Optional` on a
     /// type that is not an `Option`, `Sequence` on one that is not a run, or
     /// `Invoke` on one that is not a callback.
-    ///
-    /// The arity shapes read their inner type off the crossing rather than
-    /// stating it, so this is where a mismatch surfaces.
     WrongShape {
-        /// The crossing the recipe answers.
-        crossing: CrossingKey,
-        /// Which of the crossing's recipes was declared.
-        recipe: RecipeName,
+        /// The row whose shape is wrong.
+        recipe: RecipeKey,
         /// The shape as declared.
         shape: &'static str,
         /// What the type would have had to be.
         wanted: &'static str,
     },
+    /// A product or choice recipe was declared for a type the model gives no parts.
     NotAProduct {
-        /// The crossing the recipe answers.
-        crossing: CrossingKey,
-        /// Which of the crossing's recipes was declared.
-        recipe: RecipeName,
+        /// The row whose type has no parts.
+        recipe: RecipeKey,
     },
-    /// A site asked for a recipe that was never declared.
+    /// A site asked for a recipe row that was never declared.
     UnknownRecipe {
         /// Where the value crosses.
         site: Site,
-        /// The crossing that has no such recipe.
-        crossing: CrossingKey,
-        /// The name the site asked for.
-        recipe: RecipeName,
+        /// The complete key the site asked for.
+        recipe: RecipeKey,
     },
-    /// A caller named a recipe the crossing does not have.
+    /// A caller named a recipe row the table does not have.
     ///
     /// Distinct from [`UnknownRecipe`](Self::UnknownRecipe), which is a **site**
     /// asking for one. This is a caller compiling a named recipe directly through
     /// [`Compiler::recipe_of`](crate::recipe::Compiler::recipe_of), where there is no
-    /// site to name — an adapter checking a recipe it declared conditionally, and
-    /// getting the condition wrong.
+    /// site to name.
     NoSuchRecipe {
-        /// The crossing that has no such recipe.
-        crossing: CrossingKey,
-        /// The name the caller asked for.
-        recipe: RecipeName,
+        /// The complete key the caller asked for.
+        recipe: RecipeKey,
     },
     /// Two declarations of equal precedence bound one site to different recipes.
     Rebound {
@@ -1336,10 +1309,8 @@ pub enum RecipeError {
     /// Converting the arguments is what makes a callable callable, so taking it
     /// apart is the only thing an adapter can do with one.
     CallbackShape {
-        /// The callback crossing.
-        crossing: CrossingKey,
-        /// The recipe declared for it.
-        recipe: RecipeName,
+        /// The invalid callback row.
+        recipe: RecipeKey,
     },
 }
 
@@ -1364,73 +1335,43 @@ impl fmt::Display for RecipeError {
                     format!("{}", defaults.len())
                 }
             ),
-            RecipeError::Duplicate { crossing, recipe } => {
-                write!(f, "{crossing} declares the recipe `{recipe}` twice")
+            RecipeError::Duplicate { recipe } => {
+                write!(f, "{recipe} is declared twice")
             }
-            RecipeError::UnknownFunction {
-                crossing,
-                recipe,
-                func,
-            } => write!(
+            RecipeError::UnknownFunction { recipe, func } => write!(
                 f,
-                "recipe `{recipe}` of {crossing} names `{func}`, which no #[prebindgen] \
-                 source declares"
+                "{recipe} names `{func}`, which no #[prebindgen] source declares"
             ),
-            RecipeError::NotAConstructor {
-                crossing,
-                recipe,
-                func,
-            } => write!(
+            RecipeError::NotAConstructor { recipe, func } => write!(
                 f,
-                "recipe `{recipe}` of {crossing} builds the value with `{func}`, which does \
-                 not return that type"
+                "{recipe} builds the value with `{func}`, which does not return that type"
             ),
-            RecipeError::NotAnAccessor {
-                crossing,
-                recipe,
-                func,
-            } => write!(
+            RecipeError::NotAnAccessor { recipe, func } => write!(
                 f,
-                "recipe `{recipe}` of {crossing} reaches a part through `{func}`, whose \
-                 first parameter is not that type"
+                "{recipe} reaches a part through `{func}`, whose first parameter is not that type"
             ),
-            RecipeError::OutOfRange {
-                crossing,
-                recipe,
-                index,
-                len,
-            } => write!(
-                f,
-                "recipe `{recipe}` of {crossing} names index {index}, and the model holds {len}"
-            ),
+            RecipeError::OutOfRange { recipe, index, len } => {
+                write!(f, "{recipe} names index {index}, and the model holds {len}")
+            }
             RecipeError::WrongShape {
-                crossing,
                 recipe,
                 shape,
                 wanted,
             } => write!(
                 f,
-                "recipe `{recipe}` of {crossing} declares `{shape}`, but the type is not \
-                 {wanted}"
+                "{recipe} declares `{shape}`, but the type is not {wanted}"
             ),
-            RecipeError::NotAProduct { crossing, recipe } => write!(
+            RecipeError::NotAProduct { recipe } => write!(
                 f,
-                "recipe `{recipe}` takes {crossing} apart, and the model gives that type no \
-                 parts"
+                "{recipe} takes its type apart, and the model gives that type no parts"
             ),
-            RecipeError::NoSuchRecipe { crossing, recipe } => write!(
+            RecipeError::NoSuchRecipe { recipe } => write!(
                 f,
-                "{crossing} has no recipe `{recipe}` — it was compiled by name, not \
-                 through a site"
+                "{recipe} does not exist — it was compiled by name, not through a site"
             ),
-            RecipeError::UnknownRecipe {
-                site,
-                crossing,
-                recipe,
-            } => write!(
-                f,
-                "{site} asks for recipe `{recipe}`, which {crossing} does not have"
-            ),
+            RecipeError::UnknownRecipe { site, recipe } => {
+                write!(f, "{site} asks for {recipe}, which does not exist")
+            }
             RecipeError::Rebound { site, origin } => write!(
                 f,
                 "{site} is bound to two different recipes by {origin}; one of them has to \
@@ -1458,11 +1399,10 @@ impl fmt::Display for RecipeError {
                 f,
                 "{site} needs a {needed} value and its fragment produces a {got} one"
             ),
-            RecipeError::CallbackShape { crossing, recipe } => write!(
+            RecipeError::CallbackShape { recipe } => write!(
                 f,
-                "recipe `{recipe}` of the callback {crossing} is not `Invoke`; a callback is \
-                 always taken apart into its arguments, so that is the only shape \
-                 such a crossing takes"
+                "{recipe} is not `Invoke`; a callback is always taken apart into its \
+                 arguments, so that is the only shape such a crossing takes"
             ),
         }
     }

--- a/prebindgen-registry/src/recipe/compile.rs
+++ b/prebindgen-registry/src/recipe/compile.rs
@@ -332,7 +332,7 @@ type Built<C> = Result<Rc<<C as Compile>::Fragment>, CompileError<<C as Compile>
 /// nothing and outlive any of them.
 pub struct Compiled<F> {
     fragments: HashMap<FragmentKey, Rc<F>>,
-    /// Which recipe answered when a crossing was compiled **as a whole**, rather
+    /// Which row answered when a crossing was compiled **as a whole**, rather
     /// than as one part of a container. Recorded by [`Compiler::crossing`],
     /// which is the only entry point that consults the crossing's default —
     /// so [`Compiled::fragment`] can give back that same answer instead of
@@ -403,14 +403,15 @@ impl<F> Compiled<F> {
     /// [`Self::fragment`] would have no answer to give. Recording it keeps the
     /// adapter's emitters on one lookup instead of a per-site fall-back to
     /// whatever else knows.
-    pub fn record(&mut self, ty: TypeKey, recipe: RecipeKey, fragment: F) {
+    pub fn record(&mut self, recipe: RecipeKey, fragment: F) {
+        let ty = recipe.crossing().ty.clone();
         let direction = recipe.crossing().direction;
         self.fragments
             .insert((ty.clone(), recipe.clone()), std::rc::Rc::new(fragment));
         self.defaults.insert((ty, direction), recipe);
     }
 
-    /// The fragment for one crossing and one named recipe.
+    /// The fragment for one spelled type and one row key.
     pub fn recipe_fragment(&self, ty: &TypeKey, recipe: &RecipeKey) -> Option<Rc<F>> {
         self.fragments.get(&(ty.clone(), recipe.clone())).cloned()
     }
@@ -566,8 +567,7 @@ impl<'a, C: Compile> Compiler<'a, C> {
         let crossing_key = crossing.key();
         let Some(recipe) = self.recipes.key_of(&crossing_key, name).cloned() else {
             return Err(RecipeError::NoSuchRecipe {
-                crossing: crossing_key,
-                recipe: name.clone(),
+                recipe: crossing_key.row(name.clone()),
             }
             .into());
         };
@@ -602,7 +602,7 @@ impl<'a, C: Compile> Compiler<'a, C> {
 
     /// The fragment for one part of the recipe being compiled.
     ///
-    /// Which recipe the part takes is the site machinery's answer, asked at
+    /// Which row the part takes is the site machinery's answer, asked at
     /// [`Role::Part`] — keyed by the recipe, because that is what compilation is
     /// per. A root role such as [`Role::CallbackArg`] names a place in one
     /// exported function, so it cannot answer for a recipe every function with
@@ -648,8 +648,7 @@ impl<'a, C: Compile> Compiler<'a, C> {
         let Some(bound) = self.bindings.resolve(&site, &crossing, self.recipes) else {
             return Err(RecipeError::UnknownRecipe {
                 site,
-                crossing: crossing.key(),
-                recipe: super::RecipeName::new("<omitted>"),
+                recipe: crossing.row(super::RecipeName::new("<omitted>")),
             }
             .into());
         };
@@ -964,8 +963,7 @@ impl<'a, C: Compile> Compiler<'a, C> {
                 Reach::Field(index) => {
                     let field = fields.get(*index).ok_or_else(|| {
                         CompileError::Recipe(Box::new(RecipeError::OutOfRange {
-                            crossing: at.crossing.key(),
-                            recipe: at.recipe.name().clone(),
+                            recipe: at.recipe.clone(),
                             index: *index,
                             len: fields.len(),
                         }))
@@ -1001,8 +999,7 @@ impl<'a, C: Compile> Compiler<'a, C> {
     ) -> Result<&'a Function, CompileError<C::Error>> {
         self.model.function(name).ok_or_else(|| {
             CompileError::Recipe(Box::new(RecipeError::UnknownFunction {
-                crossing: at.crossing.key(),
-                recipe: at.recipe.name().clone(),
+                recipe: at.recipe.clone(),
                 func: name.clone(),
             }))
         })
@@ -1019,8 +1016,7 @@ impl<'a, C: Compile> Compiler<'a, C> {
         };
         alternatives.get(index).ok_or_else(|| {
             CompileError::Recipe(Box::new(RecipeError::OutOfRange {
-                crossing: at.crossing.key(),
-                recipe: at.recipe.name().clone(),
+                recipe: at.recipe.clone(),
                 index,
                 len: alternatives.len(),
             }))
@@ -1114,8 +1110,7 @@ fn element_mode(crossing: &Crossing, elem: &TypeRef) -> Mode {
 /// than stating it, so a recipe declaring one on the wrong type is caught here.
 fn wrong_shape<E>(at: At<'_>, shape: &'static str, wanted: &'static str) -> CompileError<E> {
     RecipeError::WrongShape {
-        crossing: at.crossing.key(),
-        recipe: at.recipe.name().clone(),
+        recipe: at.recipe.clone(),
         shape,
         wanted,
     }

--- a/prebindgen-registry/src/recipe/compile.rs
+++ b/prebindgen-registry/src/recipe/compile.rs
@@ -1,7 +1,7 @@
 //! Turning recipes into whatever an adapter emits from.
 //!
 //! [`Recipes`] says how a value gets across in terms of its parts; an adapter
-//! says what that costs on the wire. Its answer for one recipe is a **fragment**,
+//! says what that costs on the wire. Its answer for one recipe row is a **fragment**,
 //! a type the adapter defines and this module never looks inside. A fragment is
 //! not a wire value: it may occupy none, one or several, and the count is never
 //! asked for.
@@ -21,8 +21,8 @@
 //! called per site — is where that wrapping belongs.
 //!
 //! A crossing here is the type **as the site spelled it**, which is finer than
-//! the identity a recipe is declared under. `Sample`, `&Sample` and `Box<Sample>`
-//! find one recipe, because the same recipe assembles all three — and they get
+//! the [`RecipeKey`] a row is declared under. `Sample`, `&Sample` and `Box<Sample>`
+//! find one row, because the same row assembles all three — and they get
 //! three fragments, because taking a value out of a pointer, borrowing through
 //! one, and rebuilding a `Box` are three different pieces of Rust. Sharing the
 //! recipe is the declaration's business; sharing the code is not.
@@ -31,7 +31,7 @@ use std::{collections::HashMap, fmt, rc::Rc};
 
 use super::{
     Bindings, Bound, Construct, Crossing, Deconstruct, Direction, Mode, Reach, Recipe, RecipeError,
-    RecipeId, Recipes, Role, Shape, Site,
+    RecipeKey, RecipeName, Recipes, Role, Shape, Site,
 };
 use crate::{
     flat::{Alternative, Field, Flat, Function, Type, TypeKey, TypeKind, TypeRef},
@@ -89,8 +89,8 @@ impl fmt::Display for Validity {
 pub struct At<'a> {
     /// The crossing the recipe answers.
     pub crossing: &'a Crossing,
-    /// Which of that crossing's recipes.
-    pub recipe: &'a RecipeId,
+    /// The globally unique row being compiled.
+    pub recipe: &'a RecipeKey,
 }
 
 /// What every hook receives: a read-only view of the model and the table, and
@@ -124,12 +124,12 @@ impl Cx<'_> {
         self.recipes
     }
 
-    /// Which recipes a crossing has.
+    /// Which reusable recipe names are declared under a crossing key.
     ///
     /// Demands nothing, so an adapter may ask about an alternative it will not
     /// take. Empty for a crossing nobody declared, which still has a derived
     /// recipe.
-    pub fn recipe_names(&self, crossing: &Crossing) -> Vec<&RecipeId> {
+    pub fn recipe_names(&self, crossing: &Crossing) -> Vec<&RecipeName> {
         self.recipes.names_of(&crossing.key())
     }
 }
@@ -337,14 +337,13 @@ pub struct Compiled<F> {
     /// which is the only entry point that consults the crossing's default —
     /// so [`Compiled::fragment`] can give back that same answer instead of
     /// choosing between the recipes a crossing happens to have.
-    defaults: HashMap<(TypeKey, Direction), RecipeId>,
+    defaults: HashMap<(TypeKey, Direction), RecipeKey>,
 }
 
 /// What a fragment is memoised under: the type **as the site spelled it**, the
-/// direction, and which recipe answered. See the module docs on why the spelling
-/// and not
-/// the recipe's own identity.
-type FragmentKey = (TypeKey, Direction, RecipeId);
+/// row key. The spelling remains separate because one normalized row can serve
+/// `T`, `&T` and `Box<T>`, whose generated Rust differs.
+type FragmentKey = (TypeKey, RecipeKey);
 
 impl<F> Default for Compiled<F> {
     fn default() -> Self {
@@ -367,8 +366,7 @@ impl<F> Clone for Compiled<F> {
 }
 
 impl<F> Compiled<F> {
-    /// How many fragments have been built, which is what makes the
-    /// per-crossing promise observable.
+    /// How many fragments have been built, making memoization observable.
     pub fn len(&self) -> usize {
         self.fragments.len()
     }
@@ -394,7 +392,7 @@ impl<F> Compiled<F> {
     /// recursive lookup should not be copying.
     pub fn fragment(&self, ty: &TypeKey, direction: Direction) -> Option<Rc<F>> {
         let recipe = self.defaults.get(&(ty.clone(), direction))?;
-        self.recipe_fragment(ty, direction, recipe)
+        self.recipe_fragment(ty, recipe)
     }
 
     /// Record a fragment an adapter built **without** the compiler, as this
@@ -405,24 +403,16 @@ impl<F> Compiled<F> {
     /// [`Self::fragment`] would have no answer to give. Recording it keeps the
     /// adapter's emitters on one lookup instead of a per-site fall-back to
     /// whatever else knows.
-    pub fn record(&mut self, ty: TypeKey, direction: Direction, recipe: RecipeId, fragment: F) {
-        self.fragments.insert(
-            (ty.clone(), direction, recipe.clone()),
-            std::rc::Rc::new(fragment),
-        );
+    pub fn record(&mut self, ty: TypeKey, recipe: RecipeKey, fragment: F) {
+        let direction = recipe.crossing().direction;
+        self.fragments
+            .insert((ty.clone(), recipe.clone()), std::rc::Rc::new(fragment));
         self.defaults.insert((ty, direction), recipe);
     }
 
     /// The fragment for one crossing and one named recipe.
-    pub fn recipe_fragment(
-        &self,
-        ty: &TypeKey,
-        direction: Direction,
-        recipe: &RecipeId,
-    ) -> Option<Rc<F>> {
-        self.fragments
-            .get(&(ty.clone(), direction, recipe.clone()))
-            .cloned()
+    pub fn recipe_fragment(&self, ty: &TypeKey, recipe: &RecipeKey) -> Option<Rc<F>> {
+        self.fragments.get(&(ty.clone(), recipe.clone())).cloned()
     }
 
     /// Every fragment this compilation built, in a deterministic order.
@@ -435,13 +425,18 @@ impl<F> Compiled<F> {
     pub fn fragments(&self) -> Vec<&F> {
         let mut keyed: Vec<(&FragmentKey, &Rc<F>)> = self.fragments.iter().collect();
         keyed.sort_by(|a, b| {
-            (a.0 .0.as_str(), a.0 .1, &a.0 .2).cmp(&(b.0 .0.as_str(), b.0 .1, &b.0 .2))
+            (a.0 .0.as_str(), a.0 .1.crossing().direction, a.0 .1.name()).cmp(&(
+                b.0 .0.as_str(),
+                b.0 .1.crossing().direction,
+                b.0 .1.name(),
+            ))
         });
         keyed.into_iter().map(|(_, f)| &**f).collect()
     }
 }
 
-/// Drives an adapter over the table: one fragment per recipe, one plan per site.
+/// Drives an adapter over the table: one fragment per spelled crossing and
+/// globally identified row, one plan per site.
 pub struct Compiler<'a, C: Compile> {
     model: &'a Flat,
     recipes: &'a Recipes,
@@ -477,8 +472,7 @@ impl<'a, C: Compile> Compiler<'a, C> {
         self.compiled
     }
 
-    /// How many fragments have been built, which is what makes the
-    /// per-crossing promise observable.
+    /// How many fragments have been built, making memoization observable.
     pub fn compiled_fragments(&self) -> usize {
         self.compiled.fragments.len()
     }
@@ -567,33 +561,34 @@ impl<'a, C: Compile> Compiler<'a, C> {
         &mut self,
         adapter: &mut C,
         crossing: &Crossing,
-        recipe: &RecipeId,
+        name: &RecipeName,
     ) -> Result<Rc<C::Fragment>, CompileError<C::Error>> {
-        if self.recipes.get(&crossing.key(), recipe).is_none() {
+        let crossing_key = crossing.key();
+        let Some(recipe) = self.recipes.key_of(&crossing_key, name).cloned() else {
             return Err(RecipeError::NoSuchRecipe {
-                crossing: crossing.key(),
-                recipe: recipe.clone(),
+                crossing: crossing_key,
+                recipe: name.clone(),
             }
             .into());
-        }
-        self.recipe(adapter, crossing, recipe)
+        };
+        self.recipe(adapter, crossing, &recipe)
     }
 
     /// The fragment for one recipe, built once and reused.
-    fn recipe(&mut self, adapter: &mut C, crossing: &Crossing, recipe: &RecipeId) -> Built<C> {
-        // Keyed by the spelling, not by the recipe's identity: one recipe can answer
-        // for `T`, `&T` and `Box<T>`, and each of the three needs its own Rust.
-        let key = (
-            crossing.spelled().key(),
-            crossing.direction(),
-            recipe.clone(),
-        );
+    fn recipe(&mut self, adapter: &mut C, crossing: &Crossing, recipe: &RecipeKey) -> Built<C> {
+        debug_assert_eq!(recipe.crossing(), &crossing.key());
+        // The row has global identity, while the fragment also needs the spelling:
+        // one row can serve `T`, `&T` and `Box<T>`, whose Rust differs.
+        let key = (crossing.spelled().key(), recipe.clone());
         if let Some(built) = self.compiled.fragments.get(&key) {
             return Ok(built.clone());
         }
-        let chosen = match self.recipes.get(&crossing.key(), recipe) {
+        let chosen = match self.recipes.get(recipe) {
             Some(chosen) => chosen.clone(),
-            None => self.recipes.recipe(crossing).1.into_owned(),
+            None => {
+                debug_assert_eq!(recipe.name(), &RecipeName::derived());
+                super::derive(crossing)
+            }
         };
         let at = At { crossing, recipe };
         let fragment = match &chosen {
@@ -649,12 +644,12 @@ impl<'a, C: Compile> Compiler<'a, C> {
         wanted: Mode,
     ) -> Built<C> {
         let crossing = Crossing::new(ty.clone(), direction);
-        let site = Site::arm_part(at.crossing, at.recipe, arm, index);
+        let site = Site::arm_part(at.recipe, arm, index);
         let Some(bound) = self.bindings.resolve(&site, &crossing, self.recipes) else {
             return Err(RecipeError::UnknownRecipe {
                 site,
                 crossing: crossing.key(),
-                recipe: super::RecipeId::new("<omitted>"),
+                recipe: super::RecipeName::new("<omitted>"),
             }
             .into());
         };
@@ -970,7 +965,7 @@ impl<'a, C: Compile> Compiler<'a, C> {
                     let field = fields.get(*index).ok_or_else(|| {
                         CompileError::Recipe(Box::new(RecipeError::OutOfRange {
                             crossing: at.crossing.key(),
-                            recipe: at.recipe.clone(),
+                            recipe: at.recipe.name().clone(),
                             index: *index,
                             len: fields.len(),
                         }))
@@ -1007,7 +1002,7 @@ impl<'a, C: Compile> Compiler<'a, C> {
         self.model.function(name).ok_or_else(|| {
             CompileError::Recipe(Box::new(RecipeError::UnknownFunction {
                 crossing: at.crossing.key(),
-                recipe: at.recipe.clone(),
+                recipe: at.recipe.name().clone(),
                 func: name.clone(),
             }))
         })
@@ -1025,7 +1020,7 @@ impl<'a, C: Compile> Compiler<'a, C> {
         alternatives.get(index).ok_or_else(|| {
             CompileError::Recipe(Box::new(RecipeError::OutOfRange {
                 crossing: at.crossing.key(),
-                recipe: at.recipe.clone(),
+                recipe: at.recipe.name().clone(),
                 index,
                 len: alternatives.len(),
             }))
@@ -1120,7 +1115,7 @@ fn element_mode(crossing: &Crossing, elem: &TypeRef) -> Mode {
 fn wrong_shape<E>(at: At<'_>, shape: &'static str, wanted: &'static str) -> CompileError<E> {
     RecipeError::WrongShape {
         crossing: at.crossing.key(),
-        recipe: at.recipe.clone(),
+        recipe: at.recipe.name().clone(),
         shape,
         wanted,
     }

--- a/prebindgen-registry/src/recipe/site.rs
+++ b/prebindgen-registry/src/recipe/site.rs
@@ -1,4 +1,4 @@
-//! Which recipe a given place in the generated API uses.
+//! Which recipe-table row a given place in the generated API uses.
 //!
 //! [`Recipes`] says what rows a crossing key has; this says which row the
 //! second parameter of `z_put`, or the `Err` arm of a return, or one part of
@@ -268,8 +268,7 @@ impl BindingsBuilder {
                     let Some(recipe) = recipes.key_of(&key, name) else {
                         errors.push(RecipeError::UnknownRecipe {
                             site,
-                            crossing: key,
-                            recipe: name.clone(),
+                            recipe: key.row(name.clone()),
                         });
                         continue;
                     };
@@ -294,7 +293,7 @@ impl BindingsBuilder {
     }
 }
 
-/// Which recipe every declared site takes. Built by [`BindingsBuilder`], checked
+/// Which row every declared site takes. Built by [`BindingsBuilder`], checked
 /// once, then immutable.
 #[derive(Debug, Default)]
 pub struct Bindings {

--- a/prebindgen-registry/src/recipe/site.rs
+++ b/prebindgen-registry/src/recipe/site.rs
@@ -1,20 +1,21 @@
 //! Which recipe a given place in the generated API uses.
 //!
-//! [`Recipes`] says what recipes a crossing has; this says which of them the
+//! [`Recipes`] says what rows a crossing key has; this says which row the
 //! second parameter of `z_put`, or the `Err` arm of a return, or one part of
 //! another recipe actually takes. A declaration states that through
 //! [`BindingsBuilder::bind`], and [`Bindings::resolve`] answers it for one
 //! site.
 //!
-//! A site nobody binds uses its crossing's default recipe, so the common case is
-//! declared nowhere.
+//! Declarations select by reusable [`RecipeName`]; resolution stores the full
+//! [`RecipeKey`]. A site nobody binds uses its crossing's default row, so the
+//! common case is declared nowhere.
 
 use std::{
     collections::{BTreeMap, HashMap},
     fmt,
 };
 
-use super::{Crossing, CrossingKey, RecipeError, RecipeId, Recipes};
+use super::{Crossing, RecipeError, RecipeKey, RecipeName, Recipes};
 
 /// One place in the generated API where a value crosses.
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
@@ -35,23 +36,22 @@ impl Site {
     /// found by this key or not at all. Its `owner` is derived from the crossed
     /// type rather than chosen, so composing one by hand is a guess — this is
     /// the answer instead.
-    pub fn part(of: &Crossing, recipe: &RecipeId, index: usize) -> Self {
-        Self::arm_part(of, recipe, None, index)
+    pub fn part(recipe: &RecipeKey, index: usize) -> Self {
+        Self::arm_part(recipe, None, index)
     }
 
     /// [`Self::part`], for a part that sits inside one alternative.
     ///
     /// A part of a [`Shape::Choice`](super::Shape::Choice) recipe needs the
     /// alternative stated, because every arm numbers its parts from zero.
-    pub fn arm_part(of: &Crossing, recipe: &RecipeId, arm: Option<usize>, index: usize) -> Self {
+    pub fn arm_part(recipe: &RecipeKey, arm: Option<usize>, index: usize) -> Self {
         Self {
-            owner: of
-                .value()
-                .stripped_key()
+            owner: recipe
+                .crossing()
+                .ty
                 .ident()
                 .unwrap_or_else(|| syn::Ident::new("_", proc_macro2::Span::call_site())),
             role: Role::Part {
-                of: of.key(),
                 recipe: recipe.clone(),
                 arm,
                 index,
@@ -105,10 +105,8 @@ pub enum Role {
     },
     /// One part of another crossing's recipe.
     Part {
-        /// The crossing whose recipe names this part.
-        of: CrossingKey,
-        /// Which of that crossing's recipes.
-        recipe: RecipeId,
+        /// The globally unique row that names this part.
+        recipe: RecipeKey,
         /// Which alternative, for a part inside a [`Shape::Choice`](super::Shape::Choice)
         /// arm; `None` for a product's own part.
         ///
@@ -135,14 +133,9 @@ impl fmt::Display for Role {
             Role::CallbackArg { param, arg } => {
                 write!(f, "argument {arg} of the callback in parameter {param}")
             }
-            Role::Part {
-                of,
-                recipe,
-                arm,
-                index,
-            } => match arm {
-                Some(arm) => write!(f, "part {index} of arm {arm} of recipe `{recipe}` of {of}"),
-                None => write!(f, "part {index} of recipe `{recipe}` of {of}"),
+            Role::Part { recipe, arm, index } => match arm {
+                Some(arm) => write!(f, "part {index} of arm {arm} of {recipe}"),
+                None => write!(f, "part {index} of {recipe}"),
             },
             Role::Const => f.write_str("value"),
         }
@@ -154,8 +147,8 @@ impl fmt::Display for Role {
 pub enum Ask {
     /// The crossing's default recipe.
     Default,
-    /// This named recipe of the crossing.
-    Recipe(RecipeId),
+    /// This named recipe under the crossing key.
+    Recipe(RecipeName),
     /// This site contributes nothing.
     Omit,
 }
@@ -197,8 +190,8 @@ pub struct Bound {
     pub site: Site,
     /// What crosses, and which way.
     pub crossing: Crossing,
-    /// Which of the crossing's recipes this site takes.
-    pub recipe: RecipeId,
+    /// The globally unique row this site takes.
+    pub recipe: RecipeKey,
     /// Which declaration won, so a diagnostic can say why this recipe applies.
     pub origin: Origin,
 }
@@ -271,16 +264,16 @@ impl BindingsBuilder {
                     continue;
                 }
                 Ask::Default => recipes.recipe(&binding.crossing).0,
-                Ask::Recipe(id) => {
-                    if recipes.get(&key, id).is_none() {
+                Ask::Recipe(name) => {
+                    let Some(recipe) = recipes.key_of(&key, name) else {
                         errors.push(RecipeError::UnknownRecipe {
                             site,
                             crossing: key,
-                            recipe: id.clone(),
+                            recipe: name.clone(),
                         });
                         continue;
-                    }
-                    id.clone()
+                    };
+                    recipe.clone()
                 }
             };
             bound.insert(

--- a/prebindgen-registry/src/recipe/tests.rs
+++ b/prebindgen-registry/src/recipe/tests.rs
@@ -23,8 +23,16 @@ fn ty(model: &Flat, spelling: &str) -> TypeRef {
         .expect("classify")
 }
 
-fn id(name: &str) -> RecipeId {
-    RecipeId::new(name)
+fn recipe_name(value: &str) -> RecipeName {
+    RecipeName::new(value)
+}
+
+fn row(crossing: &Crossing, name: &str) -> RecipeKey {
+    RecipeKey::new(crossing.key(), recipe_name(name))
+}
+
+fn row_at(crossing: &CrossingKey, name: &str) -> RecipeKey {
+    RecipeKey::new(crossing.clone(), recipe_name(name))
 }
 
 fn ident(name: &str) -> syn::Ident {
@@ -55,8 +63,8 @@ fn name_of<OP>(shape: &Shape<OP>) -> &'static str {
 fn derived_shape(model: &Flat, spelling: &str) -> String {
     let table = Recipes::default();
     let crossing = Crossing::new(ty(model, spelling), Direction::Deconstruct);
-    let (id, recipe) = table.recipe(&crossing);
-    format!("{id}:{}", shape_of(&recipe))
+    let (key, recipe) = table.recipe(&crossing);
+    format!("{}:{}", key.name(), shape_of(&recipe))
 }
 
 #[test]
@@ -79,14 +87,18 @@ fn an_undeclared_crossing_gets_its_arity_row_from_the_kind() {
 fn a_borrow_and_a_wrapper_find_the_row_the_bare_type_declared() {
     let model = model(&[SAMPLE]);
     let mut builder = Recipes::builder();
-    builder.declare(ty(&model, "Sample"), id("whole"), Deconstructing::Atomic);
+    builder.declare(
+        ty(&model, "Sample"),
+        recipe_name("whole"),
+        Deconstructing::Atomic,
+    );
     let table = builder.build(&model).expect("table");
 
     for spelling in ["Sample", "&Sample", "&mut Sample", "Box<Sample>"] {
         let crossing = Crossing::new(ty(&model, spelling), Direction::Deconstruct);
         assert_eq!(
             table.recipe(&crossing).0,
-            id("whole"),
+            row(&crossing, "whole"),
             "{spelling} did not find the declared recipe"
         );
     }
@@ -112,12 +124,12 @@ fn the_shape_files_the_row_under_its_own_job() {
     builder
         .declare(
             ty(&model, "Sample"),
-            id("fields"),
+            recipe_name("fields"),
             Constructing::Product(Construct::Call(ident("sample_new"))),
         )
         .declare(
             ty(&model, "Sample"),
-            id("fields"),
+            recipe_name("fields"),
             Deconstructing::Product(Deconstruct::Fields(vec![Reach::Field(0), Reach::Field(1)])),
         );
     let table = builder.build(&model).expect("table");
@@ -126,7 +138,7 @@ fn the_shape_files_the_row_under_its_own_job() {
     for direction in [Direction::Construct, Direction::Deconstruct] {
         let key = Crossing::new(sample.clone(), direction).key();
         assert_eq!(key.direction, direction);
-        assert_eq!(table.names_of(&key), vec![&id("fields")]);
+        assert_eq!(table.names_of(&key), vec![&recipe_name("fields")]);
     }
 }
 
@@ -137,16 +149,16 @@ fn one_row_is_the_default_and_several_have_to_say_which() {
     let key = Crossing::new(sample.clone(), Direction::Deconstruct).key();
 
     let mut one = Recipes::builder();
-    one.declare(sample.clone(), id("whole"), Deconstructing::Atomic);
+    one.declare(sample.clone(), recipe_name("whole"), Deconstructing::Atomic);
     let table = one.build(&model).expect("one recipe is its own default");
-    assert_eq!(table.default_of(&key), Some(&id("whole")));
+    assert_eq!(table.default_of(&key), Some(&row_at(&key, "whole")));
 
     let mut undecided = Recipes::builder();
     undecided
-        .declare(sample.clone(), id("whole"), Deconstructing::Atomic)
+        .declare(sample.clone(), recipe_name("whole"), Deconstructing::Atomic)
         .declare(
             sample.clone(),
-            id("fields"),
+            recipe_name("fields"),
             Deconstructing::Product(Deconstruct::Fields(vec![Reach::Field(0)])),
         );
     let errors = undecided.build(&model).expect_err("no default");
@@ -157,15 +169,44 @@ fn one_row_is_the_default_and_several_have_to_say_which() {
 
     let mut decided = Recipes::builder();
     decided
-        .declare_default(sample.clone(), id("whole"), Deconstructing::Atomic)
+        .declare_default(sample.clone(), recipe_name("whole"), Deconstructing::Atomic)
         .declare(
             sample,
-            id("fields"),
+            recipe_name("fields"),
             Deconstructing::Product(Deconstruct::Fields(vec![Reach::Field(0)])),
         );
     let table = decided.build(&model).expect("one default");
-    assert_eq!(table.default_of(&key), Some(&id("whole")));
+    assert_eq!(table.default_of(&key), Some(&row_at(&key, "whole")));
     assert_eq!(table.names_of(&key).len(), 2);
+}
+
+#[test]
+fn one_name_can_label_several_globally_distinct_rows() {
+    let model = model(&[SAMPLE]);
+    let sample = ty(&model, "Sample");
+    let scalar = ty(&model, "u32");
+    let mut builder = Recipes::builder();
+    builder
+        .declare(sample.clone(), recipe_name("whole"), Constructing::Atomic)
+        .declare(sample.clone(), recipe_name("whole"), Deconstructing::Atomic)
+        .declare(scalar, recipe_name("whole"), Deconstructing::Atomic);
+    let table = builder.build(&model).expect("table");
+
+    let sample_in = Crossing::new(sample.clone(), Direction::Construct).key();
+    let sample_out = Crossing::new(sample, Direction::Deconstruct).key();
+    let scalar_out = Crossing::new(ty(&model, "u32"), Direction::Deconstruct).key();
+    let sample_in = table.key_of(&sample_in, &recipe_name("whole")).unwrap();
+    let sample_out = table.key_of(&sample_out, &recipe_name("whole")).unwrap();
+    let scalar_out = table.key_of(&scalar_out, &recipe_name("whole")).unwrap();
+
+    assert_eq!(sample_in.name(), sample_out.name());
+    assert_eq!(sample_out.name(), scalar_out.name());
+    assert_ne!(sample_in, sample_out);
+    assert_ne!(sample_out, scalar_out);
+    assert_ne!(sample_in, scalar_out);
+    assert!(table.get(sample_in).is_some());
+    assert!(table.get(sample_out).is_some());
+    assert!(table.get(scalar_out).is_some());
 }
 
 #[test]
@@ -174,10 +215,10 @@ fn two_defaults_are_as_wrong_as_none() {
     let sample = ty(&model, "Sample");
     let mut builder = Recipes::builder();
     builder
-        .declare_default(sample.clone(), id("whole"), Deconstructing::Atomic)
+        .declare_default(sample.clone(), recipe_name("whole"), Deconstructing::Atomic)
         .declare_default(
             sample,
-            id("fields"),
+            recipe_name("fields"),
             Deconstructing::Product(Deconstruct::Fields(vec![Reach::Field(0)])),
         );
     let errors = builder.build(&model).expect_err("two defaults");
@@ -193,11 +234,11 @@ fn one_name_cannot_be_declared_twice_for_one_crossing() {
     let sample = ty(&model, "Sample");
     let mut builder = Recipes::builder();
     builder
-        .declare(sample.clone(), id("whole"), Deconstructing::Atomic)
-        .declare(sample, id("whole"), Deconstructing::Atomic);
+        .declare(sample.clone(), recipe_name("whole"), Deconstructing::Atomic)
+        .declare(sample, recipe_name("whole"), Deconstructing::Atomic);
     let errors = builder.build(&model).expect_err("declared twice");
     assert!(
-        matches!(errors.as_slice(), [RecipeError::Duplicate { recipe, .. }] if recipe == &id("whole")),
+        matches!(errors.as_slice(), [RecipeError::Duplicate { recipe, .. }] if recipe == &recipe_name("whole")),
         "{errors:?}"
     );
 }
@@ -208,7 +249,7 @@ fn a_recipe_naming_a_function_the_model_lacks_is_refused() {
     let mut builder = Recipes::builder();
     builder.declare(
         ty(&model, "Sample"),
-        id("fields"),
+        recipe_name("fields"),
         Constructing::Product(Construct::Call(ident("sample_new"))),
     );
     let errors = builder.build(&model).expect_err("no such function");
@@ -224,7 +265,7 @@ fn an_accessor_whose_first_parameter_is_another_type_is_refused() {
     let mut builder = Recipes::builder();
     builder.declare(
         ty(&model, "Sample"),
-        id("fields"),
+        recipe_name("fields"),
         Deconstructing::Product(Deconstruct::Fields(vec![Reach::Accessor(ident(
             "other_key",
         ))])),
@@ -242,7 +283,7 @@ fn an_accessor_reached_through_a_borrow_is_accepted() {
     let mut builder = Recipes::builder();
     builder.declare(
         ty(&model, "Sample"),
-        id("fields"),
+        recipe_name("fields"),
         Deconstructing::Product(Deconstruct::Fields(vec![Reach::Accessor(ident(
             "sample_key",
         ))])),
@@ -256,7 +297,7 @@ fn a_field_index_past_the_end_is_refused() {
     let mut builder = Recipes::builder();
     builder.declare(
         ty(&model, "Sample"),
-        id("fields"),
+        recipe_name("fields"),
         Deconstructing::Product(Deconstruct::Fields(vec![Reach::Field(7)])),
     );
     let errors = builder.build(&model).expect_err("no field 7");
@@ -279,7 +320,7 @@ fn a_field_of_a_type_with_no_fields_is_refused() {
     let mut builder = Recipes::builder();
     builder.declare(
         ty(&model, "u32"),
-        id("fields"),
+        recipe_name("fields"),
         Deconstructing::Product(Deconstruct::Fields(vec![Reach::Field(0)])),
     );
     let errors = builder.build(&model).expect_err("a scalar has no fields");
@@ -296,7 +337,7 @@ fn an_arms_payload_supplies_the_field_indices() {
     let mut good = Recipes::builder();
     good.declare(
         reply.clone(),
-        id("variants"),
+        recipe_name("variants"),
         Deconstructing::Choice {
             arms: vec![
                 Arm {
@@ -315,7 +356,7 @@ fn an_arms_payload_supplies_the_field_indices() {
     let mut past_the_end = Recipes::builder();
     past_the_end.declare(
         reply.clone(),
-        id("variants"),
+        recipe_name("variants"),
         Deconstructing::Choice {
             arms: vec![Arm {
                 alternative: 0,
@@ -341,7 +382,7 @@ fn an_arms_payload_supplies_the_field_indices() {
     let mut no_such_arm = Recipes::builder();
     no_such_arm.declare(
         reply,
-        id("variants"),
+        recipe_name("variants"),
         Deconstructing::Choice {
             arms: vec![Arm {
                 alternative: 4,
@@ -373,7 +414,7 @@ fn a_value_form_reads_its_parts_off_what_the_accessor_returns() {
     let mut builder = Recipes::builder();
     builder.declare(
         ty(&model, "Handle"),
-        id("read"),
+        recipe_name("read"),
         Deconstructing::Product(Deconstruct::ValueForm {
             func: ident("handle_read"),
             // `Sample`'s two fields, not `Handle`'s none.
@@ -392,7 +433,7 @@ fn a_callback_takes_invoke_and_nothing_else() {
     // Any other shape is refused: converting the arguments is what makes the
     // callable callable, so there is no second answer to choose between.
     let mut builder = Recipes::builder();
-    builder.declare(callback.clone(), id("whole"), Constructing::Atomic);
+    builder.declare(callback.clone(), recipe_name("whole"), Constructing::Atomic);
     let errors = builder
         .build(&model)
         .expect_err("only `Invoke` fits a callback");
@@ -404,7 +445,7 @@ fn a_callback_takes_invoke_and_nothing_else() {
     // `Invoke` is declarable like any other shape, and states the same thing
     // the table would have derived.
     let mut builder = Recipes::builder();
-    builder.declare(callback, id("invoke"), Constructing::Invoke);
+    builder.declare(callback, recipe_name("invoke"), Constructing::Invoke);
     builder
         .build(&model)
         .expect("`Invoke` is a callback's shape");
@@ -415,7 +456,7 @@ fn invoke_on_a_type_that_is_not_a_callback_is_refused() {
     let model = model(&[SAMPLE]);
     let sample = ty(&model, "Sample");
     let mut builder = Recipes::builder();
-    builder.declare(sample, id("invoke"), Constructing::Invoke);
+    builder.declare(sample, recipe_name("invoke"), Constructing::Invoke);
     let errors = builder.build(&model).expect_err("`Sample` is not callable");
     assert!(
         matches!(
@@ -436,8 +477,8 @@ fn a_callback_derives_the_row_that_takes_it_apart() {
     let table = Recipes::default();
     for direction in [Direction::Construct, Direction::Deconstruct] {
         let crossing = Crossing::new(listen.params[0].ty.clone(), direction);
-        let (id, recipe) = table.recipe(&crossing);
-        assert_eq!(id, RecipeId::derived());
+        let (key, recipe) = table.recipe(&crossing);
+        assert_eq!(key, row(&crossing, "derived"));
         assert_eq!(shape_of(&recipe), "invoke", "{recipe:?}");
         // The recipe's own direction is the crossing's; its arguments take the other.
         assert!(recipe.is_invoke());
@@ -451,7 +492,7 @@ fn a_row_reaching_its_own_crossing_is_refused() {
     let mut builder = Recipes::builder();
     builder.declare(
         ty(&model, "Sample"),
-        id("clone"),
+        recipe_name("clone"),
         Constructing::Product(Construct::Call(ident("sample_clone"))),
     );
     let errors = builder.build(&model).expect_err("a cycle of one");
@@ -473,12 +514,12 @@ fn a_cycle_through_two_crossings_is_refused() {
     builder
         .declare(
             ty(&model, "A"),
-            id("fields"),
+            recipe_name("fields"),
             Constructing::Product(Construct::Call(ident("a_new"))),
         )
         .declare(
             ty(&model, "B"),
-            id("fields"),
+            recipe_name("fields"),
             Constructing::Product(Construct::Call(ident("b_new"))),
         );
     let errors = builder.build(&model).expect_err("A reaches A through B");
@@ -501,12 +542,12 @@ fn a_row_that_only_reaches_a_different_job_is_not_a_cycle() {
     builder
         .declare(
             ty(&model, "Sample"),
-            id("fields"),
+            recipe_name("fields"),
             Constructing::Product(Construct::Call(ident("sample_new"))),
         )
         .declare(
             ty(&model, "Sample"),
-            id("fields"),
+            recipe_name("fields"),
             Deconstructing::Product(Deconstruct::Fields(vec![Reach::Field(0), Reach::Field(1)])),
         );
     builder
@@ -521,13 +562,17 @@ fn every_problem_is_reported_at_once() {
     builder
         .declare(
             ty(&model, "Sample"),
-            id("fields"),
+            recipe_name("fields"),
             Deconstructing::Product(Deconstruct::Fields(vec![
                 Reach::Field(9),
                 Reach::Accessor(ident("nowhere")),
             ])),
         )
-        .declare(ty(&model, "Sample"), id("whole"), Deconstructing::Atomic);
+        .declare(
+            ty(&model, "Sample"),
+            recipe_name("whole"),
+            Deconstructing::Atomic,
+        );
     let errors = builder.build(&model).expect_err("three problems");
     assert_eq!(errors.len(), 3, "{errors:?}");
     assert!(errors
@@ -577,10 +622,14 @@ fn site(owner: &str, index: usize) -> Site {
 fn two_recipes(model: &Flat) -> Recipes {
     let mut builder = Recipes::builder();
     builder
-        .declare_default(ty(model, "Sample"), id("whole"), Deconstructing::Atomic)
+        .declare_default(
+            ty(model, "Sample"),
+            recipe_name("whole"),
+            Deconstructing::Atomic,
+        )
         .declare(
             ty(model, "Sample"),
-            id("fields"),
+            recipe_name("fields"),
             Deconstructing::Product(Deconstruct::Fields(vec![Reach::Field(0), Reach::Field(1)])),
         );
     builder.build(model).expect("table")
@@ -596,7 +645,7 @@ fn a_site_nobody_bound_takes_the_default_row() {
     let bound = bindings
         .resolve(&site("z_put", 0), &crossing, &recipes)
         .expect("a site nobody bound still crosses");
-    assert_eq!(bound.recipe, id("whole"));
+    assert_eq!(bound.recipe, row(&crossing, "whole"));
     assert_eq!(bound.origin, Origin::Adapter);
     assert!(!bindings.is_declared(&site("z_put", 0)));
 }
@@ -611,7 +660,7 @@ fn an_undeclared_crossing_resolves_to_its_derived_row() {
     let bound = bindings
         .resolve(&site("z_put", 0), &crossing, &recipes)
         .expect("the derived recipe");
-    assert_eq!(bound.recipe, RecipeId::derived());
+    assert_eq!(bound.recipe, row(&crossing, "derived"));
 }
 
 #[test]
@@ -623,7 +672,7 @@ fn a_site_takes_the_row_it_names() {
     builder.bind(
         site("z_put", 0),
         crossing.clone(),
-        Ask::Recipe(id("fields")),
+        Ask::Recipe(recipe_name("fields")),
         Origin::Function,
     );
     let bindings = builder.build(&recipes).expect("bindings");
@@ -631,13 +680,13 @@ fn a_site_takes_the_row_it_names() {
     let bound = bindings
         .resolve(&site("z_put", 0), &crossing, &recipes)
         .expect("bound");
-    assert_eq!(bound.recipe, id("fields"));
+    assert_eq!(bound.recipe, row(&crossing, "fields"));
     assert_eq!(bound.origin, Origin::Function);
     // Every other site of the same crossing still takes the default.
     let other = bindings
         .resolve(&site("z_get", 0), &crossing, &recipes)
         .expect("bound");
-    assert_eq!(other.recipe, id("whole"));
+    assert_eq!(other.recipe, row(&crossing, "whole"));
 }
 
 #[test]
@@ -653,8 +702,8 @@ fn the_higher_precedence_declaration_wins_whichever_was_written_first() {
         let mut builder = Bindings::builder();
         for origin in order {
             let ask = match origin {
-                Origin::Function => Ask::Recipe(id("fields")),
-                _ => Ask::Recipe(id("whole")),
+                Origin::Function => Ask::Recipe(recipe_name("fields")),
+                _ => Ask::Recipe(recipe_name("whole")),
             };
             builder.bind(site("z_put", 0), crossing.clone(), ask, origin);
         }
@@ -662,7 +711,7 @@ fn the_higher_precedence_declaration_wins_whichever_was_written_first() {
         let bound = bindings
             .resolve(&site("z_put", 0), &crossing, &recipes)
             .expect("bound");
-        assert_eq!(bound.recipe, id("fields"), "written {order:?}");
+        assert_eq!(bound.recipe, row(&crossing, "fields"), "written {order:?}");
         assert_eq!(bound.origin, Origin::Function, "written {order:?}");
     }
 }
@@ -678,13 +727,13 @@ fn two_declarations_of_equal_precedence_may_agree_and_may_not_disagree() {
         .bind(
             site("z_put", 0),
             crossing.clone(),
-            Ask::Recipe(id("fields")),
+            Ask::Recipe(recipe_name("fields")),
             Origin::Function,
         )
         .bind(
             site("z_put", 0),
             crossing.clone(),
-            Ask::Recipe(id("fields")),
+            Ask::Recipe(recipe_name("fields")),
             Origin::Function,
         );
     agreeing
@@ -696,13 +745,13 @@ fn two_declarations_of_equal_precedence_may_agree_and_may_not_disagree() {
         .bind(
             site("z_put", 0),
             crossing.clone(),
-            Ask::Recipe(id("fields")),
+            Ask::Recipe(recipe_name("fields")),
             Origin::Function,
         )
         .bind(
             site("z_put", 0),
             crossing,
-            Ask::Recipe(id("whole")),
+            Ask::Recipe(recipe_name("whole")),
             Origin::Function,
         );
     let errors = disagreeing.build(&recipes).expect_err("two answers");
@@ -754,12 +803,12 @@ fn a_site_naming_a_row_the_crossing_lacks_is_refused() {
     builder.bind(
         site("z_put", 0),
         crossing,
-        Ask::Recipe(id("jobject")),
+        Ask::Recipe(recipe_name("jobject")),
         Origin::Function,
     );
     let errors = builder.build(&recipes).expect_err("no such recipe");
     assert!(
-        matches!(errors.as_slice(), [RecipeError::UnknownRecipe { recipe, .. }] if recipe == &id("jobject")),
+        matches!(errors.as_slice(), [RecipeError::UnknownRecipe { recipe, .. }] if recipe == &recipe_name("jobject")),
         "{errors:?}"
     );
 }
@@ -796,7 +845,7 @@ fn asking_for_the_default_records_which_row_that_was() {
     let bound = bindings
         .resolve(&site("z_put", 0), &crossing, &recipes)
         .expect("bound");
-    assert_eq!(bound.recipe, id("whole"));
+    assert_eq!(bound.recipe, row(&crossing, "whole"));
     assert_eq!(bound.origin, Origin::Type);
 }
 
@@ -813,14 +862,14 @@ fn one_site_is_one_role_of_one_owner() {
     builder.bind(
         ret.clone(),
         crossing.clone(),
-        Ask::Recipe(id("fields")),
+        Ask::Recipe(recipe_name("fields")),
         Origin::Function,
     );
     let bindings = builder.build(&recipes).expect("bindings");
 
     assert_eq!(
         bindings.resolve(&ret, &crossing, &recipes).unwrap().recipe,
-        id("fields")
+        row(&crossing, "fields")
     );
     // The same function's parameter 0 is a different site.
     assert_eq!(
@@ -828,7 +877,7 @@ fn one_site_is_one_role_of_one_owner() {
             .resolve(&site("z_put", 0), &crossing, &recipes)
             .unwrap()
             .recipe,
-        id("whole")
+        row(&crossing, "whole")
     );
 }
 
@@ -1051,7 +1100,7 @@ fn a_constructors_parameters_are_the_parts() {
     let mut builder = Recipes::builder();
     builder.declare(
         ty(&model, "Sample"),
-        id("fields"),
+        recipe_name("fields"),
         Constructing::Product(Construct::Call(ident("sample_new"))),
     );
     let recipes = builder.build(&model).expect("table");
@@ -1090,7 +1139,7 @@ fn an_accessors_return_is_the_parts_type_and_its_borrowing() {
     let mut builder = Recipes::builder();
     builder.declare(
         ty(&model, "Sample"),
-        id("fields"),
+        recipe_name("fields"),
         Deconstructing::Product(Deconstruct::Fields(vec![
             Reach::Accessor(ident("sample_key")),
             Reach::Accessor(ident("sample_payload")),
@@ -1122,7 +1171,7 @@ fn a_field_reach_reads_the_models_own_field() {
     let mut builder = Recipes::builder();
     builder.declare(
         ty(&model, "Sample"),
-        id("fields"),
+        recipe_name("fields"),
         Deconstructing::Product(Deconstruct::Fields(vec![Reach::Field(1), Reach::Field(0)])),
     );
     let recipes = builder.build(&model).expect("table");
@@ -1152,7 +1201,7 @@ fn an_omitted_reach_contributes_no_part() {
     let mut builder = Recipes::builder();
     builder.declare(
         ty(&model, "Sample"),
-        id("fields"),
+        recipe_name("fields"),
         Deconstructing::Product(Deconstruct::Fields(vec![Reach::Field(0), Reach::Omit])),
     );
     let recipes = builder.build(&model).expect("table");
@@ -1179,7 +1228,11 @@ fn an_omitted_reach_contributes_no_part() {
 fn one_row_answering_three_spellings_still_builds_three_fragments() {
     let model = model(&[SAMPLE]);
     let mut builder = Recipes::builder();
-    builder.declare(ty(&model, "Sample"), id("whole"), Deconstructing::Atomic);
+    builder.declare(
+        ty(&model, "Sample"),
+        recipe_name("whole"),
+        Deconstructing::Atomic,
+    );
     let recipes = builder.build(&model).expect("table");
     let bindings = Bindings::default();
     let mut adapter = Recorder::default();
@@ -1188,7 +1241,7 @@ fn one_row_answering_three_spellings_still_builds_three_fragments() {
     for spelling in ["Sample", "&Sample", "Box<Sample>"] {
         let crossing = Crossing::new(ty(&model, spelling), Direction::Deconstruct);
         // All three find the one declared recipe …
-        assert_eq!(recipes.recipe(&crossing).0, id("whole"));
+        assert_eq!(recipes.recipe(&crossing).0, row(&crossing, "whole"));
         compiler.crossing(&mut adapter, &crossing).expect("compile");
     }
     // … and each still gets its own Rust, because taking a value out of a
@@ -1238,7 +1291,7 @@ fn a_row_is_compiled_once_however_many_sites_take_it() {
     let mut builder = Recipes::builder();
     builder.declare(
         ty(&model, "Sample"),
-        id("fields"),
+        recipe_name("fields"),
         Constructing::Product(Construct::Call(ident("sample_new"))),
     );
     let recipes = builder.build(&model).expect("table");
@@ -1470,7 +1523,7 @@ fn every_arm_of_a_choice_reaches_the_hook_already_composed() {
     let mut builder = Recipes::builder();
     builder.declare(
         ty(&model, "Reply"),
-        id("variants"),
+        recipe_name("variants"),
         Deconstructing::Choice {
             arms: vec![
                 Arm {
@@ -1556,10 +1609,14 @@ fn a_callback_argument_is_a_part_of_the_callback_row_that_names_it() {
     let callback = listen.params[0].ty.clone();
     let mut builder = Recipes::builder();
     builder
-        .declare_default(ty(&model, "Sample"), id("whole"), Deconstructing::Atomic)
+        .declare_default(
+            ty(&model, "Sample"),
+            recipe_name("whole"),
+            Deconstructing::Atomic,
+        )
         .declare(
             ty(&model, "Sample"),
-            id("fields"),
+            recipe_name("fields"),
             Deconstructing::Product(Deconstruct::Fields(vec![Reach::Field(0)])),
         );
     let recipes = builder.build(&model).expect("table");
@@ -1568,13 +1625,14 @@ fn a_callback_argument_is_a_part_of_the_callback_row_that_names_it() {
     let recipe = Crossing::new(callback.clone(), Direction::Construct);
     // Built the same way the driver builds it, which is the point of the
     // helper: a per-part binding is found by this exact key or not at all.
-    let part = Site::part(&recipe, &RecipeId::derived(), 0);
+    let recipe_key = row(&recipe, "derived");
+    let part = Site::part(&recipe_key, 0);
     let mut bound = Bindings::builder();
     bound.bind(
         part,
         // The part's own crossing carries the swap; the site does not.
         Crossing::new(ty(&model, "Sample"), Direction::Deconstruct),
-        Ask::Recipe(id("fields")),
+        Ask::Recipe(recipe_name("fields")),
         Origin::Part,
     );
     let bindings = bound.build(&recipes).expect("bindings");
@@ -1605,10 +1663,14 @@ fn a_callback_argument_is_overridden_by_compiling_it_as_its_own_site() {
     ]);
     let mut builder = Recipes::builder();
     builder
-        .declare_default(ty(&model, "Sample"), id("whole"), Deconstructing::Atomic)
+        .declare_default(
+            ty(&model, "Sample"),
+            recipe_name("whole"),
+            Deconstructing::Atomic,
+        )
         .declare(
             ty(&model, "Sample"),
-            id("fields"),
+            recipe_name("fields"),
             Deconstructing::Product(Deconstruct::Fields(vec![Reach::Field(0)])),
         );
     let recipes = builder.build(&model).expect("table");
@@ -1621,7 +1683,7 @@ fn a_callback_argument_is_overridden_by_compiling_it_as_its_own_site() {
     bound.bind(
         arg.clone(),
         Crossing::new(ty(&model, "Sample"), Direction::Deconstruct),
-        Ask::Recipe(id("fields")),
+        Ask::Recipe(recipe_name("fields")),
         Origin::Function,
     );
     let bindings = bound.build(&recipes).expect("bindings");
@@ -1648,7 +1710,7 @@ fn a_part_that_only_lends_cannot_feed_an_edge_that_consumes() {
     let mut builder = Recipes::builder();
     builder.declare(
         ty(&model, "Sample"),
-        id("fields"),
+        recipe_name("fields"),
         Constructing::Product(Construct::Call(ident("sample_new"))),
     );
     let recipes = builder.build(&model).expect("table");
@@ -1687,7 +1749,7 @@ fn a_part_producing_the_wrong_rust_type_is_refused() {
     let mut builder = Recipes::builder();
     builder.declare(
         ty(&model, "Sample"),
-        id("fields"),
+        recipe_name("fields"),
         Constructing::Product(Construct::Call(ident("sample_new"))),
     );
     let recipes = builder.build(&model).expect("table");
@@ -1859,7 +1921,7 @@ fn a_part_answering_through_a_borrow_or_a_box_still_matches_its_type() {
     let mut builder = Recipes::builder();
     builder.declare(
         ty(&model, "Sample"),
-        id("fields"),
+        recipe_name("fields"),
         Constructing::Product(Construct::Call(ident("sample_of"))),
     );
     let recipes = builder.build(&model).expect("table");
@@ -1886,7 +1948,7 @@ fn a_constructor_that_builds_another_type_is_refused() {
     let mut builder = Recipes::builder();
     builder.declare(
         ty(&model, "Sample"),
-        id("fields"),
+        recipe_name("fields"),
         Constructing::Product(Construct::Call(ident("make_other"))),
     );
     let errors = builder
@@ -1911,7 +1973,7 @@ fn a_fallible_constructor_builds_its_success_arm() {
     let mut good = Recipes::builder();
     good.declare(
         ty(&model, "Sample"),
-        id("fields"),
+        recipe_name("fields"),
         Constructing::Product(Construct::Call(ident("sample_try"))),
     );
     good.build(&model)
@@ -1920,7 +1982,7 @@ fn a_fallible_constructor_builds_its_success_arm() {
     let mut bad = Recipes::builder();
     bad.declare(
         ty(&model, "Sample"),
-        id("fields"),
+        recipe_name("fields"),
         Constructing::Product(Construct::Call(ident("other_try"))),
     );
     let errors = bad.build(&model).expect_err("Result<u32, _> does not");
@@ -1936,7 +1998,7 @@ fn a_constructor_reached_through_a_borrow_or_a_box_is_accepted() {
     let mut builder = Recipes::builder();
     builder.declare(
         ty(&model, "Sample"),
-        id("fields"),
+        recipe_name("fields"),
         Constructing::Product(Construct::Call(ident("sample_boxed"))),
     );
     builder
@@ -2124,10 +2186,14 @@ fn a_site_takes_the_row_the_binding_names_and_others_take_the_default() {
     let model = model(&[SAMPLE]);
     let mut builder = Recipes::builder();
     builder
-        .declare_default(ty(&model, "Sample"), id("whole"), Deconstructing::Atomic)
+        .declare_default(
+            ty(&model, "Sample"),
+            recipe_name("whole"),
+            Deconstructing::Atomic,
+        )
         .declare(
             ty(&model, "Sample"),
-            id("fields"),
+            recipe_name("fields"),
             Deconstructing::Product(Deconstruct::Fields(vec![Reach::Field(0), Reach::Field(1)])),
         );
     let recipes = builder.build(&model).expect("table");
@@ -2135,7 +2201,7 @@ fn a_site_takes_the_row_the_binding_names_and_others_take_the_default() {
     bound.bind(
         site("z_put", 0),
         Crossing::new(ty(&model, "Sample"), Direction::Deconstruct),
-        Ask::Recipe(id("fields")),
+        Ask::Recipe(recipe_name("fields")),
         Origin::Function,
     );
     let bindings = bound.build(&recipes).expect("bindings");
@@ -2171,7 +2237,7 @@ fn a_struct_with_no_constructor_is_built_from_its_own_fields() {
     let mut builder = Recipes::builder();
     builder.declare(
         ty(&model, "Sample"),
-        id("literal"),
+        recipe_name("literal"),
         Constructing::Product(Construct::Fields),
     );
     let recipes = builder.build(&model).expect("table");
@@ -2199,7 +2265,7 @@ fn an_arm_is_built_from_its_own_payload_fields() {
     let mut builder = Recipes::builder();
     builder.declare(
         ty(&model, "Reply"),
-        id("variants"),
+        recipe_name("variants"),
         Constructing::Choice {
             arms: vec![
                 Arm {
@@ -2243,7 +2309,7 @@ fn building_a_type_the_model_gives_no_fields_is_refused() {
     let mut builder = Recipes::builder();
     builder.declare(
         ty(&model, "u32"),
-        id("literal"),
+        recipe_name("literal"),
         Constructing::Product(Construct::Fields),
     );
     let errors = builder.build(&model).expect_err("a scalar has no fields");
@@ -2263,7 +2329,7 @@ fn a_value_form_binds_the_accessors_result_and_reads_its_fields() {
     let mut builder = Recipes::builder();
     builder.declare(
         ty(&model, "Handle"),
-        id("read"),
+        recipe_name("read"),
         Deconstructing::Product(Deconstruct::ValueForm {
             func: ident("handle_read"),
             parts: vec![Reach::Field(0), Reach::Field(1)],
@@ -2302,7 +2368,7 @@ fn an_emitter_asking_for_a_crossing_gets_the_row_the_crossing_defaults_to() {
     builder.bind(
         site("z_put", 0),
         crossing.clone(),
-        Ask::Recipe(id("fields")),
+        Ask::Recipe(recipe_name("fields")),
         Origin::Function,
     );
     let bindings = builder.build(&recipes).expect("bindings");
@@ -2326,7 +2392,7 @@ fn an_emitter_asking_for_a_crossing_gets_the_row_the_crossing_defaults_to() {
     );
     // … and a caller holding a recipe still reaches that recipe.
     assert!(compiled
-        .recipe_fragment(&key, Direction::Deconstruct, &id("fields"))
+        .recipe_fragment(&key, &row(&crossing, "fields"))
         .is_some());
     // The other direction was never crossed, so there is no answer to give.
     assert!(compiled.fragment(&key, Direction::Construct).is_none());
@@ -2354,7 +2420,7 @@ fn compiling_a_row_by_name_refuses_a_name_the_crossing_lacks() {
     let mut compiler = Compiler::new(&model, &recipes, &bindings);
 
     let err = compiler
-        .recipe_of(&mut adapter, &crossing, &id("nonesuch"))
+        .recipe_of(&mut adapter, &crossing, &recipe_name("nonesuch"))
         .expect_err("`Sample` declares `whole` and `fields`, and nothing else");
     let message = err.to_string();
     assert!(message.contains("nonesuch"), "{message}");
@@ -2362,19 +2428,16 @@ fn compiling_a_row_by_name_refuses_a_name_the_crossing_lacks() {
 
     // And nothing was filed under the name, so no emitter can read one back.
     let compiled = compiler.finish();
+    let missing = row(&crossing, "nonesuch");
     assert!(compiled
-        .recipe_fragment(
-            &ty(&model, "Sample").key(),
-            Direction::Deconstruct,
-            &id("nonesuch")
-        )
+        .recipe_fragment(&ty(&model, "Sample").key(), &missing)
         .is_none());
 
     // The two recipes that DO exist still compile by name.
     let mut compiler = Compiler::new(&model, &recipes, &bindings);
     for name in ["whole", "fields"] {
         compiler
-            .recipe_of(&mut adapter, &crossing, &id(name))
+            .recipe_of(&mut adapter, &crossing, &recipe_name(name))
             .unwrap_or_else(|e| panic!("`{name}` is declared: {e}"));
     }
 }

--- a/prebindgen-registry/src/recipe/tests.rs
+++ b/prebindgen-registry/src/recipe/tests.rs
@@ -28,11 +28,11 @@ fn recipe_name(value: &str) -> RecipeName {
 }
 
 fn row(crossing: &Crossing, name: &str) -> RecipeKey {
-    RecipeKey::new(crossing.key(), recipe_name(name))
+    crossing.row(recipe_name(name))
 }
 
 fn row_at(crossing: &CrossingKey, name: &str) -> RecipeKey {
-    RecipeKey::new(crossing.clone(), recipe_name(name))
+    crossing.row(recipe_name(name))
 }
 
 fn ident(name: &str) -> syn::Ident {
@@ -232,13 +232,14 @@ fn two_defaults_are_as_wrong_as_none() {
 fn one_name_cannot_be_declared_twice_for_one_crossing() {
     let model = model(&[SAMPLE]);
     let sample = ty(&model, "Sample");
+    let duplicate = Crossing::new(sample.clone(), Direction::Deconstruct).row(recipe_name("whole"));
     let mut builder = Recipes::builder();
     builder
         .declare(sample.clone(), recipe_name("whole"), Deconstructing::Atomic)
         .declare(sample, recipe_name("whole"), Deconstructing::Atomic);
     let errors = builder.build(&model).expect_err("declared twice");
     assert!(
-        matches!(errors.as_slice(), [RecipeError::Duplicate { recipe, .. }] if recipe == &recipe_name("whole")),
+        matches!(errors.as_slice(), [RecipeError::Duplicate { recipe, .. }] if recipe == &duplicate),
         "{errors:?}"
     );
 }
@@ -799,6 +800,7 @@ fn a_site_naming_a_row_the_crossing_lacks_is_refused() {
     let model = model(&[SAMPLE]);
     let recipes = two_recipes(&model);
     let crossing = Crossing::new(ty(&model, "Sample"), Direction::Deconstruct);
+    let missing = crossing.row(recipe_name("jobject"));
     let mut builder = Bindings::builder();
     builder.bind(
         site("z_put", 0),
@@ -808,7 +810,7 @@ fn a_site_naming_a_row_the_crossing_lacks_is_refused() {
     );
     let errors = builder.build(&recipes).expect_err("no such recipe");
     assert!(
-        matches!(errors.as_slice(), [RecipeError::UnknownRecipe { recipe, .. }] if recipe == &recipe_name("jobject")),
+        matches!(errors.as_slice(), [RecipeError::UnknownRecipe { recipe, .. }] if recipe == &missing),
         "{errors:?}"
     );
 }


### PR DESCRIPTION
## Why

`RecipeId` was not actually an identifier for one recipe-table row. It was a crossing-local semantic label: adapters deliberately reuse names such as `whole` and `parts` under many types and directions. APIs therefore depended on an implicit `(CrossingKey, RecipeId)` pair while passing only part of that identity around.

## What changed

- Rename the reusable declaration selector to `RecipeName`.
- Introduce `RecipeKey`, the deterministic composite `(CrossingKey, RecipeName)` primary key for one table row.
- Resolve names to full keys before bindings, part sites, compiler hooks, defaults, fragment memoization, and row-specific diagnostics carry them.
- Make `Crossing::row` / `CrossingKey::row` the public construction path, so callers cannot bypass crossing normalization.
- Make hand-recorded fragments derive their `TypeKey` from `RecipeKey`, removing a duplicated unchecked identity input.
- Keep fragment identity finer than row identity by pairing `RecipeKey` with the spelled type. One row may serve `T`, `&T`, and `Box<T>`, while those spellings still require different generated Rust.
- Migrate the C and JNI adapters while keeping their policy dispatch on meaningful recipe names.
- Document the distinction in `docs/model.md` and test that one name can label multiple globally distinct rows.
- Preserve and correct the neighboring `RecipeError` Rustdoc while migrating its fields, including the `NotAProduct` summary and the explanations for shape and missing-row errors.

A `RecipeKey` identifies a row position whether or not the table currently contains a row there, allowing missing-row diagnostics to carry the same complete identity.

This deliberately does not use an insertion-order numeric ID. Such a surrogate would require a second name index for declarations, would make derived rows awkward, and would add order sensitivity without replacing any lookup the model needs. The composite key is stable, complete, and already consists of the row's semantic coordinates.

## Compatibility

This is an internal identity refactor. Regenerating the checked-in C, Rust/JNI, and Kotlin artifacts produced no changes.

## Verification

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo check --workspace --all-targets`
- `cargo test --workspace`
- `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps`
- `git diff --check`

All passed locally.

