### PR TITLE
Render ordinary C sites from frozen plans

### DIFF
--- a/prebindgen-c/src/compile.rs
+++ b/prebindgen-c/src/compile.rs
@@ -12,7 +12,12 @@
 
 use prebindgen_registry::{
     flat::{Alternative, Function},
+    generation::{
+        AbiLayout, ChoiceArity, Cleanup, ConverterPlan, Failure, FixedArity, FragmentPlan,
+        FragmentUse, NichePlan, Representation, ShapePlan, SiteId, SitePlan,
+    },
     recipe::{At, Carrier, Compile, Cx, Frag, Mode, Parts, Role, Validity, Yield},
+    FragmentId,
 };
 
 use super::*;
@@ -21,9 +26,277 @@ use crate::chain::{
     SequencePlan,
 };
 
+/// The shape selected by the recipe compiler, retaining semantic child edges.
+#[derive(Clone)]
+pub(crate) enum CShape {
+    Atomic,
+    Product(Vec<FragmentUse>),
+    Optional(FragmentUse),
+    Sequence(FragmentUse),
+    Choice(Vec<Vec<FragmentUse>>),
+    Invoke(Vec<FragmentUse>),
+}
+
+/// One already-composed C wire-value operation used by an ordinary boundary site.
+#[derive(Clone)]
+pub(crate) enum CValue {
+    Direct {
+        wire: syn::Type,
+        converter: CCall,
+        niches: Niches,
+    },
+    Optional {
+        inner: Box<CValue>,
+        absent: Option<NicheSlot>,
+    },
+    OwnedSequence {
+        element_wire: syn::Type,
+        converter: CCall,
+    },
+    BorrowedSequence {
+        element_wire: syn::Type,
+        converter: CCall,
+    },
+    BorrowedInput {
+        element: TypeRef,
+        wire: syn::Type,
+        reinterpret: bool,
+    },
+}
+
+impl CValue {
+    pub(crate) fn slots(&self) -> usize {
+        match self {
+            Self::Direct { .. } => 1,
+            Self::Optional {
+                inner,
+                absent: Some(_),
+            } => inner.slots(),
+            Self::Optional {
+                inner,
+                absent: None,
+            } => 1 + inner.slots(),
+            Self::OwnedSequence { .. }
+            | Self::BorrowedSequence { .. }
+            | Self::BorrowedInput { .. } => 2,
+        }
+    }
+
+    pub(crate) fn failure(&self) -> Failure {
+        let fallible = match self {
+            Self::Direct { converter, .. }
+            | Self::OwnedSequence { converter, .. }
+            | Self::BorrowedSequence { converter, .. } => converter.fallible(),
+            Self::Optional { inner, .. } => inner.failure() == Failure::Fallible,
+            Self::BorrowedInput { .. } => false,
+        };
+        if fallible {
+            Failure::Fallible
+        } else {
+            Failure::Infallible
+        }
+    }
+
+    pub(crate) fn fields(&self) -> Vec<WireField> {
+        match self {
+            Self::Direct { wire, .. } => vec![WireField {
+                suffix: "",
+                wire: wire.clone(),
+            }],
+            Self::Optional {
+                inner,
+                absent: Some(_),
+            } => inner.fields(),
+            Self::Optional {
+                inner,
+                absent: None,
+            } => {
+                let mut fields = vec![WireField {
+                    suffix: "_present",
+                    wire: syn::parse_quote!(bool),
+                }];
+                fields.extend(inner.fields());
+                fields
+            }
+            Self::OwnedSequence { element_wire, .. }
+            | Self::BorrowedSequence { element_wire, .. } => vec![
+                WireField {
+                    suffix: "",
+                    wire: syn::parse_quote!(*mut #element_wire),
+                },
+                WireField {
+                    suffix: "_len",
+                    wire: syn::parse_quote!(usize),
+                },
+            ],
+            Self::BorrowedInput { wire, .. } => vec![
+                WireField {
+                    suffix: "",
+                    wire: wire.clone(),
+                },
+                WireField {
+                    suffix: "_len",
+                    wire: syn::parse_quote!(usize),
+                },
+            ],
+        }
+    }
+
+    pub(crate) fn encode(
+        &self,
+        val: TokenStream,
+        targets: &[TokenStream],
+        route: &ErrRoute<'_>,
+    ) -> TokenStream {
+        match self {
+            Self::Direct { converter, .. } => {
+                let conv = converter.ident();
+                let converted = if converter.fallible() {
+                    route_result(quote!(#conv(#val)), route)
+                } else {
+                    quote!(#conv(#val))
+                };
+                let target = &targets[0];
+                quote!(#target = #converted;)
+            }
+            Self::Optional {
+                inner,
+                absent: Some(slot),
+            } => {
+                let inner_encode = inner.encode(quote!(__x), targets, route);
+                let absent = &slot.value;
+                let target = &targets[0];
+                quote!(
+                    match #val {
+                        ::core::option::Option::Some(__x) => { #inner_encode }
+                        ::core::option::Option::None => { #target = #absent; }
+                    }
+                )
+            }
+            Self::Optional {
+                inner,
+                absent: None,
+            } => {
+                let present = &targets[0];
+                let inner_encode = inner.encode(quote!(__x), &targets[1..], route);
+                quote!(
+                    match #val {
+                        ::core::option::Option::Some(__x) => {
+                            #present = true;
+                            #inner_encode
+                        }
+                        ::core::option::Option::None => { #present = false; }
+                    }
+                )
+            }
+            Self::OwnedSequence {
+                element_wire,
+                converter,
+            } => {
+                let conv = converter.ident();
+                let converted = if converter.fallible() {
+                    route_result(quote!(#conv(#val)), route)
+                } else {
+                    quote!(#conv(#val))
+                };
+                let pointer = &targets[0];
+                let length = &targets[1];
+                quote!(
+                    let __arr: ::std::vec::Vec<#element_wire> = #converted;
+                    let (__p, __n) = __cbg_alloc_array(__arr);
+                    #pointer = __p;
+                    #length = __n;
+                )
+            }
+            Self::BorrowedSequence {
+                element_wire,
+                converter,
+            } => {
+                let conv = converter.ident();
+                let pointer = &targets[0];
+                let length = &targets[1];
+                if converter.fallible() {
+                    let converted = route_result(quote!(#conv(__value)), route);
+                    quote!(
+                        let mut __arr: ::std::vec::Vec<#element_wire> = ::std::vec::Vec::new();
+                        for __value in #val.iter().copied() {
+                            __arr.push(#converted);
+                        }
+                        let (__p, __n) = __cbg_alloc_array(__arr);
+                        #pointer = __p;
+                        #length = __n;
+                    )
+                } else {
+                    let map = map_arg(conv, converter.unsafe_());
+                    quote!(
+                        let __arr: ::std::vec::Vec<#element_wire> =
+                            #val.iter().copied().map(#map).collect();
+                        let (__p, __n) = __cbg_alloc_array(__arr);
+                        #pointer = __p;
+                        #length = __n;
+                    )
+                }
+            }
+            Self::BorrowedInput { .. } => {
+                unreachable!("borrowed input plan cannot encode an output")
+            }
+        }
+    }
+
+    pub(crate) fn effective_niches(&self) -> Niches {
+        match self {
+            Self::Direct { wire, niches, .. }
+                if niches.is_empty() && matches!(wire, syn::Type::Ptr(_)) =>
+            {
+                let null = null_for(wire);
+                Niches::one(syn::parse_quote!(#null), syn::parse_quote!(v.is_null()))
+            }
+            Self::Direct { niches, .. } => niches.clone(),
+            Self::Optional { inner, absent } => match absent {
+                Some(_) => inner
+                    .effective_niches()
+                    .carve()
+                    .map_or_else(Niches::empty, |(_, rest)| rest),
+                None => Niches::empty(),
+            },
+            Self::OwnedSequence { .. }
+            | Self::BorrowedSequence { .. }
+            | Self::BorrowedInput { .. } => Niches::empty(),
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) enum CFailureRoute {
+    Panic,
+    Error(SiteId),
+}
+
+/// C-specific payloads held behind the registry's generic frozen vocabulary.
+pub(crate) enum CRepresentation {}
+
+impl Representation for CRepresentation {
+    type Intermediate = TypeKey;
+    type Step = CCall;
+    type TerminalCodec = CCall;
+    type ProductBridge = CCall;
+    type OptionalBridge = CCall;
+    type SequenceBridge = CCall;
+    type ChoiceBridge = CCall;
+    type CallbackBridge = CCall;
+    type Niche = String;
+    type Cleanup = ();
+    type FailureRoute = CFailureRoute;
+    type AbiLayout = CValue;
+    type Artifact = ();
+}
+
 /// The C adapter's answer for one crossing.
 #[derive(Clone)]
 pub(crate) struct CFrag {
+    /// Stable identity and opaque source spelling of this recipe answer.
+    pub(crate) id: FragmentId,
+    pub(crate) source: TypeRef,
     /// The C wire type this crossing carries.
     pub(crate) destination: syn::Type,
     /// The generated converter's callable contract and late-rendered plan.
@@ -40,6 +313,10 @@ pub(crate) struct CFrag {
     pub(crate) arm: Option<Arm>,
     /// What the fragment produces, which is all the registry reads of it.
     pub(crate) yields: Yield,
+    /// Registry-checkable shape edges retained beside the C operation payload.
+    pub(crate) shape: CShape,
+    /// Frozen ordinary-site wire lowering. Callback delivery has its own stage.
+    pub(crate) value: CValue,
 }
 
 /// One alternative's payload plan on its way to [`Compile::choice`].
@@ -53,11 +330,16 @@ pub(crate) struct Arm {
 
 #[derive(Clone)]
 pub(crate) struct ArmPart {
+    pub(crate) use_: FragmentUse,
     pub(crate) wire: syn::Type,
     pub(crate) child: CCall,
     pub(crate) mode: Mode,
     pub(crate) hold_uninit: bool,
 }
+fn fragment_use(fragment: &CFrag) -> FragmentUse {
+    FragmentUse::new(fragment.id.clone(), fragment.yields.clone())
+}
+
 impl Carrier for CFrag {
     fn yields(&self) -> Yield {
         self.yields.clone()
@@ -65,14 +347,84 @@ impl Carrier for CFrag {
 }
 
 impl CFrag {
+    pub(crate) fn freeze(&self) -> FragmentPlan<CRepresentation> {
+        let call = self.function.call().clone();
+        let shape = match &self.shape {
+            CShape::Atomic => ShapePlan::Atomic(call),
+            CShape::Product(parts) => ShapePlan::Product {
+                bridge: FixedArity::new(parts.len(), call),
+                parts: parts.clone(),
+            },
+            CShape::Optional(value) => ShapePlan::Optional {
+                bridge: call,
+                value: value.clone(),
+            },
+            CShape::Sequence(element) => ShapePlan::Sequence {
+                bridge: call,
+                element: element.clone(),
+            },
+            CShape::Choice(arms) => ShapePlan::Choice {
+                bridge: ChoiceArity::new(arms.iter().map(Vec::len).collect(), call),
+                arms: arms.clone(),
+            },
+            CShape::Invoke(arguments) => ShapePlan::Invoke {
+                bridge: FixedArity::new(arguments.len(), call),
+                arguments: arguments.clone(),
+            },
+        };
+        let niche_key = |slot: &NicheSlot| {
+            format!(
+                "{}=>{}",
+                slot.value.to_token_stream(),
+                slot.matches.to_token_stream()
+            )
+        };
+        let exposed: Vec<String> = self
+            .value
+            .effective_niches()
+            .slots
+            .iter()
+            .map(niche_key)
+            .collect();
+        let consumed: Vec<String> = match &self.value {
+            CValue::Optional {
+                absent: Some(slot), ..
+            } => vec![niche_key(slot)],
+            _ => Vec::new(),
+        };
+        let discriminants = usize::from(!consumed.is_empty());
+        let converter = ConverterPlan::new(
+            shape,
+            NichePlan::new(discriminants, consumed, exposed),
+            self.value.failure(),
+            Cleanup::None,
+        );
+        FragmentPlan::new(
+            self.id.clone(),
+            self.source.clone(),
+            TypeKey::from_type(&self.destination),
+            converter,
+            self.yields.clone(),
+        )
+    }
+
     /// One of the adapter's existing converter builders, as a fragment.
     fn from_converter(at: At<'_>, conv: ConverterImpl) -> Self {
         let validity = validity_of(&conv, at.crossing.direction());
+        let destination = conv.destination;
+        let niches = conv.niches;
         let function = CFunction::complete(conv.function);
+        let value = CValue::Direct {
+            wire: destination.clone(),
+            converter: function.call().clone(),
+            niches: niches.clone(),
+        };
         Self {
-            destination: conv.destination,
+            id: FragmentId::new(at.crossing.spelled().key(), at.recipe.clone()),
+            source: at.crossing.spelled().clone(),
+            destination,
             function,
-            niches: conv.niches,
+            niches,
             subs: conv.subs,
             arm: None,
             yields: Yield {
@@ -80,6 +432,8 @@ impl CFrag {
                 mode: at.crossing.mode(),
                 validity,
             },
+            shape: CShape::Atomic,
+            value,
         }
     }
 }
@@ -187,9 +541,9 @@ impl<R: Conversions> CCompile<'_, R> {
 
 impl<R: Conversions> Compile for CCompile<'_, R> {
     type Fragment = CFrag;
-    /// C keeps its own per-site emission for now: the exported signature, the
-    /// call and the cleanup are built in `emit.rs` from the resolved registry.
-    type Plan = ();
+    /// Ordinary C signatures and calls render from this immutable site plan.
+    /// Callback delivery is the next migration boundary.
+    type Plan = SitePlan<CRepresentation>;
     type Error = String;
 
     fn atomic(&mut self, cx: &mut Cx<'_>, at: At<'_>) -> Frag<Self> {
@@ -255,11 +609,16 @@ impl<R: Conversions> Compile for CCompile<'_, R> {
             ));
         };
         if at.crossing.direction() == Direction::Deconstruct {
-            return self.wrap(
-                at,
-                "no C representation for this optional",
-                Some(self.gen.out_arity_marker("option", elem)),
-            );
+            let marker = self.gen.out_arity_marker("option", elem);
+            let mut fragment = CFrag::from_converter(at, marker);
+            let absent = inner.value.effective_niches().carve().map(|(slot, _)| slot);
+            fragment.shape = CShape::Optional(fragment_use(inner));
+            fragment.value = CValue::Optional {
+                inner: Box::new(inner.value.clone()),
+                absent,
+            };
+            fragment.niches = fragment.value.effective_niches();
+            return Ok(fragment);
         }
 
         let inner_wire = inner.destination.clone();
@@ -293,7 +652,14 @@ impl<R: Conversions> Compile for CCompile<'_, R> {
             repr,
             borrowed: elem.borrow_target().is_some(),
         });
+        let value = CValue::Direct {
+            wire: wire.clone(),
+            converter: function.call().clone(),
+            niches: niches.clone(),
+        };
         Ok(CFrag {
+            id: FragmentId::new(at.crossing.spelled().key(), at.recipe.clone()),
+            source: at.crossing.spelled().clone(),
             destination: wire,
             function,
             niches,
@@ -304,6 +670,8 @@ impl<R: Conversions> Compile for CCompile<'_, R> {
                 mode: at.crossing.mode(),
                 validity: Validity::SelfSufficient,
             },
+            shape: CShape::Optional(fragment_use(inner)),
+            value,
         })
     }
 
@@ -326,7 +694,13 @@ impl<R: Conversions> Compile for CCompile<'_, R> {
                         child_wire: inner.destination.clone(),
                         child: inner.function.call().clone(),
                     });
+                    let value = CValue::OwnedSequence {
+                        element_wire: inner.destination.clone(),
+                        converter: function.call().clone(),
+                    };
                     return Ok(CFrag {
+                        id: FragmentId::new(at.crossing.spelled().key(), at.recipe.clone()),
+                        source: at.crossing.spelled().clone(),
                         destination: syn::parse_quote!(()),
                         function,
                         niches: Niches::empty(),
@@ -337,6 +711,8 @@ impl<R: Conversions> Compile for CCompile<'_, R> {
                             mode: at.crossing.mode(),
                             validity: Validity::SelfSufficient,
                         },
+                        shape: CShape::Sequence(fragment_use(inner)),
+                        value,
                     });
                 }
             }
@@ -353,7 +729,20 @@ impl<R: Conversions> Compile for CCompile<'_, R> {
                 .out_slice_marker(ty)
                 .or_else(|| Some(self.gen.out_arity_marker("vec", ty.sequence_elem()?))),
         };
-        self.wrap(at, "no C representation for this run", conv)
+        let mut fragment = self.wrap(at, "no C representation for this run", conv)?;
+        fragment.shape = CShape::Sequence(fragment_use(inner));
+        fragment.value = match at.crossing.direction() {
+            Direction::Construct => CValue::BorrowedInput {
+                element: inner.source.clone(),
+                wire: fragment.destination.clone(),
+                reinterpret: scalar_ty(&inner.source).is_none(),
+            },
+            Direction::Deconstruct => CValue::BorrowedSequence {
+                element_wire: inner.destination.clone(),
+                converter: inner.function.call().clone(),
+            },
+        };
+        Ok(fragment)
     }
 
     fn construct(
@@ -435,6 +824,7 @@ impl<R: Conversions> Compile for CCompile<'_, R> {
                         .payload_field_wire(&part.ty)
                         .unwrap_or_else(|_| frag.destination.clone());
                     ArmPart {
+                        use_: fragment_use(frag),
                         hold_uninit: at.crossing.direction() == Direction::Deconstruct
                             && held_uninit(&wire, &frag.destination),
                         wire,
@@ -456,12 +846,21 @@ impl<R: Conversions> Compile for CCompile<'_, R> {
                 })
                 .map(|(p, _)| p.ty.key())
                 .collect();
+            let function = CFunction::complete(syn::parse_quote!(
+                #[allow(dead_code)]
+                fn __cbg_arm() {}
+            ));
+            let destination: syn::Type = syn::parse_quote!(());
+            let value = CValue::Direct {
+                wire: destination.clone(),
+                converter: function.call().clone(),
+                niches: Niches::empty(),
+            };
             return Ok(CFrag {
-                destination: syn::parse_quote!(()),
-                function: CFunction::complete(syn::parse_quote!(
-                    #[allow(dead_code)]
-                    fn __cbg_arm() {}
-                )),
+                id: FragmentId::new(at.crossing.spelled().key(), at.recipe.clone()),
+                source: at.crossing.spelled().clone(),
+                destination,
+                function,
                 niches: Niches::empty(),
                 subs: subs.clone(),
                 arm: Some(Arm {
@@ -473,6 +872,8 @@ impl<R: Conversions> Compile for CCompile<'_, R> {
                     mode: at.crossing.mode(),
                     validity: Validity::SelfSufficient,
                 },
+                shape: CShape::Product(parts.iter().map(|(_, frag)| fragment_use(frag)).collect()),
+                value,
             });
         }
         let c_struct = self.gen.c_type_ident(&key);
@@ -525,16 +926,24 @@ impl<R: Conversions> Compile for CCompile<'_, R> {
             Direction::Deconstruct => CbindgenBuilder::out_name_of(&key),
         };
         let wire: syn::Type = syn::parse_quote!(#c_struct);
+        let function = CFunction::product(ProductPlan {
+            ident,
+            source: at.crossing.spelled().clone(),
+            source_module: self.gen.source_module.clone(),
+            wire: wire.clone(),
+            direction,
+            fields,
+        });
+        let value = CValue::Direct {
+            wire: wire.clone(),
+            converter: function.call().clone(),
+            niches: Niches::empty(),
+        };
         Ok(CFrag {
-            destination: wire.clone(),
-            function: CFunction::product(ProductPlan {
-                ident,
-                source: at.crossing.spelled().clone(),
-                source_module: self.gen.source_module.clone(),
-                wire,
-                direction,
-                fields,
-            }),
+            id: FragmentId::new(at.crossing.spelled().key(), at.recipe.clone()),
+            source: at.crossing.spelled().clone(),
+            destination: wire,
+            function,
             niches: Niches::empty(),
             subs,
             arm: None,
@@ -543,6 +952,8 @@ impl<R: Conversions> Compile for CCompile<'_, R> {
                 mode: at.crossing.mode(),
                 validity: Validity::SelfSufficient,
             },
+            shape: CShape::Product(parts.iter().map(|(_, frag)| fragment_use(frag)).collect()),
+            value,
         })
     }
 
@@ -597,16 +1008,37 @@ impl<R: Conversions> Compile for CCompile<'_, R> {
             Direction::Construct => CbindgenBuilder::in_name_of(&key),
             Direction::Deconstruct => CbindgenBuilder::out_name_of(&key),
         };
+        let shape_arms = arms
+            .iter()
+            .map(|(_, fragment)| {
+                fragment
+                    .arm
+                    .as_ref()
+                    .expect("validated Choice arm")
+                    .parts
+                    .iter()
+                    .map(|part| part.use_.clone())
+                    .collect()
+            })
+            .collect();
+        let function = CFunction::choice(ChoicePlan {
+            ident,
+            source: at.crossing.spelled().clone(),
+            source_module: self.gen.source_module.clone(),
+            wire: cname,
+            direction,
+            arms: planned_arms,
+        });
+        let value = CValue::Direct {
+            wire: destination.clone(),
+            converter: function.call().clone(),
+            niches: Niches::empty(),
+        };
         Ok(CFrag {
+            id: FragmentId::new(at.crossing.spelled().key(), at.recipe.clone()),
+            source: at.crossing.spelled().clone(),
             destination,
-            function: CFunction::choice(ChoicePlan {
-                ident,
-                source: at.crossing.spelled().clone(),
-                source_module: self.gen.source_module.clone(),
-                wire: cname,
-                direction,
-                arms: planned_arms,
-            }),
+            function,
             niches: Niches::empty(),
             subs,
             arm: None,
@@ -615,6 +1047,8 @@ impl<R: Conversions> Compile for CCompile<'_, R> {
                 mode: at.crossing.mode(),
                 validity: Validity::SelfSufficient,
             },
+            shape: CShape::Choice(shape_arms),
+            value,
         })
     }
 
@@ -632,7 +1066,14 @@ impl<R: Conversions> Compile for CCompile<'_, R> {
             .gen
             .dispatch_fn_input(at.crossing.spelled(), args, Some(fragments), self.registry)
             .ok_or_else(|| refuse(at, "undeclared callback signature"))?;
+        let value = CValue::Direct {
+            wire: destination.clone(),
+            converter: function.call().clone(),
+            niches: Niches::empty(),
+        };
         Ok(CFrag {
+            id: FragmentId::new(at.crossing.spelled().key(), at.recipe.clone()),
+            source: at.crossing.spelled().clone(),
             destination,
             function,
             niches: Niches::empty(),
@@ -643,6 +1084,8 @@ impl<R: Conversions> Compile for CCompile<'_, R> {
                 mode: at.crossing.mode(),
                 validity: Validity::SelfSufficient,
             },
+            shape: CShape::Invoke(fragments.iter().map(|frag| fragment_use(frag)).collect()),
+            value,
         })
     }
 
