### PR TITLE
Fix chained converter reachability and output size

### DIFF
--- a/examples/covertest-kotlin/src/generated_bindings.rs
+++ b/examples/covertest-kotlin/src/generated_bindings.rs
@@ -699,9 +699,8 @@ pub(crate) unsafe fn Arrays_to_JObject_71120c08<'a>(
     clippy::nonminimal_bool,
     clippy::eq_op
 )]
-pub(crate) unsafe fn Arrays_to_jni_objects_JByteArray_jni_objects_JShortArray_jni_objects_JIntArray_jni_objects_JLongArray_jni_objects_JDoubleArray_jni_objects_JBooleanArray_jni_objects_JLongArray_c0fbd13f<
-    'a,
->(
+#[inline(always)]
+pub(crate) unsafe fn Arrays_to_tuple7_c0fbd13f<'a>(
     env: &mut jni::JNIEnv<'a>,
     v: perftest_flat::Arrays,
 ) -> ::core::result::Result<
@@ -793,9 +792,8 @@ pub(crate) unsafe fn BlobValue_to_JObject_89b5dab7<'a>(
     clippy::nonminimal_bool,
     clippy::eq_op
 )]
-pub(crate) unsafe fn BlobValue_to_jni_sys_jlong_jni_sys_jlong_jni_objects_JByteArray_jni_objects_JObject_2c75fc67<
-    'a,
->(
+#[inline(always)]
+pub(crate) unsafe fn BlobValue_to_tuple3_2c75fc67<'a>(
     env: &mut jni::JNIEnv<'a>,
     v: perftest_flat::BlobValue,
 ) -> ::core::result::Result<
@@ -807,7 +805,7 @@ pub(crate) unsafe fn BlobValue_to_jni_sys_jlong_jni_sys_jlong_jni_objects_JByteA
     __JniErr,
 > {
     ::core::result::Result::Ok((
-        Stamp_to_jni_sys_jlong_jni_sys_jlong_8d33d015(env, v.stamp)?,
+        Stamp_to_tuple2_8d33d015(env, v.stamp)?,
         Vec_u8_to_JByteArray_7936d5de(env, v.id)?,
         Vec_Vec_u8_to_JObject_43404875(env, v.chunks)?,
     ))
@@ -863,32 +861,6 @@ pub(crate) unsafe fn Box_Duration_to_jlong_0776c1ca<'a>(
                     String,
                 >>::from(__e.to_string()))?;
             u64_to_jlong_4384a5d6(env, __inner_s0)?
-        }
-    })
-}
-#[allow(
-    non_snake_case,
-    unused_mut,
-    unused_variables,
-    unused_braces,
-    unused_parens,
-    dead_code,
-    clippy::useless_conversion,
-    clippy::needless_question_mark,
-    clippy::let_and_return,
-    clippy::nonminimal_bool,
-    clippy::eq_op
-)]
-pub(crate) unsafe fn Box_Option_Summary_to_jlong_75560ba9<'a>(
-    env: &mut jni::JNIEnv<'a>,
-    v: Box<Option<perftest_flat::Summary>>,
-) -> ::core::result::Result<jni::sys::jlong, __JniErr> {
-    ::core::result::Result::Ok({
-        match *v {
-            ::core::option::Option::Some(__value) => {
-                Summary_to_jlong_3cb103b9(env, __value)?
-            }
-            ::core::option::Option::None => 0i64,
         }
     })
 }
@@ -1138,7 +1110,8 @@ pub(crate) unsafe fn DurationBoundary_to_JObject_9c5bf9bc<'a>(
     clippy::nonminimal_bool,
     clippy::eq_op
 )]
-pub(crate) unsafe fn DurationBoundary_to_jni_sys_jlong_jni_sys_jlong_3834b601<'a>(
+#[inline(always)]
+pub(crate) unsafe fn DurationBoundary_to_tuple2_3834b601<'a>(
     env: &mut jni::JNIEnv<'a>,
     v: perftest_flat::DurationBoundary,
 ) -> ::core::result::Result<(jni::sys::jlong, jni::sys::jlong), __JniErr> {
@@ -1936,43 +1909,6 @@ pub(crate) unsafe fn JObject_to_Box_Option_Payload_8d993ebb<'env, 'v>(
         };
         ::std::boxed::Box::new(__v)
     })
-}
-#[allow(
-    non_snake_case,
-    unused_mut,
-    unused_variables,
-    unused_braces,
-    unused_parens,
-    dead_code,
-    clippy::useless_conversion,
-    clippy::needless_question_mark,
-    clippy::let_and_return,
-    clippy::nonminimal_bool,
-    clippy::eq_op
-)]
-pub(crate) unsafe fn JObject_to_Box_Option_Priority_cb1cb2b5<'env, 'v>(
-    env: &mut jni::JNIEnv<'env>,
-    v: &jni::objects::JObject<'v>,
-) -> ::core::result::Result<Box<Option<perftest_flat::Priority>>, __JniErr> {
-    ::core::result::Result::Ok(
-        ::std::boxed::Box::new({
-            if (v).is_null() {
-                ::core::option::Option::None
-            } else {
-                let __present = {
-                    env.call_method(&v, "intValue", "()I", &[])
-                        .and_then(|__value| __value.i())
-                        .map(|__value| __value as jni::sys::jint)
-                        .map_err(|__error| <__JniErr as ::core::convert::From<
-                            String,
-                        >>::from(format!("Option unbox: {}", __error)))?
-                };
-                ::core::option::Option::Some(
-                    jint_to_Priority_447102d2(env, &(__present))?,
-                )
-            }
-        }),
-    )
 }
 #[allow(
     non_snake_case,
@@ -3237,39 +3173,6 @@ pub(crate) unsafe fn JObject_to_Option_Reading_80df84a9<'env, 'v>(
             if v.is_null() { None } else { Some(JObject_to_Reading_2261050f(env, v)?) }
         };
         __v
-    })
-}
-#[allow(
-    non_snake_case,
-    unused_mut,
-    unused_variables,
-    unused_braces,
-    unused_parens,
-    dead_code,
-    clippy::useless_conversion,
-    clippy::needless_question_mark,
-    clippy::let_and_return,
-    clippy::nonminimal_bool,
-    clippy::eq_op
-)]
-pub(crate) unsafe fn JObject_to_Option_f64_b3f3e9a9<'env, 'v>(
-    env: &mut jni::JNIEnv<'env>,
-    v: &jni::objects::JObject<'v>,
-) -> ::core::result::Result<Option<f64>, __JniErr> {
-    ::core::result::Result::Ok({
-        if (v).is_null() {
-            ::core::option::Option::None
-        } else {
-            let __present = {
-                env.call_method(&v, "doubleValue", "()D", &[])
-                    .and_then(|__value| __value.d())
-                    .map(|__value| __value as jni::sys::jdouble)
-                    .map_err(|__error| <__JniErr as ::core::convert::From<
-                        String,
-                    >>::from(format!("Option unbox: {}", __error)))?
-            };
-            ::core::option::Option::Some(jdouble_to_f64_9e4a8f70(env, &(__present))?)
-        }
     })
 }
 #[allow(
@@ -5188,10 +5091,7 @@ pub(crate) unsafe fn JObject_to_impl_Fn_Payload_Send_Sync_static_95073668<'env, 
                                 __chain_wire2,
                                 __chain_wire3,
                                 __chain_wire4,
-                            ) = match Payload_to_jni_sys_jlong_jni_sys_jint_jni_sys_jdouble_jni_sys_jboolean_jni_objects_JString_2ea1d0c2(
-                                &mut env,
-                                __cb_elem,
-                            ) {
+                            ) = match Payload_to_tuple5_2ea1d0c2(&mut env, __cb_elem) {
                                 ::core::result::Result::Ok(__intermediate) => __intermediate,
                                 ::core::result::Result::Err(__chain_error) => {
                                     return ::core::result::Result::Err(
@@ -5347,10 +5247,7 @@ pub(crate) unsafe fn JObject_to_impl_Fn_Payload_Send_Sync_static_96d50906<'env, 
                         __chain_wire2,
                         __chain_wire3,
                         __chain_wire4,
-                    ) = match Payload_to_jni_sys_jlong_jni_sys_jint_jni_sys_jdouble_jni_sys_jboolean_jni_objects_JString_2ea1d0c2(
-                        &mut env,
-                        __cb_arg0,
-                    ) {
+                    ) = match Payload_to_tuple5_2ea1d0c2(&mut env, __cb_arg0) {
                         ::core::result::Result::Ok(__intermediate) => __intermediate,
                         ::core::result::Result::Err(__chain_error) => {
                             return ::core::result::Result::Err(
@@ -9512,32 +9409,6 @@ pub(crate) unsafe fn Option_Vec_Option_u64_to_JObject_006312b6<'a>(
     clippy::nonminimal_bool,
     clippy::eq_op
 )]
-pub(crate) unsafe fn Option_Vec_Payload_to_JObject_b9a4637e<'a>(
-    env: &mut jni::JNIEnv<'a>,
-    v: Option<Vec<perftest_flat::Payload>>,
-) -> ::core::result::Result<jni::objects::JObject<'a>, __JniErr> {
-    ::core::result::Result::Ok({
-        match v {
-            ::core::option::Option::Some(__value) => {
-                Vec_Payload_to_JObject_8b7084d2(env, __value)?
-            }
-            ::core::option::Option::None => jni::objects::JObject::null().into(),
-        }
-    })
-}
-#[allow(
-    non_snake_case,
-    unused_mut,
-    unused_variables,
-    unused_braces,
-    unused_parens,
-    dead_code,
-    clippy::useless_conversion,
-    clippy::needless_question_mark,
-    clippy::let_and_return,
-    clippy::nonminimal_bool,
-    clippy::eq_op
-)]
 pub(crate) unsafe fn Option_f64_to_JObject_b3f3e9a9<'a>(
     env: &mut jni::JNIEnv<'a>,
     v: Option<f64>,
@@ -9758,9 +9629,8 @@ pub(crate) unsafe fn Payload_to_JObject_98f64326<'a>(
     clippy::nonminimal_bool,
     clippy::eq_op
 )]
-pub(crate) unsafe fn Payload_to_jni_sys_jlong_jni_sys_jint_jni_sys_jdouble_jni_sys_jboolean_jni_objects_JString_2ea1d0c2<
-    'a,
->(
+#[inline(always)]
+pub(crate) unsafe fn Payload_to_tuple5_2ea1d0c2<'a>(
     env: &mut jni::JNIEnv<'a>,
     v: &perftest_flat::Payload,
 ) -> ::core::result::Result<
@@ -9794,9 +9664,8 @@ pub(crate) unsafe fn Payload_to_jni_sys_jlong_jni_sys_jint_jni_sys_jdouble_jni_s
     clippy::nonminimal_bool,
     clippy::eq_op
 )]
-pub(crate) unsafe fn Payload_to_jni_sys_jlong_jni_sys_jint_jni_sys_jdouble_jni_sys_jboolean_jni_objects_JString_bbb055bc<
-    'a,
->(
+#[inline(always)]
+pub(crate) unsafe fn Payload_to_tuple5_bbb055bc<'a>(
     env: &mut jni::JNIEnv<'a>,
     v: perftest_flat::Payload,
 ) -> ::core::result::Result<
@@ -10062,7 +9931,8 @@ pub(crate) unsafe fn Stamp_to_JObject_f6b1e942<'a>(
     clippy::nonminimal_bool,
     clippy::eq_op
 )]
-pub(crate) unsafe fn Stamp_to_jni_sys_jlong_jni_sys_jlong_8d33d015<'a>(
+#[inline(always)]
+pub(crate) unsafe fn Stamp_to_tuple2_8d33d015<'a>(
     env: &mut jni::JNIEnv<'a>,
     v: perftest_flat::Stamp,
 ) -> ::core::result::Result<(jni::sys::jlong, jni::sys::jlong), __JniErr> {
@@ -10342,9 +10212,8 @@ pub(crate) unsafe fn Unsigned_to_JObject_7e3cc618<'a>(
     clippy::nonminimal_bool,
     clippy::eq_op
 )]
-pub(crate) unsafe fn Unsigned_to_jni_sys_jint_jni_sys_jint_jni_sys_jlong_jni_sys_jlong_jni_objects_JObject_371b0950<
-    'a,
->(
+#[inline(always)]
+pub(crate) unsafe fn Unsigned_to_tuple5_371b0950<'a>(
     env: &mut jni::JNIEnv<'a>,
     v: perftest_flat::Unsigned,
 ) -> ::core::result::Result<
@@ -11407,34 +11276,6 @@ pub(crate) unsafe fn jlong_to_Archive_cd73502c<'env, 'v>(
     clippy::nonminimal_bool,
     clippy::eq_op
 )]
-pub(crate) unsafe fn jlong_to_Archive_cd73502c_owned<'env, 'v>(
-    env: &mut jni::JNIEnv<'env>,
-    v: &jni::sys::jlong,
-) -> ::core::result::Result<perftest_flat::Archive, __JniErr> {
-    if *v == 0 || (*v & 1) == 1 {
-        return ::core::result::Result::Err(
-            <__JniErr as ::core::convert::From<
-                String,
-            >>::from("Operation on a closed native handle.".to_string()),
-        );
-    }
-    ::core::result::Result::Ok(unsafe {
-        *::std::boxed::Box::from_raw(*v as *mut perftest_flat::Archive)
-    })
-}
-#[allow(
-    non_snake_case,
-    unused_mut,
-    unused_variables,
-    unused_braces,
-    unused_parens,
-    dead_code,
-    clippy::useless_conversion,
-    clippy::needless_question_mark,
-    clippy::let_and_return,
-    clippy::nonminimal_bool,
-    clippy::eq_op
-)]
 pub(crate) unsafe fn jlong_to_Box_Duration_0776c1ca<'env, 'v>(
     env: &mut jni::JNIEnv<'env>,
     v: &jni::sys::jlong,
@@ -11490,34 +11331,6 @@ pub(crate) unsafe fn jlong_to_EscapeProbe_416aab42<'env, 'v>(
     clippy::nonminimal_bool,
     clippy::eq_op
 )]
