### PR TITLE
Compose callback invocation in the registry for C and JNI

### DIFF
--- a/prebindgen-c/src/builder.rs
+++ b/prebindgen-c/src/builder.rs
@@ -725,53 +725,16 @@ impl CbindgenBuilder {
         scalar_slice_elem(ty).map(|elem| (elem.clone(), elem))
     }
 
-    /// [`Self::callback_slice_elem_wire`] off the classification, for the
-    /// resolver side — the declaration side keeps the node peer above, because
-    /// a `.callback(...)` argument is written by the build script and the model
-    /// may never have interned it.
-    pub(super) fn callback_slice_elem_wire_of(
-        &self,
-        ty: &TypeRef,
-    ) -> Option<(syn::Type, syn::Type)> {
-        let elem = super::r_shared_slice_elem(ty)?;
-        let key = elem.key();
-        if let Some(wire) = self.value_opaque_ty_of(&key) {
-            return Some((self.src_ty_of(&key), wire.clone()));
-        }
-        super::scalar_ty(elem).map(|s| (s.clone(), s))
-    }
-
-    /// Like [`Self::src_ty`], but recurses into reference and slice element types so
-    /// `&ZSample` becomes `&zenoh_flat::ZSample` and `&[Payload]` becomes
-    /// `&[perftest_flat::Payload]` (needed so a callback's `Fn(&[E])` closure type
-    /// names the qualified element).
-    /// [`Self::src_ty`], recursing into a borrow's and a slice's element — off
-    /// the classification. `&ZSample` becomes `&zenoh_flat::ZSample` and
-    /// `&[Payload]` becomes `&[perftest_flat::Payload]`, so a callback's
-    /// `Fn(&[E])` closure type names the qualified element.
+    /// Wire-only callback-slice classification for the Invoke planner.
     ///
