### PR TITLE
Refuse a wrapper a composed chain cannot peel, in every planner (#513, review)

### DIFF
--- a/prebindgen-jni/src/jni/compile.rs
+++ b/prebindgen-jni/src/jni/compile.rs
@@ -877,6 +877,24 @@ impl<R: Conversions> JCompile<'_, R> {
     /// field walk, tuple construction/destruction, child calls and `?`
     /// propagation; JNI contributes only child converter contracts and ABI
     /// layout metadata.
+    /// The transparent wrappers over a crossing's value, or `None` when this
+    /// planner cannot compose through one of them.
+    ///
+    /// A composed chain reaches the canonical value by peeling every wrapper
+    /// and puts them back afterwards, so it needs the operation for the
+    /// direction it is going: `Box::new` to build, `*b` to read. A wrapper
+    /// missing that operation — `Cow`, which has no read — is not composable,
+    /// and neither is a wrapper this adapter has no entry for at all.
+    ///
+    /// Deconstructing additionally needs the crossing to **own** what it takes
+    /// apart. Reading through a shared borrow would move the value out of the
+    /// wrapper, which is what `&Box<Reading>` would do.
+    ///
+    /// Refusing here is what keeps the legacy path in control. `JSource::build`
+    /// and `JSource::read` expect the rejection to have happened while
+    /// planning: past this point an unsupported wrapper is a panic during
+    /// `write_rust`, or generated Rust that does not compile in the consumer's
+    /// crate.
     fn planned_product(&self, at: At<'_>, parts: Parts<'_, Self>) -> Option<JFrag> {
         if parts.iter().any(|(_, frag)| frag.composed_only) {
             return None;
@@ -886,19 +904,8 @@ impl<R: Conversions> JCompile<'_, R> {
             .map(|(_, frag)| frag.layout.clone())
             .collect::<Option<Vec<_>>>()?;
         let source = at.crossing.value();
-        let wrappers = source.erased_wrappers();
+        let wrappers = composable_wrappers(at.crossing)?;
         let direction = at.crossing.direction();
-        if wrappers.iter().any(|wrapper| {
-            let Some(ops) = super::trait_impl::wrapper_ops(wrapper) else {
-                return true;
-            };
-            match direction {
-                Direction::Construct => ops.build.is_none(),
-                Direction::Deconstruct => at.crossing.mode() != Mode::Owned || ops.read.is_none(),
-            }
-        }) {
-            return None;
-        }
         let TypeKind::Named { id, .. } = source.unwrapped().kind() else {
             return None;
         };
@@ -1032,6 +1039,10 @@ impl<R: Conversions> JCompile<'_, R> {
             .map(|(alternative, fragment)| Some((*alternative, fragment.choice_arm.clone()?)))
             .collect::<Option<Vec<_>>>()?;
         let source = at.crossing.value();
+        // The same gate `planned_product` applies, and for the same reasons: a
+        // choice chain peels the value's wrappers and puts them back exactly as
+        // a product chain does.
+        let wrappers = composable_wrappers(at.crossing)?;
         let TypeKind::Named { id, .. } = source.unwrapped().kind() else {
             return None;
         };
@@ -1091,7 +1102,7 @@ impl<R: Conversions> JCompile<'_, R> {
                 source: source.clone(),
                 direction,
                 source_policy: crate::jni::chain::JSource {
-                    wrappers: source.erased_wrappers(),
+                    wrappers,
                     module: Some(source_module),
                 },
                 bridge: prebindgen_registry::chain::TupleChoice {
@@ -1159,18 +1170,12 @@ impl<R: Conversions> JCompile<'_, R> {
             | (Direction::Deconstruct, TypeKind::Vec(_) | TypeKind::Slice(_)) => {}
             _ => return None,
         }
-        let wrappers = source.erased_wrappers();
-        if wrappers.iter().any(|wrapper| {
-            let Some(ops) = super::trait_impl::wrapper_ops(wrapper) else {
-                return true;
-            };
-            match direction {
-                Direction::Construct => ops.build.is_none(),
-                Direction::Deconstruct => ops.read.is_none(),
-            }
-        }) {
-            return None;
-        }
+        // The same gate the product and choice planners apply. This one used to
+        // omit the ownership clause, which a deconstructing `&Box<Vec<T>>`
+        // needs: the emitted loop reads the source with `*v` and then consumes
+        // it with `into_iter`, so a shared borrow would move the `Vec` out of
+        // the `Box`.
+        let wrappers = composable_wrappers(at.crossing)?;
 
         let child_wire = inner.conv.destination.clone();
         if !is_jobject_shaped_wire(&child_wire) {
@@ -2761,6 +2766,51 @@ impl Declarations {
 /// one is a shape the compositions decline.
 fn field_step(ident: &syn::Ident) -> prebindgen_registry::unfold::PathStep {
     prebindgen_registry::unfold::PathStep::field(ident.clone(), false)
+}
+
+/// The transparent wrappers over a crossing's value, or `None` when a composed
+/// chain cannot go through one of them.
+///
+/// A chain reaches the canonical value by peeling every wrapper and puts them
+/// back afterwards, so it needs the operation for the direction it is going:
+/// `Box::new` to build, `*b` to read. A wrapper missing that operation — `Cow`,
+/// which has no read — is not composable, and neither is a wrapper this adapter
+/// has no entry for at all.
+///
+/// Deconstructing additionally needs the crossing to **own** what it takes
+/// apart. Reading through a shared borrow would move the value out of the
+/// wrapper, which is what a `&Box<T>` would do.
+///
+/// Refusing here is what keeps the legacy path in control. `JSource::build` and
+/// `JSource::read` expect the rejection to have happened while planning: past
+/// this point an unsupported wrapper is a panic during `write_rust`, or
+/// generated Rust that does not compile in the consumer's crate.
+///
+/// One function because it is one rule. Stated per planner, the choice copy
+/// omitted it and the sequence copy omitted the ownership half.
+fn composable_wrappers(
+    crossing: &prebindgen_registry::recipe::Crossing,
+) -> Option<Vec<&'static str>> {
+    let wrappers = crossing.value().erased_wrappers();
+    let usable = |wrapper: &&'static str| -> bool {
+        let Some(ops) = crate::jni::trait_impl::wrapper_ops(wrapper) else {
+            return false;
+        };
+        match crossing.direction() {
+            Direction::Construct => ops.build.is_some(),
+            Direction::Deconstruct => crossing.mode() == Mode::Owned && ops.read.is_some(),
+        }
+    };
+    wrappers.iter().all(usable).then_some(wrappers)
+}
+
+/// Whether a composed chain can peel and restore this crossing's wrappers.
+///
+/// Test support: the three planners share one gate, and this is it, asked
+/// without building a fragment.
+#[cfg(test)]
+pub(crate) fn composable_for_test(crossing: &prebindgen_registry::recipe::Crossing) -> bool {
+    composable_wrappers(crossing).is_some()
 }
 
 /// The model field one part reads, or `None` for a part that is not a field.

--- a/prebindgen-jni/src/jni/compile.rs
+++ b/prebindgen-jni/src/jni/compile.rs
@@ -877,24 +877,6 @@ impl<R: Conversions> JCompile<'_, R> {
     /// field walk, tuple construction/destruction, child calls and `?`
     /// propagation; JNI contributes only child converter contracts and ABI
     /// layout metadata.
-    /// The transparent wrappers over a crossing's value, or `None` when this
-    /// planner cannot compose through one of them.
-    ///
-    /// A composed chain reaches the canonical value by peeling every wrapper
-    /// and puts them back afterwards, so it needs the operation for the
-    /// direction it is going: `Box::new` to build, `*b` to read. A wrapper
-    /// missing that operation — `Cow`, which has no read — is not composable,
-    /// and neither is a wrapper this adapter has no entry for at all.
-    ///
-    /// Deconstructing additionally needs the crossing to **own** what it takes
-    /// apart. Reading through a shared borrow would move the value out of the
-    /// wrapper, which is what `&Box<Reading>` would do.
-    ///
-    /// Refusing here is what keeps the legacy path in control. `JSource::build`
-    /// and `JSource::read` expect the rejection to have happened while
-    /// planning: past this point an unsupported wrapper is a panic during
-    /// `write_rust`, or generated Rust that does not compile in the consumer's
-    /// crate.
     fn planned_product(&self, at: At<'_>, parts: Parts<'_, Self>) -> Option<JFrag> {
         if parts.iter().any(|(_, frag)| frag.composed_only) {
             return None;
@@ -1296,18 +1278,7 @@ impl<R: Conversions> JCompile<'_, R> {
             return None;
         }
 
-        let wrappers = source.erased_wrappers();
-        if wrappers.iter().any(|wrapper| {
-            let Some(ops) = super::trait_impl::wrapper_ops(wrapper) else {
-                return true;
-            };
-            match direction {
-                Direction::Construct => ops.build.is_none(),
-                Direction::Deconstruct => ops.read.is_none(),
-            }
-        }) {
-            return None;
-        }
+        let wrappers = composable_wrappers(at.crossing)?;
 
         let inner_wire = inner.conv.destination.clone();
         let stages = match direction {
@@ -2787,7 +2758,8 @@ fn field_step(ident: &syn::Ident) -> prebindgen_registry::unfold::PathStep {
 /// generated Rust that does not compile in the consumer's crate.
 ///
 /// One function because it is one rule. Stated per planner, the choice copy
-/// omitted it and the sequence copy omitted the ownership half.
+/// omitted it, while the sequence and Optional copies omitted the ownership
+/// half.
 fn composable_wrappers(
     crossing: &prebindgen_registry::recipe::Crossing,
 ) -> Option<Vec<&'static str>> {
@@ -2802,15 +2774,6 @@ fn composable_wrappers(
         }
     };
     wrappers.iter().all(usable).then_some(wrappers)
-}
-
-/// Whether a composed chain can peel and restore this crossing's wrappers.
-///
-/// Test support: the three planners share one gate, and this is it, asked
-/// without building a fragment.
-#[cfg(test)]
-pub(crate) fn composable_for_test(crossing: &prebindgen_registry::recipe::Crossing) -> bool {
-    composable_wrappers(crossing).is_some()
 }
 
 /// The model field one part reads, or `None` for a part that is not a field.

--- a/prebindgen-jni/src/jni/mod.rs
+++ b/prebindgen-jni/src/jni/mod.rs
@@ -508,6 +508,73 @@ fn leaf_reach(leaf: &prebindgen_registry::unfold::UnfoldLeaf) -> String {
 
 #[cfg(test)]
 impl JniGen {
+    /// Compile one arbitrary crossing's declared `parts` row through the real
+    /// recipe driver, then render the JFunction the selected planner retained.
+    ///
+    /// Test support for planner gates: a public binding may fall back before a
+    /// late plan becomes reachable, but the recipe driver still has to select
+    /// the right fragment for that crossing.
+    pub(crate) fn parts_plan_for_test(
+        &self,
+        ty: syn::Type,
+        direction: prebindgen_registry::recipe::Direction,
+    ) -> Result<(bool, String, String), String> {
+        self.render_plan_for_test(ty, direction, true)
+    }
+
+    /// Compile and render the crossing's default row.
+    pub(crate) fn crossing_plan_for_test(
+        &self,
+        ty: syn::Type,
+        direction: prebindgen_registry::recipe::Direction,
+    ) -> Result<(bool, String, String), String> {
+        self.render_plan_for_test(ty, direction, false)
+    }
+
+    fn render_plan_for_test(
+        &self,
+        ty: syn::Type,
+        direction: prebindgen_registry::recipe::Direction,
+        parts: bool,
+    ) -> Result<(bool, String, String), String> {
+        use prebindgen_registry::{
+            recipe::{Compiler, Crossing},
+            write::RustFunction,
+        };
+
+        let reading = self
+            .registry
+            .flat()
+            .classify(&ty)
+            .map_err(|e| format!("the model does not classify {}: {e}", quote::quote!(#ty)))?;
+        let crossing = Crossing::new(reading, direction);
+        let mut compiler = Compiler::resume(
+            self.registry.flat(),
+            self.decls.recipe_table(),
+            self.decls.site_bindings(),
+            self.decls.compiled.borrow().clone(),
+        );
+        let mut adapter = crate::jni::compile::JCompile {
+            decls: &self.decls,
+            registry: &self.registry,
+            declared_return: None,
+            site: None,
+        };
+        let fragment = if parts {
+            compiler.recipe_of(&mut adapter, &crossing, &crate::jni::recipes::parts())
+        } else {
+            compiler.crossing(&mut adapter, &crossing)
+        }
+        .map_err(|e| e.to_string())?;
+        fragment.rust.mark_reachable();
+        let rendered = fragment.rust.render(&prebindgen_registry::Emit::for_test());
+        Ok((
+            fragment.composed_only,
+            fragment.conv.converter_ident().to_string(),
+            quote::quote!(#rendered).to_string(),
+        ))
+    }
+
     /// What one crossing occupies on the wire, named the way a parameter
     /// names it.
     ///

--- a/prebindgen-jni/src/jni/tests/sealed.rs
+++ b/prebindgen-jni/src/jni/tests/sealed.rs
@@ -2656,3 +2656,80 @@ fn a_decomposed_return_is_a_site_asking_for_the_parts_row() {
         "the site and the expansion plan disagree",
     );
 }
+
+/// A composed chain refuses a wrapper it cannot peel and put back, and refuses
+/// to read one it does not own — for a choice exactly as for a product.
+///
+/// Three planners state that rule: `planned_product`, `planned_choice` and
+/// `planned_sequence`. It is one rule, so they share one function; stated three
+/// times, the choice copy omitted it entirely and the sequence copy omitted the
+/// ownership half.
+///
+/// Both halves have a failure mode, and neither is caught by a test that only
+/// checks the plan was made.
+///
+/// * `&Box<Reading>` going out: reading peels with `*v`, so a chain composed
+///   over a shared borrow moves `Reading` out of the `Box` — E0507 in the
+///   consumer's crate, not here.
+/// * `Cow<'_, Reading>` coming in: `Cow` has no build operation, so planning
+///   would succeed and `JSource::build` would hit its `expect` while
+///   `write_rust` renders — a panic in the generator, after every check has
+///   passed.
+///
+/// Refusing returns the crossing to the legacy path, which is what handled
+/// these shapes before any chain existed.
+#[test]
+fn a_composed_chain_refuses_a_wrapper_it_cannot_peel() {
+    use prebindgen_registry::recipe::{Crossing, Direction};
+
+    let loc = myflat_loc();
+    let items: Vec<(syn::Item, SourceLocation)> = vec![
+        (
+            syn::Item::Enum(syn::parse_quote!(
+                pub enum Reading {
+                    Missing,
+                    Exact(i64),
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn read_one(which: i32) -> Reading {
+                    unimplemented!()
+                }
+            )),
+            loc.clone(),
+        ),
+    ];
+    let registry =
+        crate::test_util::reg_from_items(declare_referenced(items)).expect("index items");
+    let gen = JniGenBuilder::new()
+        .set_package_prefix("io.test.jni")
+        .package(
+            crate::package!()
+                .class(crate::sealed_class!(Reading))
+                .fun(prebindgen_registry::fun!(read_one)),
+        )
+        .build_with(registry)
+        .expect("resolve");
+
+    let flat = prebindgen_registry::Conversions::flat(gen.registry());
+    let composable = |spelling: &str, direction: Direction| -> bool {
+        let ty: syn::Type = syn::parse_str(spelling).expect("a type");
+        let reading = flat.classify(&ty).expect("the model knows this shape");
+        crate::jni::compile::composable_for_test(&Crossing::new(reading, direction))
+    };
+
+    // The bare sum composes in both directions, and so does a `Box` it owns.
+    assert!(composable("Reading", Direction::Deconstruct));
+    assert!(composable("Reading", Direction::Construct));
+    assert!(composable("Box<Reading>", Direction::Deconstruct));
+    assert!(composable("Box<Reading>", Direction::Construct));
+
+    // A `Box` reached through a shared borrow is not ours to read out of.
+    assert!(!composable("&Box<Reading>", Direction::Deconstruct));
+
+    // `Cow` has no build operation, so it cannot be put back.
+    assert!(!composable("Cow<'_, Reading>", Direction::Construct));
+}

--- a/prebindgen-jni/src/jni/tests/sealed.rs
+++ b/prebindgen-jni/src/jni/tests/sealed.rs
@@ -2739,11 +2739,113 @@ fn optional_wrapper_rust(
     std::fs::read_to_string(path).map_err(|e| e.to_string())
 }
 
-/// A composed chain refuses a wrapper it cannot peel and put back, and refuses
-/// to read one it does not own.
+/// Compile and render one Choice crossing through the real recipe driver.
+fn choice_wrapper_plan(
+    ty: syn::Type,
+    direction: prebindgen_registry::recipe::Direction,
+) -> Result<(bool, String, String), String> {
+    let loc = myflat_loc();
+    let items: Vec<(syn::Item, SourceLocation)> = vec![
+        (
+            syn::Item::Enum(syn::parse_quote!(
+                pub enum Reading {
+                    Missing,
+                    Exact(i64),
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn seed(n: i32, sink: impl Fn(Reading) + Send + Sync + 'static) {
+                    unimplemented!()
+                }
+            )),
+            loc.clone(),
+        ),
+    ];
+    let registry =
+        crate::test_util::reg_from_items(declare_referenced(items)).map_err(|e| e.to_string())?;
+    let gen = JniGenBuilder::new()
+        .set_package_prefix("io.test.jni")
+        .package(
+            crate::package!()
+                .class(crate::sealed_class!(Reading))
+                .fun(prebindgen_registry::fun!(seed)),
+        )
+        .build_with(registry)
+        .map_err(|e| e.to_string())?;
+    gen.parts_plan_for_test(ty, direction)
+}
+
+fn product_wrapper_plan(
+    ty: syn::Type,
+    direction: prebindgen_registry::recipe::Direction,
+) -> Result<(bool, String, String), String> {
+    let loc = myflat_loc();
+    let items: Vec<(syn::Item, SourceLocation)> = vec![
+        (
+            syn::Item::Struct(syn::parse_quote!(
+                pub struct Sample {
+                    pub label: String,
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn seed(v: Sample) {
+                    unimplemented!()
+                }
+            )),
+            loc.clone(),
+        ),
+    ];
+    let registry =
+        crate::test_util::reg_from_items(declare_referenced(items)).map_err(|e| e.to_string())?;
+    let gen = JniGenBuilder::new()
+        .set_package_prefix("io.test.jni")
+        .package(
+            crate::package!()
+                .class(crate::data_class!(Sample))
+                .fun(prebindgen_registry::fun!(seed)),
+        )
+        .build_with(registry)
+        .map_err(|e| e.to_string())?;
+    gen.parts_plan_for_test(ty, direction)
+}
+
+fn sequence_wrapper_plan(
+    ty: syn::Type,
+    direction: prebindgen_registry::recipe::Direction,
+) -> Result<(bool, String, String), String> {
+    let loc = myflat_loc();
+    let items: Vec<(syn::Item, SourceLocation)> = vec![(
+        syn::Item::Fn(syn::parse_quote!(
+            pub fn seed(v: Vec<String>) {
+                unimplemented!()
+            }
+        )),
+        loc.clone(),
+    )];
+    let registry =
+        crate::test_util::reg_from_items(declare_referenced(items)).map_err(|e| e.to_string())?;
+    let gen = JniGenBuilder::new()
+        .set_package_prefix("io.test.jni")
+        .package(crate::package!().fun(prebindgen_registry::fun!(seed)))
+        .build_with(registry)
+        .map_err(|e| e.to_string())?;
+    gen.crossing_plan_for_test(ty, direction)
+}
+
+/// Every composed planner refuses a wrapper it cannot peel and put back, and
+/// refuses to read one it does not own.
 ///
-/// This deliberately goes through planning and `write_rust`: checking the
-/// shared predicate alone would keep passing if a planner stopped asking it.
+/// Optional goes through public binding resolution and `write_rust`. Product
+/// and Choice ask their declared `parts` rows, while Sequence asks its default
+/// row; each then renders the JFunction the actual planner retained. Choice
+/// needs the explicit row because sealed-class inputs intentionally retain a
+/// whole-JObject compatibility row.
 ///
 /// Both directions exercise a supported `Box` first, proving that the composed
 /// Optional route is available rather than merely asserting every wrapper is
@@ -2757,8 +2859,10 @@ fn optional_wrapper_rust(
 ///   `write_rust` renders — a panic in the generator, after every check has
 ///   passed.
 ///
-/// Neither refused spelling has a legacy JNI representation, so the expected
-/// fallback result is a normal resolution error naming the unsupported type.
+/// Product, Sequence and Optional have no legacy JNI representation for the
+/// refused input spellings, so resolution names the unsupported type. Choice
+/// does have one: its refused crossings must retain `__jni_parts`, while an
+/// owned `Box<Reading>` renders the chain converter.
 #[test]
 fn a_composed_chain_refuses_a_wrapper_it_cannot_peel() {
     use prebindgen_registry::recipe::Direction;
@@ -2818,4 +2922,76 @@ fn a_composed_chain_refuses_a_wrapper_it_cannot_peel() {
             && cow.contains("Cow < 'static , Option < String > >"),
         "the refusal names the unsupported Cow input: {cow}"
     );
+
+    let (legacy, ident, rendered) =
+        product_wrapper_plan(syn::parse_quote!(Box<Sample>), Direction::Construct)
+            .expect("an owned Box Product composes");
+    assert!(
+        !legacy
+            && ident.starts_with("tuple1_to_Box_Sample_")
+            && rendered
+                .replace(' ', "")
+                .contains("Box::new(myflat::Sample{"),
+        "the Product parts row must retain its wrapper-aware plan: {ident}\n{rendered}"
+    );
+    let (legacy, ident, _) = product_wrapper_plan(
+        syn::parse_quote!(Cow<'static, Sample>),
+        Direction::Construct,
+    )
+    .expect("a Cow Product keeps its compatibility fragment");
+    assert!(
+        legacy && ident == "__jni_parts",
+        "the Cow Product must retain the legacy parts fragment, got {ident}"
+    );
+
+    let (legacy, ident, rendered) =
+        sequence_wrapper_plan(syn::parse_quote!(Box<Vec<String>>), Direction::Construct)
+            .expect("an owned Box Sequence composes");
+    assert!(
+        !legacy
+            && ident.starts_with("JObject_to_Box_Vec_String_")
+            && rendered
+                .replace(' ', "")
+                .contains("Box::new({let__sequence_list="),
+        "the Sequence default row must retain its wrapper-aware plan: {ident}\n{rendered}"
+    );
+    let refused = sequence_wrapper_plan(
+        syn::parse_quote!(Cow<'static, Vec<String>>),
+        Direction::Construct,
+    )
+    .expect_err("a Cow Sequence must refuse composition");
+    assert!(
+        refused.contains("no JNI representation for this run"),
+        "the Sequence refusal names its missing compatibility path: {refused}"
+    );
+
+    let (legacy, ident, rendered) =
+        choice_wrapper_plan(syn::parse_quote!(Box<Reading>), Direction::Deconstruct)
+            .expect("an owned Box Choice composes");
+    let rendered_compact: String = rendered.split_whitespace().collect();
+    assert!(!legacy, "the owned Choice must select its composed plan");
+    assert!(
+        ident.starts_with("Box_Reading_to_tuple3_") && rendered_compact.contains("match*v{"),
+        "the owned Choice renders its wrapper-aware converter: {ident}\n{rendered}"
+    );
+
+    for (label, ty, direction) in [
+        (
+            "borrowed",
+            syn::parse_quote!(&'static Box<Reading>),
+            Direction::Deconstruct,
+        ),
+        (
+            "cow",
+            syn::parse_quote!(Cow<'static, Reading>),
+            Direction::Construct,
+        ),
+    ] {
+        let (legacy, ident, _) = choice_wrapper_plan(ty, direction)
+            .unwrap_or_else(|error| panic!("the {label} Choice keeps its fallback: {error}"));
+        assert!(
+            legacy && ident == "__jni_parts",
+            "the {label} Choice must retain the legacy parts fragment, got {ident}"
+        );
+    }
 }

--- a/prebindgen-jni/src/jni/tests/sealed.rs
+++ b/prebindgen-jni/src/jni/tests/sealed.rs
@@ -2657,79 +2657,165 @@ fn a_decomposed_return_is_a_site_asking_for_the_parts_row() {
     );
 }
 
+/// Generate one Optional crossing through the real recipe driver and Rust
+/// writer. Keeping the crossing isolated lets a refused composed planner fall
+/// back without another function making the whole fixture ambiguous.
+fn optional_wrapper_rust(
+    ty: syn::Type,
+    direction: prebindgen_registry::recipe::Direction,
+    case: &str,
+) -> Result<String, String> {
+    use prebindgen_registry::recipe::Direction;
+
+    let loc = myflat_loc();
+    let gen = match direction {
+        Direction::Construct => {
+            let items: Vec<(syn::Item, SourceLocation)> = vec![(
+                syn::Item::Fn(syn::parse_quote!(
+                    pub fn cross(v: #ty) {
+                        unimplemented!()
+                    }
+                )),
+                loc.clone(),
+            )];
+            let registry = crate::test_util::reg_from_items(declare_referenced(items))
+                .map_err(|e| e.to_string())?;
+            JniGenBuilder::new()
+                .set_package_prefix("io.test.jni")
+                .package(crate::package!().fun(prebindgen_registry::fun!(cross)))
+                .build_with(registry)
+                .map_err(|e| e.to_string())?
+        }
+        Direction::Deconstruct => {
+            let items: Vec<(syn::Item, SourceLocation)> = vec![
+                (
+                    syn::Item::Struct(syn::parse_quote!(
+                        pub struct Holder {
+                            pub reading: #ty,
+                        }
+                    )),
+                    loc.clone(),
+                ),
+                (
+                    syn::Item::Fn(syn::parse_quote!(
+                        pub fn z_sample_to_holder(s: &ZSample) -> Holder {
+                            unimplemented!()
+                        }
+                    )),
+                    loc.clone(),
+                ),
+                (
+                    syn::Item::Fn(syn::parse_quote!(
+                        pub fn z_sample_sub(cb: impl Fn(ZSample) + Send + Sync + 'static) {
+                            unimplemented!()
+                        }
+                    )),
+                    loc.clone(),
+                ),
+            ];
+            let registry = crate::test_util::reg_from_items(declare_referenced(items))
+                .map_err(|e| e.to_string())?;
+            JniGenBuilder::new()
+                .set_package_prefix("io.test.jni")
+                .package(
+                    crate::package!()
+                        .class(crate::ptr_class!(ZSample))
+                        .fun(prebindgen_registry::fun!(z_sample_sub)),
+                )
+                .expand(
+                    prebindgen_registry::expand_return!(ZSample)
+                        .fields(prebindgen_registry::fields!(z_sample_to_holder)),
+                )
+                .build_with(registry)
+                .map_err(|e| e.to_string())?
+        }
+    };
+    let dir = unique_test_dir(case);
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).map_err(|e| e.to_string())?;
+    let path = gen
+        .write_rust(dir.join("g.rs"))
+        .map_err(|e| e.to_string())?;
+    std::fs::read_to_string(path).map_err(|e| e.to_string())
+}
+
 /// A composed chain refuses a wrapper it cannot peel and put back, and refuses
-/// to read one it does not own — for a choice exactly as for a product.
+/// to read one it does not own.
 ///
-/// Three planners state that rule: `planned_product`, `planned_choice` and
-/// `planned_sequence`. It is one rule, so they share one function; stated three
-/// times, the choice copy omitted it entirely and the sequence copy omitted the
-/// ownership half.
+/// This deliberately goes through planning and `write_rust`: checking the
+/// shared predicate alone would keep passing if a planner stopped asking it.
 ///
-/// Both halves have a failure mode, and neither is caught by a test that only
-/// checks the plan was made.
+/// Both directions exercise a supported `Box` first, proving that the composed
+/// Optional route is available rather than merely asserting every wrapper is
+/// refused. Their unsupported twins then exercise each half of the gate:
 ///
-/// * `&Box<Reading>` going out: reading peels with `*v`, so a chain composed
-///   over a shared borrow moves `Reading` out of the `Box` — E0507 in the
-///   consumer's crate, not here.
-/// * `Cow<'_, Reading>` coming in: `Cow` has no build operation, so planning
-///   would succeed and `JSource::build` would hit its `expect` while
+/// * `&Box<Option<String>>` going out: reading peels with `*v`, so a chain
+///   composed over a shared borrow moves the `Option` out of the `Box` — E0507
+///   in the consumer's crate, not here.
+/// * `Cow<'_, Option<String>>` coming in: `Cow` has no build operation, so
+///   planning would succeed and `JSource::build` would hit its `expect` while
 ///   `write_rust` renders — a panic in the generator, after every check has
 ///   passed.
 ///
-/// Refusing returns the crossing to the legacy path, which is what handled
-/// these shapes before any chain existed.
+/// Neither refused spelling has a legacy JNI representation, so the expected
+/// fallback result is a normal resolution error naming the unsupported type.
 #[test]
 fn a_composed_chain_refuses_a_wrapper_it_cannot_peel() {
-    use prebindgen_registry::recipe::{Crossing, Direction};
+    use prebindgen_registry::recipe::Direction;
 
-    let loc = myflat_loc();
-    let items: Vec<(syn::Item, SourceLocation)> = vec![
-        (
-            syn::Item::Enum(syn::parse_quote!(
-                pub enum Reading {
-                    Missing,
-                    Exact(i64),
-                }
-            )),
-            loc.clone(),
-        ),
-        (
-            syn::Item::Fn(syn::parse_quote!(
-                pub fn read_one(which: i32) -> Reading {
-                    unimplemented!()
-                }
-            )),
-            loc.clone(),
-        ),
-    ];
-    let registry =
-        crate::test_util::reg_from_items(declare_referenced(items)).expect("index items");
-    let gen = JniGenBuilder::new()
-        .set_package_prefix("io.test.jni")
-        .package(
-            crate::package!()
-                .class(crate::sealed_class!(Reading))
-                .fun(prebindgen_registry::fun!(read_one)),
-        )
-        .build_with(registry)
-        .expect("resolve");
+    let output = optional_wrapper_rust(
+        syn::parse_quote!(Box<Option<String>>),
+        Direction::Deconstruct,
+        "jnigen_chain_wrapper_output",
+    )
+    .expect("an owned Box output composes");
+    let output_compact: String = output.split_whitespace().collect();
+    assert!(
+        output_compact.contains("fnBox_Option_String_to_JString"),
+        "the output uses the composed Optional converter:\n{output}"
+    );
+    assert!(
+        output_compact.contains("match*v{"),
+        "the owned wrapper is peeled inside that converter:\n{output}"
+    );
 
-    let flat = prebindgen_registry::Conversions::flat(gen.registry());
-    let composable = |spelling: &str, direction: Direction| -> bool {
-        let ty: syn::Type = syn::parse_str(spelling).expect("a type");
-        let reading = flat.classify(&ty).expect("the model knows this shape");
-        crate::jni::compile::composable_for_test(&Crossing::new(reading, direction))
-    };
+    let borrowed = optional_wrapper_rust(
+        syn::parse_quote!(&'static Box<Option<String>>),
+        Direction::Deconstruct,
+        "jnigen_chain_wrapper_borrowed_output",
+    );
+    let borrowed = borrowed.expect_err("a shared Box output must refuse composition");
+    assert!(
+        borrowed.contains("unresolved prebindgen output type")
+            && borrowed.contains("Box < Option < String > >"),
+        "the refusal names the unsupported borrowed output: {borrowed}"
+    );
 
-    // The bare sum composes in both directions, and so does a `Box` it owns.
-    assert!(composable("Reading", Direction::Deconstruct));
-    assert!(composable("Reading", Direction::Construct));
-    assert!(composable("Box<Reading>", Direction::Deconstruct));
-    assert!(composable("Box<Reading>", Direction::Construct));
+    let input = optional_wrapper_rust(
+        syn::parse_quote!(Box<Option<String>>),
+        Direction::Construct,
+        "jnigen_chain_wrapper_input",
+    )
+    .expect("an owned Box input composes");
+    let input_compact: String = input.split_whitespace().collect();
+    assert!(
+        input_compact.contains("fnJString_to_Box_Option_String"),
+        "the input uses the composed Optional converter:\n{input}"
+    );
+    assert!(
+        input_compact.contains("Box::new({ifv.is_null()"),
+        "the canonical Optional is put back in its owned wrapper:\n{input}"
+    );
 
-    // A `Box` reached through a shared borrow is not ours to read out of.
-    assert!(!composable("&Box<Reading>", Direction::Deconstruct));
-
-    // `Cow` has no build operation, so it cannot be put back.
-    assert!(!composable("Cow<'_, Reading>", Direction::Construct));
+    let cow = optional_wrapper_rust(
+        syn::parse_quote!(Cow<'static, Option<String>>),
+        Direction::Construct,
+        "jnigen_chain_wrapper_cow_input",
+    );
+    let cow = cow.expect_err("a Cow input must refuse composition");
+    assert!(
+        cow.contains("unresolved prebindgen input type")
+            && cow.contains("Cow < 'static , Option < String > >"),
+        "the refusal names the unsupported Cow input: {cow}"
+    );
 }


### PR DESCRIPTION
Addresses the inline finding on [#513](https://github.com/milyin/prebindgen/pull/513) at `prebindgen-jni/src/jni/compile.rs:1094`.

## Summary

A registry-composed converter has to peel every transparent Rust wrapper before operating on the canonical shape, then restore those wrappers in the opposite direction. That requires both an adapter operation for each wrapper and ownership when deconstructing: `Box::new` can rebuild `Box<T>`, while `*v` cannot move its payload through a shared borrow.

This branch centralizes that eligibility rule in `composable_wrappers` and applies it to every composed JNI planner: Product, Choice, Sequence, and Optional. Unsupported wrappers return control to the compatibility planner; if no compatibility JNI representation exists, resolution reports the unsupported type instead of letting final Rust rendering panic or emit code that fails in the consumer crate.

It also removes duplicate helper documentation left on `planned_product`.

## Regression coverage

The regression reaches each real recipe planner and renders the `JFunction` it retained:

- Optional is exercised through public binding resolution and `write_rust` in both directions. Owned `Box<Option<String>>` composes; shared `&Box<Option<String>>` output and `Cow<Option<String>>` input are rejected.
- Product's declared `parts` row composes and renders `Box<Sample>`; `Cow<Sample>` retains the compatibility parts fragment.
- Choice's declared `parts` row composes and renders owned `Box<Reading>`; borrowed `Box<Reading>` output and `Cow<Reading>` input retain the compatibility parts fragment.
- Sequence's default row composes and renders `Box<Vec<String>>`; `Cow<Vec<String>>` is rejected because there is no compatibility representation.

Each of the four planner call sites was mutation-checked independently. Replacing its `composable_wrappers` call with the unrestricted wrapper list makes this regression fail, so no planner can silently bypass the shared rule.

Generated repository artifacts remain byte-for-byte unchanged.

## Verification

- `cargo test --workspace` — passed
- `cargo clippy --workspace --all-targets --all-features` — passed
- `RUSTDOCFLAGS="-Dwarnings" cargo doc --no-deps` — passed
- `cargo fmt --all --check` — passed
- `git diff --check` — passed
- `bash examples/regen-check.sh` — passed; generated output is byte-identical