-pub(crate) unsafe fn jlong_to_EscapeProbe_416aab42_owned<'env, 'v>(
-    env: &mut jni::JNIEnv<'env>,
-    v: &jni::sys::jlong,
-) -> ::core::result::Result<perftest_flat::EscapeProbe, __JniErr> {
-    if *v == 0 || (*v & 1) == 1 {
-        return ::core::result::Result::Err(
-            <__JniErr as ::core::convert::From<
-                String,
-            >>::from("Operation on a closed native handle.".to_string()),
-        );
-    }
-    ::core::result::Result::Ok(unsafe {
-        *::std::boxed::Box::from_raw(*v as *mut perftest_flat::EscapeProbe)
-    })
-}
-#[allow(
-    non_snake_case,
-    unused_mut,
-    unused_variables,
-    unused_braces,
-    unused_parens,
-    dead_code,
-    clippy::useless_conversion,
-    clippy::needless_question_mark,
-    clippy::let_and_return,
-    clippy::nonminimal_bool,
-    clippy::eq_op
-)]
 pub(crate) unsafe fn jlong_to_Ingot_020c3a86<'env, 'v>(
     env: &mut jni::JNIEnv<'env>,
     v: &jni::sys::jlong,
@@ -11530,34 +11343,6 @@ pub(crate) unsafe fn jlong_to_Ingot_020c3a86<'env, 'v>(
         );
     }
     Ok(unsafe { OwnedObject::from_raw(*v as *const perftest_flat::Ingot) })
-}
-#[allow(
-    non_snake_case,
-    unused_mut,
-    unused_variables,
-    unused_braces,
-    unused_parens,
-    dead_code,
-    clippy::useless_conversion,
-    clippy::needless_question_mark,
-    clippy::let_and_return,
-    clippy::nonminimal_bool,
-    clippy::eq_op
-)]
-pub(crate) unsafe fn jlong_to_Ingot_020c3a86_owned<'env, 'v>(
-    env: &mut jni::JNIEnv<'env>,
-    v: &jni::sys::jlong,
-) -> ::core::result::Result<perftest_flat::Ingot, __JniErr> {
-    if *v == 0 || (*v & 1) == 1 {
-        return ::core::result::Result::Err(
-            <__JniErr as ::core::convert::From<
-                String,
-            >>::from("Operation on a closed native handle.".to_string()),
-        );
-    }
-    ::core::result::Result::Ok(unsafe {
-        *::std::boxed::Box::from_raw(*v as *mut perftest_flat::Ingot)
-    })
 }
 #[allow(
     non_snake_case,
@@ -11694,34 +11479,6 @@ pub(crate) unsafe fn jlong_to_PayloadHandler_d61fd890<'env, 'v>(
     clippy::nonminimal_bool,
     clippy::eq_op
 )]
-pub(crate) unsafe fn jlong_to_PayloadHandler_d61fd890_owned<'env, 'v>(
-    env: &mut jni::JNIEnv<'env>,
-    v: &jni::sys::jlong,
-) -> ::core::result::Result<perftest_flat::PayloadHandler, __JniErr> {
-    if *v == 0 || (*v & 1) == 1 {
-        return ::core::result::Result::Err(
-            <__JniErr as ::core::convert::From<
-                String,
-            >>::from("Operation on a closed native handle.".to_string()),
-        );
-    }
-    ::core::result::Result::Ok(unsafe {
-        *::std::boxed::Box::from_raw(*v as *mut perftest_flat::PayloadHandler)
-    })
-}
-#[allow(
-    non_snake_case,
-    unused_mut,
-    unused_variables,
-    unused_braces,
-    unused_parens,
-    dead_code,
-    clippy::useless_conversion,
-    clippy::needless_question_mark,
-    clippy::let_and_return,
-    clippy::nonminimal_bool,
-    clippy::eq_op
-)]
 pub(crate) unsafe fn jlong_to_PayloadVecHandler_b32d2812<'env, 'v>(
     env: &mut jni::JNIEnv<'env>,
     v: &jni::sys::jlong,
@@ -11734,146 +11491,6 @@ pub(crate) unsafe fn jlong_to_PayloadVecHandler_b32d2812<'env, 'v>(
         );
     }
     Ok(unsafe { OwnedObject::from_raw(*v as *const perftest_flat::PayloadVecHandler) })
-}
-#[allow(
-    non_snake_case,
-    unused_mut,
-    unused_variables,
-    unused_braces,
-    unused_parens,
-    dead_code,
-    clippy::useless_conversion,
-    clippy::needless_question_mark,
-    clippy::let_and_return,
-    clippy::nonminimal_bool,
-    clippy::eq_op
-)]
-pub(crate) unsafe fn jlong_to_PayloadVecHandler_b32d2812_owned<'env, 'v>(
-    env: &mut jni::JNIEnv<'env>,
-    v: &jni::sys::jlong,
-) -> ::core::result::Result<perftest_flat::PayloadVecHandler, __JniErr> {
-    if *v == 0 || (*v & 1) == 1 {
-        return ::core::result::Result::Err(
-            <__JniErr as ::core::convert::From<
-                String,
-            >>::from("Operation on a closed native handle.".to_string()),
-        );
-    }
-    ::core::result::Result::Ok(unsafe {
-        *::std::boxed::Box::from_raw(*v as *mut perftest_flat::PayloadVecHandler)
-    })
-}
-#[allow(
-    non_snake_case,
-    unused_mut,
-    unused_variables,
-    unused_braces,
-    unused_parens,
-    dead_code,
-    clippy::useless_conversion,
-    clippy::needless_question_mark,
-    clippy::let_and_return,
-    clippy::nonminimal_bool,
-    clippy::eq_op
-)]
-pub(crate) unsafe fn jlong_to_Probe_76f3d10e_owned<'env, 'v>(
-    env: &mut jni::JNIEnv<'env>,
-    v: &jni::sys::jlong,
-) -> ::core::result::Result<perftest_flat::Probe, __JniErr> {
-    if *v == 0 || (*v & 1) == 1 {
-        return ::core::result::Result::Err(
-            <__JniErr as ::core::convert::From<
-                String,
-            >>::from("Operation on a closed native handle.".to_string()),
-        );
-    }
-    ::core::result::Result::Ok(unsafe {
-        *::std::boxed::Box::from_raw(*v as *mut perftest_flat::Probe)
-    })
-}
-#[allow(
-    non_snake_case,
-    unused_mut,
-    unused_variables,
-    unused_braces,
-    unused_parens,
-    dead_code,
-    clippy::useless_conversion,
-    clippy::needless_question_mark,
-    clippy::let_and_return,
-    clippy::nonminimal_bool,
-    clippy::eq_op
-)]
-pub(crate) unsafe fn jlong_to_Report_eaed4ba1_owned<'env, 'v>(
-    env: &mut jni::JNIEnv<'env>,
-    v: &jni::sys::jlong,
-) -> ::core::result::Result<perftest_flat::Report, __JniErr> {
-    if *v == 0 || (*v & 1) == 1 {
-        return ::core::result::Result::Err(
-            <__JniErr as ::core::convert::From<
-                String,
-            >>::from("Operation on a closed native handle.".to_string()),
-        );
-    }
-    ::core::result::Result::Ok(unsafe {
-        *::std::boxed::Box::from_raw(*v as *mut perftest_flat::Report)
-    })
-}
-#[allow(
-    non_snake_case,
-    unused_mut,
-    unused_variables,
-    unused_braces,
-    unused_parens,
-    dead_code,
-    clippy::useless_conversion,
-    clippy::needless_question_mark,
-    clippy::let_and_return,
-    clippy::nonminimal_bool,
-    clippy::eq_op
-)]
-pub(crate) unsafe fn jlong_to_SpanHolder_7ffe9314_owned<'env, 'v>(
-    env: &mut jni::JNIEnv<'env>,
-    v: &jni::sys::jlong,
-) -> ::core::result::Result<perftest_flat::SpanHolder, __JniErr> {
-    if *v == 0 || (*v & 1) == 1 {
-        return ::core::result::Result::Err(
-            <__JniErr as ::core::convert::From<
-                String,
-            >>::from("Operation on a closed native handle.".to_string()),
-        );
-    }
-    ::core::result::Result::Ok(unsafe {
-        *::std::boxed::Box::from_raw(*v as *mut perftest_flat::SpanHolder)
-    })
-}
-#[allow(
-    non_snake_case,
-    unused_mut,
-    unused_variables,
-    unused_braces,
-    unused_parens,
-    dead_code,
-    clippy::useless_conversion,
-    clippy::needless_question_mark,
-    clippy::let_and_return,
-    clippy::nonminimal_bool,
-    clippy::eq_op
-)]
-pub(crate) unsafe fn jlong_to_Span_6d59d587_owned<'env, 'v>(
-    env: &mut jni::JNIEnv<'env>,
-    v: &jni::sys::jlong,
-) -> ::core::result::Result<perftest_flat::Span, __JniErr> {
-    if *v == 0 || (*v & 1) == 1 {
-        return ::core::result::Result::Err(
-            <__JniErr as ::core::convert::From<
-                String,
-            >>::from("Operation on a closed native handle.".to_string()),
-        );
-    }
-    ::core::result::Result::Ok(unsafe {
-        *::std::boxed::Box::from_raw(*v as *mut perftest_flat::Span)
-    })
 }
 #[allow(
     non_snake_case,
@@ -11914,34 +11531,6 @@ pub(crate) unsafe fn jlong_to_StorageError_26b2d298<'env, 'v>(
     clippy::nonminimal_bool,
     clippy::eq_op
 )]
-pub(crate) unsafe fn jlong_to_StorageError_26b2d298_owned<'env, 'v>(
-    env: &mut jni::JNIEnv<'env>,
-    v: &jni::sys::jlong,
-) -> ::core::result::Result<perftest_flat::StorageError, __JniErr> {
-    if *v == 0 || (*v & 1) == 1 {
-        return ::core::result::Result::Err(
-            <__JniErr as ::core::convert::From<
-                String,
-            >>::from("Operation on a closed native handle.".to_string()),
-        );
-    }
-    ::core::result::Result::Ok(unsafe {
-        *::std::boxed::Box::from_raw(*v as *mut perftest_flat::StorageError)
-    })
-}
-#[allow(
-    non_snake_case,
-    unused_mut,
-    unused_variables,
-    unused_braces,
-    unused_parens,
-    dead_code,
-    clippy::useless_conversion,
-    clippy::needless_question_mark,
-    clippy::let_and_return,
-    clippy::nonminimal_bool,
-    clippy::eq_op
-)]
 pub(crate) unsafe fn jlong_to_StorageHandler_3b4d3ed3<'env, 'v>(
     env: &mut jni::JNIEnv<'env>,
     v: &jni::sys::jlong,
@@ -11968,34 +11557,6 @@ pub(crate) unsafe fn jlong_to_StorageHandler_3b4d3ed3<'env, 'v>(
     clippy::nonminimal_bool,
     clippy::eq_op
 )]
-pub(crate) unsafe fn jlong_to_StorageHandler_3b4d3ed3_owned<'env, 'v>(
-    env: &mut jni::JNIEnv<'env>,
-    v: &jni::sys::jlong,
-) -> ::core::result::Result<perftest_flat::StorageHandler, __JniErr> {
-    if *v == 0 || (*v & 1) == 1 {
-        return ::core::result::Result::Err(
-            <__JniErr as ::core::convert::From<
-                String,
-            >>::from("Operation on a closed native handle.".to_string()),
-        );
-    }
-    ::core::result::Result::Ok(unsafe {
-        *::std::boxed::Box::from_raw(*v as *mut perftest_flat::StorageHandler)
-    })
-}
-#[allow(
-    non_snake_case,
-    unused_mut,
-    unused_variables,
-    unused_braces,
-    unused_parens,
-    dead_code,
-    clippy::useless_conversion,
-    clippy::needless_question_mark,
-    clippy::let_and_return,
-    clippy::nonminimal_bool,
-    clippy::eq_op
-)]
 pub(crate) unsafe fn jlong_to_Storage_1b233abd<'env, 'v>(
     env: &mut jni::JNIEnv<'env>,
     v: &jni::sys::jlong,
@@ -12008,34 +11569,6 @@ pub(crate) unsafe fn jlong_to_Storage_1b233abd<'env, 'v>(
         );
     }
     Ok(unsafe { OwnedObject::from_raw(*v as *const perftest_flat::Storage) })
-}
-#[allow(
-    non_snake_case,
-    unused_mut,
-    unused_variables,
-    unused_braces,
-    unused_parens,
-    dead_code,
-    clippy::useless_conversion,
-    clippy::needless_question_mark,
-    clippy::let_and_return,
-    clippy::nonminimal_bool,
-    clippy::eq_op
-)]
-pub(crate) unsafe fn jlong_to_Storage_1b233abd_owned<'env, 'v>(
-    env: &mut jni::JNIEnv<'env>,
-    v: &jni::sys::jlong,
-) -> ::core::result::Result<perftest_flat::Storage, __JniErr> {
-    if *v == 0 || (*v & 1) == 1 {
-        return ::core::result::Result::Err(
-            <__JniErr as ::core::convert::From<
-                String,
-            >>::from("Operation on a closed native handle.".to_string()),
-        );
-    }
-    ::core::result::Result::Ok(unsafe {
-        *::std::boxed::Box::from_raw(*v as *mut perftest_flat::Storage)
-    })
 }
 #[allow(
     non_snake_case,
@@ -12089,62 +11622,6 @@ pub(crate) unsafe fn jlong_to_Summary_3cb103b9_owned<'env, 'v>(
     }
     ::core::result::Result::Ok(unsafe {
         *::std::boxed::Box::from_raw(*v as *mut perftest_flat::Summary)
-    })
-}
-#[allow(
-    non_snake_case,
-    unused_mut,
-    unused_variables,
-    unused_braces,
-    unused_parens,
-    dead_code,
-    clippy::useless_conversion,
-    clippy::needless_question_mark,
-    clippy::let_and_return,
-    clippy::nonminimal_bool,
-    clippy::eq_op
-)]
-pub(crate) unsafe fn jlong_to_VaultHolder_1de3f656_owned<'env, 'v>(
-    env: &mut jni::JNIEnv<'env>,
-    v: &jni::sys::jlong,
-) -> ::core::result::Result<perftest_flat::VaultHolder, __JniErr> {
-    if *v == 0 || (*v & 1) == 1 {
-        return ::core::result::Result::Err(
-            <__JniErr as ::core::convert::From<
-                String,
-            >>::from("Operation on a closed native handle.".to_string()),
-        );
-    }
-    ::core::result::Result::Ok(unsafe {
-        *::std::boxed::Box::from_raw(*v as *mut perftest_flat::VaultHolder)
-    })
-}
-#[allow(
-    non_snake_case,
-    unused_mut,
-    unused_variables,
-    unused_braces,
-    unused_parens,
-    dead_code,
-    clippy::useless_conversion,
-    clippy::needless_question_mark,
-    clippy::let_and_return,
-    clippy::nonminimal_bool,
-    clippy::eq_op
-)]
-pub(crate) unsafe fn jlong_to_Vault_4a33ea23_owned<'env, 'v>(
-    env: &mut jni::JNIEnv<'env>,
-    v: &jni::sys::jlong,
-) -> ::core::result::Result<perftest_flat::Vault, __JniErr> {
-    if *v == 0 || (*v & 1) == 1 {
-        return ::core::result::Result::Err(
-            <__JniErr as ::core::convert::From<
-                String,
-            >>::from("Operation on a closed native handle.".to_string()),
-        );
-    }
-    ::core::result::Result::Ok(unsafe {
-        *::std::boxed::Box::from_raw(*v as *mut perftest_flat::Vault)
     })
 }
 #[allow(
