### PR TITLE
Compose JNI Choice converter chains in the registry

### DIFF
--- a/docs/model.md
+++ b/docs/model.md
@@ -17,8 +17,12 @@ item of the source crate into a data file at build time. The source crate
 contains nothing about any foreign language.
 - **`prebindgen-flat`** — parses those records into **the model**, `Flat`:
 `Struct`, `Variant` (an enum whose alternatives carry payloads, each an
-`Alternative`), `Enum`, `Function`, `Field`, and `TypeRef`, the model's reading
-of one Rust type. `TypeKey` is the identity that same type is stored under.
+`Alternative`), `Enum`, `Function`, `Field`, and `TypeRef`, the model's
+reading of one Rust type. `TypeKey` is the identity that same type is stored
+under. An `Alternative` also exposes its `AlternativeForm`: unit, tuple or
+struct. Payload arity alone cannot recover this fact because `A`, `A()` and
+`A {}` are all empty but require different Rust construction and pattern
+syntax; renderers consume the Flat fact instead of inspecting source syntax.
 - **`prebindgen-registry`** — the language-agnostic half of generation. It is
 what this document describes.
 - **an adapter**, one per target language — `prebindgen-c`, whose generator type

--- a/examples/covertest-kotlin/src/generated_bindings.rs
+++ b/examples/covertest-kotlin/src/generated_bindings.rs
@@ -1384,6 +1384,45 @@ pub(crate) unsafe fn HoldPolicy_to_JObject_d2a5bcc4<'a>(
     clippy::nonminimal_bool,
     clippy::eq_op
 )]
+#[inline(always)]
+pub(crate) unsafe fn Hold_to_tuple3_bf18c116<'a>(
+    env: &mut jni::JNIEnv<'a>,
+    v: perftest_flat::Hold,
+) -> ::core::result::Result<(jni::sys::jint, (), (jni::sys::jlong,)), __JniErr> {
+    ::core::result::Result::Ok({
+        match v {
+            perftest_flat::Hold::Indefinite => (0i32, (), (0 as jni::sys::jlong,)),
+            perftest_flat::Hold::For(__part0) => {
+                (
+                    1i32,
+                    (),
+                    (
+                        {
+                            let __chain_s0 = Duration_to_u64_e3980876(env, __part0)
+                                .map_err(|__e| <__JniErr as ::core::convert::From<
+                                    String,
+                                >>::from(__e.to_string()))?;
+                            u64_to_jlong_4384a5d6(env, __chain_s0)
+                        }?,
+                    ),
+                )
+            }
+        }
+    })
+}
+#[allow(
+    non_snake_case,
+    unused_mut,
+    unused_variables,
+    unused_braces,
+    unused_parens,
+    dead_code,
+    clippy::useless_conversion,
+    clippy::needless_question_mark,
+    clippy::let_and_return,
+    clippy::nonminimal_bool,
+    clippy::eq_op
+)]
 pub(crate) unsafe fn Holder_to_JObject_c36a9705<'a>(
     env: &mut jni::JNIEnv<'a>,
     v: perftest_flat::Holder,
