### PR TITLE
Compose Sequence converters in the registry for C and JNI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -137,7 +137,10 @@ jobs:
       with:
         path: prebindgen
     - name: Install Rust
-      run: rustup toolchain install stable && rustup default stable
+      run: |
+        rustup toolchain install stable
+        rustup default stable
+        rustup target add aarch64-unknown-linux-gnu
     - uses: actions/setup-java@v4
       with:
         distribution: temurin

--- a/examples/covertest-kotlin/src/generated_bindings.rs
+++ b/examples/covertest-kotlin/src/generated_bindings.rs
@@ -2116,56 +2116,6 @@ pub(crate) unsafe fn JObject_to_Box_Payload_0d2d19da<'env, 'v>(
     clippy::nonminimal_bool,
     clippy::eq_op
 )]
-#[inline(always)]
-pub(crate) unsafe fn JObject_to_Box_Vec_Payload_ca25c6a1<'env, 'a>(
-    env: &mut jni::JNIEnv<'env>,
-    v: &jni::objects::JObject<'a>,
-) -> ::core::result::Result<Box<Vec<perftest_flat::Payload>>, __JniErr> {
-    ::core::result::Result::Ok(
-        ::std::boxed::Box::new({
-            let __sequence_list = jni::objects::JList::from_env(env, v)
-                .map_err(|e| <__JniErr as ::core::convert::From<
-                    String,
-                >>::from(format!("Vec<_>: list-from-env: {}", e)))?;
-            let mut __sequence_iter = __sequence_list
-                .iter(env)
-                .map_err(|e| <__JniErr as ::core::convert::From<
-                    String,
-                >>::from(format!("Vec<_>: list-iter: {}", e)))?;
-            let mut __sequence_values: ::std::vec::Vec<perftest_flat::Payload> = ::std::vec::Vec::new();
-            while let ::core::option::Option::Some(__sequence_part) = match __sequence_iter
-                .next(env)
-                .map_err(|e| <__JniErr as ::core::convert::From<
-                    String,
-                >>::from(format!("Vec<_>: list-next: {}", e)))?
-            {
-                ::core::option::Option::Some(__sequence_object) => {
-                    let __sequence_part: jni::objects::JObject = __sequence_object
-                        .into();
-                    ::core::option::Option::Some(__sequence_part)
-                }
-                ::core::option::Option::None => ::core::option::Option::None,
-            } {
-                __sequence_values
-                    .push(JObject_to_Payload_98f64326(env, &(__sequence_part))?);
-            }
-            __sequence_values
-        }),
-    )
-}
-#[allow(
-    non_snake_case,
-    unused_mut,
-    unused_variables,
-    unused_braces,
-    unused_parens,
-    dead_code,
-    clippy::useless_conversion,
-    clippy::needless_question_mark,
-    clippy::let_and_return,
-    clippy::nonminimal_bool,
-    clippy::eq_op
-)]
 pub(crate) unsafe fn JObject_to_CacheConfig_db89a97c<'env, 'v>(
     env: &mut jni::JNIEnv<'env>,
     v: &jni::objects::JObject<'v>,
@@ -3903,54 +3853,6 @@ pub(crate) unsafe fn JObject_to_Unsigned_7e3cc618<'env, 'v>(
     clippy::nonminimal_bool,
     clippy::eq_op
 )]
-#[inline(always)]
-pub(crate) unsafe fn JObject_to_Vec_Box_Payload_ae68babe<'env, 'a>(
-    env: &mut jni::JNIEnv<'env>,
-    v: &jni::objects::JObject<'a>,
-) -> ::core::result::Result<Vec<Box<perftest_flat::Payload>>, __JniErr> {
-    ::core::result::Result::Ok({
-        let __sequence_list = jni::objects::JList::from_env(env, v)
-            .map_err(|e| <__JniErr as ::core::convert::From<
-                String,
-            >>::from(format!("Vec<_>: list-from-env: {}", e)))?;
-        let mut __sequence_iter = __sequence_list
-            .iter(env)
-            .map_err(|e| <__JniErr as ::core::convert::From<
-                String,
-            >>::from(format!("Vec<_>: list-iter: {}", e)))?;
-        let mut __sequence_values: ::std::vec::Vec<Box<perftest_flat::Payload>> = ::std::vec::Vec::new();
-        while let ::core::option::Option::Some(__sequence_part) = match __sequence_iter
-            .next(env)
-            .map_err(|e| <__JniErr as ::core::convert::From<
-                String,
-            >>::from(format!("Vec<_>: list-next: {}", e)))?
-        {
-            ::core::option::Option::Some(__sequence_object) => {
-                let __sequence_part: jni::objects::JObject = __sequence_object.into();
-                ::core::option::Option::Some(__sequence_part)
-            }
-            ::core::option::Option::None => ::core::option::Option::None,
-        } {
-            __sequence_values
-                .push(JObject_to_Box_Payload_0d2d19da(env, &(__sequence_part))?);
-        }
-        __sequence_values
-    })
-}
-#[allow(
-    non_snake_case,
-    unused_mut,
-    unused_variables,
-    unused_braces,
-    unused_parens,
-    dead_code,
-    clippy::useless_conversion,
-    clippy::needless_question_mark,
-    clippy::let_and_return,
-    clippy::nonminimal_bool,
-    clippy::eq_op
-)]
-#[inline(always)]
 pub(crate) unsafe fn JObject_to_Vec_Label_3fdf860d<'env, 'a>(
     env: &mut jni::JNIEnv<'env>,
     v: &jni::objects::JObject<'a>,
@@ -4050,53 +3952,6 @@ pub(crate) unsafe fn JObject_to_Vec_Option_u64_a34190e7<'env, 'v>(
     clippy::nonminimal_bool,
     clippy::eq_op
 )]
-#[inline(always)]
-pub(crate) unsafe fn JObject_to_Vec_Payload_64d7995c<'env, 'a>(
-    env: &mut jni::JNIEnv<'env>,
-    v: &jni::objects::JObject<'a>,
-) -> ::core::result::Result<Vec<perftest_flat::Payload>, __JniErr> {
-    ::core::result::Result::Ok({
-        let __sequence_list = jni::objects::JList::from_env(env, v)
-            .map_err(|e| <__JniErr as ::core::convert::From<
-                String,
-            >>::from(format!("Vec<_>: list-from-env: {}", e)))?;
-        let mut __sequence_iter = __sequence_list
-            .iter(env)
-            .map_err(|e| <__JniErr as ::core::convert::From<
-                String,
-            >>::from(format!("Vec<_>: list-iter: {}", e)))?;
-        let mut __sequence_values: ::std::vec::Vec<perftest_flat::Payload> = ::std::vec::Vec::new();
-        while let ::core::option::Option::Some(__sequence_part) = match __sequence_iter
-            .next(env)
-            .map_err(|e| <__JniErr as ::core::convert::From<
-                String,
-            >>::from(format!("Vec<_>: list-next: {}", e)))?
-        {
-            ::core::option::Option::Some(__sequence_object) => {
-                let __sequence_part: jni::objects::JObject = __sequence_object.into();
-                ::core::option::Option::Some(__sequence_part)
-            }
-            ::core::option::Option::None => ::core::option::Option::None,
-        } {
-            __sequence_values
-                .push(JObject_to_Payload_98f64326(env, &(__sequence_part))?);
-        }
-        __sequence_values
-    })
-}
-#[allow(
-    non_snake_case,
-    unused_mut,
-    unused_variables,
-    unused_braces,
-    unused_parens,
-    dead_code,
-    clippy::useless_conversion,
-    clippy::needless_question_mark,
-    clippy::let_and_return,
-    clippy::nonminimal_bool,
-    clippy::eq_op
-)]
 pub(crate) unsafe fn JObject_to_Vec_Payload_8b7084d2<'env, 'v>(
     env: &mut jni::JNIEnv<'env>,
     v: &jni::objects::JObject<'v>,
@@ -4141,7 +3996,6 @@ pub(crate) unsafe fn JObject_to_Vec_Payload_8b7084d2<'env, 'v>(
     clippy::nonminimal_bool,
     clippy::eq_op
 )]
-#[inline(always)]
 pub(crate) unsafe fn JObject_to_Vec_Vec_u8_43404875<'env, 'a>(
     env: &mut jni::JNIEnv<'env>,
     v: &jni::objects::JObject<'a>,
@@ -11059,7 +10913,6 @@ pub(crate) unsafe fn Vault_to_jlong_4a33ea23<'a>(
     clippy::nonminimal_bool,
     clippy::eq_op
 )]
-#[inline(always)]
 pub(crate) unsafe fn Vec_Label_to_JObject_3fdf860d<'a>(
     env: &mut jni::JNIEnv<'a>,
     v: Vec<perftest_flat::Label>,
@@ -11106,7 +10959,6 @@ pub(crate) unsafe fn Vec_Label_to_JObject_3fdf860d<'a>(
     clippy::nonminimal_bool,
     clippy::eq_op
 )]
-#[inline(always)]
 pub(crate) unsafe fn Vec_Option_Ticks_to_JObject_2f4b03da<'a>(
     env: &mut jni::JNIEnv<'a>,
     v: Vec<Option<perftest_flat::Ticks>>,
@@ -11150,7 +11002,6 @@ pub(crate) unsafe fn Vec_Option_Ticks_to_JObject_2f4b03da<'a>(
     clippy::nonminimal_bool,
     clippy::eq_op
 )]
-#[inline(always)]
 pub(crate) unsafe fn Vec_Option_u64_to_JObject_a34190e7<'a>(
     env: &mut jni::JNIEnv<'a>,
     v: Vec<Option<u64>>,
@@ -11194,7 +11045,6 @@ pub(crate) unsafe fn Vec_Option_u64_to_JObject_a34190e7<'a>(
     clippy::nonminimal_bool,
     clippy::eq_op
 )]
-#[inline(always)]
 pub(crate) unsafe fn Vec_Vec_Option_u64_to_JObject_342a76c6<'a>(
     env: &mut jni::JNIEnv<'a>,
     v: Vec<Vec<Option<u64>>>,
@@ -11238,7 +11088,6 @@ pub(crate) unsafe fn Vec_Vec_Option_u64_to_JObject_342a76c6<'a>(
     clippy::nonminimal_bool,
     clippy::eq_op
 )]
-#[inline(always)]
 pub(crate) unsafe fn Vec_Vec_u8_to_JObject_43404875<'a>(
     env: &mut jni::JNIEnv<'a>,
     v: Vec<Vec<u8>>,

--- a/examples/covertest-kotlin/src/generated_bindings.rs
+++ b/examples/covertest-kotlin/src/generated_bindings.rs
@@ -2116,36 +2116,42 @@ pub(crate) unsafe fn JObject_to_Box_Payload_0d2d19da<'env, 'v>(
     clippy::nonminimal_bool,
     clippy::eq_op
 )]
-pub(crate) unsafe fn JObject_to_Box_Vec_Payload_ca25c6a1<'env, 'v>(
+#[inline(always)]
+pub(crate) unsafe fn JObject_to_Box_Vec_Payload_ca25c6a1<'env, 'a>(
     env: &mut jni::JNIEnv<'env>,
-    v: &jni::objects::JObject<'v>,
+    v: &jni::objects::JObject<'a>,
 ) -> ::core::result::Result<Box<Vec<perftest_flat::Payload>>, __JniErr> {
-    Ok({
-        let __list = jni::objects::JList::from_env(env, v)
-            .map_err(|e| <__JniErr as ::core::convert::From<
-                String,
-            >>::from(format!("Vec<_>: list-from-env: {}", e)))?;
-        let mut __it = __list
-            .iter(env)
-            .map_err(|e| <__JniErr as ::core::convert::From<
-                String,
-            >>::from(format!("Vec<_>: list-iter: {}", e)))?;
-        let mut __out: Vec<perftest_flat::Payload> = Vec::new();
-        while let Some(__obj) = __it
-            .next(env)
-            .map_err(|e| <__JniErr as ::core::convert::From<
-                String,
-            >>::from(format!("Vec<_>: list-next: {}", e)))?
-        {
-            let __elem_wire: jni::objects::JObject = __obj.into();
-            let __elem: perftest_flat::Payload = JObject_to_Payload_98f64326(
-                env,
-                &__elem_wire,
-            )?;
-            __out.push(__elem);
-        }
-        ::std::boxed::Box::new(__out)
-    })
+    ::core::result::Result::Ok(
+        ::std::boxed::Box::new({
+            let __sequence_list = jni::objects::JList::from_env(env, v)
+                .map_err(|e| <__JniErr as ::core::convert::From<
+                    String,
+                >>::from(format!("Vec<_>: list-from-env: {}", e)))?;
+            let mut __sequence_iter = __sequence_list
+                .iter(env)
+                .map_err(|e| <__JniErr as ::core::convert::From<
+                    String,
+                >>::from(format!("Vec<_>: list-iter: {}", e)))?;
+            let mut __sequence_values: ::std::vec::Vec<perftest_flat::Payload> = ::std::vec::Vec::new();
+            while let ::core::option::Option::Some(__sequence_part) = match __sequence_iter
+                .next(env)
+                .map_err(|e| <__JniErr as ::core::convert::From<
+                    String,
+                >>::from(format!("Vec<_>: list-next: {}", e)))?
+            {
+                ::core::option::Option::Some(__sequence_object) => {
+                    let __sequence_part: jni::objects::JObject = __sequence_object
+                        .into();
+                    ::core::option::Option::Some(__sequence_part)
+                }
+                ::core::option::Option::None => ::core::option::Option::None,
+            } {
+                __sequence_values
+                    .push(JObject_to_Payload_98f64326(env, &(__sequence_part))?);
+            }
+            __sequence_values
+        }),
+    )
 }
 #[allow(
     non_snake_case,
@@ -3897,35 +3903,38 @@ pub(crate) unsafe fn JObject_to_Unsigned_7e3cc618<'env, 'v>(
     clippy::nonminimal_bool,
     clippy::eq_op
 )]