@@ -12224,29 +11701,17 @@ pub(crate) unsafe fn jlong_to_u64_4384a5d6<'env, 'v>(
     clippy::nonminimal_bool,
     clippy::eq_op
 )]
-pub(crate) unsafe fn jni_objects_JByteArray_jni_objects_JShortArray_jni_objects_JIntArray_jni_objects_JLongArray_jni_objects_JDoubleArray_jni_objects_JBooleanArray_jni_objects_JLongArray_to_Arrays_c0fbd13f<
-    'env,
-    'a,
->(
-    env: &mut jni::JNIEnv<'env>,
-    v: (
-        jni::objects::JByteArray<'a>,
-        jni::objects::JShortArray<'a>,
-        jni::objects::JIntArray<'a>,
-        jni::objects::JLongArray<'a>,
-        jni::objects::JDoubleArray<'a>,
-        jni::objects::JBooleanArray<'a>,
-        jni::objects::JLongArray<'a>,
-    ),
-) -> ::core::result::Result<perftest_flat::Arrays, __JniErr> {
-    ::core::result::Result::Ok(perftest_flat::Arrays {
-        bytes: JByteArray_to_u8_4_39abedfa(env, &((v).0))?,
-        shorts: JShortArray_to_i16_2_098f4ad5(env, &((v).1))?,
-        ints: JIntArray_to_i32_3_60e5e35a(env, &((v).2))?,
-        longs: JLongArray_to_i64_2_73596912(env, &((v).3))?,
-        doubles: JDoubleArray_to_f64_2_dc30d1f9(env, &((v).4))?,
-        flags: JBooleanArray_to_bool_3_3f960c58(env, &((v).5))?,
-        raw: JLongArray_to_u64_2_60bcc6a5(env, &((v).6))?,
+pub(crate) unsafe fn str_to_JString_7b77dc67<'a>(
+    env: &mut jni::JNIEnv<'a>,
+    v: &str,
+) -> ::core::result::Result<jni::objects::JString<'a>, __JniErr> {
+    Ok({
+        env.new_string(v)
+            .map_err(|e| {
+                <__JniErr as ::core::convert::From<
+                    String,
+                >>::from(format!("encode_str: {}", e))
+            })?
     })
 }
 #[allow(
@@ -12262,10 +11727,8 @@ pub(crate) unsafe fn jni_objects_JByteArray_jni_objects_JShortArray_jni_objects_
     clippy::nonminimal_bool,
     clippy::eq_op
 )]
-pub(crate) unsafe fn jni_objects_JObject_jni_objects_JObject_to_HoldPolicy_c9df7bfe<
-    'env,
-    'a,
->(
+#[inline(always)]
+pub(crate) unsafe fn tuple2_to_HoldPolicy_c9df7bfe<'env, 'a>(
     env: &mut jni::JNIEnv<'env>,
     v: (jni::objects::JObject<'a>, jni::objects::JObject<'a>),
 ) -> ::core::result::Result<perftest_flat::HoldPolicy, __JniErr> {
@@ -12287,7 +11750,54 @@ pub(crate) unsafe fn jni_objects_JObject_jni_objects_JObject_to_HoldPolicy_c9df7
     clippy::nonminimal_bool,
     clippy::eq_op
 )]
-pub(crate) unsafe fn jni_sys_jlong_jni_objects_JObject_to_Tagged_b68a6969<'env, 'a>(
+#[inline(always)]
+pub(crate) unsafe fn tuple2_to_Stamp_43c8d6ce<'env, 'a>(
+    env: &mut jni::JNIEnv<'env>,
+    v: (jni::sys::jlong, jni::sys::jlong),
+) -> ::core::result::Result<perftest_flat::Stamp, __JniErr> {
+    ::core::result::Result::Ok(perftest_flat::Stamp {
+        secs: jlong_to_i64_fbf9a9bc(env, &((v).0))?,
+        nanos: jlong_to_i64_fbf9a9bc(env, &((v).1))?,
+    })
+}
+#[allow(
+    non_snake_case,
+    unused_mut,
+    unused_variables,
+    unused_braces,
+    unused_parens,
+    dead_code,
+    clippy::useless_conversion,
+    clippy::needless_question_mark,
+    clippy::let_and_return,
+    clippy::nonminimal_bool,
+    clippy::eq_op
+)]
+#[inline(always)]
+pub(crate) unsafe fn tuple2_to_Stamp_8d33d015<'env, 'a>(
+    env: &mut jni::JNIEnv<'env>,
+    v: (jni::sys::jlong, jni::sys::jlong),
+) -> ::core::result::Result<perftest_flat::Stamp, __JniErr> {
+    ::core::result::Result::Ok(perftest_flat::Stamp {
+        secs: jlong_to_i64_fbf9a9bc(env, &((v).0))?,
+        nanos: jlong_to_i64_fbf9a9bc(env, &((v).1))?,
+    })
+}
+#[allow(
+    non_snake_case,
+    unused_mut,
+    unused_variables,
+    unused_braces,
+    unused_parens,
+    dead_code,
+    clippy::useless_conversion,
+    clippy::needless_question_mark,
+    clippy::let_and_return,
+    clippy::nonminimal_bool,
+    clippy::eq_op
+)]
+#[inline(always)]
+pub(crate) unsafe fn tuple2_to_Tagged_b68a6969<'env, 'a>(
     env: &mut jni::JNIEnv<'env>,
     v: (jni::sys::jlong, jni::objects::JObject<'a>),
 ) -> ::core::result::Result<perftest_flat::Tagged, __JniErr> {
@@ -12309,10 +11819,8 @@ pub(crate) unsafe fn jni_sys_jlong_jni_objects_JObject_to_Tagged_b68a6969<'env, 
     clippy::nonminimal_bool,
     clippy::eq_op
 )]