@@ -658,7 +1101,35 @@ impl<R: Conversions> Compile for CCompile<'_, R> {
         Validity::Borrowed
     }
 
-    fn plan(&mut self, _cx: &mut Cx<'_>, _bound: &Bound, _root: &CFrag) -> Result<(), String> {
-        Ok(())
+    fn plan(
+        &mut self,
+        _cx: &mut Cx<'_>,
+        bound: &Bound,
+        root: &CFrag,
+    ) -> Result<SitePlan<CRepresentation>, String> {
+        let failure_route = (root.value.failure() == Failure::Fallible).then(|| {
+            let function = self
+                .registry
+                .flat()
+                .function(&bound.site.owner)
+                .expect("site owner is a declared function");
+            if function.ret.fallible_parts().is_some() {
+                CFailureRoute::Error(SiteId::new(prebindgen_registry::recipe::Site {
+                    owner: bound.site.owner.clone(),
+                    role: Role::Error,
+                }))
+            } else {
+                CFailureRoute::Panic
+            }
+        });
+        Ok(SitePlan::new(
+            SiteId::new(bound.site.clone()),
+            bound.clone(),
+            root.id.clone(),
+            root.yields.clone(),
+            AbiLayout::new(root.value.slots(), root.value.clone()),
+            failure_route,
+            Cleanup::None,
+        ))
     }
 }