-pub(crate) unsafe fn JObject_to_Vec_Box_Payload_ae68babe<'env, 'v>(
+#[inline(always)]
+pub(crate) unsafe fn JObject_to_Vec_Box_Payload_ae68babe<'env, 'a>(
     env: &mut jni::JNIEnv<'env>,
-    v: &jni::objects::JObject<'v>,
+    v: &jni::objects::JObject<'a>,
 ) -> ::core::result::Result<Vec<Box<perftest_flat::Payload>>, __JniErr> {
-    Ok({
-        let __list = jni::objects::JList::from_env(env, v)
+    ::core::result::Result::Ok({
+        let __sequence_list = jni::objects::JList::from_env(env, v)
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("Vec<_>: list-from-env: {}", e)))?;
-        let mut __it = __list
+        let mut __sequence_iter = __sequence_list
             .iter(env)
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("Vec<_>: list-iter: {}", e)))?;
-        let mut __out: Vec<Box<perftest_flat::Payload>> = Vec::new();
-        while let Some(__obj) = __it
+        let mut __sequence_values: ::std::vec::Vec<Box<perftest_flat::Payload>> = ::std::vec::Vec::new();
+        while let ::core::option::Option::Some(__sequence_part) = match __sequence_iter
             .next(env)
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("Vec<_>: list-next: {}", e)))?
         {
-            let __elem_wire: jni::objects::JObject = __obj.into();
-            let __elem: Box<perftest_flat::Payload> = JObject_to_Box_Payload_0d2d19da(
-                env,
-                &__elem_wire,
-            )?;
-            __out.push(__elem);
+            ::core::option::Option::Some(__sequence_object) => {
+                let __sequence_part: jni::objects::JObject = __sequence_object.into();
+                ::core::option::Option::Some(__sequence_part)
+            }
+            ::core::option::Option::None => ::core::option::Option::None,
+        } {
+            __sequence_values
+                .push(JObject_to_Box_Payload_0d2d19da(env, &(__sequence_part))?);
         }
-        __out
+        __sequence_values
     })
 }
 #[allow(
@@ -3941,39 +3950,50 @@ pub(crate) unsafe fn JObject_to_Vec_Box_Payload_ae68babe<'env, 'v>(
     clippy::nonminimal_bool,
     clippy::eq_op
 )]
-pub(crate) unsafe fn JObject_to_Vec_Label_3fdf860d<'env, 'v>(
+#[inline(always)]
+pub(crate) unsafe fn JObject_to_Vec_Label_3fdf860d<'env, 'a>(
     env: &mut jni::JNIEnv<'env>,
-    v: &jni::objects::JObject<'v>,
+    v: &jni::objects::JObject<'a>,
 ) -> ::core::result::Result<Vec<perftest_flat::Label>, __JniErr> {
-    Ok({
-        let __list = jni::objects::JList::from_env(env, v)
+    ::core::result::Result::Ok({
+        let __sequence_list = jni::objects::JList::from_env(env, v)
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("Vec<_>: list-from-env: {}", e)))?;
-        let mut __it = __list
+        let mut __sequence_iter = __sequence_list
             .iter(env)
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("Vec<_>: list-iter: {}", e)))?;
-        let mut __out: Vec<perftest_flat::Label> = Vec::new();
-        while let Some(__obj) = __it
+        let mut __sequence_values: ::std::vec::Vec<perftest_flat::Label> = ::std::vec::Vec::new();
+        while let ::core::option::Option::Some(__sequence_part) = match __sequence_iter
             .next(env)
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("Vec<_>: list-next: {}", e)))?
         {
-            let __elem_wire: jni::objects::JString = __obj.into();
-            let __elem: perftest_flat::Label = {
-                let __inner_s0 = JString_to_String_c7f3ca43(env, &__elem_wire)?;
-                let __inner_s1 = String_to_Label_c1a79668(env, __inner_s0)
-                    .map_err(|__e| <__JniErr as ::core::convert::From<
-                        String,
-                    >>::from(__e.to_string()))?;
-                __inner_s1
-            };
-            __out.push(__elem);
+            ::core::option::Option::Some(__sequence_object) => {
+                let __sequence_part: jni::objects::JString = __sequence_object.into();
+                ::core::option::Option::Some(__sequence_part)
+            }
+            ::core::option::Option::None => ::core::option::Option::None,
+        } {
+            __sequence_values
+                .push(
+                    {
+                        let __chain_s0 = JString_to_String_c7f3ca43(
+                            env,
+                            &(__sequence_part),
+                        )?;
+                        let __chain_s1 = String_to_Label_c1a79668(env, __chain_s0)
+                            .map_err(|__e| <__JniErr as ::core::convert::From<
+                                String,
+                            >>::from(__e.to_string()))?;
+                        ::core::result::Result::<_, __JniErr>::Ok(__chain_s1)
+                    }?,
+                );
         }
-        __out
+        __sequence_values
     })
 }
 #[allow(
@@ -4015,6 +4035,53 @@ pub(crate) unsafe fn JObject_to_Vec_Option_u64_a34190e7<'env, 'v>(
             __out.push(__elem);
         }
         __out
+    })
+}
+#[allow(
+    non_snake_case,
+    unused_mut,
+    unused_variables,
+    unused_braces,
+    unused_parens,
+    dead_code,
+    clippy::useless_conversion,
+    clippy::needless_question_mark,
+    clippy::let_and_return,
+    clippy::nonminimal_bool,
+    clippy::eq_op
+)]
+#[inline(always)]
+pub(crate) unsafe fn JObject_to_Vec_Payload_64d7995c<'env, 'a>(
+    env: &mut jni::JNIEnv<'env>,
+    v: &jni::objects::JObject<'a>,
+) -> ::core::result::Result<Vec<perftest_flat::Payload>, __JniErr> {
+    ::core::result::Result::Ok({
+        let __sequence_list = jni::objects::JList::from_env(env, v)
+            .map_err(|e| <__JniErr as ::core::convert::From<
+                String,
+            >>::from(format!("Vec<_>: list-from-env: {}", e)))?;
+        let mut __sequence_iter = __sequence_list
+            .iter(env)
+            .map_err(|e| <__JniErr as ::core::convert::From<
+                String,
+            >>::from(format!("Vec<_>: list-iter: {}", e)))?;
+        let mut __sequence_values: ::std::vec::Vec<perftest_flat::Payload> = ::std::vec::Vec::new();
+        while let ::core::option::Option::Some(__sequence_part) = match __sequence_iter
+            .next(env)
+            .map_err(|e| <__JniErr as ::core::convert::From<
+                String,
+            >>::from(format!("Vec<_>: list-next: {}", e)))?
+        {
+            ::core::option::Option::Some(__sequence_object) => {
+                let __sequence_part: jni::objects::JObject = __sequence_object.into();
+                ::core::option::Option::Some(__sequence_part)
+            }
+            ::core::option::Option::None => ::core::option::Option::None,
+        } {
+            __sequence_values
+                .push(JObject_to_Payload_98f64326(env, &(__sequence_part))?);
+        }
+        __sequence_values
     })
 }
 #[allow(
@@ -4074,76 +4141,38 @@ pub(crate) unsafe fn JObject_to_Vec_Payload_8b7084d2<'env, 'v>(
     clippy::nonminimal_bool,
     clippy::eq_op
 )]
-pub(crate) unsafe fn JObject_to_Vec_Vec_Option_u64_342a76c6<'env, 'v>(
+#[inline(always)]
+pub(crate) unsafe fn JObject_to_Vec_Vec_u8_43404875<'env, 'a>(
     env: &mut jni::JNIEnv<'env>,
-    v: &jni::objects::JObject<'v>,
-) -> ::core::result::Result<Vec<Vec<Option<u64>>>, __JniErr> {
-    Ok({
-        let __list = jni::objects::JList::from_env(env, v)
-            .map_err(|e| <__JniErr as ::core::convert::From<
-                String,
-            >>::from(format!("Vec<_>: list-from-env: {}", e)))?;
-        let mut __it = __list
-            .iter(env)
-            .map_err(|e| <__JniErr as ::core::convert::From<
-                String,
-            >>::from(format!("Vec<_>: list-iter: {}", e)))?;
-        let mut __out: Vec<Vec<Option<u64>>> = Vec::new();
-        while let Some(__obj) = __it
-            .next(env)
-            .map_err(|e| <__JniErr as ::core::convert::From<
-                String,
-            >>::from(format!("Vec<_>: list-next: {}", e)))?
-        {
-            let __elem_wire: jni::objects::JObject = __obj.into();
-            let __elem: Vec<Option<u64>> = JObject_to_Vec_Option_u64_a34190e7(
-                env,
-                &__elem_wire,
-            )?;
-            __out.push(__elem);
-        }
-        __out
-    })
-}
-#[allow(
-    non_snake_case,
-    unused_mut,
-    unused_variables,
-    unused_braces,
-    unused_parens,
-    dead_code,
-    clippy::useless_conversion,
-    clippy::needless_question_mark,
-    clippy::let_and_return,
-    clippy::nonminimal_bool,
-    clippy::eq_op
-)]
-pub(crate) unsafe fn JObject_to_Vec_Vec_u8_43404875<'env, 'v>(
-    env: &mut jni::JNIEnv<'env>,
-    v: &jni::objects::JObject<'v>,
+    v: &jni::objects::JObject<'a>,
 ) -> ::core::result::Result<Vec<Vec<u8>>, __JniErr> {
-    Ok({
-        let __list = jni::objects::JList::from_env(env, v)
+    ::core::result::Result::Ok({
+        let __sequence_list = jni::objects::JList::from_env(env, v)
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("Vec<_>: list-from-env: {}", e)))?;
-        let mut __it = __list
+        let mut __sequence_iter = __sequence_list
             .iter(env)
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("Vec<_>: list-iter: {}", e)))?;
-        let mut __out: Vec<Vec<u8>> = Vec::new();
-        while let Some(__obj) = __it
+        let mut __sequence_values: ::std::vec::Vec<Vec<u8>> = ::std::vec::Vec::new();
+        while let ::core::option::Option::Some(__sequence_part) = match __sequence_iter
             .next(env)
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("Vec<_>: list-next: {}", e)))?
         {
-            let __elem_wire: jni::objects::JByteArray = __obj.into();
-            let __elem: Vec<u8> = JByteArray_to_Vec_u8_7936d5de(env, &__elem_wire)?;
-            __out.push(__elem);
+            ::core::option::Option::Some(__sequence_object) => {
+                let __sequence_part: jni::objects::JByteArray = __sequence_object.into();
+                ::core::option::Option::Some(__sequence_part)
+            }
+            ::core::option::Option::None => ::core::option::Option::None,
+        } {
+            __sequence_values
+                .push(JByteArray_to_Vec_u8_7936d5de(env, &(__sequence_part))?);
         }
-        __out
+        __sequence_values
     })
 }
 #[allow(
@@ -11030,37 +11059,38 @@ pub(crate) unsafe fn Vault_to_jlong_4a33ea23<'a>(
     clippy::nonminimal_bool,
     clippy::eq_op
 )]
+#[inline(always)]
 pub(crate) unsafe fn Vec_Label_to_JObject_3fdf860d<'a>(
     env: &mut jni::JNIEnv<'a>,
     v: Vec<perftest_flat::Label>,
 ) -> ::core::result::Result<jni::objects::JObject<'a>, __JniErr> {