-pub(crate) unsafe fn jni_sys_jlong_jni_sys_jint_jni_sys_jdouble_jni_sys_jboolean_jni_objects_JString_to_Box_Payload_697caed4<
-    'env,
-    'a,
->(
+#[inline(always)]
+pub(crate) unsafe fn tuple5_to_Box_Payload_697caed4<'env, 'a>(
     env: &mut jni::JNIEnv<'env>,
     v: (
         jni::sys::jlong,
@@ -12345,10 +11853,8 @@ pub(crate) unsafe fn jni_sys_jlong_jni_sys_jint_jni_sys_jdouble_jni_sys_jboolean
     clippy::nonminimal_bool,
     clippy::eq_op
 )]
-pub(crate) unsafe fn jni_sys_jlong_jni_sys_jint_jni_sys_jdouble_jni_sys_jboolean_jni_objects_JString_to_Payload_2ea1d0c2<
-    'env,
-    'a,
->(
+#[inline(always)]
+pub(crate) unsafe fn tuple5_to_Payload_2ea1d0c2<'env, 'a>(
     env: &mut jni::JNIEnv<'env>,
     v: (
         jni::sys::jlong,
@@ -12379,10 +11885,8 @@ pub(crate) unsafe fn jni_sys_jlong_jni_sys_jint_jni_sys_jdouble_jni_sys_jboolean
     clippy::nonminimal_bool,
     clippy::eq_op
 )]
-pub(crate) unsafe fn jni_sys_jlong_jni_sys_jint_jni_sys_jdouble_jni_sys_jboolean_jni_objects_JString_to_Payload_bbb055bc<
-    'env,
-    'a,
->(
+#[inline(always)]
+pub(crate) unsafe fn tuple5_to_Payload_bbb055bc<'env, 'a>(
     env: &mut jni::JNIEnv<'env>,
     v: (
         jni::sys::jlong,
@@ -12413,61 +11917,27 @@ pub(crate) unsafe fn jni_sys_jlong_jni_sys_jint_jni_sys_jdouble_jni_sys_jboolean
     clippy::nonminimal_bool,
     clippy::eq_op
 )]
-pub(crate) unsafe fn jni_sys_jlong_jni_sys_jlong_to_Stamp_43c8d6ce<'env, 'a>(
+#[inline(always)]
+pub(crate) unsafe fn tuple7_to_Arrays_c0fbd13f<'env, 'a>(
     env: &mut jni::JNIEnv<'env>,
-    v: (jni::sys::jlong, jni::sys::jlong),
-) -> ::core::result::Result<perftest_flat::Stamp, __JniErr> {
-    ::core::result::Result::Ok(perftest_flat::Stamp {
-        secs: jlong_to_i64_fbf9a9bc(env, &((v).0))?,
-        nanos: jlong_to_i64_fbf9a9bc(env, &((v).1))?,
-    })
-}
-#[allow(
-    non_snake_case,
-    unused_mut,
-    unused_variables,
-    unused_braces,
-    unused_parens,
-    dead_code,
-    clippy::useless_conversion,
-    clippy::needless_question_mark,
-    clippy::let_and_return,
-    clippy::nonminimal_bool,
-    clippy::eq_op
-)]
-pub(crate) unsafe fn jni_sys_jlong_jni_sys_jlong_to_Stamp_8d33d015<'env, 'a>(
-    env: &mut jni::JNIEnv<'env>,
-    v: (jni::sys::jlong, jni::sys::jlong),
-) -> ::core::result::Result<perftest_flat::Stamp, __JniErr> {
-    ::core::result::Result::Ok(perftest_flat::Stamp {
-        secs: jlong_to_i64_fbf9a9bc(env, &((v).0))?,
-        nanos: jlong_to_i64_fbf9a9bc(env, &((v).1))?,
-    })
-}
-#[allow(
-    non_snake_case,
-    unused_mut,
-    unused_variables,
-    unused_braces,
-    unused_parens,
-    dead_code,
-    clippy::useless_conversion,
-    clippy::needless_question_mark,
-    clippy::let_and_return,
-    clippy::nonminimal_bool,
-    clippy::eq_op
-)]
-pub(crate) unsafe fn str_to_JString_7b77dc67<'a>(
-    env: &mut jni::JNIEnv<'a>,
-    v: &str,
-) -> ::core::result::Result<jni::objects::JString<'a>, __JniErr> {
-    Ok({
-        env.new_string(v)
-            .map_err(|e| {
-                <__JniErr as ::core::convert::From<
-                    String,
-                >>::from(format!("encode_str: {}", e))
-            })?
+    v: (
+        jni::objects::JByteArray<'a>,
+        jni::objects::JShortArray<'a>,
+        jni::objects::JIntArray<'a>,
+        jni::objects::JLongArray<'a>,
+        jni::objects::JDoubleArray<'a>,
+        jni::objects::JBooleanArray<'a>,
+        jni::objects::JLongArray<'a>,
+    ),
+) -> ::core::result::Result<perftest_flat::Arrays, __JniErr> {
+    ::core::result::Result::Ok(perftest_flat::Arrays {
+        bytes: JByteArray_to_u8_4_39abedfa(env, &((v).0))?,
+        shorts: JShortArray_to_i16_2_098f4ad5(env, &((v).1))?,
+        ints: JIntArray_to_i32_3_60e5e35a(env, &((v).2))?,
+        longs: JLongArray_to_i64_2_73596912(env, &((v).3))?,
+        doubles: JDoubleArray_to_f64_2_dc30d1f9(env, &((v).4))?,
+        flags: JBooleanArray_to_bool_3_3f960c58(env, &((v).5))?,
+        raw: JLongArray_to_u64_2_60bcc6a5(env, &((v).6))?,
     })
 }
 #[allow(
@@ -12956,7 +12426,7 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_annotatedNew<'a>
     static __SINK_MID: ::prebindgen_jni_runtime::CachedIfaceMethod = ::prebindgen_jni_runtime::CachedIfaceMethod::new();
     const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
     const __SINK_DESCR: &str = "(Ljava/lang/String;)Ljava/lang/Object;";
-    let payload = match jni_sys_jlong_jni_sys_jint_jni_sys_jdouble_jni_sys_jboolean_jni_objects_JString_to_Payload_bbb055bc(
+    let payload = match tuple5_to_Payload_bbb055bc(
         &mut env,
         (payload_id, payload_seq, payload_value, payload_flag, payload_label),
     ) {
@@ -14620,7 +14090,7 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_arraysEcho<'a>(
     static __SINK_MID: ::prebindgen_jni_runtime::CachedIfaceMethod = ::prebindgen_jni_runtime::CachedIfaceMethod::new();
     const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
     const __SINK_DESCR: &str = "(Ljava/lang/String;)Ljava/lang/Object;";
-    let a = match jni_objects_JByteArray_jni_objects_JShortArray_jni_objects_JIntArray_jni_objects_JLongArray_jni_objects_JDoubleArray_jni_objects_JBooleanArray_jni_objects_JLongArray_to_Arrays_c0fbd13f(
+    let a = match tuple7_to_Arrays_c0fbd13f(
         &mut env,
         (a_bytes, a_shorts, a_ints, a_longs, a_doubles, a_flags, a_raw),
     ) {
@@ -14650,10 +14120,7 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_arraysEcho<'a>(
         __chain_wire4,
         __chain_wire5,
         __chain_wire6,
-    ) = match Arrays_to_jni_objects_JByteArray_jni_objects_JShortArray_jni_objects_JIntArray_jni_objects_JLongArray_jni_objects_JDoubleArray_jni_objects_JBooleanArray_jni_objects_JLongArray_c0fbd13f(
-        &mut env,
-        __out,
-    ) {
+    ) = match Arrays_to_tuple7_c0fbd13f(&mut env, __out) {
         ::core::result::Result::Ok(__intermediate) => __intermediate,
         ::core::result::Result::Err(__chain_error) => {
             signal_binding_error(
@@ -14756,7 +14223,7 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_blobValueEcho<'a
     const __CB_FQN: &str = "io/prebindgen/covertest/model/BlobValueBuilder";
     const __CB_DESCR: &str = "(JJ[BLjava/util/List;)Ljava/lang/Object;";
     let __out = perftest_flat::blob_value_echo(value);
-    let ((__chain_wire0, __chain_wire1), __chain_wire2, __chain_wire3) = match BlobValue_to_jni_sys_jlong_jni_sys_jlong_jni_objects_JByteArray_jni_objects_JObject_2c75fc67(
+    let ((__chain_wire0, __chain_wire1), __chain_wire2, __chain_wire3) = match BlobValue_to_tuple3_2c75fc67(
         &mut env,
         __out,
     ) {
@@ -14880,7 +14347,7 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_blobValueNew<'a>
     const __CB_FQN: &str = "io/prebindgen/covertest/model/BlobValueBuilder";
     const __CB_DESCR: &str = "(JJ[BLjava/util/List;)Ljava/lang/Object;";
     let __out = perftest_flat::blob_value_new(secs, id, chunks);
-    let ((__chain_wire0, __chain_wire1), __chain_wire2, __chain_wire3) = match BlobValue_to_jni_sys_jlong_jni_sys_jlong_jni_objects_JByteArray_jni_objects_JObject_2c75fc67(
+    let ((__chain_wire0, __chain_wire1), __chain_wire2, __chain_wire3) = match BlobValue_to_tuple3_2c75fc67(
         &mut env,
         __out,
     ) {
@@ -15353,7 +14820,7 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_boxedPayloadId<'
     static __SINK_MID: ::prebindgen_jni_runtime::CachedIfaceMethod = ::prebindgen_jni_runtime::CachedIfaceMethod::new();
     const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
     const __SINK_DESCR: &str = "(Ljava/lang/String;)Ljava/lang/Object;";
-    let p = match jni_sys_jlong_jni_sys_jint_jni_sys_jdouble_jni_sys_jboolean_jni_objects_JString_to_Box_Payload_697caed4(
+    let p = match tuple5_to_Box_Payload_697caed4(
         &mut env,
         (p_id, p_seq, p_value, p_flag, p_label),
     ) {
@@ -15725,7 +15192,7 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_durationBoundary
     const __CB_FQN: &str = "io/prebindgen/covertest/model/DurationBoundaryBuilderRaw";
     const __CB_DESCR: &str = "(JJ)Ljava/lang/Object;";
     let __out = perftest_flat::duration_boundary_echo(&value);
-    let (__chain_wire0, __chain_wire1) = match DurationBoundary_to_jni_sys_jlong_jni_sys_jlong_3834b601(
+    let (__chain_wire0, __chain_wire1) = match DurationBoundary_to_tuple2_3834b601(
         &mut env,
         __out,
     ) {
@@ -16118,10 +15585,7 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_holdPolicyEcho<'
     static __SINK_MID: ::prebindgen_jni_runtime::CachedIfaceMethod = ::prebindgen_jni_runtime::CachedIfaceMethod::new();
     const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
     const __SINK_DESCR: &str = "(Ljava/lang/String;)Ljava/lang/Object;";
-    let p = match jni_objects_JObject_jni_objects_JObject_to_HoldPolicy_c9df7bfe(
-        &mut env,
-        (p_hold, p_grace),
-    ) {
+    let p = match tuple2_to_HoldPolicy_c9df7bfe(&mut env, (p_hold, p_grace)) {
         ::core::result::Result::Ok(__value) => __value,
         ::core::result::Result::Err(__error) => {
             signal_binding_error(
@@ -18477,7 +17941,7 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_payloadLabelLen<
     static __SINK_MID: ::prebindgen_jni_runtime::CachedIfaceMethod = ::prebindgen_jni_runtime::CachedIfaceMethod::new();
     const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
     const __SINK_DESCR: &str = "(Ljava/lang/String;)Ljava/lang/Object;";
-    let p = match jni_sys_jlong_jni_sys_jint_jni_sys_jdouble_jni_sys_jboolean_jni_objects_JString_to_Payload_2ea1d0c2(
+    let p = match tuple5_to_Payload_2ea1d0c2(
         &mut env,
         (p_id, p_seq, p_value, p_flag, p_label),
     ) {
@@ -18526,7 +17990,7 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_payloadPriority<
     static __SINK_MID: ::prebindgen_jni_runtime::CachedIfaceMethod = ::prebindgen_jni_runtime::CachedIfaceMethod::new();
     const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
     const __SINK_DESCR: &str = "(Ljava/lang/String;)Ljava/lang/Object;";
-    let p = match jni_sys_jlong_jni_sys_jint_jni_sys_jdouble_jni_sys_jboolean_jni_objects_JString_to_Payload_2ea1d0c2(
+    let p = match tuple5_to_Payload_2ea1d0c2(
         &mut env,
         (p_id, p_seq, p_value, p_flag, p_label),
     ) {
@@ -20298,10 +19762,7 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_stampNanos<'a>(
     static __SINK_MID: ::prebindgen_jni_runtime::CachedIfaceMethod = ::prebindgen_jni_runtime::CachedIfaceMethod::new();
     const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
     const __SINK_DESCR: &str = "(Ljava/lang/String;)Ljava/lang/Object;";
-    let s = match jni_sys_jlong_jni_sys_jlong_to_Stamp_43c8d6ce(
-        &mut env,
-        (s_secs, s_nanos),
-    ) {
+    let s = match tuple2_to_Stamp_43c8d6ce(&mut env, (s_secs, s_nanos)) {
         ::core::result::Result::Ok(__value) => __value,
         ::core::result::Result::Err(__error) => {
             signal_binding_error(
@@ -20378,7 +19839,7 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_stampNew<'a>(
     const __CB_FQN: &str = "io/prebindgen/covertest/model/StampBuilder";
     const __CB_DESCR: &str = "(JJ)Ljava/lang/Object;";
     let __out = perftest_flat::stamp_new(secs, nanos);
-    let (__chain_wire0, __chain_wire1) = match Stamp_to_jni_sys_jlong_jni_sys_jlong_8d33d015(
+    let (__chain_wire0, __chain_wire1) = match Stamp_to_tuple2_8d33d015(
         &mut env,
         __out,
     ) {
@@ -20442,10 +19903,7 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_stampSecs<'a>(
     static __SINK_MID: ::prebindgen_jni_runtime::CachedIfaceMethod = ::prebindgen_jni_runtime::CachedIfaceMethod::new();
     const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
     const __SINK_DESCR: &str = "(Ljava/lang/String;)Ljava/lang/Object;";
-    let s = match jni_sys_jlong_jni_sys_jlong_to_Stamp_43c8d6ce(
-        &mut env,
-        (s_secs, s_nanos),
-    ) {
+    let s = match tuple2_to_Stamp_43c8d6ce(&mut env, (s_secs, s_nanos)) {
         ::core::result::Result::Ok(__value) => __value,
         ::core::result::Result::Err(__error) => {
             signal_binding_error(
@@ -20510,7 +19968,7 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_stampSeries<'a>(
     let __vec = perftest_flat::stamp_series(count);
     let mut __acc = __acc;
     for __elem in __vec.into_iter() {
-        let (__chain_wire0, __chain_wire1) = match Stamp_to_jni_sys_jlong_jni_sys_jlong_8d33d015(
+        let (__chain_wire0, __chain_wire1) = match Stamp_to_tuple2_8d33d015(
             &mut env,
             __elem,
         ) {
@@ -21050,10 +20508,7 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_storageGet<'a>(
                 __chain_wire2,
                 __chain_wire3,
                 __chain_wire4,
-            ) = match Payload_to_jni_sys_jlong_jni_sys_jint_jni_sys_jdouble_jni_sys_jboolean_jni_objects_JString_bbb055bc(
-                &mut env,
-                __inner,
-            ) {
+            ) = match Payload_to_tuple5_bbb055bc(&mut env, __inner) {
                 ::core::result::Result::Ok(__intermediate) => __intermediate,
                 ::core::result::Result::Err(__chain_error) => {
                     signal_binding_error(
@@ -21162,10 +20617,7 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_storageGetVec<'a
                     __chain_wire2,
                     __chain_wire3,
                     __chain_wire4,
-                ) = match Payload_to_jni_sys_jlong_jni_sys_jint_jni_sys_jdouble_jni_sys_jboolean_jni_objects_JString_bbb055bc(
-                    &mut env,
-                    __elem,
-                ) {
+                ) = match Payload_to_tuple5_bbb055bc(&mut env, __elem) {
                     ::core::result::Result::Ok(__intermediate) => __intermediate,
                     ::core::result::Result::Err(__chain_error) => {
                         signal_binding_error(
@@ -21640,7 +21092,7 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_storagePutByRead
             return ();
         }
     };
-    let payload = match jni_sys_jlong_jni_sys_jint_jni_sys_jdouble_jni_sys_jboolean_jni_objects_JString_to_Payload_2ea1d0c2(
+    let payload = match tuple5_to_Payload_2ea1d0c2(
         &mut env,
         (payload_id, payload_seq, payload_value, payload_flag, payload_label),
     ) {
@@ -21704,7 +21156,7 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_storagePutByTake
             return ();
         }
     };
-    let payload = match jni_sys_jlong_jni_sys_jint_jni_sys_jdouble_jni_sys_jboolean_jni_objects_JString_to_Payload_bbb055bc(
+    let payload = match tuple5_to_Payload_bbb055bc(
         &mut env,
         (payload_id, payload_seq, payload_value, payload_flag, payload_label),
     ) {
@@ -22596,10 +22048,7 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_storageTryFromSt
     static __DSINK_MID: ::prebindgen_jni_runtime::CachedIfaceMethod = ::prebindgen_jni_runtime::CachedIfaceMethod::new();
     const __DSINK_FQN: &str = "io/prebindgen/covertest/errors/StorageErrorHandlerRaw";
     const __DSINK_DESCR: &str = "(Ljava/lang/String;J)Ljava/lang/Object;";
-    let s = match jni_sys_jlong_jni_sys_jlong_to_Stamp_8d33d015(
-        &mut env,
-        (s_secs, s_nanos),
-    ) {
+    let s = match tuple2_to_Stamp_8d33d015(&mut env, (s_secs, s_nanos)) {
         ::core::result::Result::Ok(__value) => __value,
         ::core::result::Result::Err(__error) => {
             signal_binding_error(
@@ -22790,7 +22239,7 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_storageWithPaylo
     static __SINK_MID: ::prebindgen_jni_runtime::CachedIfaceMethod = ::prebindgen_jni_runtime::CachedIfaceMethod::new();
     const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
     const __SINK_DESCR: &str = "(Ljava/lang/String;)Ljava/lang/Object;";
-    let payload = match jni_sys_jlong_jni_sys_jint_jni_sys_jdouble_jni_sys_jboolean_jni_objects_JString_to_Payload_bbb055bc(
+    let payload = match tuple5_to_Payload_bbb055bc(
         &mut env,
         (payload_id, payload_seq, payload_value, payload_flag, payload_label),
     ) {
@@ -24486,10 +23935,7 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_taggedRank<'a>(
     static __SINK_MID: ::prebindgen_jni_runtime::CachedIfaceMethod = ::prebindgen_jni_runtime::CachedIfaceMethod::new();
     const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
     const __SINK_DESCR: &str = "(Ljava/lang/String;)Ljava/lang/Object;";
-    let t = match jni_sys_jlong_jni_objects_JObject_to_Tagged_b68a6969(
-        &mut env,
-        (t_id, t_marker),
-    ) {
+    let t = match tuple2_to_Tagged_b68a6969(&mut env, (t_id, t_marker)) {
         ::core::result::Result::Ok(__value) => __value,
         ::core::result::Result::Err(__error) => {
             signal_binding_error(
@@ -24874,7 +24320,7 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_unsignedRoundTri
     const __CB_FQN: &str = "io/prebindgen/covertest/model/UnsignedBuilderRaw";
     const __CB_DESCR: &str = "(IIJJLjava/lang/Long;)Ljava/lang/Object;";
     let __out = perftest_flat::unsigned_round_trip(byte, short, int, long, maybe_long);
-    let (__chain_wire0, __chain_wire1, __chain_wire2, __chain_wire3, __chain_wire4) = match Unsigned_to_jni_sys_jint_jni_sys_jint_jni_sys_jlong_jni_sys_jlong_jni_objects_JObject_371b0950(
+    let (__chain_wire0, __chain_wire1, __chain_wire2, __chain_wire3, __chain_wire4) = match Unsigned_to_tuple5_371b0950(
         &mut env,
         __out,
     ) {

--- a/examples/emitcheck/src/generated_bindings.rs
+++ b/examples/emitcheck/src/generated_bindings.rs
@@ -126,32 +126,6 @@ const _: () = {
     clippy::nonminimal_bool,
     clippy::eq_op
 )]
-pub(crate) unsafe fn Box_Option_ZKeyExpr_to_jlong_98f8412f<'a>(
-    env: &mut jni::JNIEnv<'a>,
-    v: Box<Option<myflat::ZKeyExpr>>,
-) -> ::core::result::Result<jni::sys::jlong, __JniErr> {
-    ::core::result::Result::Ok({
-        match *v {
-            ::core::option::Option::Some(__value) => {
-                ZKeyExpr_to_jlong_37f9dc18(env, __value)?
-            }
-            ::core::option::Option::None => 0i64,
-        }
-    })
-}
-#[allow(
-    non_snake_case,
-    unused_mut,
-    unused_variables,
-    unused_braces,
-    unused_parens,
-    dead_code,
-    clippy::useless_conversion,
-    clippy::needless_question_mark,
-    clippy::let_and_return,
-    clippy::nonminimal_bool,
-    clippy::eq_op
-)]
 pub(crate) unsafe fn Box_String_to_JString_027f6250<'a>(
     env: &mut jni::JNIEnv<'a>,
     v: Box<String>,
@@ -412,32 +386,6 @@ pub(crate) unsafe fn JObject_to_impl_Fn_ZSample_Send_Sync_static_24e97b15<'env, 
     clippy::nonminimal_bool,
     clippy::eq_op
 )]
-pub(crate) unsafe fn Option_ZKeyExpr_to_jlong_ffed55c9<'a>(
-    env: &mut jni::JNIEnv<'a>,
-    v: Option<myflat::ZKeyExpr>,
-) -> ::core::result::Result<jni::sys::jlong, __JniErr> {
-    ::core::result::Result::Ok({
-        match v {
-            ::core::option::Option::Some(__value) => {
-                ZKeyExpr_to_jlong_37f9dc18(env, __value)?
-            }
-            ::core::option::Option::None => 0i64,
-        }
-    })
-}
-#[allow(
-    non_snake_case,
-    unused_mut,
-    unused_variables,
-    unused_braces,
-    unused_parens,
-    dead_code,
-    clippy::useless_conversion,
-    clippy::needless_question_mark,
-    clippy::let_and_return,
-    clippy::nonminimal_bool,
-    clippy::eq_op
-)]
 pub(crate) unsafe fn String_to_JString_c7f3ca43<'a>(
     env: &mut jni::JNIEnv<'a>,
     v: String,
@@ -514,62 +462,6 @@ pub(crate) unsafe fn ZSample_to_jlong_757bca9c<'a>(
     v: myflat::ZSample,
 ) -> ::core::result::Result<jni::sys::jlong, __JniErr> {
     Ok(std::boxed::Box::into_raw(std::boxed::Box::new(v)) as i64)
-}
-#[allow(
-    non_snake_case,
-    unused_mut,
-    unused_variables,
-    unused_braces,
-    unused_parens,
-    dead_code,
-    clippy::useless_conversion,
-    clippy::needless_question_mark,
-    clippy::let_and_return,
-    clippy::nonminimal_bool,
-    clippy::eq_op
-)]
-pub(crate) unsafe fn jlong_to_ZKeyExpr_37f9dc18_owned<'env, 'v>(
-    env: &mut jni::JNIEnv<'env>,
-    v: &jni::sys::jlong,
-) -> ::core::result::Result<myflat::ZKeyExpr, __JniErr> {
-    if *v == 0 || (*v & 1) == 1 {
-        return ::core::result::Result::Err(
-            <__JniErr as ::core::convert::From<
-                String,
-            >>::from("Operation on a closed native handle.".to_string()),
-        );
-    }
-    ::core::result::Result::Ok(unsafe {
-        *::std::boxed::Box::from_raw(*v as *mut myflat::ZKeyExpr)
-    })
-}
-#[allow(
-    non_snake_case,
-    unused_mut,
-    unused_variables,
-    unused_braces,
-    unused_parens,
-    dead_code,
-    clippy::useless_conversion,
-    clippy::needless_question_mark,
-    clippy::let_and_return,
-    clippy::nonminimal_bool,
-    clippy::eq_op
-)]
-pub(crate) unsafe fn jlong_to_ZSample_757bca9c_owned<'env, 'v>(
-    env: &mut jni::JNIEnv<'env>,
-    v: &jni::sys::jlong,
-) -> ::core::result::Result<myflat::ZSample, __JniErr> {
-    if *v == 0 || (*v & 1) == 1 {
-        return ::core::result::Result::Err(
-            <__JniErr as ::core::convert::From<
-                String,
-            >>::from("Operation on a closed native handle.".to_string()),
-        );
-    }
-    ::core::result::Result::Ok(unsafe {
-        *::std::boxed::Box::from_raw(*v as *mut myflat::ZSample)
-    })
 }
 #[allow(
     non_snake_case,

--- a/examples/perftest-kotlin/src/generated_bindings.rs
+++ b/examples/perftest-kotlin/src/generated_bindings.rs
@@ -809,10 +809,7 @@ pub(crate) unsafe fn JObject_to_impl_Fn_Payload_Send_Sync_static_95073668<'env, 
                                 __chain_wire2,
                                 __chain_wire3,
                                 __chain_wire4,
-                            ) = match Payload_to_jni_sys_jlong_jni_sys_jint_jni_sys_jdouble_jni_sys_jboolean_jni_objects_JString_2ea1d0c2(
-                                &mut env,
-                                __cb_elem,
-                            ) {
+                            ) = match Payload_to_tuple5_2ea1d0c2(&mut env, __cb_elem) {
                                 ::core::result::Result::Ok(__intermediate) => __intermediate,
                                 ::core::result::Result::Err(__chain_error) => {
                                     return ::core::result::Result::Err(
@@ -968,10 +965,7 @@ pub(crate) unsafe fn JObject_to_impl_Fn_Payload_Send_Sync_static_96d50906<'env, 
                         __chain_wire2,
                         __chain_wire3,
                         __chain_wire4,
-                    ) = match Payload_to_jni_sys_jlong_jni_sys_jint_jni_sys_jdouble_jni_sys_jboolean_jni_objects_JString_2ea1d0c2(
-                        &mut env,
-                        __cb_arg0,
-                    ) {
+                    ) = match Payload_to_tuple5_2ea1d0c2(&mut env, __cb_arg0) {
                         ::core::result::Result::Ok(__intermediate) => __intermediate,
                         ::core::result::Result::Err(__chain_error) => {
                             return ::core::result::Result::Err(
@@ -2505,58 +2499,6 @@ pub(crate) unsafe fn Option_Box_String_to_JString_071e4c8c<'a>(
     clippy::nonminimal_bool,
     clippy::eq_op
 )]
-pub(crate) unsafe fn Option_Payload_to_JObject_97036642<'a>(
-    env: &mut jni::JNIEnv<'a>,
-    v: Option<perftest_flat::Payload>,
-) -> ::core::result::Result<jni::objects::JObject<'a>, __JniErr> {
-    ::core::result::Result::Ok({
-        match v {
-            ::core::option::Option::Some(__value) => {
-                Payload_to_JObject_98f64326(env, __value)?
-            }
-            ::core::option::Option::None => jni::objects::JObject::null().into(),
-        }
-    })
-}
-#[allow(
-    non_snake_case,
-    unused_mut,
-    unused_variables,
-    unused_braces,
-    unused_parens,
-    dead_code,
-    clippy::useless_conversion,
-    clippy::needless_question_mark,
-    clippy::let_and_return,
-    clippy::nonminimal_bool,
-    clippy::eq_op
-)]
-pub(crate) unsafe fn Option_Vec_Payload_to_JObject_b9a4637e<'a>(
-    env: &mut jni::JNIEnv<'a>,
-    v: Option<Vec<perftest_flat::Payload>>,
-) -> ::core::result::Result<jni::objects::JObject<'a>, __JniErr> {
-    ::core::result::Result::Ok({
-        match v {
-            ::core::option::Option::Some(__value) => {
-                Vec_Payload_to_JObject_8b7084d2(env, __value)?
-            }
-            ::core::option::Option::None => jni::objects::JObject::null().into(),
-        }
-    })
-}
-#[allow(
-    non_snake_case,
-    unused_mut,
-    unused_variables,
-    unused_braces,
-    unused_parens,
-    dead_code,
-    clippy::useless_conversion,
-    clippy::needless_question_mark,
-    clippy::let_and_return,
-    clippy::nonminimal_bool,
-    clippy::eq_op
-)]
 pub(crate) unsafe fn PayloadHandler_to_jlong_d61fd890<'a>(
     env: &mut jni::JNIEnv<'a>,
     v: perftest_flat::PayloadHandler,
@@ -2687,9 +2629,8 @@ pub(crate) unsafe fn Payload_to_JObject_98f64326<'a>(
     clippy::nonminimal_bool,
     clippy::eq_op
 )]
-pub(crate) unsafe fn Payload_to_jni_sys_jlong_jni_sys_jint_jni_sys_jdouble_jni_sys_jboolean_jni_objects_JString_2ea1d0c2<
-    'a,
->(
+#[inline(always)]
+pub(crate) unsafe fn Payload_to_tuple5_2ea1d0c2<'a>(
     env: &mut jni::JNIEnv<'a>,
     v: &perftest_flat::Payload,
 ) -> ::core::result::Result<
@@ -2723,9 +2664,8 @@ pub(crate) unsafe fn Payload_to_jni_sys_jlong_jni_sys_jint_jni_sys_jdouble_jni_s
     clippy::nonminimal_bool,
     clippy::eq_op
 )]
-pub(crate) unsafe fn Payload_to_jni_sys_jlong_jni_sys_jint_jni_sys_jdouble_jni_sys_jboolean_jni_objects_JString_bbb055bc<
-    'a,
->(
+#[inline(always)]
+pub(crate) unsafe fn Payload_to_tuple5_bbb055bc<'a>(
     env: &mut jni::JNIEnv<'a>,
     v: perftest_flat::Payload,
 ) -> ::core::result::Result<
@@ -3015,34 +2955,6 @@ pub(crate) unsafe fn jlong_to_PayloadHandler_d61fd890<'env, 'v>(
     clippy::nonminimal_bool,
     clippy::eq_op
 )]
-pub(crate) unsafe fn jlong_to_PayloadHandler_d61fd890_owned<'env, 'v>(
-    env: &mut jni::JNIEnv<'env>,
-    v: &jni::sys::jlong,
-) -> ::core::result::Result<perftest_flat::PayloadHandler, __JniErr> {
-    if *v == 0 || (*v & 1) == 1 {
-        return ::core::result::Result::Err(
-            <__JniErr as ::core::convert::From<
-                String,
-            >>::from("Operation on a closed native handle.".to_string()),
-        );
-    }
-    ::core::result::Result::Ok(unsafe {
-        *::std::boxed::Box::from_raw(*v as *mut perftest_flat::PayloadHandler)
-    })
-}
-#[allow(
-    non_snake_case,
-    unused_mut,
-    unused_variables,
-    unused_braces,
-    unused_parens,
-    dead_code,
-    clippy::useless_conversion,
-    clippy::needless_question_mark,
-    clippy::let_and_return,
-    clippy::nonminimal_bool,
-    clippy::eq_op
-)]
 pub(crate) unsafe fn jlong_to_PayloadVecHandler_b32d2812<'env, 'v>(
     env: &mut jni::JNIEnv<'env>,
     v: &jni::sys::jlong,
@@ -3055,34 +2967,6 @@ pub(crate) unsafe fn jlong_to_PayloadVecHandler_b32d2812<'env, 'v>(
         );
     }
     Ok(unsafe { OwnedObject::from_raw(*v as *const perftest_flat::PayloadVecHandler) })
-}
-#[allow(
-    non_snake_case,
-    unused_mut,
-    unused_variables,
-    unused_braces,
-    unused_parens,
-    dead_code,
-    clippy::useless_conversion,
-    clippy::needless_question_mark,
-    clippy::let_and_return,
-    clippy::nonminimal_bool,
-    clippy::eq_op
-)]
-pub(crate) unsafe fn jlong_to_PayloadVecHandler_b32d2812_owned<'env, 'v>(
-    env: &mut jni::JNIEnv<'env>,
-    v: &jni::sys::jlong,
-) -> ::core::result::Result<perftest_flat::PayloadVecHandler, __JniErr> {
-    if *v == 0 || (*v & 1) == 1 {
-        return ::core::result::Result::Err(
-            <__JniErr as ::core::convert::From<
-                String,
-            >>::from("Operation on a closed native handle.".to_string()),
-        );
-    }
-    ::core::result::Result::Ok(unsafe {
-        *::std::boxed::Box::from_raw(*v as *mut perftest_flat::PayloadVecHandler)
-    })
 }
 #[allow(
     non_snake_case,
@@ -3123,34 +3007,6 @@ pub(crate) unsafe fn jlong_to_Storage_1b233abd<'env, 'v>(
     clippy::nonminimal_bool,
     clippy::eq_op
 )]
-pub(crate) unsafe fn jlong_to_Storage_1b233abd_owned<'env, 'v>(
-    env: &mut jni::JNIEnv<'env>,
-    v: &jni::sys::jlong,
-) -> ::core::result::Result<perftest_flat::Storage, __JniErr> {
-    if *v == 0 || (*v & 1) == 1 {
-        return ::core::result::Result::Err(
-            <__JniErr as ::core::convert::From<
-                String,
-            >>::from("Operation on a closed native handle.".to_string()),
-        );
-    }
-    ::core::result::Result::Ok(unsafe {
-        *::std::boxed::Box::from_raw(*v as *mut perftest_flat::Storage)
-    })
-}
-#[allow(
-    non_snake_case,
-    unused_mut,
-    unused_variables,
-    unused_braces,
-    unused_parens,
-    dead_code,
-    clippy::useless_conversion,
-    clippy::needless_question_mark,
-    clippy::let_and_return,
-    clippy::nonminimal_bool,
-    clippy::eq_op
-)]
 pub(crate) unsafe fn jlong_to_TokenGc_5e58352a<'env, 'v>(
     env: &mut jni::JNIEnv<'env>,
     v: &jni::sys::jlong,
@@ -3163,34 +3019,6 @@ pub(crate) unsafe fn jlong_to_TokenGc_5e58352a<'env, 'v>(
         );
     }
     Ok(unsafe { OwnedObject::from_raw(*v as *const perftest_flat::TokenGc) })
-}
-#[allow(
-    non_snake_case,
-    unused_mut,
-    unused_variables,
-    unused_braces,
-    unused_parens,
-    dead_code,
-    clippy::useless_conversion,
-    clippy::needless_question_mark,
-    clippy::let_and_return,
-    clippy::nonminimal_bool,
-    clippy::eq_op
-)]
-pub(crate) unsafe fn jlong_to_TokenGc_5e58352a_owned<'env, 'v>(
-    env: &mut jni::JNIEnv<'env>,
-    v: &jni::sys::jlong,
-) -> ::core::result::Result<perftest_flat::TokenGc, __JniErr> {
-    if *v == 0 || (*v & 1) == 1 {
-        return ::core::result::Result::Err(
-            <__JniErr as ::core::convert::From<
-                String,
-            >>::from("Operation on a closed native handle.".to_string()),
-        );
-    }
-    ::core::result::Result::Ok(unsafe {
-        *::std::boxed::Box::from_raw(*v as *mut perftest_flat::TokenGc)
-    })
 }
 #[allow(
     non_snake_case,
@@ -3231,34 +3059,6 @@ pub(crate) unsafe fn jlong_to_Token_4f7adafa<'env, 'v>(
     clippy::nonminimal_bool,
     clippy::eq_op
 )]
-pub(crate) unsafe fn jlong_to_Token_4f7adafa_owned<'env, 'v>(
-    env: &mut jni::JNIEnv<'env>,
-    v: &jni::sys::jlong,
-) -> ::core::result::Result<perftest_flat::Token, __JniErr> {
-    if *v == 0 || (*v & 1) == 1 {
-        return ::core::result::Result::Err(
-            <__JniErr as ::core::convert::From<
-                String,
-            >>::from("Operation on a closed native handle.".to_string()),
-        );
-    }
-    ::core::result::Result::Ok(unsafe {
-        *::std::boxed::Box::from_raw(*v as *mut perftest_flat::Token)
-    })
-}
-#[allow(
-    non_snake_case,
-    unused_mut,
-    unused_variables,
-    unused_braces,
-    unused_parens,
-    dead_code,
-    clippy::useless_conversion,
-    clippy::needless_question_mark,
-    clippy::let_and_return,
-    clippy::nonminimal_bool,
-    clippy::eq_op
-)]
 pub(crate) unsafe fn jlong_to_i64_fbf9a9bc<'env, 'v>(
     env: &mut jni::JNIEnv<'env>,
     v: &jni::sys::jlong,
@@ -3278,25 +3078,13 @@ pub(crate) unsafe fn jlong_to_i64_fbf9a9bc<'env, 'v>(
     clippy::nonminimal_bool,
     clippy::eq_op
 )]
-pub(crate) unsafe fn jni_sys_jlong_jni_sys_jint_jni_sys_jdouble_jni_sys_jboolean_jni_objects_JString_to_Payload_2ea1d0c2<
-    'env,
-    'a,
->(
+#[inline(always)]
+pub(crate) unsafe fn tuple1_to_ObjectBoundaryLeaf_9ca2c370<'env, 'a>(
     env: &mut jni::JNIEnv<'env>,
-    v: (
-        jni::sys::jlong,
-        jni::sys::jint,
-        jni::sys::jdouble,
-        jni::sys::jboolean,
-        jni::objects::JString<'a>,
-    ),
-) -> ::core::result::Result<perftest_flat::Payload, __JniErr> {
-    ::core::result::Result::Ok(perftest_flat::Payload {
-        id: jlong_to_i64_fbf9a9bc(env, &((v).0))?,
-        seq: jint_to_i32_a3e3b6ef(env, &((v).1))?,
-        value: jdouble_to_f64_9e4a8f70(env, &((v).2))?,
-        flag: jboolean_to_bool_31306d98(env, &((v).3))?,
-        label: JString_to_Option_Box_String_071e4c8c(env, &((v).4))?,
+    v: (jni::sys::jlong,),
+) -> ::core::result::Result<perftest_flat::ObjectBoundaryLeaf, __JniErr> {
+    ::core::result::Result::Ok(perftest_flat::ObjectBoundaryLeaf {
+        value: jlong_to_i64_fbf9a9bc(env, &((v).0))?,
     })
 }
 #[allow(
@@ -3312,25 +3100,35 @@ pub(crate) unsafe fn jni_sys_jlong_jni_sys_jint_jni_sys_jdouble_jni_sys_jboolean
     clippy::nonminimal_bool,
     clippy::eq_op
 )]
-pub(crate) unsafe fn jni_sys_jlong_jni_sys_jint_jni_sys_jdouble_jni_sys_jboolean_jni_objects_JString_to_Payload_bbb055bc<
-    'env,
-    'a,
->(
+#[inline(always)]
+pub(crate) unsafe fn tuple2_to_ObjectBoundary16_008c43d9<'env, 'a>(
     env: &mut jni::JNIEnv<'env>,
     v: (
-        jni::sys::jlong,
-        jni::sys::jint,
-        jni::sys::jdouble,
-        jni::sys::jboolean,
-        jni::objects::JString<'a>,
+        (
+            (
+                ((jni::sys::jlong,), (jni::sys::jlong,)),
+                ((jni::sys::jlong,), (jni::sys::jlong,)),
+            ),
+            (
+                ((jni::sys::jlong,), (jni::sys::jlong,)),
+                ((jni::sys::jlong,), (jni::sys::jlong,)),
+            ),
+        ),
+        (
+            (
+                ((jni::sys::jlong,), (jni::sys::jlong,)),
+                ((jni::sys::jlong,), (jni::sys::jlong,)),
+            ),
+            (
+                ((jni::sys::jlong,), (jni::sys::jlong,)),
+                ((jni::sys::jlong,), (jni::sys::jlong,)),
+            ),
+        ),
     ),
-) -> ::core::result::Result<perftest_flat::Payload, __JniErr> {
-    ::core::result::Result::Ok(perftest_flat::Payload {
-        id: jlong_to_i64_fbf9a9bc(env, &((v).0))?,
-        seq: jint_to_i32_a3e3b6ef(env, &((v).1))?,
-        value: jdouble_to_f64_9e4a8f70(env, &((v).2))?,
-        flag: jboolean_to_bool_31306d98(env, &((v).3))?,
-        label: JString_to_Option_Box_String_071e4c8c(env, &((v).4))?,
+) -> ::core::result::Result<perftest_flat::ObjectBoundary16, __JniErr> {
+    ::core::result::Result::Ok(perftest_flat::ObjectBoundary16 {
+        left: tuple2_to_ObjectBoundary8_cd26fc2d(env, (v).0)?,
+        right: tuple2_to_ObjectBoundary8_cd26fc2d(env, (v).1)?,
     })
 }
 #[allow(
@@ -3346,10 +3144,125 @@ pub(crate) unsafe fn jni_sys_jlong_jni_sys_jint_jni_sys_jdouble_jni_sys_jboolean
     clippy::nonminimal_bool,
     clippy::eq_op
 )]
-pub(crate) unsafe fn jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_to_ObjectBoundary64_ad107808<
-    'env,
-    'a,
->(
+#[inline(always)]
+pub(crate) unsafe fn tuple2_to_ObjectBoundary2_5cc5ebe2<'env, 'a>(
+    env: &mut jni::JNIEnv<'env>,
+    v: ((jni::sys::jlong,), (jni::sys::jlong,)),
+) -> ::core::result::Result<perftest_flat::ObjectBoundary2, __JniErr> {
+    ::core::result::Result::Ok(perftest_flat::ObjectBoundary2 {
+        left: tuple1_to_ObjectBoundaryLeaf_9ca2c370(env, (v).0)?,
+        right: tuple1_to_ObjectBoundaryLeaf_9ca2c370(env, (v).1)?,
+    })
+}
+#[allow(
+    non_snake_case,
+    unused_mut,
+    unused_variables,
+    unused_braces,
+    unused_parens,
+    dead_code,
+    clippy::useless_conversion,
+    clippy::needless_question_mark,
+    clippy::let_and_return,
+    clippy::nonminimal_bool,
+    clippy::eq_op
+)]
+#[inline(always)]
+pub(crate) unsafe fn tuple2_to_ObjectBoundary32_caac6c41<'env, 'a>(
+    env: &mut jni::JNIEnv<'env>,
+    v: (
+        (
+            (
+                (
+                    ((jni::sys::jlong,), (jni::sys::jlong,)),
+                    ((jni::sys::jlong,), (jni::sys::jlong,)),
+                ),
+                (
+                    ((jni::sys::jlong,), (jni::sys::jlong,)),
+                    ((jni::sys::jlong,), (jni::sys::jlong,)),
+                ),
+            ),
+            (
+                (
+                    ((jni::sys::jlong,), (jni::sys::jlong,)),
+                    ((jni::sys::jlong,), (jni::sys::jlong,)),
+                ),
+                (
+                    ((jni::sys::jlong,), (jni::sys::jlong,)),
+                    ((jni::sys::jlong,), (jni::sys::jlong,)),
+                ),
+            ),
+        ),
+        (
+            (
+                (
+                    ((jni::sys::jlong,), (jni::sys::jlong,)),
+                    ((jni::sys::jlong,), (jni::sys::jlong,)),
+                ),
+                (
+                    ((jni::sys::jlong,), (jni::sys::jlong,)),
+                    ((jni::sys::jlong,), (jni::sys::jlong,)),
+                ),
+            ),
+            (
+                (
+                    ((jni::sys::jlong,), (jni::sys::jlong,)),
+                    ((jni::sys::jlong,), (jni::sys::jlong,)),
+                ),
+                (
+                    ((jni::sys::jlong,), (jni::sys::jlong,)),
+                    ((jni::sys::jlong,), (jni::sys::jlong,)),
+                ),
+            ),
+        ),
+    ),
+) -> ::core::result::Result<perftest_flat::ObjectBoundary32, __JniErr> {
+    ::core::result::Result::Ok(perftest_flat::ObjectBoundary32 {
+        left: tuple2_to_ObjectBoundary16_008c43d9(env, (v).0)?,
+        right: tuple2_to_ObjectBoundary16_008c43d9(env, (v).1)?,
+    })
+}
+#[allow(
+    non_snake_case,
+    unused_mut,
+    unused_variables,
+    unused_braces,
+    unused_parens,
+    dead_code,
+    clippy::useless_conversion,
+    clippy::needless_question_mark,
+    clippy::let_and_return,
+    clippy::nonminimal_bool,
+    clippy::eq_op
+)]
+#[inline(always)]
+pub(crate) unsafe fn tuple2_to_ObjectBoundary4_0b5422b8<'env, 'a>(
+    env: &mut jni::JNIEnv<'env>,
+    v: (
+        ((jni::sys::jlong,), (jni::sys::jlong,)),
+        ((jni::sys::jlong,), (jni::sys::jlong,)),
+    ),
+) -> ::core::result::Result<perftest_flat::ObjectBoundary4, __JniErr> {
+    ::core::result::Result::Ok(perftest_flat::ObjectBoundary4 {
+        left: tuple2_to_ObjectBoundary2_5cc5ebe2(env, (v).0)?,
+        right: tuple2_to_ObjectBoundary2_5cc5ebe2(env, (v).1)?,
+    })
+}
+#[allow(
+    non_snake_case,
+    unused_mut,
+    unused_variables,
+    unused_braces,
+    unused_parens,
+    dead_code,
+    clippy::useless_conversion,
+    clippy::needless_question_mark,
+    clippy::let_and_return,
+    clippy::nonminimal_bool,
+    clippy::eq_op
+)]
+#[inline(always)]
+pub(crate) unsafe fn tuple2_to_ObjectBoundary64_ad107808<'env, 'a>(
     env: &mut jni::JNIEnv<'env>,
     v: (
         (
@@ -3447,14 +3360,8 @@ pub(crate) unsafe fn jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni
     ),
 ) -> ::core::result::Result<perftest_flat::ObjectBoundary64, __JniErr> {
     ::core::result::Result::Ok(perftest_flat::ObjectBoundary64 {
-        left: jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_to_ObjectBoundary32_caac6c41(
-            env,
-            (v).0,
-        )?,
-        right: jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_to_ObjectBoundary32_caac6c41(
-            env,
-            (v).1,
-        )?,
+        left: tuple2_to_ObjectBoundary32_caac6c41(env, (v).0)?,
+        right: tuple2_to_ObjectBoundary32_caac6c41(env, (v).1)?,
     })
 }
 #[allow(
@@ -3470,138 +3377,8 @@ pub(crate) unsafe fn jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni
     clippy::nonminimal_bool,
     clippy::eq_op
 )]
-pub(crate) unsafe fn jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_to_ObjectBoundary32_caac6c41<
-    'env,
-    'a,
->(
-    env: &mut jni::JNIEnv<'env>,
-    v: (
-        (
-            (
-                (
-                    ((jni::sys::jlong,), (jni::sys::jlong,)),
-                    ((jni::sys::jlong,), (jni::sys::jlong,)),
-                ),
-                (
-                    ((jni::sys::jlong,), (jni::sys::jlong,)),
-                    ((jni::sys::jlong,), (jni::sys::jlong,)),
-                ),
-            ),
-            (
-                (
-                    ((jni::sys::jlong,), (jni::sys::jlong,)),
-                    ((jni::sys::jlong,), (jni::sys::jlong,)),
-                ),
-                (
-                    ((jni::sys::jlong,), (jni::sys::jlong,)),
-                    ((jni::sys::jlong,), (jni::sys::jlong,)),
-                ),
-            ),
-        ),
-        (
-            (
-                (
-                    ((jni::sys::jlong,), (jni::sys::jlong,)),
-                    ((jni::sys::jlong,), (jni::sys::jlong,)),
-                ),
-                (
-                    ((jni::sys::jlong,), (jni::sys::jlong,)),
-                    ((jni::sys::jlong,), (jni::sys::jlong,)),
-                ),
-            ),
-            (
-                (
-                    ((jni::sys::jlong,), (jni::sys::jlong,)),
-                    ((jni::sys::jlong,), (jni::sys::jlong,)),
-                ),
-                (
-                    ((jni::sys::jlong,), (jni::sys::jlong,)),
-                    ((jni::sys::jlong,), (jni::sys::jlong,)),
-                ),
-            ),
-        ),
-    ),
-) -> ::core::result::Result<perftest_flat::ObjectBoundary32, __JniErr> {
-    ::core::result::Result::Ok(perftest_flat::ObjectBoundary32 {
-        left: jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_to_ObjectBoundary16_008c43d9(
-            env,
-            (v).0,
-        )?,
-        right: jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_to_ObjectBoundary16_008c43d9(
-            env,
-            (v).1,
-        )?,
-    })
-}
-#[allow(
-    non_snake_case,
-    unused_mut,
-    unused_variables,
-    unused_braces,
-    unused_parens,
-    dead_code,
-    clippy::useless_conversion,
-    clippy::needless_question_mark,
-    clippy::let_and_return,
-    clippy::nonminimal_bool,
-    clippy::eq_op
-)]
-pub(crate) unsafe fn jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_to_ObjectBoundary16_008c43d9<
-    'env,
-    'a,
->(
-    env: &mut jni::JNIEnv<'env>,
-    v: (
-        (
-            (
-                ((jni::sys::jlong,), (jni::sys::jlong,)),
-                ((jni::sys::jlong,), (jni::sys::jlong,)),
-            ),
-            (
-                ((jni::sys::jlong,), (jni::sys::jlong,)),
-                ((jni::sys::jlong,), (jni::sys::jlong,)),
-            ),
-        ),
-        (
-            (
-                ((jni::sys::jlong,), (jni::sys::jlong,)),
-                ((jni::sys::jlong,), (jni::sys::jlong,)),
-            ),
-            (
-                ((jni::sys::jlong,), (jni::sys::jlong,)),
-                ((jni::sys::jlong,), (jni::sys::jlong,)),
-            ),
-        ),
-    ),
-) -> ::core::result::Result<perftest_flat::ObjectBoundary16, __JniErr> {
-    ::core::result::Result::Ok(perftest_flat::ObjectBoundary16 {
-        left: jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_to_ObjectBoundary8_cd26fc2d(
-            env,
-            (v).0,
-        )?,
-        right: jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_to_ObjectBoundary8_cd26fc2d(
-            env,
-            (v).1,
-        )?,
-    })
-}
-#[allow(
-    non_snake_case,
-    unused_mut,
-    unused_variables,
-    unused_braces,
-    unused_parens,
-    dead_code,
-    clippy::useless_conversion,
-    clippy::needless_question_mark,
-    clippy::let_and_return,
-    clippy::nonminimal_bool,
-    clippy::eq_op
-)]
-pub(crate) unsafe fn jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_to_ObjectBoundary8_cd26fc2d<
-    'env,
-    'a,
->(
+#[inline(always)]
+pub(crate) unsafe fn tuple2_to_ObjectBoundary8_cd26fc2d<'env, 'a>(
     env: &mut jni::JNIEnv<'env>,
     v: (
         (
@@ -3615,14 +3392,8 @@ pub(crate) unsafe fn jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni
     ),
 ) -> ::core::result::Result<perftest_flat::ObjectBoundary8, __JniErr> {
     ::core::result::Result::Ok(perftest_flat::ObjectBoundary8 {
-        left: jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_to_ObjectBoundary4_0b5422b8(
-            env,
-            (v).0,
-        )?,
-        right: jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_to_ObjectBoundary4_0b5422b8(
-            env,
-            (v).1,
-        )?,
+        left: tuple2_to_ObjectBoundary4_0b5422b8(env, (v).0)?,
+        right: tuple2_to_ObjectBoundary4_0b5422b8(env, (v).1)?,
     })
 }
 #[allow(
@@ -3638,19 +3409,23 @@ pub(crate) unsafe fn jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni
     clippy::nonminimal_bool,
     clippy::eq_op
 )]
-pub(crate) unsafe fn jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_to_ObjectBoundary4_0b5422b8<
-    'env,
-    'a,
->(
+#[inline(always)]
+pub(crate) unsafe fn tuple5_to_Payload_2ea1d0c2<'env, 'a>(
     env: &mut jni::JNIEnv<'env>,
     v: (
-        ((jni::sys::jlong,), (jni::sys::jlong,)),
-        ((jni::sys::jlong,), (jni::sys::jlong,)),
+        jni::sys::jlong,
+        jni::sys::jint,
+        jni::sys::jdouble,
+        jni::sys::jboolean,
+        jni::objects::JString<'a>,
     ),
-) -> ::core::result::Result<perftest_flat::ObjectBoundary4, __JniErr> {
-    ::core::result::Result::Ok(perftest_flat::ObjectBoundary4 {
-        left: jni_sys_jlong_jni_sys_jlong_to_ObjectBoundary2_5cc5ebe2(env, (v).0)?,
-        right: jni_sys_jlong_jni_sys_jlong_to_ObjectBoundary2_5cc5ebe2(env, (v).1)?,
+) -> ::core::result::Result<perftest_flat::Payload, __JniErr> {
+    ::core::result::Result::Ok(perftest_flat::Payload {
+        id: jlong_to_i64_fbf9a9bc(env, &((v).0))?,
+        seq: jint_to_i32_a3e3b6ef(env, &((v).1))?,
+        value: jdouble_to_f64_9e4a8f70(env, &((v).2))?,
+        flag: jboolean_to_bool_31306d98(env, &((v).3))?,
+        label: JString_to_Option_Box_String_071e4c8c(env, &((v).4))?,
     })
 }
 #[allow(
@@ -3666,34 +3441,23 @@ pub(crate) unsafe fn jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_to_
     clippy::nonminimal_bool,
     clippy::eq_op
 )]
-pub(crate) unsafe fn jni_sys_jlong_jni_sys_jlong_to_ObjectBoundary2_5cc5ebe2<'env, 'a>(
+#[inline(always)]
+pub(crate) unsafe fn tuple5_to_Payload_bbb055bc<'env, 'a>(
     env: &mut jni::JNIEnv<'env>,
-    v: ((jni::sys::jlong,), (jni::sys::jlong,)),
-) -> ::core::result::Result<perftest_flat::ObjectBoundary2, __JniErr> {
-    ::core::result::Result::Ok(perftest_flat::ObjectBoundary2 {
-        left: jni_sys_jlong_to_ObjectBoundaryLeaf_9ca2c370(env, (v).0)?,
-        right: jni_sys_jlong_to_ObjectBoundaryLeaf_9ca2c370(env, (v).1)?,
-    })
-}
-#[allow(
-    non_snake_case,
-    unused_mut,
-    unused_variables,
-    unused_braces,
-    unused_parens,
-    dead_code,
-    clippy::useless_conversion,
-    clippy::needless_question_mark,
-    clippy::let_and_return,
-    clippy::nonminimal_bool,
-    clippy::eq_op
-)]
-pub(crate) unsafe fn jni_sys_jlong_to_ObjectBoundaryLeaf_9ca2c370<'env, 'a>(
-    env: &mut jni::JNIEnv<'env>,
-    v: (jni::sys::jlong,),
-) -> ::core::result::Result<perftest_flat::ObjectBoundaryLeaf, __JniErr> {
-    ::core::result::Result::Ok(perftest_flat::ObjectBoundaryLeaf {
-        value: jlong_to_i64_fbf9a9bc(env, &((v).0))?,
+    v: (
+        jni::sys::jlong,
+        jni::sys::jint,
+        jni::sys::jdouble,
+        jni::sys::jboolean,
+        jni::objects::JString<'a>,
+    ),
+) -> ::core::result::Result<perftest_flat::Payload, __JniErr> {
+    ::core::result::Result::Ok(perftest_flat::Payload {
+        id: jlong_to_i64_fbf9a9bc(env, &((v).0))?,
+        seq: jint_to_i32_a3e3b6ef(env, &((v).1))?,
+        value: jdouble_to_f64_9e4a8f70(env, &((v).2))?,
+        flag: jboolean_to_bool_31306d98(env, &((v).3))?,
+        label: JString_to_Option_Box_String_071e4c8c(env, &((v).4))?,
     })
 }
 #[allow(
@@ -3790,7 +3554,7 @@ pub unsafe extern "C" fn Java_io_prebindgen_perftest_JNINative_largeFlatInputSum
     static __SINK_MID: ::prebindgen_jni_runtime::CachedIfaceMethod = ::prebindgen_jni_runtime::CachedIfaceMethod::new();
     const __SINK_FQN: &str = "io/prebindgen/perftest/JniErrorHandler";
     const __SINK_DESCR: &str = "(Ljava/lang/String;)Ljava/lang/Object;";
-    let value = match jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_jni_sys_jlong_to_ObjectBoundary64_ad107808(
+    let value = match tuple2_to_ObjectBoundary64_ad107808(
         &mut env,
         (
             (
@@ -4292,10 +4056,7 @@ pub unsafe extern "C" fn Java_io_prebindgen_perftest_JNINative_storageGet<'a>(
                 __chain_wire2,
                 __chain_wire3,
                 __chain_wire4,
-            ) = match Payload_to_jni_sys_jlong_jni_sys_jint_jni_sys_jdouble_jni_sys_jboolean_jni_objects_JString_bbb055bc(
-                &mut env,
-                __inner,
-            ) {
+            ) = match Payload_to_tuple5_bbb055bc(&mut env, __inner) {
                 ::core::result::Result::Ok(__intermediate) => __intermediate,
                 ::core::result::Result::Err(__chain_error) => {
                     signal_binding_error(
@@ -4404,10 +4165,7 @@ pub unsafe extern "C" fn Java_io_prebindgen_perftest_JNINative_storageGetVec<'a>
                     __chain_wire2,
                     __chain_wire3,
                     __chain_wire4,
-                ) = match Payload_to_jni_sys_jlong_jni_sys_jint_jni_sys_jdouble_jni_sys_jboolean_jni_objects_JString_bbb055bc(
-                    &mut env,
-                    __elem,
-                ) {
+                ) = match Payload_to_tuple5_bbb055bc(&mut env, __elem) {
                     ::core::result::Result::Ok(__intermediate) => __intermediate,
                     ::core::result::Result::Err(__chain_error) => {
                         signal_binding_error(
@@ -4536,7 +4294,7 @@ pub unsafe extern "C" fn Java_io_prebindgen_perftest_JNINative_storagePutByRead<
             return ();
         }
     };
-    let payload = match jni_sys_jlong_jni_sys_jint_jni_sys_jdouble_jni_sys_jboolean_jni_objects_JString_to_Payload_2ea1d0c2(
+    let payload = match tuple5_to_Payload_2ea1d0c2(
         &mut env,
         (payload_id, payload_seq, payload_value, payload_flag, payload_label),
     ) {
@@ -4600,7 +4358,7 @@ pub unsafe extern "C" fn Java_io_prebindgen_perftest_JNINative_storagePutByTake<
             return ();
         }
     };
-    let payload = match jni_sys_jlong_jni_sys_jint_jni_sys_jdouble_jni_sys_jboolean_jni_objects_JString_to_Payload_bbb055bc(
+    let payload = match tuple5_to_Payload_bbb055bc(
         &mut env,
         (payload_id, payload_seq, payload_value, payload_flag, payload_label),
     ) {

--- a/prebindgen-c/src/chain.rs
+++ b/prebindgen-c/src/chain.rs
@@ -239,10 +239,10 @@ impl chain::OptionalBridge for COptionalBridge {
         self.wire.clone()
     }
 
-    fn is_absent(&self, value: TokenStream) -> TokenStream {
+    fn is_absent(&self) -> TokenStream {
         match &self.repr {
             OptionalRepr::Niche { absent } => quote!(#absent),
-            OptionalRepr::Nullable { .. } => quote!((#value).is_null()),
+            OptionalRepr::Nullable { .. } => quote!((v).is_null()),
         }
     }
 

--- a/prebindgen-jni/src/jni/chain.rs
+++ b/prebindgen-jni/src/jni/chain.rs
@@ -524,8 +524,9 @@ pub(crate) fn planned_name(
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use prebindgen_registry::flat::ScalarKind;
+
+    use super::*;
 
     #[test]
     fn planned_tuple_names_are_bounded_by_arity() {

--- a/prebindgen-jni/src/jni/chain.rs
+++ b/prebindgen-jni/src/jni/chain.rs
@@ -38,11 +38,22 @@ impl JFunction {
     pub(crate) fn optional(plan: JOptionalPlan) -> Self {
         Self(JBody::Optional(Box::new(plan)))
     }
+
     pub(crate) fn mark_reachable(&self) {
-        if let JBody::Product(plan) = &self.0 {
-            plan.reachable.set(true);
-            for dependency in &plan.dependencies {
-                dependency.mark_reachable();
+        match &self.0 {
+            JBody::Complete(_) => {}
+            JBody::OwnedHandle(plan) => plan.reachable.set(true),
+            JBody::Product(plan) => {
+                plan.reachable.set(true);
+                for dependency in &plan.dependencies {
+                    dependency.mark_reachable();
+                }
+            }
+            JBody::Optional(plan) => {
+                plan.reachable.set(true);
+                for dependency in &plan.dependencies {
+                    dependency.mark_reachable();
+                }
             }
         }
     }
@@ -51,8 +62,10 @@ impl JFunction {
 impl RustFunction for JFunction {
     fn should_emit(&self) -> bool {
         match &self.0 {
+            JBody::Complete(_) => true,
+            JBody::OwnedHandle(plan) => plan.reachable.get(),
             JBody::Product(plan) => plan.reachable.get(),
-            _ => true,
+            JBody::Optional(plan) => plan.reachable.get(),
         }
     }
 
@@ -249,6 +262,7 @@ impl shared::Child for JChild {
 #[derive(Clone)]
 pub(crate) struct JOwnedHandlePlan {
     pub(crate) ident: syn::Ident,
+    pub(crate) reachable: std::rc::Rc<std::cell::Cell<bool>>,
     pub(crate) source: TypeRef,
     pub(crate) module: syn::Path,
 }
@@ -308,6 +322,7 @@ impl JProductPlan {
                 let intermediate = annotate_jobject_with_lifetime(intermediate, "a");
                 syn::parse_quote!(
                     #allow
+                    #[inline(always)]
                     pub(crate) unsafe fn #name<'env, 'a>(
                         env: &mut jni::JNIEnv<'env>,
                         v: #intermediate,
@@ -325,6 +340,7 @@ impl JProductPlan {
                 };
                 syn::parse_quote!(
                     #allow
+                    #[inline(always)]
                     pub(crate) unsafe fn #name<'a>(
                         env: &mut jni::JNIEnv<'a>,
                         #input,
@@ -370,10 +386,10 @@ impl shared::OptionalBridge for JOptionalBridge {
         }
     }
 
-    fn is_absent(&self, value: TokenStream) -> TokenStream {
+    fn is_absent(&self) -> TokenStream {
         match self {
             Self::InputNiche { absent, .. } => quote!(#absent),
-            Self::InputBoxed { .. } => quote!((#value).is_null()),
+            Self::InputBoxed { .. } => quote!((v).is_null()),
             Self::OutputNiche { .. } | Self::OutputBoxed { .. } => {
                 unreachable!("optional bridge operation does not match its planned direction")
             }
@@ -433,6 +449,8 @@ impl shared::OptionalBridge for JOptionalBridge {
 #[derive(Clone)]
 pub(crate) struct JOptionalPlan {
     pub(crate) ident: syn::Ident,
+    pub(crate) reachable: std::rc::Rc<std::cell::Cell<bool>>,
+    pub(crate) dependencies: Vec<JFunction>,
     pub(crate) chain: shared::Optional<JSource, JOptionalBridge, JChild>,
 }
 
@@ -493,10 +511,34 @@ pub(crate) fn planned_name(
     let key = source.key();
     let source_key = key.as_str();
     let source_id = crate::jni::emit::sanitize_for_ident(source_key);
-    let wire_id = crate::jni::emit::wire_short(intermediate);
+    let wire_id = match intermediate {
+        syn::Type::Tuple(tuple) => format!("tuple{}", tuple.elems.len()),
+        _ => crate::jni::emit::wire_short(intermediate),
+    };
     let suffix = crate::jni::emit::hash_name_pair(source_key, intermediate) & 0xffff_ffff;
     match direction {
         Direction::Construct => format_ident!("{wire_id}_to_{source_id}_{suffix:08x}"),
         Direction::Deconstruct => format_ident!("{source_id}_to_{wire_id}_{suffix:08x}"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use prebindgen_registry::flat::ScalarKind;
+
+    #[test]
+    fn planned_tuple_names_are_bounded_by_arity() {
+        let tuple = vec!["jni::sys::jlong"; 64].join(",");
+        let intermediate: syn::Type =
+            syn::parse_str(&format!("({tuple},)")).expect("parse large tuple intermediate");
+        let name = planned_name(
+            Direction::Construct,
+            &TypeRef::scalar(ScalarKind::I64),
+            &intermediate,
+        )
+        .to_string();
+        assert!(name.starts_with("tuple64_to_i64_"), "{name}");
+        assert!(name.len() < 64, "{name}");
     }
 }

--- a/prebindgen-jni/src/jni/compile.rs
+++ b/prebindgen-jni/src/jni/compile.rs
@@ -544,7 +544,7 @@ impl JFrag {
         }
     }
 
-    fn product_chain_unmarked(&self) -> Option<ProductChain> {
+    pub(crate) fn product_chain(&self) -> Option<ProductChain> {
         if !self.composed_only {
             if let Some(layout @ JLayout::Product(_)) = self.layout.clone() {
                 return Some(ProductChain {
@@ -555,12 +555,6 @@ impl JFrag {
             }
         }
         self.nested_product.clone()
-    }
-
-    pub(crate) fn product_chain(&self) -> Option<ProductChain> {
-        let chain = self.product_chain_unmarked()?;
-        chain.mark_reachable();
-        Some(chain)
     }
 }
 
@@ -773,6 +767,7 @@ impl<R: Conversions> JCompile<'_, R> {
         let rust =
             crate::jni::chain::JFunction::owned_handle(crate::jni::chain::JOwnedHandlePlan {
                 ident,
+                reachable: std::rc::Rc::new(std::cell::Cell::new(false)),
                 source: source.clone(),
                 module,
             });
@@ -1069,6 +1064,8 @@ impl<R: Conversions> JCompile<'_, R> {
         let marker = crate::jni::chain::planned_marker(&ident);
         let rust = crate::jni::chain::JFunction::optional(crate::jni::chain::JOptionalPlan {
             ident,
+            reachable: std::rc::Rc::new(std::cell::Cell::new(false)),
+            dependencies: vec![inner.rust.clone()],
             chain: prebindgen_registry::chain::Optional {
                 source: source.clone(),
                 direction,
@@ -1080,7 +1077,6 @@ impl<R: Conversions> JCompile<'_, R> {
                 child,
             },
         });
-        inner.rust.mark_reachable();
         Some(JFrag {
             conv: ConverterImpl {
                 destination,
@@ -1244,7 +1240,7 @@ impl<R: Conversions> Compile for JCompile<'_, R> {
                 }),
         };
         let mut frag = self.wrap(at, "no JNI representation for this run", conv)?;
-        frag.nested_product = inner.product_chain_unmarked();
+        frag.nested_product = inner.product_chain();
         Ok(frag)
     }
 
@@ -1427,6 +1423,9 @@ impl<R: Conversions> Compile for JCompile<'_, R> {
             .site
             .as_ref()
             .ok_or_else(|| JErr::Refused("JniGen: a site compiled with no site context".into()))?;
+        if matches!(root.layout, Some(JLayout::Leaf)) {
+            root.rust.mark_reachable();
+        }
         let site = match site {
             PlanSite::Return => {
                 // A fragment that occupies several wires IS the decomposed
@@ -1587,7 +1586,7 @@ pub(crate) struct ProductChain {
 }
 
 impl ProductChain {
-    fn mark_reachable(&self) {
+    pub(crate) fn activate(&self) {
         self.rust.mark_reachable();
     }
 }
@@ -1599,6 +1598,12 @@ impl ProductChain {
 /// conversion through it costs a refcount instead of a whole `syn::ItemFn` per
 /// lookup.
 pub(crate) struct Conv(std::rc::Rc<JFrag>);
+
+impl Conv {
+    pub(crate) fn activate(&self) {
+        self.0.rust.mark_reachable();
+    }
+}
 
 impl std::ops::Deref for Conv {
     type Target = ConverterImpl<KotlinMeta>;

--- a/prebindgen-jni/src/jni/emit/callback.rs
+++ b/prebindgen-jni/src/jni/emit/callback.rs
@@ -251,6 +251,7 @@ pub(crate) fn callback_input(
                 (quote!((#cb_arg).clone()), ext.out_frag(core)?)
             }
         };
+        arg_entry.activate();
         let arg_wire = arg_entry.destination.clone();
         let enc_ident = format_ident!("__cb{}_enc", i);
         let obj_ident = format_ident!("__cb{}_obj", i);

--- a/prebindgen-jni/src/jni/emit/delivery.rs
+++ b/prebindgen-jni/src/jni/emit/delivery.rs
@@ -972,6 +972,7 @@ pub(crate) fn encode_plan_leaves(
             )
         });
         if let Some(chain) = chain.filter(|chain| chain.layout.leaf_count() == n) {
+            chain.activate();
             let encoded: Vec<syn::Ident> = (0..n)
                 .map(|index| format_ident!("__chain_wire{index}"))
                 .collect();
@@ -1222,6 +1223,7 @@ pub(crate) fn encode_plan_leaves(
                 leaf.out_ty.key()
             )
         });
+        out_entry.activate();
         let conv_fail = fail(quote!(__e.to_string()));
         // The leaf's COMPLETE Rust -> wire chain: the rust-side stages a custom
         // `convert!` declaration inserts (`Duration -> u64`), then the

--- a/prebindgen-jni/src/jni/emit/flat_input.rs
+++ b/prebindgen-jni/src/jni/emit/flat_input.rs
@@ -46,6 +46,7 @@ pub(crate) fn struct_input_body(
         // reading straight to its entry — the `reading_of` hop only ever
         // recovered what the field already carried.
         let field_entry = ext.in_frag(&field.ty)?;
+        field_entry.activate();
         // The optional layer off the MODEL, asked once and reused: every site
         // below that wants "is this field optional" reads this, so they cannot
         // disagree with each other the way four independent path-segment tests
@@ -115,8 +116,10 @@ pub(crate) fn struct_input_body(
                             proj.strategy,
                             FoldStrategy::Optional(NullableKind::Niche, _)
                         );
+                        let inner_entry = ext.in_frag(inner)?;
+                        inner_entry.activate();
                         let inner_conv =
-                            composed_entry_decode(&*ext.in_frag(inner)?, &raw_ident, &fname_ident);
+                            composed_entry_decode(&inner_entry, &raw_ident, &fname_ident);
                         let tmp_ident = format_ident!("__{}_jobj", fname_ident);
                         let decode = if niche {
                             // The Kotlin data-class property is still `ULong?`
@@ -178,8 +181,9 @@ pub(crate) fn struct_input_body(
             .map(|v| v.to_string())
             {
                 let sig = format!("L{};", fqn.replace('.', "/"));
-                let inner_conv =
-                    composed_entry_decode(&*ext.in_frag(inner)?, &raw_ident, &fname_ident);
+                let inner_entry = ext.in_frag(inner)?;
+                inner_entry.activate();
+                let inner_conv = composed_entry_decode(&inner_entry, &raw_ident, &fname_ident);
                 let tmp_ident = format_ident!("__{}_jobj", fname_ident);
                 let decode = if field_optional {
                     quote! {
@@ -504,7 +508,9 @@ fn read_kotlin_property(
         // Under `Option`, JVM null is `None` and the INNER converter decodes
         // the discriminant; the outer converter would expect a boxed Integer.
         let decode = if optional {
-            let inner_conv = composed_entry_decode(&*ext.in_frag(inner)?, &raw, bind);
+            let inner_entry = ext.in_frag(inner)?;
+            inner_entry.activate();
+            let inner_conv = composed_entry_decode(&inner_entry, &raw, bind);
             quote! {
                 let #bind = if #obj.is_null() {
                     ::core::option::Option::None
@@ -1230,6 +1236,9 @@ pub(crate) fn build_flat_input_plan(
     let chain = ext
         .product_chain(arg, prebindgen_registry::recipe::Direction::Construct)
         .filter(|chain| chain.layout.leaf_count() == leaves.len());
+    if let Some(chain) = &chain {
+        chain.activate();
+    }
 
     // 3. The tree the Rust side rebuilds through, over those same wires in the
     //    order the recipe states them.

--- a/prebindgen-jni/src/jni/emit/sum_out.rs
+++ b/prebindgen-jni/src/jni/emit/sum_out.rs
@@ -327,6 +327,7 @@ fn encode_group_leaf(
             leaf.out_ty.key()
         )
     });
+    out_entry.activate();
     let wire = out_entry.destination.clone();
     let conv_fail = fail(quote!(__e.to_string()));
     let enc = format_ident!("__enc_{}", obj_ident);

--- a/prebindgen-jni/src/jni/emit/wrapper.rs
+++ b/prebindgen-jni/src/jni/emit/wrapper.rs
@@ -236,6 +236,9 @@ pub(crate) fn emit_jni_function_wrapper_with_callee(
         ),
         FnOutputPlan::Unfold(_) => None,
     };
+    if let Some(entry) = &output_entry {
+        entry.activate();
+    }
     let wire_ty = plan.output.wire_ty();
     let wire_return = annotate_jobject_with_lifetime(&wire_ty, "a").to_token_stream();
     let on_err = sentinel_for_wire(&wire_ty);
@@ -744,6 +747,7 @@ fn emit_input_param(
                     .message(original_ident)
                 )
             });
+            entry.activate();
             emit_plain_decode(&entry, arg_ident, arg_ty, on_err)
         }
     }

--- a/prebindgen-jni/src/jni/struct_plan.rs
+++ b/prebindgen-jni/src/jni/struct_plan.rs
@@ -302,6 +302,7 @@ pub(crate) fn classify_field(
     }
 
     let field_entry = ext.out_frag(reading)?;
+    field_entry.activate();
     let conv = ConvChain::of(&field_entry);
 
     {

--- a/prebindgen-jni/src/jni/tests/values.rs
+++ b/prebindgen-jni/src/jni/tests/values.rs
@@ -166,11 +166,11 @@ fn flattened_field_composes_bounded_conversion_stages() {
     );
     assert!(!rc.contains("let___delay:jni::objects::JObject"), "{rust}");
     assert!(
-        rc.contains("jni_sys_jlong_to_Timed_") && rc.contains("(&mutenv,(value_delay,))"),
+        rc.contains("tuple1_to_Timed_") && rc.contains("(&mutenv,(value_delay,))"),
         "the wrapper must delegate Product reconstruction to its registry chain:\n{rust}"
     );
     assert!(
-        rc.contains("Timed_to_jni_sys_jlong_") && rc.contains("let(__chain_wire0,)=match"),
+        rc.contains("Timed_to_tuple1_") && rc.contains("let(__chain_wire0,)=match"),
         "output delivery must delegate Product deconstruction to the same chain:\n{rust}"
     );
 }
@@ -1217,16 +1217,22 @@ fn recursive_flattened_owned_handles_join_lock_and_consume_scaffold() {
     assert!(kc.contains("e.token.markConsumed()"), "{kotlin}");
     assert!(kc.contains("e.spare?.markConsumed()"), "{kotlin}");
     assert!(
-        rc.contains("lete=matchjni_sys_jlong_jni_sys_jlong_to_Envelope_")
-            && rc.contains("e_token,e_spare"),
+        rc.contains("lete=matchtuple2_to_Envelope_") && rc.contains("e_token,e_spare"),
         "the wrapper must hand the two handle wires to one Product chain:\n{rust}"
     );
+    let token_converter_suffix = rc
+        .split("token:jlong_to_Token_")
+        .nth(1)
+        .and_then(|tail| tail.split_once("(env,&((v).0))?"))
+        .map(|(suffix, _)| suffix)
+        .expect("the Product chain must call Token's converter");
     assert!(
-        rc.contains("token:jlong_to_Token_")
-            && rc.contains("env,&((v).0))?")
-            && rc.contains("spare:jlong_to_Option_Token_")
-            && rc.contains("env,&((v).1))?"),
-        "the registry chain must own both field conversions:\n{rust}"
+        token_converter_suffix.ends_with("_owned"),
+        "the Product chain must consume Token through its owned converter:\n{rust}"
+    );
+    assert!(
+        rc.contains("spare:jlong_to_Option_Token_") && rc.contains("env,&((v).1))?"),
+        "the registry chain must own the optional field conversion:\n{rust}"
     );
 }
 

--- a/prebindgen-jni/src/jni/trait_impl.rs
+++ b/prebindgen-jni/src/jni/trait_impl.rs
@@ -1171,6 +1171,7 @@ impl Declarations {
         if !is_jobject_shaped_wire(&inner_wire) {
             return None;
         }
+        inner.activate();
         // The element's COMPLETE wire -> Rust chain: a `convert!` element
         // (`Label` -> `String`) reaches its value through the rust-side stages,
         // not through the wire-facing converter alone.
@@ -2603,6 +2604,7 @@ impl Declarations {
         // type, rather than resolving and emitting Rust the consumer cannot
         // build.
         let read = read_through_erased_wrappers(reading, quote!(v))?;
+        entry.activate();
         // The inner's COMPLETE chain, stages included: a `convert!` type reaches
         // its wire through them.
         let inner_call = crate::jni::emit::composed_inner_output(&entry, quote!(__inner));
@@ -2677,6 +2679,7 @@ impl Declarations {
         // refusal — the crossing then stays unresolved and names the type,
         // rather than resolving and emitting Rust the consumer cannot build.
         let built = build_through_erased_wrappers(reading, quote!(__inner))?;
+        entry.activate();
         // The inner's COMPLETE chain, stages included. This called
         // `entry.function` directly and left `pre_stages` empty, which SKIPPED
         // them: a `convert!`-declared type reaches its Rust value through those
@@ -3024,6 +3027,7 @@ impl Declarations {
             if !is_jobject_shaped_wire(&inner_wire) {
                 return None;
             }
+            inner.activate();
             // The element's COMPLETE Rust -> wire chain (see the input peer).
             let inner_conv = crate::jni::emit::composed_inner_output(&inner, quote::quote!(__elem));
             let outer_ty = produced.key();
@@ -3106,6 +3110,7 @@ impl Declarations {
         if !is_jobject_shaped_wire(&inner_wire) {
             return None;
         }
+        inner.activate();
         // The element's COMPLETE Rust -> wire chain (see the `Vec<_>` peer).
         let inner_conv = crate::jni::emit::composed_inner_output(
             &inner,

--- a/prebindgen-registry/src/chain.rs
+++ b/prebindgen-registry/src/chain.rs
@@ -193,8 +193,11 @@ pub trait OptionalBridge: Clone {
     /// The one intermediate Rust type assigned to this fragment.
     fn intermediate(&self) -> syn::Type;
 
-    /// Whether an inbound intermediate represents absence.
-    fn is_absent(&self, value: TokenStream) -> TokenStream;
+    /// Whether an inbound intermediate named `v` represents absence.
+    ///
+    /// The composer binds its input as `v` before splicing this predicate,
+    /// matching the invariant carried by adapter niche predicates.
+    fn is_absent(&self) -> TokenStream;
 
     /// Extract the child intermediate from a present inbound value.
     fn present(&self, value: TokenStream) -> TokenStream;
@@ -316,7 +319,7 @@ where
         let fallible = self.child.call().fallible();
         let body = match self.direction {
             Direction::Construct => {
-                let absent = self.bridge.is_absent(quote::quote!(v));
+                let absent = self.bridge.is_absent();
                 let present = self.bridge.present(quote::quote!(v));
                 let child = child_value(&self.child, quote::quote!(__present));
                 let canonical = quote::quote!({
@@ -382,8 +385,8 @@ mod tests {
             syn::parse_quote!(i64)
         }
 
-        fn is_absent(&self, value: TokenStream) -> TokenStream {
-            quote!(*#value == 0)
+        fn is_absent(&self) -> TokenStream {
+            quote!(*v == 0)
         }
 
         fn present(&self, value: TokenStream) -> TokenStream {


### PR DESCRIPTION
## Summary

- make every planned JNI converter opt in to emission, propagate activation through Product and Optional dependencies, and activate chains only after callers accept their layout
- keep chain lookup pure and make live legacy converter uses explicit, removing 21 unreachable owned-handle converters while preserving every referenced definition
- bound Product converter names by tuple arity, define the Optional absence predicate against its canonical v binding, and strengthen the owned-handle regression assertion
- inline Product converters; the 64-Long large_flat benchmark returned from the reported 104–106 ns/op regression to 96.47 ns/op

The regenerated Rust artifacts are 904 lines smaller overall (310 additions, 1,214 deletions). Generated Rust and the foreign-language behavior remain semantically unchanged; private converter names and dead helper emission intentionally change.

Related to #512.

## Verification

- cargo fmt --all -- --check — passed
- git diff --check — passed
- cargo test --all --all-features — passed
- bash examples/regen-check.sh — passed after committing the regenerated artifacts
- bash examples/perftest-bench.sh --n 2000000 — passed correctness checks; large_flat measured 96.47 ns/op