--- a/prebindgen-c/src/emit.rs
+++ b/prebindgen-c/src/emit.rs
@@ -478,10 +478,35 @@ impl CbindgenBuilder {
     }
 
     /// Assemble the `#[no_mangle] extern "C"` wrapper for one declared fn.
+    fn generation_site(
+        &self,
+        owner: &syn::Ident,
+        role: prebindgen_registry::recipe::Role,
+    ) -> &prebindgen_registry::generation::SitePlan<crate::compile::CRepresentation> {
+        let id = prebindgen_registry::generation::SiteId::new(prebindgen_registry::recipe::Site {
+            owner: owner.clone(),
+            role,
+        });
+        let site = self
+            .generation
+            .as_ref()
+            .expect("C generation plan was not frozen")
+            .site(&id)
+            .unwrap_or_else(|| panic!("C generation plan has no site {id}"));
+        assert!(
+            matches!(
+                site.cleanup(),
+                prebindgen_registry::generation::Cleanup::None
+            ),
+            "ordinary C sites cannot carry a deferred cleanup operation"
+        );
+        site
+    }
+
     pub(super) fn emit_function_wrapper(
         &self,
         f: &prebindgen_registry::flat::Function,
-        registry: &Registry,
+        _registry: &Registry,
         emit: &prebindgen_registry::Emit,
     ) -> TokenStream {
         let orig = &f.name;
@@ -492,10 +517,12 @@ impl CbindgenBuilder {
         // already classified. An elided return is `TypeKind::Unit`, which is
         // the `ReturnType::Default` arm this used to write.
 
-        let has_fallible_input = f.params.iter().any(|p| {
-            self.in_frag(&p.ty)
-                .map(|e| e.function.call().fallible())
-                .unwrap_or(false)
+        let has_fallible_input = f.params.iter().enumerate().any(|(index, _)| {
+            self.generation_site(orig, prebindgen_registry::recipe::Role::Param { index })
+                .abi()
+                .payload()
+                .failure()
+                == prebindgen_registry::generation::Failure::Fallible
         });
 
         // Peel an outer `Result<_, E>`; `value_ty` is the success/return value.
@@ -507,7 +534,11 @@ impl CbindgenBuilder {
             None => (&f.ret, None),
         };
         let err_ty: Option<syn::Type> = err_reading.map(|t| spelled(t, emit));
-        let has_fallible_output = self.output_is_fallible(value_ty);
+        let value_site = (!matches!(value_ty.kind(), TypeKind::Unit))
+            .then(|| self.generation_site(orig, prebindgen_registry::recipe::Role::Return));
+        let has_fallible_output = value_site.is_some_and(|site| {
+            site.abi().payload().failure() == prebindgen_registry::generation::Failure::Fallible
+        });
 
         // Error wiring: the error type must be declared via `.error()`.
         let err_bits = err_ty.as_ref().map(|err_ty| {
@@ -520,21 +551,14 @@ impl CbindgenBuilder {
                 TypeKey::from_type(err_ty),
                 TypeKey::from_type(err_ty),
             );
-            let entry = registry
-                .reading_of(err_ty)
-                .and_then(|tr| self.out_frag(&tr))
-                .unwrap_or_else(|| {
-                    panic!(
-                        "Cbindgen::on_function: error type `{}` of `{}` has no output converter",
-                        TypeKey::from_type(err_ty),
-                        orig
-                    )
-                });
-            (
-                entry.destination.clone(),
-                entry.function.call().ident().clone(),
-                self.src_ty(err_ty),
-            )
+            let site = self.generation_site(orig, prebindgen_registry::recipe::Role::Error);
+            let crate::compile::CValue::Direct {
+                wire, converter, ..
+            } = site.abi().payload()
+            else {
+                panic!("C error site must have one direct wire");
+            };
+            (wire.clone(), converter.ident().clone(), self.src_ty(err_ty))
         });
 
         // No `Result` channel ⇒ a fallible input must be declared `.panic()`.
@@ -554,7 +578,16 @@ impl CbindgenBuilder {
         //   * Result + a free pointer niche  → NULL marks `Err` (value in-band);
         //   * Result without a free niche     → `bool` status, value to out-params;
         //   * no Result                       → field 0 is the C return, rest out.
-        let shape = self.lower_shape(value_ty, registry);
+        let shape = value_site.map_or(
+            ValueShape {
+                fields: Vec::new(),
+                niches: Niches::empty(),
+            },
+            |site| ValueShape {
+                fields: site.abi().payload().fields(),
+                niches: site.abi().payload().effective_niches(),
+            },
+        );
         let result_slot = shape.niches.clone().carve().map(|(slot, _)| slot);
         let result_in_band = err_ty.is_some() && result_slot.is_some();
         let field0_is_return = result_in_band || err_ty.is_none();
@@ -612,6 +645,49 @@ impl CbindgenBuilder {
         } else {
             quote!(false)
         };
+        let mut planned_routes = f
+            .params
+            .iter()
+            .enumerate()
+            .filter_map(|(index, _)| {
+                self.generation_site(orig, prebindgen_registry::recipe::Role::Param { index })
+                    .failure_route()
+            })
+            .chain(
+                value_site
+                    .into_iter()
+                    .filter_map(|site| site.failure_route()),
+            );
+        let planned_route = planned_routes.next();
+        assert!(
+            planned_routes.all(|route| Some(route) == planned_route),
+            "C function sites disagree on their frozen failure route"
+        );
+        match planned_route {
+            Some(crate::compile::CFailureRoute::Panic) => {
+                assert!(
+                    err_bits.is_none(),
+                    "panic route attached to a Result function"
+                );
+            }
+            Some(crate::compile::CFailureRoute::Error(error_site)) => {
+                assert!(
+                    err_bits.is_some(),
+                    "error route attached without a Result channel"
+                );
+                let expected = prebindgen_registry::generation::SiteId::new(
+                    prebindgen_registry::recipe::Site {
+                        owner: orig.clone(),
+                        role: prebindgen_registry::recipe::Role::Error,
+                    },
+                );
+                assert_eq!(
+                    error_site, &expected,
+                    "failure route names the wrong error site"
+                );
+            }
+            None => {}
+        }
         let input_route = match &err_bits {
             Some((_, e_conv, e_ty_src)) => ErrRoute::Result {
                 e_conv,
@@ -620,8 +696,7 @@ impl CbindgenBuilder {
             },
             None => ErrRoute::Panic,
         };
-        let (in_params, decodes, call_args) =
-            self.emit_inputs(orig, f, registry, &input_route, emit);
+        let (in_params, decodes, call_args) = self.emit_planned_inputs(orig, f, &input_route, emit);
         let call = quote!(#call_path(#(#call_args),*));
 
         let e_param = err_bits
@@ -634,8 +709,11 @@ impl CbindgenBuilder {
             // No `Result`: straight-line. `void` when there are no fields.
             (None, _) => {
                 if let Some(field0_wire) = field0_wire.as_ref() {
-                    let enc =
-                        self.encode_value(value_ty, quote!(__v), &targets, registry, &input_route);
+                    let enc = value_site.map_or_else(TokenStream::new, |site| {
+                        site.abi()
+                            .payload()
+                            .encode(quote!(__v), &targets, &input_route)
+                    });
                     quote!(
                         #(#decodes)*
                         let __v = #call;
@@ -654,8 +732,11 @@ impl CbindgenBuilder {
                     .as_ref()
                     .expect("in-band result has a niche")
                     .value;
-                let enc =
-                    self.encode_value(value_ty, quote!(__v), &targets, registry, &input_route);
+                let enc = value_site.map_or_else(TokenStream::new, |site| {
+                    site.abi()
+                        .payload()
+                        .encode(quote!(__v), &targets, &input_route)
+                });
                 quote!(
                     #(#decodes)*
                     match #call {
@@ -669,8 +750,11 @@ impl CbindgenBuilder {
             }
             // `Result` without a free niche: `bool` status, value to out-params.
             (Some((_, e_conv, _)), false) => {
-                let enc =
-                    self.encode_value(value_ty, quote!(__v), &targets, registry, &input_route);
+                let enc = value_site.map_or_else(TokenStream::new, |site| {
+                    site.abi()
+                        .payload()
+                        .encode(quote!(__v), &targets, &input_route)
+                });
                 quote!(
                     #(#decodes)*
                     match #call {
@@ -934,32 +1018,6 @@ impl CbindgenBuilder {
         }
     }
 
-    fn output_is_fallible(&self, ty: &TypeRef) -> bool {
-        // The third walk over the same value, and it stops where the other two
-        // do: a node with a wire of its own is encoded by its own converter, so
-        // whether the encode can fail is THAT converter's answer. Peeling past
-        // it asks about a converter that never runs — which decides whether the
-        // binding needs `.panic()`, so the two disagreeing is a wrapper that
-        // aborts where nothing opted in, or an opt-in demanded for a conversion
-        // that cannot fail (#428 review).
-        if !self.has_own_wire(ty) {
-            let vec_elem = match ty.kind() {
-                TypeKind::Vec(e) => Some(&**e),
-                _ => None,
-            };
-            if let Some(inner) = ty
-                .optional_inner()
-                .or(vec_elem)
-                .or_else(|| r_cow_slice_elem(ty))
-                .or_else(|| r_scalar_slice_elem(ty))
-            {
-                return self.output_is_fallible(inner);
-            }
-        }
-        self.out_frag(ty)
-            .is_some_and(|entry| entry.function.call().fallible())
-    }
-
     /// How one parameter *uses* the resource it names — the axis the alias rule
     /// is stated on. `None` ⇒ the parameter names no single owned resource (a
     /// scalar, a string, a slice block, an undeclared type), so it cannot alias
@@ -1073,104 +1131,66 @@ impl CbindgenBuilder {
     /// argument expressions. Fallible inputs (converter returns `Result<_,
     /// String>`) route their `Err(msg)` per `route`; infallible inputs decode
     /// directly.
-    pub(super) fn emit_inputs(
+    pub(super) fn emit_planned_inputs(
         &self,
         orig: &syn::Ident,
         f: &prebindgen_registry::flat::Function,
-        registry: &Registry,
-        route: &ErrRoute,
+        route: &ErrRoute<'_>,
         emit: &prebindgen_registry::Emit,
     ) -> (Vec<TokenStream>, Vec<TokenStream>, Vec<TokenStream>) {
         let mut params = Vec::new();
-        // The alias preflight runs BEFORE every decode, which is the whole
-        // point: by the time the first converter has run, one of the aliased
-        // arguments has already been consumed.
         let mut decodes: Vec<TokenStream> = self.alias_preflight(f, route).into_iter().collect();
         let mut call_args = Vec::new();
 
-        for param in &f.params {
+        for (index, param) in f.params.iter().enumerate() {
             let ident = &param.name;
-            let arg_reading = &param.ty;
-            let arg_ty = &emit.spell_ty(arg_reading);
-
-            // `&[E]` slice (scalar `E`): two wire params (`*const E`, `usize`),
-            // decoded zero-copy. NULL pointer ⇒ empty slice (not an error).
-            if let Some(elem) = r_scalar_slice_elem(arg_reading).map(|t| spelled(t, emit)) {
-                let len_id = format_ident!("{}_len", ident);
-                params.push(quote!(#ident: *const #elem));
-                params.push(quote!(#len_id: usize));
-                decodes.push(quote!(
-                    let #ident: &[#elem] = if #ident.is_null() {
-                        &[]
+            let site =
+                self.generation_site(orig, prebindgen_registry::recipe::Role::Param { index });
+            match site.abi().payload() {
+                crate::compile::CValue::BorrowedInput {
+                    element,
+                    wire,
+                    reinterpret,
+                } => {
+                    let len_id = format_ident!("{}_len", ident);
+                    let source = self.src_ty(&spelled(element, emit));
+                    params.push(quote!(#ident: #wire));
+                    params.push(quote!(#len_id: usize));
+                    let from_parts = if *reinterpret {
+                        quote!(::core::slice::from_raw_parts(
+                            #ident as *const #source,
+                            #len_id,
+                        ))
                     } else {
-                        ::core::slice::from_raw_parts(#ident, #len_id)
+                        quote!(::core::slice::from_raw_parts(#ident, #len_id))
                     };
-                ));
-                call_args.push(quote!(#ident));
-                continue;
-            }
-
-            // `&[E]` slice (inline-opaque by-value `E`, e.g. a `repr_c_struct`):
-            // two wire params (`*const E_counterpart`, `usize`), reinterpreted to
-            // `&[E]` zero-copy. The counterpart is layout-identical to `E` (asserted
-            // by a generated `const _`), so the whole block transmutes in one shot —
-            // the slice analogue of the single-`&E` `__cbg_in_*` converter. NULL ⇒
-            // empty slice.
-            if let Some(elem) = self
-                .r_value_opaque_slice_elem(arg_reading)
-                .map(|t| spelled(t, emit))
-            {
-                // The C wire element is the inline-opaque counterpart (e.g. the
-                // generated `payload_t` mirror), layout-identical to the Rust value.
-                let elem_wire = self
-                    .value_opaque_ty(&elem)
-                    .expect("value_opaque_slice_elem guaranteed a value_opaque element")
-                    .clone();
-                let src = self.src_ty(&elem);
-                let len_id = format_ident!("{}_len", ident);
-                params.push(quote!(#ident: *const #elem_wire));
-                params.push(quote!(#len_id: usize));
-                decodes.push(quote!(
-                    let #ident: &[#src] = if #ident.is_null() {
-                        &[]
+                    decodes.push(quote!(
+                        let #ident: &[#source] = if #ident.is_null() {
+                            &[]
+                        } else {
+                            #from_parts
+                        };
+                    ));
+                }
+                crate::compile::CValue::Direct {
+                    wire, converter, ..
+                } => {
+                    let conv = converter.ident();
+                    params.push(quote!(#ident: #wire));
+                    if converter.fallible() {
+                        let on_err = route_message(route);
+                        decodes.push(quote!(
+                            let #ident = match #conv(#ident) {
+                                ::core::result::Result::Ok(__v) => __v,
+                                ::core::result::Result::Err(__msg) => { #on_err }
+                            };
+                        ));
                     } else {
-                        ::core::slice::from_raw_parts(#ident as *const #src, #len_id)
-                    };
-                ));
-                call_args.push(quote!(#ident));
-                continue;
+                        decodes.push(quote!(let #ident = #conv(#ident);));
+                    }
+                }
+                _ => panic!("C input site has an output-only ABI plan"),
             }
-
-            let entry = registry
-                .reading_of(arg_ty)
-                .and_then(|tr| self.in_frag(&tr))
-                .unwrap_or_else(|| {
-                    panic!(
-                        "Cbindgen::on_function: input type `{}` of `{}` has no input converter",
-                        TypeKey::from_type(arg_ty),
-                        orig
-                    )
-                });
-            let wire = &entry.destination;
-            let conv = entry.function.call().ident();
-
-            params.push(quote!(#ident: #wire));
-
-            if entry.function.call().fallible() {
-                let on_err = route_message(route);
-                decodes.push(quote!(
-                    let #ident = match #conv(#ident) {
-                        ::core::result::Result::Ok(__v) => __v,
-                        ::core::result::Result::Err(__msg) => { #on_err }
-                    };
-                ));
-            } else {
-                decodes.push(quote!(let #ident = #conv(#ident);));
-            }
-
-            // Each input converter produces exactly the source param type
-            // (`String` by value, `&T` for borrows, owned `T` for consume), so
-            // the decoded binding is passed straight through.
             call_args.push(quote!(#ident));
         }
 

--- a/prebindgen-c/src/emit.rs
+++ b/prebindgen-c/src/emit.rs
@@ -506,7 +506,6 @@ impl CbindgenBuilder {
     pub(super) fn emit_function_wrapper(
         &self,
         f: &prebindgen_registry::flat::Function,
-        _registry: &Registry,
         emit: &prebindgen_registry::Emit,
     ) -> TokenStream {
         let orig = &f.name;

--- a/prebindgen-c/src/lib.rs
+++ b/prebindgen-c/src/lib.rs
@@ -444,7 +444,8 @@ pub struct CbindgenBuilder {
     pub(crate) sources: prebindgen_registry::flat::FlatBuilder,
     /// Every conversion this binding compiled, keyed by crossing.
     ///
-    /// What the emitters ask instead of the converter table. The table can only
+    /// What callback compatibility emission asks instead of the frozen generation
+    /// plan. The table can only
     /// name **one** wire type per crossing, so it stops being able to answer as
     /// soon as a crossing occupies several — and the answer an emitter wants
     /// was always the adapter's own.
@@ -458,6 +459,9 @@ pub struct CbindgenBuilder {
     pub(crate) compiled: std::rc::Rc<
         std::cell::RefCell<prebindgen_registry::recipe::Compiled<crate::compile::CFrag>>,
     >,
+    /// Immutable registry-owned C generation plan for ordinary boundary sites.
+    pub(crate) generation:
+        Option<prebindgen_registry::generation::GenerationPlan<crate::compile::CRepresentation>>,
     /// Every converter artifact this binding planned.
     ///
     /// Filled once by [`Self::build_with`] and handed to `write_rust` directly.

--- a/prebindgen-c/src/tests/boundary_invariants.rs
+++ b/prebindgen-c/src/tests/boundary_invariants.rs
@@ -378,3 +378,40 @@ fn no_raw_pointer_is_dereferenced_without_a_null_check() {
         "expected the corpus to exercise several pointer-reconstituting fns, saw {checked}\n{src}"
     );
 }
+
+#[test]
+fn ordinary_wrapper_rendering_cannot_resume_legacy_planning() {
+    let source = include_str!("../emit.rs");
+    let wrapper = source
+        .split("pub(super) fn emit_function_wrapper")
+        .nth(1)
+        .expect("ordinary wrapper renderer")
+        .split("pub(super) fn lower_shape")
+        .next()
+        .expect("end of ordinary wrapper renderer");
+
+    for forbidden in [
+        "lower_shape(",
+        "encode_value(",
+        "output_is_fallible(",
+        ".in_frag(",
+        ".out_frag(",
+        "registry.",
+    ] {
+        assert!(
+            !wrapper.contains(forbidden),
+            "ordinary wrapper renderer resumed legacy planning through {forbidden}"
+        );
+    }
+    for required in [
+        "generation_site(",
+        "failure_route()",
+        "emit_planned_inputs(",
+        ".encode(",
+    ] {
+        assert!(
+            wrapper.contains(required),
+            "ordinary wrapper renderer stopped consuming frozen plans through {required}"
+        );
+    }
+}

--- a/prebindgen-c/src/tests/boundary_invariants.rs
+++ b/prebindgen-c/src/tests/boundary_invariants.rs
@@ -396,7 +396,6 @@ fn ordinary_wrapper_rendering_cannot_resume_legacy_planning() {
         "output_is_fallible(",
         ".in_frag(",
         ".out_frag(",
-        "registry.",
     ] {
         assert!(
             !wrapper.contains(forbidden),

--- a/prebindgen-c/src/trait_impl.rs
+++ b/prebindgen-c/src/trait_impl.rs
@@ -388,22 +388,26 @@ impl CbindgenBuilder {
     /// rather than by luck, and the composition contracts — a part's type and
     /// how it is held — are what actually run.
     ///
-    /// The plans are discarded. C's per-item emitter still builds each wrapper
-    /// from the converter table, and moving that is a change of its own.
-    fn check_sites<'v>(
+    /// The returned plans become the immutable site store consumed by ordinary
+    /// wrapper emission. Callback delivery is frozen separately in the next stage.
+    fn compile_sites<'v>(
         &'v self,
         compiler: &mut prebindgen_registry::recipe::Compiler<
             '_,
             crate::compile::CCompile<'v, Registry>,
         >,
         registry: &'v Registry,
-    ) -> Result<(), String> {
+    ) -> Result<
+        Vec<prebindgen_registry::generation::SitePlan<crate::compile::CRepresentation>>,
+        String,
+    > {
         use prebindgen_registry::recipe::{Crossing, Direction, Role, Site};
 
         let mut adapter = crate::compile::CCompile {
             gen: self,
             registry,
         };
+        let mut plans = Vec::new();
         let declared = self.declared_functions();
         let mut names: Vec<&syn::Ident> = declared.iter().collect();
         names.sort_by_key(|i| i.to_string());
@@ -417,9 +421,12 @@ impl CbindgenBuilder {
                     role: Role::Param { index },
                 };
                 let crossing = Crossing::new(param.ty.clone(), Direction::Construct);
-                compiler
+                if let Some(plan) = compiler
                     .site(&mut adapter, site, crossing)
-                    .map_err(|e| e.to_string())?;
+                    .map_err(|e| e.to_string())?
+                {
+                    plans.push(plan);
+                }
             }
             // A `Result`'s arms are their own sites; the whole `Result` is not
             // a value C ever holds, so it is not one.
@@ -437,12 +444,15 @@ impl CbindgenBuilder {
                     role,
                 };
                 let crossing = Crossing::new(ty.clone(), Direction::Deconstruct);
-                compiler
+                if let Some(plan) = compiler
                     .site(&mut adapter, site, crossing)
-                    .map_err(|e| e.to_string())?;
+                    .map_err(|e| e.to_string())?
+                {
+                    plans.push(plan);
+                }
             }
         }
-        Ok(())
+        Ok(plans)
     }
 
     /// Which alternative of `key` these parts came from, by matching their
@@ -1543,23 +1553,32 @@ impl CbindgenBuilder {
                 conv.map(|c| prebindgen_registry::Answer::over(c.subs))
             })?
             .build()?;
-        // Every site of every exported function, compiled. Nothing consumes
-        // the plans yet — C's per-item emitter still builds each wrapper — but
-        // it is what makes the contracts a site owns run against real positions
-        // rather than only inside a product. What each one demands is the
-        // target's answer: see `CCompile::tolerates` for why C accepts a
-        // borrowed return where the JVM must not.
-        {
+        // Freeze every ordinary function position and the fragment graph it reaches.
+        let sites = {
             let mut compiler = prebindgen_registry::recipe::Compiler::resume(
                 &model,
                 &recipes,
                 &bindings,
                 self.compiled.borrow().clone(),
             );
-            self.check_sites(&mut compiler, &registry)
+            let sites = self
+                .compile_sites(&mut compiler, &registry)
                 .map_err(|message| prebindgen_registry::ScanError::AdapterInvariant { message })?;
             *self.compiled.borrow_mut() = compiler.finish();
+            sites
+        };
+        let mut generation = prebindgen_registry::generation::GenerationPlanBuilder::new();
+        for fragment in self.compiled.borrow().fragments() {
+            generation.fragment(fragment.freeze());
         }
+        for site in sites {
+            generation.site(site);
+        }
+        self.generation = Some(generation.build().map_err(|errors| {
+            prebindgen_registry::ScanError::AdapterInvariant {
+                message: errors.to_string(),
+            }
+        })?);
         // What the compilation produced, kept for emission and for lookup.
         self.compiled_fns = self
             .compiled
@@ -2095,8 +2114,9 @@ impl CbindgenBuilder {
 /// peels `ty`'s outermost layer and composes the inner's converter; `subs`
 /// lists the immediate inner(s) it looked up.
 impl CbindgenBuilder {
-    /// `&[E]` slice **input**: marker only — the two-param (`*const E_wire`,
-    /// `usize`) lowering is done structurally in `emit_inputs`.
+    /// `&[E]` slice **input**: marker only for converter-artifact compatibility.
+    /// The frozen site plan owns the two-parameter (`*const E_wire`, `usize`)
+    /// ABI and zero-copy decode.
     pub(crate) fn in_slice(&self, ty: &TypeRef) -> Option<ConverterImpl> {
         let e = r_shared_slice_elem(ty)?;
         // #170, the slice instance. The two-param lowering builds the

--- a/prebindgen-c/src/trait_impl.rs
+++ b/prebindgen-c/src/trait_impl.rs
@@ -1904,10 +1904,10 @@ impl Prebindgen for CbindgenBuilder {
     fn on_function(
         &self,
         f: &prebindgen_registry::flat::Function,
-        registry: &Registry,
+        _registry: &Registry,
         emit: &prebindgen_registry::Emit,
     ) -> TokenStream {
-        self.emit_function_wrapper(f, registry, emit)
+        self.emit_function_wrapper(f, emit)
     }
 
     fn on_struct(

--- a/prebindgen-registry/src/generation.rs
+++ b/prebindgen-registry/src/generation.rs
@@ -4,7 +4,9 @@
 //! module can spell it. Adapter-owned associated types describe target
 //! representations and operations; the registry owns identity, composition,
 //! reachability, ordering, and the contracts that can be checked without Rust
-//! source syntax.
+//! source syntax. Those opaque payloads may use syntax for types invented by
+//! the target adapter, such as a C wire type; they must not contain source Rust
+//! syntax obtained by spelling a [`TypeRef`] before final emission.
 
 use std::{
     collections::{HashMap, HashSet},
@@ -158,6 +160,9 @@ impl std::error::Error for IdentityError {}
 ///
 /// Associated values describe semantics, never rendered source items. The
 /// registry compares niche identities and treats every other payload as opaque.
+/// A payload may retain target-language syntax owned by the adapter. Source
+/// Rust syntax remains forbidden until final emission spells an opaque
+/// [`TypeRef`].
 pub trait Representation {
     /// A syntax-free identity for a private Rust carrier in a converter graph.
     type Intermediate: Clone + Eq;


### PR DESCRIPTION
## Summary

- Freeze every declared ordinary C parameter, return, and error position as a registry-owned site plan, backed by validated fragment identities and shape edges.
- Put C application binary interface (ABI) arity, Optional niche/presence layout, Sequence pointer-plus-length layout, converter fallibility, typed error routing, and the no-cleanup policy in adapter payloads on that plan.
- Render ordinary wrappers only from the frozen sites. The renderer cannot receive `&Registry`, and no longer walks `TypeRef` shapes, calls `lower_shape` / `encode_value`, or independently derives fallibility. A seam test guards the remaining legacy entry points that the type boundary cannot exclude.

## Design boundary

This is stage 2 of #513. It migrates ordinary C functions as one complete production path while preserving zero-copy scalar and inline-opaque slice inputs, alias preflight ordering, `MaybeUninit` handling inside composed converters, Optional niche stacking, and `Result` error channels.

This PR consumes the site half of the vocabulary introduced by #521: `SitePlan` ABI payloads, failure routes, and cleanup policy drive ordinary wrappers. C fragment, shape, and converter plans are frozen and registry-validated, but their bridge payloads are not rendered from `FragmentPlan` yet; converter artifacts continue through the existing `chain` renderer until the terminal-codec cutover in stage 7. This PR therefore proves registry-owned site rendering, not the eventual fragment-plan renderer.

Callback delivery still uses the compatibility shape lowering and is intentionally left for stage 3, where callback arguments will reuse these same deconstruct plans. Stages 2 and 3 are one legacy-deletion unit: `lower_shape`, `encode_value`, and their callback marker/query support can only be removed after the callback path moves. The converter-artifact cache also remains until the later terminal-codec and writer cutovers.

Frozen adapter payloads may carry adapter-invented target syntax, such as C wire `syn::Type`s. They still cannot spell source Rust types: source values remain opaque `TypeRef`s until final emission receives `Emit`.

Generated Rust and C artifacts are byte-identical after regeneration; there is no C ABI or behavior change.

## Verification

- `cargo test --workspace` — passed
- `cargo test -p prebindgen-c --lib` — passed, 95 tests
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` — passed
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps` — passed
- `bash examples/regen-check.sh` — passed; committed generated output is byte-identical
- `cargo fmt --all -- --check` — passed
- `git diff --check` — passed

Related to #513 and #506.