-    Ok({
-        let v: Vec<perftest_flat::Label> = v;
-        let __list_obj = env
+    ::core::result::Result::Ok({
+        let __sequence_source = v;
+        let __sequence_output = env
             .new_object("java/util/ArrayList", "()V", &[])
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("Vec<_>: new ArrayList: {}", e)))?;
-        let __list = jni::objects::JList::from_env(env, &__list_obj)
+        let __sequence_list = jni::objects::JList::from_env(env, &__sequence_output)
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("Vec<_>: list-from-env: {}", e)))?;
-        for __elem in v.into_iter() {
-            let __elem_wire = {
-                let __inner_s0 = Label_to_String_63dec766(env, __elem)
+        for __sequence_element in __sequence_source.into_iter() {
+            let __sequence_part = {
+                let __chain_s0 = Label_to_String_63dec766(env, __sequence_element)
                     .map_err(|__e| <__JniErr as ::core::convert::From<
                         String,
                     >>::from(__e.to_string()))?;
-                String_to_JString_c7f3ca43(env, __inner_s0)?
-            };
-            let __elem_obj: jni::objects::JObject = __elem_wire.into();
-            __list
-                .add(env, &__elem_obj)
+                String_to_JString_c7f3ca43(env, __chain_s0)
+            }?;
+            let __sequence_object: jni::objects::JObject = __sequence_part.into();
+            __sequence_list
+                .add(env, &__sequence_object)
                 .map_err(|e| <__JniErr as ::core::convert::From<
                     String,
                 >>::from(format!("Vec<_>: list-add: {}", e)))?;
         }
-        __list_obj
+        __sequence_output
     })
 }
 #[allow(
@@ -11076,31 +11106,35 @@ pub(crate) unsafe fn Vec_Label_to_JObject_3fdf860d<'a>(
     clippy::nonminimal_bool,
     clippy::eq_op
 )]
+#[inline(always)]
 pub(crate) unsafe fn Vec_Option_Ticks_to_JObject_2f4b03da<'a>(
     env: &mut jni::JNIEnv<'a>,
     v: Vec<Option<perftest_flat::Ticks>>,
 ) -> ::core::result::Result<jni::objects::JObject<'a>, __JniErr> {
-    Ok({
-        let v: Vec<Option<perftest_flat::Ticks>> = v;
-        let __list_obj = env
+    ::core::result::Result::Ok({
+        let __sequence_source = v;
+        let __sequence_output = env
             .new_object("java/util/ArrayList", "()V", &[])
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("Vec<_>: new ArrayList: {}", e)))?;
-        let __list = jni::objects::JList::from_env(env, &__list_obj)
+        let __sequence_list = jni::objects::JList::from_env(env, &__sequence_output)
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("Vec<_>: list-from-env: {}", e)))?;
-        for __elem in v.into_iter() {
-            let __elem_wire = Option_Ticks_to_JObject_95efad57(env, __elem)?;
-            let __elem_obj: jni::objects::JObject = __elem_wire.into();
-            __list
-                .add(env, &__elem_obj)
+        for __sequence_element in __sequence_source.into_iter() {
+            let __sequence_part = Option_Ticks_to_JObject_95efad57(
+                env,
+                __sequence_element,
+            )?;
+            let __sequence_object: jni::objects::JObject = __sequence_part.into();
+            __sequence_list
+                .add(env, &__sequence_object)
                 .map_err(|e| <__JniErr as ::core::convert::From<
                     String,
                 >>::from(format!("Vec<_>: list-add: {}", e)))?;
         }
-        __list_obj
+        __sequence_output
     })
 }
 #[allow(
@@ -11116,31 +11150,35 @@ pub(crate) unsafe fn Vec_Option_Ticks_to_JObject_2f4b03da<'a>(
     clippy::nonminimal_bool,
     clippy::eq_op
 )]
+#[inline(always)]
 pub(crate) unsafe fn Vec_Option_u64_to_JObject_a34190e7<'a>(
     env: &mut jni::JNIEnv<'a>,
     v: Vec<Option<u64>>,
 ) -> ::core::result::Result<jni::objects::JObject<'a>, __JniErr> {
-    Ok({
-        let v: Vec<Option<u64>> = v;
-        let __list_obj = env
+    ::core::result::Result::Ok({
+        let __sequence_source = v;
+        let __sequence_output = env
             .new_object("java/util/ArrayList", "()V", &[])
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("Vec<_>: new ArrayList: {}", e)))?;
-        let __list = jni::objects::JList::from_env(env, &__list_obj)
+        let __sequence_list = jni::objects::JList::from_env(env, &__sequence_output)
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("Vec<_>: list-from-env: {}", e)))?;
-        for __elem in v.into_iter() {
-            let __elem_wire = Option_u64_to_JObject_32be16a2(env, __elem)?;
-            let __elem_obj: jni::objects::JObject = __elem_wire.into();
-            __list
-                .add(env, &__elem_obj)
+        for __sequence_element in __sequence_source.into_iter() {
+            let __sequence_part = Option_u64_to_JObject_32be16a2(
+                env,
+                __sequence_element,
+            )?;
+            let __sequence_object: jni::objects::JObject = __sequence_part.into();
+            __sequence_list
+                .add(env, &__sequence_object)
                 .map_err(|e| <__JniErr as ::core::convert::From<
                     String,
                 >>::from(format!("Vec<_>: list-add: {}", e)))?;
         }
-        __list_obj
+        __sequence_output
     })
 }
 #[allow(
@@ -11156,151 +11194,35 @@ pub(crate) unsafe fn Vec_Option_u64_to_JObject_a34190e7<'a>(
     clippy::nonminimal_bool,
     clippy::eq_op
 )]
-pub(crate) unsafe fn Vec_Payload_to_JObject_8b7084d2<'a>(
-    env: &mut jni::JNIEnv<'a>,
-    v: Vec<perftest_flat::Payload>,
-) -> ::core::result::Result<jni::objects::JObject<'a>, __JniErr> {
-    Ok({
-        let v: Vec<perftest_flat::Payload> = v;
-        let __list_obj = env
-            .new_object("java/util/ArrayList", "()V", &[])
-            .map_err(|e| <__JniErr as ::core::convert::From<
-                String,
-            >>::from(format!("Vec<_>: new ArrayList: {}", e)))?;
-        let __list = jni::objects::JList::from_env(env, &__list_obj)
-            .map_err(|e| <__JniErr as ::core::convert::From<
-                String,
-            >>::from(format!("Vec<_>: list-from-env: {}", e)))?;
-        for __elem in v.into_iter() {
-            let __elem_wire = Payload_to_JObject_98f64326(env, __elem)?;
-            let __elem_obj: jni::objects::JObject = __elem_wire.into();
-            __list
-                .add(env, &__elem_obj)
-                .map_err(|e| <__JniErr as ::core::convert::From<
-                    String,
-                >>::from(format!("Vec<_>: list-add: {}", e)))?;
-        }
-        __list_obj
-    })
-}
-#[allow(
-    non_snake_case,
-    unused_mut,
-    unused_variables,
-    unused_braces,
-    unused_parens,
-    dead_code,
-    clippy::useless_conversion,
-    clippy::needless_question_mark,
-    clippy::let_and_return,
-    clippy::nonminimal_bool,
-    clippy::eq_op
-)]
-pub(crate) unsafe fn Vec_Stamp_to_JObject_8954d9be<'a>(
-    env: &mut jni::JNIEnv<'a>,
-    v: Vec<perftest_flat::Stamp>,
-) -> ::core::result::Result<jni::objects::JObject<'a>, __JniErr> {
-    Ok({
-        let v: Vec<perftest_flat::Stamp> = v;
-        let __list_obj = env
-            .new_object("java/util/ArrayList", "()V", &[])
-            .map_err(|e| <__JniErr as ::core::convert::From<
-                String,
-            >>::from(format!("Vec<_>: new ArrayList: {}", e)))?;
-        let __list = jni::objects::JList::from_env(env, &__list_obj)
-            .map_err(|e| <__JniErr as ::core::convert::From<
-                String,
-            >>::from(format!("Vec<_>: list-from-env: {}", e)))?;
-        for __elem in v.into_iter() {
-            let __elem_wire = Stamp_to_JObject_f6b1e942(env, __elem)?;
-            let __elem_obj: jni::objects::JObject = __elem_wire.into();
-            __list
-                .add(env, &__elem_obj)
-                .map_err(|e| <__JniErr as ::core::convert::From<
-                    String,
-                >>::from(format!("Vec<_>: list-add: {}", e)))?;
-        }
-        __list_obj
-    })
-}
-#[allow(
-    non_snake_case,
-    unused_mut,
-    unused_variables,
-    unused_braces,
-    unused_parens,
-    dead_code,
-    clippy::useless_conversion,
-    clippy::needless_question_mark,
-    clippy::let_and_return,
-    clippy::nonminimal_bool,
-    clippy::eq_op
-)]
-pub(crate) unsafe fn Vec_String_to_JObject_1e282499<'a>(
-    env: &mut jni::JNIEnv<'a>,
-    v: Vec<String>,
-) -> ::core::result::Result<jni::objects::JObject<'a>, __JniErr> {
-    Ok({
-        let v: Vec<String> = v;
-        let __list_obj = env
-            .new_object("java/util/ArrayList", "()V", &[])
-            .map_err(|e| <__JniErr as ::core::convert::From<
-                String,
-            >>::from(format!("Vec<_>: new ArrayList: {}", e)))?;
-        let __list = jni::objects::JList::from_env(env, &__list_obj)
-            .map_err(|e| <__JniErr as ::core::convert::From<
-                String,
-            >>::from(format!("Vec<_>: list-from-env: {}", e)))?;
-        for __elem in v.into_iter() {
-            let __elem_wire = String_to_JString_c7f3ca43(env, __elem)?;
-            let __elem_obj: jni::objects::JObject = __elem_wire.into();
-            __list
-                .add(env, &__elem_obj)
-                .map_err(|e| <__JniErr as ::core::convert::From<
-                    String,
-                >>::from(format!("Vec<_>: list-add: {}", e)))?;
-        }
-        __list_obj
-    })
-}
-#[allow(
-    non_snake_case,
-    unused_mut,
-    unused_variables,
-    unused_braces,
-    unused_parens,
-    dead_code,
-    clippy::useless_conversion,
-    clippy::needless_question_mark,
-    clippy::let_and_return,
-    clippy::nonminimal_bool,
-    clippy::eq_op
-)]
+#[inline(always)]
 pub(crate) unsafe fn Vec_Vec_Option_u64_to_JObject_342a76c6<'a>(
     env: &mut jni::JNIEnv<'a>,
     v: Vec<Vec<Option<u64>>>,
 ) -> ::core::result::Result<jni::objects::JObject<'a>, __JniErr> {
-    Ok({
-        let v: Vec<Vec<Option<u64>>> = v;
-        let __list_obj = env
+    ::core::result::Result::Ok({
+        let __sequence_source = v;
+        let __sequence_output = env
             .new_object("java/util/ArrayList", "()V", &[])
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("Vec<_>: new ArrayList: {}", e)))?;
-        let __list = jni::objects::JList::from_env(env, &__list_obj)
+        let __sequence_list = jni::objects::JList::from_env(env, &__sequence_output)
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("Vec<_>: list-from-env: {}", e)))?;
-        for __elem in v.into_iter() {
-            let __elem_wire = Vec_Option_u64_to_JObject_a34190e7(env, __elem)?;
-            let __elem_obj: jni::objects::JObject = __elem_wire.into();
-            __list
-                .add(env, &__elem_obj)
+        for __sequence_element in __sequence_source.into_iter() {
+            let __sequence_part = Vec_Option_u64_to_JObject_a34190e7(
+                env,
+                __sequence_element,
+            )?;
+            let __sequence_object: jni::objects::JObject = __sequence_part.into();
+            __sequence_list
+                .add(env, &__sequence_object)
                 .map_err(|e| <__JniErr as ::core::convert::From<
                     String,
                 >>::from(format!("Vec<_>: list-add: {}", e)))?;
         }
-        __list_obj
+        __sequence_output
     })
 }
 #[allow(
@@ -11316,31 +11238,35 @@ pub(crate) unsafe fn Vec_Vec_Option_u64_to_JObject_342a76c6<'a>(
     clippy::nonminimal_bool,
     clippy::eq_op
 )]
+#[inline(always)]
 pub(crate) unsafe fn Vec_Vec_u8_to_JObject_43404875<'a>(
     env: &mut jni::JNIEnv<'a>,
     v: Vec<Vec<u8>>,
 ) -> ::core::result::Result<jni::objects::JObject<'a>, __JniErr> {
-    Ok({
-        let v: Vec<Vec<u8>> = v;
-        let __list_obj = env
+    ::core::result::Result::Ok({
+        let __sequence_source = v;
+        let __sequence_output = env
             .new_object("java/util/ArrayList", "()V", &[])
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("Vec<_>: new ArrayList: {}", e)))?;
-        let __list = jni::objects::JList::from_env(env, &__list_obj)
+        let __sequence_list = jni::objects::JList::from_env(env, &__sequence_output)
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("Vec<_>: list-from-env: {}", e)))?;
-        for __elem in v.into_iter() {
-            let __elem_wire = Vec_u8_to_JByteArray_7936d5de(env, __elem)?;
-            let __elem_obj: jni::objects::JObject = __elem_wire.into();
-            __list
-                .add(env, &__elem_obj)
+        for __sequence_element in __sequence_source.into_iter() {
+            let __sequence_part = Vec_u8_to_JByteArray_7936d5de(
+                env,
+                __sequence_element,
+            )?;
+            let __sequence_object: jni::objects::JObject = __sequence_part.into();
+            __sequence_list
+                .add(env, &__sequence_object)
                 .map_err(|e| <__JniErr as ::core::convert::From<
                     String,
                 >>::from(format!("Vec<_>: list-add: {}", e)))?;
         }
-        __list_obj
+        __sequence_output
     })
 }
 #[allow(