-    /// The two recursing forms are `TypeKind::Ref` and `TypeKind::Slice`, which
-    /// is what the `syn::Type::Reference` / `syn::Type::Slice` match this
-    /// replaces was reading — and the borrow's lifetime and mutability are on
-    /// the kind, so the rebuilt spelling says what the source said.
-    pub(super) fn src_ty_deep_of(&self, ty: &TypeRef) -> syn::Type {
-        match ty.kind() {
-            TypeKind::Ref {
-                lifetime,
-                mutable,
-                inner,
-            } => {
-                let inner = self.src_ty_deep_of(inner);
-                let lt = lifetime.as_ref().map(|l| quote!(#l)).unwrap_or_default();
-                let m = if *mutable { quote!(mut) } else { quote!() };
-                syn::parse_quote!(& #lt #m #inner)
-            }
-            TypeKind::Slice(elem) => {
-                let elem = self.src_ty_deep_of(elem);
-                syn::parse_quote!([#elem])
-            }
-            _ => self.src_ty_of(&ty.key()),
-        }
+    /// The declaration-side [`Self::callback_slice_elem_wire`] also returns a
+    /// source element spelling. Resolution deliberately does not: the shared
+    /// Invoke composer owns that spelling at final render time.
+    pub(super) fn callback_slice_elem_wire_type_of(&self, ty: &TypeRef) -> Option<syn::Type> {
+        let elem = super::r_shared_slice_elem(ty)?;
+        self.value_opaque_ty_of(&elem.key())
+            .cloned()
+            .or_else(|| super::scalar_ty(elem))
     }
 
     /// [`Self::in_name`] off the **identity**, for a caller holding a reading

--- a/prebindgen-c/src/chain.rs
+++ b/prebindgen-c/src/chain.rs
@@ -154,18 +154,16 @@ impl RustFunction for CFunction {
 /// One C callback argument's already-resolved wire delivery.
 #[derive(Clone)]
 pub(crate) struct InvokePart {
+    pub(crate) source: syn::Ident,
     pub(crate) prepare: TokenStream,
     pub(crate) arguments: Vec<TokenStream>,
     pub(crate) cleanup: TokenStream,
 }
 
 impl chain::InvokePart for InvokePart {
-    fn render(
-        &self,
-        _value: TokenStream,
-        _index: usize,
-        _emit: &Emit,
-    ) -> chain::RenderedInvokePart {
+    fn render(&self, value: &syn::Ident, index: usize, _emit: &Emit) -> chain::RenderedInvokePart {
+        assert_eq!(value, &invoke_argument_name(index));
+        assert_eq!(value, &self.source);
         chain::RenderedInvokePart {
             prepare: self.prepare.clone(),
             arguments: self.arguments.clone(),
@@ -179,6 +177,10 @@ struct CInvokeBridge {
     wire: syn::Type,
 }
 
+pub(crate) fn invoke_argument_name(index: usize) -> syn::Ident {
+    format_ident!("__a{}", index)
+}
+
 impl chain::InvokeBridge for CInvokeBridge {
     fn intermediate(&self) -> syn::Type {
         self.wire.clone()
@@ -189,7 +191,7 @@ impl chain::InvokeBridge for CInvokeBridge {
     }
 
     fn argument_name(&self, index: usize) -> syn::Ident {
-        format_ident!("__a{}", index)
+        invoke_argument_name(index)
     }
 
     fn capture(&self, value: TokenStream, closure: TokenStream) -> TokenStream {
@@ -226,6 +228,12 @@ impl chain::InvokeBridge for CInvokeBridge {
         invoke: TokenStream,
         cleanup: TokenStream,
     ) -> TokenStream {
+        // Encode inside the NULL-call guard. A closure whose `call` is NULL
+        // receives nothing; encoding before the guard would leak every
+        // allocation produced for an undelivered value (for example a
+        // `Vec`/`Cow` array or `String` buffer). Invoke owns phase order, but
+        // this bridge must keep the whole prepare/invoke/cleanup sequence
+        // inside the target-specific guard (#428 review).
         quote!({
             if let ::core::option::Option::Some(__f) = __call {
                 #prepare
@@ -271,14 +279,11 @@ impl InvokePlan {
         let syn::Expr::Block(body) = &rendered.body else {
             unreachable!("the C Invoke bridge captures its callable in a block")
         };
-        let mut function: syn::ItemFn = syn::parse_quote!(
+        let block = &body.block;
+        syn::parse_quote!(
             #[allow(non_snake_case, unused_variables, dead_code)]
-            pub(crate) unsafe fn #name(c: #intermediate) -> #source {
-                unreachable!()
-            }
-        );
-        function.block = Box::new(body.block.clone());
-        function
+            pub(crate) unsafe fn #name(c: #intermediate) -> #source #block
+        )
     }
 }
 

--- a/prebindgen-c/src/chain.rs
+++ b/prebindgen-c/src/chain.rs
@@ -59,6 +59,7 @@ enum CBody {
     Optional(OptionalPlan),
     Sequence(SequencePlan),
     Choice(ChoicePlan),
+    Invoke(InvokePlan),
 }
 
 impl CFunction {
@@ -124,6 +125,14 @@ impl CFunction {
         }
     }
 
+    pub(crate) fn invoke(plan: InvokePlan) -> Self {
+        let call = CCall(chain::Call::new(plan.ident.clone(), false, true));
+        Self {
+            call,
+            body: CBody::Invoke(plan),
+        }
+    }
+
     pub(crate) fn call(&self) -> &CCall {
         &self.call
     }
@@ -137,7 +146,139 @@ impl RustFunction for CFunction {
             CBody::Choice(plan) => plan.render(emit),
             CBody::Sequence(plan) => plan.render(emit),
             CBody::Optional(plan) => plan.render(emit),
+            CBody::Invoke(plan) => plan.render(emit),
         }
+    }
+}
+
+/// One C callback argument's already-resolved wire delivery.
+#[derive(Clone)]
+pub(crate) struct InvokePart {
+    pub(crate) prepare: TokenStream,
+    pub(crate) arguments: Vec<TokenStream>,
+    pub(crate) cleanup: TokenStream,
+}
+
+impl chain::InvokePart for InvokePart {
+    fn render(
+        &self,
+        _value: TokenStream,
+        _index: usize,
+        _emit: &Emit,
+    ) -> chain::RenderedInvokePart {
+        chain::RenderedInvokePart {
+            prepare: self.prepare.clone(),
+            arguments: self.arguments.clone(),
+            cleanup: self.cleanup.clone(),
+        }
+    }
+}
+
+#[derive(Clone)]
+struct CInvokeBridge {
+    wire: syn::Type,
+}
+
+impl chain::InvokeBridge for CInvokeBridge {
+    fn intermediate(&self) -> syn::Type {
+        self.wire.clone()
+    }
+
+    fn value_name(&self) -> syn::Ident {
+        format_ident!("c")
+    }
+
+    fn argument_name(&self, index: usize) -> syn::Ident {
+        format_ident!("__a{}", index)
+    }
+
+    fn capture(&self, value: TokenStream, closure: TokenStream) -> TokenStream {
+        quote!({
+            struct __Ctx {
+                context: *mut ::core::ffi::c_void,
+                drop: ::core::option::Option<unsafe extern "C" fn(*mut ::core::ffi::c_void)>,
+            }
+            unsafe impl ::core::marker::Send for __Ctx {}
+            unsafe impl ::core::marker::Sync for __Ctx {}
+            impl ::core::ops::Drop for __Ctx {
+                fn drop(&mut self) {
+                    if let ::core::option::Option::Some(__d) = self.drop {
+                        unsafe { __d(self.context) }
+                    }
+                }
+            }
+            let __call = #value.call;
+            let __ctx = ::std::sync::Arc::new(__Ctx {
+                context: #value.context,
+                drop: #value.drop,
+            });
+            #closure
+        })
+    }
+
+    fn invoke(&self, arguments: &[TokenStream]) -> TokenStream {
+        quote!(unsafe { __f(#(#arguments,)* __ctx.context) })
+    }
+
+    fn surround(
+        &self,
+        prepare: TokenStream,
+        invoke: TokenStream,
+        cleanup: TokenStream,
+    ) -> TokenStream {
+        quote!({
+            if let ::core::option::Option::Some(__f) = __call {
+                #prepare
+                #invoke
+                #cleanup
+            }
+        })
+    }
+
+    fn fallible(&self) -> bool {
+        false
+    }
+}
+
+/// A callback chain. Its `impl Fn(..)` spelling remains opaque until render.
+#[derive(Clone)]
+pub(crate) struct InvokePlan {
+    pub(crate) ident: syn::Ident,
+    pub(crate) source: TypeRef,
+    pub(crate) source_module: Option<syn::Path>,
+    pub(crate) wire: syn::Type,
+    pub(crate) arguments: Vec<TypeRef>,
+    pub(crate) parts: Vec<InvokePart>,
+}
+
+impl InvokePlan {
+    fn render(&self, emit: &Emit) -> syn::ItemFn {
+        let plan = chain::Invoke {
+            source: self.source.clone(),
+            arguments: self.arguments.clone(),
+            source_policy: CSource {
+                module: self.source_module.clone(),
+            },
+            bridge: CInvokeBridge {
+                wire: self.wire.clone(),
+            },
+            parts: self.parts.clone(),
+        };
+        let rendered = plan.render(emit);
+        let name = &self.ident;
+        let source = &rendered.source;
+        let intermediate = &rendered.intermediate;
+        let syn::Expr::Block(body) = &rendered.body else {
+            unreachable!("the C Invoke bridge captures its callable in a block")
+        };
+        let mut function: syn::ItemFn = syn::parse_quote!(
+            #[allow(non_snake_case, unused_variables, dead_code)]
+            pub(crate) unsafe fn #name(c: #intermediate) -> #source {
+                unreachable!()
+            }
+        );
+        function.block = Box::new(body.block.clone());
+        function
     }
 }
 

--- a/prebindgen-c/src/compile.rs
+++ b/prebindgen-c/src/compile.rs
@@ -237,13 +237,7 @@ impl<R: Conversions> Compile for CCompile<'_, R> {
                 .or_else(|| self.gen.in_str(ty))
                 .or_else(|| self.gen.in_bool(ty))
                 .or_else(|| self.gen.in_scalar(ty))
-                .or_else(|| self.gen.in_borrow(ty))
-                .or_else(|| {
-                    // A callback whose signature was declared: its own
-                    // `#[repr(C)]` closure struct.
-                    let args = ty.callback_args()?;
-                    self.gen.dispatch_fn_input(args, None, self.registry)
-                }),
+                .or_else(|| self.gen.in_borrow(ty)),
             Direction::Deconstruct => self
                 .gen
                 .out_custom(ty, self.registry, cx.emit())
@@ -634,10 +628,22 @@ impl<R: Conversions> Compile for CCompile<'_, R> {
         let Some(args) = at.crossing.value().callback_args() else {
             return Err(refuse(at, "a callback recipe over a type that is not one"));
         };
-        let conv = self
+        let (destination, function) = self
             .gen
-            .dispatch_fn_input(args, Some(fragments), self.registry);
-        self.wrap(at, "undeclared callback signature", conv)
+            .dispatch_fn_input(at.crossing.spelled(), args, Some(fragments), self.registry)
+            .ok_or_else(|| refuse(at, "undeclared callback signature"))?;
+        Ok(CFrag {
+            destination,
+            function,
+            niches: Niches::empty(),
+            subs: Vec::new(),
+            arm: None,
+            yields: Yield {
+                ty: at.crossing.value().stripped_key(),
+                mode: at.crossing.mode(),
+                validity: Validity::SelfSufficient,
+            },
+        })
     }
 
     /// C hands out borrows deliberately, so a returned one is not an error.

--- a/prebindgen-c/src/tests/callbacks.rs
+++ b/prebindgen-c/src/tests/callbacks.rs
@@ -42,7 +42,7 @@ fn takeable_callback_param() {
     // Trampoline passes `&mut __w0` and drops it after the call.
     assert!(compact.contains("&mut__w0as*mutz_sample_t"), "{src}");
     assert!(
-        compact.contains("<z_sample_tas::prebindgen_c_runtime::Transmute>::into_rust(__w0)"),
+        compact.contains("<z_sample_tas::prebindgen_c_runtime::Transmute>::into_rust(__w0"),
         "{src}"
     );
     // Public take (move) function emitted (no name mangler in this test ⇒

--- a/prebindgen-c/src/tests/callbacks.rs
+++ b/prebindgen-c/src/tests/callbacks.rs
@@ -42,7 +42,7 @@ fn takeable_callback_param() {
     // Trampoline passes `&mut __w0` and drops it after the call.
     assert!(compact.contains("&mut__w0as*mutz_sample_t"), "{src}");
     assert!(
-        compact.contains("<z_sample_tas::prebindgen_c_runtime::Transmute>::into_rust(__w0"),
+        compact.contains("<z_sample_tas::prebindgen_c_runtime::Transmute>::into_rust(__w0)"),
         "{src}"
     );
     // Public take (move) function emitted (no name mangler in this test ⇒

--- a/prebindgen-c/src/trait_impl.rs
+++ b/prebindgen-c/src/trait_impl.rs
@@ -1655,10 +1655,11 @@ impl CbindgenBuilder {
             // the call). The element wire is layout-identical to `E`, so the pointer
             // cast is sound; no per-element encode and no post-call drop.
             if let Some(elem_wire) = self.callback_slice_elem_wire_type_of(arg) {
-                let ai = format_ident!("__a{}", i);
+                let ai = crate::chain::invoke_argument_name(i);
                 call_args.push(quote!(#ai.as_ptr() as *const #elem_wire));
                 call_args.push(quote!(#ai.len()));
                 parts.push(crate::chain::InvokePart {
+                    source: ai,
                     prepare: encode_stmts,
                     arguments: call_args,
                     cleanup: post_drops,
@@ -1671,7 +1672,7 @@ impl CbindgenBuilder {
             let conv = entry.function.call().ident().clone();
             let opaque = entry.destination.clone();
             let fallible = entry.function.call().fallible();
-            let ai = format_ident!("__a{}", i);
+            let ai = crate::chain::invoke_argument_name(i);
             let wi = format_ident!("__w{}", i);
             let is_takeable = takeable.contains(&i);
             // A COMPOSITE argument — `Option<T>`, `Vec<T>`, `Cow<'_, [T]>` — has
@@ -1759,6 +1760,7 @@ impl CbindgenBuilder {
                     &ErrRoute::Panic,
                 ));
                 parts.push(crate::chain::InvokePart {
+                    source: ai.clone(),
                     prepare: encode_stmts,
                     arguments: call_args,
                     cleanup: post_drops,
@@ -1789,6 +1791,7 @@ impl CbindgenBuilder {
                 call_args.push(quote!(#wi));
             }
             parts.push(crate::chain::InvokePart {
+                source: ai.clone(),
                 prepare: encode_stmts,
                 arguments: call_args,
                 cleanup: post_drops,

--- a/prebindgen-c/src/trait_impl.rs
+++ b/prebindgen-c/src/trait_impl.rs
@@ -1625,10 +1625,11 @@ impl CbindgenBuilder {
 impl CbindgenBuilder {
     pub(crate) fn dispatch_fn_input(
         &self,
+        source: &TypeRef,
         args: &[TypeRef],
         fragments: Option<&[&crate::compile::CFrag]>,
         registry: &impl Conversions,
-    ) -> Option<ConverterImpl> {
+    ) -> Option<(syn::Type, crate::chain::CFunction)> {
         let key: CallbackKey = args.iter().map(|a| a.key()).collect();
         if !self.callbacks.contains_key(&key) {
             // Undeclared callback signature: leave unresolved so the registry
@@ -1644,20 +1645,24 @@ impl CbindgenBuilder {
         // **takeable** arg is passed as `&mut __wN` (`*mut z_x_t`) and dropped here
         // after the call (no-op if the C side took it, leaving a gravestone).
         let takeable = &self.callbacks.get(&key).expect("callback cfg").takeable;
-        let mut closure_params: Vec<TokenStream> = Vec::new();
-        let mut encode_stmts: Vec<TokenStream> = Vec::new();
-        let mut call_args: Vec<TokenStream> = Vec::new();
-        let mut post_drops: Vec<TokenStream> = Vec::new();
+        let mut parts: Vec<crate::chain::InvokePart> = Vec::new();
         for (i, arg) in args.iter().enumerate() {
+            let mut encode_stmts = TokenStream::new();
+            let mut call_args: Vec<TokenStream> = Vec::new();
+            let mut post_drops = TokenStream::new();
             // `&[E]` slice arg: deliver the slice to the C `call` **by reference** —
             // `(*const E_wire, size_t)`, zero-copy (the closure borrows the slice for
             // the call). The element wire is layout-identical to `E`, so the pointer
             // cast is sound; no per-element encode and no post-call drop.
-            if let Some((src_elem, elem_wire)) = self.callback_slice_elem_wire_of(arg) {
+            if let Some(elem_wire) = self.callback_slice_elem_wire_type_of(arg) {
                 let ai = format_ident!("__a{}", i);
-                closure_params.push(quote!(#ai: &[#src_elem]));
                 call_args.push(quote!(#ai.as_ptr() as *const #elem_wire));
                 call_args.push(quote!(#ai.len()));
+                parts.push(crate::chain::InvokePart {
+                    prepare: encode_stmts,
+                    arguments: call_args,
+                    cleanup: post_drops,
+                });
                 continue;
             }
             let supplied = fragments.and_then(|fragments| fragments.get(i).copied());
@@ -1666,7 +1671,6 @@ impl CbindgenBuilder {
             let conv = entry.function.call().ident().clone();
             let opaque = entry.destination.clone();
             let fallible = entry.function.call().fallible();
-            let src = self.src_ty_deep_of(arg);
             let ai = format_ident!("__a{}", i);
             let wi = format_ident!("__w{}", i);
             let is_takeable = takeable.contains(&i);
@@ -1712,7 +1716,6 @@ impl CbindgenBuilder {
                 && self.is_lowered_composite(arg);
             if composite {
                 let shape = self.lower_shape(arg, registry);
-                closure_params.push(quote!(#ai: #src));
                 let mut targets = Vec::new();
                 for (f, field) in shape.fields.iter().enumerate() {
                     let fi = if shape.fields.len() == 1 {
@@ -1741,26 +1744,30 @@ impl CbindgenBuilder {
                     // writes, which is the encoder's business and not this
                     // caller's.
                     encode_stmts
-                        .push(quote!(let mut #fi = ::core::mem::MaybeUninit::<#wire>::zeroed();));
+                        .extend(quote!(let mut #fi = ::core::mem::MaybeUninit::<#wire>::zeroed();));
                     targets.push(quote!(*#fi.as_mut_ptr()));
                     call_args.push(quote!(#fi));
                 }
                 // A firing callback has no error channel, so a fallible
                 // converter aborts — the same answer the single-value path
                 // below gives, spelled by the route the emitters share.
-                encode_stmts.push(self.encode_value(
+                encode_stmts.extend(self.encode_value(
                     arg,
                     quote!(#ai),
                     &targets,
                     registry,
                     &ErrRoute::Panic,
                 ));
+                parts.push(crate::chain::InvokePart {
+                    prepare: encode_stmts,
+                    arguments: call_args,
+                    cleanup: post_drops,
+                });
                 continue;
             }
-            closure_params.push(quote!(#ai: #src));
             let mut_kw = if is_takeable { quote!(mut) } else { quote!() };
             if fallible {
-                encode_stmts.push(quote!(
+                encode_stmts.extend(quote!(
                     let #mut_kw #wi = match #conv(#ai) {
                         ::core::result::Result::Ok(__v) => __v,
                         ::core::result::Result::Err(__e) => {
@@ -1769,70 +1776,36 @@ impl CbindgenBuilder {
                     };
                 ));
             } else {
-                encode_stmts.push(quote!(let #mut_kw #wi = #conv(#ai);));
+                encode_stmts.extend(quote!(let #mut_kw #wi = #conv(#ai);));
             }
             if is_takeable {
                 call_args.push(quote!(&mut #wi as *mut #opaque));
                 // Always drop after the call (leak-safe): live value if untaken,
                 // gravestone (no-op) if the C side took it via `z_x_take`.
-                post_drops.push(
+                post_drops.extend(
                     quote!(let _ = <#opaque as ::prebindgen_c_runtime::Transmute>::into_rust(#wi);),
                 );
             } else {
                 call_args.push(quote!(#wi));
             }
+            parts.push(crate::chain::InvokePart {
+                prepare: encode_stmts,
+                arguments: call_args,
+                cleanup: post_drops,
+            });
         }
 
-        let fn_ty = callback_fn_type(
-            &args
-                .iter()
-                .map(|a| self.src_ty_deep_of(a))
-                .collect::<Vec<_>>(),
-        );
         let name = format_ident!("__cbg_in_{}", self.callback_c_name(&key));
-        let function: syn::ItemFn = syn::parse_quote!(
-            #[allow(non_snake_case, unused_variables, dead_code)]
-            pub(crate) unsafe fn #name(c: #c_struct) -> #fn_ty {
-                struct __Ctx {
-                    context: *mut ::core::ffi::c_void,
-                    drop: ::core::option::Option<unsafe extern "C" fn(*mut ::core::ffi::c_void)>,
-                }
-                unsafe impl ::core::marker::Send for __Ctx {}
-                unsafe impl ::core::marker::Sync for __Ctx {}
-                impl ::core::ops::Drop for __Ctx {
-                    fn drop(&mut self) {
-                        if let ::core::option::Option::Some(__d) = self.drop {
-                            unsafe { __d(self.context) }
-                        }
-                    }
-                }
-                let __call = c.call;
-                let __ctx = ::std::sync::Arc::new(__Ctx { context: c.context, drop: c.drop });
-                move |#(#closure_params),*| {
-                    // Encode INSIDE the guard: a closure struct whose `call` is
-                    // NULL receives nothing, and a converter that allocates —
-                    // `Vec`/`Cow` into a malloc'd array, a `String` into a
-                    // malloc'd `char *` — would hand that allocation to nobody
-                    // on every invocation (#428 review). Not converting at all
-                    // is also what the argument's own `Drop` expects: the value
-                    // is simply dropped, which is neither a leak nor a double
-                    // free.
-                    if let ::core::option::Option::Some(__f) = __call {
-                        #(#encode_stmts)*
-                        unsafe { __f(#(#call_args,)* __ctx.context) }
-                        #(#post_drops)*
-                    }
-                }
-            }
-        );
-        Some(ConverterImpl {
-            subs: vec![],
-            destination: syn::parse_quote!(#c_struct),
-            function,
-            pre_stages: vec![],
-            niches: Niches::empty(),
-            metadata: (),
-        })
+        let wire: syn::Type = syn::parse_quote!(#c_struct);
+        let function = crate::chain::CFunction::invoke(crate::chain::InvokePlan {
+            ident: name,
+            source: source.clone(),
+            source_module: self.source_module.clone(),
+            wire: wire.clone(),
+            arguments: args.to_vec(),
+            parts,
+        });
+        Some((wire, function))
     }
 }
 

--- a/prebindgen-jni/src/jni/chain.rs
+++ b/prebindgen-jni/src/jni/chain.rs
@@ -22,6 +22,7 @@ enum JBody {
     Choice(Box<JChoicePlan>),
     Sequence(Box<JSequencePlan>),
     Optional(Box<JOptionalPlan>),
+    Invoke(Box<crate::jni::emit::JInvokePlan>),
 }
 
 impl JFunction {
@@ -47,6 +48,10 @@ impl JFunction {
 
     pub(crate) fn choice(plan: JChoicePlan) -> Self {
         Self(JBody::Choice(Box::new(plan)))
+    }
+
+    pub(crate) fn invoke(plan: crate::jni::emit::JInvokePlan) -> Self {
+        Self(JBody::Invoke(Box::new(plan)))
     }
 
     pub(crate) fn mark_reachable(&self) {
@@ -77,6 +82,7 @@ impl JFunction {
                     dependency.mark_reachable();
                 }
             }
+            JBody::Invoke(_) => {}
         }
     }
 }
@@ -90,6 +96,7 @@ impl RustFunction for JFunction {
             JBody::Optional(plan) => plan.reachable.get(),
             JBody::Sequence(plan) => plan.reachable.get(),
             JBody::Choice(plan) => plan.reachable.get(),
+            JBody::Invoke(_) => true,
         }
     }
 
@@ -101,6 +108,7 @@ impl RustFunction for JFunction {
             JBody::Optional(plan) => plan.render(emit),
             JBody::Choice(plan) => plan.render(emit),
             JBody::Sequence(plan) => plan.render(emit),
+            JBody::Invoke(plan) => plan.render(emit),
         }
     }
 }

--- a/prebindgen-jni/src/jni/chain.rs
+++ b/prebindgen-jni/src/jni/chain.rs
@@ -54,6 +54,11 @@ impl JFunction {
         Self(JBody::Invoke(Box::new(plan)))
     }
 
+    #[cfg(test)]
+    pub(crate) fn is_invoke(&self) -> bool {
+        matches!(self.0, JBody::Invoke(_))
+    }
+
     pub(crate) fn mark_reachable(&self) {
         match &self.0 {
             JBody::Complete(_) => {}

--- a/prebindgen-jni/src/jni/chain.rs
+++ b/prebindgen-jni/src/jni/chain.rs
@@ -82,6 +82,10 @@ impl JFunction {
                     dependency.mark_reachable();
                 }
             }
+            // An Invoke plan exists only for a declared callback crossing and
+            // is called directly by that crossing's wrapper. Unlike reusable
+            // child converters, it is reachable by construction and needs no
+            // later activation pass.
             JBody::Invoke(_) => {}
         }
     }
@@ -96,6 +100,8 @@ impl RustFunction for JFunction {
             JBody::Optional(plan) => plan.reachable.get(),
             JBody::Sequence(plan) => plan.reachable.get(),
             JBody::Choice(plan) => plan.reachable.get(),
+            // See `mark_reachable`: callback converters are roots, never
+            // dormant dependencies waiting for a parent to activate them.
             JBody::Invoke(_) => true,
         }
     }

--- a/prebindgen-jni/src/jni/compile.rs
+++ b/prebindgen-jni/src/jni/compile.rs
@@ -1530,17 +1530,7 @@ impl<R: Conversions> Compile for JCompile<'_, R> {
                 .decls
                 .input_terminal(ty, self.registry, emit)
                 .or_else(|| self.borrow(ty, emit, true))
-                .or_else(|| self.decls.input_transparent_bridge(ty, self.registry, emit))
-                .or_else(|| {
-                    // `impl Fn(args)` that nothing else claimed. Callback args
-                    // cross in the opposite direction, which is why their
-                    // required-ness rides `immediate_edges` rather than `subs`.
-                    let TypeKind::Callback { args } = ty.unwrapped().kind() else {
-                        return None;
-                    };
-                    self.decls
-                        .dispatch_fn_input(args, self.registry, None, emit)
-                }),
+                .or_else(|| self.decls.input_transparent_bridge(ty, self.registry, emit)),
             Direction::Deconstruct => self
                 .decls
                 .output_terminal(ty, self.registry, emit)
@@ -1820,10 +1810,13 @@ impl<R: Conversions> Compile for JCompile<'_, R> {
         let TypeKind::Callback { args } = ty.unwrapped().kind() else {
             return Err(refuse(at, "a callback recipe over a type that is not one"));
         };
-        let conv =
+        let planned =
             self.decls
-                .dispatch_fn_input(args, self.registry, Some(arg_fragments), cx.emit());
-        self.wrap(at, "undeclared callback signature", conv)
+                .dispatch_fn_input(ty, args, self.registry, Some(arg_fragments), cx.emit());
+        let (conv, rust) = planned.ok_or_else(|| refuse(at, "undeclared callback signature"))?;
+        let mut fragment = JFrag::new(at, conv);
+        fragment.rust = rust;
+        Ok(fragment)
     }
 
     /// One site: which of the seven wire layouts this parameter takes, and the

--- a/prebindgen-jni/src/jni/compile.rs
+++ b/prebindgen-jni/src/jni/compile.rs
@@ -536,8 +536,17 @@ impl JFrag {
     /// Registry recipes handle composable callback products. Irregular layouts
     /// still enter through this compatibility path and are indexed as fragments
     /// so downstream emitters use the same lookup in either case.
+    #[cfg(test)]
     pub(crate) fn by_hand(ty: TypeKey, conv: ConverterImpl<KotlinMeta>) -> Self {
         let rust = crate::jni::chain::JFunction::complete(conv.function.clone());
+        Self::by_hand_with_rust(ty, conv, rust)
+    }
+
+    pub(crate) fn by_hand_with_rust(
+        ty: TypeKey,
+        conv: ConverterImpl<KotlinMeta>,
+        rust: crate::jni::chain::JFunction,
+    ) -> Self {
         Self {
             conv,
             rust,
@@ -1525,20 +1534,24 @@ impl<R: Conversions> Compile for JCompile<'_, R> {
         if let Some(frag) = self.planned_owned_handle(at) {
             return Ok(frag);
         }
+        if at.crossing.direction() == Direction::Construct {
+            if let TypeKind::Callback { args } = ty.unwrapped().kind() {
+                if let Some((conv, rust)) =
+                    self.decls
+                        .dispatch_fn_input(ty, args, self.registry, None, emit)
+                {
+                    let mut fragment = JFrag::new(at, conv);
+                    fragment.rust = rust;
+                    return Ok(fragment);
+                }
+            }
+        }
         let conv = match at.crossing.direction() {
             Direction::Construct => self
                 .decls
                 .input_terminal(ty, self.registry, emit)
                 .or_else(|| self.borrow(ty, emit, true))
-                .or_else(|| self.decls.input_transparent_bridge(ty, self.registry, emit))
-                .or_else(|| {
-                    let TypeKind::Callback { args } = ty.unwrapped().kind() else {
-                        return None;
-                    };
-                    self.decls
-                        .dispatch_fn_input(ty, args, self.registry, None, emit)
-                        .map(|(conv, _)| conv)
-                }),
+                .or_else(|| self.decls.input_transparent_bridge(ty, self.registry, emit)),
             Direction::Deconstruct => self
                 .decls
                 .output_terminal(ty, self.registry, emit)

--- a/prebindgen-jni/src/jni/compile.rs
+++ b/prebindgen-jni/src/jni/compile.rs
@@ -1530,7 +1530,15 @@ impl<R: Conversions> Compile for JCompile<'_, R> {
                 .decls
                 .input_terminal(ty, self.registry, emit)
                 .or_else(|| self.borrow(ty, emit, true))
-                .or_else(|| self.decls.input_transparent_bridge(ty, self.registry, emit)),
+                .or_else(|| self.decls.input_transparent_bridge(ty, self.registry, emit))
+                .or_else(|| {
+                    let TypeKind::Callback { args } = ty.unwrapped().kind() else {
+                        return None;
+                    };
+                    self.decls
+                        .dispatch_fn_input(ty, args, self.registry, None, emit)
+                        .map(|(conv, _)| conv)
+                }),
             Direction::Deconstruct => self
                 .decls
                 .output_terminal(ty, self.registry, emit)

--- a/prebindgen-jni/src/jni/emit/callback.rs
+++ b/prebindgen-jni/src/jni/emit/callback.rs
@@ -7,6 +7,7 @@ use super::*;
 
 #[derive(Clone)]
 struct JInvokePart {
+    source: syn::Ident,
     prepare: TokenStream,
     arguments: Vec<TokenStream>,
 }
@@ -14,10 +15,12 @@ struct JInvokePart {
 impl prebindgen_registry::chain::InvokePart for JInvokePart {
     fn render(
         &self,
-        _value: TokenStream,
-        _index: usize,
+        value: &syn::Ident,
+        index: usize,
         _emit: &prebindgen_registry::Emit,
     ) -> prebindgen_registry::chain::RenderedInvokePart {
+        assert_eq!(value, &callback_argument_name(index));
+        assert_eq!(value, &self.source);
         prebindgen_registry::chain::RenderedInvokePart {
             prepare: self.prepare.clone(),
             arguments: self.arguments.clone(),
@@ -34,6 +37,10 @@ struct JInvokeBridge {
     fold_setups: Vec<TokenStream>,
 }
 
+fn callback_argument_name(index: usize) -> syn::Ident {
+    format_ident!("__cb_arg{}", index)
+}
+
 /// A registry-composed callback retained until the final Rust writer runs.
 #[derive(Clone)]
 pub(crate) struct JInvokePlan {
@@ -43,6 +50,10 @@ pub(crate) struct JInvokePlan {
 }
 
 impl JInvokePlan {
+    pub(crate) fn name(&self) -> &syn::Ident {
+        &self.name
+    }
+
     pub(crate) fn render(&self, emit: &prebindgen_registry::Emit) -> syn::ItemFn {
         let rendered = self.chain.render(emit);
         let name = &self.name;
@@ -67,13 +78,19 @@ impl prebindgen_registry::chain::InvokeBridge for JInvokeBridge {
     }
 
     fn argument_name(&self, index: usize) -> syn::Ident {
-        format_ident!("__cb_arg{}", index)
+        callback_argument_name(index)
     }
 
     fn capture(&self, value: TokenStream, closure: TokenStream) -> TokenStream {
         let name = &self.name;
         let descriptor = &self.descriptor;
         let fold_setups = &self.fold_setups;
+        // Resolve the typed callback interface's `run` method once, while the
+        // trampoline is created. `JNIEnv::call_method` reparses the descriptor
+        // and resolves the method on every call; that measured at roughly 33%
+        // of subscriber hot-path delivery time. `JMethodID` is Copy + Send +
+        // Sync and remains valid because the global ref pins the callback and
+        // therefore its class for the closure's lifetime.
         quote!({
             use std::sync::Arc;
             let java_vm = Arc::new(env.get_java_vm()
@@ -90,6 +107,15 @@ impl prebindgen_registry::chain::InvokeBridge for JInvokeBridge {
     }
 
     fn invoke(&self, arguments: &[TokenStream]) -> TokenStream {
+        // SAFETY: `__invoke_id` was resolved on this callback object's exact
+        // class with the exact descriptor represented by `arguments`; the
+        // global ref keeps that class loaded. `run` returns void, primitives
+        // occupy their matching raw jvalue fields, and exception handling is
+        // the same checked JNI path used by `call_method`.
+        //
+        // A plan-less owned-handle argument's per-invocation Box is closed by
+        // Kotlin's `asRaw` proxy in `finally { close() }` (a no-op if taken), so
+        // the Rust invocation has no matching post-call close.
         quote! {
             let __call_res: ::core::result::Result<(), __JniErr> = unsafe {
                 env.call_method_unchecked(
@@ -116,6 +142,11 @@ impl prebindgen_registry::chain::InvokeBridge for JInvokeBridge {
     ) -> TokenStream {
         let name = &self.name;
         let frame_capacity = &self.frame_capacity;
+        // Callbacks may run on daemon-attached Zenoh receive threads that never
+        // return through a JNI stack frame. Give every invocation its own local
+        // frame so encoded leaves, handle wrappers and call temporaries cannot
+        // accumulate until `OutOfMemoryError`; pop it unconditionally after the
+        // inner Result, including every early `?`/error path.
         quote!({
             let _ = (|| -> ::core::result::Result<(), __JniErr> {
                 let mut env = java_vm
@@ -164,7 +195,7 @@ pub(crate) fn callback_input(
     registry: &impl Conversions,
     arg_fragments: Option<&[&crate::jni::compile::JFrag]>,
     emit: &prebindgen_registry::Emit,
-) -> Option<(syn::Type, syn::Type, syn::Expr, JInvokePlan)> {
+) -> Option<(syn::Type, JInvokePlan)> {
     // Human-readable tag for attach/log messages.
     let name = format!(
         "Fn({})",
@@ -184,9 +215,7 @@ pub(crate) fn callback_input(
         }
     };
 
-    let arg_names: Vec<syn::Ident> = (0..args.len())
-        .map(|i| format_ident!("__cb_arg{}", i))
-        .collect();
+    let arg_names: Vec<syn::Ident> = (0..args.len()).map(callback_argument_name).collect();
     // Per-arg encode preludes binding the typed `run`'s args in declared
     // order (a decomposed arg contributes one arg per leaf). Each entry of
     // `jvalue_exprs` is a typed `jvalue`: raw primitives for primitive-wire
@@ -518,14 +547,16 @@ pub(crate) fn callback_input(
 
     let parts = part_ranges
         .into_iter()
-        .map(|(ps, pe, as_, ae)| JInvokePart {
+        .enumerate()
+        .map(|(index, (ps, pe, as_, ae))| JInvokePart {
+            source: arg_names[index].clone(),
             prepare: {
                 let values = &preludes[ps..pe];
                 quote!(#(#values)*)
             },
             arguments: jvalue_exprs[as_..ae].to_vec(),
         })
-        .collect();
+        .collect::<Vec<_>>();
     let chain = prebindgen_registry::chain::Invoke {
         source: source.clone(),
         arguments: args.to_vec(),
@@ -541,21 +572,16 @@ pub(crate) fn callback_input(
         },
         parts,
     };
-    let rendered = chain.render(emit);
+    let intermediate: syn::Type = syn::parse_quote!(jni::objects::JObject);
     let rust_plan = JInvokePlan {
-        name: input_name(&rendered.source.to_token_stream(), &rendered.intermediate),
+        name: crate::jni::chain::planned_name(Direction::Construct, source, &intermediate),
         chain,
     };
 
     // The wire type for an `impl Fn(args)` parameter is JObject (the erased
     // Kotlin lambda). The converter returns Box<dyn Fn(args) + Send + Sync>,
     // which coerces to the source's impl-trait param type.
-    Some((
-        rendered.source,
-        rendered.intermediate,
-        rendered.body,
-        rust_plan,
-    ))
+    Some((intermediate, rust_plan))
 }
 
 /// Hard-error guard for `Vec<opaque-handle>` element types. A handle's wire is

--- a/prebindgen-jni/src/jni/emit/callback.rs
+++ b/prebindgen-jni/src/jni/emit/callback.rs
@@ -55,7 +55,7 @@ impl JInvokePlan {
                 env: &mut jni::JNIEnv<'env>,
                 v: &jni::objects::JObject<'v>,
             ) -> ::core::result::Result<#source, __JniErr> {
-                ::core::result::Result::Ok(#body)
+                Ok(#body)
             }
         )
     }

--- a/prebindgen-jni/src/jni/emit/callback.rs
+++ b/prebindgen-jni/src/jni/emit/callback.rs
@@ -1,9 +1,146 @@
 //! `impl Fn(args)` inputs: the native trampoline calling the typed
 //! Kotlin `run`.
 
-use prebindgen_registry::Conversions;
+use prebindgen_registry::{chain::Chain as _, Conversions};
 
 use super::*;
+
+#[derive(Clone)]
+struct JInvokePart {
+    prepare: TokenStream,
+    arguments: Vec<TokenStream>,
+}
+
+impl prebindgen_registry::chain::InvokePart for JInvokePart {
+    fn render(
+        &self,
+        _value: TokenStream,
+        _index: usize,
+        _emit: &prebindgen_registry::Emit,
+    ) -> prebindgen_registry::chain::RenderedInvokePart {
+        prebindgen_registry::chain::RenderedInvokePart {
+            prepare: self.prepare.clone(),
+            arguments: self.arguments.clone(),
+            cleanup: TokenStream::new(),
+        }
+    }
+}
+
+#[derive(Clone)]
+struct JInvokeBridge {
+    name: syn::LitStr,
+    descriptor: syn::LitStr,
+    frame_capacity: syn::LitInt,
+    fold_setups: Vec<TokenStream>,
+}
+
+/// A registry-composed callback retained until the final Rust writer runs.
+#[derive(Clone)]
+pub(crate) struct JInvokePlan {
+    name: syn::Ident,
+    chain:
+        prebindgen_registry::chain::Invoke<crate::jni::chain::JSource, JInvokeBridge, JInvokePart>,
+}
+
+impl JInvokePlan {
+    pub(crate) fn render(&self, emit: &prebindgen_registry::Emit) -> syn::ItemFn {
+        let rendered = self.chain.render(emit);
+        let name = &self.name;
+        let source = &rendered.source;
+        let body = &rendered.body;
+        let gen_allow = crate::jni::trait_impl::generated_converter_attr();
+        syn::parse_quote!(
+            #gen_allow
+            pub(crate) unsafe fn #name<'env, 'v>(
+                env: &mut jni::JNIEnv<'env>,
+                v: &jni::objects::JObject<'v>,
+            ) -> ::core::result::Result<#source, __JniErr> {
+                ::core::result::Result::Ok(#body)
+            }
+        )
+    }
+}
+
+impl prebindgen_registry::chain::InvokeBridge for JInvokeBridge {
+    fn intermediate(&self) -> syn::Type {
+        syn::parse_quote!(jni::objects::JObject)
+    }
+
+    fn argument_name(&self, index: usize) -> syn::Ident {
+        format_ident!("__cb_arg{}", index)
+    }
+
+    fn capture(&self, value: TokenStream, closure: TokenStream) -> TokenStream {
+        let name = &self.name;
+        let descriptor = &self.descriptor;
+        let fold_setups = &self.fold_setups;
+        quote!({
+            use std::sync::Arc;
+            let java_vm = Arc::new(env.get_java_vm()
+                .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(format!("Unable to retrieve JVM: {}", e)))?);
+            let callback_global_ref = env.new_global_ref(&#value)
+                .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(format!("Unable to global-ref callback: {}", e)))?;
+            let __invoke_class = env.get_object_class(&#value)
+                .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(format!("Unable to get callback class for {}: {}", #name, e)))?;
+            let __invoke_id = env.get_method_id(&__invoke_class, "run", #descriptor)
+                .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(format!("Unable to resolve run for {}: {}", #name, e)))?;
+            #(#fold_setups)*
+            Box::new(#closure)
+        })
+    }
+
+    fn invoke(&self, arguments: &[TokenStream]) -> TokenStream {
+        quote! {
+            let __call_res: ::core::result::Result<(), __JniErr> = unsafe {
+                env.call_method_unchecked(
+                    &callback_global_ref,
+                    __invoke_id,
+                    jni::signature::ReturnType::Primitive(jni::signature::Primitive::Void),
+                    &[#(#arguments),*],
+                )
+            }
+            .map(|_| ())
+            .map_err(|e| {
+                let _ = env.exception_describe();
+                <__JniErr as ::core::convert::From<String>>::from(e.to_string())
+            });
+            __call_res?;
+        }
+    }
+
+    fn surround(
+        &self,
+        prepare: TokenStream,
+        invoke: TokenStream,
+        cleanup: TokenStream,
+    ) -> TokenStream {
+        let name = &self.name;
+        let frame_capacity = &self.frame_capacity;
+        quote!({
+            let _ = (|| -> ::core::result::Result<(), __JniErr> {
+                let mut env = java_vm
+                    .attach_current_thread_as_daemon()
+                    .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(format!("Attach thread for {}: {}", #name, e)))?;
+                env.push_local_frame(#frame_capacity)
+                    .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(format!("push local frame for {}: {}", #name, e)))?;
+                let __frame_res = (|| -> ::core::result::Result<(), __JniErr> {
+                    #prepare
+                    #invoke
+                    #cleanup
+                    Ok(())
+                })();
+                let _ = unsafe { env.pop_local_frame(&jni::objects::JObject::null()) };
+                __frame_res?;
+                Ok(())
+            })()
+            .map_err(|e| tracing::error!("{} callback error: {e}", #name));
+        })
+    }
+
+    fn fallible(&self) -> bool {
+        true
+    }
+}
 
 /// Build the input-converter body for an `impl Fn(args)` parameter: a
 /// trampoline that wraps the Kotlin **lambda** (`(leaves…) -> Unit`, erased to
@@ -22,11 +159,12 @@ use super::*;
 /// returned), so they are converted to `__JniErr` and logged via `tracing`.
 pub(crate) fn callback_input(
     ext: &Declarations,
+    source: &prebindgen_registry::flat::TypeRef,
     args: &[prebindgen_registry::flat::TypeRef],
     registry: &impl Conversions,
     arg_fragments: Option<&[&crate::jni::compile::JFrag]>,
     emit: &prebindgen_registry::Emit,
-) -> Option<(syn::Type, syn::Expr)> {
+) -> Option<(syn::Type, syn::Type, syn::Expr, JInvokePlan)> {
     // Human-readable tag for attach/log messages.
     let name = format!(
         "Fn({})",
@@ -49,14 +187,6 @@ pub(crate) fn callback_input(
     let arg_names: Vec<syn::Ident> = (0..args.len())
         .map(|i| format_ident!("__cb_arg{}", i))
         .collect();
-    let arg_pat_ty: Vec<TokenStream> = args
-        .iter()
-        .map(|t| {
-            let t = emit.spell(t);
-            quote!(#t)
-        })
-        .collect();
-
     // Per-arg encode preludes binding the typed `run`'s args in declared
     // order (a decomposed arg contributes one arg per leaf). Each entry of
     // `jvalue_exprs` is a typed `jvalue`: raw primitives for primitive-wire
@@ -69,8 +199,11 @@ pub(crate) fn callback_input(
     // `&[data_class]` fold arg), spliced before the `Box::new` so the move
     // closure captures them.
     let mut fold_setups: Vec<TokenStream> = Vec::new();
+    let mut part_ranges = Vec::with_capacity(args.len());
 
     for (i, arg_ty) in args.iter().enumerate() {
+        let prelude_start = preludes.len();
+        let argument_start = jvalue_exprs.len();
         let cb_arg = &arg_names[i];
 
         // `&[data_class]` fold arg: instead of building the whole `List` on the
@@ -175,6 +308,12 @@ pub(crate) fn callback_input(
             });
             jvalue_exprs.push(quote!(jni::sys::jvalue { l: #acc.as_raw() }));
             total += 1;
+            part_ranges.push((
+                prelude_start,
+                preludes.len(),
+                argument_start,
+                jvalue_exprs.len(),
+            ));
             continue;
         }
 
@@ -220,6 +359,12 @@ pub(crate) fn callback_input(
             preludes.push(stmts);
             total += arg_exprs.len();
             jvalue_exprs.extend(arg_exprs);
+            part_ranges.push((
+                prelude_start,
+                preludes.len(),
+                argument_start,
+                jvalue_exprs.len(),
+            ));
             continue;
         }
 
@@ -305,6 +450,12 @@ pub(crate) fn callback_input(
                 });
                 jvalue_exprs.push(quote!(jni::sys::jvalue { j: #enc_ident }));
                 total += 1;
+                part_ranges.push((
+                    prelude_start,
+                    preludes.len(),
+                    argument_start,
+                    jvalue_exprs.len(),
+                ));
                 continue;
             }
         }
@@ -328,6 +479,12 @@ pub(crate) fn callback_input(
             });
             jvalue_exprs.push(quote!(jni::sys::jvalue { #letter: #enc_ident }));
             total += 1;
+            part_ranges.push((
+                prelude_start,
+                preludes.len(),
+                argument_start,
+                jvalue_exprs.len(),
+            ));
             continue;
         }
         let cast = cast_wire_to_jobject(&enc_ident, &arg_wire, &fail);
@@ -337,6 +494,12 @@ pub(crate) fn callback_input(
         });
         jvalue_exprs.push(quote!(jni::sys::jvalue { l: #obj_ident.as_raw() }));
         total += 1;
+        part_ranges.push((
+            prelude_start,
+            preludes.len(),
+            argument_start,
+            jvalue_exprs.len(),
+        ));
     }
 
     // Typed `run` descriptor of the generated callback interface — the SAME
@@ -353,85 +516,46 @@ pub(crate) fn callback_input(
     let frame_cap = std::cmp::max(16, 2 * total + 6);
     let frame_cap_lit = syn::LitInt::new(&frame_cap.to_string(), Span::call_site());
 
-    let body: syn::Expr = syn::parse_quote!({
-        use std::sync::Arc;
-        let java_vm = Arc::new(env.get_java_vm()
-            .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(format!("Unable to retrieve JVM: {}", e)))?);
-        let callback_global_ref = env.new_global_ref(&v)
-            .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(format!("Unable to global-ref callback: {}", e)))?;
-        // Resolve the typed callback interface's `run` method ID ONCE, here
-        // at trampoline creation. The safe `JNIEnv::call_method` re-parses
-        // the descriptor string (a `combine`-parser run) and re-resolves the
-        // method through the JVM symbol table on EVERY call — measured at
-        // ~33% of per-message delivery time on the subscriber hot path. The
-        // `JMethodID` is `Copy + Send + Sync` and stays valid for the
-        // closure's lifetime: the global ref pins the callback instance and
-        // therefore its class.
-        let __invoke_class = env.get_object_class(&v)
-            .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(format!("Unable to get callback class for {}: {}", #name_lit, e)))?;
-        let __invoke_id = env.get_method_id(&__invoke_class, "run", #descr_lit)
-            .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(format!("Unable to resolve run for {}: {}", #name_lit, e)))?;
-        // One-time fold setup (folder singleton global ref + `run` method id),
-        // captured by the move closure below.
-        #(#fold_setups)*
-        Box::new(move |#(#arg_names: #arg_pat_ty),*| {
-            let _ = (|| -> ::core::result::Result<(), __JniErr> {
-                let mut env = java_vm
-                    .attach_current_thread_as_daemon()
-                    .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(format!("Attach thread for {}: {}", #name_lit, e)))?;
-                // The callback fires on a daemon-attached zenoh RX thread that
-                // never returns through a JNI stack frame, so the JNI local
-                // refs each invocation creates (encoded leaves, wrapped handle
-                // objects, call temporaries) would otherwise accumulate for
-                // the thread's lifetime and exhaust the JVM heap
-                // (OutOfMemoryError). Bracket each invocation in an explicit
-                // local frame so every local is released when the frame pops —
-                // popped unconditionally below so an early `?`/error path
-                // still frees it.
-                env.push_local_frame(#frame_cap_lit)
-                    .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(format!("push local frame for {}: {}", #name_lit, e)))?;
-                let __frame_res = (|| -> ::core::result::Result<(), __JniErr> {
-                    #(#preludes)*
-                    // SAFETY: `__invoke_id` was resolved on this exact
-                    // callback object's class with this exact descriptor, and
-                    // the global ref keeps the class loaded. Exception-check
-                    // semantics are identical to the safe `call_method` (both
-                    // route through the same checked JNI invoke). `run`
-                    // returns void; primitives ride the jvalues raw.
-                    let __call_res: ::core::result::Result<(), __JniErr> = unsafe {
-                        env.call_method_unchecked(
-                            &callback_global_ref,
-                            __invoke_id,
-                            jni::signature::ReturnType::Primitive(jni::signature::Primitive::Void),
-                            &[#(#jvalue_exprs),*],
-                        )
-                    }
-                    .map(|_| ())
-                    .map_err(|e| {
-                        // `exception_describe` also clears the pending exception.
-                        let _ = env.exception_describe();
-                        <__JniErr as ::core::convert::From<String>>::from(e.to_string())
-                    });
-                    // A plan-less opaque-handle arg's per-invocation `Box` is
-                    // freed Kotlin-side by the `asRaw` proxy's `finally { close() }`
-                    // (close-unless-taken), so there is no Rust-side close here.
-                    __call_res?;
-                    Ok(())
-                })();
-                // Pop the frame unconditionally so locals are freed even when
-                // the body above returned `Err` early.
-                let _ = unsafe { env.pop_local_frame(&jni::objects::JObject::null()) };
-                __frame_res?;
-                Ok(())
-            })()
-            .map_err(|e| tracing::error!("{} callback error: {e}", #name_lit));
+    let parts = part_ranges
+        .into_iter()
+        .map(|(ps, pe, as_, ae)| JInvokePart {
+            prepare: {
+                let values = &preludes[ps..pe];
+                quote!(#(#values)*)
+            },
+            arguments: jvalue_exprs[as_..ae].to_vec(),
         })
-    });
+        .collect();
+    let chain = prebindgen_registry::chain::Invoke {
+        source: source.clone(),
+        arguments: args.to_vec(),
+        source_policy: crate::jni::chain::JSource {
+            wrappers: Vec::new(),
+            module: None,
+        },
+        bridge: JInvokeBridge {
+            name: name_lit,
+            descriptor: descr_lit,
+            frame_capacity: frame_cap_lit,
+            fold_setups,
+        },
+        parts,
+    };
+    let rendered = chain.render(emit);
+    let rust_plan = JInvokePlan {
+        name: input_name(&rendered.source.to_token_stream(), &rendered.intermediate),
+        chain,
+    };
 
     // The wire type for an `impl Fn(args)` parameter is JObject (the erased
     // Kotlin lambda). The converter returns Box<dyn Fn(args) + Send + Sync>,
     // which coerces to the source's impl-trait param type.
-    Some((syn::parse_quote!(jni::objects::JObject), body))
+    Some((
+        rendered.source,
+        rendered.intermediate,
+        rendered.body,
+        rust_plan,
+    ))
 }
 
 /// Hard-error guard for `Vec<opaque-handle>` element types. A handle's wire is
@@ -454,17 +578,4 @@ pub(crate) fn reject_vec_of_handle(
             );
         }
     }
-}
-
-/// Reconstruct the `impl Fn(args...) + Send + Sync + 'static` syn::Type
-/// from a flat slice of arg types. Used by the rank-1/2/3 callback impls
-/// to feed `input_wrapper` the original outer type.
-pub(crate) fn build_fn_type(
-    args: &[prebindgen_registry::flat::TypeRef],
-    emit: &prebindgen_registry::Emit,
-) -> syn::Type {
-    // The args as the source spelled them — the callback's Rust type is
-    // re-emitted, never re-derived.
-    let arg_iter = args.iter().map(|a| emit.spell(a));
-    syn::parse_quote!(impl Fn( #(#arg_iter),* ) + Send + Sync + 'static)
 }

--- a/prebindgen-jni/src/jni/mod.rs
+++ b/prebindgen-jni/src/jni/mod.rs
@@ -722,6 +722,29 @@ impl JniGen {
             .wires
             .clone()
     }
+
+    /// The whole-value callback compatibility row, when one was required.
+    ///
+    /// Recipe-built callbacks occupy their ordinary crossing row. Only the
+    /// adapter-refusal fallback records this deliberately named row, so asking
+    /// for it pins the compatibility seam rather than callback generation in
+    /// general. The boolean distinguishes the retained late plan from a
+    /// complete function rendered during resolution.
+    #[cfg(test)]
+    pub(crate) fn compatibility_callback_for_test(&self, spelling: &str) -> Option<(String, bool)> {
+        use prebindgen_registry::recipe::{Crossing, Direction, RecipeName};
+
+        let ty: syn::Type = syn::parse_str(spelling).ok()?;
+        let reading = prebindgen_registry::Conversions::reading_of(&self.registry, &ty)?;
+        let key = reading.key();
+        let row = Crossing::new(reading, Direction::Construct).row(RecipeName::new("callback"));
+        let compiled = self.decls.compiled.borrow();
+        let fragment = compiled.recipe_fragment(&key, &row)?;
+        Some((
+            fragment.conv.converter_ident().to_string(),
+            fragment.rust.is_invoke(),
+        ))
+    }
 }
 
 // Opaque — exists so `Result<JniGen, _>::expect_err` works in tests.

--- a/prebindgen-jni/src/jni/mod.rs
+++ b/prebindgen-jni/src/jni/mod.rs
@@ -732,12 +732,12 @@ impl JniGen {
     /// complete function rendered during resolution.
     #[cfg(test)]
     pub(crate) fn compatibility_callback_for_test(&self, spelling: &str) -> Option<(String, bool)> {
-        use prebindgen_registry::recipe::{Crossing, Direction, RecipeName};
+        use prebindgen_registry::recipe::{Crossing, Direction};
 
         let ty: syn::Type = syn::parse_str(spelling).ok()?;
         let reading = prebindgen_registry::Conversions::reading_of(&self.registry, &ty)?;
         let key = reading.key();
-        let row = Crossing::new(reading, Direction::Construct).row(RecipeName::new("callback"));
+        let row = Crossing::new(reading, Direction::Construct).row(crate::jni::recipes::callback());
         let compiled = self.decls.compiled.borrow();
         let fragment = compiled.recipe_fragment(&key, &row)?;
         Some((

--- a/prebindgen-jni/src/jni/recipes.rs
+++ b/prebindgen-jni/src/jni/recipes.rs
@@ -254,6 +254,11 @@ pub(crate) fn parts() -> RecipeName {
     RecipeName::new("parts")
 }
 
+/// The compatibility row for a callback whose arguments cannot be composed.
+pub(crate) fn callback() -> RecipeName {
+    RecipeName::new("callback")
+}
+
 impl Declarations {
     /// Every recipe this binding's declarations state.
     ///

--- a/prebindgen-jni/src/jni/tests/callbacks.rs
+++ b/prebindgen-jni/src/jni/tests/callbacks.rs
@@ -239,6 +239,67 @@ fn declared_optional_conversion_callback_falls_back_to_whole_value() {
     assert!(!kc.contains("payloadPresent:Boolean"), "{kotlin}");
 }
 
+/// `Ledger` has an output expansion but is deliberately not a declared Kotlin
+/// class. Its fields reach a consuming `Report` value form through two
+/// conditional (`Option`) accessors. The recipe compiler cannot turn that
+/// irregular callback argument into a reusable parts converter, so callback
+/// delivery takes the whole-value compatibility seam. That seam must keep the
+/// `Invoke` plan late and pair it with the conversion the resolver returns.
+#[test]
+fn undeclared_expanded_callback_retains_its_late_compatibility_plan() {
+    let loc = myflat_loc();
+    let items: Vec<(syn::Item, SourceLocation)> = [
+        "pub struct ReportStruct { pub label: String }",
+        "pub fn report_into_struct(r: Report) -> ReportStruct { unimplemented!() }",
+        "pub fn ledger_filed(l: &Ledger) -> Option<&Report> { unimplemented!() }",
+        "pub fn ledger_archived(l: &Ledger) -> Option<Report> { unimplemented!() }",
+        "pub fn ledger_each(sink: impl Fn(Ledger) + Send + Sync + 'static) { unimplemented!() }",
+    ]
+    .into_iter()
+    .map(|source| (syn::parse_str(source).unwrap(), loc.clone()))
+    .collect();
+    let registry =
+        crate::test_util::reg_from_items(declare_referenced(items)).expect("index items");
+    let jni = JniGenBuilder::new()
+        .set_package_prefix("io.test.jni")
+        .package(
+            crate::package!()
+                .class(crate::ptr_class!(Report))
+                .fun(prebindgen_registry::fun!(ledger_each)),
+        )
+        .expand(
+            prebindgen_registry::expand_return!(Report)
+                .fields_self_into(prebindgen_registry::fields!(report_into_struct)),
+        )
+        .expand(
+            prebindgen_registry::expand_return!(Ledger)
+                .field(prebindgen_registry::fun!(ledger_filed))
+                .field(prebindgen_registry::fun!(ledger_archived)),
+        );
+
+    let dir = unique_test_dir("jnigen_ledger_callback_compatibility");
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    let generation = jni.build_with(registry).expect("resolve");
+    let callback = "impl Fn(Ledger) + Send + Sync + 'static";
+    let (converter, is_late_invoke) = generation
+        .compatibility_callback_for_test(callback)
+        .expect("Ledger callback uses the whole-value compatibility row");
+    assert!(
+        is_late_invoke,
+        "the compatibility row must retain an unrendered Invoke plan"
+    );
+
+    let rust = std::fs::read_to_string(generation.write_rust(dir.join("gen.rs")).unwrap()).unwrap();
+    assert_eq!(
+        rust.matches(&format!("fn {converter}")).count(),
+        1,
+        "the retained callback plan is rendered exactly once:\n{rust}"
+    );
+    assert!(rust.contains("ledger_filed(&__cb_arg0)"), "{rust}");
+    assert!(rust.contains("ledger_archived(&__cb_arg0)"), "{rust}");
+}
+
 /// Regression: a callback-delivered type that has BOTH a nested handle identity
 /// (a child `ptr_class` reached by an accessor) AND its own root identity
 /// (`expand_return!` `.field_self()`) must emit the root MOVE after every borrow of

--- a/prebindgen-jni/src/jni/tests/callbacks.rs
+++ b/prebindgen-jni/src/jni/tests/callbacks.rs
@@ -294,7 +294,7 @@ fn undeclared_expanded_callback_retains_its_late_compatibility_plan() {
     assert_eq!(
         rust.matches(&format!("fn {converter}")).count(),
         1,
-        "the retained callback plan is rendered exactly once:\n{rust}"
+        "the retained callback plan must be emitted:\n{rust}"
     );
     assert!(rust.contains("ledger_filed(&__cb_arg0)"), "{rust}");
     assert!(rust.contains("ledger_archived(&__cb_arg0)"), "{rust}");

--- a/prebindgen-jni/src/jni/trait_impl.rs
+++ b/prebindgen-jni/src/jni/trait_impl.rs
@@ -1449,22 +1449,23 @@ impl JniGenBuilder {
         // built out of the conversions for its inners, which are compiled
         // first. That is the same order the converter table was filled in, so
         // a fragment is there exactly when a table entry would have been.
-        // Callback layouts that recipes cannot express (currently sums and other
-        // irregular arms) fall back to the legacy whole-callback emitter.
-        // Registry-composable scalar and sequence products skip this list.
+        // Callback layouts whose arguments have no composable deconstructor
+        // still use the shared Invoke composer, but enter it without child
+        // fragments and retain the resulting complete function here.
         let mut uncompiled: Vec<syn::ItemFn> = Vec::new();
         // Compositions that refused. See `compile_crossing`: these are adapter
         // invariants, reported together once the walk is done.
         let mut refusals: Vec<String> = Vec::new();
         let registry = declared
-            .convert_with(|crossing, built, _emit| {
+            .convert_with(|crossing, built, emit| {
                 let mut compiler = prebindgen_registry::recipe::Compiler::resume(
                     &model,
                     decls.recipe_table(),
                     decls.site_bindings(),
                     decls.compiled.borrow().clone(),
                 );
-                let conv = decls.compile_crossing(&mut compiler, crossing, built, &mut refusals);
+                let conv =
+                    decls.compile_crossing(&mut compiler, crossing, built, emit, &mut refusals);
                 *decls.compiled.borrow_mut() = compiler.finish();
                 let (dir, key) = crossing;
                 let compiled_by_recipe = decls.compiled.borrow().fragment(key, *dir).is_some();
@@ -1474,9 +1475,9 @@ impl JniGenBuilder {
                     compiled_by_recipe,
                 ) {
                     uncompiled.push(c.function.clone());
-                    // Index a legacy fallback with the same lookup used for
-                    // recipe-built callbacks, while keeping its complete
-                    // function in `uncompiled`.
+                    // Index the whole-value compatibility plan with the same
+                    // lookup used for recipe-built callbacks, while keeping
+                    // its complete function in `uncompiled`.
                     decls.compiled.borrow_mut().record(
                         prebindgen_registry::recipe::CrossingKey {
                             ty: key.clone(),
@@ -1640,6 +1641,7 @@ impl Declarations {
         >,
         crossing: &Crossing,
         built: &'v R,
+        emit: &prebindgen_registry::Emit,
         refusals: &mut Vec<String>,
     ) -> Option<ConverterImpl<KotlinMeta>> {
         let (dir, key) = crossing;
@@ -1654,7 +1656,22 @@ impl Declarations {
             site: None,
         };
         let crossing = prebindgen_registry::recipe::Crossing::new(reading, direction);
-        let fragment = compiler.crossing(&mut adapter, &crossing).ok()?;
+        let fragment = match compiler.crossing(&mut adapter, &crossing) {
+            Ok(fragment) => fragment,
+            Err(prebindgen_registry::recipe::CompileError::Adapter(
+                crate::jni::compile::JErr::Refused(_),
+            )) => {
+                let prebindgen_registry::flat::TypeKind::Callback { args } =
+                    crossing.spelled().unwrapped().kind()
+                else {
+                    return None;
+                };
+                return self
+                    .dispatch_fn_input(crossing.spelled(), args, built, None, emit)
+                    .map(|(conv, _)| conv);
+            }
+            Err(_) => return None,
+        };
         // A `data_class` also states a recipe that says what it is made of.
         // Compiling that named recipe equips whole-value input, output and
         // callback paths with the same registry-owned Product descriptor.

--- a/prebindgen-jni/src/jni/trait_impl.rs
+++ b/prebindgen-jni/src/jni/trait_impl.rs
@@ -1457,15 +1457,14 @@ impl JniGenBuilder {
         // invariants, reported together once the walk is done.
         let mut refusals: Vec<String> = Vec::new();
         let registry = declared
-            .convert_with(|crossing, built, emit| {
+            .convert_with(|crossing, built, _emit| {
                 let mut compiler = prebindgen_registry::recipe::Compiler::resume(
                     &model,
                     decls.recipe_table(),
                     decls.site_bindings(),
                     decls.compiled.borrow().clone(),
                 );
-                let conv =
-                    decls.compile_crossing(&mut compiler, crossing, built, emit, &mut refusals);
+                let conv = decls.compile_crossing(&mut compiler, crossing, built, &mut refusals);
                 *decls.compiled.borrow_mut() = compiler.finish();
                 let (dir, key) = crossing;
                 let compiled_by_recipe = decls.compiled.borrow().fragment(key, *dir).is_some();
@@ -1641,7 +1640,6 @@ impl Declarations {
         >,
         crossing: &Crossing,
         built: &'v R,
-        emit: &prebindgen_registry::Emit,
         refusals: &mut Vec<String>,
     ) -> Option<ConverterImpl<KotlinMeta>> {
         let (dir, key) = crossing;
@@ -1656,17 +1654,7 @@ impl Declarations {
             site: None,
         };
         let crossing = prebindgen_registry::recipe::Crossing::new(reading, direction);
-        let fragment = match compiler.crossing(&mut adapter, &crossing) {
-            Ok(fragment) => fragment,
-            Err(_) => {
-                let prebindgen_registry::flat::TypeKind::Callback { args } =
-                    crossing.spelled().unwrapped().kind()
-                else {
-                    return None;
-                };
-                return self.dispatch_fn_input(args, built, None, emit);
-            }
-        };
+        let fragment = compiler.crossing(&mut adapter, &crossing).ok()?;
         // A `data_class` also states a recipe that says what it is made of.
         // Compiling that named recipe equips whole-value input, output and
         // callback paths with the same registry-owned Product descriptor.
@@ -1948,26 +1936,28 @@ fn flat_unit_enum<'r>(
 impl Declarations {
     pub(crate) fn dispatch_fn_input(
         &self,
+        source: &prebindgen_registry::flat::TypeRef,
         args: &[prebindgen_registry::flat::TypeRef],
         registry: &impl Conversions,
         arg_fragments: Option<&[&crate::jni::compile::JFrag]>,
         emit: &prebindgen_registry::Emit,
-    ) -> Option<ConverterImpl<KotlinMeta>> {
-        let outer_ty = build_fn_type(args, emit);
-        let (wire, body) = callback_input(self, args, registry, arg_fragments, emit)?;
+    ) -> Option<(ConverterImpl<KotlinMeta>, crate::jni::chain::JFunction)> {
+        let (outer_ty, wire, body, plan) =
+            callback_input(self, source, args, registry, arg_fragments, emit)?;
         let niches = default_niches_for_wire(&wire);
         // `impl Fn(...)` crosses the extern tier as the erased lambda object
         // (`Any`) — same as the unfold builder / error-sink params. The typed
         // wrapper-level lambda signature is computed at render time from the
         // arg types' callback plans, not carried in metadata.
-        Some(ConverterImpl {
+        let conv = ConverterImpl {
             subs: vec![],
             pre_stages: vec![],
             function: self.build_input_fn_composed(&outer_ty, &wire, &body, None),
             destination: wire,
             niches,
             metadata: self.framework_meta(Some(KtType::any())),
-        })
+        };
+        Some((conv, crate::jni::chain::JFunction::invoke(plan)))
     }
 }
 

--- a/prebindgen-jni/src/jni/trait_impl.rs
+++ b/prebindgen-jni/src/jni/trait_impl.rs
@@ -1451,8 +1451,8 @@ impl JniGenBuilder {
         // a fragment is there exactly when a table entry would have been.
         // Callback layouts whose arguments have no composable deconstructor
         // still use the shared Invoke composer, but enter it without child
-        // fragments and retain the resulting complete function here.
-        let mut uncompiled: Vec<syn::ItemFn> = Vec::new();
+        // fragments. Their late plan is recorded beside the compatibility
+        // fragment below, so neither path renders during resolution.
         // Compositions that refused. See `compile_crossing`: these are adapter
         // invariants, reported together once the walk is done.
         let mut refusals: Vec<String> = Vec::new();
@@ -1464,33 +1464,35 @@ impl JniGenBuilder {
                     decls.site_bindings(),
                     decls.compiled.borrow().clone(),
                 );
-                let conv =
+                let compiled =
                     decls.compile_crossing(&mut compiler, crossing, built, emit, &mut refusals);
                 *decls.compiled.borrow_mut() = compiler.finish();
+                let (conv, compatibility) = compiled?;
                 let (dir, key) = crossing;
                 let compiled_by_recipe = decls.compiled.borrow().fragment(key, *dir).is_some();
-                if let (Some(c), true, false) = (
-                    conv.as_ref(),
-                    decls.is_callback_crossing(crossing, built),
-                    compiled_by_recipe,
-                ) {
-                    uncompiled.push(c.function.clone());
+                if decls.is_callback_crossing(crossing, built) && !compiled_by_recipe {
+                    let rust = compatibility.expect(
+                        "a callback outside the recipe compiler retains its late Invoke plan",
+                    );
                     // Index the whole-value compatibility plan with the same
-                    // lookup used for recipe-built callbacks, while keeping
-                    // its complete function in `uncompiled`.
+                    // lookup and late renderer used for recipe-built callbacks.
                     decls.compiled.borrow_mut().record(
                         prebindgen_registry::recipe::CrossingKey {
                             ty: key.clone(),
                             direction: *dir,
                         }
                         .row(prebindgen_registry::recipe::RecipeName::new("callback")),
-                        crate::jni::compile::JFrag::by_hand(key.clone(), c.clone()),
+                        crate::jni::compile::JFrag::by_hand_with_rust(
+                            key.clone(),
+                            conv.clone(),
+                            rust,
+                        ),
                     );
                 }
                 // The conversion stays here; what the registry gets back is
                 // which other crossings this one delegates to, which is what
                 // its reachability walk needs.
-                conv.map(|c| prebindgen_registry::Answer::over(c.subs))
+                Some(prebindgen_registry::Answer::over(conv.subs))
             })?
             .build()?;
         if !refusals.is_empty() {
@@ -1604,11 +1606,6 @@ impl JniGenBuilder {
                         .map(|s| crate::jni::chain::JFunction::complete(s.function.clone())),
                 )
             })
-            .chain(
-                uncompiled
-                    .into_iter()
-                    .map(crate::jni::chain::JFunction::complete),
-            )
             .collect();
         Ok(JniGen { decls, registry })
     }
@@ -1643,7 +1640,10 @@ impl Declarations {
         built: &'v R,
         emit: &prebindgen_registry::Emit,
         refusals: &mut Vec<String>,
-    ) -> Option<ConverterImpl<KotlinMeta>> {
+    ) -> Option<(
+        ConverterImpl<KotlinMeta>,
+        Option<crate::jni::chain::JFunction>,
+    )> {
         let (dir, key) = crossing;
         // The reading the scan already took for this crossing, fetched by the
         // key the crossing IS.
@@ -1668,7 +1668,7 @@ impl Declarations {
                 };
                 return self
                     .dispatch_fn_input(crossing.spelled(), args, built, None, emit)
-                    .map(|(conv, _)| conv);
+                    .map(|(conv, rust)| (conv, Some(rust)));
             }
             Err(_) => return None,
         };
@@ -1712,7 +1712,7 @@ impl Declarations {
                 ));
             }
         }
-        Some((*fragment).clone().conv)
+        Some(((*fragment).clone().conv, None))
     }
 
     pub fn declare_into(
@@ -1959,8 +1959,7 @@ impl Declarations {
         arg_fragments: Option<&[&crate::jni::compile::JFrag]>,
         emit: &prebindgen_registry::Emit,
     ) -> Option<(ConverterImpl<KotlinMeta>, crate::jni::chain::JFunction)> {
-        let (outer_ty, wire, body, plan) =
-            callback_input(self, source, args, registry, arg_fragments, emit)?;
+        let (wire, plan) = callback_input(self, source, args, registry, arg_fragments, emit)?;
         let niches = default_niches_for_wire(&wire);
         // `impl Fn(...)` crosses the extern tier as the erased lambda object
         // (`Any`) — same as the unfold builder / error-sink params. The typed
@@ -1969,7 +1968,7 @@ impl Declarations {
         let conv = ConverterImpl {
             subs: vec![],
             pre_stages: vec![],
-            function: self.build_input_fn_composed(&outer_ty, &wire, &body, None),
+            function: crate::jni::chain::planned_marker(plan.name()),
             destination: wire,
             niches,
             metadata: self.framework_meta(Some(KtType::any())),

--- a/prebindgen-jni/src/jni/trait_impl.rs
+++ b/prebindgen-jni/src/jni/trait_impl.rs
@@ -1481,7 +1481,7 @@ impl JniGenBuilder {
                             ty: key.clone(),
                             direction: *dir,
                         }
-                        .row(prebindgen_registry::recipe::RecipeName::new("callback")),
+                        .row(crate::jni::recipes::callback()),
                         crate::jni::compile::JFrag::by_hand_with_rust(
                             key.clone(),
                             conv.clone(),

--- a/prebindgen-registry/src/chain.rs
+++ b/prebindgen-registry/src/chain.rs
@@ -442,10 +442,10 @@ pub struct RenderedInvokePart {
 ///
 /// The source [`TypeRef`] is deliberately absent from this hook. The shared
 /// composer spells and binds source arguments only during final rendering and
-/// hands the adapter the resulting local expression.
+/// hands the adapter the resulting local identifier.
 pub trait InvokePart: Clone {
     /// Render target-side delivery for one already-bound source argument.
-    fn render(&self, value: TokenStream, index: usize, emit: &Emit) -> RenderedInvokePart;
+    fn render(&self, value: &syn::Ident, index: usize, emit: &Emit) -> RenderedInvokePart;
 }
 
 /// Adapter-selected callable and invocation protocol for one [`Invoke`] shape.
@@ -454,6 +454,13 @@ pub trait InvokePart: Clone {
 /// runs for every invocation and receives the three ordered phases assembled
 /// by the registry. This keeps target-specific guards, local frames and error
 /// routes in the adapter without giving it ownership of the source-value walk.
+///
+/// Tokens returned by `capture`, `invoke`, and `surround` share one generated
+/// lexical scope. An adapter that coordinates those hooks through local names
+/// therefore owns those names as a reserved-identifier contract. Likewise, an
+/// adapter that prepares an [`InvokePart`] against [`Self::argument_name`] must
+/// derive both uses from one helper; the composer supplies that same identifier
+/// to [`InvokePart::render`] so the contract can be checked at final emission.
 pub trait InvokeBridge: Clone {
     /// The one intermediate callable type accepted by the converter.
     fn intermediate(&self) -> syn::Type;
@@ -863,7 +870,7 @@ where
             .iter()
             .zip(&names)
             .enumerate()
-            .map(|(index, (part, name))| part.render(quote::quote!(#name), index, emit))
+            .map(|(index, (part, name))| part.render(name, index, emit))
             .collect();
         let prepare = rendered.iter().map(|part| &part.prepare);
         let call_arguments: Vec<_> = rendered
@@ -1147,7 +1154,7 @@ mod tests {
     struct TestInvokePart(&'static str);
 
     impl InvokePart for TestInvokePart {
-        fn render(&self, value: TokenStream, _index: usize, _emit: &Emit) -> RenderedInvokePart {
+        fn render(&self, value: &syn::Ident, _index: usize, _emit: &Emit) -> RenderedInvokePart {
             let prepare = syn::Ident::new(
                 &format!("prepare_{}", self.0),
                 proc_macro2::Span::call_site(),

--- a/prebindgen-registry/src/chain.rs
+++ b/prebindgen-registry/src/chain.rs
@@ -423,6 +423,89 @@ pub struct Choice<S, B, P, C> {
     pub arms: Vec<ChoiceArm<P, C>>,
 }
 
+/// One callback argument after its adapter-owned delivery has been rendered.
+///
+/// A source callback argument may occupy any number of target-language call
+/// arguments. The registry owns their ordering and the lifetime of the
+/// preparation/cleanup around the foreign invocation; the adapter owns only
+/// how its intermediate values are represented.
+pub struct RenderedInvokePart {
+    /// Statements that turn one source callback argument into intermediates.
+    pub prepare: TokenStream,
+    /// Target-language call arguments contributed by this source argument.
+    pub arguments: Vec<TokenStream>,
+    /// Statements run after the target-language invocation.
+    pub cleanup: TokenStream,
+}
+
+/// Adapter plan for delivering one argument of an [`Invoke`] shape.
+///
+/// The source [`TypeRef`] is deliberately absent from this hook. The shared
+/// composer spells and binds source arguments only during final rendering and
+/// hands the adapter the resulting local expression.
+pub trait InvokePart: Clone {
+    /// Render target-side delivery for one already-bound source argument.
+    fn render(&self, value: TokenStream, index: usize, emit: &Emit) -> RenderedInvokePart;
+}
+
+/// Adapter-selected callable and invocation protocol for one [`Invoke`] shape.
+///
+/// `capture` runs once while the source callback is constructed. `surround`
+/// runs for every invocation and receives the three ordered phases assembled
+/// by the registry. This keeps target-specific guards, local frames and error
+/// routes in the adapter without giving it ownership of the source-value walk.
+pub trait InvokeBridge: Clone {
+    /// The one intermediate callable type accepted by the converter.
+    fn intermediate(&self) -> syn::Type;
+
+    /// Stable local name for the inbound target callable.
+    fn value_name(&self) -> syn::Ident {
+        syn::Ident::new("v", proc_macro2::Span::call_site())
+    }
+
+    /// Stable local name for one source callback argument.
+    fn argument_name(&self, index: usize) -> syn::Ident {
+        syn::Ident::new(
+            &format!("__invoke_arg{index}"),
+            proc_macro2::Span::call_site(),
+        )
+    }
+
+    /// Capture the target callable and produce the source callback value.
+    fn capture(&self, value: TokenStream, closure: TokenStream) -> TokenStream;
+
+    /// Invoke the captured target callable with the flattened arguments.
+    fn invoke(&self, arguments: &[TokenStream]) -> TokenStream;
+
+    /// Bracket one invocation with adapter-specific control flow.
+    fn surround(
+        &self,
+        prepare: TokenStream,
+        invoke: TokenStream,
+        cleanup: TokenStream,
+    ) -> TokenStream {
+        quote::quote!({ #prepare #invoke #cleanup })
+    }
+
+    /// Whether constructing the source callback can fail.
+    fn fallible(&self) -> bool;
+}
+
+/// Registry-composed converter plan for an Invoke recipe.
+#[derive(Clone)]
+pub struct Invoke<S, B, P> {
+    /// Exact callback spelling, opaque until rendering.
+    pub source: TypeRef,
+    /// Exact callback argument spellings, opaque until rendering.
+    pub arguments: Vec<TypeRef>,
+    /// Source spelling and transparent-wrapper policy.
+    pub source_policy: S,
+    /// Adapter callable/call-site protocol.
+    pub bridge: B,
+    /// Ordered adapter delivery plans, one per callback argument.
+    pub parts: Vec<P>,
+}
+
 /// A rendered chain body and the types needed to put a function around it.
 pub struct Rendered {
     /// Exact source type, spelled only at final emission.
@@ -752,6 +835,59 @@ where
     }
 }
 
+impl<S, B, P> Chain for Invoke<S, B, P>
+where
+    S: Source,
+    B: InvokeBridge,
+    P: InvokePart,
+{
+    fn render(&self, emit: &Emit) -> Rendered {
+        assert_eq!(
+            self.arguments.len(),
+            self.parts.len(),
+            "an Invoke plan has one delivery plan per callback argument"
+        );
+        let source = self.source_policy.spell(&self.source, emit);
+        let intermediate = self.bridge.intermediate();
+        let value_name = self.bridge.value_name();
+        let names: Vec<_> = (0..self.arguments.len())
+            .map(|index| self.bridge.argument_name(index))
+            .collect();
+        let types: Vec<_> = self
+            .arguments
+            .iter()
+            .map(|argument| self.source_policy.spell(argument, emit))
+            .collect();
+        let rendered: Vec<_> = self
+            .parts
+            .iter()
+            .zip(&names)
+            .enumerate()
+            .map(|(index, (part, name))| part.render(quote::quote!(#name), index, emit))
+            .collect();
+        let prepare = rendered.iter().map(|part| &part.prepare);
+        let call_arguments: Vec<_> = rendered
+            .iter()
+            .flat_map(|part| part.arguments.iter().cloned())
+            .collect();
+        let cleanup = rendered.iter().map(|part| &part.cleanup);
+        let invocation = self.bridge.invoke(&call_arguments);
+        let surrounded = self.bridge.surround(
+            quote::quote!(#(#prepare)*),
+            invocation,
+            quote::quote!(#(#cleanup)*),
+        );
+        let closure = quote::quote!(move |#(#names: #types),*| #surrounded);
+        let body = self.bridge.capture(quote::quote!(#value_name), closure);
+        Rendered {
+            source,
+            intermediate,
+            body: syn::parse2(body).expect("an Invoke callback constructor is a valid expression"),
+            fallible: self.bridge.fallible(),
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::{cell::Cell, rc::Rc};
@@ -1005,5 +1141,81 @@ mod tests {
             }
             assert!(rendered.fallible);
         }
+    }
+
+    #[derive(Clone)]
+    struct TestInvokePart(&'static str);
+
+    impl InvokePart for TestInvokePart {
+        fn render(&self, value: TokenStream, _index: usize, _emit: &Emit) -> RenderedInvokePart {
+            let prepare = syn::Ident::new(
+                &format!("prepare_{}", self.0),
+                proc_macro2::Span::call_site(),
+            );
+            let cleanup = syn::Ident::new(
+                &format!("cleanup_{}", self.0),
+                proc_macro2::Span::call_site(),
+            );
+            RenderedInvokePart {
+                prepare: quote!(let #prepare = deliver(#value);),
+                arguments: vec![quote!(#prepare)],
+                cleanup: quote!(#cleanup();),
+            }
+        }
+    }
+
+    #[derive(Clone)]
+    struct TestInvoke;
+
+    impl InvokeBridge for TestInvoke {
+        fn intermediate(&self) -> syn::Type {
+            syn::parse_quote!(Callable)
+        }
+
+        fn capture(&self, value: TokenStream, closure: TokenStream) -> TokenStream {
+            quote!(capture(#value, #closure))
+        }
+
+        fn invoke(&self, arguments: &[TokenStream]) -> TokenStream {
+            quote!(call(#(#arguments),*);)
+        }
+
+        fn fallible(&self) -> bool {
+            false
+        }
+    }
+
+    #[test]
+    fn invoke_spells_only_at_render_and_owns_delivery_order() {
+        let spells = Rc::new(Cell::new(0));
+        let plan = Invoke {
+            source: TypeRef::scalar(ScalarKind::I64),
+            arguments: vec![
+                TypeRef::scalar(ScalarKind::I32),
+                TypeRef::scalar(ScalarKind::U64),
+            ],
+            source_policy: TestSource {
+                spells: spells.clone(),
+            },
+            bridge: TestInvoke,
+            parts: vec![TestInvokePart("a"), TestInvokePart("b")],
+        };
+
+        assert_eq!(spells.get(), 0, "planning must not spell callback types");
+        let rendered = plan.render(&Emit::for_test());
+        assert_eq!(spells.get(), 3);
+        let body = rendered.body.to_token_stream().to_string();
+        let prepare_a = body.find("prepare_a").unwrap();
+        let prepare_b = body.find("prepare_b").unwrap();
+        let call = body.find("call (prepare_a , prepare_b)").unwrap();
+        let cleanup_a = body.find("cleanup_a").unwrap();
+        let cleanup_b = body.find("cleanup_b").unwrap();
+        assert!(prepare_a < prepare_b && prepare_b < call);
+        assert!(call < cleanup_a && cleanup_a < cleanup_b);
+        assert_eq!(
+            rendered.intermediate.to_token_stream().to_string(),
+            "Callable"
+        );
+        assert!(!rendered.fallible);
     }
 }


### PR DESCRIPTION
## Summary

- add a registry-owned `Invoke` composer that keeps callback `TypeRef`s opaque until rendering and owns source-argument binding, ordered preparation, flattened target arguments, invocation, and cleanup
- move C callbacks to a late `CFunction` plan; C now supplies only its closure-struct capture, NULL-call guard, wire delivery, and takeable-value cleanup, and no longer reconstructs callback Rust types during resolution
- move JNI callbacks to a late `JFunction` plan; JNI supplies JVM/global-reference capture, cached typed `run` lookup, daemon attachment, local-frame cleanup, argument delivery, and exception logging through the same shared lifecycle
- route every C and JNI callback renderer through the shared `Invoke` composer; recipe-composable callbacks remain late plans, while JNI callbacks whose arguments intentionally have no deconstructing recipe enter the same composer without child fragments and retain its late plan on a compatibility fragment

The compatibility seam is currently exercised by whole-value `Ledger` callback delivery. It does not restore the old adapter-owned invocation pipeline: capture, source binding, target invocation, and cleanup still come from `Invoke`. The fallback is limited to an adapter refusal while deconstructing a callback argument, so malformed recipes are not hidden. A dedicated Ledger-shaped unit fixture asserts that this path records the named compatibility row, retains an unrendered `Invoke` plan, and emits its callback converter into the generated file.

Both adapters retain `Invoke` as a genuinely late plan. In particular, JNI resolution stores a stable marker name and the unrendered plan—even for the whole-value compatibility path—and materializes the callback type and body only from `JInvokePlan::render` during final Rust writing. The bridge documents and checks its reserved identifiers, and the C/JNI safety, cleanup, local-frame, and cached-method-ID invariants remain next to the hooks that enforce them.

Generated C review artifacts and JNI Rust/Kotlin snapshots remain unchanged. This PR is stacked on the chain-generation umbrella branch and is related to #513.

## Verification

- `cargo test -p prebindgen-registry -p prebindgen-c -p prebindgen-jni --lib --quiet` — passed (192 registry, 94 C, 279 JNI tests)
- `cargo test --workspace --all-targets` — passed
- `cargo build -p example-cbindgen -p perftest-c` — passed; committed generated artifacts have no diff
- `cargo check -p covertest-kotlin -p emitcheck -p perftest-kotlin` — passed; committed JNI Rust/Kotlin snapshots have no diff
- `cargo clippy --workspace --all-targets --all-features -- --deny warnings` — passed
- `RUSTDOCFLAGS='-D warnings' cargo doc --no-deps` — passed
- `bash examples/regen-check.sh` — passed; in-repo generated output is byte-identical
- `cd examples/covertest-kotlin && ./gradlew run` — passed all 57 runtime sections
- `cargo fmt --all -- --check` — passed
- `git diff --check` — passed