@@ -3355,11 +3394,13 @@ pub(crate) unsafe fn JObject_to_Option_Reading_80df84a9<'env, 'v>(
     env: &mut jni::JNIEnv<'env>,
     v: &jni::objects::JObject<'v>,
 ) -> ::core::result::Result<Option<perftest_flat::Reading>, __JniErr> {
-    Ok({
-        let __v: ::core::option::Option<perftest_flat::Reading> = {
-            if v.is_null() { None } else { Some(JObject_to_Reading_2261050f(env, v)?) }
-        };
-        __v
+    ::core::result::Result::Ok({
+        if v.is_null() {
+            ::core::option::Option::None
+        } else {
+            let __present = v;
+            ::core::option::Option::Some(JObject_to_Reading_2261050f(env, __present)?)
+        }
     })
 }
 #[allow(
@@ -5059,54 +5100,26 @@ pub(crate) unsafe fn JObject_to_impl_Fn_Lookup_Send_Sync_static_4a65bc23<'env, '
                         String,
                     >>::from(format!("push local frame for {}: {}", "Fn(Lookup)", e)))?;
                 let __frame_res = (|| -> ::core::result::Result<(), __JniErr> {
-                    let __cb0_obj0: jni::sys::jvalue;
-                    let __cb0_obj1: jni::sys::jvalue;
-                    let __cb0_obj2: jni::objects::JObject;
-                    match &__cb_arg0 {
-                        perftest_flat::Lookup::Absent => {
-                            __cb0_obj0 = jni::sys::jvalue { i: 0 };
-                            __cb0_obj1 = jni::sys::jvalue { j: 0i64 };
-                            __cb0_obj2 = jni::objects::JObject::null();
+                    let (__chain_wire0, (), (__chain_wire1,), (__chain_wire2,)) = match Lookup_to_tuple4_68d54df3(
+                        &mut env,
+                        __cb_arg0,
+                    ) {
+                        ::core::result::Result::Ok(__intermediate) => __intermediate,
+                        ::core::result::Result::Err(__chain_error) => {
+                            return ::core::result::Result::Err(
+                                <__JniErr as ::core::convert::From<
+                                    String,
+                                >>::from(__chain_error.to_string()),
+                            );
                         }
-                        perftest_flat::Lookup::Found(__sv0) => {
-                            let __enc___cb0_obj1 = match Summary_to_jlong_3cb103b9(
-                                &mut env,
-                                __sv0.clone(),
-                            ) {
-                                ::core::result::Result::Ok(__w) => __w,
-                                ::core::result::Result::Err(__e) => {
-                                    return ::core::result::Result::Err(
-                                        <__JniErr as ::core::convert::From<
-                                            String,
-                                        >>::from(__e.to_string()),
-                                    );
-                                }
-                            };
-                            __cb0_obj1 = jni::sys::jvalue {
-                                j: __enc___cb0_obj1,
-                            };
-                            __cb0_obj0 = jni::sys::jvalue { i: 1 };
-                            __cb0_obj2 = jni::objects::JObject::null();
-                        }
-                        perftest_flat::Lookup::Failed(__sv0) => {
-                            let __enc___cb0_obj2 = match String_to_JString_c7f3ca43(
-                                &mut env,
-                                __sv0.clone(),
-                            ) {
-                                ::core::result::Result::Ok(__w) => __w,
-                                ::core::result::Result::Err(__e) => {
-                                    return ::core::result::Result::Err(
-                                        <__JniErr as ::core::convert::From<
-                                            String,
-                                        >>::from(__e.to_string()),
-                                    );
-                                }
-                            };
-                            __cb0_obj2 = __enc___cb0_obj2.into();
-                            __cb0_obj0 = jni::sys::jvalue { i: 2 };
-                            __cb0_obj1 = jni::sys::jvalue { j: 0i64 };
-                        }
-                    }
+                    };
+                    let __cb0_obj0 = jni::sys::jvalue {
+                        i: __chain_wire0,
+                    };
+                    let __cb0_obj1 = jni::sys::jvalue {
+                        j: __chain_wire1,
+                    };
+                    let __cb0_obj2: jni::objects::JObject = __chain_wire2.into();
                     let __call_res: ::core::result::Result<(), __JniErr> = unsafe {
                         env.call_method_unchecked(
                             &callback_global_ref,
@@ -6059,148 +6072,42 @@ pub(crate) unsafe fn JObject_to_impl_Fn_Reading_Send_Sync_static_5964f1fc<'env, 
                         String,
                     >>::from(format!("push local frame for {}: {}", "Fn(Reading)", e)))?;
                 let __frame_res = (|| -> ::core::result::Result<(), __JniErr> {
-                    let __cb0_obj0: jni::sys::jvalue;
-                    let __cb0_obj1: jni::sys::jvalue;
-                    let __cb0_obj2: jni::sys::jvalue;
-                    let __cb0_obj3: jni::sys::jvalue;
-                    let __cb0_obj4: jni::objects::JObject;
-                    let __cb0_obj5: jni::sys::jvalue;
-                    let __cb0_obj6: jni::sys::jvalue;
-                    match &__cb_arg0 {
-                        perftest_flat::Reading::Missing => {
-                            __cb0_obj0 = jni::sys::jvalue { i: 0 };
-                            __cb0_obj1 = jni::sys::jvalue { j: 0i64 };
-                            __cb0_obj2 = jni::sys::jvalue { j: 0i64 };
-                            __cb0_obj3 = jni::sys::jvalue { j: 0i64 };
-                            __cb0_obj4 = jni::objects::JObject::null();
-                            __cb0_obj5 = jni::sys::jvalue { i: 0i32 };
-                            __cb0_obj6 = jni::sys::jvalue { j: 0i64 };
+                    let (
+                        __chain_wire0,
+                        (),
+                        (__chain_wire1,),
+                        (__chain_wire2, __chain_wire3),
+                        (__chain_wire4, __chain_wire5),
+                        (__chain_wire6,),
+                    ) = match Reading_to_tuple6_69702d1f(&mut env, __cb_arg0) {
+                        ::core::result::Result::Ok(__intermediate) => __intermediate,
+                        ::core::result::Result::Err(__chain_error) => {
+                            return ::core::result::Result::Err(
+                                <__JniErr as ::core::convert::From<
+                                    String,
+                                >>::from(__chain_error.to_string()),
+                            );
                         }
-                        perftest_flat::Reading::Exact(__sv0) => {
-                            let __enc___cb0_obj1 = match i64_to_jlong_fbf9a9bc(
-                                &mut env,
-                                __sv0.clone(),
-                            ) {
-                                ::core::result::Result::Ok(__w) => __w,
-                                ::core::result::Result::Err(__e) => {
-                                    return ::core::result::Result::Err(
-                                        <__JniErr as ::core::convert::From<
-                                            String,
-                                        >>::from(__e.to_string()),
-                                    );
-                                }
-                            };
-                            __cb0_obj1 = jni::sys::jvalue {
-                                j: __enc___cb0_obj1,
-                            };
-                            __cb0_obj0 = jni::sys::jvalue { i: 1 };
-                            __cb0_obj2 = jni::sys::jvalue { j: 0i64 };
-                            __cb0_obj3 = jni::sys::jvalue { j: 0i64 };
-                            __cb0_obj4 = jni::objects::JObject::null();
-                            __cb0_obj5 = jni::sys::jvalue { i: 0i32 };
-                            __cb0_obj6 = jni::sys::jvalue { j: 0i64 };
-                        }
-                        perftest_flat::Reading::Range { low: __sv0, high: __sv1 } => {
-                            let __enc___cb0_obj2 = match i64_to_jlong_fbf9a9bc(
-                                &mut env,
-                                __sv0.clone(),
-                            ) {
-                                ::core::result::Result::Ok(__w) => __w,
-                                ::core::result::Result::Err(__e) => {
-                                    return ::core::result::Result::Err(
-                                        <__JniErr as ::core::convert::From<
-                                            String,
-                                        >>::from(__e.to_string()),
-                                    );
-                                }
-                            };
-                            __cb0_obj2 = jni::sys::jvalue {
-                                j: __enc___cb0_obj2,
-                            };
-                            let __enc___cb0_obj3 = match i64_to_jlong_fbf9a9bc(
-                                &mut env,
-                                __sv1.clone(),
-                            ) {
-                                ::core::result::Result::Ok(__w) => __w,
-                                ::core::result::Result::Err(__e) => {
-                                    return ::core::result::Result::Err(
-                                        <__JniErr as ::core::convert::From<
-                                            String,
-                                        >>::from(__e.to_string()),
-                                    );
-                                }
-                            };
-                            __cb0_obj3 = jni::sys::jvalue {
-                                j: __enc___cb0_obj3,
-                            };
-                            __cb0_obj0 = jni::sys::jvalue { i: 2 };
-                            __cb0_obj1 = jni::sys::jvalue { j: 0i64 };
-                            __cb0_obj4 = jni::objects::JObject::null();
-                            __cb0_obj5 = jni::sys::jvalue { i: 0i32 };
-                            __cb0_obj6 = jni::sys::jvalue { j: 0i64 };
-                        }
-                        perftest_flat::Reading::Labeled(__sv0, __sv1) => {
-                            let __enc___cb0_obj4 = match String_to_JString_c7f3ca43(
-                                &mut env,
-                                __sv0.clone(),
-                            ) {
-                                ::core::result::Result::Ok(__w) => __w,
-                                ::core::result::Result::Err(__e) => {
-                                    return ::core::result::Result::Err(
-                                        <__JniErr as ::core::convert::From<
-                                            String,
-                                        >>::from(__e.to_string()),
-                                    );
-                                }
-                            };
-                            __cb0_obj4 = __enc___cb0_obj4.into();
-                            let __enc___cb0_obj5 = match Priority_to_jint_447102d2(
-                                &mut env,
-                                __sv1.clone(),
-                            ) {
-                                ::core::result::Result::Ok(__w) => __w,
-                                ::core::result::Result::Err(__e) => {
-                                    return ::core::result::Result::Err(
-                                        <__JniErr as ::core::convert::From<
-                                            String,
-                                        >>::from(__e.to_string()),
-                                    );
-                                }
-                            };
-                            __cb0_obj5 = jni::sys::jvalue {
-                                i: __enc___cb0_obj5,
-                            };
-                            __cb0_obj0 = jni::sys::jvalue { i: 3 };
-                            __cb0_obj1 = jni::sys::jvalue { j: 0i64 };
-                            __cb0_obj2 = jni::sys::jvalue { j: 0i64 };
-                            __cb0_obj3 = jni::sys::jvalue { j: 0i64 };
-                            __cb0_obj6 = jni::sys::jvalue { j: 0i64 };
-                        }
-                        perftest_flat::Reading::Companion(__sv0) => {
-                            let __enc___cb0_obj6 = match i64_to_jlong_fbf9a9bc(
-                                &mut env,
-                                __sv0.clone(),
-                            ) {
-                                ::core::result::Result::Ok(__w) => __w,
-                                ::core::result::Result::Err(__e) => {
-                                    return ::core::result::Result::Err(
-                                        <__JniErr as ::core::convert::From<
-                                            String,
-                                        >>::from(__e.to_string()),
-                                    );
-                                }
-                            };
-                            __cb0_obj6 = jni::sys::jvalue {
-                                j: __enc___cb0_obj6,
-                            };
-                            __cb0_obj0 = jni::sys::jvalue { i: 4 };
-                            __cb0_obj1 = jni::sys::jvalue { j: 0i64 };
-                            __cb0_obj2 = jni::sys::jvalue { j: 0i64 };
-                            __cb0_obj3 = jni::sys::jvalue { j: 0i64 };
-                            __cb0_obj4 = jni::objects::JObject::null();
-                            __cb0_obj5 = jni::sys::jvalue { i: 0i32 };
-                        }
-                    }
+                    };
+                    let __cb0_obj0 = jni::sys::jvalue {
+                        i: __chain_wire0,
+                    };
+                    let __cb0_obj1 = jni::sys::jvalue {
+                        j: __chain_wire1,
+                    };
+                    let __cb0_obj2 = jni::sys::jvalue {
+                        j: __chain_wire2,
+                    };
+                    let __cb0_obj3 = jni::sys::jvalue {
+                        j: __chain_wire3,
+                    };
+                    let __cb0_obj4: jni::objects::JObject = __chain_wire4.into();
+                    let __cb0_obj5 = jni::sys::jvalue {
+                        i: __chain_wire5,
+                    };
+                    let __cb0_obj6 = jni::sys::jvalue {
+                        j: __chain_wire6,
+                    };
                     let __call_res: ::core::result::Result<(), __JniErr> = unsafe {
                         env.call_method_unchecked(
                             &callback_global_ref,
@@ -6980,6 +6887,207 @@ pub(crate) unsafe fn Label_to_String_63dec766<'a>(
     v: perftest_flat::Label,
 ) -> ::core::result::Result<String, __JniErr> {
     Ok(crate::label_out(v))
+}
+#[allow(
+    non_snake_case,
+    unused_mut,
+    unused_variables,
+    unused_braces,
+    unused_parens,
+    dead_code,
+    clippy::useless_conversion,
+    clippy::needless_question_mark,
+    clippy::let_and_return,
+    clippy::nonminimal_bool,
+    clippy::eq_op
+)]
+#[inline(always)]
+pub(crate) unsafe fn Layered_to_tuple8_4f5948ba<'a>(
+    env: &mut jni::JNIEnv<'a>,
+    v: perftest_flat::Layered,
+) -> ::core::result::Result<
+    (
+        jni::sys::jint,
+        (jni::objects::JObject<'a>,),
+        (jni::sys::jlong,),
+        (jni::objects::JObject<'a>,),
+        (jni::objects::JObject<'a>,),
+        (jni::objects::JObject<'a>,),
+        (jni::objects::JByteArray<'a>,),
+        (jni::sys::jlong,),
+    ),
+    __JniErr,
+> {
+    ::core::result::Result::Ok({
+        match v {
+            perftest_flat::Layered::Count(__part0) => {
+                (
+                    0i32,
+                    (Option_u64_to_JObject_32be16a2(env, __part0)?,),
+                    (0 as jni::sys::jlong,),
+                    (jni::objects::JObject::null().into(),),
+                    (jni::objects::JObject::null().into(),),
+                    (jni::objects::JObject::null().into(),),
+                    (jni::objects::JObject::null().into(),),
+                    (0 as jni::sys::jlong,),
+                )
+            }
+            perftest_flat::Layered::Held(__part0) => {
+                (
+                    1i32,
+                    (jni::objects::JObject::null().into(),),
+                    (Option_Summary_to_jlong_252ef2ba(env, __part0)?,),
+                    (jni::objects::JObject::null().into(),),
+                    (jni::objects::JObject::null().into(),),
+                    (jni::objects::JObject::null().into(),),
+                    (jni::objects::JObject::null().into(),),
+                    (0 as jni::sys::jlong,),
+                )
+            }
+            perftest_flat::Layered::Many(__part0) => {
+                (
+                    2i32,
+                    (jni::objects::JObject::null().into(),),
+                    (0 as jni::sys::jlong,),
+                    (Vec_Option_u64_to_JObject_a34190e7(env, __part0)?,),
+                    (jni::objects::JObject::null().into(),),
+                    (jni::objects::JObject::null().into(),),
+                    (jni::objects::JObject::null().into(),),
+                    (0 as jni::sys::jlong,),
+                )
+            }
+            perftest_flat::Layered::Values(__part0) => {
+                (
+                    3i32,
+                    (jni::objects::JObject::null().into(),),
+                    (0 as jni::sys::jlong,),
+                    (jni::objects::JObject::null().into(),),
+                    (Option_Vec_Option_u64_to_JObject_006312b6(env, __part0)?,),
+                    (jni::objects::JObject::null().into(),),
+                    (jni::objects::JObject::null().into(),),
+                    (0 as jni::sys::jlong,),
+                )
+            }
+            perftest_flat::Layered::Nested(__part0) => {
+                (
+                    4i32,
+                    (jni::objects::JObject::null().into(),),
+                    (0 as jni::sys::jlong,),
+                    (jni::objects::JObject::null().into(),),
+                    (jni::objects::JObject::null().into(),),
+                    (Vec_Vec_Option_u64_to_JObject_342a76c6(env, __part0)?,),
+                    (jni::objects::JObject::null().into(),),
+                    (0 as jni::sys::jlong,),
+                )
+            }
+            perftest_flat::Layered::Blob(__part0) => {
+                (
+                    5i32,
+                    (jni::objects::JObject::null().into(),),
+                    (0 as jni::sys::jlong,),
+                    (jni::objects::JObject::null().into(),),
+                    (jni::objects::JObject::null().into(),),
+                    (jni::objects::JObject::null().into(),),
+                    (Vec_u8_to_JByteArray_7936d5de(env, __part0)?,),
+                    (0 as jni::sys::jlong,),
+                )
+            }
+            perftest_flat::Layered::Plain(__part0) => {
+                (
+                    6i32,
+                    (jni::objects::JObject::null().into(),),
+                    (0 as jni::sys::jlong,),
+                    (jni::objects::JObject::null().into(),),
+                    (jni::objects::JObject::null().into(),),
+                    (jni::objects::JObject::null().into(),),
+                    (jni::objects::JObject::null().into(),),
+                    (i64_to_jlong_fbf9a9bc(env, __part0)?,),
+                )
+            }
+        }
+    })
+}
+#[allow(
+    non_snake_case,
+    unused_mut,
+    unused_variables,
+    unused_braces,
+    unused_parens,
+    dead_code,
+    clippy::useless_conversion,
+    clippy::needless_question_mark,
+    clippy::let_and_return,
+    clippy::nonminimal_bool,
+    clippy::eq_op
+)]
+#[inline(always)]
+pub(crate) unsafe fn Lookup_to_tuple4_68d54df3<'a>(
+    env: &mut jni::JNIEnv<'a>,
+    v: perftest_flat::Lookup,
+) -> ::core::result::Result<
+    (jni::sys::jint, (), (jni::sys::jlong,), (jni::objects::JString<'a>,)),
+    __JniErr,
+> {
+    ::core::result::Result::Ok({
+        match v {
+            perftest_flat::Lookup::Absent => {
+                (
+                    0i32,
+                    (),
+                    (0 as jni::sys::jlong,),
+                    (jni::objects::JObject::null().into(),),
+                )
+            }
+            perftest_flat::Lookup::Found(__part0) => {
+                (
+                    1i32,
+                    (),
+                    (Summary_to_jlong_3cb103b9(env, __part0)?,),
+                    (jni::objects::JObject::null().into(),),
+                )
+            }
+            perftest_flat::Lookup::Failed(__part0) => {
+                (
+                    2i32,
+                    (),
+                    (0 as jni::sys::jlong,),
+                    (String_to_JString_c7f3ca43(env, __part0)?,),
+                )
+            }
+        }
+    })
+}
+#[allow(
+    non_snake_case,
+    unused_mut,
+    unused_variables,
+    unused_braces,
+    unused_parens,
+    dead_code,
+    clippy::useless_conversion,
+    clippy::needless_question_mark,
+    clippy::let_and_return,
+    clippy::nonminimal_bool,
+    clippy::eq_op
+)]
+#[inline(always)]
+pub(crate) unsafe fn Marker_to_tuple3_8b7f3646<'a>(
+    env: &mut jni::JNIEnv<'a>,
+    v: perftest_flat::Marker,
+) -> ::core::result::Result<
+    (jni::sys::jint, (), (jni::objects::JObject<'a>,)),
+    __JniErr,
+> {
+    ::core::result::Result::Ok({
+        match v {
+            perftest_flat::Marker::None_ => {
+                (0i32, (), (jni::objects::JObject::null().into(),))
+            }
+            perftest_flat::Marker::Ranked(__part0) => {
+                (1i32, (), (Option_Priority_to_JObject_ad5cbb32(env, __part0)?,))
+            }
+        }
+    })
 }
 #[allow(
     non_snake_case,
@@ -10304,6 +10412,95 @@ pub(crate) unsafe fn Probe_to_jlong_76f3d10e<'a>(
     clippy::nonminimal_bool,
     clippy::eq_op
 )]
+#[inline(always)]
+pub(crate) unsafe fn Reading_to_tuple6_69702d1f<'a>(
+    env: &mut jni::JNIEnv<'a>,
+    v: perftest_flat::Reading,
+) -> ::core::result::Result<
+    (
+        jni::sys::jint,
+        (),
+        (jni::sys::jlong,),
+        (jni::sys::jlong, jni::sys::jlong),
+        (jni::objects::JString<'a>, jni::sys::jint),
+        (jni::sys::jlong,),
+    ),
+    __JniErr,
+> {
+    ::core::result::Result::Ok({
+        match v {
+            perftest_flat::Reading::Missing => {
+                (
+                    0i32,
+                    (),
+                    (0 as jni::sys::jlong,),
+                    (0 as jni::sys::jlong, 0 as jni::sys::jlong),
+                    (jni::objects::JObject::null().into(), 0 as jni::sys::jint),
+                    (0 as jni::sys::jlong,),
+                )
+            }
+            perftest_flat::Reading::Exact(__part0) => {
+                (
+                    1i32,
+                    (),
+                    (i64_to_jlong_fbf9a9bc(env, __part0)?,),
+                    (0 as jni::sys::jlong, 0 as jni::sys::jlong),
+                    (jni::objects::JObject::null().into(), 0 as jni::sys::jint),
+                    (0 as jni::sys::jlong,),
+                )
+            }
+            perftest_flat::Reading::Range { low: __part0, high: __part1 } => {
+                (
+                    2i32,
+                    (),
+                    (0 as jni::sys::jlong,),
+                    (
+                        i64_to_jlong_fbf9a9bc(env, __part0)?,
+                        i64_to_jlong_fbf9a9bc(env, __part1)?,
+                    ),
+                    (jni::objects::JObject::null().into(), 0 as jni::sys::jint),
+                    (0 as jni::sys::jlong,),
+                )
+            }
+            perftest_flat::Reading::Labeled(__part0, __part1) => {
+                (
+                    3i32,
+                    (),
+                    (0 as jni::sys::jlong,),
+                    (0 as jni::sys::jlong, 0 as jni::sys::jlong),
+                    (
+                        String_to_JString_c7f3ca43(env, __part0)?,
+                        Priority_to_jint_447102d2(env, __part1)?,
+                    ),
+                    (0 as jni::sys::jlong,),
+                )
+            }
+            perftest_flat::Reading::Companion(__part0) => {
+                (
+                    4i32,
+                    (),
+                    (0 as jni::sys::jlong,),
+                    (0 as jni::sys::jlong, 0 as jni::sys::jlong),
+                    (jni::objects::JObject::null().into(), 0 as jni::sys::jint),
+                    (i64_to_jlong_fbf9a9bc(env, __part0)?,),
+                )
+            }
+        }
+    })
+}
+#[allow(
+    non_snake_case,
+    unused_mut,
+    unused_variables,
+    unused_braces,
+    unused_parens,
+    dead_code,
+    clippy::useless_conversion,
+    clippy::needless_question_mark,
+    clippy::let_and_return,
+    clippy::nonminimal_bool,
+    clippy::eq_op
+)]
 pub(crate) unsafe fn RepliesConfig_to_JObject_eb8e9079<'a>(
     env: &mut jni::JNIEnv<'a>,
     v: perftest_flat::RepliesConfig,
@@ -12496,6 +12693,42 @@ pub(crate) unsafe fn tuple2_to_Option_Payload_af2bd54b<'env, 'v>(
     clippy::nonminimal_bool,
     clippy::eq_op
 )]
+pub(crate) unsafe fn tuple2_to_Option_Reading_550e9a70<'env, 'v>(
+    env: &mut jni::JNIEnv<'env>,
+    v: (
+        jni::sys::jboolean,
+        (
+            jni::sys::jint,
+            (),
+            (jni::sys::jlong,),
+            (jni::sys::jlong, jni::sys::jlong),
+            (jni::objects::JString<'v>, jni::sys::jint),
+            (jni::sys::jlong,),
+        ),
+    ),
+) -> ::core::result::Result<Option<perftest_flat::Reading>, __JniErr> {
+    ::core::result::Result::Ok({
+        if (v).0 == 0u8 {
+            ::core::option::Option::None
+        } else {
+            let __present = (v).1;
+            ::core::option::Option::Some(tuple6_to_Reading_69702d1f(env, __present)?)
+        }
+    })
+}
+#[allow(
+    non_snake_case,
+    unused_mut,
+    unused_variables,
+    unused_braces,
+    unused_parens,
+    dead_code,
+    clippy::useless_conversion,
+    clippy::needless_question_mark,
+    clippy::let_and_return,
+    clippy::nonminimal_bool,
+    clippy::eq_op
+)]
 #[inline(always)]
 pub(crate) unsafe fn tuple2_to_RepliesConfig_e72c0bc9<'env, 'a>(
     env: &mut jni::JNIEnv<'env>,
@@ -12573,6 +12806,53 @@ pub(crate) unsafe fn tuple2_to_Tagged_b68a6969<'env, 'a>(
     ::core::result::Result::Ok(perftest_flat::Tagged {
         id: jlong_to_i64_fbf9a9bc(env, &((v).0))?,
         marker: JObject_to_Marker_3dc81334(env, &((v).1))?,
+    })
+}
+#[allow(
+    non_snake_case,
+    unused_mut,
+    unused_variables,
+    unused_braces,
+    unused_parens,
+    dead_code,
+    clippy::useless_conversion,
+    clippy::needless_question_mark,
+    clippy::let_and_return,
+    clippy::nonminimal_bool,
+    clippy::eq_op
+)]
+#[inline(always)]
+pub(crate) unsafe fn tuple4_to_Observation_438d4015<'env, 'a>(
+    env: &mut jni::JNIEnv<'env>,
+    v: (
+        jni::sys::jlong,
+        (
+            jni::sys::jint,
+            (),
+            (jni::sys::jlong,),
+            (jni::sys::jlong, jni::sys::jlong),
+            (jni::objects::JString<'a>, jni::sys::jint),
+            (jni::sys::jlong,),
+        ),
+        (
+            jni::sys::jboolean,
+            (
+                jni::sys::jint,
+                (),
+                (jni::sys::jlong,),
+                (jni::sys::jlong, jni::sys::jlong),
+                (jni::objects::JString<'a>, jni::sys::jint),
+                (jni::sys::jlong,),
+            ),
+        ),
+        jni::objects::JString<'a>,
+    ),
+) -> ::core::result::Result<perftest_flat::Observation, __JniErr> {
+    ::core::result::Result::Ok(perftest_flat::Observation {
+        id: jlong_to_i64_fbf9a9bc(env, &((v).0))?,
+        reading: tuple6_to_Reading_69702d1f(env, (v).1)?,
+        fallback: tuple2_to_Option_Reading_550e9a70(env, (v).2)?,
+        note: JString_to_String_c7f3ca43(env, &((v).3))?,
     })
 }
 #[allow(
@@ -12671,6 +12951,71 @@ pub(crate) unsafe fn tuple5_to_Payload_bbb055bc<'env, 'a>(
         value: jdouble_to_f64_9e4a8f70(env, &((v).2))?,
         flag: jboolean_to_bool_31306d98(env, &((v).3))?,
         label: JString_to_Option_Box_String_071e4c8c(env, &((v).4))?,
+    })
+}
+#[allow(
+    non_snake_case,
+    unused_mut,
+    unused_variables,
+    unused_braces,
+    unused_parens,
+    dead_code,
+    clippy::useless_conversion,
+    clippy::needless_question_mark,
+    clippy::let_and_return,
+    clippy::nonminimal_bool,
+    clippy::eq_op
+)]
+#[inline(always)]
+pub(crate) unsafe fn tuple6_to_Reading_69702d1f<'env, 'a>(
+    env: &mut jni::JNIEnv<'env>,
+    v: (
+        jni::sys::jint,
+        (),
+        (jni::sys::jlong,),
+        (jni::sys::jlong, jni::sys::jlong),
+        (jni::objects::JString<'a>, jni::sys::jint),
+        (jni::sys::jlong,),
+    ),
+) -> ::core::result::Result<perftest_flat::Reading, __JniErr> {
+    ::core::result::Result::Ok({
+        match (v).0 {
+            0i32 => {
+                let __arm = (v).1;
+                perftest_flat::Reading::Missing
+            }
+            1i32 => {
+                let __arm = (v).2;
+                perftest_flat::Reading::Exact(jlong_to_i64_fbf9a9bc(env, &((__arm).0))?)
+            }
+            2i32 => {
+                let __arm = (v).3;
+                perftest_flat::Reading::Range {
+                    low: jlong_to_i64_fbf9a9bc(env, &((__arm).0))?,
+                    high: jlong_to_i64_fbf9a9bc(env, &((__arm).1))?,
+                }
+            }
+            3i32 => {
+                let __arm = (v).4;
+                perftest_flat::Reading::Labeled(
+                    JString_to_String_c7f3ca43(env, &((__arm).0))?,
+                    jint_to_Priority_447102d2(env, &((__arm).1))?,
+                )
+            }
+            4i32 => {
+                let __arm = (v).5;
+                perftest_flat::Reading::Companion(
+                    jlong_to_i64_fbf9a9bc(env, &((__arm).0))?,
+                )
+            }
+            _ => {
+                return ::core::result::Result::Err(
+                    <__JniErr as ::core::convert::From<
+                        String,
+                    >>::from(format!(concat!("Reading", ": invalid tag"))),
+                );
+            }
+        }
     })
 }
 #[allow(
@@ -16216,51 +16561,29 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_holdEcho<'a>(
     const __CB_FQN: &str = "io/prebindgen/covertest/model/HoldBuilderRaw";
     const __CB_DESCR: &str = "(IJ)Ljava/lang/Object;";
     let __out = perftest_flat::hold_echo(h);
-    let __obj0: jni::sys::jvalue;
-    let __obj1: jni::sys::jvalue;
-    match &__out {
-        perftest_flat::Hold::Indefinite => {
-            __obj0 = jni::sys::jvalue { i: 0 };
-            __obj1 = jni::sys::jvalue { j: 0i64 };
-        }
-        perftest_flat::Hold::For(__sv0) => {
-            let __enc___obj1_s0 = match Duration_to_u64_e3980876(
+    let (__chain_wire0, (), (__chain_wire1,)) = match Hold_to_tuple3_bf18c116(
+        &mut env,
+        __out,
+    ) {
+        ::core::result::Result::Ok(__intermediate) => __intermediate,
+        ::core::result::Result::Err(__chain_error) => {
+            signal_binding_error(
                 &mut env,
-                __sv0.clone(),
-            ) {
-                ::core::result::Result::Ok(__w) => __w,
-                ::core::result::Result::Err(__e) => {
-                    signal_binding_error(
-                        &mut env,
-                        &__error_sink,
-                        &__SINK_MID,
-                        __SINK_FQN,
-                        __SINK_DESCR,
-                        &__e.to_string(),
-                    );
-                    return jni::objects::JObject::null().into();
-                }
-            };
-            let __enc___obj1 = match u64_to_jlong_4384a5d6(&mut env, __enc___obj1_s0) {
-                ::core::result::Result::Ok(__w) => __w,
-                ::core::result::Result::Err(__e) => {
-                    signal_binding_error(
-                        &mut env,
-                        &__error_sink,
-                        &__SINK_MID,
-                        __SINK_FQN,
-                        __SINK_DESCR,
-                        &__e.to_string(),
-                    );
-                    return jni::objects::JObject::null().into();
-                }
-            };
-            __obj1 = jni::sys::jvalue {
-                j: __enc___obj1,
-            };
-            __obj0 = jni::sys::jvalue { i: 1 };
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__chain_error.to_string(),
+            );
+            return jni::objects::JObject::null().into();
         }
-    }
+    };
+    let __obj0 = jni::sys::jvalue {
+        i: __chain_wire0,
+    };
+    let __obj1 = jni::sys::jvalue {
+        j: __chain_wire1,
+    };
     match __CB_MID
         .call_object(
             &mut env,
@@ -16580,206 +16903,43 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_layeredOf<'a>(
     const __CB_FQN: &str = "io/prebindgen/covertest/model/LayeredBuilderRaw";
     const __CB_DESCR: &str = "(ILjava/lang/Long;JLjava/util/List;Ljava/util/List;Ljava/util/List;[BJ)Ljava/lang/Object;";
     let __out = perftest_flat::layered_of(which);
-    let __obj0: jni::sys::jvalue;
-    let __obj1: jni::objects::JObject;
-    let __obj2: jni::sys::jvalue;
-    let __obj3: jni::objects::JObject;
-    let __obj4: jni::objects::JObject;
-    let __obj5: jni::objects::JObject;
-    let __obj6: jni::objects::JObject;
-    let __obj7: jni::sys::jvalue;
-    match &__out {
-        perftest_flat::Layered::Count(__sv0) => {
-            let __enc___obj1 = match Option_u64_to_JObject_32be16a2(
+    let (
+        __chain_wire0,
+        (__chain_wire1,),
+        (__chain_wire2,),
+        (__chain_wire3,),
+        (__chain_wire4,),
+        (__chain_wire5,),
+        (__chain_wire6,),
+        (__chain_wire7,),
+    ) = match Layered_to_tuple8_4f5948ba(&mut env, __out) {
+        ::core::result::Result::Ok(__intermediate) => __intermediate,
+        ::core::result::Result::Err(__chain_error) => {
+            signal_binding_error(
                 &mut env,
-                __sv0.clone(),
-            ) {
-                ::core::result::Result::Ok(__w) => __w,
-                ::core::result::Result::Err(__e) => {
-                    signal_binding_error(
-                        &mut env,
-                        &__error_sink,
-                        &__SINK_MID,
-                        __SINK_FQN,
-                        __SINK_DESCR,
-                        &__e.to_string(),
-                    );
-                    return jni::objects::JObject::null().into();
-                }
-            };
-            __obj1 = __enc___obj1;
-            __obj0 = jni::sys::jvalue { i: 0 };
-            __obj2 = jni::sys::jvalue { j: 0i64 };
-            __obj3 = jni::objects::JObject::null();
-            __obj4 = jni::objects::JObject::null();
-            __obj5 = jni::objects::JObject::null();
-            __obj6 = jni::objects::JObject::null();
-            __obj7 = jni::sys::jvalue { j: 0i64 };
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__chain_error.to_string(),
+            );
+            return jni::objects::JObject::null().into();
         }
-        perftest_flat::Layered::Held(__sv0) => {
-            let __enc___obj2 = match Option_Summary_to_jlong_252ef2ba(
-                &mut env,
-                __sv0.clone(),
-            ) {
-                ::core::result::Result::Ok(__w) => __w,
-                ::core::result::Result::Err(__e) => {
-                    signal_binding_error(
-                        &mut env,
-                        &__error_sink,
-                        &__SINK_MID,
-                        __SINK_FQN,
-                        __SINK_DESCR,
-                        &__e.to_string(),
-                    );
-                    return jni::objects::JObject::null().into();
-                }
-            };
-            __obj2 = jni::sys::jvalue {
-                j: __enc___obj2,
-            };
-            __obj0 = jni::sys::jvalue { i: 1 };
-            __obj1 = jni::objects::JObject::null();
-            __obj3 = jni::objects::JObject::null();
-            __obj4 = jni::objects::JObject::null();
-            __obj5 = jni::objects::JObject::null();
-            __obj6 = jni::objects::JObject::null();
-            __obj7 = jni::sys::jvalue { j: 0i64 };
-        }
-        perftest_flat::Layered::Many(__sv0) => {
-            let __enc___obj3 = match Vec_Option_u64_to_JObject_a34190e7(
-                &mut env,
-                __sv0.clone(),
-            ) {
-                ::core::result::Result::Ok(__w) => __w,
-                ::core::result::Result::Err(__e) => {
-                    signal_binding_error(
-                        &mut env,
-                        &__error_sink,
-                        &__SINK_MID,
-                        __SINK_FQN,
-                        __SINK_DESCR,
-                        &__e.to_string(),
-                    );
-                    return jni::objects::JObject::null().into();
-                }
-            };
-            __obj3 = __enc___obj3;
-            __obj0 = jni::sys::jvalue { i: 2 };
-            __obj1 = jni::objects::JObject::null();
-            __obj2 = jni::sys::jvalue { j: 0i64 };
-            __obj4 = jni::objects::JObject::null();
-            __obj5 = jni::objects::JObject::null();
-            __obj6 = jni::objects::JObject::null();
-            __obj7 = jni::sys::jvalue { j: 0i64 };
-        }
-        perftest_flat::Layered::Values(__sv0) => {
-            let __enc___obj4 = match Option_Vec_Option_u64_to_JObject_006312b6(
-                &mut env,
-                __sv0.clone(),
-            ) {
-                ::core::result::Result::Ok(__w) => __w,
-                ::core::result::Result::Err(__e) => {
-                    signal_binding_error(
-                        &mut env,
-                        &__error_sink,
-                        &__SINK_MID,
-                        __SINK_FQN,
-                        __SINK_DESCR,
-                        &__e.to_string(),
-                    );
-                    return jni::objects::JObject::null().into();
-                }
-            };
-            __obj4 = __enc___obj4;
-            __obj0 = jni::sys::jvalue { i: 3 };
-            __obj1 = jni::objects::JObject::null();
-            __obj2 = jni::sys::jvalue { j: 0i64 };
-            __obj3 = jni::objects::JObject::null();
-            __obj5 = jni::objects::JObject::null();
-            __obj6 = jni::objects::JObject::null();
-            __obj7 = jni::sys::jvalue { j: 0i64 };
-        }
-        perftest_flat::Layered::Nested(__sv0) => {
-            let __enc___obj5 = match Vec_Vec_Option_u64_to_JObject_342a76c6(
-                &mut env,
-                __sv0.clone(),
-            ) {
-                ::core::result::Result::Ok(__w) => __w,
-                ::core::result::Result::Err(__e) => {
-                    signal_binding_error(
-                        &mut env,
-                        &__error_sink,
-                        &__SINK_MID,
-                        __SINK_FQN,
-                        __SINK_DESCR,
-                        &__e.to_string(),
-                    );
-                    return jni::objects::JObject::null().into();
-                }
-            };
-            __obj5 = __enc___obj5;
-            __obj0 = jni::sys::jvalue { i: 4 };
-            __obj1 = jni::objects::JObject::null();
-            __obj2 = jni::sys::jvalue { j: 0i64 };
-            __obj3 = jni::objects::JObject::null();
-            __obj4 = jni::objects::JObject::null();
-            __obj6 = jni::objects::JObject::null();
-            __obj7 = jni::sys::jvalue { j: 0i64 };
-        }
-        perftest_flat::Layered::Blob(__sv0) => {
-            let __enc___obj6 = match Vec_u8_to_JByteArray_7936d5de(
-                &mut env,
-                __sv0.clone(),
-            ) {
-                ::core::result::Result::Ok(__w) => __w,
-                ::core::result::Result::Err(__e) => {
-                    signal_binding_error(
-                        &mut env,
-                        &__error_sink,
-                        &__SINK_MID,
-                        __SINK_FQN,
-                        __SINK_DESCR,
-                        &__e.to_string(),
-                    );
-                    return jni::objects::JObject::null().into();
-                }
-            };
-            __obj6 = __enc___obj6.into();
-            __obj0 = jni::sys::jvalue { i: 5 };
-            __obj1 = jni::objects::JObject::null();
-            __obj2 = jni::sys::jvalue { j: 0i64 };
-            __obj3 = jni::objects::JObject::null();
-            __obj4 = jni::objects::JObject::null();
-            __obj5 = jni::objects::JObject::null();
-            __obj7 = jni::sys::jvalue { j: 0i64 };
-        }
-        perftest_flat::Layered::Plain(__sv0) => {
-            let __enc___obj7 = match i64_to_jlong_fbf9a9bc(&mut env, __sv0.clone()) {
-                ::core::result::Result::Ok(__w) => __w,
-                ::core::result::Result::Err(__e) => {
-                    signal_binding_error(
-                        &mut env,
-                        &__error_sink,
-                        &__SINK_MID,
-                        __SINK_FQN,
-                        __SINK_DESCR,
-                        &__e.to_string(),
-                    );
-                    return jni::objects::JObject::null().into();
-                }
-            };
-            __obj7 = jni::sys::jvalue {
-                j: __enc___obj7,
-            };
-            __obj0 = jni::sys::jvalue { i: 6 };
-            __obj1 = jni::objects::JObject::null();
-            __obj2 = jni::sys::jvalue { j: 0i64 };
-            __obj3 = jni::objects::JObject::null();
-            __obj4 = jni::objects::JObject::null();
-            __obj5 = jni::objects::JObject::null();
-            __obj6 = jni::objects::JObject::null();
-        }
-    }
+    };
+    let __obj0 = jni::sys::jvalue {
+        i: __chain_wire0,
+    };
+    let __obj1: jni::objects::JObject = __chain_wire1;
+    let __obj2 = jni::sys::jvalue {
+        j: __chain_wire2,
+    };
+    let __obj3: jni::objects::JObject = __chain_wire3;
+    let __obj4: jni::objects::JObject = __chain_wire4;
+    let __obj5: jni::objects::JObject = __chain_wire5;
+    let __obj6: jni::objects::JObject = __chain_wire6.into();
+    let __obj7 = jni::sys::jvalue {
+        j: __chain_wire7,
+    };
     match __CB_MID
         .call_object(
             &mut env,
@@ -17758,59 +17918,30 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_lookupOf<'a>(
     const __CB_FQN: &str = "io/prebindgen/covertest/model/LookupBuilderRaw";
     const __CB_DESCR: &str = "(IJLjava/lang/String;)Ljava/lang/Object;";
     let __out = perftest_flat::lookup_of(count, total);
-    let __obj0: jni::sys::jvalue;
-    let __obj1: jni::sys::jvalue;
-    let __obj2: jni::objects::JObject;
-    match &__out {
-        perftest_flat::Lookup::Absent => {
-            __obj0 = jni::sys::jvalue { i: 0 };
-            __obj1 = jni::sys::jvalue { j: 0i64 };
-            __obj2 = jni::objects::JObject::null();
-        }
-        perftest_flat::Lookup::Found(__sv0) => {
-            let __enc___obj1 = match Summary_to_jlong_3cb103b9(&mut env, __sv0.clone()) {
-                ::core::result::Result::Ok(__w) => __w,
-                ::core::result::Result::Err(__e) => {
-                    signal_binding_error(
-                        &mut env,
-                        &__error_sink,
-                        &__SINK_MID,
-                        __SINK_FQN,
-                        __SINK_DESCR,
-                        &__e.to_string(),
-                    );
-                    return jni::objects::JObject::null().into();
-                }
-            };
-            __obj1 = jni::sys::jvalue {
-                j: __enc___obj1,
-            };
-            __obj0 = jni::sys::jvalue { i: 1 };
-            __obj2 = jni::objects::JObject::null();
-        }
-        perftest_flat::Lookup::Failed(__sv0) => {
-            let __enc___obj2 = match String_to_JString_c7f3ca43(
+    let (__chain_wire0, (), (__chain_wire1,), (__chain_wire2,)) = match Lookup_to_tuple4_68d54df3(
+        &mut env,
+        __out,
+    ) {
+        ::core::result::Result::Ok(__intermediate) => __intermediate,
+        ::core::result::Result::Err(__chain_error) => {
+            signal_binding_error(
                 &mut env,
-                __sv0.clone(),
-            ) {
-                ::core::result::Result::Ok(__w) => __w,
-                ::core::result::Result::Err(__e) => {
-                    signal_binding_error(
-                        &mut env,
-                        &__error_sink,
-                        &__SINK_MID,
-                        __SINK_FQN,
-                        __SINK_DESCR,
-                        &__e.to_string(),
-                    );
-                    return jni::objects::JObject::null().into();
-                }
-            };
-            __obj2 = __enc___obj2.into();
-            __obj0 = jni::sys::jvalue { i: 2 };
-            __obj1 = jni::sys::jvalue { j: 0i64 };
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__chain_error.to_string(),
+            );
+            return jni::objects::JObject::null().into();
         }
-    }
+    };
+    let __obj0 = jni::sys::jvalue {
+        i: __chain_wire0,
+    };
+    let __obj1 = jni::sys::jvalue {
+        j: __chain_wire1,
+    };
+    let __obj2: jni::objects::JObject = __chain_wire2.into();
     match __CB_MID
         .call_object(
             &mut env,
@@ -17877,35 +18008,27 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_markerOf<'a>(
     const __CB_FQN: &str = "io/prebindgen/covertest/model/MarkerBuilder";
     const __CB_DESCR: &str = "(ILjava/lang/Integer;)Ljava/lang/Object;";
     let __out = perftest_flat::marker_of(which);
-    let __obj0: jni::sys::jvalue;
-    let __obj1: jni::objects::JObject;
-    match &__out {
-        perftest_flat::Marker::None_ => {
-            __obj0 = jni::sys::jvalue { i: 0 };
-            __obj1 = jni::objects::JObject::null();
-        }
-        perftest_flat::Marker::Ranked(__sv0) => {
-            let __enc___obj1 = match Option_Priority_to_JObject_ad5cbb32(
+    let (__chain_wire0, (), (__chain_wire1,)) = match Marker_to_tuple3_8b7f3646(
+        &mut env,
+        __out,
+    ) {
+        ::core::result::Result::Ok(__intermediate) => __intermediate,
+        ::core::result::Result::Err(__chain_error) => {
+            signal_binding_error(
                 &mut env,
-                __sv0.clone(),
-            ) {
-                ::core::result::Result::Ok(__w) => __w,
-                ::core::result::Result::Err(__e) => {
-                    signal_binding_error(
-                        &mut env,
-                        &__error_sink,
-                        &__SINK_MID,
-                        __SINK_FQN,
-                        __SINK_DESCR,
-                        &__e.to_string(),
-                    );
-                    return jni::objects::JObject::null().into();
-                }
-            };
-            __obj1 = __enc___obj1;
-            __obj0 = jni::sys::jvalue { i: 1 };
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__chain_error.to_string(),
+            );
+            return jni::objects::JObject::null().into();
         }
-    }
+    };
+    let __obj0 = jni::sys::jvalue {
+        i: __chain_wire0,
+    };
+    let __obj1: jni::objects::JObject = __chain_wire1;
     match __CB_MID
         .call_object(
             &mut env,
@@ -18252,318 +18375,45 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_observationWhich
     static __SINK_MID: ::prebindgen_jni_runtime::CachedIfaceMethod = ::prebindgen_jni_runtime::CachedIfaceMethod::new();
     const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
     const __SINK_DESCR: &str = "(Ljava/lang/String;)Ljava/lang/Object;";
-    let __flat_o_id = match jlong_to_i64_fbf9a9bc(&mut env, &o_id) {
-        ::core::result::Result::Ok(__v) => __v,
-        ::core::result::Result::Err(__e) => {
+    let o = match tuple4_to_Observation_438d4015(
+        &mut env,
+        (
+            o_id,
+            (
+                o_reading__tag,
+                (),
+                (o_reading_exact_v0,),
+                (o_reading_range_low, o_reading_range_high),
+                (o_reading_tagged_v0, o_reading_tagged_v1),
+                (o_reading_companion_v0,),
+            ),
+            (
+                o_fallback_present,
+                (
+                    o_fallback__tag,
+                    (),
+                    (o_fallback_exact_v0,),
+                    (o_fallback_range_low, o_fallback_range_high),
+                    (o_fallback_tagged_v0, o_fallback_tagged_v1),
+                    (o_fallback_companion_v0,),
+                ),
+            ),
+            o_note,
+        ),
+    ) {
+        ::core::result::Result::Ok(__value) => __value,
+        ::core::result::Result::Err(__error) => {
             signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                &__e.to_string(),
+                &__error.to_string(),
             );
             return 0 as jni::sys::jint;
         }
     };
-    let __flat_o_reading: perftest_flat::Reading = match o_reading__tag {
-        0 => perftest_flat::Reading::Missing,
-        1 => {
-            let __flat_o_reading_o_reading_exact_v0 = match jlong_to_i64_fbf9a9bc(
-                &mut env,
-                &o_reading_exact_v0,
-            ) {
-                ::core::result::Result::Ok(__v) => __v,
-                ::core::result::Result::Err(__e) => {
-                    signal_binding_error(
-                        &mut env,
-                        &__error_sink,
-                        &__SINK_MID,
-                        __SINK_FQN,
-                        __SINK_DESCR,
-                        &__e.to_string(),
-                    );
-                    return 0 as jni::sys::jint;
-                }
-            };
-            perftest_flat::Reading::Exact(__flat_o_reading_o_reading_exact_v0)
-        }
-        2 => {
-            let __flat_o_reading_o_reading_range_low = match jlong_to_i64_fbf9a9bc(
-                &mut env,
-                &o_reading_range_low,
-            ) {
-                ::core::result::Result::Ok(__v) => __v,
-                ::core::result::Result::Err(__e) => {
-                    signal_binding_error(
-                        &mut env,
-                        &__error_sink,
-                        &__SINK_MID,
-                        __SINK_FQN,
-                        __SINK_DESCR,
-                        &__e.to_string(),
-                    );
-                    return 0 as jni::sys::jint;
-                }
-            };
-            let __flat_o_reading_o_reading_range_high = match jlong_to_i64_fbf9a9bc(
-                &mut env,
-                &o_reading_range_high,
-            ) {
-                ::core::result::Result::Ok(__v) => __v,
-                ::core::result::Result::Err(__e) => {
-                    signal_binding_error(
-                        &mut env,
-                        &__error_sink,
-                        &__SINK_MID,
-                        __SINK_FQN,
-                        __SINK_DESCR,
-                        &__e.to_string(),
-                    );
-                    return 0 as jni::sys::jint;
-                }
-            };
-            perftest_flat::Reading::Range {
-                low: __flat_o_reading_o_reading_range_low,
-                high: __flat_o_reading_o_reading_range_high,
-            }
-        }
-        3 => {
-            let __flat_o_reading_o_reading_tagged_v0 = match JString_to_String_c7f3ca43(
-                &mut env,
-                &o_reading_tagged_v0,
-            ) {
-                ::core::result::Result::Ok(__v) => __v,
-                ::core::result::Result::Err(__e) => {
-                    signal_binding_error(
-                        &mut env,
-                        &__error_sink,
-                        &__SINK_MID,
-                        __SINK_FQN,
-                        __SINK_DESCR,
-                        &__e.to_string(),
-                    );
-                    return 0 as jni::sys::jint;
-                }
-            };
-            let __flat_o_reading_o_reading_tagged_v1 = match jint_to_Priority_447102d2(
-                &mut env,
-                &o_reading_tagged_v1,
-            ) {
-                ::core::result::Result::Ok(__v) => __v,
-                ::core::result::Result::Err(__e) => {
-                    signal_binding_error(
-                        &mut env,
-                        &__error_sink,
-                        &__SINK_MID,
-                        __SINK_FQN,
-                        __SINK_DESCR,
-                        &__e.to_string(),
-                    );
-                    return 0 as jni::sys::jint;
-                }
-            };
-            perftest_flat::Reading::Labeled(
-                __flat_o_reading_o_reading_tagged_v0,
-                __flat_o_reading_o_reading_tagged_v1,
-            )
-        }
-        4 => {
-            let __flat_o_reading_o_reading_companion_v0 = match jlong_to_i64_fbf9a9bc(
-                &mut env,
-                &o_reading_companion_v0,
-            ) {
-                ::core::result::Result::Ok(__v) => __v,
-                ::core::result::Result::Err(__e) => {
-                    signal_binding_error(
-                        &mut env,
-                        &__error_sink,
-                        &__SINK_MID,
-                        __SINK_FQN,
-                        __SINK_DESCR,
-                        &__e.to_string(),
-                    );
-                    return 0 as jni::sys::jint;
-                }
-            };
-            perftest_flat::Reading::Companion(__flat_o_reading_o_reading_companion_v0)
-        }
-        _ => {
-            signal_binding_error(
-                &mut env,
-                &__error_sink,
-                &__SINK_MID,
-                __SINK_FQN,
-                __SINK_DESCR,
-                "Reading: invalid tag",
-            );
-            return 0 as jni::sys::jint;
-        }
-    };
-    let __flat_o_fallback: Option<perftest_flat::Reading> = if o_fallback_present != 0u8
-    {
-        ::core::option::Option::Some(
-            match o_fallback__tag {
-                0 => perftest_flat::Reading::Missing,
-                1 => {
-                    let __flat_o_fallback_o_fallback_exact_v0 = match jlong_to_i64_fbf9a9bc(
-                        &mut env,
-                        &o_fallback_exact_v0,
-                    ) {
-                        ::core::result::Result::Ok(__v) => __v,
-                        ::core::result::Result::Err(__e) => {
-                            signal_binding_error(
-                                &mut env,
-                                &__error_sink,
-                                &__SINK_MID,
-                                __SINK_FQN,
-                                __SINK_DESCR,
-                                &__e.to_string(),
-                            );
-                            return 0 as jni::sys::jint;
-                        }
-                    };
-                    perftest_flat::Reading::Exact(__flat_o_fallback_o_fallback_exact_v0)
-                }
-                2 => {
-                    let __flat_o_fallback_o_fallback_range_low = match jlong_to_i64_fbf9a9bc(
-                        &mut env,
-                        &o_fallback_range_low,
-                    ) {
-                        ::core::result::Result::Ok(__v) => __v,
-                        ::core::result::Result::Err(__e) => {
-                            signal_binding_error(
-                                &mut env,
-                                &__error_sink,
-                                &__SINK_MID,
-                                __SINK_FQN,
-                                __SINK_DESCR,
-                                &__e.to_string(),
-                            );
-                            return 0 as jni::sys::jint;
-                        }
-                    };
-                    let __flat_o_fallback_o_fallback_range_high = match jlong_to_i64_fbf9a9bc(
-                        &mut env,
-                        &o_fallback_range_high,
-                    ) {
-                        ::core::result::Result::Ok(__v) => __v,
-                        ::core::result::Result::Err(__e) => {
-                            signal_binding_error(
-                                &mut env,
-                                &__error_sink,
-                                &__SINK_MID,
-                                __SINK_FQN,
-                                __SINK_DESCR,
-                                &__e.to_string(),
-                            );
-                            return 0 as jni::sys::jint;
-                        }
-                    };
-                    perftest_flat::Reading::Range {
-                        low: __flat_o_fallback_o_fallback_range_low,
-                        high: __flat_o_fallback_o_fallback_range_high,
-                    }
-                }
-                3 => {
-                    let __flat_o_fallback_o_fallback_tagged_v0 = match JString_to_String_c7f3ca43(
-                        &mut env,
-                        &o_fallback_tagged_v0,
-                    ) {
-                        ::core::result::Result::Ok(__v) => __v,
-                        ::core::result::Result::Err(__e) => {
-                            signal_binding_error(
-                                &mut env,
-                                &__error_sink,
-                                &__SINK_MID,
-                                __SINK_FQN,
-                                __SINK_DESCR,
-                                &__e.to_string(),
-                            );
-                            return 0 as jni::sys::jint;
-                        }
-                    };
-                    let __flat_o_fallback_o_fallback_tagged_v1 = match jint_to_Priority_447102d2(
-                        &mut env,
-                        &o_fallback_tagged_v1,
-                    ) {
-                        ::core::result::Result::Ok(__v) => __v,
-                        ::core::result::Result::Err(__e) => {
-                            signal_binding_error(
-                                &mut env,
-                                &__error_sink,
-                                &__SINK_MID,
-                                __SINK_FQN,
-                                __SINK_DESCR,
-                                &__e.to_string(),
-                            );
-                            return 0 as jni::sys::jint;
-                        }
-                    };
-                    perftest_flat::Reading::Labeled(
-                        __flat_o_fallback_o_fallback_tagged_v0,
-                        __flat_o_fallback_o_fallback_tagged_v1,
-                    )
-                }
-                4 => {
-                    let __flat_o_fallback_o_fallback_companion_v0 = match jlong_to_i64_fbf9a9bc(
-                        &mut env,
-                        &o_fallback_companion_v0,
-                    ) {
-                        ::core::result::Result::Ok(__v) => __v,
-                        ::core::result::Result::Err(__e) => {
-                            signal_binding_error(
-                                &mut env,
-                                &__error_sink,
-                                &__SINK_MID,
-                                __SINK_FQN,
-                                __SINK_DESCR,
-                                &__e.to_string(),
-                            );
-                            return 0 as jni::sys::jint;
-                        }
-                    };
-                    perftest_flat::Reading::Companion(
-                        __flat_o_fallback_o_fallback_companion_v0,
-                    )
-                }
-                _ => {
-                    signal_binding_error(
-                        &mut env,
-                        &__error_sink,
-                        &__SINK_MID,
-                        __SINK_FQN,
-                        __SINK_DESCR,
-                        "Reading: invalid tag",
-                    );
-                    return 0 as jni::sys::jint;
-                }
-            },
-        )
-    } else {
-        ::core::option::Option::None
-    };
-    let __flat_o_note = match JString_to_String_c7f3ca43(&mut env, &o_note) {
-        ::core::result::Result::Ok(__v) => __v,
-        ::core::result::Result::Err(__e) => {
-            signal_binding_error(
-                &mut env,
-                &__error_sink,
-                &__SINK_MID,
-                __SINK_FQN,
-                __SINK_DESCR,
-                &__e.to_string(),
-            );
-            return 0 as jni::sys::jint;
-        }
-    };
-    let __flat_o = perftest_flat::Observation {
-        id: __flat_o_id,
-        reading: __flat_o_reading,
-        fallback: __flat_o_fallback,
-        note: __flat_o_note,
-    };
-    let o = __flat_o;
     let __out = perftest_flat::observation_which(o);
     match i32_to_jint_a3e3b6ef(&mut env, __out) {
         ::core::result::Result::Ok(__w) => __w,
@@ -19539,172 +19389,46 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_readingMaybe<'a>
     let __out = perftest_flat::reading_maybe(which);
     match __out {
         ::core::option::Option::Some(__inner) => {
-            let __obj0: jni::sys::jvalue;
-            let __obj1: jni::sys::jvalue;
-            let __obj2: jni::sys::jvalue;
-            let __obj3: jni::sys::jvalue;
-            let __obj4: jni::objects::JObject;
-            let __obj5: jni::sys::jvalue;
-            let __obj6: jni::sys::jvalue;
-            match &__inner {
-                perftest_flat::Reading::Missing => {
-                    __obj0 = jni::sys::jvalue { i: 0 };
-                    __obj1 = jni::sys::jvalue { j: 0i64 };
-                    __obj2 = jni::sys::jvalue { j: 0i64 };
-                    __obj3 = jni::sys::jvalue { j: 0i64 };
-                    __obj4 = jni::objects::JObject::null();
-                    __obj5 = jni::sys::jvalue { i: 0i32 };
-                    __obj6 = jni::sys::jvalue { j: 0i64 };
+            let (
+                __chain_wire0,
+                (),
+                (__chain_wire1,),
+                (__chain_wire2, __chain_wire3),
+                (__chain_wire4, __chain_wire5),
+                (__chain_wire6,),
+            ) = match Reading_to_tuple6_69702d1f(&mut env, __inner) {
+                ::core::result::Result::Ok(__intermediate) => __intermediate,
+                ::core::result::Result::Err(__chain_error) => {
+                    signal_binding_error(
+                        &mut env,
+                        &__error_sink,
+                        &__SINK_MID,
+                        __SINK_FQN,
+                        __SINK_DESCR,
+                        &__chain_error.to_string(),
+                    );
+                    return jni::objects::JObject::null().into();
                 }
-                perftest_flat::Reading::Exact(__sv0) => {
-                    let __enc___obj1 = match i64_to_jlong_fbf9a9bc(
-                        &mut env,
-                        __sv0.clone(),
-                    ) {
-                        ::core::result::Result::Ok(__w) => __w,
-                        ::core::result::Result::Err(__e) => {
-                            signal_binding_error(
-                                &mut env,
-                                &__error_sink,
-                                &__SINK_MID,
-                                __SINK_FQN,
-                                __SINK_DESCR,
-                                &__e.to_string(),
-                            );
-                            return jni::objects::JObject::null().into();
-                        }
-                    };
-                    __obj1 = jni::sys::jvalue {
-                        j: __enc___obj1,
-                    };
-                    __obj0 = jni::sys::jvalue { i: 1 };
-                    __obj2 = jni::sys::jvalue { j: 0i64 };
-                    __obj3 = jni::sys::jvalue { j: 0i64 };
-                    __obj4 = jni::objects::JObject::null();
-                    __obj5 = jni::sys::jvalue { i: 0i32 };
-                    __obj6 = jni::sys::jvalue { j: 0i64 };
-                }
-                perftest_flat::Reading::Range { low: __sv0, high: __sv1 } => {
-                    let __enc___obj2 = match i64_to_jlong_fbf9a9bc(
-                        &mut env,
-                        __sv0.clone(),
-                    ) {
-                        ::core::result::Result::Ok(__w) => __w,
-                        ::core::result::Result::Err(__e) => {
-                            signal_binding_error(
-                                &mut env,
-                                &__error_sink,
-                                &__SINK_MID,
-                                __SINK_FQN,
-                                __SINK_DESCR,
-                                &__e.to_string(),
-                            );
-                            return jni::objects::JObject::null().into();
-                        }
-                    };
-                    __obj2 = jni::sys::jvalue {
-                        j: __enc___obj2,
-                    };
-                    let __enc___obj3 = match i64_to_jlong_fbf9a9bc(
-                        &mut env,
-                        __sv1.clone(),
-                    ) {
-                        ::core::result::Result::Ok(__w) => __w,
-                        ::core::result::Result::Err(__e) => {
-                            signal_binding_error(
-                                &mut env,
-                                &__error_sink,
-                                &__SINK_MID,
-                                __SINK_FQN,
-                                __SINK_DESCR,
-                                &__e.to_string(),
-                            );
-                            return jni::objects::JObject::null().into();
-                        }
-                    };
-                    __obj3 = jni::sys::jvalue {
-                        j: __enc___obj3,
-                    };
-                    __obj0 = jni::sys::jvalue { i: 2 };
-                    __obj1 = jni::sys::jvalue { j: 0i64 };
-                    __obj4 = jni::objects::JObject::null();
-                    __obj5 = jni::sys::jvalue { i: 0i32 };
-                    __obj6 = jni::sys::jvalue { j: 0i64 };
-                }
-                perftest_flat::Reading::Labeled(__sv0, __sv1) => {
-                    let __enc___obj4 = match String_to_JString_c7f3ca43(
-                        &mut env,
-                        __sv0.clone(),
-                    ) {
-                        ::core::result::Result::Ok(__w) => __w,
-                        ::core::result::Result::Err(__e) => {
-                            signal_binding_error(
-                                &mut env,
-                                &__error_sink,
-                                &__SINK_MID,
-                                __SINK_FQN,
-                                __SINK_DESCR,
-                                &__e.to_string(),
-                            );
-                            return jni::objects::JObject::null().into();
-                        }
-                    };
-                    __obj4 = __enc___obj4.into();
-                    let __enc___obj5 = match Priority_to_jint_447102d2(
-                        &mut env,
-                        __sv1.clone(),
-                    ) {
-                        ::core::result::Result::Ok(__w) => __w,
-                        ::core::result::Result::Err(__e) => {
-                            signal_binding_error(
-                                &mut env,
-                                &__error_sink,
-                                &__SINK_MID,
-                                __SINK_FQN,
-                                __SINK_DESCR,
-                                &__e.to_string(),
-                            );
-                            return jni::objects::JObject::null().into();
-                        }
-                    };
-                    __obj5 = jni::sys::jvalue {
-                        i: __enc___obj5,
-                    };
-                    __obj0 = jni::sys::jvalue { i: 3 };
-                    __obj1 = jni::sys::jvalue { j: 0i64 };
-                    __obj2 = jni::sys::jvalue { j: 0i64 };
-                    __obj3 = jni::sys::jvalue { j: 0i64 };
-                    __obj6 = jni::sys::jvalue { j: 0i64 };
-                }
-                perftest_flat::Reading::Companion(__sv0) => {
-                    let __enc___obj6 = match i64_to_jlong_fbf9a9bc(
-                        &mut env,
-                        __sv0.clone(),
-                    ) {
-                        ::core::result::Result::Ok(__w) => __w,
-                        ::core::result::Result::Err(__e) => {
-                            signal_binding_error(
-                                &mut env,
-                                &__error_sink,
-                                &__SINK_MID,
-                                __SINK_FQN,
-                                __SINK_DESCR,
-                                &__e.to_string(),
-                            );
-                            return jni::objects::JObject::null().into();
-                        }
-                    };
-                    __obj6 = jni::sys::jvalue {
-                        j: __enc___obj6,
-                    };
-                    __obj0 = jni::sys::jvalue { i: 4 };
-                    __obj1 = jni::sys::jvalue { j: 0i64 };
-                    __obj2 = jni::sys::jvalue { j: 0i64 };
-                    __obj3 = jni::sys::jvalue { j: 0i64 };
-                    __obj4 = jni::objects::JObject::null();
-                    __obj5 = jni::sys::jvalue { i: 0i32 };
-                }
-            }
+            };
+            let __obj0 = jni::sys::jvalue {
+                i: __chain_wire0,
+            };
+            let __obj1 = jni::sys::jvalue {
+                j: __chain_wire1,
+            };
+            let __obj2 = jni::sys::jvalue {
+                j: __chain_wire2,
+            };
+            let __obj3 = jni::sys::jvalue {
+                j: __chain_wire3,
+            };
+            let __obj4: jni::objects::JObject = __chain_wire4.into();
+            let __obj5 = jni::sys::jvalue {
+                i: __chain_wire5,
+            };
+            let __obj6 = jni::sys::jvalue {
+                j: __chain_wire6,
+            };
             match __CB_MID
                 .call_object(
                     &mut env,
@@ -19778,157 +19502,46 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_readingOf<'a>(
     const __CB_FQN: &str = "io/prebindgen/covertest/model/ReadingBuilder";
     const __CB_DESCR: &str = "(IJJJLjava/lang/String;IJ)Ljava/lang/Object;";
     let __out = perftest_flat::reading_of(which);
-    let __obj0: jni::sys::jvalue;
-    let __obj1: jni::sys::jvalue;
-    let __obj2: jni::sys::jvalue;
-    let __obj3: jni::sys::jvalue;
-    let __obj4: jni::objects::JObject;
-    let __obj5: jni::sys::jvalue;
-    let __obj6: jni::sys::jvalue;
-    match &__out {
-        perftest_flat::Reading::Missing => {
-            __obj0 = jni::sys::jvalue { i: 0 };
-            __obj1 = jni::sys::jvalue { j: 0i64 };
-            __obj2 = jni::sys::jvalue { j: 0i64 };
-            __obj3 = jni::sys::jvalue { j: 0i64 };
-            __obj4 = jni::objects::JObject::null();
-            __obj5 = jni::sys::jvalue { i: 0i32 };
-            __obj6 = jni::sys::jvalue { j: 0i64 };
-        }
-        perftest_flat::Reading::Exact(__sv0) => {
-            let __enc___obj1 = match i64_to_jlong_fbf9a9bc(&mut env, __sv0.clone()) {
-                ::core::result::Result::Ok(__w) => __w,
-                ::core::result::Result::Err(__e) => {
-                    signal_binding_error(
-                        &mut env,
-                        &__error_sink,
-                        &__SINK_MID,
-                        __SINK_FQN,
-                        __SINK_DESCR,
-                        &__e.to_string(),
-                    );
-                    return jni::objects::JObject::null().into();
-                }
-            };
-            __obj1 = jni::sys::jvalue {
-                j: __enc___obj1,
-            };
-            __obj0 = jni::sys::jvalue { i: 1 };
-            __obj2 = jni::sys::jvalue { j: 0i64 };
-            __obj3 = jni::sys::jvalue { j: 0i64 };
-            __obj4 = jni::objects::JObject::null();
-            __obj5 = jni::sys::jvalue { i: 0i32 };
-            __obj6 = jni::sys::jvalue { j: 0i64 };
-        }
-        perftest_flat::Reading::Range { low: __sv0, high: __sv1 } => {
-            let __enc___obj2 = match i64_to_jlong_fbf9a9bc(&mut env, __sv0.clone()) {
-                ::core::result::Result::Ok(__w) => __w,
-                ::core::result::Result::Err(__e) => {
-                    signal_binding_error(
-                        &mut env,
-                        &__error_sink,
-                        &__SINK_MID,
-                        __SINK_FQN,
-                        __SINK_DESCR,
-                        &__e.to_string(),
-                    );
-                    return jni::objects::JObject::null().into();
-                }
-            };
-            __obj2 = jni::sys::jvalue {
-                j: __enc___obj2,
-            };
-            let __enc___obj3 = match i64_to_jlong_fbf9a9bc(&mut env, __sv1.clone()) {
-                ::core::result::Result::Ok(__w) => __w,
-                ::core::result::Result::Err(__e) => {
-                    signal_binding_error(
-                        &mut env,
-                        &__error_sink,
-                        &__SINK_MID,
-                        __SINK_FQN,
-                        __SINK_DESCR,
-                        &__e.to_string(),
-                    );
-                    return jni::objects::JObject::null().into();
-                }
-            };
-            __obj3 = jni::sys::jvalue {
-                j: __enc___obj3,
-            };
-            __obj0 = jni::sys::jvalue { i: 2 };
-            __obj1 = jni::sys::jvalue { j: 0i64 };
-            __obj4 = jni::objects::JObject::null();
-            __obj5 = jni::sys::jvalue { i: 0i32 };
-            __obj6 = jni::sys::jvalue { j: 0i64 };
-        }
-        perftest_flat::Reading::Labeled(__sv0, __sv1) => {
-            let __enc___obj4 = match String_to_JString_c7f3ca43(
+    let (
+        __chain_wire0,
+        (),
+        (__chain_wire1,),
+        (__chain_wire2, __chain_wire3),
+        (__chain_wire4, __chain_wire5),
+        (__chain_wire6,),
+    ) = match Reading_to_tuple6_69702d1f(&mut env, __out) {
+        ::core::result::Result::Ok(__intermediate) => __intermediate,
+        ::core::result::Result::Err(__chain_error) => {
+            signal_binding_error(
                 &mut env,
-                __sv0.clone(),
-            ) {
-                ::core::result::Result::Ok(__w) => __w,
-                ::core::result::Result::Err(__e) => {
-                    signal_binding_error(
-                        &mut env,
-                        &__error_sink,
-                        &__SINK_MID,
-                        __SINK_FQN,
-                        __SINK_DESCR,
-                        &__e.to_string(),
-                    );
-                    return jni::objects::JObject::null().into();
-                }
-            };
-            __obj4 = __enc___obj4.into();
-            let __enc___obj5 = match Priority_to_jint_447102d2(&mut env, __sv1.clone()) {
-                ::core::result::Result::Ok(__w) => __w,
-                ::core::result::Result::Err(__e) => {
-                    signal_binding_error(
-                        &mut env,
-                        &__error_sink,
-                        &__SINK_MID,
-                        __SINK_FQN,
-                        __SINK_DESCR,
-                        &__e.to_string(),
-                    );
-                    return jni::objects::JObject::null().into();
-                }
-            };
-            __obj5 = jni::sys::jvalue {
-                i: __enc___obj5,
-            };
-            __obj0 = jni::sys::jvalue { i: 3 };
-            __obj1 = jni::sys::jvalue { j: 0i64 };
-            __obj2 = jni::sys::jvalue { j: 0i64 };
-            __obj3 = jni::sys::jvalue { j: 0i64 };
-            __obj6 = jni::sys::jvalue { j: 0i64 };
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__chain_error.to_string(),
+            );
+            return jni::objects::JObject::null().into();
         }
-        perftest_flat::Reading::Companion(__sv0) => {
-            let __enc___obj6 = match i64_to_jlong_fbf9a9bc(&mut env, __sv0.clone()) {
-                ::core::result::Result::Ok(__w) => __w,
-                ::core::result::Result::Err(__e) => {
-                    signal_binding_error(
-                        &mut env,
-                        &__error_sink,
-                        &__SINK_MID,
-                        __SINK_FQN,
-                        __SINK_DESCR,
-                        &__e.to_string(),
-                    );
-                    return jni::objects::JObject::null().into();
-                }
-            };
-            __obj6 = jni::sys::jvalue {
-                j: __enc___obj6,
-            };
-            __obj0 = jni::sys::jvalue { i: 4 };
-            __obj1 = jni::sys::jvalue { j: 0i64 };
-            __obj2 = jni::sys::jvalue { j: 0i64 };
-            __obj3 = jni::sys::jvalue { j: 0i64 };
-            __obj4 = jni::objects::JObject::null();
-            __obj5 = jni::sys::jvalue { i: 0i32 };
-        }
-    }
+    };
+    let __obj0 = jni::sys::jvalue {
+        i: __chain_wire0,
+    };
+    let __obj1 = jni::sys::jvalue {
+        j: __chain_wire1,
+    };
+    let __obj2 = jni::sys::jvalue {
+        j: __chain_wire2,
+    };
+    let __obj3 = jni::sys::jvalue {
+        j: __chain_wire3,
+    };
+    let __obj4: jni::objects::JObject = __chain_wire4.into();
+    let __obj5 = jni::sys::jvalue {
+        i: __chain_wire5,
+    };
+    let __obj6 = jni::sys::jvalue {
+        j: __chain_wire6,
+    };
     match __CB_MID
         .call_object(
             &mut env,
@@ -20002,160 +19615,46 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_readingSeries<'a
     let __vec = perftest_flat::reading_series(n);
     let mut __acc = __acc;
     for __elem in __vec.into_iter() {
-        let __obj0: jni::sys::jvalue;
-        let __obj1: jni::sys::jvalue;
-        let __obj2: jni::sys::jvalue;
-        let __obj3: jni::sys::jvalue;
-        let __obj4: jni::objects::JObject;
-        let __obj5: jni::sys::jvalue;
-        let __obj6: jni::sys::jvalue;
-        match &__elem {
-            perftest_flat::Reading::Missing => {
-                __obj0 = jni::sys::jvalue { i: 0 };
-                __obj1 = jni::sys::jvalue { j: 0i64 };
-                __obj2 = jni::sys::jvalue { j: 0i64 };
-                __obj3 = jni::sys::jvalue { j: 0i64 };
-                __obj4 = jni::objects::JObject::null();
-                __obj5 = jni::sys::jvalue { i: 0i32 };
-                __obj6 = jni::sys::jvalue { j: 0i64 };
-            }
-            perftest_flat::Reading::Exact(__sv0) => {
-                let __enc___obj1 = match i64_to_jlong_fbf9a9bc(&mut env, __sv0.clone()) {
-                    ::core::result::Result::Ok(__w) => __w,
-                    ::core::result::Result::Err(__e) => {
-                        signal_binding_error(
-                            &mut env,
-                            &__error_sink,
-                            &__SINK_MID,
-                            __SINK_FQN,
-                            __SINK_DESCR,
-                            &__e.to_string(),
-                        );
-                        return jni::objects::JObject::null().into();
-                    }
-                };
-                __obj1 = jni::sys::jvalue {
-                    j: __enc___obj1,
-                };
-                __obj0 = jni::sys::jvalue { i: 1 };
-                __obj2 = jni::sys::jvalue { j: 0i64 };
-                __obj3 = jni::sys::jvalue { j: 0i64 };
-                __obj4 = jni::objects::JObject::null();
-                __obj5 = jni::sys::jvalue { i: 0i32 };
-                __obj6 = jni::sys::jvalue { j: 0i64 };
-            }
-            perftest_flat::Reading::Range { low: __sv0, high: __sv1 } => {
-                let __enc___obj2 = match i64_to_jlong_fbf9a9bc(&mut env, __sv0.clone()) {
-                    ::core::result::Result::Ok(__w) => __w,
-                    ::core::result::Result::Err(__e) => {
-                        signal_binding_error(
-                            &mut env,
-                            &__error_sink,
-                            &__SINK_MID,
-                            __SINK_FQN,
-                            __SINK_DESCR,
-                            &__e.to_string(),
-                        );
-                        return jni::objects::JObject::null().into();
-                    }
-                };
-                __obj2 = jni::sys::jvalue {
-                    j: __enc___obj2,
-                };
-                let __enc___obj3 = match i64_to_jlong_fbf9a9bc(&mut env, __sv1.clone()) {
-                    ::core::result::Result::Ok(__w) => __w,
-                    ::core::result::Result::Err(__e) => {
-                        signal_binding_error(
-                            &mut env,
-                            &__error_sink,
-                            &__SINK_MID,
-                            __SINK_FQN,
-                            __SINK_DESCR,
-                            &__e.to_string(),
-                        );
-                        return jni::objects::JObject::null().into();
-                    }
-                };
-                __obj3 = jni::sys::jvalue {
-                    j: __enc___obj3,
-                };
-                __obj0 = jni::sys::jvalue { i: 2 };
-                __obj1 = jni::sys::jvalue { j: 0i64 };
-                __obj4 = jni::objects::JObject::null();
-                __obj5 = jni::sys::jvalue { i: 0i32 };
-                __obj6 = jni::sys::jvalue { j: 0i64 };
-            }
-            perftest_flat::Reading::Labeled(__sv0, __sv1) => {
-                let __enc___obj4 = match String_to_JString_c7f3ca43(
+        let (
+            __chain_wire0,
+            (),
+            (__chain_wire1,),
+            (__chain_wire2, __chain_wire3),
+            (__chain_wire4, __chain_wire5),
+            (__chain_wire6,),
+        ) = match Reading_to_tuple6_69702d1f(&mut env, __elem) {
+            ::core::result::Result::Ok(__intermediate) => __intermediate,
+            ::core::result::Result::Err(__chain_error) => {
+                signal_binding_error(
                     &mut env,
-                    __sv0.clone(),
-                ) {
-                    ::core::result::Result::Ok(__w) => __w,
-                    ::core::result::Result::Err(__e) => {
-                        signal_binding_error(
-                            &mut env,
-                            &__error_sink,
-                            &__SINK_MID,
-                            __SINK_FQN,
-                            __SINK_DESCR,
-                            &__e.to_string(),
-                        );
-                        return jni::objects::JObject::null().into();
-                    }
-                };
-                __obj4 = __enc___obj4.into();
-                let __enc___obj5 = match Priority_to_jint_447102d2(
-                    &mut env,
-                    __sv1.clone(),
-                ) {
-                    ::core::result::Result::Ok(__w) => __w,
-                    ::core::result::Result::Err(__e) => {
-                        signal_binding_error(
-                            &mut env,
-                            &__error_sink,
-                            &__SINK_MID,
-                            __SINK_FQN,
-                            __SINK_DESCR,
-                            &__e.to_string(),
-                        );
-                        return jni::objects::JObject::null().into();
-                    }
-                };
-                __obj5 = jni::sys::jvalue {
-                    i: __enc___obj5,
-                };
-                __obj0 = jni::sys::jvalue { i: 3 };
-                __obj1 = jni::sys::jvalue { j: 0i64 };
-                __obj2 = jni::sys::jvalue { j: 0i64 };
-                __obj3 = jni::sys::jvalue { j: 0i64 };
-                __obj6 = jni::sys::jvalue { j: 0i64 };
+                    &__error_sink,
+                    &__SINK_MID,
+                    __SINK_FQN,
+                    __SINK_DESCR,
+                    &__chain_error.to_string(),
+                );
+                return jni::objects::JObject::null().into();
             }
-            perftest_flat::Reading::Companion(__sv0) => {
-                let __enc___obj6 = match i64_to_jlong_fbf9a9bc(&mut env, __sv0.clone()) {
-                    ::core::result::Result::Ok(__w) => __w,
-                    ::core::result::Result::Err(__e) => {
-                        signal_binding_error(
-                            &mut env,
-                            &__error_sink,
-                            &__SINK_MID,
-                            __SINK_FQN,
-                            __SINK_DESCR,
-                            &__e.to_string(),
-                        );
-                        return jni::objects::JObject::null().into();
-                    }
-                };
-                __obj6 = jni::sys::jvalue {
-                    j: __enc___obj6,
-                };
-                __obj0 = jni::sys::jvalue { i: 4 };
-                __obj1 = jni::sys::jvalue { j: 0i64 };
-                __obj2 = jni::sys::jvalue { j: 0i64 };
-                __obj3 = jni::sys::jvalue { j: 0i64 };
-                __obj4 = jni::objects::JObject::null();
-                __obj5 = jni::sys::jvalue { i: 0i32 };
-            }
-        }
+        };
+        let __obj0 = jni::sys::jvalue {
+            i: __chain_wire0,
+        };
+        let __obj1 = jni::sys::jvalue {
+            j: __chain_wire1,
+        };
+        let __obj2 = jni::sys::jvalue {
+            j: __chain_wire2,
+        };
+        let __obj3 = jni::sys::jvalue {
+            j: __chain_wire3,
+        };
+        let __obj4: jni::objects::JObject = __chain_wire4.into();
+        let __obj5 = jni::sys::jvalue {
+            i: __chain_wire5,
+        };
+        let __obj6 = jni::sys::jvalue {
+            j: __chain_wire6,
+        };
         __acc = match __CB_MID
             .call_object(
                 &mut env,

--- a/prebindgen-flat/src/flat/element.rs
+++ b/prebindgen-flat/src/flat/element.rs
@@ -350,6 +350,18 @@ impl Variant {
     }
 }
 
+/// Delimiter form of one sum alternative.
+///
+/// This is source structure retained by Flat, not adapter rendering policy.
+/// Empty unit, tuple and struct alternatives have the same payload arity but
+/// require different construction and pattern syntax.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum AlternativeForm {
+    Unit,
+    Tuple,
+    Struct,
+}
+
 /// One alternative of a [`Variant`].
 #[derive(Clone, Debug)]
 pub struct Alternative {
@@ -371,6 +383,16 @@ pub struct Alternative {
 }
 
 impl Alternative {
+    /// Whether this alternative uses no delimiters, tuple parentheses or
+    /// struct braces in source Rust.
+    pub fn form(&self) -> AlternativeForm {
+        match &self.origin.as_syn().fields {
+            syn::Fields::Unit => AlternativeForm::Unit,
+            syn::Fields::Unnamed(_) => AlternativeForm::Tuple,
+            syn::Fields::Named(_) => AlternativeForm::Struct,
+        }
+    }
+
     /// True when this alternative carries no payload.
     ///
     /// The *group* question, not the syntax one: `B`, `B()` and `B {}` are all

--- a/prebindgen-flat/src/flat/mod.rs
+++ b/prebindgen-flat/src/flat/mod.rs
@@ -203,8 +203,8 @@ use self::{array_len::ConstIndex, ty::lower_type};
 pub use self::{
     array_len::{ArrayExtent, ArrayLenReason, ConstId, ExtentSource, UnsupportedArrayLen},
     element::{
-        Alternative, Constant, Element, Enum, EnumValue, Extern, Field, Function, Guard, Param,
-        Struct, Type, Unsupported, Variant,
+        Alternative, AlternativeForm, Constant, Element, Enum, EnumValue, Extern, Field, Function,
+        Guard, Param, Struct, Type, Unsupported, Variant,
     },
     key::{TypeKey, TypeKeyParseError},
     origin::Origin,

--- a/prebindgen-jni/src/jni/chain.rs
+++ b/prebindgen-jni/src/jni/chain.rs
@@ -19,6 +19,7 @@ enum JBody {
     Complete(Box<syn::ItemFn>),
     OwnedHandle(Box<JOwnedHandlePlan>),
     Product(Box<JProductPlan>),
+    Choice(Box<JChoicePlan>),
     Optional(Box<JOptionalPlan>),
 }
 
@@ -39,11 +40,21 @@ impl JFunction {
         Self(JBody::Optional(Box::new(plan)))
     }
 
+    pub(crate) fn choice(plan: JChoicePlan) -> Self {
+        Self(JBody::Choice(Box::new(plan)))
+    }
+
     pub(crate) fn mark_reachable(&self) {
         match &self.0 {
             JBody::Complete(_) => {}
             JBody::OwnedHandle(plan) => plan.reachable.set(true),
             JBody::Product(plan) => {
+                plan.reachable.set(true);
+                for dependency in &plan.dependencies {
+                    dependency.mark_reachable();
+                }
+            }
+            JBody::Choice(plan) => {
                 plan.reachable.set(true);
                 for dependency in &plan.dependencies {
                     dependency.mark_reachable();
@@ -66,6 +77,7 @@ impl RustFunction for JFunction {
             JBody::OwnedHandle(plan) => plan.reachable.get(),
             JBody::Product(plan) => plan.reachable.get(),
             JBody::Optional(plan) => plan.reachable.get(),
+            JBody::Choice(plan) => plan.reachable.get(),
         }
     }
 
@@ -75,6 +87,7 @@ impl RustFunction for JFunction {
             JBody::OwnedHandle(plan) => plan.render(emit),
             JBody::Product(plan) => plan.render(emit),
             JBody::Optional(plan) => plan.render(emit),
+            JBody::Choice(plan) => plan.render(emit),
         }
     }
 }
@@ -333,6 +346,55 @@ impl JProductPlan {
             }
             Direction::Deconstruct => {
                 let intermediate = annotate_jobject_with_lifetime(intermediate, "a");
+                let input = match self.mode {
+                    Mode::Owned => quote!(v: #source),
+                    Mode::Shared => quote!(v: &#source),
+                    Mode::Exclusive => quote!(v: &mut #source),
+                };
+                syn::parse_quote!(
+                    #allow
+                    #[inline(always)]
+                    pub(crate) unsafe fn #name<'a>(
+                        env: &mut jni::JNIEnv<'a>,
+                        #input,
+                    ) -> ::core::result::Result<#intermediate, __JniErr> {
+                        ::core::result::Result::Ok(#body)
+                    }
+                )
+            }
+        }
+    }
+}
+
+#[derive(Clone)]
+pub(crate) struct JChoicePlan {
+    pub(crate) ident: syn::Ident,
+    pub(crate) reachable: std::rc::Rc<std::cell::Cell<bool>>,
+    pub(crate) dependencies: Vec<JFunction>,
+    pub(crate) mode: Mode,
+    pub(crate) chain: shared::Choice<JSource, shared::TupleChoice, shared::TupleProduct, JChild>,
+}
+
+impl JChoicePlan {
+    fn render(&self, emit: &Emit) -> syn::ItemFn {
+        let rendered = self.chain.render(emit);
+        let name = &self.ident;
+        let source = &rendered.source;
+        let intermediate = annotate_jobject_with_lifetime(&rendered.intermediate, "a");
+        let body = &rendered.body;
+        let allow = crate::jni::trait_impl::generated_converter_attr();
+        match self.chain.direction {
+            Direction::Construct => syn::parse_quote!(
+                #allow
+                #[inline(always)]
+                pub(crate) unsafe fn #name<'env, 'a>(
+                    env: &mut jni::JNIEnv<'env>,
+                    v: #intermediate,
+                ) -> ::core::result::Result<#source, __JniErr> {
+                    ::core::result::Result::Ok(#body)
+                }
+            ),
+            Direction::Deconstruct => {
                 let input = match self.mode {
                     Mode::Owned => quote!(v: #source),
                     Mode::Shared => quote!(v: &#source),

--- a/prebindgen-jni/src/jni/compile.rs
+++ b/prebindgen-jni/src/jni/compile.rs
@@ -77,6 +77,8 @@ pub(crate) struct JFrag {
     pub(crate) yields: Yield,
     /// Shape of the single adapter-side intermediate over flattened ABI leaves.
     pub(crate) layout: Option<JLayout>,
+    /// Payload composition retained until `choice` supplies the variant.
+    choice_arm: Option<JChoiceArmPlan>,
     /// Composed element retained by a containing sequence for callback folding.
     pub(crate) nested_chain: Option<ComposedChain>,
     /// The wire values this crossing occupies, when it occupies more than the
@@ -118,6 +120,7 @@ pub(crate) enum JLayout {
     Leaf,
     Product(Vec<JLayout>),
     Optional(Box<JLayout>),
+    Choice(Vec<JLayout>),
 }
 
 impl JLayout {
@@ -126,6 +129,7 @@ impl JLayout {
             Self::Leaf => 1,
             Self::Product(parts) => parts.iter().map(Self::leaf_count).sum(),
             Self::Optional(inner) => 1 + inner.leaf_count(),
+            Self::Choice(arms) => 1 + arms.iter().map(Self::leaf_count).sum::<usize>(),
         }
     }
 
@@ -146,6 +150,11 @@ impl JLayout {
                     let value = build(inner, leaves, next);
                     quote!((#present, #value))
                 }
+                JLayout::Choice(arms) => {
+                    let tag = build(&JLayout::Leaf, leaves, next);
+                    let arms = arms.iter().map(|arm| build(arm, leaves, next));
+                    quote!((#tag, #(#arms,)*))
+                }
             }
         }
         assert_eq!(self.leaf_count(), leaves.len());
@@ -153,12 +162,20 @@ impl JLayout {
     }
 
     pub(crate) fn is_composed(&self) -> bool {
-        matches!(self, Self::Product(_) | Self::Optional(_))
+        matches!(self, Self::Product(_) | Self::Optional(_) | Self::Choice(_))
     }
 
     pub(crate) fn pattern(&self, leaves: &[syn::Ident]) -> TokenStream {
         self.expression(leaves)
     }
+}
+
+#[derive(Clone)]
+struct JChoiceArmPlan {
+    dependencies: Vec<crate::jni::chain::JFunction>,
+    bridge: prebindgen_registry::chain::TupleProduct,
+    parts: Vec<prebindgen_registry::chain::ChoicePart<crate::jni::chain::JChild>>,
+    layout: JLayout,
 }
 
 /// One step of the walk from the object a site names to a wire's value.
@@ -524,6 +541,7 @@ impl JFrag {
             conv,
             rust,
             layout: Some(JLayout::Leaf),
+            choice_arm: None,
             nested_chain: None,
             wires: None,
             out_wires: None,
@@ -542,6 +560,7 @@ impl JFrag {
         Self {
             conv,
             rust,
+            choice_arm: None,
             layout: Some(JLayout::Leaf),
             nested_chain: None,
             wires: None,
@@ -791,6 +810,7 @@ impl<R: Conversions> JCompile<'_, R> {
                 metadata: self.decls.opaque_leaf_meta(source.key()),
                 subs: Vec::new(),
             },
+            choice_arm: None,
             rust,
             layout: Some(JLayout::Leaf),
             nested_chain: None,
@@ -803,6 +823,45 @@ impl<R: Conversions> JCompile<'_, R> {
                 validity: Validity::SelfSufficient,
             },
         })
+    }
+    fn planned_child(
+        direction: Direction,
+        part: &Part<'_>,
+        frag: &JFrag,
+    ) -> crate::jni::chain::JChild {
+        let stages = match direction {
+            Direction::Construct => frag
+                .conv
+                .input_stage_order()
+                .map(|(_, stage)| stage.function.sig.ident.clone())
+                .collect(),
+            Direction::Deconstruct => frag
+                .conv
+                .output_stage_order()
+                .map(|(_, stage)| stage.function.sig.ident.clone())
+                .collect(),
+        };
+        match direction {
+            Direction::Construct => crate::jni::chain::JChild::input(
+                frag.conv.converter_ident().clone(),
+                stages,
+                if matches!(frag.conv.destination, syn::Type::Ptr(_))
+                    || frag.layout.as_ref().is_some_and(JLayout::is_composed)
+                {
+                    crate::jni::chain::JValueUse::Direct
+                } else {
+                    crate::jni::chain::JValueUse::SharedRef
+                },
+            ),
+            Direction::Deconstruct => crate::jni::chain::JChild::output(
+                frag.conv.converter_ident().clone(),
+                stages,
+                match part.mode {
+                    Mode::Owned => crate::jni::chain::JValueUse::Direct,
+                    Mode::Shared | Mode::Exclusive => crate::jni::chain::JValueUse::Cloned,
+                },
+            ),
+        }
     }
 
     /// Describe a Product as one tuple intermediate. The registry owns the
@@ -850,39 +909,7 @@ impl<R: Conversions> JCompile<'_, R> {
         let children = parts
             .iter()
             .map(|(part, frag)| {
-                let stages = match direction {
-                    Direction::Construct => frag
-                        .conv
-                        .input_stage_order()
-                        .map(|(_, stage)| stage.function.sig.ident.clone())
-                        .collect(),
-                    Direction::Deconstruct => frag
-                        .conv
-                        .output_stage_order()
-                        .map(|(_, stage)| stage.function.sig.ident.clone())
-                        .collect(),
-                };
-                let child = match direction {
-                    Direction::Construct => crate::jni::chain::JChild::input(
-                        frag.conv.converter_ident().clone(),
-                        stages,
-                        if matches!(frag.conv.destination, syn::Type::Ptr(_))
-                            || frag.layout.as_ref().is_some_and(JLayout::is_composed)
-                        {
-                            crate::jni::chain::JValueUse::Direct
-                        } else {
-                            crate::jni::chain::JValueUse::SharedRef
-                        },
-                    ),
-                    Direction::Deconstruct => crate::jni::chain::JChild::output(
-                        frag.conv.converter_ident().clone(),
-                        stages,
-                        match part.mode {
-                            Mode::Owned => crate::jni::chain::JValueUse::Direct,
-                            Mode::Shared | Mode::Exclusive => crate::jni::chain::JValueUse::Cloned,
-                        },
-                    ),
-                };
+                let child = Self::planned_child(direction, part, frag);
                 prebindgen_registry::chain::ProductPart {
                     name: format_ident!("{}", part.name),
                     child,
@@ -921,9 +948,167 @@ impl<R: Conversions> JCompile<'_, R> {
             },
             rust,
             layout: Some(JLayout::Product(layouts)),
+            choice_arm: None,
             nested_chain: None,
             wires: None,
             out_wires: None,
+            composed_only: false,
+            yields: Yield {
+                ty: at.crossing.value().stripped_key(),
+                mode: at.crossing.mode(),
+                validity: Validity::SelfSufficient,
+            },
+        })
+    }
+
+    /// Retain one sum arm's child chains until `choice` supplies its variant
+    /// and tag. The current sealed-class ABI gives each payload field one slot,
+    /// so composed child layouts remain a later stage.
+    fn planned_choice_arm(&self, at: At<'_>, parts: Parts<'_, Self>) -> Option<JChoiceArmPlan> {
+        if parts.iter().any(|(_, frag)| frag.composed_only) {
+            return None;
+        }
+        let layouts = parts
+            .iter()
+            .map(|(_, frag)| frag.layout.clone())
+            .collect::<Option<Vec<_>>>()?;
+        if layouts
+            .iter()
+            .any(|layout| !matches!(layout, JLayout::Leaf))
+        {
+            return None;
+        }
+        let direction = at.crossing.direction();
+        let intermediate_parts: Vec<syn::Type> = parts
+            .iter()
+            .map(|(_, frag)| frag.conv.destination.clone())
+            .collect();
+        let dependencies = parts
+            .iter()
+            .map(|(_, fragment)| fragment.rust.clone())
+            .collect();
+        let children = parts
+            .iter()
+            .map(|(part, frag)| {
+                let child = Self::planned_child(direction, part, frag);
+                Some(prebindgen_registry::chain::ChoicePart {
+                    member: part_member(part)?,
+                    child,
+                    mode: part.mode,
+                })
+            })
+            .collect::<Option<Vec<_>>>()?;
+        Some(JChoiceArmPlan {
+            dependencies,
+            bridge: prebindgen_registry::chain::TupleProduct {
+                parts: intermediate_parts,
+            },
+            parts: children,
+            layout: JLayout::Product(layouts),
+        })
+    }
+
+    /// Finish the arm plans the registry handed to `choice` as one tuple
+    /// intermediate. The plan keeps only Flat identities and adapter
+    /// representation data; the source enum is spelled by the final renderer.
+    fn planned_choice(
+        &self,
+        at: At<'_>,
+        arms: &[(&Alternative, &JFrag)],
+        wires: Option<Vec<Wire>>,
+        out_wires: Option<Vec<OutWire>>,
+    ) -> Option<JFrag> {
+        let planned = arms
+            .iter()
+            .map(|(alternative, fragment)| Some((*alternative, fragment.choice_arm.clone()?)))
+            .collect::<Option<Vec<_>>>()?;
+        let source = at.crossing.value();
+        let TypeKind::Named { id, .. } = source.unwrapped().kind() else {
+            return None;
+        };
+        let source_ident = id.ident()?;
+        let source_module = self.decls.fn_module(self.registry, &source_ident);
+        let direction = at.crossing.direction();
+        let arm_types: Vec<syn::Type> = planned
+            .iter()
+            .map(|(_, arm)| {
+                let parts = &arm.bridge.parts;
+                syn::parse_quote!((#(#parts,)*))
+            })
+            .collect();
+        let destination: syn::Type = {
+            let arms = &arm_types;
+            syn::parse_quote!((jni::sys::jint, #(#arms,)*))
+        };
+        let tags: Vec<syn::Expr> = planned
+            .iter()
+            .map(|(alternative, _)| {
+                let tag = crate::jni::struct_plan::sum_tag(alternative);
+                syn::parse_quote!(#tag)
+            })
+            .collect();
+        let inactive = arm_types.iter().map(Self::inactive_intermediate).collect();
+        let source_name = source_ident.to_string();
+        let invalid = quote!(<__JniErr as ::core::convert::From<String>>::from(format!(
+            concat!(#source_name, ": invalid tag")
+        )));
+        let choice_arms = planned
+            .iter()
+            .map(|(alternative, arm)| {
+                let tag = crate::jni::struct_plan::sum_tag(alternative);
+                prebindgen_registry::chain::ChoiceArm {
+                    variant: alternative.name.clone(),
+                    form: alternative.form(),
+                    tag: syn::parse_quote!(#tag),
+                    bridge: arm.bridge.clone(),
+                    parts: arm.parts.clone(),
+                }
+            })
+            .collect();
+        let dependencies = planned
+            .iter()
+            .flat_map(|(_, arm)| arm.dependencies.iter().cloned())
+            .collect();
+        let layouts = planned.iter().map(|(_, arm)| arm.layout.clone()).collect();
+        let ident = crate::jni::chain::planned_name(direction, at.crossing.spelled(), &destination);
+        let marker = crate::jni::chain::planned_marker(&ident);
+        let rust = crate::jni::chain::JFunction::choice(crate::jni::chain::JChoicePlan {
+            ident,
+            reachable: std::rc::Rc::new(std::cell::Cell::new(false)),
+            dependencies,
+            mode: at.crossing.mode(),
+            chain: prebindgen_registry::chain::Choice {
+                source: source.clone(),
+                direction,
+                source_policy: crate::jni::chain::JSource {
+                    wrappers: source.erased_wrappers(),
+                    module: Some(source_module),
+                },
+                bridge: prebindgen_registry::chain::TupleChoice {
+                    tag: syn::parse_quote!(jni::sys::jint),
+                    arms: arm_types,
+                    tags,
+                    inactive,
+                    invalid,
+                },
+                arms: choice_arms,
+            },
+        });
+        Some(JFrag {
+            conv: ConverterImpl {
+                destination,
+                function: marker,
+                pre_stages: Vec::new(),
+                niches: Niches::empty(),
+                metadata: KotlinMeta::default(),
+                subs: parts_subs(arms),
+            },
+            rust,
+            layout: Some(JLayout::Choice(layouts)),
+            choice_arm: None,
+            nested_chain: None,
+            wires,
+            out_wires,
             composed_only: false,
             yields: Yield {
                 ty: at.crossing.value().stripped_key(),
@@ -1185,6 +1370,7 @@ impl<R: Conversions> JCompile<'_, R> {
             },
             rust,
             layout: Some(layout),
+            choice_arm: None,
             nested_chain: None,
             wires: None,
             out_wires,
@@ -1367,16 +1553,23 @@ impl<R: Conversions> Compile for JCompile<'_, R> {
         // to `choice`. Which alternative that is stays `choice`'s to fill in,
         // being the only hook told — so both directions leave a hole here.
         let sum = self.is_sum(cx, at);
-        if at.crossing.direction() != Direction::Construct {
-            return match sum {
-                true => Ok(self.out_arm(at, parts)),
-                false => Ok(self.out_product(at, parts)),
-            };
-        }
         if sum {
-            // Its parts are read off a cast rather than off the value, so they
-            // take the slot form.
-            return Ok(self.arm(at, parts));
+            let direction = at.crossing.direction();
+            let mut frag = match direction {
+                Direction::Construct => self.arm(at, parts),
+                Direction::Deconstruct => self.out_arm(at, parts),
+            };
+            let represented = match direction {
+                Direction::Construct => frag.wires.is_some(),
+                Direction::Deconstruct => frag.out_wires.is_some(),
+            };
+            if represented {
+                frag.choice_arm = self.planned_choice_arm(at, parts);
+            }
+            return Ok(frag);
+        }
+        if at.crossing.direction() == Direction::Deconstruct {
+            return Ok(self.out_product(at, parts));
         }
         // A `data_class` crosses as its fields, and a field that is itself one
         // contributes its own several — which is the recursion, stated once
@@ -1452,31 +1645,34 @@ impl<R: Conversions> Compile for JCompile<'_, R> {
         at: At<'_>,
         arms: &[(&Alternative, &JFrag)],
     ) -> Frag<Self> {
-        if at.crossing.direction() != Direction::Construct {
-            return self.selected_out(at, arms);
-        }
-        // Which alternative is live crosses as its own `jint`, and every
-        // alternative's slots cross on every call — the inert ones carrying the
-        // literal their wire takes when the cast finds nothing. The N-way form
-        // of the presence flag an optional already uses.
-        match self.selected(at, arms) {
-            Some(wires) => {
-                let mut frag = JFrag::new(at, self.parts_marker(parts_subs(arms)));
-                frag.wires = Some(wires);
-                frag.composed_only = true;
-                Ok(frag)
-            }
-            // A payload this adapter has no slot for — a nested object, a
-            // handle — leaves the whole sum object-shaped, which is the recipe it
-            // already had. Stated as a fragment with no wires rather than as a
-            // refusal: the site that asked composes it as one value, exactly as
-            // it did before a `parts` recipe existed.
-            None => {
-                let conv = self
-                    .decls
-                    .in_frag(at.crossing.spelled())
-                    .ok_or_else(|| refuse(at, "no JNI representation for this sum"))?;
-                Ok(JFrag::new(at, (*conv).clone()))
+        match at.crossing.direction() {
+            Direction::Construct => match self.selected(at, arms) {
+                Some(wires) => {
+                    if let Some(planned) = self.planned_choice(at, arms, Some(wires.clone()), None)
+                    {
+                        return Ok(planned);
+                    }
+                    let mut legacy = JFrag::new(at, self.parts_marker(parts_subs(arms)));
+                    legacy.wires = Some(wires);
+                    legacy.composed_only = true;
+                    Ok(legacy)
+                }
+                // A payload this adapter has no slot for — a nested object or
+                // handle — keeps the explicit whole-value sealed-class decoder.
+                None => {
+                    let conv = self
+                        .decls
+                        .in_frag(at.crossing.spelled())
+                        .ok_or_else(|| refuse(at, "no JNI representation for this sum"))?;
+                    Ok(JFrag::new(at, (*conv).clone()))
+                }
+            },
+            Direction::Deconstruct => {
+                let legacy = self.selected_out(at, arms)?;
+                let out_wires = legacy.out_wires.clone();
+                Ok(self
+                    .planned_choice(at, arms, None, out_wires)
+                    .unwrap_or(legacy))
             }
         }
     }

--- a/prebindgen-jni/src/jni/emit/delivery.rs
+++ b/prebindgen-jni/src/jni/emit/delivery.rs
@@ -971,9 +971,9 @@ pub(crate) fn encode_plan_leaves(
         }
     }
 
-    // A synthesized data-class decomposition is exactly the Product recipe.
-    // Invoke that converter once, then adapt its intermediate leaves to the
-    // JNI call ABI. Callback and ordinary output delivery therefore share the
+    // A fixed decomposition has one Product, Optional or Choice intermediate.
+    // Invoke its converter once, then adapt the intermediate leaves to the JNI
+    // call ABI. Callback and ordinary output delivery therefore share the
     // same Rust-value walk; only the final delivery remains JNI-specific.
     if fixed_product && hoists.is_empty() {
         let crossing = if by_ref {
@@ -1020,9 +1020,15 @@ pub(crate) fn encode_plan_leaves(
             for (index, leaf) in wires.iter().enumerate() {
                 let encoded = &encoded[index];
                 let object = &obj_idents[index];
+                if leaf.is_tag() {
+                    stmts.extend(quote! {
+                        let #object = jni::sys::jvalue { i: #encoded };
+                    });
+                    continue;
+                }
                 let out_entry = ext.out_frag(&leaf.out_ty).unwrap_or_else(|| {
                     panic!(
-                        "jnigen Product leaf `{}` has no registered output converter",
+                        "jnigen composed leaf `{}` has no registered output converter",
                         leaf.out_ty.key()
                     )
                 });

--- a/prebindgen-jni/src/jni/tests/flatten.rs
+++ b/prebindgen-jni/src/jni/tests/flatten.rs
@@ -2392,6 +2392,23 @@ fn a_sealed_class_field_crosses_as_a_tag_and_every_arm_s_slots() {
             "oFallbackTaggedV1: Int = (o.fallback as? io.test.jni.Reading.Tagged)?.v1?.value ?: 0",
         ],
     );
+
+    let dir = unique_test_dir("sealed_choice_input_chain");
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    let rust = std::fs::read_to_string(gen.write_rust(dir.join("g.rs")).expect("write Rust"))
+        .expect("read Rust");
+    let rc: String = rust.split_whitespace().collect();
+    assert!(
+        rc.contains("reading:tuple5_to_Reading_")
+            && rc.contains("fallback:tuple2_to_Option_Reading_")
+            && rc.contains("::core::option::Option::Some(tuple5_to_Reading_"),
+        "Product and Optional parents must delegate the sum walk to the Choice converter:\n{rust}"
+    );
+    assert!(
+        !rc.contains("matcho_reading__tag"),
+        "the exported wrapper must not reconstruct the sum inline:\n{rust}"
+    );
 }
 
 /// Every spelling the walk flattens states the same recipe.

--- a/prebindgen-jni/src/jni/tests/sealed.rs
+++ b/prebindgen-jni/src/jni/tests/sealed.rs
@@ -1121,19 +1121,17 @@ fn sum_from_parts_stays_the_property_typed_convenience() {
     );
 }
 
-/// The Rust side emits ONE `match` over the returned value: the live arm
-/// converts its own group's payloads and every other slot takes the wire
-/// default. No leaf is an independent expression — that is what a product
-/// decomposition does, and a sum is not one.
+/// The registry-composed Choice converter emits one `match` over the returned
+/// value: the live arm invokes its child chains and every other arm
+/// intermediate takes the adapter's inactive value. The exported wrapper calls
+/// that converter instead of reconstructing the sum walk itself.
 #[test]
 fn sum_return_emits_one_match_with_wire_defaults() {
     let (rust, _) = sum_returns("jnigen_sum_match");
-    let at = rust
-        .find("fn Java_io_test_jni_JNINative_readOne")
-        .expect("extern");
-    let body = &rust[at..at + 4000];
+    let at = rust.find("fn Reading_to_tuple").expect("Choice converter");
+    let body = &rust[at..(at + 5000).min(rust.len())];
     assert!(
-        body.contains("match &__out"),
+        body.contains("match v"),
         "one match over the value:\n{body}"
     );
     assert!(
@@ -1141,10 +1139,18 @@ fn sum_return_emits_one_match_with_wire_defaults() {
             && body.contains("myflat::Reading::Range { low"),
         "arms bind each variant's payload by pattern:\n{body}"
     );
-    // The payload-less arm assigns the tag and defaults every group slot.
     assert!(
         body.contains("jni :: objects :: JObject :: null ()") || body.contains("JObject::null()"),
-        "an inert object slot is wire-defaulted to null:\n{body}"
+        "an inactive object arm is wire-defaulted to null:\n{body}"
+    );
+
+    let wrapper_at = rust
+        .find("fn Java_io_test_jni_JNINative_readOne")
+        .expect("extern");
+    let wrapper = &rust[wrapper_at..];
+    assert!(
+        wrapper.contains("Reading_to_tuple"),
+        "the wrapper delegates to the Choice converter:\n{wrapper}"
     );
 }
 

--- a/prebindgen-registry/src/chain.rs
+++ b/prebindgen-registry/src/chain.rs
@@ -8,7 +8,7 @@
 use proc_macro2::TokenStream;
 
 use crate::{
-    flat::TypeRef,
+    flat::{AlternativeForm, TypeRef},
     recipe::{Direction, Mode},
     Emit,
 };
@@ -224,6 +224,120 @@ pub struct Optional<S, B, C> {
     pub child: C,
 }
 
+/// One source field inside one [`Choice`] arm.
+#[derive(Clone)]
+pub struct ChoicePart<C> {
+    /// Named or positional Rust member, taken from the Flat model.
+    pub member: syn::Member,
+    /// Child converter selected by the recipe driver.
+    pub child: C,
+    /// How the part is reached through its containing source value.
+    pub mode: Mode,
+}
+
+/// One already-composed arm of a [`Choice`] recipe.
+#[derive(Clone)]
+pub struct ChoiceArm<B, C> {
+    /// Rust variant name, taken from the Flat model.
+    pub variant: syn::Ident,
+    /// Unit, tuple or struct delimiter form, taken from Flat.
+    pub form: AlternativeForm,
+    /// Adapter tag pattern selecting this arm.
+    pub tag: syn::Pat,
+    /// Product representation of this arm's intermediate parts.
+    pub bridge: B,
+    /// Ordered payload parts and their resolved child chains.
+    pub parts: Vec<ChoicePart<C>>,
+}
+
+/// Adapter-selected representation protocol for one Choice shape.
+pub trait ChoiceBridge: Clone {
+    /// The one intermediate Rust type assigned to the Choice fragment.
+    fn intermediate(&self) -> syn::Type;
+
+    /// Read the selector from an inbound intermediate value.
+    fn tag(&self, value: TokenStream) -> TokenStream;
+
+    /// Read one arm's Product intermediate from an inbound value.
+    fn arm(&self, value: TokenStream, index: usize) -> TokenStream;
+
+    /// Construct the outbound Choice intermediate with `active` selected.
+    ///
+    /// Inactive arm storage is representation policy. Implementations must not
+    /// manufacture source or child-intermediate values merely to fill it.
+    fn build(&self, active: usize, value: TokenStream) -> TokenStream;
+
+    /// Error returned when an inbound selector names no arm.
+    fn invalid_tag(&self) -> TokenStream;
+}
+
+/// Registry-owned tuple representation for Choice intermediates.
+///
+/// Position zero is the selector. Every remaining position holds one arm's
+/// Product intermediate. Inactive values are adapter-provided ABI-safe storage,
+/// not values of the source type.
+#[derive(Clone)]
+pub struct TupleChoice {
+    /// Selector type.
+    pub tag: syn::Type,
+    /// One Product intermediate type per arm.
+    pub arms: Vec<syn::Type>,
+    /// Selector value emitted for each arm.
+    pub tags: Vec<syn::Expr>,
+    /// ABI-safe inactive storage for each arm.
+    pub inactive: Vec<TokenStream>,
+    /// Adapter error expression for an invalid inbound selector.
+    pub invalid: TokenStream,
+}
+
+impl ChoiceBridge for TupleChoice {
+    fn intermediate(&self) -> syn::Type {
+        let tag = &self.tag;
+        let arms = &self.arms;
+        syn::parse_quote!((#tag, #(#arms,)*))
+    }
+
+    fn tag(&self, value: TokenStream) -> TokenStream {
+        quote::quote!((#value).0)
+    }
+
+    fn arm(&self, value: TokenStream, index: usize) -> TokenStream {
+        let index = syn::Index::from(index + 1);
+        quote::quote!((#value).#index)
+    }
+
+    fn build(&self, active: usize, value: TokenStream) -> TokenStream {
+        let tag = &self.tags[active];
+        let arms = self.inactive.iter().enumerate().map(|(index, inactive)| {
+            if index == active {
+                value.clone()
+            } else {
+                inactive.clone()
+            }
+        });
+        quote::quote!((#tag, #(#arms,)*))
+    }
+
+    fn invalid_tag(&self) -> TokenStream {
+        self.invalid.clone()
+    }
+}
+
+/// Registry-composed converter plan for a Choice recipe.
+#[derive(Clone)]
+pub struct Choice<S, B, P, C> {
+    /// Exact source spelling, opaque until rendering.
+    pub source: TypeRef,
+    /// Direction of the source/intermediate relation.
+    pub direction: Direction,
+    /// Source spelling and transparent-wrapper policy.
+    pub source_policy: S,
+    /// Adapter intermediate representation.
+    pub bridge: B,
+    /// Every source alternative, already composed from child chains.
+    pub arms: Vec<ChoiceArm<P, C>>,
+}
+
 /// A rendered chain body and the types needed to put a function around it.
 pub struct Rendered {
     /// Exact source type, spelled only at final emission.
@@ -356,6 +470,141 @@ where
     }
 }
 
+impl<S, B, P, C> Chain for Choice<S, B, P, C>
+where
+    S: Source,
+    B: ChoiceBridge,
+    P: ProductBridge,
+    C: Child,
+{
+    fn render(&self, emit: &Emit) -> Rendered {
+        let source = self.source_policy.spell(&self.source, emit);
+        let intermediate = self.bridge.intermediate();
+        let child_fallible = self
+            .arms
+            .iter()
+            .flat_map(|arm| &arm.parts)
+            .any(|part| part.child.call().fallible());
+        let body = match self.direction {
+            Direction::Construct => {
+                let canonical_source = self.source_policy.spell(self.source.unwrapped(), emit);
+                let tag = self.bridge.tag(quote::quote!(v));
+                let arms = self.arms.iter().enumerate().map(|(arm_index, arm)| {
+                    let tag_pattern = &arm.tag;
+                    let variant = &arm.variant;
+                    let arm_value = self.bridge.arm(quote::quote!(v), arm_index);
+                    let fields: Vec<_> = arm
+                        .parts
+                        .iter()
+                        .enumerate()
+                        .map(|(part_index, part)| {
+                            let name = match &part.member {
+                                syn::Member::Named(name) => name.clone(),
+                                syn::Member::Unnamed(index) => {
+                                    syn::Ident::new(&format!("v{}", index.index), index.span)
+                                }
+                            };
+                            let value = arm.bridge.part(quote::quote!(__arm), part_index, &name);
+                            (part.member.clone(), child_value(&part.child, value))
+                        })
+                        .collect();
+                    let canonical = match arm.form {
+                        AlternativeForm::Unit => {
+                            quote::quote!(#canonical_source::#variant)
+                        }
+                        AlternativeForm::Tuple => {
+                            let values = fields.iter().map(|(_, value)| value);
+                            quote::quote!(#canonical_source::#variant(#(#values),*))
+                        }
+                        AlternativeForm::Struct => {
+                            let names = fields.iter().map(|(member, _)| match member {
+                                syn::Member::Named(name) => name,
+                                syn::Member::Unnamed(_) => unreachable!(),
+                            });
+                            let values = fields.iter().map(|(_, value)| value);
+                            quote::quote!(#canonical_source::#variant { #(#names: #values),* })
+                        }
+                    };
+                    let built = self.source_policy.build(canonical);
+                    quote::quote!(#tag_pattern => {
+                        let __arm = #arm_value;
+                        #built
+                    })
+                });
+                let invalid = self.bridge.invalid_tag();
+                syn::parse2(quote::quote!({
+                    match #tag {
+                        #(#arms,)*
+                        _ => return ::core::result::Result::Err(#invalid),
+                    }
+                }))
+                .expect("a Choice source constructor is a valid expression")
+            }
+            Direction::Deconstruct => {
+                let canonical_source = self.source_policy.spell(self.source.unwrapped(), emit);
+                let value = self.source_policy.read(quote::quote!(v));
+                let arms = self.arms.iter().enumerate().map(|(arm_index, arm)| {
+                    let variant = &arm.variant;
+                    let bindings: Vec<_> = arm
+                        .parts
+                        .iter()
+                        .enumerate()
+                        .map(|(index, _)| {
+                            syn::Ident::new(&format!("__part{index}"), variant.span())
+                        })
+                        .collect();
+                    let pattern = match arm.form {
+                        AlternativeForm::Unit => {
+                            quote::quote!(#canonical_source::#variant)
+                        }
+                        AlternativeForm::Tuple => {
+                            quote::quote!(#canonical_source::#variant(#(#bindings),*))
+                        }
+                        AlternativeForm::Struct => {
+                            let names = arm.parts.iter().map(|part| match &part.member {
+                                syn::Member::Named(name) => name,
+                                syn::Member::Unnamed(_) => unreachable!(),
+                            });
+                            quote::quote!(#canonical_source::#variant { #(#names: #bindings),* })
+                        }
+                    };
+                    let parts: Vec<_> = arm
+                        .parts
+                        .iter()
+                        .zip(&bindings)
+                        .map(|(part, binding)| {
+                            let value = match part.mode {
+                                Mode::Owned => quote::quote!(#binding),
+                                Mode::Shared => quote::quote!(&*#binding),
+                                Mode::Exclusive => quote::quote!(&mut *#binding),
+                            };
+                            let value = child_value(&part.child, value);
+                            let name = match &part.member {
+                                syn::Member::Named(name) => name.clone(),
+                                syn::Member::Unnamed(index) => {
+                                    syn::Ident::new(&format!("v{}", index.index), index.span)
+                                }
+                            };
+                            (name, value)
+                        })
+                        .collect();
+                    let arm_value = arm.bridge.build(&parts);
+                    let built = self.bridge.build(arm_index, arm_value);
+                    quote::quote!(#pattern => #built)
+                });
+                syn::parse2(quote::quote!({ match #value { #(#arms,)* } }))
+                    .expect("a Choice intermediate constructor is a valid expression")
+            }
+        };
+        Rendered {
+            source,
+            intermediate,
+            body,
+            fallible: child_fallible || self.direction == Direction::Construct,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::{cell::Cell, rc::Rc};
@@ -429,5 +678,88 @@ mod tests {
             "{body}"
         );
         assert!(rendered.fallible);
+    }
+    fn choice_plan(
+        direction: Direction,
+        spells: Rc<Cell<usize>>,
+    ) -> Choice<TestSource, TupleChoice, TupleProduct, Call> {
+        let child = Call::new(
+            syn::Ident::new(
+                match direction {
+                    Direction::Construct => "decode",
+                    Direction::Deconstruct => "encode",
+                },
+                proc_macro2::Span::call_site(),
+            ),
+            true,
+            false,
+        );
+        Choice {
+            source: TypeRef::scalar(ScalarKind::I64),
+            direction,
+            source_policy: TestSource { spells },
+            bridge: TupleChoice {
+                tag: syn::parse_quote!(i32),
+                arms: vec![syn::parse_quote!(()), syn::parse_quote!((i64,))],
+                tags: vec![syn::parse_quote!(0), syn::parse_quote!(1)],
+                inactive: vec![quote!(()), quote!((0,))],
+                invalid: quote!("invalid tag"),
+            },
+            arms: vec![
+                ChoiceArm {
+                    variant: syn::parse_quote!(A),
+                    form: AlternativeForm::Unit,
+                    tag: syn::parse_quote!(0),
+                    bridge: TupleProduct { parts: Vec::new() },
+                    parts: Vec::new(),
+                },
+                ChoiceArm {
+                    variant: syn::parse_quote!(B),
+                    form: AlternativeForm::Tuple,
+                    tag: syn::parse_quote!(1),
+                    bridge: TupleProduct {
+                        parts: vec![syn::parse_quote!(i64)],
+                    },
+                    parts: vec![ChoicePart {
+                        member: syn::Member::Unnamed(syn::Index::from(0)),
+                        child,
+                        mode: Mode::Owned,
+                    }],
+                },
+            ],
+        }
+    }
+
+    #[test]
+    fn choice_spells_only_at_render_and_owns_arm_control_flow() {
+        for direction in [Direction::Construct, Direction::Deconstruct] {
+            let spells = Rc::new(Cell::new(0));
+            let plan = choice_plan(direction, spells.clone());
+
+            assert_eq!(spells.get(), 0, "planning must not spell the TypeRef");
+            let rendered = plan.render(&Emit::for_test());
+            assert_eq!(spells.get(), 2);
+            let body = rendered.body.to_token_stream().to_string();
+            match direction {
+                Direction::Construct => {
+                    assert!(body.contains("match (v) . 0"), "{body}");
+                    assert!(body.contains("i64 :: B (decode ((__arm) . 0) ?)"), "{body}");
+                    assert!(
+                        body.contains("return :: core :: result :: Result :: Err"),
+                        "{body}"
+                    );
+                }
+                Direction::Deconstruct => {
+                    assert!(body.contains("match v"), "{body}");
+                    assert!(body.contains("i64 :: B (__part0)"), "{body}");
+                    assert!(body.contains("encode (__part0) ?"), "{body}");
+                    assert!(
+                        body.contains("(1 , () , (encode (__part0) ? ,) ,)"),
+                        "{body}"
+                    );
+                }
+            }
+            assert!(rendered.fallible);
+        }
     }
 }


### PR DESCRIPTION
## Summary

- add registry-owned Choice composition with one tuple intermediate containing the tag and one Product intermediate per arm
- move JniGen's fixed sealed-class construction and deconstruction, including Product/Optional parents and callbacks, onto the shared chain
- expose unit/tuple/struct alternative form in Flat so final rendering never needs to inspect source syntax
- retain the whole-object input fallback only for layouts the current fixed sealed ABI cannot decompose
- regenerate the covertest Rust fixture, removing 501 net generated lines while leaving generated Kotlin unchanged

## Why

Choice was the remaining structural shape whose tag dispatch, variant construction/pattern matching, child calls and inactive-arm storage were assembled inside JniGen call paths. The registry already resolved the arm children, but the adapter discarded that structure and rebuilt the conversion wherever a sealed value crossed.

This stage makes the registry own that recursive walk. JniGen now declares the selector and arm representations, tag values, invalid-tag error and ABI-safe inactive slots; wrappers and callback delivery invoke the resulting converter.

The Flat-model boundary remains strict: planning retains TypeRef identity but neither inspects nor spells the Rust type. Source type and variant syntax are consumed only by the final chain renderer, after Flat supplies the otherwise-missing AlternativeForm semantic fact.

## Representation

The Choice intermediate is:

```text
(tag, arm_0_product, arm_1_product, ...)
```

Only the selected arm is converted. Deconstruction fills inactive arm storage with adapter-provided JNI-safe values; it never manufactures source values or child intermediates. Construction rejects unknown tags through the binding error path.

JniGen currently composes the fixed sealed ABI's one-slot payload fields. A whole-object sealed input remains a terminal decoder when its declared layout cannot be represented by those slots. Later shape stages can broaden the child layouts without changing the registry Choice protocol.

## Compatibility

Generated Rust helper structure and names change, but the generated JNI and Kotlin surfaces remain semantically compatible. The committed generated Kotlin output is unchanged.

The shared Choice converter replaces repeated inline walks in the Rust fixture: that file changes by 898 insertions and 1,399 deletions, a net reduction of 501 lines.

## Verification

- `cargo test --all --all-features --quiet`
- `cargo clippy --all-targets --all-features -- --deny warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
- `bash examples/regen-check.sh`
- `examples/covertest-kotlin/gradlew run --console=plain` — all 57 runtime sections passed

Part of #513.