--- a/examples/example-cbindgen/generated/example_flat_aarch64.rs
+++ b/examples/example-cbindgen/generated/example_flat_aarch64.rs
@@ -843,6 +843,7 @@ pub(crate) fn __cbg_out_bool_field(v: bool) -> ::core::mem::MaybeUninit<bool> {
     ::core::mem::MaybeUninit::new(v)
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
+#[inline(always)]
 pub(crate) fn __cbg_out_chain_vec_f64(v: ::std::vec::Vec<f64>) -> ::std::vec::Vec<f64> {
     {
         let __sequence_source = v;

--- a/examples/example-cbindgen/generated/example_flat_aarch64.rs
+++ b/examples/example-cbindgen/generated/example_flat_aarch64.rs
@@ -595,10 +595,7 @@ pub(crate) unsafe fn __cbg_in_closure_history_batch_t(
         if let ::core::option::Option::Some(__f) = __call {
             let mut __w0_0 = ::core::mem::MaybeUninit::<*mut f64>::zeroed();
             let mut __w0_1 = ::core::mem::MaybeUninit::<usize>::zeroed();
-            let __arr: ::std::vec::Vec<f64> = __a0
-                .into_iter()
-                .map(__cbg_out_f64)
-                .collect();
+            let __arr: ::std::vec::Vec<f64> = __cbg_out_chain_vec_f64(__a0);
             let (__p, __n) = __cbg_alloc_array(__arr);
             *__w0_0.as_mut_ptr() = __p;
             *__w0_1.as_mut_ptr() = __n;
@@ -846,6 +843,20 @@ pub(crate) fn __cbg_out_bool_field(v: bool) -> ::core::mem::MaybeUninit<bool> {
     ::core::mem::MaybeUninit::new(v)
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
+pub(crate) fn __cbg_out_chain_vec_f64(v: ::std::vec::Vec<f64>) -> ::std::vec::Vec<f64> {
+    {
+        let __sequence_source = v;
+        let mut __sequence_output: ::std::vec::Vec<f64> = ::std::vec::Vec::with_capacity(
+            (__sequence_source).len(),
+        );
+        for __sequence_element in __sequence_source.into_iter() {
+            let __sequence_part = __cbg_out_f64(__sequence_element);
+            __sequence_output.push(__sequence_part);
+        }
+        __sequence_output
+    }
+}
+#[allow(non_snake_case, unused_variables, dead_code)]
 pub(crate) fn __cbg_out_f64(v: f64) -> f64 {
     v
 }
@@ -863,8 +874,6 @@ pub(crate) fn __cbg_out_unit(v: ()) {}
 pub(crate) fn __cbg_outmark_option_Grade() {}
 #[allow(non_snake_case, dead_code, unused)]
 pub(crate) fn __cbg_outmark_option_f64() {}
-#[allow(non_snake_case, dead_code, unused)]
-pub(crate) fn __cbg_outmark_vec_f64() {}
 #[allow(non_snake_case, dead_code, unused)]
 pub(crate) fn __cbg_result_Result___Calculator___Error__() {}
 #[allow(non_snake_case, dead_code, unused)]
@@ -1021,7 +1030,7 @@ pub unsafe extern "C" fn calculator_get_history(
     };
     let __v = example_flat::calculator_get_history(c);
     let __ret: *mut f64;
-    let __arr: ::std::vec::Vec<f64> = __v.into_iter().map(__cbg_out_f64).collect();
+    let __arr: ::std::vec::Vec<f64> = __cbg_out_chain_vec_f64(__v);
     let (__p, __n) = __cbg_alloc_array(__arr);
     __ret = __p;
     *len = __n;

--- a/examples/example-cbindgen/generated/example_flat_aarch64_internal_unstable.rs
+++ b/examples/example-cbindgen/generated/example_flat_aarch64_internal_unstable.rs
@@ -843,6 +843,7 @@ pub(crate) fn __cbg_out_bool_field(v: bool) -> ::core::mem::MaybeUninit<bool> {
     ::core::mem::MaybeUninit::new(v)
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
+#[inline(always)]
 pub(crate) fn __cbg_out_chain_vec_f64(v: ::std::vec::Vec<f64>) -> ::std::vec::Vec<f64> {
     {
         let __sequence_source = v;

--- a/examples/example-cbindgen/generated/example_flat_aarch64_internal_unstable.rs
+++ b/examples/example-cbindgen/generated/example_flat_aarch64_internal_unstable.rs
@@ -595,10 +595,7 @@ pub(crate) unsafe fn __cbg_in_closure_history_batch_t(
         if let ::core::option::Option::Some(__f) = __call {
             let mut __w0_0 = ::core::mem::MaybeUninit::<*mut f64>::zeroed();
             let mut __w0_1 = ::core::mem::MaybeUninit::<usize>::zeroed();
-            let __arr: ::std::vec::Vec<f64> = __a0
-                .into_iter()
-                .map(__cbg_out_f64)
-                .collect();
+            let __arr: ::std::vec::Vec<f64> = __cbg_out_chain_vec_f64(__a0);
             let (__p, __n) = __cbg_alloc_array(__arr);
             *__w0_0.as_mut_ptr() = __p;
             *__w0_1.as_mut_ptr() = __n;
@@ -846,6 +843,20 @@ pub(crate) fn __cbg_out_bool_field(v: bool) -> ::core::mem::MaybeUninit<bool> {
     ::core::mem::MaybeUninit::new(v)
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
+pub(crate) fn __cbg_out_chain_vec_f64(v: ::std::vec::Vec<f64>) -> ::std::vec::Vec<f64> {
+    {
+        let __sequence_source = v;
+        let mut __sequence_output: ::std::vec::Vec<f64> = ::std::vec::Vec::with_capacity(
+            (__sequence_source).len(),
+        );
+        for __sequence_element in __sequence_source.into_iter() {
+            let __sequence_part = __cbg_out_f64(__sequence_element);
+            __sequence_output.push(__sequence_part);
+        }
+        __sequence_output
+    }
+}
+#[allow(non_snake_case, unused_variables, dead_code)]
 pub(crate) fn __cbg_out_f64(v: f64) -> f64 {
     v
 }
@@ -863,8 +874,6 @@ pub(crate) fn __cbg_out_unit(v: ()) {}
 pub(crate) fn __cbg_outmark_option_Grade() {}
 #[allow(non_snake_case, dead_code, unused)]
 pub(crate) fn __cbg_outmark_option_f64() {}
-#[allow(non_snake_case, dead_code, unused)]
-pub(crate) fn __cbg_outmark_vec_f64() {}
 #[allow(non_snake_case, dead_code, unused)]
 pub(crate) fn __cbg_result_Result___Calculator___Error__() {}
 #[allow(non_snake_case, dead_code, unused)]
@@ -1021,7 +1030,7 @@ pub unsafe extern "C" fn calculator_get_history(
     };
     let __v = example_flat::calculator_get_history(c);
     let __ret: *mut f64;
-    let __arr: ::std::vec::Vec<f64> = __v.into_iter().map(__cbg_out_f64).collect();
+    let __arr: ::std::vec::Vec<f64> = __cbg_out_chain_vec_f64(__v);
     let (__p, __n) = __cbg_alloc_array(__arr);
     __ret = __p;
     *len = __n;

--- a/examples/example-cbindgen/generated/example_flat_aarch64_unstable.rs
+++ b/examples/example-cbindgen/generated/example_flat_aarch64_unstable.rs
@@ -843,6 +843,7 @@ pub(crate) fn __cbg_out_bool_field(v: bool) -> ::core::mem::MaybeUninit<bool> {
     ::core::mem::MaybeUninit::new(v)
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
+#[inline(always)]
 pub(crate) fn __cbg_out_chain_vec_f64(v: ::std::vec::Vec<f64>) -> ::std::vec::Vec<f64> {
     {
         let __sequence_source = v;

--- a/examples/example-cbindgen/generated/example_flat_aarch64_unstable.rs
+++ b/examples/example-cbindgen/generated/example_flat_aarch64_unstable.rs
@@ -595,10 +595,7 @@ pub(crate) unsafe fn __cbg_in_closure_history_batch_t(
         if let ::core::option::Option::Some(__f) = __call {
             let mut __w0_0 = ::core::mem::MaybeUninit::<*mut f64>::zeroed();
             let mut __w0_1 = ::core::mem::MaybeUninit::<usize>::zeroed();
-            let __arr: ::std::vec::Vec<f64> = __a0
-                .into_iter()
-                .map(__cbg_out_f64)
-                .collect();
+            let __arr: ::std::vec::Vec<f64> = __cbg_out_chain_vec_f64(__a0);
             let (__p, __n) = __cbg_alloc_array(__arr);
             *__w0_0.as_mut_ptr() = __p;
             *__w0_1.as_mut_ptr() = __n;
@@ -846,6 +843,20 @@ pub(crate) fn __cbg_out_bool_field(v: bool) -> ::core::mem::MaybeUninit<bool> {
     ::core::mem::MaybeUninit::new(v)
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
+pub(crate) fn __cbg_out_chain_vec_f64(v: ::std::vec::Vec<f64>) -> ::std::vec::Vec<f64> {
+    {
+        let __sequence_source = v;
+        let mut __sequence_output: ::std::vec::Vec<f64> = ::std::vec::Vec::with_capacity(
+            (__sequence_source).len(),
+        );
+        for __sequence_element in __sequence_source.into_iter() {
+            let __sequence_part = __cbg_out_f64(__sequence_element);
+            __sequence_output.push(__sequence_part);
+        }
+        __sequence_output
+    }
+}
+#[allow(non_snake_case, unused_variables, dead_code)]
 pub(crate) fn __cbg_out_f64(v: f64) -> f64 {
     v
 }
@@ -863,8 +874,6 @@ pub(crate) fn __cbg_out_unit(v: ()) {}
 pub(crate) fn __cbg_outmark_option_Grade() {}
 #[allow(non_snake_case, dead_code, unused)]
 pub(crate) fn __cbg_outmark_option_f64() {}
-#[allow(non_snake_case, dead_code, unused)]
-pub(crate) fn __cbg_outmark_vec_f64() {}
 #[allow(non_snake_case, dead_code, unused)]
 pub(crate) fn __cbg_result_Result___Calculator___Error__() {}
 #[allow(non_snake_case, dead_code, unused)]
@@ -1021,7 +1030,7 @@ pub unsafe extern "C" fn calculator_get_history(
     };
     let __v = example_flat::calculator_get_history(c);
     let __ret: *mut f64;
-    let __arr: ::std::vec::Vec<f64> = __v.into_iter().map(__cbg_out_f64).collect();
+    let __arr: ::std::vec::Vec<f64> = __cbg_out_chain_vec_f64(__v);
     let (__p, __n) = __cbg_alloc_array(__arr);
     __ret = __p;
     *len = __n;

--- a/examples/example-cbindgen/generated/example_flat_x86_64.rs
+++ b/examples/example-cbindgen/generated/example_flat_x86_64.rs
@@ -843,6 +843,7 @@ pub(crate) fn __cbg_out_bool_field(v: bool) -> ::core::mem::MaybeUninit<bool> {
     ::core::mem::MaybeUninit::new(v)
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
+#[inline(always)]
 pub(crate) fn __cbg_out_chain_vec_f64(v: ::std::vec::Vec<f64>) -> ::std::vec::Vec<f64> {
     {
         let __sequence_source = v;

--- a/examples/example-cbindgen/generated/example_flat_x86_64.rs
+++ b/examples/example-cbindgen/generated/example_flat_x86_64.rs
@@ -595,10 +595,7 @@ pub(crate) unsafe fn __cbg_in_closure_history_batch_t(
         if let ::core::option::Option::Some(__f) = __call {
             let mut __w0_0 = ::core::mem::MaybeUninit::<*mut f64>::zeroed();
             let mut __w0_1 = ::core::mem::MaybeUninit::<usize>::zeroed();
-            let __arr: ::std::vec::Vec<f64> = __a0
-                .into_iter()
-                .map(__cbg_out_f64)
-                .collect();
+            let __arr: ::std::vec::Vec<f64> = __cbg_out_chain_vec_f64(__a0);
             let (__p, __n) = __cbg_alloc_array(__arr);
             *__w0_0.as_mut_ptr() = __p;
             *__w0_1.as_mut_ptr() = __n;
@@ -846,6 +843,20 @@ pub(crate) fn __cbg_out_bool_field(v: bool) -> ::core::mem::MaybeUninit<bool> {
     ::core::mem::MaybeUninit::new(v)
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
+pub(crate) fn __cbg_out_chain_vec_f64(v: ::std::vec::Vec<f64>) -> ::std::vec::Vec<f64> {
+    {
+        let __sequence_source = v;
+        let mut __sequence_output: ::std::vec::Vec<f64> = ::std::vec::Vec::with_capacity(
+            (__sequence_source).len(),
+        );
+        for __sequence_element in __sequence_source.into_iter() {
+            let __sequence_part = __cbg_out_f64(__sequence_element);
+            __sequence_output.push(__sequence_part);
+        }
+        __sequence_output
+    }
+}
+#[allow(non_snake_case, unused_variables, dead_code)]
 pub(crate) fn __cbg_out_f64(v: f64) -> f64 {
     v
 }
@@ -863,8 +874,6 @@ pub(crate) fn __cbg_out_unit(v: ()) {}
 pub(crate) fn __cbg_outmark_option_Grade() {}
 #[allow(non_snake_case, dead_code, unused)]
 pub(crate) fn __cbg_outmark_option_f64() {}
-#[allow(non_snake_case, dead_code, unused)]
-pub(crate) fn __cbg_outmark_vec_f64() {}
 #[allow(non_snake_case, dead_code, unused)]
 pub(crate) fn __cbg_result_Result___Calculator___Error__() {}
 #[allow(non_snake_case, dead_code, unused)]
@@ -1021,7 +1030,7 @@ pub unsafe extern "C" fn calculator_get_history(
     };
     let __v = example_flat::calculator_get_history(c);
     let __ret: *mut f64;
-    let __arr: ::std::vec::Vec<f64> = __v.into_iter().map(__cbg_out_f64).collect();
+    let __arr: ::std::vec::Vec<f64> = __cbg_out_chain_vec_f64(__v);
     let (__p, __n) = __cbg_alloc_array(__arr);
     __ret = __p;
     *len = __n;

--- a/examples/example-cbindgen/generated/example_flat_x86_64_internal_unstable.rs
+++ b/examples/example-cbindgen/generated/example_flat_x86_64_internal_unstable.rs
@@ -843,6 +843,7 @@ pub(crate) fn __cbg_out_bool_field(v: bool) -> ::core::mem::MaybeUninit<bool> {
     ::core::mem::MaybeUninit::new(v)
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
+#[inline(always)]
 pub(crate) fn __cbg_out_chain_vec_f64(v: ::std::vec::Vec<f64>) -> ::std::vec::Vec<f64> {
     {
         let __sequence_source = v;

--- a/examples/example-cbindgen/generated/example_flat_x86_64_internal_unstable.rs
+++ b/examples/example-cbindgen/generated/example_flat_x86_64_internal_unstable.rs
@@ -595,10 +595,7 @@ pub(crate) unsafe fn __cbg_in_closure_history_batch_t(
         if let ::core::option::Option::Some(__f) = __call {
             let mut __w0_0 = ::core::mem::MaybeUninit::<*mut f64>::zeroed();
             let mut __w0_1 = ::core::mem::MaybeUninit::<usize>::zeroed();
-            let __arr: ::std::vec::Vec<f64> = __a0
-                .into_iter()
-                .map(__cbg_out_f64)
-                .collect();
+            let __arr: ::std::vec::Vec<f64> = __cbg_out_chain_vec_f64(__a0);
             let (__p, __n) = __cbg_alloc_array(__arr);
             *__w0_0.as_mut_ptr() = __p;
             *__w0_1.as_mut_ptr() = __n;
@@ -846,6 +843,20 @@ pub(crate) fn __cbg_out_bool_field(v: bool) -> ::core::mem::MaybeUninit<bool> {
     ::core::mem::MaybeUninit::new(v)
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
+pub(crate) fn __cbg_out_chain_vec_f64(v: ::std::vec::Vec<f64>) -> ::std::vec::Vec<f64> {
+    {
+        let __sequence_source = v;
+        let mut __sequence_output: ::std::vec::Vec<f64> = ::std::vec::Vec::with_capacity(
+            (__sequence_source).len(),
+        );
+        for __sequence_element in __sequence_source.into_iter() {
+            let __sequence_part = __cbg_out_f64(__sequence_element);
+            __sequence_output.push(__sequence_part);
+        }
+        __sequence_output
+    }
+}
+#[allow(non_snake_case, unused_variables, dead_code)]
 pub(crate) fn __cbg_out_f64(v: f64) -> f64 {
     v
 }
@@ -863,8 +874,6 @@ pub(crate) fn __cbg_out_unit(v: ()) {}
 pub(crate) fn __cbg_outmark_option_Grade() {}
 #[allow(non_snake_case, dead_code, unused)]
 pub(crate) fn __cbg_outmark_option_f64() {}
-#[allow(non_snake_case, dead_code, unused)]
-pub(crate) fn __cbg_outmark_vec_f64() {}
 #[allow(non_snake_case, dead_code, unused)]
 pub(crate) fn __cbg_result_Result___Calculator___Error__() {}
 #[allow(non_snake_case, dead_code, unused)]
@@ -1021,7 +1030,7 @@ pub unsafe extern "C" fn calculator_get_history(
     };
     let __v = example_flat::calculator_get_history(c);
     let __ret: *mut f64;
-    let __arr: ::std::vec::Vec<f64> = __v.into_iter().map(__cbg_out_f64).collect();
+    let __arr: ::std::vec::Vec<f64> = __cbg_out_chain_vec_f64(__v);
     let (__p, __n) = __cbg_alloc_array(__arr);
     __ret = __p;
     *len = __n;

--- a/examples/perftest-c/generated/perftest.rs
+++ b/examples/perftest-c/generated/perftest.rs
@@ -440,6 +440,7 @@ pub(crate) fn __cbg_out_bool(v: bool) -> bool {
     v
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
+#[inline(always)]
 pub(crate) fn __cbg_out_chain_vec_Payload(
     v: ::std::vec::Vec<perftest_flat::Payload>,
 ) -> ::std::vec::Vec<payload_t> {

--- a/examples/perftest-c/generated/perftest.rs
+++ b/examples/perftest-c/generated/perftest.rs
@@ -440,6 +440,22 @@ pub(crate) fn __cbg_out_bool(v: bool) -> bool {
     v
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
+pub(crate) fn __cbg_out_chain_vec_Payload(
+    v: ::std::vec::Vec<perftest_flat::Payload>,
+) -> ::std::vec::Vec<payload_t> {
+    {
+        let __sequence_source = v;
+        let mut __sequence_output: ::std::vec::Vec<payload_t> = ::std::vec::Vec::with_capacity(
+            (__sequence_source).len(),
+        );
+        for __sequence_element in __sequence_source.into_iter() {
+            let __sequence_part = __cbg_out_Payload(__sequence_element);
+            __sequence_output.push(__sequence_part);
+        }
+        __sequence_output
+    }
+}
+#[allow(non_snake_case, unused_variables, dead_code)]
 pub(crate) fn __cbg_out_f64(v: f64) -> f64 {
     v
 }
@@ -619,10 +635,7 @@ pub unsafe extern "C" fn storage_get_vec(
     match __v {
         ::core::option::Option::Some(__x) => {
             __ret = true;
-            let __arr: ::std::vec::Vec<payload_t> = __x
-                .into_iter()
-                .map(__cbg_out_Payload)
-                .collect();
+            let __arr: ::std::vec::Vec<payload_t> = __cbg_out_chain_vec_Payload(__x);
             let (__p, __n) = __cbg_alloc_array(__arr);
             *out = __p;
             *out_len = __n;

--- a/examples/perftest-kotlin/src/generated_bindings.rs
+++ b/examples/perftest-kotlin/src/generated_bindings.rs
@@ -2805,46 +2805,6 @@ pub(crate) unsafe fn Token_to_jlong_4f7adafa<'a>(
     clippy::nonminimal_bool,
     clippy::eq_op
 )]
-pub(crate) unsafe fn Vec_Payload_to_JObject_8b7084d2<'a>(
-    env: &mut jni::JNIEnv<'a>,
-    v: Vec<perftest_flat::Payload>,
-) -> ::core::result::Result<jni::objects::JObject<'a>, __JniErr> {
-    Ok({
-        let v: Vec<perftest_flat::Payload> = v;
-        let __list_obj = env
-            .new_object("java/util/ArrayList", "()V", &[])
-            .map_err(|e| <__JniErr as ::core::convert::From<
-                String,
-            >>::from(format!("Vec<_>: new ArrayList: {}", e)))?;
-        let __list = jni::objects::JList::from_env(env, &__list_obj)
-            .map_err(|e| <__JniErr as ::core::convert::From<
-                String,
-            >>::from(format!("Vec<_>: list-from-env: {}", e)))?;
-        for __elem in v.into_iter() {
-            let __elem_wire = Payload_to_JObject_98f64326(env, __elem)?;
-            let __elem_obj: jni::objects::JObject = __elem_wire.into();
-            __list
-                .add(env, &__elem_obj)
-                .map_err(|e| <__JniErr as ::core::convert::From<
-                    String,
-                >>::from(format!("Vec<_>: list-add: {}", e)))?;
-        }
-        __list_obj
-    })
-}
-#[allow(
-    non_snake_case,
-    unused_mut,
-    unused_variables,
-    unused_braces,
-    unused_parens,
-    dead_code,
-    clippy::useless_conversion,
-    clippy::needless_question_mark,
-    clippy::let_and_return,
-    clippy::nonminimal_bool,
-    clippy::eq_op
-)]
 pub(crate) unsafe fn bool_to_jboolean_31306d98<'a>(
     env: &mut jni::JNIEnv<'a>,
     v: bool,

--- a/examples/regen-check.sh
+++ b/examples/regen-check.sh
@@ -16,6 +16,9 @@
 #       ../../zenoh-flat-jni relative to this script) and diff ITS committed
 #       generated files. Requires that checkout to be clean in those paths.
 #
+# The in-repo check requires the `aarch64-unknown-linux-gnu` Rust target because
+# example-cbindgen commits target-specific golden Rust files.
+#
 set -euo pipefail
 
 repo_root="$(cd "$(dirname "$0")/.." && pwd)"
@@ -48,6 +51,14 @@ cargo build --release \
 # it the all-features artifacts would be committed but never checked.
 echo "== regenerating example-cbindgen (--all-features)"
 cargo build --release --all-features -p example-cbindgen
+
+# The host builds above cannot touch the committed aarch64 variants. `check`
+# runs the target-aware build script without requiring an aarch64 linker, and
+# the three invocations cover every aarch64 feature variant committed here.
+echo "== regenerating example-cbindgen (aarch64 variants)"
+cargo check -p example-cbindgen --target aarch64-unknown-linux-gnu
+cargo check -p example-cbindgen --target aarch64-unknown-linux-gnu --features unstable
+cargo check -p example-cbindgen --target aarch64-unknown-linux-gnu --all-features
 
 echo "== diffing committed generated files"
 # `git status --porcelain` catches modified AND newly created files (a new

--- a/prebindgen-c/src/chain.rs
+++ b/prebindgen-c/src/chain.rs
@@ -57,6 +57,7 @@ enum CBody {
     Complete(syn::ItemFn),
     Product(ProductPlan),
     Optional(OptionalPlan),
+    Sequence(SequencePlan),
     Choice(ChoicePlan),
 }
 
@@ -93,6 +94,18 @@ impl CFunction {
         }
     }
 
+    pub(crate) fn sequence(plan: SequencePlan) -> Self {
+        let call = CCall(chain::Call::new(
+            plan.ident.clone(),
+            plan.child.fallible(),
+            plan.child.unsafe_(),
+        ));
+        Self {
+            call,
+            body: CBody::Sequence(plan),
+        }
+    }
+
     pub(crate) fn choice(plan: ChoicePlan) -> Self {
         let fallible = plan.direction == Direction::Construct
             || plan
@@ -122,6 +135,7 @@ impl RustFunction for CFunction {
             CBody::Complete(function) => function.clone(),
             CBody::Product(plan) => plan.render(emit),
             CBody::Choice(plan) => plan.render(emit),
+            CBody::Sequence(plan) => plan.render(emit),
             CBody::Optional(plan) => plan.render(emit),
         }
     }
@@ -328,6 +342,98 @@ impl OptionalPlan {
             syn::parse_quote!(
                 #[allow(non_snake_case, unused_variables, dead_code)]
                 pub(crate) unsafe fn #name #lifetime(v: #intermediate) -> #source {
+                    #body
+                }
+            )
+        }
+    }
+}
+
+/// A Vec of one child wire for one registry-owned Sequence loop.
+#[derive(Clone)]
+struct CSequenceBridge {
+    child: syn::Type,
+}
+
+impl chain::SequenceBridge for CSequenceBridge {
+    fn intermediate(&self) -> syn::Type {
+        let child = &self.child;
+        syn::parse_quote!(::std::vec::Vec<#child>)
+    }
+
+    fn begin(&self, _value: TokenStream) -> TokenStream {
+        unreachable!("C Sequence input is represented by the specialized slice path")
+    }
+
+    fn next(&self) -> TokenStream {
+        unreachable!("C Sequence input is represented by the specialized slice path")
+    }
+
+    fn begin_output(&self, source: TokenStream) -> TokenStream {
+        let child = &self.child;
+        quote!(
+            let mut __sequence_output: ::std::vec::Vec<#child> =
+                ::std::vec::Vec::with_capacity((#source).len());
+        )
+    }
+
+    fn push(&self, value: TokenStream) -> TokenStream {
+        quote!(__sequence_output.push(#value);)
+    }
+
+    fn finish(&self) -> TokenStream {
+        quote!(__sequence_output)
+    }
+
+    fn fallible(&self) -> bool {
+        false
+    }
+}
+
+/// One C Vec-output converter composed by the registry.
+#[derive(Clone)]
+pub(crate) struct SequencePlan {
+    pub(crate) ident: syn::Ident,
+    pub(crate) source: TypeRef,
+    pub(crate) element: TypeRef,
+    pub(crate) source_module: Option<syn::Path>,
+    pub(crate) child_wire: syn::Type,
+    pub(crate) child: CCall,
+}
+
+impl SequencePlan {
+    fn render(&self, emit: &Emit) -> syn::ItemFn {
+        let composed = chain::Sequence {
+            source: self.source.clone(),
+            element: self.element.clone(),
+            direction: Direction::Deconstruct,
+            source_policy: CSource {
+                module: self.source_module.clone(),
+            },
+            bridge: CSequenceBridge {
+                child: self.child_wire.clone(),
+            },
+            child: self.child.clone(),
+        };
+        let rendered = composed.render(emit);
+        let name = &self.ident;
+        let source = &rendered.source;
+        let intermediate = &rendered.intermediate;
+        let body = &rendered.body;
+        let unsafe_ = self.child.unsafe_().then(|| quote!(unsafe));
+        if rendered.fallible {
+            syn::parse_quote!(
+                #[allow(non_snake_case, unused_variables, dead_code)]
+                pub(crate) #unsafe_ fn #name(v: #source)
+                    -> ::core::result::Result<#intermediate, ::std::string::String>
+                {
+                    ::core::result::Result::Ok(#body)
+                }
+            )
+        } else {
+            syn::parse_quote!(
+                #[allow(non_snake_case, unused_variables, dead_code)]
+                pub(crate) #unsafe_ fn #name(v: #source) -> #intermediate {
                     #body
                 }
             )

--- a/prebindgen-c/src/chain.rs
+++ b/prebindgen-c/src/chain.rs
@@ -424,6 +424,7 @@ impl SequencePlan {
         if rendered.fallible {
             syn::parse_quote!(
                 #[allow(non_snake_case, unused_variables, dead_code)]
+                #[inline(always)]
                 pub(crate) #unsafe_ fn #name(v: #source)
                     -> ::core::result::Result<#intermediate, ::std::string::String>
                 {
@@ -433,6 +434,7 @@ impl SequencePlan {
         } else {
             syn::parse_quote!(
                 #[allow(non_snake_case, unused_variables, dead_code)]
+                #[inline(always)]
                 pub(crate) #unsafe_ fn #name(v: #source) -> #intermediate {
                     #body
                 }

--- a/prebindgen-c/src/compile.rs
+++ b/prebindgen-c/src/compile.rs
@@ -18,6 +18,7 @@ use prebindgen_registry::{
 use super::*;
 use crate::chain::{
     CCall, CFunction, ChoicePlan, OptionalPlan, OptionalRepr, ProductField, ProductPlan,
+    SequencePlan,
 };
 
 /// The C adapter's answer for one crossing.
@@ -317,9 +318,35 @@ impl<R: Conversions> Compile for CCompile<'_, R> {
         _cx: &mut Cx<'_>,
         at: At<'_>,
         _elements: Mode,
-        _inner: &CFrag,
+        inner: &CFrag,
     ) -> Frag<Self> {
         let ty = at.crossing.spelled();
+        if at.crossing.direction() == Direction::Deconstruct {
+            if let TypeKind::Vec(element) = at.crossing.value().kind() {
+                if !marker_destination(&inner.destination) {
+                    let function = CFunction::sequence(SequencePlan {
+                        ident: format_ident!("__cbg_out_chain_vec_{}", sanitize(&element.key())),
+                        source: ty.clone(),
+                        element: (**element).clone(),
+                        source_module: self.gen.source_module.clone(),
+                        child_wire: inner.destination.clone(),
+                        child: inner.function.call().clone(),
+                    });
+                    return Ok(CFrag {
+                        destination: syn::parse_quote!(()),
+                        function,
+                        niches: Niches::empty(),
+                        subs: vec![element.key()],
+                        arm: None,
+                        yields: Yield {
+                            ty: at.crossing.value().stripped_key(),
+                            mode: at.crossing.mode(),
+                            validity: Validity::SelfSufficient,
+                        },
+                    });
+                }
+            }
+        }
         let conv = match at.crossing.direction() {
             // A `&[E]` is the only run C builds a Rust value out of, and it does
             // it zero-copy from the caller's own block.

--- a/prebindgen-c/src/emit.rs
+++ b/prebindgen-c/src/emit.rs
@@ -849,32 +849,23 @@ impl CbindgenBuilder {
         // same value and must stop at the same places (#428 review).
         if !self.has_own_wire(ty) {
             if let TypeKind::Vec(elem) = ty.kind() {
-                let entry = self.out_frag(elem).expect("Vec element converter");
-                let elem_conv = entry.function.call().ident().clone();
-                let elem_map = map_arg(&elem_conv, entry.function.call().unsafe_());
-                let elem_wire = entry.destination.clone();
+                let element = self.out_frag(elem).expect("Vec element converter");
+                let elem_wire = element.destination.clone();
+                let sequence = self.out_frag(ty).expect("Vec Sequence converter");
+                let sequence_conv = sequence.function.call().ident();
+                let converted = if sequence.function.call().fallible() {
+                    route_result(quote!(#sequence_conv(#val)), route)
+                } else {
+                    quote!(#sequence_conv(#val))
+                };
                 let t_ptr = &targets[0];
                 let t_len = &targets[1];
-                if entry.function.call().fallible() {
-                    let converted = route_result(quote!(#elem_conv(__value)), route);
-                    return quote!(
-                        let mut __arr: ::std::vec::Vec<#elem_wire> = ::std::vec::Vec::new();
-                        for __value in #val {
-                            __arr.push(#converted);
-                        }
-                        let (__p, __n) = __cbg_alloc_array(__arr);
-                        #t_ptr = __p;
-                        #t_len = __n;
-                    );
-                } else {
-                    return quote!(
-                        let __arr: ::std::vec::Vec<#elem_wire> =
-                            #val.into_iter().map(#elem_map).collect();
-                        let (__p, __n) = __cbg_alloc_array(__arr);
-                        #t_ptr = __p;
-                        #t_len = __n;
-                    );
-                }
+                return quote!(
+                    let __arr: ::std::vec::Vec<#elem_wire> = #converted;
+                    let (__p, __n) = __cbg_alloc_array(__arr);
+                    #t_ptr = __p;
+                    #t_len = __n;
+                );
             }
             if let Some(elem) = r_cow_slice_elem(ty).or_else(|| r_scalar_slice_elem(ty)) {
                 let entry = self.out_frag(elem).expect("slice element converter");

--- a/prebindgen-c/src/tests/returns.rs
+++ b/prebindgen-c/src/tests/returns.rs
@@ -204,9 +204,17 @@ fn vec_string_returns_ptr_and_len() {
     assert!(compact.contains("->*mut*mut::core::ffi::c_char"), "{src}");
     assert!(compact.contains("len:*mutusize"), "{src}");
     assert!(!compact.contains("e:*mut"), "{src}");
-    // Built from the element converter via the malloc'd array helper.
+    // The registry-owned Sequence loop invokes the element converter; the ABI
+    // wrapper only transfers its one Vec intermediate to the array helper.
+    assert!(compact.contains("fn__cbg_out_chain_vec_String("), "{src}");
     assert!(
-        compact.contains(".map(__cbg_out_String).collect()"),
+        compact.contains("__cbg_out_String(__sequence_element)"),
+        "{src}"
+    );
+    assert!(
+        compact.contains(
+            "let__arr:::std::vec::Vec<*mut::core::ffi::c_char>=__cbg_out_chain_vec_String("
+        ),
         "{src}"
     );
     assert!(
@@ -358,7 +366,11 @@ fn vec_of_borrows_calls_the_unsafe_element_converter() {
 
     assert!(compact.contains("->*mut*constz_handle"), "{src}");
     assert!(
-        compact.contains(".map(|__value|__cbg_out_ref_ZHandle(__value))"),
+        compact.contains("unsafefn__cbg_out_chain_vec____static_ZHandle("),
+        "{src}"
+    );
+    assert!(
+        compact.contains("__cbg_out_ref_ZHandle(__sequence_element)"),
         "{src}"
     );
 }

--- a/prebindgen-jni/src/jni/chain.rs
+++ b/prebindgen-jni/src/jni/chain.rs
@@ -548,7 +548,6 @@ impl JSequencePlan {
         match self.chain.direction {
             Direction::Construct => syn::parse_quote!(
                 #allow
-                #[inline(always)]
                 pub(crate) unsafe fn #name<'env, 'a>(
                     env: &mut jni::JNIEnv<'env>,
                     v: &#intermediate,
@@ -564,7 +563,6 @@ impl JSequencePlan {
                 };
                 syn::parse_quote!(
                     #allow
-                    #[inline(always)]
                     pub(crate) unsafe fn #name<'a>(
                         env: &mut jni::JNIEnv<'a>,
                         #input,

--- a/prebindgen-jni/src/jni/chain.rs
+++ b/prebindgen-jni/src/jni/chain.rs
@@ -20,6 +20,7 @@ enum JBody {
     OwnedHandle(Box<JOwnedHandlePlan>),
     Product(Box<JProductPlan>),
     Choice(Box<JChoicePlan>),
+    Sequence(Box<JSequencePlan>),
     Optional(Box<JOptionalPlan>),
 }
 
@@ -38,6 +39,10 @@ impl JFunction {
 
     pub(crate) fn optional(plan: JOptionalPlan) -> Self {
         Self(JBody::Optional(Box::new(plan)))
+    }
+
+    pub(crate) fn sequence(plan: JSequencePlan) -> Self {
+        Self(JBody::Sequence(Box::new(plan)))
     }
 
     pub(crate) fn choice(plan: JChoicePlan) -> Self {
@@ -60,6 +65,12 @@ impl JFunction {
                     dependency.mark_reachable();
                 }
             }
+            JBody::Sequence(plan) => {
+                plan.reachable.set(true);
+                for dependency in &plan.dependencies {
+                    dependency.mark_reachable();
+                }
+            }
             JBody::Optional(plan) => {
                 plan.reachable.set(true);
                 for dependency in &plan.dependencies {
@@ -77,6 +88,7 @@ impl RustFunction for JFunction {
             JBody::OwnedHandle(plan) => plan.reachable.get(),
             JBody::Product(plan) => plan.reachable.get(),
             JBody::Optional(plan) => plan.reachable.get(),
+            JBody::Sequence(plan) => plan.reachable.get(),
             JBody::Choice(plan) => plan.reachable.get(),
         }
     }
@@ -88,6 +100,7 @@ impl RustFunction for JFunction {
             JBody::Product(plan) => plan.render(emit),
             JBody::Optional(plan) => plan.render(emit),
             JBody::Choice(plan) => plan.render(emit),
+            JBody::Sequence(plan) => plan.render(emit),
         }
     }
 }
@@ -390,6 +403,155 @@ impl JChoicePlan {
                 pub(crate) unsafe fn #name<'env, 'a>(
                     env: &mut jni::JNIEnv<'env>,
                     v: #intermediate,
+                ) -> ::core::result::Result<#source, __JniErr> {
+                    ::core::result::Result::Ok(#body)
+                }
+            ),
+            Direction::Deconstruct => {
+                let input = match self.mode {
+                    Mode::Owned => quote!(v: #source),
+                    Mode::Shared => quote!(v: &#source),
+                    Mode::Exclusive => quote!(v: &mut #source),
+                };
+                syn::parse_quote!(
+                    #allow
+                    #[inline(always)]
+                    pub(crate) unsafe fn #name<'a>(
+                        env: &mut jni::JNIEnv<'a>,
+                        #input,
+                    ) -> ::core::result::Result<#intermediate, __JniErr> {
+                        ::core::result::Result::Ok(#body)
+                    }
+                )
+            }
+        }
+    }
+}
+
+/// Java List operations for one registry-owned Sequence loop.
+#[derive(Clone)]
+pub(crate) enum JSequenceBridge {
+    Input { child: Box<syn::Type> },
+    Output,
+}
+
+impl shared::SequenceBridge for JSequenceBridge {
+    fn intermediate(&self) -> syn::Type {
+        syn::parse_quote!(jni::objects::JObject)
+    }
+
+    fn begin(&self, value: TokenStream) -> TokenStream {
+        match self {
+            Self::Input { .. } => quote! {
+                let __sequence_list = jni::objects::JList::from_env(env, #value)
+                    .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(
+                        format!("Vec<_>: list-from-env: {}", e)
+                    ))?;
+                let mut __sequence_iter = __sequence_list.iter(env)
+                    .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(
+                        format!("Vec<_>: list-iter: {}", e)
+                    ))?;
+            },
+            Self::Output => {
+                unreachable!("sequence bridge operation does not match its planned direction")
+            }
+        }
+    }
+
+    fn next(&self) -> TokenStream {
+        match self {
+            Self::Input { child } => quote! {
+                match __sequence_iter.next(env)
+                    .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(
+                        format!("Vec<_>: list-next: {}", e)
+                    ))?
+                {
+                    ::core::option::Option::Some(__sequence_object) => {
+                        let __sequence_part: #child = __sequence_object.into();
+                        ::core::option::Option::Some(__sequence_part)
+                    }
+                    ::core::option::Option::None => ::core::option::Option::None,
+                }
+            },
+            Self::Output => {
+                unreachable!("sequence bridge operation does not match its planned direction")
+            }
+        }
+    }
+
+    fn begin_output(&self, _source: TokenStream) -> TokenStream {
+        match self {
+            Self::Output => quote! {
+                let __sequence_output = env
+                    .new_object("java/util/ArrayList", "()V", &[])
+                    .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(
+                        format!("Vec<_>: new ArrayList: {}", e)
+                    ))?;
+                let __sequence_list = jni::objects::JList::from_env(env, &__sequence_output)
+                    .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(
+                        format!("Vec<_>: list-from-env: {}", e)
+                    ))?;
+            },
+            Self::Input { .. } => {
+                unreachable!("sequence bridge operation does not match its planned direction")
+            }
+        }
+    }
+
+    fn push(&self, value: TokenStream) -> TokenStream {
+        match self {
+            Self::Output => quote! {
+                let __sequence_object: jni::objects::JObject = #value.into();
+                __sequence_list.add(env, &__sequence_object)
+                    .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(
+                        format!("Vec<_>: list-add: {}", e)
+                    ))?;
+            },
+            Self::Input { .. } => {
+                unreachable!("sequence bridge operation does not match its planned direction")
+            }
+        }
+    }
+
+    fn finish(&self) -> TokenStream {
+        match self {
+            Self::Output => quote!(__sequence_output),
+            Self::Input { .. } => {
+                unreachable!("sequence bridge operation does not match its planned direction")
+            }
+        }
+    }
+
+    fn fallible(&self) -> bool {
+        true
+    }
+}
+
+/// One late-rendered JniGen Sequence converter.
+#[derive(Clone)]
+pub(crate) struct JSequencePlan {
+    pub(crate) ident: syn::Ident,
+    pub(crate) reachable: std::rc::Rc<std::cell::Cell<bool>>,
+    pub(crate) dependencies: Vec<JFunction>,
+    pub(crate) mode: Mode,
+    pub(crate) chain: shared::Sequence<JSource, JSequenceBridge, JChild>,
+}
+
+impl JSequencePlan {
+    fn render(&self, emit: &Emit) -> syn::ItemFn {
+        let rendered = self.chain.render(emit);
+        let name = &self.ident;
+        let source = &rendered.source;
+        let intermediate = annotate_jobject_with_lifetime(&rendered.intermediate, "a");
+        let body = &rendered.body;
+        let allow = crate::jni::trait_impl::generated_converter_attr();
+        match self.chain.direction {
+            Direction::Construct => syn::parse_quote!(
+                #allow
+                #[inline(always)]
+                pub(crate) unsafe fn #name<'env, 'a>(
+                    env: &mut jni::JNIEnv<'env>,
+                    v: &#intermediate,
                 ) -> ::core::result::Result<#source, __JniErr> {
                     ::core::result::Result::Ok(#body)
                 }

--- a/prebindgen-jni/src/jni/compile.rs
+++ b/prebindgen-jni/src/jni/compile.rs
@@ -1842,11 +1842,11 @@ impl<R: Conversions> Compile for JCompile<'_, R> {
             .site
             .as_ref()
             .ok_or_else(|| JErr::Refused("JniGen: a site compiled with no site context".into()))?;
-        if matches!(root.layout, Some(JLayout::Leaf)) {
-            root.rust.mark_reachable();
-        }
         let site = match site {
             PlanSite::Return => {
+                if matches!(root.layout, Some(JLayout::Leaf)) {
+                    root.rust.mark_reachable();
+                }
                 // A fragment that occupies several wires IS the decomposed
                 // return: the site asked for the `parts` recipe and got what that
                 // recipe states. Nothing else distinguishes the two cases, and
@@ -1910,6 +1910,17 @@ impl<R: Conversions> Compile for JCompile<'_, R> {
                 None => InputKind::Plain,
             }
         };
+
+        // VecBuild constructs a Rust collection through its handle helpers and
+        // never calls the root JObject converter. Activating that converter
+        // would emit an orphan list decoder; for a bare Vec it also duplicates
+        // the legacy decoder. Other leaf parameter plans still consume their
+        // root conversion.
+        if matches!(root.layout, Some(JLayout::Leaf))
+            && !matches!(&kind, InputKind::VecBuild { .. })
+        {
+            root.rust.mark_reachable();
+        }
 
         // Typed surface: handle/value projections show their Kotlin class (from
         // the projection's leaf key); everything else the conversion's resolved

--- a/prebindgen-jni/src/jni/compile.rs
+++ b/prebindgen-jni/src/jni/compile.rs
@@ -6,6 +6,7 @@
 //! its inner crossing already produced, so nothing here decides which arity
 //! layer it is looking at and nothing here recurses.
 
+use kotlin_codegen::KtType;
 use prebindgen_registry::{
     flat::{Alternative, Function, TypeKind, TypeRef},
     recipe::{
@@ -829,6 +830,14 @@ impl<R: Conversions> JCompile<'_, R> {
         part: &Part<'_>,
         frag: &JFrag,
     ) -> crate::jni::chain::JChild {
+        Self::planned_child_mode(direction, part.mode, frag)
+    }
+
+    fn planned_child_mode(
+        direction: Direction,
+        mode: Mode,
+        frag: &JFrag,
+    ) -> crate::jni::chain::JChild {
         let stages = match direction {
             Direction::Construct => frag
                 .conv
@@ -856,7 +865,7 @@ impl<R: Conversions> JCompile<'_, R> {
             Direction::Deconstruct => crate::jni::chain::JChild::output(
                 frag.conv.converter_ident().clone(),
                 stages,
-                match part.mode {
+                match mode {
                     Mode::Owned => crate::jni::chain::JValueUse::Direct,
                     Mode::Shared | Mode::Exclusive => crate::jni::chain::JValueUse::Cloned,
                 },
@@ -1130,6 +1139,125 @@ impl<R: Conversions> JCompile<'_, R> {
             }
             wire => crate::jni::emit::sentinel_for_wire(wire),
         }
+    }
+
+    /// Plan a Java List-backed Sequence as one intermediate collection.
+    ///
+    /// The registry owns source collection traversal, element conversion and
+    /// collection construction. JNI supplies only its List iterator/appender
+    /// operations. Primitive arrays, handle-vector builders and multi-slot
+    /// element folds retain their specialized representations.
+    fn planned_sequence(&self, at: At<'_>, elements: Mode, inner: &JFrag) -> Option<JFrag> {
+        if inner.composed_only || inner.wires.is_some() || inner.out_wires.is_some() {
+            return None;
+        }
+        let source = at.crossing.value();
+        let element = source.sequence_elem()?.clone();
+        let direction = at.crossing.direction();
+        match (direction, source.unwrapped().kind()) {
+            (Direction::Construct, TypeKind::Vec(_))
+            | (Direction::Deconstruct, TypeKind::Vec(_) | TypeKind::Slice(_)) => {}
+            _ => return None,
+        }
+        let wrappers = source.erased_wrappers();
+        if wrappers.iter().any(|wrapper| {
+            let Some(ops) = super::trait_impl::wrapper_ops(wrapper) else {
+                return true;
+            };
+            match direction {
+                Direction::Construct => ops.build.is_none(),
+                Direction::Deconstruct => ops.read.is_none(),
+            }
+        }) {
+            return None;
+        }
+
+        let child_wire = inner.conv.destination.clone();
+        if !is_jobject_shaped_wire(&child_wire) {
+            return None;
+        }
+        if direction == Direction::Construct {
+            reject_vec_of_handle(&inner.conv.metadata.projection, &element);
+        }
+        let child = Self::planned_child_mode(direction, elements, inner);
+        let destination: syn::Type = syn::parse_quote!(jni::objects::JObject);
+        let ident = crate::jni::chain::planned_name(direction, at.crossing.spelled(), &destination);
+        let marker = crate::jni::chain::planned_marker(&ident);
+        let bridge = match direction {
+            Direction::Construct => crate::jni::chain::JSequenceBridge::Input {
+                child: Box::new(child_wire),
+            },
+            Direction::Deconstruct => crate::jni::chain::JSequenceBridge::Output,
+        };
+        let rust = crate::jni::chain::JFunction::sequence(crate::jni::chain::JSequencePlan {
+            ident,
+            reachable: std::rc::Rc::new(std::cell::Cell::new(false)),
+            dependencies: vec![inner.rust.clone()],
+            mode: at.crossing.mode(),
+            chain: prebindgen_registry::chain::Sequence {
+                source: source.clone(),
+                element: element.clone(),
+                direction,
+                source_policy: crate::jni::chain::JSource {
+                    wrappers,
+                    module: None,
+                },
+                bridge,
+                child,
+            },
+        });
+
+        let inner_kotlin = inner.conv.metadata.kotlin_name.clone()?;
+        let kotlin_name = self.decls.override_kotlin_name(
+            &at.crossing.spelled().key(),
+            Some(KtType::generic("List", [inner_kotlin])),
+        );
+        let projection = if direction == Direction::Deconstruct {
+            inner
+                .conv
+                .metadata
+                .projection
+                .clone()
+                .map(|projection| Projection {
+                    strategy: FoldStrategy::Iterable(Box::new(projection.strategy)),
+                    ..projection
+                })
+        } else {
+            None
+        };
+        let niches = match direction {
+            Direction::Construct => Niches::empty(),
+            Direction::Deconstruct => default_niches_for_wire(&destination),
+        };
+        Some(JFrag {
+            conv: ConverterImpl {
+                destination,
+                function: marker,
+                pre_stages: Vec::new(),
+                niches,
+                metadata: KotlinMeta {
+                    kotlin_name,
+                    value_rust_type: None,
+                    projection,
+                },
+                subs: vec![element.key()],
+            },
+            rust,
+            layout: Some(JLayout::Leaf),
+            choice_arm: None,
+            // Iterable callback delivery converts one element at a time. Keep
+            // exposing the element chain there until Invoke composition owns
+            // that site explicitly.
+            nested_chain: inner.composed_chain(),
+            wires: None,
+            out_wires: None,
+            composed_only: false,
+            yields: Yield {
+                ty: at.crossing.value().stripped_key(),
+                mode: at.crossing.mode(),
+                validity: Validity::SelfSufficient,
+            },
+        })
     }
 
     /// Plan an Optional over one already-composed child intermediate without
@@ -1495,11 +1623,14 @@ impl<R: Conversions> Compile for JCompile<'_, R> {
         &mut self,
         cx: &mut Cx<'_>,
         at: At<'_>,
-        _elements: Mode,
+        elements: Mode,
         inner: &JFrag,
     ) -> Frag<Self> {
         let ty = at.crossing.spelled();
         let emit = cx.emit();
+        if let Some(planned) = self.planned_sequence(at, elements, inner) {
+            return Ok(planned);
+        }
         let conv = match at.crossing.direction() {
             Direction::Construct => self
                 .decls

--- a/prebindgen-jni/src/jni/tests/values.rs
+++ b/prebindgen-jni/src/jni/tests/values.rs
@@ -2760,6 +2760,62 @@ fn a_wrapped_vec_element_keeps_the_push_path_and_shares_one_trio() {
     );
 }
 
+/// A parameter-specific Vec-build plan bypasses the root `JObject -> Vec<T>`
+/// converter. The crossing may still have a registry-composed Sequence plan,
+/// but that plan must remain unreachable or it duplicates the legacy decoder
+/// without any call site.
+#[test]
+fn a_vec_build_parameter_does_not_emit_an_unused_sequence_decoder() {
+    let loc = myflat_loc();
+    let items: Vec<(syn::Item, SourceLocation)> = vec![
+        (
+            syn::parse_quote!(
+                pub struct Foo {
+                    pub id: i64,
+                }
+            ),
+            loc.clone(),
+        ),
+        (
+            syn::parse_quote!(
+                pub fn put_boxed_run(v: Box<Vec<Foo>>) {
+                    unimplemented!()
+                }
+            ),
+            loc,
+        ),
+    ];
+    let registry =
+        crate::test_util::reg_from_items(declare_referenced(items)).expect("index items");
+    let jni = JniGenBuilder::new()
+        .set_package_prefix("io.test.jni")
+        .package(
+            crate::package!("foo")
+                .class(crate::data_class!(Foo))
+                .fun(prebindgen_registry::fun!(put_boxed_run)),
+        );
+
+    let dir = unique_test_dir("jnigen_vec_build_sequence_reachability");
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+
+    let gen = jni.build_with(registry).expect("resolve");
+    let rust_path = gen.write_rust(dir.join("gen.rs")).expect("write_rust");
+    let rust = std::fs::read_to_string(&rust_path).expect("read rust");
+    let compact: String = rust.split_whitespace().collect();
+
+    assert!(
+        compact.contains("v_handleas*mutVec<myflat::Foo>"),
+        "the fixture must take the parameter-specific Vec-build path:\n{rust}"
+    );
+    assert_eq!(
+        rust.matches("Vec<_>: list-from-env").count(),
+        0,
+        "the parameter uses only its Vec-build handle; no list decoder has a \
+         call site in this fixture:\n{rust}"
+    );
+}
+
 /// An exclusive-borrow parameter resolves only over an opaque handle, whose
 /// object the JVM keeps alive on the Rust side. Over anything decoded onto the
 /// Rust stack the callee's writes are dropped with the wrapper's frame, so the

--- a/prebindgen-registry/src/chain.rs
+++ b/prebindgen-registry/src/chain.rs
@@ -230,6 +230,11 @@ pub struct Optional<S, B, C> {
 /// child converter call. The adapter supplies only operations on its one
 /// intermediate collection value. Operation snippets use the local names
 /// documented on each method and are rendered only during final emission.
+///
+/// The composer reserves `__sequence_values`, `__sequence_part`,
+/// `__sequence_source`, and `__sequence_element`. Bridge snippets must not
+/// bind or shadow those names; they may refer to a name only where its method
+/// documents that name as an argument.
 pub trait SequenceBridge: Clone {
     /// The one intermediate Rust type assigned to the Sequence fragment.
     fn intermediate(&self) -> syn::Type;

--- a/prebindgen-registry/src/chain.rs
+++ b/prebindgen-registry/src/chain.rs
@@ -224,6 +224,64 @@ pub struct Optional<S, B, C> {
     pub child: C,
 }
 
+/// Adapter-selected representation protocol for one Sequence shape.
+///
+/// The shared composer owns the source collection, its element loop and the
+/// child converter call. The adapter supplies only operations on its one
+/// intermediate collection value. Operation snippets use the local names
+/// documented on each method and are rendered only during final emission.
+pub trait SequenceBridge: Clone {
+    /// The one intermediate Rust type assigned to the Sequence fragment.
+    fn intermediate(&self) -> syn::Type;
+
+    /// Prepare to read elements from the inbound intermediate value.
+    ///
+    /// The returned statements may bind adapter state. The next operation is
+    /// rendered in the same scope.
+    fn begin(&self, value: TokenStream) -> TokenStream;
+
+    /// Produce the next child intermediate, or None when input is exhausted.
+    ///
+    /// This expression is rendered as the condition of the registry-owned
+    /// while-let loop.
+    fn next(&self) -> TokenStream;
+
+    /// Prepare one outbound intermediate before source elements are visited.
+    /// `source` names the canonical source collection before it is consumed,
+    /// so an adapter may inspect its length or other representation metadata.
+    ///
+    /// The returned statements may bind adapter state. Push and finish are
+    /// rendered in the same scope.
+    fn begin_output(&self, source: TokenStream) -> TokenStream;
+
+    /// Append one converted child intermediate to the outbound representation.
+    fn push(&self, value: TokenStream) -> TokenStream;
+
+    /// Produce the completed outbound intermediate.
+    fn finish(&self) -> TokenStream;
+
+    /// Whether the representation operations can fail independently of the
+    /// child converter.
+    fn fallible(&self) -> bool;
+}
+
+/// Registry-composed converter plan for a Sequence recipe.
+#[derive(Clone)]
+pub struct Sequence<S, B, C> {
+    /// Exact source spelling, opaque until rendering.
+    pub source: TypeRef,
+    /// Exact element spelling, opaque until rendering.
+    pub element: TypeRef,
+    /// Direction of the source/intermediate relation.
+    pub direction: Direction,
+    /// Source spelling and transparent-wrapper policy.
+    pub source_policy: S,
+    /// Adapter collection representation operations.
+    pub bridge: B,
+    /// Resolved element converter chain.
+    pub child: C,
+}
+
 /// One source field inside one [`Choice`] arm.
 #[derive(Clone)]
 pub struct ChoicePart<C> {
@@ -492,6 +550,60 @@ where
     }
 }
 
+impl<S, B, C> Chain for Sequence<S, B, C>
+where
+    S: Source,
+    B: SequenceBridge,
+    C: Child,
+{
+    fn render(&self, emit: &Emit) -> Rendered {
+        let source = self.source_policy.spell(&self.source, emit);
+        let element = self.source_policy.spell(&self.element, emit);
+        let intermediate = self.bridge.intermediate();
+        let body = match self.direction {
+            Direction::Construct => {
+                let begin = self.bridge.begin(quote::quote!(v));
+                let next = self.bridge.next();
+                let child = child_value(&self.child, quote::quote!(__sequence_part));
+                let canonical = quote::quote!({
+                    #begin
+                    let mut __sequence_values: ::std::vec::Vec<#element> =
+                        ::std::vec::Vec::new();
+                    while let ::core::option::Option::Some(__sequence_part) = #next {
+                        __sequence_values.push(#child);
+                    }
+                    __sequence_values
+                });
+                let built = self.source_policy.build(canonical);
+                syn::parse2(built).expect("a Sequence source constructor is a valid expression")
+            }
+            Direction::Deconstruct => {
+                let value = self.source_policy.read(quote::quote!(v));
+                let begin = self.bridge.begin_output(quote::quote!(__sequence_source));
+                let child = child_value(&self.child, quote::quote!(__sequence_element));
+                let push = self.bridge.push(quote::quote!(__sequence_part));
+                let finish = self.bridge.finish();
+                syn::parse2(quote::quote!({
+                    let __sequence_source = #value;
+                    #begin
+                    for __sequence_element in __sequence_source.into_iter() {
+                        let __sequence_part = #child;
+                        #push
+                    }
+                    #finish
+                }))
+                .expect("a Sequence intermediate constructor is a valid expression")
+            }
+        };
+        Rendered {
+            source,
+            intermediate,
+            body,
+            fallible: self.bridge.fallible() || self.child.call().fallible(),
+        }
+    }
+}
+
 impl<S, B, P, C> Chain for Choice<S, B, P, C>
 where
     S: Source,
@@ -729,6 +841,83 @@ mod tests {
             "{body}"
         );
         assert!(rendered.fallible);
+    }
+
+    #[derive(Clone)]
+    struct TestSequence;
+
+    impl SequenceBridge for TestSequence {
+        fn intermediate(&self) -> syn::Type {
+            syn::parse_quote!(Vec<i32>)
+        }
+
+        fn begin(&self, value: TokenStream) -> TokenStream {
+            quote!(let mut __test_sequence = (#value).into_iter();)
+        }
+
+        fn next(&self) -> TokenStream {
+            quote!(__test_sequence.next())
+        }
+
+        fn begin_output(&self, _source: TokenStream) -> TokenStream {
+            quote!(let mut __test_sequence = Vec::new();)
+        }
+
+        fn push(&self, value: TokenStream) -> TokenStream {
+            quote!(__test_sequence.push(#value);)
+        }
+
+        fn finish(&self) -> TokenStream {
+            quote!(__test_sequence)
+        }
+
+        fn fallible(&self) -> bool {
+            false
+        }
+    }
+
+    #[test]
+    fn sequence_owns_both_loops_and_child_error_propagation() {
+        for direction in [Direction::Construct, Direction::Deconstruct] {
+            let spells = Rc::new(Cell::new(0));
+            let child_name = match direction {
+                Direction::Construct => "decode",
+                Direction::Deconstruct => "encode",
+            };
+            let plan = Sequence {
+                source: TypeRef::scalar(ScalarKind::I64),
+                element: TypeRef::scalar(ScalarKind::I64),
+                direction,
+                source_policy: TestSource {
+                    spells: spells.clone(),
+                },
+                bridge: TestSequence,
+                child: Call::new(
+                    syn::Ident::new(child_name, proc_macro2::Span::call_site()),
+                    true,
+                    false,
+                ),
+            };
+
+            assert_eq!(spells.get(), 0);
+            let rendered = plan.render(&Emit::for_test());
+            assert_eq!(spells.get(), 2);
+            let body = rendered.body.to_token_stream().to_string();
+            match direction {
+                Direction::Construct => {
+                    assert!(
+                        body.contains("while let :: core :: option :: Option :: Some"),
+                        "{body}"
+                    );
+                    assert!(body.contains("decode (__sequence_part) ?"), "{body}");
+                }
+                Direction::Deconstruct => {
+                    assert!(body.contains("for __sequence_element in"), "{body}");
+                    assert!(body.contains("encode (__sequence_element) ?"), "{body}");
+                }
+            }
+            assert!(rendered.fallible);
+        }
     }
     fn choice_plan(
         direction: Direction,


### PR DESCRIPTION
## Summary

Move `Shape::Sequence` collection traversal into the registry-owned converter composer and use that composer from both `prebindgen-c` and `prebindgen-jni`.

The registry now owns both Sequence directions: reading child intermediates into the source collection, and visiting source elements to build one adapter-selected collection intermediate. It also owns child-call error propagation. Adapters provide only the intermediate type and its iterator/append operations, and source `TypeRef` values remain opaque until final `Chain::render` emission.

JniGen adopts the shared chain for object-shaped Java `List<T>` input and output. Cbindgen adopts it for owned `Vec<T>` outputs: the shared converter produces one `Vec<child-wire>`, and the ABI wrapper only transfers that completed intermediate to pointer-plus-length output slots.

## All-chain universality

This completes a two-adapter implementation proof for every currently shared shape composer:

- Product is used by C and JNI in both directions.
- Optional is used by C for its single-intermediate niche/nullable input and by JNI in both directions.
- Choice is used by C and JNI in both directions after #517.
- Sequence is used by C for owned-vector output and by JNI for List input and output in this PR.

The adapters do not share a Rust-writing pipeline. They share the shape walk, child chaining, and fallibility rules; each adapter supplies its one intermediate representation protocol.

## Representation boundaries

The specialized paths that remain do not duplicate the supported shared Sequence loop:

- C input slices stay zero-copy pointer-plus-length views. C borrowed callback slices also retain their lifetime-bearing ABI path.
- JNI primitive arrays, typed-handle vector folds, and multi-slot element folds retain their distinct representations.
- Callback invocation/delivery is an `Invoke` concern rather than a Sequence concern. Until that composer exists, JniGen preserves the element's nested chain for iterable callback delivery. The JVM covertest exercises callbacks carrying both optional and collection layers.

Generated C headers and generated Kotlin remain unchanged. Generated Rust is semantically equivalent but now visibly delegates supported collection conversion to the registry chain.

The optimization boundary follows the code before this refactoring: C Sequence helpers are `#[inline(always)]` because their loops formerly lived directly inside ABI wrappers, including the measured `get_vec` path. JNI Sequence converters retain their previous ordinary out-of-line policy. The C output bridge also reserves the exact source length.

Parameter-site reachability now leaves a root Sequence converter inactive when JNI's specialized `VecBuild` handle path bypasses it. This removes three uncalled composed list decoders from the covertest output, including the reported `JObject_to_Vec_Payload_64d7995c`, while retaining the legacy decoder that still has callers. A focused unit test covers the zero-decoder case.

`SequenceBridge` now documents the four local identifiers reserved by the shared composer, so future adapter snippets can avoid silent shadowing.

## Validation

- `cargo test --workspace` — passed (191 registry, 94 C, 278 JNI tests)
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` — passed
- `cargo fmt --all -- --check` — passed
- `git diff --check` — passed
- `bash examples/regen-check.sh` — passed
- `cd examples/covertest-kotlin && ./gradlew run` — passed all 57 sections
- `bash examples/perftest-bench.sh --quick` — completed; C correctness and RSS checks passed
- regenerated every tracked x86_64/aarch64 C feature variant; no header changed

## Stack

This PR is based on #517 (`fix/chained-choice-universal`) so the diff contains only Sequence composition. It should merge after #517.
