### PR TITLE
Make Choice chain composition usable by C and JNI

### DIFF
--- a/docs/model.md
+++ b/docs/model.md
@@ -19,10 +19,9 @@ contains nothing about any foreign language.
 `Struct`, `Variant` (an enum whose alternatives carry payloads, each an
 `Alternative`), `Enum`, `Function`, `Field`, and `TypeRef`, the model's
 reading of one Rust type. `TypeKey` is the identity that same type is stored
-under. An `Alternative` also exposes its `AlternativeForm`: unit, tuple or
-struct. Payload arity alone cannot recover this fact because `A`, `A()` and
-`A {}` are all empty but require different Rust construction and pattern
-syntax; renderers consume the Flat fact instead of inspecting source syntax.
+under. Its captured delimiters remain part of the `Alternative`; final Rust
+renderers pass the model node to Flat's shape renderer, so `A`, `A()` and
+`A {}` remain distinct without copying that syntax fact into another model.
 - **`prebindgen-registry`** — the language-agnostic half of generation. It is
 what this document describes.
 - **an adapter**, one per target language — `prebindgen-c`, whose generator type

--- a/examples/covertest-kotlin/src/generated_bindings.rs
+++ b/examples/covertest-kotlin/src/generated_bindings.rs
@@ -12979,41 +12979,44 @@ pub(crate) unsafe fn tuple6_to_Reading_69702d1f<'env, 'a>(
     ),
 ) -> ::core::result::Result<perftest_flat::Reading, __JniErr> {
     ::core::result::Result::Ok({
-        match (v).0 {
-            0i32 => {
-                let __arm = (v).1;
-                perftest_flat::Reading::Missing
-            }
+        let __tag = (v).0;
+        match __tag {
+            0i32 => perftest_flat::Reading::Missing,
             1i32 => {
-                let __arm = (v).2;
+                let __choice = v;
+                let __arm = (__choice).2;
                 perftest_flat::Reading::Exact(jlong_to_i64_fbf9a9bc(env, &((__arm).0))?)
             }
             2i32 => {
-                let __arm = (v).3;
+                let __choice = v;
+                let __arm = (__choice).3;
                 perftest_flat::Reading::Range {
                     low: jlong_to_i64_fbf9a9bc(env, &((__arm).0))?,
                     high: jlong_to_i64_fbf9a9bc(env, &((__arm).1))?,
                 }
             }
             3i32 => {
-                let __arm = (v).4;
+                let __choice = v;
+                let __arm = (__choice).4;
                 perftest_flat::Reading::Labeled(
                     JString_to_String_c7f3ca43(env, &((__arm).0))?,
                     jint_to_Priority_447102d2(env, &((__arm).1))?,
                 )
             }
             4i32 => {
-                let __arm = (v).5;
+                let __choice = v;
+                let __arm = (__choice).5;
                 perftest_flat::Reading::Companion(
                     jlong_to_i64_fbf9a9bc(env, &((__arm).0))?,
                 )
             }
             _ => {
-                return ::core::result::Result::Err(
+                return ::core::result::Result::Err({
+                    let __invalid_tag = __tag;
                     <__JniErr as ::core::convert::From<
                         String,
-                    >>::from(format!(concat!("Reading", ": invalid tag"))),
-                );
+                    >>::from(format!("{}: invalid tag {}", "Reading", __invalid_tag,))
+                });
             }
         }
     })

--- a/examples/example-cbindgen/generated/example_flat_aarch64.rs
+++ b/examples/example-cbindgen/generated/example_flat_aarch64.rs
@@ -228,13 +228,9 @@ pub(crate) unsafe fn __cbg_in_Calculator(
 #[allow(non_snake_case, unused_variables, dead_code)]
 pub(crate) unsafe fn __cbg_in_Caption(v: caption_t) -> example_flat::Caption {
     example_flat::Caption {
-        id: v.id,
-        text: if v.text.is_null() {
-            ::std::string::String::new()
-        } else {
-            ::std::ffi::CStr::from_ptr(v.text).to_string_lossy().into_owned()
-        },
-        emphatic: ::core::ptr::read(v.emphatic.as_ptr() as *const u8) != 0,
+        id: __cbg_in_u64(v.id),
+        text: __cbg_in_String_field(v.text),
+        emphatic: __cbg_in_bool(v.emphatic),
     }
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
@@ -242,16 +238,16 @@ pub(crate) unsafe fn __cbg_in_Drawing(
     v: drawing_t,
 ) -> ::core::result::Result<example_flat::Drawing, ::std::string::String> {
     ::core::result::Result::Ok(example_flat::Drawing {
-        id: v.id,
+        id: __cbg_in_u64(v.id),
         shape: __cbg_in_Shape(v.shape)?,
     })
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
 pub(crate) unsafe fn __cbg_in_Foo(v: foo_t) -> example_flat::Foo {
     example_flat::Foo {
-        id: v.id,
-        aarch64_field: v.aarch64_field,
-        stable_field: v.stable_field,
+        id: __cbg_in_u64(v.id),
+        aarch64_field: __cbg_in_u64(v.aarch64_field),
+        stable_field: __cbg_in_u64(v.stable_field),
     }
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
@@ -320,37 +316,77 @@ pub(crate) fn __cbg_in_Millis(v: u64) -> example_flat::Millis {
 pub(crate) unsafe fn __cbg_in_Note(
     v: ::core::mem::MaybeUninit<note_t>,
 ) -> ::core::result::Result<example_flat::Note, ::std::string::String> {
-    const _: () = {
-        assert!(
-            ::core::mem::size_of:: < note_t > () >= ::core::mem::size_of:: <
-            ::core::ffi::c_int > (),
-            "`note_t`: a #[repr(C)] enum with payload variants must be at least as large as its C `int` discriminant"
-        );
-    };
-    let __tag: ::core::ffi::c_int = ::core::ptr::read(
-        v.as_ptr() as *const ::core::ffi::c_int,
-    );
-    if !((__tag as i64) >= 0 && (__tag as i64) < 5i64) {
-        return ::core::result::Result::Err(
-            ::std::format!("invalid tag {} for `note_t` (expected 0..5)", __tag),
-        );
-    }
-    let v = v.assume_init();
-    ::core::result::Result::Ok(
-        match v {
-            note_t::Silent => example_flat::Note::Silent,
-            note_t::Titled(__f0) => example_flat::Note::Titled(__cbg_in_Caption(__f0)),
-            note_t::After(__f0) => example_flat::Note::After(__cbg_in_Millis(__f0)),
-            note_t::Flagged(__f0) => {
-                example_flat::Note::Flagged(
-                    ::core::ptr::read(__f0.as_ptr() as *const u8) != 0,
-                )
+    ::core::result::Result::Ok({
+        let __tag = {
+            const _: () = {
+                assert!(
+                    ::core::mem::size_of:: < note_t > () >= ::core::mem::size_of:: <
+                    ::core::ffi::c_int > (),
+                    "`note_t`: a #[repr(C)] enum with payload variants must be at least as large as its C `int` discriminant"
+                );
+            };
+            unsafe { ::core::ptr::read((v).as_ptr() as *const ::core::ffi::c_int) }
+        };
+        match __tag {
+            0 => example_flat::Note::Silent,
+            1 => {
+                let __choice = unsafe { (v).assume_init() };
+                let __arm = {
+                    match __choice {
+                        note_t::Titled(__wire_part0) => (__wire_part0,),
+                        _ => {
+                            unreachable!("validated Choice tag selected a different arm")
+                        }
+                    }
+                };
+                example_flat::Note::Titled(__cbg_in_Caption((__arm).0))
             }
-            note_t::Sketched(__f0) => {
-                example_flat::Note::Sketched(__cbg_in_Drawing(__f0)?)
+            2 => {
+                let __choice = unsafe { (v).assume_init() };
+                let __arm = {
+                    match __choice {
+                        note_t::After(__wire_part0) => (__wire_part0,),
+                        _ => {
+                            unreachable!("validated Choice tag selected a different arm")
+                        }
+                    }
+                };
+                example_flat::Note::After(__cbg_in_Millis((__arm).0))
             }
-        },
-    )
+            3 => {
+                let __choice = unsafe { (v).assume_init() };
+                let __arm = {
+                    match __choice {
+                        note_t::Flagged(__wire_part0) => (__wire_part0,),
+                        _ => {
+                            unreachable!("validated Choice tag selected a different arm")
+                        }
+                    }
+                };
+                example_flat::Note::Flagged(__cbg_in_bool((__arm).0))
+            }
+            4 => {
+                let __choice = unsafe { (v).assume_init() };
+                let __arm = {
+                    match __choice {
+                        note_t::Sketched(__wire_part0) => (__wire_part0,),
+                        _ => {
+                            unreachable!("validated Choice tag selected a different arm")
+                        }
+                    }
+                };
+                example_flat::Note::Sketched(__cbg_in_Drawing((__arm).0)?)
+            }
+            _ => {
+                return ::core::result::Result::Err(
+                    ::std::format!(
+                        "invalid tag {} for `{}` (expected 0..{})", __tag,
+                        stringify!(note_t), 5usize,
+                    ),
+                );
+            }
+        }
+    })
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
 pub(crate) unsafe fn __cbg_in_Operation(
@@ -391,44 +427,75 @@ pub(crate) unsafe fn __cbg_in_Operation(
 pub(crate) unsafe fn __cbg_in_Shape(
     v: ::core::mem::MaybeUninit<shape_t>,
 ) -> ::core::result::Result<example_flat::Shape, ::std::string::String> {
-    const _: () = {
-        assert!(
-            ::core::mem::size_of:: < shape_t > () >= ::core::mem::size_of:: <
-            ::core::ffi::c_int > (),
-            "`shape_t`: a #[repr(C)] enum with payload variants must be at least as large as its C `int` discriminant"
-        );
-    };
-    let __tag: ::core::ffi::c_int = ::core::ptr::read(
-        v.as_ptr() as *const ::core::ffi::c_int,
-    );
-    if !((__tag as i64) >= 0 && (__tag as i64) < 4i64) {
-        return ::core::result::Result::Err(
-            ::std::format!("invalid tag {} for `shape_t` (expected 0..4)", __tag),
-        );
-    }
-    let v = v.assume_init();
-    ::core::result::Result::Ok(
-        match v {
-            shape_t::Empty => example_flat::Shape::Empty,
-            shape_t::Circle(__f0) => example_flat::Shape::Circle(__f0),
-            shape_t::Rect { width: __f0, height: __f1 } => {
+    ::core::result::Result::Ok({
+        let __tag = {
+            const _: () = {
+                assert!(
+                    ::core::mem::size_of:: < shape_t > () >= ::core::mem::size_of:: <
+                    ::core::ffi::c_int > (),
+                    "`shape_t`: a #[repr(C)] enum with payload variants must be at least as large as its C `int` discriminant"
+                );
+            };
+            unsafe { ::core::ptr::read((v).as_ptr() as *const ::core::ffi::c_int) }
+        };
+        match __tag {
+            0 => example_flat::Shape::Empty,
+            1 => {
+                let __choice = unsafe { (v).assume_init() };
+                let __arm = {
+                    match __choice {
+                        shape_t::Circle(__wire_part0) => (__wire_part0,),
+                        _ => {
+                            unreachable!("validated Choice tag selected a different arm")
+                        }
+                    }
+                };
+                example_flat::Shape::Circle(__cbg_in_f64((__arm).0))
+            }
+            2 => {
+                let __choice = unsafe { (v).assume_init() };
+                let __arm = {
+                    match __choice {
+                        shape_t::Rect { width: __wire_part0, height: __wire_part1 } => {
+                            (__wire_part0, __wire_part1)
+                        }
+                        _ => {
+                            unreachable!("validated Choice tag selected a different arm")
+                        }
+                    }
+                };
                 example_flat::Shape::Rect {
-                    width: __f0,
-                    height: __f1,
+                    width: __cbg_in_f64((__arm).0),
+                    height: __cbg_in_f64((__arm).1),
                 }
             }
-            shape_t::Labeled(__f0, __f1) => {
+            3 => {
+                let __choice = unsafe { (v).assume_init() };
+                let __arm = {
+                    match __choice {
+                        shape_t::Labeled(__wire_part0, __wire_part1) => {
+                            (__wire_part0, __wire_part1)
+                        }
+                        _ => {
+                            unreachable!("validated Choice tag selected a different arm")
+                        }
+                    }
+                };
                 example_flat::Shape::Labeled(
-                    if __f0.is_null() {
-                        ::std::string::String::new()
-                    } else {
-                        ::std::ffi::CStr::from_ptr(__f0).to_string_lossy().into_owned()
-                    },
-                    __cbg_in_Operation(__f1)?,
+                    __cbg_in_String_field((__arm).0),
+                    __cbg_in_Operation((__arm).1)?,
                 )
             }
-        },
-    )
+            _ => {
+                return ::core::result::Result::Err(
+                    ::std::format!(
+                        "invalid tag {} for `{}` (expected 0..{})", __tag,
+                        stringify!(shape_t), 4usize,
+                    ),
+                );
+            }
+        }
+    })
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
 pub(crate) unsafe fn __cbg_in_String(
@@ -446,6 +513,16 @@ pub(crate) unsafe fn __cbg_in_String(
                 ::std::string::String::from("invalid UTF-8 in String argument"),
             )
         }
+    }
+}
+#[allow(non_snake_case, unused_variables, dead_code)]
+pub(crate) unsafe fn __cbg_in_String_field(
+    v: *const ::core::ffi::c_char,
+) -> ::std::string::String {
+    if v.is_null() {
+        ::std::string::String::new()
+    } else {
+        ::std::ffi::CStr::from_ptr(v).to_string_lossy().into_owned()
     }
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
@@ -653,15 +730,15 @@ pub(crate) fn __cbg_out_Calculator(v: example_flat::Calculator) -> *mut calculat
 #[allow(non_snake_case, unused_variables, dead_code)]
 pub(crate) fn __cbg_out_Caption(v: example_flat::Caption) -> caption_t {
     caption_t {
-        id: v.id,
-        text: __cbg_alloc_cstr(v.text),
-        emphatic: ::core::mem::MaybeUninit::new(v.emphatic),
+        id: __cbg_out_u64(v.id),
+        text: __cbg_out_String(v.text),
+        emphatic: __cbg_out_bool_field(v.emphatic),
     }
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
 pub(crate) fn __cbg_out_Drawing(v: example_flat::Drawing) -> drawing_t {
     drawing_t {
-        id: v.id,
+        id: __cbg_out_u64(v.id),
         shape: __cbg_out_Shape(v.shape),
     }
 }
@@ -672,9 +749,9 @@ pub(crate) fn __cbg_out_Error(v: example_flat::Error) -> *mut ::core::ffi::c_cha
 #[allow(non_snake_case, unused_variables, dead_code)]
 pub(crate) fn __cbg_out_Foo(v: example_flat::Foo) -> foo_t {
     foo_t {
-        id: v.id,
-        aarch64_field: v.aarch64_field,
-        stable_field: v.stable_field,
+        id: __cbg_out_u64(v.id),
+        aarch64_field: __cbg_out_u64(v.aarch64_field),
+        stable_field: __cbg_out_u64(v.stable_field),
     }
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
@@ -697,19 +774,27 @@ pub(crate) fn __cbg_out_Millis(v: example_flat::Millis) -> u64 {
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
 pub(crate) fn __cbg_out_Note(v: example_flat::Note) -> ::core::mem::MaybeUninit<note_t> {
-    ::core::mem::MaybeUninit::new(
+    ::core::mem::MaybeUninit::new({
         match v {
             example_flat::Note::Silent => note_t::Silent,
-            example_flat::Note::Titled(__f0) => note_t::Titled(__cbg_out_Caption(__f0)),
-            example_flat::Note::After(__f0) => note_t::After(__cbg_out_Millis(__f0)),
-            example_flat::Note::Flagged(__f0) => {
-                note_t::Flagged(::core::mem::MaybeUninit::new(__f0))
+            example_flat::Note::Titled(__part0) => {
+                let __built_arm = (__cbg_out_Caption(__part0),);
+                note_t::Titled(__built_arm.0)
             }
-            example_flat::Note::Sketched(__f0) => {
-                note_t::Sketched(__cbg_out_Drawing(__f0))
+            example_flat::Note::After(__part0) => {
+                let __built_arm = (__cbg_out_Millis(__part0),);
+                note_t::After(__built_arm.0)
             }
-        },
-    )
+            example_flat::Note::Flagged(__part0) => {
+                let __built_arm = (__cbg_out_bool_field(__part0),);
+                note_t::Flagged(__built_arm.0)
+            }
+            example_flat::Note::Sketched(__part0) => {
+                let __built_arm = (__cbg_out_Drawing(__part0),);
+                note_t::Sketched(__built_arm.0)
+            }
+        }
+    })
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
 pub(crate) fn __cbg_out_Operation(v: example_flat::Operation) -> operation_t {
@@ -724,24 +809,29 @@ pub(crate) fn __cbg_out_Operation(v: example_flat::Operation) -> operation_t {
 pub(crate) fn __cbg_out_Shape(
     v: example_flat::Shape,
 ) -> ::core::mem::MaybeUninit<shape_t> {
-    ::core::mem::MaybeUninit::new(
+    ::core::mem::MaybeUninit::new({
         match v {
             example_flat::Shape::Empty => shape_t::Empty,
-            example_flat::Shape::Circle(__f0) => shape_t::Circle(__f0),
-            example_flat::Shape::Rect { width: __f0, height: __f1 } => {
+            example_flat::Shape::Circle(__part0) => {
+                let __built_arm = (__cbg_out_f64(__part0),);
+                shape_t::Circle(__built_arm.0)
+            }
+            example_flat::Shape::Rect { width: __part0, height: __part1 } => {
+                let __built_arm = (__cbg_out_f64(__part0), __cbg_out_f64(__part1));
                 shape_t::Rect {
-                    width: __f0,
-                    height: __f1,
+                    width: __built_arm.0,
+                    height: __built_arm.1,
                 }
             }
-            example_flat::Shape::Labeled(__f0, __f1) => {
-                shape_t::Labeled(
-                    __cbg_alloc_cstr(__f0),
-                    ::core::mem::MaybeUninit::new(__cbg_out_Operation(__f1)),
-                )
+            example_flat::Shape::Labeled(__part0, __part1) => {
+                let __built_arm = (
+                    __cbg_out_String(__part0),
+                    ::core::mem::MaybeUninit::new(__cbg_out_Operation(__part1)),
+                );
+                shape_t::Labeled(__built_arm.0, __built_arm.1)
             }
-        },
-    )
+        }
+    })
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
 pub(crate) fn __cbg_out_String(v: ::std::string::String) -> *mut ::core::ffi::c_char {
@@ -750,6 +840,10 @@ pub(crate) fn __cbg_out_String(v: ::std::string::String) -> *mut ::core::ffi::c_
 #[allow(non_snake_case, unused_variables, dead_code)]
 pub(crate) fn __cbg_out_bool(v: bool) -> bool {
     v
+}
+#[allow(non_snake_case, unused_variables, dead_code)]
+pub(crate) fn __cbg_out_bool_field(v: bool) -> ::core::mem::MaybeUninit<bool> {
+    ::core::mem::MaybeUninit::new(v)
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
 pub(crate) fn __cbg_out_f64(v: f64) -> f64 {

--- a/examples/example-cbindgen/generated/example_flat_aarch64_internal_unstable.rs
+++ b/examples/example-cbindgen/generated/example_flat_aarch64_internal_unstable.rs
@@ -228,13 +228,9 @@ pub(crate) unsafe fn __cbg_in_Calculator(
 #[allow(non_snake_case, unused_variables, dead_code)]
 pub(crate) unsafe fn __cbg_in_Caption(v: caption_t) -> example_flat::Caption {
     example_flat::Caption {
-        id: v.id,
-        text: if v.text.is_null() {
-            ::std::string::String::new()
-        } else {
-            ::std::ffi::CStr::from_ptr(v.text).to_string_lossy().into_owned()
-        },
-        emphatic: ::core::ptr::read(v.emphatic.as_ptr() as *const u8) != 0,
+        id: __cbg_in_u64(v.id),
+        text: __cbg_in_String_field(v.text),
+        emphatic: __cbg_in_bool(v.emphatic),
     }
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
@@ -242,16 +238,16 @@ pub(crate) unsafe fn __cbg_in_Drawing(
     v: drawing_t,
 ) -> ::core::result::Result<example_flat::Drawing, ::std::string::String> {
     ::core::result::Result::Ok(example_flat::Drawing {
-        id: v.id,
+        id: __cbg_in_u64(v.id),
         shape: __cbg_in_Shape(v.shape)?,
     })
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
 pub(crate) unsafe fn __cbg_in_Foo(v: foo_t) -> example_flat::Foo {
     example_flat::Foo {
-        id: v.id,
-        aarch64_field: v.aarch64_field,
-        unstable_field: v.unstable_field,
+        id: __cbg_in_u64(v.id),
+        aarch64_field: __cbg_in_u64(v.aarch64_field),
+        unstable_field: __cbg_in_u64(v.unstable_field),
     }
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
@@ -320,37 +316,77 @@ pub(crate) fn __cbg_in_Millis(v: u64) -> example_flat::Millis {
 pub(crate) unsafe fn __cbg_in_Note(
     v: ::core::mem::MaybeUninit<note_t>,
 ) -> ::core::result::Result<example_flat::Note, ::std::string::String> {
-    const _: () = {
-        assert!(
-            ::core::mem::size_of:: < note_t > () >= ::core::mem::size_of:: <
-            ::core::ffi::c_int > (),
-            "`note_t`: a #[repr(C)] enum with payload variants must be at least as large as its C `int` discriminant"
-        );
-    };
-    let __tag: ::core::ffi::c_int = ::core::ptr::read(
-        v.as_ptr() as *const ::core::ffi::c_int,
-    );
-    if !((__tag as i64) >= 0 && (__tag as i64) < 5i64) {
-        return ::core::result::Result::Err(
-            ::std::format!("invalid tag {} for `note_t` (expected 0..5)", __tag),
-        );
-    }
-    let v = v.assume_init();
-    ::core::result::Result::Ok(
-        match v {
-            note_t::Silent => example_flat::Note::Silent,
-            note_t::Titled(__f0) => example_flat::Note::Titled(__cbg_in_Caption(__f0)),
-            note_t::After(__f0) => example_flat::Note::After(__cbg_in_Millis(__f0)),
-            note_t::Flagged(__f0) => {
-                example_flat::Note::Flagged(
-                    ::core::ptr::read(__f0.as_ptr() as *const u8) != 0,
-                )
+    ::core::result::Result::Ok({
+        let __tag = {
+            const _: () = {
+                assert!(
+                    ::core::mem::size_of:: < note_t > () >= ::core::mem::size_of:: <
+                    ::core::ffi::c_int > (),
+                    "`note_t`: a #[repr(C)] enum with payload variants must be at least as large as its C `int` discriminant"
+                );
+            };
+            unsafe { ::core::ptr::read((v).as_ptr() as *const ::core::ffi::c_int) }
+        };
+        match __tag {
+            0 => example_flat::Note::Silent,
+            1 => {
+                let __choice = unsafe { (v).assume_init() };
+                let __arm = {
+                    match __choice {
+                        note_t::Titled(__wire_part0) => (__wire_part0,),
+                        _ => {
+                            unreachable!("validated Choice tag selected a different arm")
+                        }
+                    }
+                };
+                example_flat::Note::Titled(__cbg_in_Caption((__arm).0))
             }
-            note_t::Sketched(__f0) => {
-                example_flat::Note::Sketched(__cbg_in_Drawing(__f0)?)
+            2 => {
+                let __choice = unsafe { (v).assume_init() };
+                let __arm = {
+                    match __choice {
+                        note_t::After(__wire_part0) => (__wire_part0,),
+                        _ => {
+                            unreachable!("validated Choice tag selected a different arm")
+                        }
+                    }
+                };
+                example_flat::Note::After(__cbg_in_Millis((__arm).0))
             }
-        },
-    )
+            3 => {
+                let __choice = unsafe { (v).assume_init() };
+                let __arm = {
+                    match __choice {
+                        note_t::Flagged(__wire_part0) => (__wire_part0,),
+                        _ => {
+                            unreachable!("validated Choice tag selected a different arm")
+                        }
+                    }
+                };
+                example_flat::Note::Flagged(__cbg_in_bool((__arm).0))
+            }
+            4 => {
+                let __choice = unsafe { (v).assume_init() };
+                let __arm = {
+                    match __choice {
+                        note_t::Sketched(__wire_part0) => (__wire_part0,),
+                        _ => {
+                            unreachable!("validated Choice tag selected a different arm")
+                        }
+                    }
+                };
+                example_flat::Note::Sketched(__cbg_in_Drawing((__arm).0)?)
+            }
+            _ => {
+                return ::core::result::Result::Err(
+                    ::std::format!(
+                        "invalid tag {} for `{}` (expected 0..{})", __tag,
+                        stringify!(note_t), 5usize,
+                    ),
+                );
+            }
+        }
+    })
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
 pub(crate) unsafe fn __cbg_in_Operation(
@@ -391,44 +427,75 @@ pub(crate) unsafe fn __cbg_in_Operation(
 pub(crate) unsafe fn __cbg_in_Shape(
     v: ::core::mem::MaybeUninit<shape_t>,
 ) -> ::core::result::Result<example_flat::Shape, ::std::string::String> {
-    const _: () = {
-        assert!(
-            ::core::mem::size_of:: < shape_t > () >= ::core::mem::size_of:: <
-            ::core::ffi::c_int > (),
-            "`shape_t`: a #[repr(C)] enum with payload variants must be at least as large as its C `int` discriminant"
-        );
-    };
-    let __tag: ::core::ffi::c_int = ::core::ptr::read(
-        v.as_ptr() as *const ::core::ffi::c_int,
-    );
-    if !((__tag as i64) >= 0 && (__tag as i64) < 4i64) {
-        return ::core::result::Result::Err(
-            ::std::format!("invalid tag {} for `shape_t` (expected 0..4)", __tag),
-        );
-    }
-    let v = v.assume_init();
-    ::core::result::Result::Ok(
-        match v {
-            shape_t::Empty => example_flat::Shape::Empty,
-            shape_t::Circle(__f0) => example_flat::Shape::Circle(__f0),
-            shape_t::Rect { width: __f0, height: __f1 } => {
+    ::core::result::Result::Ok({
+        let __tag = {
+            const _: () = {
+                assert!(
+                    ::core::mem::size_of:: < shape_t > () >= ::core::mem::size_of:: <
+                    ::core::ffi::c_int > (),
+                    "`shape_t`: a #[repr(C)] enum with payload variants must be at least as large as its C `int` discriminant"
+                );
+            };
+            unsafe { ::core::ptr::read((v).as_ptr() as *const ::core::ffi::c_int) }
+        };
+        match __tag {
+            0 => example_flat::Shape::Empty,
+            1 => {
+                let __choice = unsafe { (v).assume_init() };
+                let __arm = {
+                    match __choice {
+                        shape_t::Circle(__wire_part0) => (__wire_part0,),
+                        _ => {
+                            unreachable!("validated Choice tag selected a different arm")
+                        }
+                    }
+                };
+                example_flat::Shape::Circle(__cbg_in_f64((__arm).0))
+            }
+            2 => {
+                let __choice = unsafe { (v).assume_init() };
+                let __arm = {
+                    match __choice {
+                        shape_t::Rect { width: __wire_part0, height: __wire_part1 } => {
+                            (__wire_part0, __wire_part1)
+                        }
+                        _ => {
+                            unreachable!("validated Choice tag selected a different arm")
+                        }
+                    }
+                };
                 example_flat::Shape::Rect {
-                    width: __f0,
-                    height: __f1,
+                    width: __cbg_in_f64((__arm).0),
+                    height: __cbg_in_f64((__arm).1),
                 }
             }
-            shape_t::Labeled(__f0, __f1) => {
+            3 => {
+                let __choice = unsafe { (v).assume_init() };
+                let __arm = {
+                    match __choice {
+                        shape_t::Labeled(__wire_part0, __wire_part1) => {
+                            (__wire_part0, __wire_part1)
+                        }
+                        _ => {
+                            unreachable!("validated Choice tag selected a different arm")
+                        }
+                    }
+                };
                 example_flat::Shape::Labeled(
-                    if __f0.is_null() {
-                        ::std::string::String::new()
-                    } else {
-                        ::std::ffi::CStr::from_ptr(__f0).to_string_lossy().into_owned()
-                    },
-                    __cbg_in_Operation(__f1)?,
+                    __cbg_in_String_field((__arm).0),
+                    __cbg_in_Operation((__arm).1)?,
                 )
             }
-        },
-    )
+            _ => {
+                return ::core::result::Result::Err(
+                    ::std::format!(
+                        "invalid tag {} for `{}` (expected 0..{})", __tag,
+                        stringify!(shape_t), 4usize,
+                    ),
+                );
+            }
+        }
+    })
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
 pub(crate) unsafe fn __cbg_in_String(
@@ -446,6 +513,16 @@ pub(crate) unsafe fn __cbg_in_String(
                 ::std::string::String::from("invalid UTF-8 in String argument"),
             )
         }
+    }
+}
+#[allow(non_snake_case, unused_variables, dead_code)]
+pub(crate) unsafe fn __cbg_in_String_field(
+    v: *const ::core::ffi::c_char,
+) -> ::std::string::String {
+    if v.is_null() {
+        ::std::string::String::new()
+    } else {
+        ::std::ffi::CStr::from_ptr(v).to_string_lossy().into_owned()
     }
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
@@ -653,15 +730,15 @@ pub(crate) fn __cbg_out_Calculator(v: example_flat::Calculator) -> *mut calculat
 #[allow(non_snake_case, unused_variables, dead_code)]
 pub(crate) fn __cbg_out_Caption(v: example_flat::Caption) -> caption_t {
     caption_t {
-        id: v.id,
-        text: __cbg_alloc_cstr(v.text),
-        emphatic: ::core::mem::MaybeUninit::new(v.emphatic),
+        id: __cbg_out_u64(v.id),
+        text: __cbg_out_String(v.text),
+        emphatic: __cbg_out_bool_field(v.emphatic),
     }
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
 pub(crate) fn __cbg_out_Drawing(v: example_flat::Drawing) -> drawing_t {
     drawing_t {
-        id: v.id,
+        id: __cbg_out_u64(v.id),
         shape: __cbg_out_Shape(v.shape),
     }
 }
@@ -672,9 +749,9 @@ pub(crate) fn __cbg_out_Error(v: example_flat::Error) -> *mut ::core::ffi::c_cha
 #[allow(non_snake_case, unused_variables, dead_code)]
 pub(crate) fn __cbg_out_Foo(v: example_flat::Foo) -> foo_t {
     foo_t {
-        id: v.id,
-        aarch64_field: v.aarch64_field,
-        unstable_field: v.unstable_field,
+        id: __cbg_out_u64(v.id),
+        aarch64_field: __cbg_out_u64(v.aarch64_field),
+        unstable_field: __cbg_out_u64(v.unstable_field),
     }
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
@@ -697,19 +774,27 @@ pub(crate) fn __cbg_out_Millis(v: example_flat::Millis) -> u64 {
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
 pub(crate) fn __cbg_out_Note(v: example_flat::Note) -> ::core::mem::MaybeUninit<note_t> {
-    ::core::mem::MaybeUninit::new(
+    ::core::mem::MaybeUninit::new({
         match v {
             example_flat::Note::Silent => note_t::Silent,
-            example_flat::Note::Titled(__f0) => note_t::Titled(__cbg_out_Caption(__f0)),
-            example_flat::Note::After(__f0) => note_t::After(__cbg_out_Millis(__f0)),
-            example_flat::Note::Flagged(__f0) => {
-                note_t::Flagged(::core::mem::MaybeUninit::new(__f0))
+            example_flat::Note::Titled(__part0) => {
+                let __built_arm = (__cbg_out_Caption(__part0),);
+                note_t::Titled(__built_arm.0)
             }
-            example_flat::Note::Sketched(__f0) => {
-                note_t::Sketched(__cbg_out_Drawing(__f0))
+            example_flat::Note::After(__part0) => {
+                let __built_arm = (__cbg_out_Millis(__part0),);
+                note_t::After(__built_arm.0)
             }
-        },
-    )
+            example_flat::Note::Flagged(__part0) => {
+                let __built_arm = (__cbg_out_bool_field(__part0),);
+                note_t::Flagged(__built_arm.0)
+            }
+            example_flat::Note::Sketched(__part0) => {
+                let __built_arm = (__cbg_out_Drawing(__part0),);
+                note_t::Sketched(__built_arm.0)
+            }
+        }
+    })
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
 pub(crate) fn __cbg_out_Operation(v: example_flat::Operation) -> operation_t {
@@ -724,24 +809,29 @@ pub(crate) fn __cbg_out_Operation(v: example_flat::Operation) -> operation_t {
 pub(crate) fn __cbg_out_Shape(
     v: example_flat::Shape,
 ) -> ::core::mem::MaybeUninit<shape_t> {
-    ::core::mem::MaybeUninit::new(
+    ::core::mem::MaybeUninit::new({
         match v {
             example_flat::Shape::Empty => shape_t::Empty,
-            example_flat::Shape::Circle(__f0) => shape_t::Circle(__f0),
-            example_flat::Shape::Rect { width: __f0, height: __f1 } => {
+            example_flat::Shape::Circle(__part0) => {
+                let __built_arm = (__cbg_out_f64(__part0),);
+                shape_t::Circle(__built_arm.0)
+            }
+            example_flat::Shape::Rect { width: __part0, height: __part1 } => {
+                let __built_arm = (__cbg_out_f64(__part0), __cbg_out_f64(__part1));
                 shape_t::Rect {
-                    width: __f0,
-                    height: __f1,
+                    width: __built_arm.0,
+                    height: __built_arm.1,
                 }
             }
-            example_flat::Shape::Labeled(__f0, __f1) => {
-                shape_t::Labeled(
-                    __cbg_alloc_cstr(__f0),
-                    ::core::mem::MaybeUninit::new(__cbg_out_Operation(__f1)),
-                )
+            example_flat::Shape::Labeled(__part0, __part1) => {
+                let __built_arm = (
+                    __cbg_out_String(__part0),
+                    ::core::mem::MaybeUninit::new(__cbg_out_Operation(__part1)),
+                );
+                shape_t::Labeled(__built_arm.0, __built_arm.1)
             }
-        },
-    )
+        }
+    })
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
 pub(crate) fn __cbg_out_String(v: ::std::string::String) -> *mut ::core::ffi::c_char {
@@ -750,6 +840,10 @@ pub(crate) fn __cbg_out_String(v: ::std::string::String) -> *mut ::core::ffi::c_
 #[allow(non_snake_case, unused_variables, dead_code)]
 pub(crate) fn __cbg_out_bool(v: bool) -> bool {
     v
+}
+#[allow(non_snake_case, unused_variables, dead_code)]
+pub(crate) fn __cbg_out_bool_field(v: bool) -> ::core::mem::MaybeUninit<bool> {
+    ::core::mem::MaybeUninit::new(v)
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
 pub(crate) fn __cbg_out_f64(v: f64) -> f64 {

--- a/examples/example-cbindgen/generated/example_flat_aarch64_unstable.rs
+++ b/examples/example-cbindgen/generated/example_flat_aarch64_unstable.rs
@@ -228,13 +228,9 @@ pub(crate) unsafe fn __cbg_in_Calculator(
 #[allow(non_snake_case, unused_variables, dead_code)]
 pub(crate) unsafe fn __cbg_in_Caption(v: caption_t) -> example_flat::Caption {
     example_flat::Caption {
-        id: v.id,
-        text: if v.text.is_null() {
-            ::std::string::String::new()
-        } else {
-            ::std::ffi::CStr::from_ptr(v.text).to_string_lossy().into_owned()
-        },
-        emphatic: ::core::ptr::read(v.emphatic.as_ptr() as *const u8) != 0,
+        id: __cbg_in_u64(v.id),
+        text: __cbg_in_String_field(v.text),
+        emphatic: __cbg_in_bool(v.emphatic),
     }
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
@@ -242,16 +238,16 @@ pub(crate) unsafe fn __cbg_in_Drawing(
     v: drawing_t,
 ) -> ::core::result::Result<example_flat::Drawing, ::std::string::String> {
     ::core::result::Result::Ok(example_flat::Drawing {
-        id: v.id,
+        id: __cbg_in_u64(v.id),
         shape: __cbg_in_Shape(v.shape)?,
     })
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
 pub(crate) unsafe fn __cbg_in_Foo(v: foo_t) -> example_flat::Foo {
     example_flat::Foo {
-        id: v.id,
-        aarch64_field: v.aarch64_field,
-        unstable_field: v.unstable_field,
+        id: __cbg_in_u64(v.id),
+        aarch64_field: __cbg_in_u64(v.aarch64_field),
+        unstable_field: __cbg_in_u64(v.unstable_field),
     }
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
@@ -320,37 +316,77 @@ pub(crate) fn __cbg_in_Millis(v: u64) -> example_flat::Millis {
 pub(crate) unsafe fn __cbg_in_Note(
     v: ::core::mem::MaybeUninit<note_t>,
 ) -> ::core::result::Result<example_flat::Note, ::std::string::String> {
-    const _: () = {
-        assert!(
-            ::core::mem::size_of:: < note_t > () >= ::core::mem::size_of:: <
-            ::core::ffi::c_int > (),
-            "`note_t`: a #[repr(C)] enum with payload variants must be at least as large as its C `int` discriminant"
-        );
-    };
-    let __tag: ::core::ffi::c_int = ::core::ptr::read(
-        v.as_ptr() as *const ::core::ffi::c_int,
-    );
-    if !((__tag as i64) >= 0 && (__tag as i64) < 5i64) {
-        return ::core::result::Result::Err(
-            ::std::format!("invalid tag {} for `note_t` (expected 0..5)", __tag),
-        );
-    }
-    let v = v.assume_init();
-    ::core::result::Result::Ok(
-        match v {
-            note_t::Silent => example_flat::Note::Silent,
-            note_t::Titled(__f0) => example_flat::Note::Titled(__cbg_in_Caption(__f0)),
-            note_t::After(__f0) => example_flat::Note::After(__cbg_in_Millis(__f0)),
-            note_t::Flagged(__f0) => {
-                example_flat::Note::Flagged(
-                    ::core::ptr::read(__f0.as_ptr() as *const u8) != 0,
-                )
+    ::core::result::Result::Ok({
+        let __tag = {
+            const _: () = {
+                assert!(
+                    ::core::mem::size_of:: < note_t > () >= ::core::mem::size_of:: <
+                    ::core::ffi::c_int > (),
+                    "`note_t`: a #[repr(C)] enum with payload variants must be at least as large as its C `int` discriminant"
+                );
+            };
+            unsafe { ::core::ptr::read((v).as_ptr() as *const ::core::ffi::c_int) }
+        };
+        match __tag {
+            0 => example_flat::Note::Silent,
+            1 => {
+                let __choice = unsafe { (v).assume_init() };
+                let __arm = {
+                    match __choice {
+                        note_t::Titled(__wire_part0) => (__wire_part0,),
+                        _ => {
+                            unreachable!("validated Choice tag selected a different arm")
+                        }
+                    }
+                };
+                example_flat::Note::Titled(__cbg_in_Caption((__arm).0))
             }
-            note_t::Sketched(__f0) => {
-                example_flat::Note::Sketched(__cbg_in_Drawing(__f0)?)
+            2 => {
+                let __choice = unsafe { (v).assume_init() };
+                let __arm = {
+                    match __choice {
+                        note_t::After(__wire_part0) => (__wire_part0,),
+                        _ => {
+                            unreachable!("validated Choice tag selected a different arm")
+                        }
+                    }
+                };
+                example_flat::Note::After(__cbg_in_Millis((__arm).0))
             }
-        },
-    )
+            3 => {
+                let __choice = unsafe { (v).assume_init() };
+                let __arm = {
+                    match __choice {
+                        note_t::Flagged(__wire_part0) => (__wire_part0,),
+                        _ => {
+                            unreachable!("validated Choice tag selected a different arm")
+                        }
+                    }
+                };
+                example_flat::Note::Flagged(__cbg_in_bool((__arm).0))
+            }
+            4 => {
+                let __choice = unsafe { (v).assume_init() };
+                let __arm = {
+                    match __choice {
+                        note_t::Sketched(__wire_part0) => (__wire_part0,),
+                        _ => {
+                            unreachable!("validated Choice tag selected a different arm")
+                        }
+                    }
+                };
+                example_flat::Note::Sketched(__cbg_in_Drawing((__arm).0)?)
+            }
+            _ => {
+                return ::core::result::Result::Err(
+                    ::std::format!(
+                        "invalid tag {} for `{}` (expected 0..{})", __tag,
+                        stringify!(note_t), 5usize,
+                    ),
+                );
+            }
+        }
+    })
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
 pub(crate) unsafe fn __cbg_in_Operation(
@@ -391,44 +427,75 @@ pub(crate) unsafe fn __cbg_in_Operation(
 pub(crate) unsafe fn __cbg_in_Shape(
     v: ::core::mem::MaybeUninit<shape_t>,
 ) -> ::core::result::Result<example_flat::Shape, ::std::string::String> {
-    const _: () = {
-        assert!(
-            ::core::mem::size_of:: < shape_t > () >= ::core::mem::size_of:: <
-            ::core::ffi::c_int > (),
-            "`shape_t`: a #[repr(C)] enum with payload variants must be at least as large as its C `int` discriminant"
-        );
-    };
-    let __tag: ::core::ffi::c_int = ::core::ptr::read(
-        v.as_ptr() as *const ::core::ffi::c_int,
-    );
-    if !((__tag as i64) >= 0 && (__tag as i64) < 4i64) {
-        return ::core::result::Result::Err(
-            ::std::format!("invalid tag {} for `shape_t` (expected 0..4)", __tag),
-        );
-    }
-    let v = v.assume_init();
-    ::core::result::Result::Ok(
-        match v {
-            shape_t::Empty => example_flat::Shape::Empty,
-            shape_t::Circle(__f0) => example_flat::Shape::Circle(__f0),
-            shape_t::Rect { width: __f0, height: __f1 } => {
+    ::core::result::Result::Ok({
+        let __tag = {
+            const _: () = {
+                assert!(
+                    ::core::mem::size_of:: < shape_t > () >= ::core::mem::size_of:: <
+                    ::core::ffi::c_int > (),
+                    "`shape_t`: a #[repr(C)] enum with payload variants must be at least as large as its C `int` discriminant"
+                );
+            };
+            unsafe { ::core::ptr::read((v).as_ptr() as *const ::core::ffi::c_int) }
+        };
+        match __tag {
+            0 => example_flat::Shape::Empty,
+            1 => {
+                let __choice = unsafe { (v).assume_init() };
+                let __arm = {
+                    match __choice {
+                        shape_t::Circle(__wire_part0) => (__wire_part0,),
+                        _ => {
+                            unreachable!("validated Choice tag selected a different arm")
+                        }
+                    }
+                };
+                example_flat::Shape::Circle(__cbg_in_f64((__arm).0))
+            }
+            2 => {
+                let __choice = unsafe { (v).assume_init() };
+                let __arm = {
+                    match __choice {
+                        shape_t::Rect { width: __wire_part0, height: __wire_part1 } => {
+                            (__wire_part0, __wire_part1)
+                        }
+                        _ => {
+                            unreachable!("validated Choice tag selected a different arm")
+                        }
+                    }
+                };
                 example_flat::Shape::Rect {
-                    width: __f0,
-                    height: __f1,
+                    width: __cbg_in_f64((__arm).0),
+                    height: __cbg_in_f64((__arm).1),
                 }
             }
-            shape_t::Labeled(__f0, __f1) => {
+            3 => {
+                let __choice = unsafe { (v).assume_init() };
+                let __arm = {
+                    match __choice {
+                        shape_t::Labeled(__wire_part0, __wire_part1) => {
+                            (__wire_part0, __wire_part1)
+                        }
+                        _ => {
+                            unreachable!("validated Choice tag selected a different arm")
+                        }
+                    }
+                };
                 example_flat::Shape::Labeled(
-                    if __f0.is_null() {
-                        ::std::string::String::new()
-                    } else {
-                        ::std::ffi::CStr::from_ptr(__f0).to_string_lossy().into_owned()
-                    },
-                    __cbg_in_Operation(__f1)?,
+                    __cbg_in_String_field((__arm).0),
+                    __cbg_in_Operation((__arm).1)?,
                 )
             }
-        },
-    )
+            _ => {
+                return ::core::result::Result::Err(
+                    ::std::format!(
+                        "invalid tag {} for `{}` (expected 0..{})", __tag,
+                        stringify!(shape_t), 4usize,
+                    ),
+                );
+            }
+        }
+    })
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
 pub(crate) unsafe fn __cbg_in_String(
@@ -446,6 +513,16 @@ pub(crate) unsafe fn __cbg_in_String(
                 ::std::string::String::from("invalid UTF-8 in String argument"),
             )
         }
+    }
+}
+#[allow(non_snake_case, unused_variables, dead_code)]
+pub(crate) unsafe fn __cbg_in_String_field(
+    v: *const ::core::ffi::c_char,
+) -> ::std::string::String {
+    if v.is_null() {
+        ::std::string::String::new()
+    } else {
+        ::std::ffi::CStr::from_ptr(v).to_string_lossy().into_owned()
     }
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
@@ -653,15 +730,15 @@ pub(crate) fn __cbg_out_Calculator(v: example_flat::Calculator) -> *mut calculat
 #[allow(non_snake_case, unused_variables, dead_code)]
 pub(crate) fn __cbg_out_Caption(v: example_flat::Caption) -> caption_t {
     caption_t {
-        id: v.id,
-        text: __cbg_alloc_cstr(v.text),
-        emphatic: ::core::mem::MaybeUninit::new(v.emphatic),
+        id: __cbg_out_u64(v.id),
+        text: __cbg_out_String(v.text),
+        emphatic: __cbg_out_bool_field(v.emphatic),
     }
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
 pub(crate) fn __cbg_out_Drawing(v: example_flat::Drawing) -> drawing_t {
     drawing_t {
-        id: v.id,
+        id: __cbg_out_u64(v.id),
         shape: __cbg_out_Shape(v.shape),
     }
 }
@@ -672,9 +749,9 @@ pub(crate) fn __cbg_out_Error(v: example_flat::Error) -> *mut ::core::ffi::c_cha
 #[allow(non_snake_case, unused_variables, dead_code)]
 pub(crate) fn __cbg_out_Foo(v: example_flat::Foo) -> foo_t {
     foo_t {
-        id: v.id,
-        aarch64_field: v.aarch64_field,
-        unstable_field: v.unstable_field,
+        id: __cbg_out_u64(v.id),
+        aarch64_field: __cbg_out_u64(v.aarch64_field),
+        unstable_field: __cbg_out_u64(v.unstable_field),
     }
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
@@ -697,19 +774,27 @@ pub(crate) fn __cbg_out_Millis(v: example_flat::Millis) -> u64 {
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
 pub(crate) fn __cbg_out_Note(v: example_flat::Note) -> ::core::mem::MaybeUninit<note_t> {
-    ::core::mem::MaybeUninit::new(
+    ::core::mem::MaybeUninit::new({
         match v {
             example_flat::Note::Silent => note_t::Silent,
-            example_flat::Note::Titled(__f0) => note_t::Titled(__cbg_out_Caption(__f0)),
-            example_flat::Note::After(__f0) => note_t::After(__cbg_out_Millis(__f0)),
-            example_flat::Note::Flagged(__f0) => {
-                note_t::Flagged(::core::mem::MaybeUninit::new(__f0))
+            example_flat::Note::Titled(__part0) => {
+                let __built_arm = (__cbg_out_Caption(__part0),);
+                note_t::Titled(__built_arm.0)
             }
-            example_flat::Note::Sketched(__f0) => {
-                note_t::Sketched(__cbg_out_Drawing(__f0))
+            example_flat::Note::After(__part0) => {
+                let __built_arm = (__cbg_out_Millis(__part0),);
+                note_t::After(__built_arm.0)
             }
-        },
-    )
+            example_flat::Note::Flagged(__part0) => {
+                let __built_arm = (__cbg_out_bool_field(__part0),);
+                note_t::Flagged(__built_arm.0)
+            }
+            example_flat::Note::Sketched(__part0) => {
+                let __built_arm = (__cbg_out_Drawing(__part0),);
+                note_t::Sketched(__built_arm.0)
+            }
+        }
+    })
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
 pub(crate) fn __cbg_out_Operation(v: example_flat::Operation) -> operation_t {
@@ -724,24 +809,29 @@ pub(crate) fn __cbg_out_Operation(v: example_flat::Operation) -> operation_t {
 pub(crate) fn __cbg_out_Shape(
     v: example_flat::Shape,
 ) -> ::core::mem::MaybeUninit<shape_t> {
-    ::core::mem::MaybeUninit::new(
+    ::core::mem::MaybeUninit::new({
         match v {
             example_flat::Shape::Empty => shape_t::Empty,
-            example_flat::Shape::Circle(__f0) => shape_t::Circle(__f0),
-            example_flat::Shape::Rect { width: __f0, height: __f1 } => {
+            example_flat::Shape::Circle(__part0) => {
+                let __built_arm = (__cbg_out_f64(__part0),);
+                shape_t::Circle(__built_arm.0)
+            }
+            example_flat::Shape::Rect { width: __part0, height: __part1 } => {
+                let __built_arm = (__cbg_out_f64(__part0), __cbg_out_f64(__part1));
                 shape_t::Rect {
-                    width: __f0,
-                    height: __f1,
+                    width: __built_arm.0,
+                    height: __built_arm.1,
                 }
             }
-            example_flat::Shape::Labeled(__f0, __f1) => {
-                shape_t::Labeled(
-                    __cbg_alloc_cstr(__f0),
-                    ::core::mem::MaybeUninit::new(__cbg_out_Operation(__f1)),
-                )
+            example_flat::Shape::Labeled(__part0, __part1) => {
+                let __built_arm = (
+                    __cbg_out_String(__part0),
+                    ::core::mem::MaybeUninit::new(__cbg_out_Operation(__part1)),
+                );
+                shape_t::Labeled(__built_arm.0, __built_arm.1)
             }
-        },
-    )
+        }
+    })
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
 pub(crate) fn __cbg_out_String(v: ::std::string::String) -> *mut ::core::ffi::c_char {
@@ -750,6 +840,10 @@ pub(crate) fn __cbg_out_String(v: ::std::string::String) -> *mut ::core::ffi::c_
 #[allow(non_snake_case, unused_variables, dead_code)]
 pub(crate) fn __cbg_out_bool(v: bool) -> bool {
     v
+}
+#[allow(non_snake_case, unused_variables, dead_code)]
+pub(crate) fn __cbg_out_bool_field(v: bool) -> ::core::mem::MaybeUninit<bool> {
+    ::core::mem::MaybeUninit::new(v)
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
 pub(crate) fn __cbg_out_f64(v: f64) -> f64 {

--- a/examples/example-cbindgen/generated/example_flat_x86_64.rs
+++ b/examples/example-cbindgen/generated/example_flat_x86_64.rs
@@ -316,33 +316,77 @@ pub(crate) fn __cbg_in_Millis(v: u64) -> example_flat::Millis {
 pub(crate) unsafe fn __cbg_in_Note(
     v: ::core::mem::MaybeUninit<note_t>,
 ) -> ::core::result::Result<example_flat::Note, ::std::string::String> {
-    const _: () = {
-        assert!(
-            ::core::mem::size_of:: < note_t > () >= ::core::mem::size_of:: <
-            ::core::ffi::c_int > (),
-            "`note_t`: a #[repr(C)] enum with payload variants must be at least as large as its C `int` discriminant"
-        );
-    };
-    let __tag: ::core::ffi::c_int = ::core::ptr::read(
-        v.as_ptr() as *const ::core::ffi::c_int,
-    );
-    if !((__tag as i64) >= 0 && (__tag as i64) < 5i64) {
-        return ::core::result::Result::Err(
-            ::std::format!("invalid tag {} for `note_t` (expected 0..5)", __tag),
-        );
-    }
-    let v = v.assume_init();
-    ::core::result::Result::Ok(
-        match v {
-            note_t::Silent => example_flat::Note::Silent,
-            note_t::Titled(__f0) => example_flat::Note::Titled(__cbg_in_Caption(__f0)),
-            note_t::After(__f0) => example_flat::Note::After(__cbg_in_Millis(__f0)),
-            note_t::Flagged(__f0) => example_flat::Note::Flagged(__cbg_in_bool(__f0)),
-            note_t::Sketched(__f0) => {
-                example_flat::Note::Sketched(__cbg_in_Drawing(__f0)?)
+    ::core::result::Result::Ok({
+        let __tag = {
+            const _: () = {
+                assert!(
+                    ::core::mem::size_of:: < note_t > () >= ::core::mem::size_of:: <
+                    ::core::ffi::c_int > (),
+                    "`note_t`: a #[repr(C)] enum with payload variants must be at least as large as its C `int` discriminant"
+                );
+            };
+            unsafe { ::core::ptr::read((v).as_ptr() as *const ::core::ffi::c_int) }
+        };
+        match __tag {
+            0 => example_flat::Note::Silent,
+            1 => {
+                let __choice = unsafe { (v).assume_init() };
+                let __arm = {
+                    match __choice {
+                        note_t::Titled(__wire_part0) => (__wire_part0,),
+                        _ => {
+                            unreachable!("validated Choice tag selected a different arm")
+                        }
+                    }
+                };
+                example_flat::Note::Titled(__cbg_in_Caption((__arm).0))
             }
-        },
-    )
+            2 => {
+                let __choice = unsafe { (v).assume_init() };
+                let __arm = {
+                    match __choice {
+                        note_t::After(__wire_part0) => (__wire_part0,),
+                        _ => {
+                            unreachable!("validated Choice tag selected a different arm")
+                        }
+                    }
+                };
+                example_flat::Note::After(__cbg_in_Millis((__arm).0))
+            }
+            3 => {
+                let __choice = unsafe { (v).assume_init() };
+                let __arm = {
+                    match __choice {
+                        note_t::Flagged(__wire_part0) => (__wire_part0,),
+                        _ => {
+                            unreachable!("validated Choice tag selected a different arm")
+                        }
+                    }
+                };
+                example_flat::Note::Flagged(__cbg_in_bool((__arm).0))
+            }
+            4 => {
+                let __choice = unsafe { (v).assume_init() };
+                let __arm = {
+                    match __choice {
+                        note_t::Sketched(__wire_part0) => (__wire_part0,),
+                        _ => {
+                            unreachable!("validated Choice tag selected a different arm")
+                        }
+                    }
+                };
+                example_flat::Note::Sketched(__cbg_in_Drawing((__arm).0)?)
+            }
+            _ => {
+                return ::core::result::Result::Err(
+                    ::std::format!(
+                        "invalid tag {} for `{}` (expected 0..{})", __tag,
+                        stringify!(note_t), 5usize,
+                    ),
+                );
+            }
+        }
+    })
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
 pub(crate) unsafe fn __cbg_in_Operation(
@@ -383,40 +427,75 @@ pub(crate) unsafe fn __cbg_in_Operation(
 pub(crate) unsafe fn __cbg_in_Shape(
     v: ::core::mem::MaybeUninit<shape_t>,
 ) -> ::core::result::Result<example_flat::Shape, ::std::string::String> {
-    const _: () = {
-        assert!(
-            ::core::mem::size_of:: < shape_t > () >= ::core::mem::size_of:: <
-            ::core::ffi::c_int > (),
-            "`shape_t`: a #[repr(C)] enum with payload variants must be at least as large as its C `int` discriminant"
-        );
-    };
-    let __tag: ::core::ffi::c_int = ::core::ptr::read(
-        v.as_ptr() as *const ::core::ffi::c_int,
-    );
-    if !((__tag as i64) >= 0 && (__tag as i64) < 4i64) {
-        return ::core::result::Result::Err(
-            ::std::format!("invalid tag {} for `shape_t` (expected 0..4)", __tag),
-        );
-    }
-    let v = v.assume_init();
-    ::core::result::Result::Ok(
-        match v {
-            shape_t::Empty => example_flat::Shape::Empty,
-            shape_t::Circle(__f0) => example_flat::Shape::Circle(__cbg_in_f64(__f0)),
-            shape_t::Rect { width: __f0, height: __f1 } => {
+    ::core::result::Result::Ok({
+        let __tag = {
+            const _: () = {
+                assert!(
+                    ::core::mem::size_of:: < shape_t > () >= ::core::mem::size_of:: <
+                    ::core::ffi::c_int > (),
+                    "`shape_t`: a #[repr(C)] enum with payload variants must be at least as large as its C `int` discriminant"
+                );
+            };
+            unsafe { ::core::ptr::read((v).as_ptr() as *const ::core::ffi::c_int) }
+        };
+        match __tag {
+            0 => example_flat::Shape::Empty,
+            1 => {
+                let __choice = unsafe { (v).assume_init() };
+                let __arm = {
+                    match __choice {
+                        shape_t::Circle(__wire_part0) => (__wire_part0,),
+                        _ => {
+                            unreachable!("validated Choice tag selected a different arm")
+                        }
+                    }
+                };
+                example_flat::Shape::Circle(__cbg_in_f64((__arm).0))
+            }
+            2 => {
+                let __choice = unsafe { (v).assume_init() };
+                let __arm = {
+                    match __choice {
+                        shape_t::Rect { width: __wire_part0, height: __wire_part1 } => {
+                            (__wire_part0, __wire_part1)
+                        }
+                        _ => {
+                            unreachable!("validated Choice tag selected a different arm")
+                        }
+                    }
+                };
                 example_flat::Shape::Rect {
-                    width: __cbg_in_f64(__f0),
-                    height: __cbg_in_f64(__f1),
+                    width: __cbg_in_f64((__arm).0),
+                    height: __cbg_in_f64((__arm).1),
                 }
             }
-            shape_t::Labeled(__f0, __f1) => {
+            3 => {
+                let __choice = unsafe { (v).assume_init() };
+                let __arm = {
+                    match __choice {
+                        shape_t::Labeled(__wire_part0, __wire_part1) => {
+                            (__wire_part0, __wire_part1)
+                        }
+                        _ => {
+                            unreachable!("validated Choice tag selected a different arm")
+                        }
+                    }
+                };
                 example_flat::Shape::Labeled(
-                    __cbg_in_String_field(__f0),
-                    __cbg_in_Operation(__f1)?,
+                    __cbg_in_String_field((__arm).0),
+                    __cbg_in_Operation((__arm).1)?,
                 )
             }
-        },
-    )
+            _ => {
+                return ::core::result::Result::Err(
+                    ::std::format!(
+                        "invalid tag {} for `{}` (expected 0..{})", __tag,
+                        stringify!(shape_t), 4usize,
+                    ),
+                );
+            }
+        }
+    })
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
 pub(crate) unsafe fn __cbg_in_String(
@@ -695,19 +774,27 @@ pub(crate) fn __cbg_out_Millis(v: example_flat::Millis) -> u64 {
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
 pub(crate) fn __cbg_out_Note(v: example_flat::Note) -> ::core::mem::MaybeUninit<note_t> {
-    ::core::mem::MaybeUninit::new(
+    ::core::mem::MaybeUninit::new({
         match v {
             example_flat::Note::Silent => note_t::Silent,
-            example_flat::Note::Titled(__f0) => note_t::Titled(__cbg_out_Caption(__f0)),
-            example_flat::Note::After(__f0) => note_t::After(__cbg_out_Millis(__f0)),
-            example_flat::Note::Flagged(__f0) => {
-                note_t::Flagged(__cbg_out_bool_field(__f0))
+            example_flat::Note::Titled(__part0) => {
+                let __built_arm = (__cbg_out_Caption(__part0),);
+                note_t::Titled(__built_arm.0)
             }
-            example_flat::Note::Sketched(__f0) => {
-                note_t::Sketched(__cbg_out_Drawing(__f0))
+            example_flat::Note::After(__part0) => {
+                let __built_arm = (__cbg_out_Millis(__part0),);
+                note_t::After(__built_arm.0)
             }
-        },
-    )
+            example_flat::Note::Flagged(__part0) => {
+                let __built_arm = (__cbg_out_bool_field(__part0),);
+                note_t::Flagged(__built_arm.0)
+            }
+            example_flat::Note::Sketched(__part0) => {
+                let __built_arm = (__cbg_out_Drawing(__part0),);
+                note_t::Sketched(__built_arm.0)
+            }
+        }
+    })
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
 pub(crate) fn __cbg_out_Operation(v: example_flat::Operation) -> operation_t {
@@ -722,24 +809,29 @@ pub(crate) fn __cbg_out_Operation(v: example_flat::Operation) -> operation_t {
 pub(crate) fn __cbg_out_Shape(
     v: example_flat::Shape,
 ) -> ::core::mem::MaybeUninit<shape_t> {
-    ::core::mem::MaybeUninit::new(
+    ::core::mem::MaybeUninit::new({
         match v {
             example_flat::Shape::Empty => shape_t::Empty,
-            example_flat::Shape::Circle(__f0) => shape_t::Circle(__cbg_out_f64(__f0)),
-            example_flat::Shape::Rect { width: __f0, height: __f1 } => {
+            example_flat::Shape::Circle(__part0) => {
+                let __built_arm = (__cbg_out_f64(__part0),);
+                shape_t::Circle(__built_arm.0)
+            }
+            example_flat::Shape::Rect { width: __part0, height: __part1 } => {
+                let __built_arm = (__cbg_out_f64(__part0), __cbg_out_f64(__part1));
                 shape_t::Rect {
-                    width: __cbg_out_f64(__f0),
-                    height: __cbg_out_f64(__f1),
+                    width: __built_arm.0,
+                    height: __built_arm.1,
                 }
             }
-            example_flat::Shape::Labeled(__f0, __f1) => {
-                shape_t::Labeled(
-                    __cbg_out_String(__f0),
-                    ::core::mem::MaybeUninit::new(__cbg_out_Operation(__f1)),
-                )
+            example_flat::Shape::Labeled(__part0, __part1) => {
+                let __built_arm = (
+                    __cbg_out_String(__part0),
+                    ::core::mem::MaybeUninit::new(__cbg_out_Operation(__part1)),
+                );
+                shape_t::Labeled(__built_arm.0, __built_arm.1)
             }
-        },
-    )
+        }
+    })
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
 pub(crate) fn __cbg_out_String(v: ::std::string::String) -> *mut ::core::ffi::c_char {

--- a/examples/example-cbindgen/generated/example_flat_x86_64_internal_unstable.rs
+++ b/examples/example-cbindgen/generated/example_flat_x86_64_internal_unstable.rs
@@ -316,33 +316,77 @@ pub(crate) fn __cbg_in_Millis(v: u64) -> example_flat::Millis {
 pub(crate) unsafe fn __cbg_in_Note(
     v: ::core::mem::MaybeUninit<note_t>,
 ) -> ::core::result::Result<example_flat::Note, ::std::string::String> {
-    const _: () = {
-        assert!(
-            ::core::mem::size_of:: < note_t > () >= ::core::mem::size_of:: <
-            ::core::ffi::c_int > (),
-            "`note_t`: a #[repr(C)] enum with payload variants must be at least as large as its C `int` discriminant"
-        );
-    };
-    let __tag: ::core::ffi::c_int = ::core::ptr::read(
-        v.as_ptr() as *const ::core::ffi::c_int,
-    );
-    if !((__tag as i64) >= 0 && (__tag as i64) < 5i64) {
-        return ::core::result::Result::Err(
-            ::std::format!("invalid tag {} for `note_t` (expected 0..5)", __tag),
-        );
-    }
-    let v = v.assume_init();
-    ::core::result::Result::Ok(
-        match v {
-            note_t::Silent => example_flat::Note::Silent,
-            note_t::Titled(__f0) => example_flat::Note::Titled(__cbg_in_Caption(__f0)),
-            note_t::After(__f0) => example_flat::Note::After(__cbg_in_Millis(__f0)),
-            note_t::Flagged(__f0) => example_flat::Note::Flagged(__cbg_in_bool(__f0)),
-            note_t::Sketched(__f0) => {
-                example_flat::Note::Sketched(__cbg_in_Drawing(__f0)?)
+    ::core::result::Result::Ok({
+        let __tag = {
+            const _: () = {
+                assert!(
+                    ::core::mem::size_of:: < note_t > () >= ::core::mem::size_of:: <
+                    ::core::ffi::c_int > (),
+                    "`note_t`: a #[repr(C)] enum with payload variants must be at least as large as its C `int` discriminant"
+                );
+            };
+            unsafe { ::core::ptr::read((v).as_ptr() as *const ::core::ffi::c_int) }
+        };
+        match __tag {
+            0 => example_flat::Note::Silent,
+            1 => {
+                let __choice = unsafe { (v).assume_init() };
+                let __arm = {
+                    match __choice {
+                        note_t::Titled(__wire_part0) => (__wire_part0,),
+                        _ => {
+                            unreachable!("validated Choice tag selected a different arm")
+                        }
+                    }
+                };
+                example_flat::Note::Titled(__cbg_in_Caption((__arm).0))
             }
-        },
-    )
+            2 => {
+                let __choice = unsafe { (v).assume_init() };
+                let __arm = {
+                    match __choice {
+                        note_t::After(__wire_part0) => (__wire_part0,),
+                        _ => {
+                            unreachable!("validated Choice tag selected a different arm")
+                        }
+                    }
+                };
+                example_flat::Note::After(__cbg_in_Millis((__arm).0))
+            }
+            3 => {
+                let __choice = unsafe { (v).assume_init() };
+                let __arm = {
+                    match __choice {
+                        note_t::Flagged(__wire_part0) => (__wire_part0,),
+                        _ => {
+                            unreachable!("validated Choice tag selected a different arm")
+                        }
+                    }
+                };
+                example_flat::Note::Flagged(__cbg_in_bool((__arm).0))
+            }
+            4 => {
+                let __choice = unsafe { (v).assume_init() };
+                let __arm = {
+                    match __choice {
+                        note_t::Sketched(__wire_part0) => (__wire_part0,),
+                        _ => {
+                            unreachable!("validated Choice tag selected a different arm")
+                        }
+                    }
+                };
+                example_flat::Note::Sketched(__cbg_in_Drawing((__arm).0)?)
+            }
+            _ => {
+                return ::core::result::Result::Err(
+                    ::std::format!(
+                        "invalid tag {} for `{}` (expected 0..{})", __tag,
+                        stringify!(note_t), 5usize,
+                    ),
+                );
+            }
+        }
+    })
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
 pub(crate) unsafe fn __cbg_in_Operation(
@@ -383,40 +427,75 @@ pub(crate) unsafe fn __cbg_in_Operation(
 pub(crate) unsafe fn __cbg_in_Shape(
     v: ::core::mem::MaybeUninit<shape_t>,
 ) -> ::core::result::Result<example_flat::Shape, ::std::string::String> {
-    const _: () = {
-        assert!(
-            ::core::mem::size_of:: < shape_t > () >= ::core::mem::size_of:: <
-            ::core::ffi::c_int > (),
-            "`shape_t`: a #[repr(C)] enum with payload variants must be at least as large as its C `int` discriminant"
-        );
-    };
-    let __tag: ::core::ffi::c_int = ::core::ptr::read(
-        v.as_ptr() as *const ::core::ffi::c_int,
-    );
-    if !((__tag as i64) >= 0 && (__tag as i64) < 4i64) {
-        return ::core::result::Result::Err(
-            ::std::format!("invalid tag {} for `shape_t` (expected 0..4)", __tag),
-        );
-    }
-    let v = v.assume_init();
-    ::core::result::Result::Ok(
-        match v {
-            shape_t::Empty => example_flat::Shape::Empty,
-            shape_t::Circle(__f0) => example_flat::Shape::Circle(__cbg_in_f64(__f0)),
-            shape_t::Rect { width: __f0, height: __f1 } => {
+    ::core::result::Result::Ok({
+        let __tag = {
+            const _: () = {
+                assert!(
+                    ::core::mem::size_of:: < shape_t > () >= ::core::mem::size_of:: <
+                    ::core::ffi::c_int > (),
+                    "`shape_t`: a #[repr(C)] enum with payload variants must be at least as large as its C `int` discriminant"
+                );
+            };
+            unsafe { ::core::ptr::read((v).as_ptr() as *const ::core::ffi::c_int) }
+        };
+        match __tag {
+            0 => example_flat::Shape::Empty,
+            1 => {
+                let __choice = unsafe { (v).assume_init() };
+                let __arm = {
+                    match __choice {
+                        shape_t::Circle(__wire_part0) => (__wire_part0,),
+                        _ => {
+                            unreachable!("validated Choice tag selected a different arm")
+                        }
+                    }
+                };
+                example_flat::Shape::Circle(__cbg_in_f64((__arm).0))
+            }
+            2 => {
+                let __choice = unsafe { (v).assume_init() };
+                let __arm = {
+                    match __choice {
+                        shape_t::Rect { width: __wire_part0, height: __wire_part1 } => {
+                            (__wire_part0, __wire_part1)
+                        }
+                        _ => {
+                            unreachable!("validated Choice tag selected a different arm")
+                        }
+                    }
+                };
                 example_flat::Shape::Rect {
-                    width: __cbg_in_f64(__f0),
-                    height: __cbg_in_f64(__f1),
+                    width: __cbg_in_f64((__arm).0),
+                    height: __cbg_in_f64((__arm).1),
                 }
             }
-            shape_t::Labeled(__f0, __f1) => {
+            3 => {
+                let __choice = unsafe { (v).assume_init() };
+                let __arm = {
+                    match __choice {
+                        shape_t::Labeled(__wire_part0, __wire_part1) => {
+                            (__wire_part0, __wire_part1)
+                        }
+                        _ => {
+                            unreachable!("validated Choice tag selected a different arm")
+                        }
+                    }
+                };
                 example_flat::Shape::Labeled(
-                    __cbg_in_String_field(__f0),
-                    __cbg_in_Operation(__f1)?,
+                    __cbg_in_String_field((__arm).0),
+                    __cbg_in_Operation((__arm).1)?,
                 )
             }
-        },
-    )
+            _ => {
+                return ::core::result::Result::Err(
+                    ::std::format!(
+                        "invalid tag {} for `{}` (expected 0..{})", __tag,
+                        stringify!(shape_t), 4usize,
+                    ),
+                );
+            }
+        }
+    })
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
 pub(crate) unsafe fn __cbg_in_String(
@@ -695,19 +774,27 @@ pub(crate) fn __cbg_out_Millis(v: example_flat::Millis) -> u64 {
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
 pub(crate) fn __cbg_out_Note(v: example_flat::Note) -> ::core::mem::MaybeUninit<note_t> {
-    ::core::mem::MaybeUninit::new(
+    ::core::mem::MaybeUninit::new({
         match v {
             example_flat::Note::Silent => note_t::Silent,
-            example_flat::Note::Titled(__f0) => note_t::Titled(__cbg_out_Caption(__f0)),
-            example_flat::Note::After(__f0) => note_t::After(__cbg_out_Millis(__f0)),
-            example_flat::Note::Flagged(__f0) => {
-                note_t::Flagged(__cbg_out_bool_field(__f0))
+            example_flat::Note::Titled(__part0) => {
+                let __built_arm = (__cbg_out_Caption(__part0),);
+                note_t::Titled(__built_arm.0)
             }
-            example_flat::Note::Sketched(__f0) => {
-                note_t::Sketched(__cbg_out_Drawing(__f0))
+            example_flat::Note::After(__part0) => {
+                let __built_arm = (__cbg_out_Millis(__part0),);
+                note_t::After(__built_arm.0)
             }
-        },
-    )
+            example_flat::Note::Flagged(__part0) => {
+                let __built_arm = (__cbg_out_bool_field(__part0),);
+                note_t::Flagged(__built_arm.0)
+            }
+            example_flat::Note::Sketched(__part0) => {
+                let __built_arm = (__cbg_out_Drawing(__part0),);
+                note_t::Sketched(__built_arm.0)
+            }
+        }
+    })
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
 pub(crate) fn __cbg_out_Operation(v: example_flat::Operation) -> operation_t {
@@ -722,24 +809,29 @@ pub(crate) fn __cbg_out_Operation(v: example_flat::Operation) -> operation_t {
 pub(crate) fn __cbg_out_Shape(
     v: example_flat::Shape,
 ) -> ::core::mem::MaybeUninit<shape_t> {
-    ::core::mem::MaybeUninit::new(
+    ::core::mem::MaybeUninit::new({
         match v {
             example_flat::Shape::Empty => shape_t::Empty,
-            example_flat::Shape::Circle(__f0) => shape_t::Circle(__cbg_out_f64(__f0)),
-            example_flat::Shape::Rect { width: __f0, height: __f1 } => {
+            example_flat::Shape::Circle(__part0) => {
+                let __built_arm = (__cbg_out_f64(__part0),);
+                shape_t::Circle(__built_arm.0)
+            }
+            example_flat::Shape::Rect { width: __part0, height: __part1 } => {
+                let __built_arm = (__cbg_out_f64(__part0), __cbg_out_f64(__part1));
                 shape_t::Rect {
-                    width: __cbg_out_f64(__f0),
-                    height: __cbg_out_f64(__f1),
+                    width: __built_arm.0,
+                    height: __built_arm.1,
                 }
             }
-            example_flat::Shape::Labeled(__f0, __f1) => {
-                shape_t::Labeled(
-                    __cbg_out_String(__f0),
-                    ::core::mem::MaybeUninit::new(__cbg_out_Operation(__f1)),
-                )
+            example_flat::Shape::Labeled(__part0, __part1) => {
+                let __built_arm = (
+                    __cbg_out_String(__part0),
+                    ::core::mem::MaybeUninit::new(__cbg_out_Operation(__part1)),
+                );
+                shape_t::Labeled(__built_arm.0, __built_arm.1)
             }
-        },
-    )
+        }
+    })
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
 pub(crate) fn __cbg_out_String(v: ::std::string::String) -> *mut ::core::ffi::c_char {

--- a/prebindgen-c/src/chain.rs
+++ b/prebindgen-c/src/chain.rs
@@ -8,7 +8,7 @@
 
 use prebindgen_registry::{
     chain::{self, Chain as _},
-    flat::TypeRef,
+    flat::{Alternative, TypeRef},
     recipe::Mode,
     write::RustFunction,
     Emit,
@@ -57,6 +57,7 @@ enum CBody {
     Complete(syn::ItemFn),
     Product(ProductPlan),
     Optional(OptionalPlan),
+    Choice(ChoicePlan),
 }
 
 impl CFunction {
@@ -92,6 +93,24 @@ impl CFunction {
         }
     }
 
+    pub(crate) fn choice(plan: ChoicePlan) -> Self {
+        let fallible = plan.direction == Direction::Construct
+            || plan
+                .arms
+                .iter()
+                .flat_map(|arm| &arm.parts)
+                .any(|part| part.child.fallible());
+        let call = CCall(chain::Call::new(
+            plan.ident.clone(),
+            fallible,
+            plan.direction == Direction::Construct,
+        ));
+        Self {
+            call,
+            body: CBody::Choice(plan),
+        }
+    }
+
     pub(crate) fn call(&self) -> &CCall {
         &self.call
     }
@@ -102,6 +121,7 @@ impl RustFunction for CFunction {
         match &self.body {
             CBody::Complete(function) => function.clone(),
             CBody::Product(plan) => plan.render(emit),
+            CBody::Choice(plan) => plan.render(emit),
             CBody::Optional(plan) => plan.render(emit),
         }
     }
@@ -311,6 +331,165 @@ impl OptionalPlan {
                     #body
                 }
             )
+        }
+    }
+}
+#[derive(Clone)]
+struct CChoiceBridge {
+    wire: syn::Ident,
+    alternatives: Vec<Alternative>,
+}
+
+impl chain::ChoiceBridge for CChoiceBridge {
+    fn intermediate(&self) -> syn::Type {
+        let wire = &self.wire;
+        syn::parse_quote!(::core::mem::MaybeUninit<#wire>)
+    }
+
+    fn tag(&self, value: TokenStream) -> TokenStream {
+        let wire = &self.wire;
+        let bounds_msg = format!(
+            "`{wire}`: a #[repr(C)] enum with payload variants must be at least as large as its C `int` discriminant"
+        );
+        quote!({
+            const _: () = {
+                assert!(
+                    ::core::mem::size_of::<#wire>()
+                        >= ::core::mem::size_of::<::core::ffi::c_int>(),
+                    #bounds_msg
+                );
+            };
+            unsafe {
+                ::core::ptr::read((#value).as_ptr() as *const ::core::ffi::c_int)
+            }
+        })
+    }
+
+    fn prepare(&self, value: TokenStream) -> TokenStream {
+        quote!(unsafe { (#value).assume_init() })
+    }
+
+    fn arm(&self, emit: &Emit, value: TokenStream, index: usize) -> TokenStream {
+        let wire = &self.wire;
+        let alternative = &self.alternatives[index];
+        let variant = &alternative.name;
+        let bindings: Vec<_> = alternative
+            .fields
+            .iter()
+            .enumerate()
+            .map(|(index, _)| format_ident!("__wire_part{index}"))
+            .collect();
+        let bound: Vec<_> = alternative
+            .fields
+            .iter()
+            .zip(&bindings)
+            .map(|(field, binding)| field.bind(binding))
+            .collect();
+        let pattern = emit.shape_alternative(alternative, quote!(#wire::#variant), &bound);
+        quote!({
+            match #value {
+                #pattern => (#(#bindings,)*),
+                _ => unreachable!("validated Choice tag selected a different arm"),
+            }
+        })
+    }
+
+    fn build(&self, emit: &Emit, active: usize, value: TokenStream) -> TokenStream {
+        let wire = &self.wire;
+        let alternative = &self.alternatives[active];
+        let variant = &alternative.name;
+        if alternative.fields.is_empty() {
+            return emit.shape_alternative(alternative, quote!(#wire::#variant), &[]);
+        }
+        let fields: Vec<_> = alternative
+            .fields
+            .iter()
+            .enumerate()
+            .map(|(index, field)| {
+                let index = syn::Index::from(index);
+                field.bind(&quote!(__built_arm.#index))
+            })
+            .collect();
+        let built = emit.shape_alternative(alternative, quote!(#wire::#variant), &fields);
+        quote!({
+            let __built_arm = #value;
+            #built
+        })
+    }
+
+    fn finish(&self, value: TokenStream) -> TokenStream {
+        quote!(::core::mem::MaybeUninit::new(#value))
+    }
+
+    fn invalid_tag(&self, tag: TokenStream) -> TokenStream {
+        let wire = &self.wire;
+        let variants = self.alternatives.len();
+        quote!(::std::format!(
+            "invalid tag {} for `{}` (expected 0..{})",
+            #tag,
+            stringify!(#wire),
+            #variants,
+        ))
+    }
+}
+
+/// A tagged-union Choice chain. Raw C storage is represented by its bridge;
+/// source syntax remains behind `source` until `render`.
+#[derive(Clone)]
+pub(crate) struct ChoicePlan {
+    pub(crate) ident: syn::Ident,
+    pub(crate) source: TypeRef,
+    pub(crate) source_module: Option<syn::Path>,
+    pub(crate) wire: syn::Ident,
+    pub(crate) direction: Direction,
+    pub(crate) arms: Vec<chain::ChoiceArm<chain::TupleProduct, CCall>>,
+}
+
+impl ChoicePlan {
+    fn render(&self, emit: &Emit) -> syn::ItemFn {
+        let composed = chain::Choice {
+            source: self.source.clone(),
+            direction: self.direction,
+            source_policy: CSource {
+                module: self.source_module.clone(),
+            },
+            bridge: CChoiceBridge {
+                wire: self.wire.clone(),
+                alternatives: self
+                    .arms
+                    .iter()
+                    .map(|arm| arm.alternative.clone())
+                    .collect(),
+            },
+            arms: self.arms.clone(),
+        };
+        let rendered = composed.render(emit);
+        let name = &self.ident;
+        let source = &rendered.source;
+        let intermediate = &rendered.intermediate;
+        let body = &rendered.body;
+
+        match self.direction {
+            Direction::Construct => syn::parse_quote!(
+                #[allow(non_snake_case, unused_variables, dead_code)]
+                pub(crate) unsafe fn #name(
+                    v: #intermediate,
+                ) -> ::core::result::Result<#source, ::std::string::String> {
+                    ::core::result::Result::Ok(#body)
+                }
+            ),
+            Direction::Deconstruct => {
+                assert!(
+                    !rendered.fallible,
+                    "fallible C Choice output must be refused while planning"
+                );
+                syn::parse_quote!(
+                    #[allow(non_snake_case, unused_variables, dead_code)]
+                    pub(crate) fn #name(v: #source) -> #intermediate {
+                        #body
+                    }
+                )
+            }
         }
     }
 }

--- a/prebindgen-c/src/compile.rs
+++ b/prebindgen-c/src/compile.rs
@@ -16,7 +16,9 @@ use prebindgen_registry::{
 };
 
 use super::*;
-use crate::chain::{CFunction, OptionalPlan, OptionalRepr, ProductField, ProductPlan};
+use crate::chain::{
+    CCall, CFunction, ChoicePlan, OptionalPlan, OptionalRepr, ProductField, ProductPlan,
+};
 
 /// The C adapter's answer for one crossing.
 #[derive(Clone)]
@@ -30,35 +32,31 @@ pub(crate) struct CFrag {
     /// Inner types this fragment composed from, which is what marks them
     /// reachable in the registry that still emits them.
     pub(crate) subs: Vec<TypeKey>,
-    /// One arm's payload, converted, for a fragment on its way from
+    /// One arm's payload plan on its way from
     /// [`Compile::fields`] to [`Compile::choice`].
     ///
-    /// A union's arm is a product whose parts do not assemble into a value of
-    /// their own — they are bound in a `match` and rebuilt on the other side —
-    /// so the arm's fragment carries the converted expressions rather than a
-    /// function. `None` for every other fragment, which is what a struct's is.
+    /// `None` for every other fragment, which is what a struct's is.
     pub(crate) arm: Option<Arm>,
     /// What the fragment produces, which is all the registry reads of it.
     pub(crate) yields: Yield,
 }
 
-/// One alternative's payload, converted in both directions.
-///
-/// What [`Compile::fields`] hands [`Compile::choice`] for a tagged union: the
-/// per-field expressions, keyed by nothing because their order is the
-/// alternative's own.
+/// One alternative's payload plan on its way to [`Compile::choice`].
 #[derive(Clone)]
 pub(crate) struct Arm {
-    /// Converted payload expressions, in field order, over the bindings
-    /// `__f0..__fN` a `match` arm introduces.
-    pub(crate) exprs: Vec<TokenStream>,
-    /// Whether any of them can fail, so the union's own converter knows
-    /// whether it needs a `Result`.
-    pub(crate) fallible: bool,
+    /// Ordered payload wires and resolved child calls.
+    pub(crate) parts: Vec<ArmPart>,
     /// Inner types the payloads composed from.
     pub(crate) subs: Vec<TypeKey>,
 }
 
+#[derive(Clone)]
+pub(crate) struct ArmPart {
+    pub(crate) wire: syn::Type,
+    pub(crate) child: CCall,
+    pub(crate) mode: Mode,
+    pub(crate) hold_uninit: bool,
+}
 impl Carrier for CFrag {
     fn yields(&self) -> Yield {
         self.yields.clone()
@@ -172,10 +170,6 @@ fn held_uninit(declared: &syn::Type, produced: &syn::Type) -> bool {
     };
     matches!(args.args.first(), Some(syn::GenericArgument::Type(inner))
         if TypeKey::from_type(inner) == TypeKey::from_type(produced))
-}
-
-fn fallible(function: &CFunction) -> bool {
-    function.call().fallible()
 }
 
 /// A refusal naming the crossing that could not be answered.
@@ -409,31 +403,22 @@ impl<R: Conversions> Compile for CCompile<'_, R> {
                     );
                 }
             }
-            let exprs = parts
+            let arm_parts = parts
                 .iter()
-                .enumerate()
-                .map(|(i, (part, frag))| {
-                    let bind = format_ident!("__f{}", i);
-                    let conv = frag.function.call().ident();
-                    let call = if fallible(&frag.function) {
-                        quote!(#conv(#bind)?)
-                    } else {
-                        quote!(#conv(#bind))
-                    };
-                    // The union holds a payload whose bytes C may write —
-                    // a nested enum or a `bool` — as `MaybeUninit`, so the
-                    // decode can check them before assuming them valid. Same
-                    // holding form a struct's mirror field takes, and the same
-                    // reason: the wrap belongs to whatever holds the value, not
-                    // to the value's own conversion.
-                    match (
-                        at.crossing.direction(),
-                        self.gen.payload_field_wire(&part.ty),
-                    ) {
-                        (Direction::Deconstruct, Ok(w)) if held_uninit(&w, &frag.destination) => {
-                            quote!(::core::mem::MaybeUninit::new(#call))
-                        }
-                        _ => call,
+                .map(|(part, frag)| {
+                    // Input planning can precede the matching output fragment.
+                    // The output pass later validates the one-wire contract
+                    // and refuses fallible encoders before planning Choice.
+                    let wire = self
+                        .gen
+                        .payload_field_wire(&part.ty)
+                        .unwrap_or_else(|_| frag.destination.clone());
+                    ArmPart {
+                        hold_uninit: at.crossing.direction() == Direction::Deconstruct
+                            && held_uninit(&wire, &frag.destination),
+                        wire,
+                        child: frag.function.call().clone(),
+                        mode: part.mode,
                     }
                 })
                 .collect();
@@ -459,9 +444,8 @@ impl<R: Conversions> Compile for CCompile<'_, R> {
                 niches: Niches::empty(),
                 subs: subs.clone(),
                 arm: Some(Arm {
-                    fallible: parts.iter().any(|(_, f)| fallible(&f.function)),
                     subs,
-                    exprs,
+                    parts: arm_parts,
                 }),
                 yields: Yield {
                     ty: at.crossing.value().stripped_key(),
@@ -543,118 +527,74 @@ impl<R: Conversions> Compile for CCompile<'_, R> {
 
     fn choice(
         &mut self,
-        cx: &mut Cx<'_>,
+        _cx: &mut Cx<'_>,
         at: At<'_>,
         arms: &[(&Alternative, &CFrag)],
     ) -> Frag<Self> {
-        let ty = at.crossing.spelled();
-        let key = ty.key();
+        let key = at.crossing.spelled().key();
         let cname = self.gen.c_type_ident(&key);
-        let src = self.gen.src_ty_of(&key);
-        let emit = cx.emit();
-        let construct = at.crossing.direction() == Direction::Construct;
-
-        let mut subs: Vec<TypeKey> = Vec::new();
-        let mut fallible_any = false;
-        let mut match_arms: Vec<TokenStream> = Vec::new();
-        for (alternative, frag) in arms {
-            let Some(arm) = frag.arm.as_ref() else {
+        let direction = at.crossing.direction();
+        let mut subs = Vec::new();
+        let mut planned_arms = Vec::with_capacity(arms.len());
+        for (alternative, fragment) in arms {
+            let Some(arm) = fragment.arm.as_ref() else {
                 return Err(refuse(at, "an arm that composed no payload"));
             };
-            subs.extend(arm.subs.iter().cloned());
-            fallible_any |= arm.fallible;
-            let vident = &alternative.name;
-            let binds: Vec<syn::Ident> = (0..alternative.fields.len())
-                .map(|i| format_ident!("__f{}", i))
-                .collect();
-            let bound: Vec<TokenStream> = alternative
-                .fields
-                .iter()
-                .zip(&binds)
-                .map(|(f, b)| f.bind(b))
-                .collect();
-            let built: Vec<TokenStream> = alternative
-                .fields
-                .iter()
-                .zip(&arm.exprs)
-                .map(|(f, e)| f.bind(e))
-                .collect();
-            // The alternative's own delimiters on both sides, so a tuple arm
-            // and a braced one each spell themselves.
-            let (from_head, to_head) = if construct {
-                (quote!(#cname::#vident), quote!(#src::#vident))
-            } else {
-                (quote!(#src::#vident), quote!(#cname::#vident))
-            };
-            let from = emit.shape_alternative(alternative, from_head, &bound);
-            let to = emit.shape_alternative(alternative, to_head, &built);
-            match_arms.push(quote!(#from => #to,));
-        }
-
-        let conv = if construct {
-            let name = CbindgenBuilder::in_name_of(&key);
-            let bad = format!(
-                "invalid tag {{}} for `{cname}` (expected 0..{})",
-                arms.len()
-            );
-            // A C-supplied mirror may hold any discriminant, so the tag is
-            // checked before the value is assumed initialised. Neither the tag
-            // nor the check is a crossing — the adapter invents both, which is
-            // why no recipe mentions them.
-            let guard = self.gen.tag_guard(
-                &cname,
-                arms.len(),
-                quote!(v),
-                quote!(return ::core::result::Result::Err(::std::format!(#bad, __tag));),
-            );
-            let function: syn::ItemFn = syn::parse_quote!(
-                #[allow(non_snake_case, unused_variables, dead_code)]
-                pub(crate) unsafe fn #name(
-                    v: ::core::mem::MaybeUninit<#cname>,
-                ) -> ::core::result::Result<#src, ::std::string::String> {
-                    #guard
-                    let v = v.assume_init();
-                    ::core::result::Result::Ok(match v { #(#match_arms)* })
-                }
-            );
-            ConverterImpl {
-                subs,
-                destination: syn::parse_quote!(::core::mem::MaybeUninit<#cname>),
-                function,
-                pre_stages: vec![],
-                niches: Niches::empty(),
-                metadata: (),
-            }
-        } else {
-            if fallible_any {
+            if direction == Direction::Deconstruct
+                && arm.parts.iter().any(|part| part.child.fallible())
+            {
                 return Err(refuse(
                     at,
                     "a payload whose encode can fail, which a union has no way to report",
                 ));
             }
-            let name = CbindgenBuilder::out_name_of(&key);
-            // `MaybeUninit`, matching the wire the decode takes: one C type for
-            // both directions, so a union returned by one function can be
-            // handed straight to another that takes one. The value written is
-            // always initialised — only the *type* has room for a discriminant
-            // C might not have written.
-            let function: syn::ItemFn = syn::parse_quote!(
-                #[allow(non_snake_case, unused_variables, dead_code)]
-                pub(crate) fn #name(v: #src) -> ::core::mem::MaybeUninit<#cname> {
-                    ::core::mem::MaybeUninit::new(match v { #(#match_arms)* })
-                }
-            );
-            ConverterImpl {
-                subs,
-                destination: syn::parse_quote!(::core::mem::MaybeUninit<#cname>),
-                function,
-                pre_stages: vec![],
-                niches: Niches::empty(),
-                metadata: (),
-            }
+            subs.extend(arm.subs.iter().cloned());
+            planned_arms.push(prebindgen_registry::chain::ChoiceArm {
+                alternative: (*alternative).clone(),
+                tag: {
+                    let tag =
+                        syn::LitInt::new(&alternative.index.to_string(), alternative.name.span());
+                    syn::parse_quote!(#tag)
+                },
+                bridge: prebindgen_registry::chain::TupleProduct {
+                    parts: arm.parts.iter().map(|part| part.wire.clone()).collect(),
+                },
+                parts: arm
+                    .parts
+                    .iter()
+                    .map(|part| prebindgen_registry::chain::ChoicePart {
+                        child: part.child.clone(),
+                        mode: part.mode,
+                        hold_uninit: part.hold_uninit,
+                    })
+                    .collect(),
+            });
+        }
+
+        let destination: syn::Type = syn::parse_quote!(::core::mem::MaybeUninit<#cname>);
+        let ident = match direction {
+            Direction::Construct => CbindgenBuilder::in_name_of(&key),
+            Direction::Deconstruct => CbindgenBuilder::out_name_of(&key),
         };
-        let _ = fallible_any;
-        Ok(CFrag::from_converter(at, conv))
+        Ok(CFrag {
+            destination,
+            function: CFunction::choice(ChoicePlan {
+                ident,
+                source: at.crossing.spelled().clone(),
+                source_module: self.gen.source_module.clone(),
+                wire: cname,
+                direction,
+                arms: planned_arms,
+            }),
+            niches: Niches::empty(),
+            subs,
+            arm: None,
+            yields: Yield {
+                ty: at.crossing.value().stripped_key(),
+                mode: at.crossing.mode(),
+                validity: Validity::SelfSufficient,
+            },
+        })
     }
 
     fn callback(

--- a/prebindgen-c/src/tests/tagged_unions.rs
+++ b/prebindgen-c/src/tests/tagged_unions.rs
@@ -75,26 +75,22 @@ fn tagged_union_mirror_and_converters() {
     );
 
     // Output: match the source enum, convert each arm's fields.
-    assert!(
-        compact.contains("example_flat::Shape::Empty=>shape_t::Empty,"),
-        "{src}"
-    );
+    assert!(compact.contains("example_flat::Shape::Empty=>"), "{src}");
     assert!(
         // The payload converts through its own scalar conversion rather than
         // passing through inline — same value, named once.
-        compact
-            .contains("example_flat::Shape::Circle(__f0)=>shape_t::Circle(__cbg_out_f64(__f0)),"),
+        compact.contains("let__built_arm=(__cbg_out_f64(__part0),);shape_t::Circle(__built_arm.0)"),
         "{src}"
     );
     assert!(
         // The `String` payload allocates through `String`'s own conversion,
         // which is where `__cbg_alloc_cstr` lives — one statement of it rather
         // than one per payload position.
-        compact.contains("shape_t::Labeled(__cbg_out_String(__f0),"),
+        compact.contains("__cbg_out_String(__part0),"),
         "{src}"
     );
     assert!(
-        compact.contains("::core::mem::MaybeUninit::new(__cbg_out_Operation(__f1)),"),
+        compact.contains("::core::mem::MaybeUninit::new(__cbg_out_Operation(__part1)),"),
         "{src}"
     );
 
@@ -106,23 +102,20 @@ fn tagged_union_mirror_and_converters() {
         "{src}"
     );
     assert!(
-        compact.contains("let__tag:::core::ffi::c_int=::core::ptr::read(v.as_ptr()"),
+        compact.contains("::core::ptr::read((v).as_ptr()as*const::core::ffi::c_int)"),
+        "{src}"
+    );
+    assert!(compact.contains("match__tag{"), "{src}");
+    assert!(
+        compact.contains("invalidtag{}for`{}`(expected0..{})"),
         "{src}"
     );
     assert!(
-        compact.contains("if!((__tagasi64)>=0&&(__tagasi64)<4i64)"),
+        compact.contains("let__choice=unsafe{(v).assume_init()};"),
         "{src}"
     );
-    assert!(
-        compact.contains("invalidtag{}for`shape_t`(expected0..4)"),
-        "{src}"
-    );
-    assert!(compact.contains("letv=v.assume_init();"), "{src}");
-    assert!(
-        compact.contains("shape_t::Empty=>example_flat::Shape::Empty,"),
-        "{src}"
-    );
-    assert!(compact.contains("__cbg_in_Operation(__f1)?,"), "{src}");
+    assert!(compact.contains("0=>example_flat::Shape::Empty"), "{src}");
+    assert!(compact.contains("__cbg_in_Operation((__arm).1)?,"), "{src}");
     // A union taken by value is a fallible input like any other: with no
     // `Result` channel the declaration had to opt into aborting.
     assert!(compact.contains("panic!("), "{src}");
@@ -570,7 +563,7 @@ fn null_opaque_payload_is_reported_not_materialised() {
     );
     assert!(compact.contains("nullpayloadfor`Blob`"), "{src}");
     assert!(
-        compact.contains("Slot::Filled(__cbg_in_Box___Blob___payload(__f0)?)"),
+        compact.contains("Slot::Filled(__cbg_in_Box___Blob___payload((__arm).0)?)"),
         "{src}"
     );
     // The `Option` arm keeps NULL as a legitimate value.
@@ -676,20 +669,14 @@ fn payload_wires_come_from_the_converter_destination() {
     assert!(compact.contains("Titled(caption_t),"), "{src}");
     assert!(compact.contains("After(u64),"), "{src}");
     // Both directions route through the payload's own converter.
+    assert!(compact.contains("__cbg_out_Caption(__part0)"), "{src}");
+    assert!(compact.contains("__cbg_out_Millis(__part0)"), "{src}");
     assert!(
-        compact.contains("note_t::Titled(__cbg_out_Caption(__f0))"),
+        compact.contains("example_flat::Note::Titled(__cbg_in_Caption((__arm).0))"),
         "{src}"
     );
     assert!(
-        compact.contains("note_t::After(__cbg_out_Millis(__f0))"),
-        "{src}"
-    );
-    assert!(
-        compact.contains("example_flat::Note::Titled(__cbg_in_Caption(__f0))"),
-        "{src}"
-    );
-    assert!(
-        compact.contains("example_flat::Note::After(__cbg_in_Millis(__f0))"),
+        compact.contains("example_flat::Note::After(__cbg_in_Millis((__arm).0))"),
         "{src}"
     );
     // The struct payload owns a `char *`, so the union's drop reaches THROUGH
@@ -764,18 +751,14 @@ fn bool_payload_is_normalised_not_materialised() {
     // The payload converts through `bool`'s own field reading rather than
     // inline: same normalisation, named once.
     assert!(
-        compact.contains("example_flat::Flagged::On(__cbg_in_bool(__f0))"),
+        compact.contains("example_flat::Flagged::On(__cbg_in_bool((__arm).0))"),
         "{src}"
     );
     assert!(
         compact.contains("__cbg_in_bool(v:::core::mem::MaybeUninit<bool>)->bool"),
         "{src}"
     );
-    assert!(
-        compact
-            .contains("example_flat::Flagged::On(__f0)=>flagged_t::On(__cbg_out_bool_field(__f0))"),
-        "{src}"
-    );
+    assert!(compact.contains("__cbg_out_bool_field(__part0)"), "{src}");
     // A bool owns nothing, so the union still gets no typed drop.
     assert!(!compact.contains("flagged_drop"), "{src}");
 }

--- a/prebindgen-flat/src/flat/element.rs
+++ b/prebindgen-flat/src/flat/element.rs
@@ -350,18 +350,6 @@ impl Variant {
     }
 }
 
-/// Delimiter form of one sum alternative.
-///
-/// This is source structure retained by Flat, not adapter rendering policy.
-/// Empty unit, tuple and struct alternatives have the same payload arity but
-/// require different construction and pattern syntax.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum AlternativeForm {
-    Unit,
-    Tuple,
-    Struct,
-}
-
 /// One alternative of a [`Variant`].
 #[derive(Clone, Debug)]
 pub struct Alternative {
@@ -383,16 +371,6 @@ pub struct Alternative {
 }
 
 impl Alternative {
-    /// Whether this alternative uses no delimiters, tuple parentheses or
-    /// struct braces in source Rust.
-    pub fn form(&self) -> AlternativeForm {
-        match &self.origin.as_syn().fields {
-            syn::Fields::Unit => AlternativeForm::Unit,
-            syn::Fields::Unnamed(_) => AlternativeForm::Tuple,
-            syn::Fields::Named(_) => AlternativeForm::Struct,
-        }
-    }
-
     /// True when this alternative carries no payload.
     ///
     /// The *group* question, not the syntax one: `B`, `B()` and `B {}` are all

--- a/prebindgen-flat/src/flat/mod.rs
+++ b/prebindgen-flat/src/flat/mod.rs
@@ -203,8 +203,8 @@ use self::{array_len::ConstIndex, ty::lower_type};
 pub use self::{
     array_len::{ArrayExtent, ArrayLenReason, ConstId, ExtentSource, UnsupportedArrayLen},
     element::{
-        Alternative, AlternativeForm, Constant, Element, Enum, EnumValue, Extern, Field, Function,
-        Guard, Param, Struct, Type, Unsupported, Variant,
+        Alternative, Constant, Element, Enum, EnumValue, Extern, Field, Function, Guard, Param,
+        Struct, Type, Unsupported, Variant,
     },
     key::{TypeKey, TypeKeyParseError},
     origin::Origin,

--- a/prebindgen-jni/src/jni/compile.rs
+++ b/prebindgen-jni/src/jni/compile.rs
@@ -992,9 +992,9 @@ impl<R: Conversions> JCompile<'_, R> {
             .map(|(part, frag)| {
                 let child = Self::planned_child(direction, part, frag);
                 Some(prebindgen_registry::chain::ChoicePart {
-                    member: part_member(part)?,
                     child,
                     mode: part.mode,
+                    hold_uninit: false,
                 })
             })
             .collect::<Option<Vec<_>>>()?;
@@ -1050,15 +1050,16 @@ impl<R: Conversions> JCompile<'_, R> {
         let inactive = arm_types.iter().map(Self::inactive_intermediate).collect();
         let source_name = source_ident.to_string();
         let invalid = quote!(<__JniErr as ::core::convert::From<String>>::from(format!(
-            concat!(#source_name, ": invalid tag")
+            "{}: invalid tag {}",
+            #source_name,
+            __invalid_tag,
         )));
         let choice_arms = planned
             .iter()
             .map(|(alternative, arm)| {
                 let tag = crate::jni::struct_plan::sum_tag(alternative);
                 prebindgen_registry::chain::ChoiceArm {
-                    variant: alternative.name.clone(),
-                    form: alternative.form(),
+                    alternative: (*alternative).clone(),
                     tag: syn::parse_quote!(#tag),
                     bridge: arm.bridge.clone(),
                     parts: arm.parts.clone(),

--- a/prebindgen-registry/src/chain.rs
+++ b/prebindgen-registry/src/chain.rs
@@ -8,7 +8,7 @@
 use proc_macro2::TokenStream;
 
 use crate::{
-    flat::{AlternativeForm, TypeRef},
+    flat::{Alternative, TypeRef},
     recipe::{Direction, Mode},
     Emit,
 };
@@ -227,21 +227,21 @@ pub struct Optional<S, B, C> {
 /// One source field inside one [`Choice`] arm.
 #[derive(Clone)]
 pub struct ChoicePart<C> {
-    /// Named or positional Rust member, taken from the Flat model.
-    pub member: syn::Member,
     /// Child converter selected by the recipe driver.
     pub child: C,
     /// How the part is reached through its containing source value.
     pub mode: Mode,
+    /// Wrap the converted child in `MaybeUninit` in the arm intermediate.
+    pub hold_uninit: bool,
 }
 
 /// One already-composed arm of a [`Choice`] recipe.
 #[derive(Clone)]
 pub struct ChoiceArm<B, C> {
-    /// Rust variant name, taken from the Flat model.
-    pub variant: syn::Ident,
-    /// Unit, tuple or struct delimiter form, taken from Flat.
-    pub form: AlternativeForm,
+    /// The Flat alternative, including its field addresses and delimiters.
+    ///
+    /// It remains model data until [`Chain::render`] hands it to [`Emit`].
+    pub alternative: Alternative,
     /// Adapter tag pattern selecting this arm.
     pub tag: syn::Pat,
     /// Product representation of this arm's intermediate parts.
@@ -258,17 +258,31 @@ pub trait ChoiceBridge: Clone {
     /// Read the selector from an inbound intermediate value.
     fn tag(&self, value: TokenStream) -> TokenStream;
 
+    /// Prepare a validated inbound Choice representation for arm access.
+    ///
+    /// The selector is read and matched before this operation. This lets an
+    /// adapter validate raw storage before turning it into its intermediate
+    /// type, and guarantees the whole value is prepared at most once.
+    fn prepare(&self, value: TokenStream) -> TokenStream {
+        value
+    }
+
     /// Read one arm's Product intermediate from an inbound value.
-    fn arm(&self, value: TokenStream, index: usize) -> TokenStream;
+    fn arm(&self, emit: &Emit, value: TokenStream, index: usize) -> TokenStream;
 
     /// Construct the outbound Choice intermediate with `active` selected.
     ///
     /// Inactive arm storage is representation policy. Implementations must not
     /// manufacture source or child-intermediate values merely to fill it.
-    fn build(&self, active: usize, value: TokenStream) -> TokenStream;
+    fn build(&self, emit: &Emit, active: usize, value: TokenStream) -> TokenStream;
+
+    /// Finish the whole outbound representation after its active arm is built.
+    fn finish(&self, value: TokenStream) -> TokenStream {
+        value
+    }
 
     /// Error returned when an inbound selector names no arm.
-    fn invalid_tag(&self) -> TokenStream;
+    fn invalid_tag(&self, tag: TokenStream) -> TokenStream;
 }
 
 /// Registry-owned tuple representation for Choice intermediates.
@@ -301,12 +315,12 @@ impl ChoiceBridge for TupleChoice {
         quote::quote!((#value).0)
     }
 
-    fn arm(&self, value: TokenStream, index: usize) -> TokenStream {
+    fn arm(&self, _emit: &Emit, value: TokenStream, index: usize) -> TokenStream {
         let index = syn::Index::from(index + 1);
         quote::quote!((#value).#index)
     }
 
-    fn build(&self, active: usize, value: TokenStream) -> TokenStream {
+    fn build(&self, _emit: &Emit, active: usize, value: TokenStream) -> TokenStream {
         let tag = &self.tags[active];
         let arms = self.inactive.iter().enumerate().map(|(index, inactive)| {
             if index == active {
@@ -318,8 +332,12 @@ impl ChoiceBridge for TupleChoice {
         quote::quote!((#tag, #(#arms,)*))
     }
 
-    fn invalid_tag(&self) -> TokenStream {
-        self.invalid.clone()
+    fn invalid_tag(&self, tag: TokenStream) -> TokenStream {
+        let invalid = &self.invalid;
+        quote::quote!({
+            let __invalid_tag = #tag;
+            #invalid
+        })
     }
 }
 
@@ -335,6 +353,10 @@ pub struct Choice<S, B, P, C> {
     /// Adapter intermediate representation.
     pub bridge: B,
     /// Every source alternative, already composed from child chains.
+    ///
+    /// Outbound child conversion may be fallible. An adapter whose generated
+    /// boundary has no error channel must refuse that crossing before it
+    /// creates this plan; the shared composer propagates every accepted error.
     pub arms: Vec<ChoiceArm<P, C>>,
 }
 
@@ -491,49 +513,52 @@ where
                 let tag = self.bridge.tag(quote::quote!(v));
                 let arms = self.arms.iter().enumerate().map(|(arm_index, arm)| {
                     let tag_pattern = &arm.tag;
-                    let variant = &arm.variant;
-                    let arm_value = self.bridge.arm(quote::quote!(v), arm_index);
+                    let variant = &arm.alternative.name;
                     let fields: Vec<_> = arm
                         .parts
                         .iter()
                         .enumerate()
                         .map(|(part_index, part)| {
-                            let name = match &part.member {
+                            let member = arm.alternative.fields[part_index].member();
+                            let name = match &member {
                                 syn::Member::Named(name) => name.clone(),
                                 syn::Member::Unnamed(index) => {
                                     syn::Ident::new(&format!("v{}", index.index), index.span)
                                 }
                             };
                             let value = arm.bridge.part(quote::quote!(__arm), part_index, &name);
-                            (part.member.clone(), child_value(&part.child, value))
+                            child_value(&part.child, value)
                         })
                         .collect();
-                    let canonical = match arm.form {
-                        AlternativeForm::Unit => {
-                            quote::quote!(#canonical_source::#variant)
-                        }
-                        AlternativeForm::Tuple => {
-                            let values = fields.iter().map(|(_, value)| value);
-                            quote::quote!(#canonical_source::#variant(#(#values),*))
-                        }
-                        AlternativeForm::Struct => {
-                            let names = fields.iter().map(|(member, _)| match member {
-                                syn::Member::Named(name) => name,
-                                syn::Member::Unnamed(_) => unreachable!(),
-                            });
-                            let values = fields.iter().map(|(_, value)| value);
-                            quote::quote!(#canonical_source::#variant { #(#names: #values),* })
-                        }
-                    };
+                    let shaped: Vec<_> = arm
+                        .alternative
+                        .fields
+                        .iter()
+                        .zip(&fields)
+                        .map(|(field, value)| field.bind(value))
+                        .collect();
+                    let canonical = emit.shape_alternative(
+                        &arm.alternative,
+                        quote::quote!(#canonical_source::#variant),
+                        &shaped,
+                    );
                     let built = self.source_policy.build(canonical);
-                    quote::quote!(#tag_pattern => {
-                        let __arm = #arm_value;
-                        #built
-                    })
+                    if arm.parts.is_empty() {
+                        quote::quote!(#tag_pattern => #built)
+                    } else {
+                        let prepared = self.bridge.prepare(quote::quote!(v));
+                        let arm_value = self.bridge.arm(emit, quote::quote!(__choice), arm_index);
+                        quote::quote!(#tag_pattern => {
+                            let __choice = #prepared;
+                            let __arm = #arm_value;
+                            #built
+                        })
+                    }
                 });
-                let invalid = self.bridge.invalid_tag();
+                let invalid = self.bridge.invalid_tag(quote::quote!(__tag));
                 syn::parse2(quote::quote!({
-                    match #tag {
+                    let __tag = #tag;
+                    match __tag {
                         #(#arms,)*
                         _ => return ::core::result::Result::Err(#invalid),
                     }
@@ -544,7 +569,7 @@ where
                 let canonical_source = self.source_policy.spell(self.source.unwrapped(), emit);
                 let value = self.source_policy.read(quote::quote!(v));
                 let arms = self.arms.iter().enumerate().map(|(arm_index, arm)| {
-                    let variant = &arm.variant;
+                    let variant = &arm.alternative.name;
                     let bindings: Vec<_> = arm
                         .parts
                         .iter()
@@ -553,33 +578,36 @@ where
                             syn::Ident::new(&format!("__part{index}"), variant.span())
                         })
                         .collect();
-                    let pattern = match arm.form {
-                        AlternativeForm::Unit => {
-                            quote::quote!(#canonical_source::#variant)
-                        }
-                        AlternativeForm::Tuple => {
-                            quote::quote!(#canonical_source::#variant(#(#bindings),*))
-                        }
-                        AlternativeForm::Struct => {
-                            let names = arm.parts.iter().map(|part| match &part.member {
-                                syn::Member::Named(name) => name,
-                                syn::Member::Unnamed(_) => unreachable!(),
-                            });
-                            quote::quote!(#canonical_source::#variant { #(#names: #bindings),* })
-                        }
-                    };
+                    let bound: Vec<_> = arm
+                        .alternative
+                        .fields
+                        .iter()
+                        .zip(&bindings)
+                        .map(|(field, binding)| field.bind(binding))
+                        .collect();
+                    let pattern = emit.shape_alternative(
+                        &arm.alternative,
+                        quote::quote!(#canonical_source::#variant),
+                        &bound,
+                    );
                     let parts: Vec<_> = arm
                         .parts
                         .iter()
                         .zip(&bindings)
-                        .map(|(part, binding)| {
+                        .zip(&arm.alternative.fields)
+                        .map(|((part, binding), field)| {
                             let value = match part.mode {
                                 Mode::Owned => quote::quote!(#binding),
                                 Mode::Shared => quote::quote!(&*#binding),
                                 Mode::Exclusive => quote::quote!(&mut *#binding),
                             };
                             let value = child_value(&part.child, value);
-                            let name = match &part.member {
+                            let value = if part.hold_uninit {
+                                quote::quote!(::core::mem::MaybeUninit::new(#value))
+                            } else {
+                                value
+                            };
+                            let name = match field.member() {
                                 syn::Member::Named(name) => name.clone(),
                                 syn::Member::Unnamed(index) => {
                                     syn::Ident::new(&format!("v{}", index.index), index.span)
@@ -589,10 +617,12 @@ where
                         })
                         .collect();
                     let arm_value = arm.bridge.build(&parts);
-                    let built = self.bridge.build(arm_index, arm_value);
+                    let built = self.bridge.build(emit, arm_index, arm_value);
                     quote::quote!(#pattern => #built)
                 });
-                syn::parse2(quote::quote!({ match #value { #(#arms,)* } }))
+                let built = quote::quote!({ match #value { #(#arms,)* } });
+                let finished = self.bridge.finish(built);
+                syn::parse2(finished)
                     .expect("a Choice intermediate constructor is a valid expression")
             }
         };
@@ -612,7 +642,28 @@ mod tests {
     use quote::{quote, ToTokens};
 
     use super::*;
-    use crate::flat::ScalarKind;
+    use crate::flat::{Alternative, Field, Origin, ScalarKind};
+
+    fn alternative(syntax: syn::Variant, index: usize) -> Alternative {
+        let location: Rc<prebindgen::SourceLocation> = Rc::new(Default::default());
+        let fields = syntax
+            .fields
+            .iter()
+            .enumerate()
+            .map(|(index, field)| Field {
+                name: field.ident.clone(),
+                index,
+                ty: TypeRef::scalar(ScalarKind::I64),
+                origin: Origin::new(field.clone(), location.clone()),
+            })
+            .collect();
+        Alternative {
+            name: syntax.ident.clone(),
+            index,
+            fields,
+            origin: Origin::new(syntax, location),
+        }
+    }
 
     #[derive(Clone)]
     struct TestSource {
@@ -707,23 +758,21 @@ mod tests {
             },
             arms: vec![
                 ChoiceArm {
-                    variant: syn::parse_quote!(A),
-                    form: AlternativeForm::Unit,
+                    alternative: alternative(syn::parse_quote!(A), 0),
                     tag: syn::parse_quote!(0),
                     bridge: TupleProduct { parts: Vec::new() },
                     parts: Vec::new(),
                 },
                 ChoiceArm {
-                    variant: syn::parse_quote!(B),
-                    form: AlternativeForm::Tuple,
+                    alternative: alternative(syn::parse_quote!(B(i64)), 1),
                     tag: syn::parse_quote!(1),
                     bridge: TupleProduct {
                         parts: vec![syn::parse_quote!(i64)],
                     },
                     parts: vec![ChoicePart {
-                        member: syn::Member::Unnamed(syn::Index::from(0)),
                         child,
                         mode: Mode::Owned,
+                        hold_uninit: false,
                     }],
                 },
             ],
@@ -742,7 +791,8 @@ mod tests {
             let body = rendered.body.to_token_stream().to_string();
             match direction {
                 Direction::Construct => {
-                    assert!(body.contains("match (v) . 0"), "{body}");
+                    assert!(body.contains("let __tag = (v) . 0"), "{body}");
+                    assert!(body.contains("match __tag"), "{body}");
                     assert!(body.contains("i64 :: B (decode ((__arm) . 0) ?)"), "{body}");
                     assert!(
                         body.contains("return :: core :: result :: Result :: Err"),


### PR DESCRIPTION
## Why

#516 proved shared Choice composition with JniGen, but its review exposed that the bridge contract still assumed an already-valid tuple representation. C tagged unions receive `MaybeUninit<mirror>`: they must read and validate the raw tag before assuming the enum is initialized, and they wrap the completed outbound enum only after the active arm has been built. Without whole-value hooks, C had to retain its own complete Choice renderer.

That meant the API was not yet language-adapter-neutral.

## What changed

- Let each `ChoiceArm` retain the Flat `Alternative` and render it through `Emit::shape_alternative`.
  - Removes the duplicate public `AlternativeForm` model.
  - Removes copied field-member metadata from `ChoicePart`.
- Extend `ChoiceBridge` with representation-level boundaries:
  - `prepare` runs after tag validation and at most once for the selected inbound arm.
  - `finish` wraps the completed outbound choice.
  - `invalid_tag` receives the rejected tag.
  - arm read/build operations receive `Emit` only at final Rust rendering.
- Keep unit alternatives free of unused arm bindings.
- Document that adapters without an outbound error channel must reject fallible child encoders before planning a Choice.
- Migrate C tagged-union converters from their adapter-owned match renderer to the registry-owned `chain::Choice`.
  - C supplies raw-tag reading, delayed `assume_init`, C mirror arm access/building, `MaybeUninit` finishing, and its error text.
  - The registry supplies source-arm matching/construction, ownership modes, child invocation, and error propagation.
- Include the offending selector in JNI invalid-tag errors.
- Regenerate the committed C and JNI Rust artifacts.

## Safety and model boundary

A C-supplied enum is not materialized until its leading `c_int` selector has matched a declared alternative. Payload types with restricted validity remain held in `MaybeUninit`. Outbound arm child expressions are evaluated once before the C mirror is assembled.

Planning still stores Flat `TypeRef` and `Alternative` data only. Exact source Rust types and alternative delimiters are accessed through `Emit` during final `Chain::render`, after resolution is complete.

## Universality evidence

After this change:

- Product composition is registry-driven in C and JNI.
- Optional composition is registry-driven in JNI in both directions and in C for the single-intermediate input representation C supports; C output Option remains an arity marker.
- Choice composition is registry-driven in C and JNI.

The generated Rust changes local control-flow structure but preserves the C ABI, JNI ABI, Kotlin surface, ownership, validation, and conversion semantics. The additional nested arm match in C is statically selected after tag validation and remains optimizer-visible; this PR does not claim generated source-line reduction.

## Validation

- `cargo check -p prebindgen-registry -p prebindgen-c -p prebindgen-jni -p example-cbindgen`
- `cargo test -p prebindgen-registry -p prebindgen-c -p prebindgen-jni`
  - registry: 190 passed
  - C: 94 passed
  - JNI: 277 passed
- `examples/covertest-kotlin/gradlew run`
  - PASS: 57 sections
- `git diff --check`

Follow-up to #516.
