### PR TITLE
Freeze JNI generation decisions before rendering

### DIFF
--- a/prebindgen-jni/src/jni/builder.rs
+++ b/prebindgen-jni/src/jni/builder.rs
@@ -172,6 +172,10 @@ impl Default for Declarations {
             local_fns: Vec::new(),
             iface_specs: Default::default(),
             fn_plans: Default::default(),
+            struct_plans: Default::default(),
+            sum_plans: Default::default(),
+            vec_build_plans: Default::default(),
+            generation: None,
         }
     }
 }

--- a/prebindgen-jni/src/jni/compile.rs
+++ b/prebindgen-jni/src/jni/compile.rs
@@ -1876,6 +1876,7 @@ impl<R: Conversions> Compile for JCompile<'_, R> {
                 elem: v.elem,
                 by_ref: v.by_ref,
                 elem_wrappers: v.elem_wrappers,
+                helpers: v.helpers,
             }
         } else if let Some(sp) =
             crate::jni::emit::build_option_scalar_input_plan(ext, ident, reading)
@@ -1887,6 +1888,18 @@ impl<R: Conversions> Compile for JCompile<'_, R> {
             match entry.metadata.projection.as_ref().map(|p| p.kind.clone()) {
                 Some(ProjectionKind::Handle) => InputKind::Handle {
                     direct: entry.metadata.is_direct_handle(),
+                    mode: if reading
+                        .optional_inner()
+                        .is_some_and(|inner| inner.borrow_target().is_some())
+                    {
+                        crate::jni::HandleMode::BorrowNullable
+                    } else if reading.optional_inner().is_some() {
+                        crate::jni::HandleMode::ConsumeNullable
+                    } else if reading.borrow_target().is_some() {
+                        crate::jni::HandleMode::Borrow
+                    } else {
+                        crate::jni::HandleMode::Consume
+                    },
                 },
                 Some(ProjectionKind::Unsigned64) => InputKind::Unsigned64 {
                     niche: entry.metadata.projection.as_ref().and_then(|p| {

--- a/prebindgen-jni/src/jni/emit/struct_out.rs
+++ b/prebindgen-jni/src/jni/emit/struct_out.rs
@@ -121,7 +121,7 @@ pub(crate) fn flatten_struct_encode(
     depth: usize,
     env_expr: &TokenStream,
 ) -> Option<(TokenStream, Vec<EncSlot>)> {
-    let plan = build_struct_plan(ext, registry, s, depth)?;
+    let plan = ext.struct_plan(registry, s, depth)?;
     Some(encode_plan(&plan, access, prefix, depth, env_expr))
 }
 

--- a/prebindgen-jni/src/jni/emit/vec_build.rs
+++ b/prebindgen-jni/src/jni/emit/vec_build.rs
@@ -188,20 +188,23 @@ pub(crate) struct VecBuildHelpers {
     pub plan: FlatInputPlan,
 }
 
-/// Build the helper descriptor for one flattenable element type, or `None` if it
-/// doesn't flatten (caller keeps the `input_vec` path). The base name is derived
-/// from the element's **Kotlin** data-class short name (first char lowercased) so
-/// the generated methods read naturally (`Payload` → `payloadVec`).
+/// During resolution, build the helper descriptor for one flattenable element
+/// type, or `None` if it doesn't flatten (caller keeps the `input_vec` path).
+/// The artifact writers enumerate the frozen generation plan directly; they
+/// cannot call this constructor and resume planning. The base name is derived
+/// from the element's **Kotlin** data-class short name (first char lowercased)
+/// so the generated methods read naturally (`Payload` → `payloadVec`).
 impl Declarations {
     pub(crate) fn vec_build_helpers(
         &self,
         registry: &impl prebindgen_registry::Conversions,
         elem: &TypeRef,
     ) -> Option<std::rc::Rc<VecBuildHelpers>> {
+        assert!(
+            self.generation.is_none(),
+            "Vec helper construction is resolution-only"
+        );
         let key = elem.key();
-        if let Some(generation) = &self.generation {
-            return generation.vec_build(&key);
-        }
         if let Some(hit) = self.vec_build_plans.borrow().get(&key).cloned() {
             return Some(hit);
         }

--- a/prebindgen-jni/src/jni/emit/vec_build.rs
+++ b/prebindgen-jni/src/jni/emit/vec_build.rs
@@ -39,6 +39,9 @@ pub(crate) struct VecBuildElem {
     /// only part a rebuild uses, and it rides in [`InputKind::VecBuild`], whose
     /// size every variant pays.
     pub elem_wrappers: Vec<&'static str>,
+    /// The canonical helper ABI shared by every function using this element
+    /// and by both the Rust and Kotlin synthetic-helper writers.
+    pub helpers: std::rc::Rc<VecBuildHelpers>,
 }
 
 /// `Some(..)` when `arg_ty` is a slice/`Vec` input whose element is a
@@ -147,27 +150,12 @@ pub(crate) fn vec_build_elem(
     // business. `unwrapped` and not `stripped_syntax` because this stays a model
     // node — it still has to answer `key`, `kind` and its own spelling.
     let elem = elem.unwrapped();
-    // The element must flatten; the probe ident is irrelevant here.
-    let plan = build_flat_input_plan(ext, registry, &format_ident!("e"), elem)
-        .ok()
-        .flatten()?;
-    // Recursive/optional element decomposition is intentionally outside this
-    // increment: retain the existing List/JObject collection path rather than
-    // silently changing the Vec helper ABI.
-    if plan.contains_nested
-        || plan.leaves.iter().any(|l| {
-            l.is_present_flag()
-                || l.wire.handle_target.is_some()
-                || l.entry().is_none()
-                || l.wire.staged()
-        })
-    {
-        return None;
-    }
+    let helpers = ext.vec_build_helpers(registry, elem)?;
     Some(VecBuildElem {
         elem: elem.clone(),
         by_ref,
         elem_wrappers,
+        helpers,
     })
 }
 
@@ -181,31 +169,19 @@ pub(crate) fn vec_build_elem(
 /// [`vec_build_elem`] answers with — so `Vec<Payload>` and `Vec<Box<Payload>>`
 /// land on one entry and get one trio, rather than two storages contending for
 /// the name `payloadVec` (#296).
-pub(crate) fn collect_vec_build_elem_types(
-    ext: &Declarations,
-    registry: &Registry,
-) -> Vec<TypeRef> {
-    let declared = ext.declared_functions();
-    let mut seen: std::collections::BTreeMap<String, TypeRef> = std::collections::BTreeMap::new();
-    // Over the model's params, which already carry a reading each — the
-    // `sig.inputs` walk had to re-derive one per argument.
-    for f in registry.flat().functions() {
-        if !declared.contains(&f.name) {
-            continue;
-        }
-        for p in &f.params {
-            if let Some(v) = vec_build_elem(ext, registry, &p.ty) {
-                seen.insert(v.elem.key().as_str().to_string(), v.elem);
-            }
-        }
-    }
-    seen.into_values().collect()
+pub(crate) fn collect_vec_build_helpers(ext: &Declarations) -> Vec<std::rc::Rc<VecBuildHelpers>> {
+    ext.generation
+        .as_deref()
+        .expect("Vec helper emission requires a frozen JNI generation plan")
+        .vec_builds()
 }
 
 /// One element type's `…VecNew/Push/Free` helper trio: the flatten plan whose
 /// leaves are the per-element push params, plus the camelCase base name
 /// (`payloadVec`) the Kotlin methods and Rust JNI symbols share.
 pub(crate) struct VecBuildHelpers {
+    /// Canonical element reading stored by the Rust helper trio.
+    pub elem: TypeRef,
     /// camelCase base, e.g. `"payloadVec"` (Kotlin method = `<base>New/Push/Free`).
     pub base: String,
     /// Element flatten plan (built with the synthetic param ident `e`).
@@ -216,40 +192,53 @@ pub(crate) struct VecBuildHelpers {
 /// doesn't flatten (caller keeps the `input_vec` path). The base name is derived
 /// from the element's **Kotlin** data-class short name (first char lowercased) so
 /// the generated methods read naturally (`Payload` → `payloadVec`).
-pub(crate) fn vec_build_helpers(
-    ext: &Declarations,
-    registry: &Registry,
-    elem: &TypeRef,
-) -> Option<VecBuildHelpers> {
-    let plan = build_flat_input_plan(ext, registry, &format_ident!("e"), elem)
-        .ok()
-        .flatten()?;
-    if plan.contains_nested
-        || plan.leaves.iter().any(|l| {
-            l.is_present_flag()
-                || l.wire.handle_target.is_some()
-                || l.entry().is_none()
-                || l.wire.staged()
-        })
-    {
-        return None;
+impl Declarations {
+    pub(crate) fn vec_build_helpers(
+        &self,
+        registry: &impl prebindgen_registry::Conversions,
+        elem: &TypeRef,
+    ) -> Option<std::rc::Rc<VecBuildHelpers>> {
+        let key = elem.key();
+        if let Some(generation) = &self.generation {
+            return generation.vec_build(&key);
+        }
+        if let Some(hit) = self.vec_build_plans.borrow().get(&key).cloned() {
+            return Some(hit);
+        }
+        let plan = build_flat_input_plan(self, registry, &format_ident!("e"), elem)
+            .ok()
+            .flatten()?;
+        if plan.contains_nested
+            || plan.leaves.iter().any(|l| {
+                l.is_present_flag()
+                    || l.wire.handle_target.is_some()
+                    || l.entry().is_none()
+                    || l.wire.staged()
+            })
+        {
+            return None;
+        }
+        let kt_fqn = self
+            .types
+            .get(&key)
+            .and_then(|c| c.name_spec.as_ref())
+            .map(|s| self.fqn_of(s))?;
+        let short = kt_fqn.rsplit('.').next().unwrap_or(&kt_fqn);
+        let mut chars = short.chars();
+        let base_lc = match chars.next() {
+            Some(f) => format!("{}{}", f.to_lowercase(), chars.as_str()),
+            None => short.to_string(),
+        };
+        let helper = std::rc::Rc::new(VecBuildHelpers {
+            elem: elem.clone(),
+            base: format!("{base_lc}Vec"),
+            plan,
+        });
+        self.vec_build_plans
+            .borrow_mut()
+            .insert(key, helper.clone());
+        Some(helper)
     }
-    let key = elem.key();
-    let kt_fqn = ext
-        .types
-        .get(&key)
-        .and_then(|c| c.name_spec.as_ref())
-        .map(|s| ext.fqn_of(s))?;
-    let short = kt_fqn.rsplit('.').next().unwrap_or(&kt_fqn);
-    let mut chars = short.chars();
-    let base_lc = match chars.next() {
-        Some(f) => format!("{}{}", f.to_lowercase(), chars.as_str()),
-        None => short.to_string(),
-    };
-    Some(VecBuildHelpers {
-        base: format!("{base_lc}Vec"),
-        plan,
-    })
 }
 
 /// Kotlin `external fun` short name for a vec helper (`payloadVecNew`), routed
@@ -284,17 +273,13 @@ fn vec_helper_symbol(ext: &Declarations, base: &str, suffix: &str) -> String {
 /// push loop free of a per-element failure check.
 pub(crate) fn build_vec_build_helper_items(
     ext: &Declarations,
-    registry: &Registry,
     emit: &prebindgen_registry::Emit,
 ) -> Vec<syn::Item> {
     let mut named: Vec<(String, syn::Item)> = Vec::new();
-    for elem_reading in collect_vec_build_elem_types(ext, registry) {
+    for h in collect_vec_build_helpers(ext) {
         // Generated Rust spells `spell()`; the reading is what the plan
         // and the key are taken from.
-        let elem = emit.spell(&elem_reading);
-        let Some(h) = vec_build_helpers(ext, registry, &elem_reading) else {
-            continue;
-        };
+        let elem = emit.spell(&h.elem);
         let new_sym = vec_helper_symbol(ext, &h.base, "New");
         let push_sym = vec_helper_symbol(ext, &h.base, "Push");
         let free_sym = vec_helper_symbol(ext, &h.base, "Free");

--- a/prebindgen-jni/src/jni/emit/wrapper.rs
+++ b/prebindgen-jni/src/jni/emit/wrapper.rs
@@ -218,13 +218,13 @@ pub(crate) fn emit_jni_function_wrapper_with_callee(
     //     value is **returned** directly through its ordinary output
     //     converter — the wrapper behaves exactly like a normal function
     //     whose return type is `convert_out_ty`.
-    let unfold_plan = registry.unfold_plans().get(original_ident);
+    let unfold_plan = plan.unfold.as_ref();
     // Error-position expansion: when the fn returns `Result<T, E>` and an error
     // plan is declared, the **`?`** is applied here — the extern peels the
     // `Result` (Err arm decomposes `E` into the `ze` leaves and invokes the
     // typed DOMAIN handler), and the success path uses `T`'s converter (not the
     // `Result<T, E>` rank-2 wrapper).
-    let error_plan = registry.error_plans().get(original_ident);
+    let error_plan = plan.error.as_ref();
     let is_convert = matches!(&plan.output, FnOutputPlan::Value(v) if v.is_convert);
     // The output converter entry (`None` for callback delivery). The lookup
     // was validated at plan build; re-resolving here keeps the plan free of
@@ -543,11 +543,7 @@ fn emit_input_param(
     // flattened leaves. Decode each leaf with its own converter, run the
     // (pure-Rust) fold to build the value, then pass it to the call.
     let leaf = match &param.form {
-        ParamForm::Expanded(leaves) => {
-            let fold = registry
-                .expansion_plans()
-                .get(&(original_ident.clone(), param.ident.clone()))
-                .expect("ParamForm::Expanded ⇒ expansion plan present");
+        ParamForm::Expanded { plan: fold, leaves } => {
             return emit_expanded_param(ext, registry, fold, leaves, &param.ident, on_err, emit);
         }
         ParamForm::Single(leaf) => &**leaf,
@@ -623,6 +619,7 @@ fn emit_input_param(
             elem,
             by_ref,
             elem_wrappers,
+            ..
         } => {
             // Generated Rust spells the reading's own tokens. This is the
             // CANONICAL element, which is what the helper trio stores — so the
@@ -698,7 +695,7 @@ fn emit_input_param(
         // bound, so non-Clone handles (e.g. `Publisher<'a>`) work too.
         // A null or tagged (closed) pointer — a close that raced past
         // the pre-lock guard — is rejected before any dereference.
-        InputKind::Handle { direct: true }
+        InputKind::Handle { direct: true, .. }
             if !matches!(
                 arg_ty.kind(),
                 prebindgen_registry::flat::TypeKind::Ref { .. }
@@ -986,7 +983,7 @@ pub(crate) fn emit_expanded_param(
         // Direct owned-handle leaf (e.g. an identity-variant `T`): consume the
         // jlong handle inline, mirroring the normal by-value-handle path —
         // including its null/tagged (closed) pointer guard.
-        let is_consume = matches!(classified.kind, InputKind::Handle { direct: true })
+        let is_consume = matches!(classified.kind, InputKind::Handle { direct: true, .. })
             && !matches!(
                 leaf_ty.kind(),
                 prebindgen_registry::flat::TypeKind::Ref { .. }

--- a/prebindgen-jni/src/jni/fn_plan.rs
+++ b/prebindgen-jni/src/jni/fn_plan.rs
@@ -39,6 +39,13 @@ pub(crate) struct JniFunctionPlan {
     /// cannot drift. `None` = the domain channel is underivable (the Rust
     /// emitter panics, the Kotlin renderer skips).
     pub onerror_iface: Option<ErrorIfaces>,
+    /// Registry-resolved output decomposition selected for this function.
+    /// Rust delivery, Kotlin surface/KDoc, and the report all consume this
+    /// owned plan after the registry phase is closed.
+    pub unfold: Option<prebindgen_registry::unfold::UnfoldPlan>,
+    /// Registry-resolved domain-error decomposition selected for this
+    /// function. Rust encoding and every Kotlin artifact share this value.
+    pub error: Option<prebindgen_registry::unfold::UnfoldPlan>,
     pub params: Vec<PlanParam>,
     pub output: FnOutputPlan,
 }
@@ -66,7 +73,13 @@ pub(crate) enum ParamForm {
     /// same recursive data-class probe as ordinary parameters (vec-build
     /// remains a source-parameter-only collection optimization), so all three
     /// sites agree on the leaf wire.
-    Expanded(Vec<PlanLeaf>),
+    Expanded {
+        /// The registry-built constructor plan. Keeping it beside its lowered
+        /// leaves lets Rust reconstruction and Kotlin/report descriptions use
+        /// the same decision after resolution.
+        plan: Box<prebindgen_registry::expand::FoldPlan>,
+        leaves: Vec<PlanLeaf>,
+    },
 }
 
 /// One classified effective parameter (a source param, or one expansion leaf).
@@ -126,6 +139,7 @@ pub(crate) enum InputKind {
         elem: TypeRef,
         by_ref: bool,
         elem_wrappers: Vec<&'static str>,
+        helpers: std::rc::Rc<VecBuildHelpers>,
     },
     /// Bare `Option<primitive>` / `Option<enum>`: a decoupled
     /// `(present: jboolean, value: <wire>)` pair.
@@ -135,12 +149,20 @@ pub(crate) enum InputKind {
     /// Lockable opaque-handle projection (`jlong` wire). `direct` is
     /// [`KotlinMeta::is_direct_handle`] — `true` only for the bare
     /// `T`/`&T` shape, the by-value consume fast-path trigger.
-    Handle { direct: bool },
+    Handle { direct: bool, mode: HandleMode },
     /// Rust `u64`: typed Kotlin `ULong`, raw JNI `Long`. The wrapper passes
     /// the bit-preserving `toLong()` representation and takes no lock.
     Unsigned64 { niche: Option<String> },
     /// Everything else: the resolved entry's converter/wire as-is.
     Plain,
+}
+
+/// Frozen Kotlin ownership/locking mode for an opaque-handle leaf.
+pub(crate) enum HandleMode {
+    Borrow,
+    Consume,
+    BorrowNullable,
+    ConsumeNullable,
 }
 
 /// How the return value crosses the boundary. Mirrors the unfold plan's
@@ -168,6 +190,10 @@ pub(crate) struct UnfoldOutputPlan {
     pub fixed_builder: bool,
     /// `plan.element.is_some()` — whole-element (M4) vs decomposed (M5) fold.
     pub whole_element: bool,
+    /// Declaration-normalized decomposition used by fixed Kotlin
+    /// builder/folder singletons. `None` for a whole-element fold, which has
+    /// no deconstructor declaration.
+    pub decon: Option<std::rc::Rc<prebindgen_registry::unfold::DeconSpec>>,
     /// Kotlin type variable of the wrapper: `None` for a fixed builder,
     /// `"A"` for an `Iterable` fold (bare or `Optional`-wrapped), `"R"`
     /// otherwise.
@@ -469,13 +495,22 @@ impl Declarations {
     /// (an unresolved converter) is passed through — it only occurs at the
     /// validation phase, which reports it and fails `resolve` before any
     /// emitter runs. Same interior-mutable contract as
-    /// [`Declarations::iface_spec`]; drift is guarded externally by the byte-identity
-    /// regen check (a plan change alters generated code).
+    /// [`Declarations::iface_spec`]. Once resolution finishes both memos are
+    /// drained into [`crate::jni::generation::JniGenerationPlan`], so emission
+    /// cannot resume either derivation.
     pub(crate) fn fn_plan(
         &self,
         registry: &Registry,
         f: &prebindgen_registry::flat::Function,
     ) -> Result<std::rc::Rc<JniFunctionPlan>, PlanError> {
+        if let Some(generation) = &self.generation {
+            return Ok(generation.function(&f.name).unwrap_or_else(|| {
+                panic!(
+                    "frozen JNI generation plan has no function entry for `{}`",
+                    f.name
+                )
+            }));
+        }
         if let Some(hit) = self.fn_plans.borrow().get(&f.name).cloned() {
             return Ok(hit);
         }
@@ -498,11 +533,13 @@ impl JniFunctionPlan {
     ) -> Result<Self, PlanError> {
         let jni_method = ext.mangle_jni_method(&kt_snake_to_camel(&f.name.to_string()));
         let native_symbol = ext.native_method_symbol(&jni_method);
+        let unfold = registry.unfold_plans().get(&f.name).cloned();
+        let error = registry.error_plans().get(&f.name).cloned();
         let onerror_iface = onerror_iface_spec(ext, registry, &f.name);
         // Output first: the Rust emitter historically resolved the output
         // before the inputs, so an unresolved-output failure takes precedence
         // over an unresolved-input one.
-        let output = build_output(ext, registry, f)?;
+        let output = build_output(ext, registry, f, unfold.as_ref(), error.as_ref())?;
         let mut params = Vec::new();
         // The element's parameters: each already a name and a `TypeRef`, so
         // there is no `FnArg`/`Pat` destructuring and no position that could
@@ -524,7 +561,10 @@ impl JniFunctionPlan {
                         ext, registry, &leaf.name, &leaf.ty, /*expanded=*/ true, &ident,
                     )?);
                 }
-                ParamForm::Expanded(leaves)
+                ParamForm::Expanded {
+                    plan: Box::new(plan.clone()),
+                    leaves,
+                }
             } else {
                 ParamForm::Single(Box::new(classify_leaf(
                     ext, registry, &ident, &param.ty, /*expanded=*/ false, &ident,
@@ -536,10 +576,12 @@ impl JniFunctionPlan {
             jni_method,
             native_symbol,
             onerror_iface,
+            unfold,
+            error,
             params,
             output,
         };
-        let slots = result.jvm_parameter_slots(ext, registry, f);
+        let slots = result.jvm_parameter_slots(ext);
         if slots > 255 {
             return Err(PlanError::JvmParameterLimit { slots });
         }
@@ -551,16 +593,11 @@ impl JniFunctionPlan {
     pub fn leaves(&self) -> impl Iterator<Item = &PlanLeaf> {
         self.params.iter().flat_map(|p| match &p.form {
             ParamForm::Single(l) => std::slice::from_ref(&**l).iter(),
-            ParamForm::Expanded(ls) => ls.iter(),
+            ParamForm::Expanded { leaves, .. } => leaves.iter(),
         })
     }
 
-    fn jvm_parameter_slots(
-        &self,
-        ext: &Declarations,
-        registry: &Registry,
-        f: &prebindgen_registry::flat::Function,
-    ) -> usize {
+    fn jvm_parameter_slots(&self, ext: &Declarations) -> usize {
         // `JNINative` is a Kotlin object, so its external methods are instance
         // methods and the JVM counts the implicit receiver as one unit.
         let mut slots = 1usize;
@@ -589,7 +626,7 @@ impl JniFunctionPlan {
             FnOutputPlan::Value(_) => 0,
         };
         slots += 1; // binding-error sink
-        if registry.error_plans().contains_key(&f.name) {
+        if self.error.is_some() {
             slots += 1;
         }
         slots
@@ -761,10 +798,11 @@ fn build_output(
     ext: &Declarations,
     registry: &Registry,
     f: &prebindgen_registry::flat::Function,
+    unfold_plan: Option<&prebindgen_registry::unfold::UnfoldPlan>,
+    error_plan: Option<&prebindgen_registry::unfold::UnfoldPlan>,
 ) -> Result<FnOutputPlan, PlanError> {
     use prebindgen_registry::unfold::{Delivery, UnfoldShape};
     let ident = &f.name;
-    let unfold_plan = registry.unfold_plans().get(ident);
 
     // Callback delivery: the return is decomposed to a foreign builder/fold
     // lambda; no output converter runs and the wire is the erased `JObject`.
@@ -792,11 +830,21 @@ fn build_output(
                 .expect("record-built plan carries its DeconId");
             ext.iface_spec(registry, &SpecKey::Builder(decon))
         };
+        let decon = plan.decon.as_ref().map(|id| {
+            std::rc::Rc::new(
+                registry
+                    .decon_plans()
+                    .get(id)
+                    .unwrap_or_else(|| panic!("unfold plan names unknown deconstructor `{id:?}`"))
+                    .clone(),
+            )
+        });
         return Ok(FnOutputPlan::Unfold(UnfoldOutputPlan {
             iterable_fold,
             optional,
             fixed_builder,
             whole_element: plan.element.is_some(),
+            decon,
             generic,
             iface,
         }));
@@ -808,7 +856,6 @@ fn build_output(
     let is_convert = unfold_plan.is_some();
     // The element normalizes an elided return and a written `-> ()` to one
     // `Unit` reading, so there is no `ReturnType` match here.
-    let error_plan = registry.error_plans().get(ident);
     // The `Ok` side off `TypeKind::Fallible`, where `result_ok_type` found the
     // `Result` in a path first.
     let ok_ty = error_plan

--- a/prebindgen-jni/src/jni/fold.rs
+++ b/prebindgen-jni/src/jni/fold.rs
@@ -197,7 +197,7 @@ pub(crate) fn flatten_struct_factory(
     imports: &mut BTreeSet<String>,
     depth: usize,
 ) -> Option<StructFactory> {
-    let plan = build_struct_plan(ext, registry, s, depth)?;
+    let plan = ext.struct_plan(registry, s, depth)?;
     let (params, reconstruct) = factory_from_plan(&plan, prefix, class_name, imports)?;
     Some((params, reconstruct, plan_mints_handle(&plan)))
 }

--- a/prebindgen-jni/src/jni/generation.rs
+++ b/prebindgen-jni/src/jni/generation.rs
@@ -107,10 +107,6 @@ impl JniGenerationPlan {
             .clone()
     }
 
-    pub(crate) fn vec_build(&self, key: &TypeKey) -> Option<Rc<VecBuildHelpers>> {
-        self.vec_builds.get(key).cloned()
-    }
-
     pub(crate) fn sealed_class_plan(
         &self,
         key: &TypeKey,

--- a/prebindgen-jni/src/jni/generation.rs
+++ b/prebindgen-jni/src/jni/generation.rs
@@ -38,6 +38,10 @@ impl JniGenerationPlan {
         // declared data class before the mutable planning store is drained.
         // Planning every source struct would activate converters for types the
         // adapter never declared, changing otherwise unrelated generated Rust.
+        // The panic-backed frozen lookup is sound only while this filter
+        // matches every top-level struct key a writer can request. Nested
+        // layouts are embedded in their parent's `StructPlan`; a nested type
+        // that is independently declared is also enumerated here.
         let data_classes: Vec<_> = decls
             .types
             .iter()
@@ -67,6 +71,8 @@ impl JniGenerationPlan {
                 _ => None,
             })
             .collect();
+        // As with data classes, every writer-visible sealed-class key must be
+        // covered here before lookup becomes panic-backed after the freeze.
         for item in &sealed_classes {
             let _ = decls.sealed_class_plan(registry, item);
         }

--- a/prebindgen-jni/src/jni/generation.rs
+++ b/prebindgen-jni/src/jni/generation.rs
@@ -1,0 +1,134 @@
+//! Immutable JNI generation decisions shared by the Rust and Kotlin writers.
+//!
+//! Resolution may derive function, interface, and whole-value struct plans in
+//! whatever dependency order their converters require. [`JniGenerationPlan`]
+//! is the phase boundary: it drains those mutable planning memos once the
+//! registry is complete, and every artifact writer subsequently reads the same
+//! allocations. A writer cannot create a new ABI, projection, callback
+//! descriptor, expansion, error channel, or struct-leaf layout.
+
+use std::rc::Rc;
+
+use super::*;
+
+/// All cross-artifact JNI decisions frozen at the end of resolution.
+pub(crate) struct JniGenerationPlan {
+    functions: HashMap<syn::Ident, Rc<JniFunctionPlan>>,
+    interfaces: BTreeMap<SpecKey, Arc<IfaceSpec>>,
+    /// Every declared data class is recorded, including an explicit `None` for
+    /// a shape that has no complete whole-value bridge. Recording refusals
+    /// makes the writer a lookup rather than a second attempt at
+    /// classification.
+    structs: HashMap<TypeKey, Option<Rc<StructPlan>>>,
+    sums: HashMap<TypeKey, Rc<crate::jni::kotlin_emit::SealedClassPlan>>,
+    vec_builds: HashMap<TypeKey, Rc<VecBuildHelpers>>,
+}
+
+impl JniGenerationPlan {
+    /// Finish planning and take ownership of every derived memo.
+    pub(crate) fn freeze(decls: &mut Declarations, registry: &Registry) -> Self {
+        assert!(
+            decls.generation.is_none(),
+            "JNI generation plan may be frozen only once"
+        );
+
+        // Whole-value struct plans used to be the remaining independently
+        // rebuilt decision: Rust encoding and Kotlin data/fromParts emission
+        // each called `build_struct_plan`. Populate one answer for every
+        // declared data class before the mutable planning store is drained.
+        // Planning every source struct would activate converters for types the
+        // adapter never declared, changing otherwise unrelated generated Rust.
+        let data_classes: Vec<_> = decls
+            .types
+            .iter()
+            .filter(|(_, cfg)| !cfg.special_decl() && cfg.name_spec.is_some())
+            .filter_map(|(key, _)| {
+                let ident = key.ident()?;
+                registry.flat().struct_type(&ident)
+            })
+            .cloned()
+            .collect();
+        for item in &data_classes {
+            let _ = decls.struct_plan(registry, item, 0);
+        }
+
+        let sealed_classes: Vec<_> = registry
+            .flat()
+            .types()
+            .filter_map(|ty| match ty {
+                prebindgen_registry::flat::Type::Variant(item)
+                    if decls
+                        .types
+                        .get(&item.type_ref().key())
+                        .is_some_and(|cfg| cfg.sum().is_some()) =>
+                {
+                    Some(item.clone())
+                }
+                _ => None,
+            })
+            .collect();
+        for item in &sealed_classes {
+            let _ = decls.sealed_class_plan(registry, item);
+        }
+
+        Self {
+            functions: std::mem::take(decls.fn_plans.get_mut()),
+            interfaces: std::mem::take(decls.iface_specs.get_mut()),
+            structs: std::mem::take(decls.struct_plans.get_mut()),
+            sums: std::mem::take(decls.sum_plans.get_mut()),
+            vec_builds: std::mem::take(decls.vec_build_plans.get_mut()),
+        }
+    }
+
+    pub(crate) fn function(&self, ident: &syn::Ident) -> Option<Rc<JniFunctionPlan>> {
+        self.functions.get(ident).cloned()
+    }
+
+    pub(crate) fn functions(&self) -> Vec<Rc<JniFunctionPlan>> {
+        let mut plans: Vec<_> = self.functions.iter().collect();
+        plans.sort_by_key(|(ident, _)| (*ident).clone());
+        plans.into_iter().map(|(_, plan)| plan.clone()).collect()
+    }
+
+    pub(crate) fn interface(&self, key: &SpecKey) -> Option<Arc<IfaceSpec>> {
+        self.interfaces.get(key).cloned()
+    }
+
+    pub(crate) fn struct_plan(&self, key: &TypeKey) -> Option<Rc<StructPlan>> {
+        self.structs
+            .get(key)
+            .unwrap_or_else(|| panic!("frozen JNI plan has no struct entry for `{key}`"))
+            .clone()
+    }
+
+    pub(crate) fn vec_build(&self, key: &TypeKey) -> Option<Rc<VecBuildHelpers>> {
+        self.vec_builds.get(key).cloned()
+    }
+
+    pub(crate) fn sealed_class_plan(
+        &self,
+        key: &TypeKey,
+    ) -> Rc<crate::jni::kotlin_emit::SealedClassPlan> {
+        self.sums
+            .get(key)
+            .unwrap_or_else(|| panic!("frozen JNI plan has no sealed-class entry for `{key}`"))
+            .clone()
+    }
+
+    pub(crate) fn vec_builds(&self) -> Vec<Rc<VecBuildHelpers>> {
+        let mut plans: Vec<_> = self.vec_builds.values().cloned().collect();
+        plans.sort_by(|a, b| a.elem.key().as_str().cmp(b.elem.key().as_str()));
+        plans
+    }
+
+    #[cfg(test)]
+    pub(crate) fn counts(&self) -> (usize, usize, usize, usize, usize) {
+        (
+            self.functions.len(),
+            self.interfaces.len(),
+            self.structs.len(),
+            self.sums.len(),
+            self.vec_builds.len(),
+        )
+    }
+}

--- a/prebindgen-jni/src/jni/iface.rs
+++ b/prebindgen-jni/src/jni/iface.rs
@@ -1201,20 +1201,6 @@ pub(crate) fn fixed_decon_ids(registry: &impl Conversions) -> std::collections::
     fixed
 }
 
-/// Element type keys whose whole-element fold is fixed (a synthesized
-/// single-leaf `Vec<T>` fold) — the leaf dual of [`fixed_decon_ids`], used
-/// by the declaration emitter for the hoisted appender singleton.
-pub(crate) fn fixed_leaf_element_keys(registry: &Registry) -> std::collections::HashSet<TypeKey> {
-    registry
-        .unfold_plans()
-        .values()
-        .chain(registry.callback_arg_plans().values())
-        .filter(|p| p.fixed_builder)
-        .filter_map(|p| p.element.as_ref())
-        .map(|el| el.key())
-        .collect()
-}
-
 /// Derive the spec for one identity — the SINGLE construction point behind
 /// [`Declarations::iface_spec`]. Any `syn` context is **looked up**, never
 /// rebuilt from the key: `Registry::reading` answers from the type table, and a
@@ -1279,6 +1265,9 @@ impl Declarations {
         registry: &impl Conversions,
         key: &SpecKey,
     ) -> Option<std::sync::Arc<IfaceSpec>> {
+        if let Some(generation) = &self.generation {
+            return generation.interface(key);
+        }
         let hit = self.iface_specs.borrow().get(key).cloned();
         if let Some(hit) = hit {
             #[cfg(debug_assertions)]

--- a/prebindgen-jni/src/jni/kotlin_emit.rs
+++ b/prebindgen-jni/src/jni/kotlin_emit.rs
@@ -58,6 +58,94 @@ pub(crate) struct TypedHandle<'a> {
     pub key: &'a TypeKey,
 }
 
+/// Kotlin-facing payload and ownership decisions for one sealed class,
+/// frozen before any Kotlin artifact is rendered.
+pub(crate) struct SealedClassPlan {
+    pub variants: Vec<SealedVariantPlan>,
+}
+
+pub(crate) struct SealedVariantPlan {
+    pub rust_ident: syn::Ident,
+    pub kotlin_name: String,
+    pub fields: Vec<SealedFieldPlan>,
+}
+
+pub(crate) struct SealedFieldPlan {
+    pub member: syn::Member,
+    pub property: String,
+    pub kotlin: KtType,
+    pub close: Option<FoldStrategy>,
+}
+
+fn sealed_payload_kt_type(
+    ext: &Declarations,
+    sum_name: &syn::Ident,
+    variant: &syn::Ident,
+    prop: &str,
+    field: &prebindgen_registry::flat::Field,
+) -> KtType {
+    let field_ty = &field.ty;
+    let where_ = || format!("sealed_class!({sum_name}) payload `{variant}.{prop}`");
+    let out = ext.out_frag(field_ty).unwrap_or_else(|| {
+        panic!(
+            "{}: `{}` has no resolved OUTPUT converter, so the Kotlin surface for it \
+             cannot be derived — register converters for the payload type before \
+             declaring the sealed class",
+            where_(),
+            field_ty,
+        )
+    });
+
+    if let Some(projection) = out.metadata.projection.clone() {
+        let leaf = projection_leaf_kt(ext, &projection).unwrap_or_else(|| {
+            panic!(
+                "{}: leaf `{}` has no Kotlin FQN registered (ptr_class)",
+                where_(),
+                projection.leaf_key
+            )
+        });
+        return handle_kt_type(&projection.strategy, &leaf);
+    }
+
+    let ty = out.metadata.kotlin_name.clone().unwrap_or_else(|| {
+        panic!(
+            "{}: `{}` has no Kotlin type mapping on its output converter",
+            where_(),
+            field_ty,
+        )
+    });
+    if let Some(inp) = ext.in_frag(field_ty) {
+        if let (Some(in_ty), (Some(a), Some(b))) = (
+            inp.metadata.kotlin_name.clone(),
+            (
+                inp.metadata
+                    .kotlin_name
+                    .as_ref()
+                    .and_then(|t| t.leaf_name())
+                    .map(str::to_string),
+                ty.leaf_name().map(str::to_string),
+            ),
+        ) {
+            assert!(
+                a == b,
+                "{}: the input and output converters for `{}` disagree on its Kotlin \
+                 type (`{}` in, `{}` out) — a sealed class's properties are read by both \
+                 directions, so they must map to one type",
+                where_(),
+                field_ty,
+                in_ty,
+                ty,
+            );
+        }
+    }
+    let primitive_wire = crate::jni::is_jni_primitive(&out.destination);
+    if field_ty.optional_inner().is_some() && !primitive_wire {
+        ty.nullable()
+    } else {
+        ty
+    }
+}
+
 impl super::JniGen {
     /// Unified Kotlin emission — the JNI adapter's second artifact,
     /// alongside [`write_rust`](Self::write_rust). Each per-kind emitter
@@ -77,6 +165,57 @@ impl super::JniGen {
 }
 
 impl Declarations {
+    /// Resolve or look up the one sealed-class plan. Before the freeze this
+    /// classifies payload types and close ownership once; afterwards it can
+    /// only read the immutable generation plan.
+    pub(crate) fn sealed_class_plan(
+        &self,
+        registry: &Registry,
+        sum: &prebindgen_registry::flat::Variant,
+    ) -> std::rc::Rc<SealedClassPlan> {
+        let key = sum.type_ref().key();
+        if let Some(generation) = &self.generation {
+            return generation.sealed_class_plan(&key);
+        }
+        if let Some(hit) = self.sum_plans.borrow().get(&key).cloned() {
+            return hit;
+        }
+        let cfg = self
+            .types
+            .get(&key)
+            .and_then(|cfg| cfg.sum())
+            .unwrap_or_else(|| panic!("`{}` is not declared as a sealed class", sum.name));
+        let variants = sum
+            .alternatives
+            .iter()
+            .map(|alt| SealedVariantPlan {
+                rust_ident: alt.name.clone(),
+                kotlin_name: self.sum_variant_class_name(cfg, &alt.name),
+                fields: alt
+                    .fields
+                    .iter()
+                    .map(|field| {
+                        let member = field.member();
+                        let property = sum_field_prop_name(&member);
+                        SealedFieldPlan {
+                            member,
+                            kotlin: sealed_payload_kt_type(
+                                self, &sum.name, &alt.name, &property, field,
+                            ),
+                            close: crate::jni::struct_plan::type_close_strategy(
+                                self, registry, &field.ty, 0,
+                            ),
+                            property,
+                        }
+                    })
+                    .collect(),
+            })
+            .collect();
+        let plan = std::rc::Rc::new(SealedClassPlan { variants });
+        self.sum_plans.borrow_mut().insert(key, plan.clone());
+        plan
+    }
+
     /// Kotlin emission body — the public entry point is
     /// `JniGen::write_kotlin`, which guarantees the registry
     /// was resolved first.
@@ -648,7 +787,8 @@ impl Declarations {
                 Some((p, c)) => (p.to_string(), c.to_string()),
                 None => (String::new(), kotlin_fqn.clone()),
             };
-            let mut class = self.build_sealed_class(registry, &class_name, sum, sum_cfg);
+            let plan = self.sealed_class_plan(registry, sum);
+            let mut class = self.build_sealed_class(&class_name, sum, sum_cfg, &plan);
             let mut file = KtFile::new(package);
             if let Some(iface) =
                 self.apply_class_interface(key, &mut class, &class_name, &[], Vec::new(), true)
@@ -667,11 +807,18 @@ impl Declarations {
     /// identically.
     fn build_sealed_class(
         &self,
-        registry: &Registry,
         class_name: &str,
         sum: &prebindgen_registry::flat::Variant,
         sum_cfg: &SumConfig,
+        plan: &SealedClassPlan,
     ) -> KtClass {
+        let variants = &plan.variants;
+        assert_eq!(
+            sum.alternatives.len(),
+            variants.len(),
+            "sealed class `{}` model/plan alternative count drifted",
+            sum.name
+        );
         // Everything below comes off the element: `alternatives` for the
         // classes, `Field::member()` for the property names, `docs()` for the
         // prose the source wrote.
@@ -694,13 +841,9 @@ impl Declarations {
         // type changed.
         // A variant closes what its own payload owns; the interface is
         // closeable if any alternative is.
-        let payload_close = |field: &prebindgen_registry::flat::Field| {
-            crate::jni::struct_plan::type_close_strategy(self, registry, &field.ty, 0)
-        };
-        let any_closeable = sum
-            .alternatives
+        let any_closeable = variants
             .iter()
-            .any(|alt| alt.fields.iter().any(|f| payload_close(f).is_some()));
+            .any(|alt| alt.fields.iter().any(|f| f.close.is_some()));
 
         let mut class = KtClass::sealed_interface(class_name)
             .vis(KtVis::Public)
@@ -718,26 +861,28 @@ impl Declarations {
         }
 
         // Nested variant classes, in declaration (tag) order.
-        for alt in &sum.alternatives {
-            let vname = self.sum_variant_class_name(sum_cfg, &alt.name);
+        for (alt, alt_plan) in sum.alternatives.iter().zip(variants) {
+            assert_eq!(alt.name, alt_plan.rust_ident);
+            let vname = &alt_plan.kotlin_name;
             // Payload properties are built first: a `data class` declares its
             // first constructor property at construction, and a payload-free
             // alternative is a `data object` with none at all.
             let mut vprops: Vec<(String, KtType)> = Vec::new();
             let mut vparams: Vec<KtCtorParam> = Vec::new();
             let mut vcloses: Vec<String> = Vec::new();
-            for field in &alt.fields {
-                let prop = sum_field_prop_name(&field.member());
-                let ty = self.sum_payload_kt_type(&sum.name, &alt.name, &prop, field);
-                if let Some(strategy) = payload_close(field) {
-                    vcloses.push(render_handle_close(&strategy, &prop));
+            for (field, field_plan) in alt.fields.iter().zip(&alt_plan.fields) {
+                assert_eq!(field.member(), field_plan.member);
+                let prop = field_plan.property.clone();
+                let ty = field_plan.kotlin.clone();
+                if let Some(strategy) = &field_plan.close {
+                    vcloses.push(render_handle_close(strategy, &prop));
                 }
                 vprops.push((prop.clone(), ty.clone()));
                 vparams.push(KtCtorParam::new(&prop, ty).val().vis(KtVis::Public));
             }
             let mut vparams = vparams.into_iter();
             let mut vclass = if alt.is_empty() {
-                KtClass::data_object(&vname)
+                KtClass::data_object(vname)
             } else {
                 let first = vparams.next().unwrap_or_else(|| {
                     panic!(
@@ -746,7 +891,7 @@ impl Declarations {
                         sum.name, alt.name
                     )
                 });
-                KtClass::data(&vname, first)
+                KtClass::data(vname, first)
             }
             .vis(KtVis::Public)
             .implements(KtType::cls(class_name));
@@ -758,7 +903,7 @@ impl Declarations {
             }
             // An array-backed payload (a `Vec<u8>` variant field) compares by
             // identity otherwise — same rule as a data-class property.
-            for m in crate::jni::equality::content_equality_members(&vname, &vprops)
+            for m in crate::jni::equality::content_equality_members(vname, &vprops)
                 .into_iter()
                 .flatten()
             {
@@ -782,7 +927,7 @@ impl Declarations {
         // by side, in the same order both sides enumerate them.
         // No raw-pointer guard here, unlike the data class's `fromParts`. This
         // one's parameters are the variants' **property** types
-        // (`sum_payload_kt_type`), so a handle payload arrives as its typed
+        // (the frozen sealed payload plan), so a handle payload arrives as its typed
         // handle class, never as a `Long` — there is no pointer to forge. The
         // wire-shaped reassembly a sum actually needs is the inlined `when`
         // over the tag that `sum_builder_singleton` emits, not this factory.
@@ -791,25 +936,25 @@ impl Declarations {
             .annotation("JvmStatic")
             .param(KtParam::new("tag", KtType::int()))
             .returns(KtType::cls(class_name));
-        for alt in &sum.alternatives {
-            let vname = self.sum_variant_class_name(sum_cfg, &alt.name);
-            for field in &alt.fields {
-                let prop = sum_field_prop_name(&field.member());
-                let ty = self.sum_payload_kt_type(&sum.name, &alt.name, &prop, field);
-                factory = factory.param(KtParam::new(sum_slot_fragment(&vname, &prop), ty));
+        for (alt, alt_plan) in sum.alternatives.iter().zip(variants) {
+            let vname = &alt_plan.kotlin_name;
+            for (_field, field_plan) in alt.fields.iter().zip(&alt_plan.fields) {
+                let prop = field_plan.property.clone();
+                let ty = field_plan.kotlin.clone();
+                factory = factory.param(KtParam::new(sum_slot_fragment(vname, &prop), ty));
             }
         }
         let mut body = KtCode::new();
         body = body.blk("when (tag) {", |mut w| {
-            for alt in &sum.alternatives {
-                let vname = self.sum_variant_class_name(sum_cfg, &alt.name);
-                let args: Vec<String> = alt
+            for (alt, alt_plan) in sum.alternatives.iter().zip(variants) {
+                let vname = &alt_plan.kotlin_name;
+                let args: Vec<String> = alt_plan
                     .fields
                     .iter()
-                    .map(|f| sum_slot_fragment(&vname, &sum_field_prop_name(&f.member())))
+                    .map(|f| sum_slot_fragment(vname, &f.property))
                     .collect();
                 let ctor = if alt.is_empty() {
-                    vname
+                    vname.clone()
                 } else {
                     format!("{vname}({})", args.join(", "))
                 };
@@ -878,117 +1023,6 @@ impl Declarations {
         match sum_cfg.variant_names.get(&rust) {
             Some(n) => n.clone(),
             None => mangle_kotlin_ident(&rust),
-        }
-    }
-
-    /// Kotlin type of one payload field, derived from the **output**
-    /// converter entry — one direction, authoritatively.
-    ///
-    /// A sealed class is a bidirectional contract: the Rust output encoder
-    /// builds it through `fromParts`, and the Kotlin input destructure reads
-    /// the same properties back out. The property's Kotlin type, its
-    /// nullability and its wire slot are therefore **one** decision, and
-    /// every fact behind it has to come from the same entry — deriving the
-    /// type from whichever direction happens to have resolved while reading
-    /// the wire from the other is how the two flatten paths drift apart.
-    /// Output is the authoritative side because this emitter declares the
-    /// `fromParts` slots the output encoder fills.
-    ///
-    /// So there is deliberately **no** output-then-input fallback here:
-    ///
-    /// * a missing output entry is a generation error naming the payload,
-    ///   rather than a Kotlin surface quietly emitted for a direction that
-    ///   never resolved;
-    /// * an input entry that disagrees on the Kotlin type is a generation
-    ///   error too — that disagreement is exactly the drift the shared plans
-    ///   exist to prevent, and it must surface at the declaration, not as an
-    ///   ABI mismatch at runtime.
-    fn sum_payload_kt_type(
-        &self,
-        sum_name: &syn::Ident,
-        variant: &syn::Ident,
-        prop: &str,
-        field: &prebindgen_registry::flat::Field,
-    ) -> KtType {
-        // The field's own reading: the nullability question below is answered
-        // from `kind`, so a wrapped spelling answers as the bare one does and
-        // nothing is looked up (#275). It is named only in the three panics
-        // below, which is a diagnostic and needs no emission capability.
-        let field_ty = &field.ty;
-        let where_ = || format!("sealed_class!({}) payload `{variant}.{prop}`", sum_name);
-        let out = self.out_frag(&field.ty).unwrap_or_else(|| {
-            panic!(
-                "{}: `{}` has no resolved OUTPUT converter, so the Kotlin surface for it \
-                 cannot be derived — register converters for the payload type before \
-                 declaring the sealed class",
-                where_(),
-                field_ty,
-            )
-        });
-
-        if let Some(h) = out.metadata.projection.clone() {
-            let leaf = projection_leaf_kt(self, &h).unwrap_or_else(|| {
-                panic!(
-                    "{}: leaf `{}` has no Kotlin FQN registered (ptr_class)",
-                    where_(),
-                    h.leaf_key
-                )
-            });
-            return handle_kt_type(&h.strategy, &leaf);
-        }
-
-        let ty = out.metadata.kotlin_name.clone().unwrap_or_else(|| {
-            panic!(
-                "{}: `{}` has no Kotlin type mapping on its output converter",
-                where_(),
-                field_ty,
-            )
-        });
-        // The input side must agree on WHICH TYPE the property is — Kotlin
-        // reads these very properties back when the value crosses the other
-        // way, so a genuine disagreement (`String` in, `Long` out) is drift
-        // that belongs at the declaration.
-        //
-        // Nullability is deliberately excluded from the comparison: the two
-        // directions record it by different conventions. For `Option<T>` the
-        // output converter's name carries the `?` while the input converter's
-        // does not, because the input side expresses absence in the wire (a
-        // boxed value, a present flag, a niche) rather than in the type name.
-        // Comparing the rendered types would reject that legitimate shape —
-        // which is what an `Option<enum>` payload does.
-        if let Some(inp) = self.in_frag(&field.ty) {
-            if let (Some(in_ty), (Some(a), Some(b))) = (
-                inp.metadata.kotlin_name.clone(),
-                (
-                    inp.metadata
-                        .kotlin_name
-                        .as_ref()
-                        .and_then(|t| t.leaf_name())
-                        .map(str::to_string),
-                    ty.leaf_name().map(str::to_string),
-                ),
-            ) {
-                assert!(
-                    a == b,
-                    "{}: the input and output converters for `{}` disagree on its Kotlin \
-                     type (`{}` in, `{}` out) — a sealed class's properties are read by both \
-                     directions, so they must map to one type",
-                    where_(),
-                    field_ty,
-                    in_ty,
-                    ty,
-                );
-            }
-        }
-        // An `Option<T>` payload whose wire is a JNI primitive is encoded as
-        // the bare primitive with a sentinel, exactly as for a data-class
-        // field — the Kotlin type must match that slot. Read from the same
-        // entry the type came from.
-        let primitive_wire = crate::jni::is_jni_primitive(&out.destination);
-        if field.ty.optional_inner().is_some() && !primitive_wire {
-            ty.nullable()
-        } else {
-            ty
         }
     }
 
@@ -1130,151 +1164,132 @@ impl Declarations {
     /// Emit every typed callback `fun interface` the declared functions
     /// reference — impl-`Fn` delivery callbacks, output-expansion builders
     /// and folders, and onError handlers (plus the shared `JniErrorHandler`
-    /// for infallible functions). The function walk only **collects which
-    /// identities are used** (emission stays opt-in: an unused declaration
-    /// emits nothing); each spec is then derived exactly once per identity
-    /// from the declaration's representative plan (`registry.decon_plans`) —
-    /// the same source the native emitters read, so all sites agree by
-    /// construction (no dedup, no signature reconciliation).
+    /// for infallible functions). The immutable generation plan supplies both
+    /// the interface allocation and its fixed-singleton request; this emitter
+    /// only deduplicates identities and renders them.
     pub(crate) fn write_callback_ifaces(&self, registry: &Registry) -> Vec<KtFile> {
-        use prebindgen_registry::unfold::{DeconId, Delivery};
-
-        // Distinct interface identities in use — [`SpecKey`] (`Ord`, so
-        // emission is deterministic). The memo derives each spec from the
-        // key alone, so no side context is carried.
-        let mut uses: BTreeSet<SpecKey> = BTreeSet::new();
-
         /// A hoisted-singleton request emitted alongside an interface: the
         /// `fromParts` builder / folder for a synthesized `data_class`, or the
         /// single-leaf appender for a whole-element leaf fold. The wrapper
         /// references the singleton instead of taking a caller `build`/`fold`.
         enum FixedSingleton {
-            StructBuilder(DeconId),
-            StructFolder(DeconId),
+            StructBuilder(std::rc::Rc<prebindgen_registry::unfold::DeconSpec>),
+            StructFolder(std::rc::Rc<prebindgen_registry::unfold::DeconSpec>),
             /// A decomposed **sum**: the reassembly is a `when` over the tag
             /// picking the live group, not a `fromParts` over a fixed product.
-            SumBuilder(DeconId),
-            SumFolder(DeconId),
+            SumBuilder(std::rc::Rc<prebindgen_registry::unfold::DeconSpec>),
+            SumFolder(std::rc::Rc<prebindgen_registry::unfold::DeconSpec>),
             LeafFolder,
         }
-        // A decomposition is a sum's when it carries the synthesized selector.
-        let is_sum = |d: &DeconId| {
-            registry
-                .decon_plans()
-                .get(d)
-                .is_some_and(|p| is_sum_row(&crate::jni::compile::OutWire::from_leaves(&p.leaves)))
-        };
-
-        // Fixedness sets shared with the memo derivation (`iface.rs`): a
-        // fixed DeconId gets a hoisted `__<Name>Builder` / folder-appender
-        // singleton emitted alongside its interface; a fixed whole-element
-        // key gets the `__<Elem>FolderRaw` appender, the leaf dual.
-        let fixed_decons = fixed_decon_ids(registry);
-        let fixed_leaf_elements = fixed_leaf_element_keys(registry);
-
-        // Walk every declared function — free `.fun`s AND class methods/factories
-        // (`.method`/`.accessor`/`.constructor`): a method can also need a
-        // generated interface (e.g. a `Vec<T>` whole-element folder). The `uses`
-        // map dedups, so an identity shared across positions emits once.
-        let declared_idents: std::collections::BTreeSet<syn::Ident> = self
-            .packages
-            .values()
-            .flat_map(|p| p.functions.iter().map(|e| e.rust_ident.clone()))
-            .chain(
-                self.class_members
-                    .values()
-                    .flatten()
-                    .map(|m| m.rust_ident.clone()),
-            )
-            .collect();
-        for ident in &declared_idents {
-            {
-                // The ELEMENT, so the callback params come off the model's own
-                // classification rather than a second walk of the bounds.
-                let Some(func) = registry.flat().function(&ident) else {
-                    continue;
-                };
-                for p in &func.params {
-                    if let Some(cb_args) = p.ty.callback_args() {
-                        uses.insert(SpecKey::callback(cb_args));
-                    }
+        // The interface allocations and their use-site roles are already in
+        // the frozen function plans. Keep the original `SpecKey` ordering so
+        // freezing changes ownership, not generated declaration order.
+        let mut uses: BTreeMap<SpecKey, (std::sync::Arc<IfaceSpec>, bool, Option<FixedSingleton>)> =
+            BTreeMap::new();
+        let mut add = |key: SpecKey,
+                       spec: std::sync::Arc<IfaceSpec>,
+                       is_error: bool,
+                       fixed: Option<FixedSingleton>| {
+            use std::collections::btree_map::Entry;
+            match uses.entry(key) {
+                Entry::Vacant(entry) => {
+                    entry.insert((spec, is_error, fixed));
                 }
-                if let Some(plan) = registry
-                    .unfold_plans()
-                    .get(&func.name)
-                    .filter(|p| p.delivery == Delivery::Callback)
-                {
-                    let iterable = is_iterable_fold(&plan.shape);
-                    match (iterable, &plan.element, &plan.decon) {
-                        (true, Some(el), _) => {
-                            uses.insert(SpecKey::whole_folder(el));
-                        }
-                        (true, None, Some(d)) => {
-                            uses.insert(SpecKey::Folder(d.clone()));
-                        }
-                        (false, _, Some(d)) => {
-                            uses.insert(SpecKey::Builder(d.clone()));
-                        }
-                        _ => {}
-                    }
-                }
-                match registry.error_plans().get(&func.name) {
-                    Some(ep) => {
-                        let d = ep
-                            .decon
-                            .clone()
-                            .expect("error plans are always record-built (decon is Some)");
-                        uses.insert(SpecKey::Handler(d));
-                    }
-                    None => {
-                        uses.insert(SpecKey::JniErrorHandler);
+                Entry::Occupied(mut entry) => {
+                    let (known_spec, known_error, known_fixed) = entry.get_mut();
+                    debug_assert!(std::sync::Arc::ptr_eq(known_spec, &spec));
+                    *known_error |= is_error;
+                    if known_fixed.is_none() {
+                        *known_fixed = fixed;
                     }
                 }
             }
+        };
+        let generation = self
+            .generation
+            .as_deref()
+            .expect("callback-interface emission requires a frozen JNI plan");
+        for fplan in generation.functions() {
+            for leaf in fplan.leaves() {
+                if let InputKind::Callback { iface: Some(spec) } = &leaf.kind {
+                    let args = leaf
+                        .reading
+                        .callback_args()
+                        .expect("callback ABI leaf carries callback arguments");
+                    add(SpecKey::callback(args), spec.clone(), false, None);
+                }
+            }
+            if let FnOutputPlan::Unfold(output) = &fplan.output {
+                if let Some(spec) = &output.iface {
+                    let fixed = output.fixed_builder.then(|| {
+                        if output.whole_element {
+                            return FixedSingleton::LeafFolder;
+                        }
+                        let unfold = fplan
+                            .unfold
+                            .as_ref()
+                            .expect("unfold output carries its frozen registry plan");
+                        let decon = output
+                            .decon
+                            .clone()
+                            .expect("fixed decomposed output carries its declaration plan");
+                        let sum =
+                            is_sum_row(&crate::jni::compile::OutWire::from_leaves(&unfold.leaves));
+                        match (output.iterable_fold, sum) {
+                            (true, true) => FixedSingleton::SumFolder(decon),
+                            (true, false) => FixedSingleton::StructFolder(decon),
+                            (false, true) => FixedSingleton::SumBuilder(decon),
+                            (false, false) => FixedSingleton::StructBuilder(decon),
+                        }
+                    });
+                    let unfold = fplan
+                        .unfold
+                        .as_ref()
+                        .expect("unfold output carries its frozen registry plan");
+                    let key = if output.iterable_fold {
+                        match (&unfold.element, &unfold.decon) {
+                            (Some(element), _) => SpecKey::whole_folder(element),
+                            (None, Some(decon)) => SpecKey::Folder(decon.clone()),
+                            _ => panic!("iterable output has no interface identity"),
+                        }
+                    } else {
+                        SpecKey::Builder(
+                            unfold
+                                .decon
+                                .clone()
+                                .expect("builder output carries a DeconId"),
+                        )
+                    };
+                    add(key, spec.clone(), false, fixed);
+                }
+            }
+            let ifaces = fplan
+                .onerror_iface
+                .as_ref()
+                .expect("resolved function carries error-channel interfaces");
+            if fplan.error.is_some() {
+                add(
+                    SpecKey::Handler(
+                        fplan
+                            .error
+                            .as_ref()
+                            .and_then(|plan| plan.decon.clone())
+                            .expect("domain error plan carries a DeconId"),
+                    ),
+                    ifaces
+                        .domain
+                        .as_ref()
+                        .expect("frozen domain error plan carries its interface")
+                        .clone(),
+                    true,
+                    None,
+                );
+            } else {
+                add(SpecKey::JniErrorHandler, ifaces.binding.clone(), true, None);
+            }
         }
 
-        uses.into_iter()
-            .filter_map(|u| {
-                // Every spec comes from the SAME memo the wrappers and the
-                // resolve-time trampoline read ([`Declarations::iface_spec`]) —
-                // this site only classifies the extras: `is_error` ⇒ also
-                // emit the zero-alloc capture holder used by the generated
-                // wrappers' error channel; `fixed` carries a
-                // hoisted-singleton request (the `fromParts` builder /
-                // folder-appender for a synthesized `data_class`, or the
-                // single-leaf appender for a fixed whole-element fold).
-                let (is_error, fixed) = match &u {
-                    SpecKey::Callback(_) => (false, None),
-                    SpecKey::Builder(d) => (
-                        false,
-                        fixed_decons.contains(d).then(|| {
-                            if is_sum(d) {
-                                FixedSingleton::SumBuilder(d.clone())
-                            } else {
-                                FixedSingleton::StructBuilder(d.clone())
-                            }
-                        }),
-                    ),
-                    SpecKey::Folder(d) => (
-                        false,
-                        fixed_decons.contains(d).then(|| {
-                            if is_sum(d) {
-                                FixedSingleton::SumFolder(d.clone())
-                            } else {
-                                FixedSingleton::StructFolder(d.clone())
-                            }
-                        }),
-                    ),
-                    SpecKey::WholeFolder(el_key) => (
-                        false,
-                        fixed_leaf_elements
-                            .contains(el_key)
-                            .then_some(FixedSingleton::LeafFolder),
-                    ),
-                    SpecKey::Handler(_) | SpecKey::JniErrorHandler => (true, None),
-                };
-                self.iface_spec(registry, &u).map(|s| (s, is_error, fixed))
-            })
+        uses.into_values()
             .map(|(s, is_error, fixed)| {
                 // A **fixed** builder/folder has no user-facing side: the only
                 // implementation is the hoisted singleton emitted below, which
@@ -1331,10 +1346,10 @@ impl Declarations {
                 if let Some(fixed) = fixed {
                     let decl = match fixed {
                         FixedSingleton::StructBuilder(decon) => {
-                            self.value_struct_builder_singleton(registry, &s, &decon)
+                            self.value_struct_builder_singleton(&s, &decon)
                         }
                         FixedSingleton::StructFolder(decon) => {
-                            self.value_struct_folder_singleton(registry, &s, &decon)
+                            self.value_struct_folder_singleton(&s, &decon)
                         }
                         FixedSingleton::SumBuilder(decon) => {
                             self.sum_builder_singleton(registry, &s, &decon)
@@ -1362,11 +1377,10 @@ impl Declarations {
     /// positionally with `fromParts`.
     fn value_struct_builder_singleton(
         &self,
-        registry: &Registry,
         spec: &crate::jni::IfaceSpec,
-        decon: &prebindgen_registry::unfold::DeconId,
+        decon: &prebindgen_registry::unfold::DeconSpec,
     ) -> KtDecl {
-        let source = &registry.decon_plans()[decon].source;
+        let source = &decon.source;
         let class_fqn = self
             .kotlin_fqn(&source.key())
             .unwrap_or_else(|| panic!("value-struct builder: no Kotlin FQN for {}", source.key()));
@@ -1409,11 +1423,10 @@ impl Declarations {
     /// `[acc, leaf0, …]`; `fromParts` takes the element leaves (all but `acc`).
     fn value_struct_folder_singleton(
         &self,
-        registry: &Registry,
         spec: &crate::jni::IfaceSpec,
-        decon: &prebindgen_registry::unfold::DeconId,
+        decon: &prebindgen_registry::unfold::DeconSpec,
     ) -> KtDecl {
-        let source = &registry.decon_plans()[decon].source;
+        let source = &decon.source;
         let class_fqn = self
             .kotlin_fqn(&source.key())
             .unwrap_or_else(|| panic!("value-struct folder: no Kotlin FQN for {}", source.key()));
@@ -1471,9 +1484,8 @@ impl Declarations {
         &self,
         registry: &Registry,
         spec: &crate::jni::IfaceSpec,
-        decon: &prebindgen_registry::unfold::DeconId,
+        plan: &prebindgen_registry::unfold::DeconSpec,
     ) -> KtDecl {
-        let plan = &registry.decon_plans()[decon];
         let mut imports: BTreeSet<String> = BTreeSet::new();
         let names: Vec<String> = spec.params.iter().map(|p| p.name.clone()).collect();
         let (iface_short, when) = self.sum_reconstruct(
@@ -1514,9 +1526,8 @@ impl Declarations {
         &self,
         registry: &Registry,
         spec: &crate::jni::IfaceSpec,
-        decon: &prebindgen_registry::unfold::DeconId,
+        plan: &prebindgen_registry::unfold::DeconSpec,
     ) -> KtDecl {
-        let plan = &registry.decon_plans()[decon];
         let mut imports: BTreeSet<String> = BTreeSet::new();
         let names: Vec<String> = spec.params.iter().map(|p| p.name.clone()).collect();
         let (iface_short, when) = self.sum_reconstruct(
@@ -1960,10 +1971,7 @@ impl Declarations {
         // `external fun` halves of `build_vec_build_helper_items`. Kotlin builds
         // the Rust-side `Vec` by pushing each element's leaves (decoupled raw
         // params), then passes the handle (see `ParamMode::VecBuild`).
-        for elem in crate::jni::collect_vec_build_elem_types(self, registry) {
-            let Some(h) = crate::jni::vec_build_helpers(self, registry, &elem) else {
-                continue;
-            };
+        for h in crate::jni::collect_vec_build_helpers(self) {
             let new_m = crate::jni::vec_helper_method_name(self, &h.base, "New");
             let push_m = crate::jni::vec_helper_method_name(self, &h.base, "Push");
             let free_m = crate::jni::vec_helper_method_name(self, &h.base, "Free");

--- a/prebindgen-jni/src/jni/mod.rs
+++ b/prebindgen-jni/src/jni/mod.rs
@@ -17,6 +17,7 @@
 //   * `kotlin_emit` / `render` / `fold` — the Kotlin source emitters.
 
 mod chain;
+mod generation;
 mod metadata;
 pub(crate) mod wire_access;
 
@@ -855,6 +856,15 @@ impl JniGen {
     pub fn declarations(&self) -> &Declarations {
         &self.decls
     }
+
+    /// The immutable cross-artifact plan shared by Rust and Kotlin emission.
+    #[cfg(test)]
+    pub(crate) fn generation_plan(&self) -> &generation::JniGenerationPlan {
+        self.decls
+            .generation
+            .as_deref()
+            .expect("resolved JniGen has no frozen generation plan")
+    }
 }
 
 /// Everything a binding **declared**, once it is done declaring.
@@ -1069,6 +1079,25 @@ pub struct Declarations {
     /// "derived state, keyed by `(self, registry)`" contract as
     /// [`Self::iface_specs`].
     pub(crate) fn_plans: std::cell::RefCell<HashMap<syn::Ident, std::rc::Rc<JniFunctionPlan>>>,
+
+    /// Whole-value struct layouts accumulated during resolution. The frozen
+    /// generation plan drains this store together with the function and
+    /// interface memos, so Rust and Kotlin cannot rebuild the layout apart.
+    pub(crate) struct_plans: std::cell::RefCell<HashMap<TypeKey, Option<std::rc::Rc<StructPlan>>>>,
+
+    /// Sealed-class payload/ownership layouts accumulated during resolution.
+    pub(crate) sum_plans:
+        std::cell::RefCell<HashMap<TypeKey, std::rc::Rc<kotlin_emit::SealedClassPlan>>>,
+
+    /// Synthetic `Vec<T>` helper ABI plans, interned by canonical element
+    /// type while function sites are compiled and drained into the frozen
+    /// generation plan before any artifact writer runs.
+    pub(crate) vec_build_plans: std::cell::RefCell<HashMap<TypeKey, std::rc::Rc<VecBuildHelpers>>>,
+
+    /// Present only after resolution has finished. All artifact writers reach
+    /// derived JNI decisions through this one immutable store; the mutable
+    /// memos above are empty after it is installed.
+    pub(crate) generation: Option<std::rc::Rc<generation::JniGenerationPlan>>,
 }
 
 /// Describe a JNI binding: state the Kotlin surface, then [`build`](Self::build).

--- a/prebindgen-jni/src/jni/overloads.rs
+++ b/prebindgen-jni/src/jni/overloads.rs
@@ -313,15 +313,21 @@ fn find_block(params: &[KtParam], leaf_names: &[String]) -> Option<usize> {
 /// hard errors — the user explicitly asked to split it).
 fn resolve_split<'a>(
     registry: &'a Registry,
+    fplan: &'a JniFunctionPlan,
     f: &prebindgen_registry::flat::Function,
     sel_fun: &KtFun,
     param_name: &str,
     multi: bool,
 ) -> Split<'a> {
     let param = syn::Ident::new(param_name, Span::call_site());
-    let plan = registry
-        .expansion_plans()
-        .get(&(f.name.clone(), param.clone()))
+    let plan = fplan
+        .params
+        .iter()
+        .find(|planned| planned.ident == param)
+        .and_then(|planned| match &planned.form {
+            ParamForm::Expanded { plan, .. } => Some(plan.as_ref()),
+            ParamForm::Single(_) => None,
+        })
         .unwrap_or_else(|| {
             panic!(
                 "fun!({}).split_on_param(\"{param_name}\"): `{param_name}` is not an expandable \
@@ -433,10 +439,16 @@ pub(crate) fn render_param_overloads(
         }
     }
 
+    let fplan = ext.fn_plan(registry, f).unwrap_or_else(|_| {
+        panic!(
+            "fun!({}): its frozen JNI generation plan is unavailable",
+            f.name
+        )
+    });
     let multi = requested.len() > 1;
     let splits: Vec<Split> = requested
         .iter()
-        .map(|name| resolve_split(registry, f, sel_fun, name, multi))
+        .map(|name| resolve_split(registry, &fplan, f, sel_fun, name, multi))
         .collect();
 
     // Cartesian product of arm indices across all split params.

--- a/prebindgen-jni/src/jni/render.rs
+++ b/prebindgen-jni/src/jni/render.rs
@@ -8,7 +8,6 @@ use kotlin_codegen::{
     KtClass, KtCode, KtCompanion, KtCtorParam, KtEnumEntry, KtFun, KtParam, KtProperty, KtType,
     KtVis,
 };
-use prebindgen_registry::Conversions;
 
 use super::*;
 
@@ -98,15 +97,17 @@ pub(crate) fn build_data_class(
     // factory and the Rust encoder walk. Deriving it separately — a third
     // classification with its own rules — is what let a property's type
     // disagree with its own factory parameter (#156).
-    let plan = build_struct_plan(ext, registry, item_struct, 0).unwrap_or_else(|| {
-        panic!(
-            "data class `{}`: could not classify every field for the fromParts bridge. Each \
+    let plan = ext
+        .struct_plan(registry, item_struct, 0)
+        .unwrap_or_else(|| {
+            panic!(
+                "data class `{}`: could not classify every field for the fromParts bridge. Each \
              field needs a resolved OUTPUT converter (that direction declares the slot the \
              encoder fills) AND the Kotlin metadata that converter carries — a `kotlin_name`, \
              or a registered class for a projection leaf",
-            item_struct.name
-        )
-    });
+                item_struct.name
+            )
+        });
 
     let mut ctor_params: Vec<KtCtorParam> = Vec::new();
     // Property (name, type) pairs, for the content-equality members an
@@ -594,7 +595,7 @@ pub(crate) fn render_extern_decl(
     // erased to `Any` (JObject) on the wire; the wrapper passes a capture for
     // each. A domain plan ⇒ `error_plans` has this fn.
     params.push(KtParam::new("errorSink", KtType::any()));
-    if registry.error_plans().contains_key(&f.name) {
+    if fplan.error.is_some() {
         params.push(KtParam::new("domainSink", KtType::any()));
     }
 
@@ -861,11 +862,10 @@ fn build_wrapper_surface_with_recovery(
         None => kt_snake_to_camel(&f.name.to_string()),
     };
     let jni_call = fplan.jni_method.clone();
-    let (params, receiver_idx) =
-        classify_params(ext, &fplan, registry, &mut body_imports, receiver_key)?;
-    let out = classify_output(ext, f, &fplan, registry, &mut body_imports)?;
+    let (params, receiver_idx) = classify_params(&fplan, &mut body_imports, receiver_key)?;
+    let out = classify_output(ext, &fplan, &mut body_imports)?;
     let r_ty = recovery_return_type(&out, recovery);
-    let sink = error_sink_parts(f, &fplan, registry, &mut body_imports, &r_ty)?;
+    let sink = error_sink_parts(&fplan, &mut body_imports, &r_ty)?;
 
     let mut fun = KtFun::new(&kt_name).vis(KtVis::Public);
     if let Some(g) = &out.generic {
@@ -963,7 +963,8 @@ fn render_wrapper_fn_with_recovery(
     // KDoc: the Rust fn's `///` prose first, then generated notes for every
     // position an expansion reshaped away from the Rust signature (N1).
     // Emission-only — the validator skips it.
-    if let Some(doc) = wrapper_kdoc(f, registry) {
+    let fplan = ext.fn_plan(registry, f).ok()?;
+    if let Some(doc) = wrapper_kdoc(f, &fplan) {
         fun = fun.kdoc(doc);
     }
     // Collect the opaque-handle params so we can scaffold pointer-ordered
@@ -1209,9 +1210,7 @@ struct DomainSink {
 /// instance-method receiver (the first param whose peeled type matches
 /// `receiver_key`), which is bound to `this` and dropped from the signature.
 fn classify_params(
-    ext: &Declarations,
     fplan: &JniFunctionPlan,
-    registry: &Registry,
     imports: &mut BTreeSet<String>,
     receiver_key: Option<&TypeKey>,
 ) -> Option<(Vec<Param>, Option<usize>)> {
@@ -1269,14 +1268,12 @@ fn classify_params(
 
         // Map the plan's crossing form to the Kotlin call-site mode.
         let mode = match &leaf.kind {
-            InputKind::VecBuild { elem, .. } => {
+            InputKind::VecBuild { helpers, .. } => {
                 // Slice/Vec of a flattenable data_class: build the Rust-side
                 // Vec by pushing each element's leaves, pass the handle (see
                 // the body direction + `build_vec_build_helper_items`). The
                 // high-level signature stays `List<T>` (registered below).
-                let h = crate::jni::vec_build_helpers(ext, registry, elem)
-                    .expect("vec_build_elem Some ⇒ vec_build_helpers Some");
-                let elem_accesses = h
+                let elem_accesses = helpers
                     .plan
                     .leaves
                     .iter()
@@ -1284,7 +1281,7 @@ fn classify_params(
                     .map(|l| l.kt_access("__e"))
                     .collect();
                 ParamMode::VecBuild {
-                    base: h.base,
+                    base: helpers.base.clone(),
                     elem_accesses,
                 }
             }
@@ -1342,27 +1339,12 @@ fn classify_params(
                     handles,
                 }
             }
-            InputKind::Handle { .. } => {
-                // Handle → Borrow/Consume by Rust syntactic shape (locked);
-                // `Option<&T>` / by-value `Option<T>` mark the param nullable
-                // and the wrapper body branches on null before lock selection.
-                // Both read off the leaf's own reading — no lookup, and a
-                // wrapped spelling answers as the bare one does.
-                if leaf
-                    .reading
-                    .optional_inner()
-                    .is_some_and(|i| i.borrow_target().is_some())
-                {
-                    ParamMode::BorrowNullable
-                } else if leaf.reading.optional_inner().is_some() {
-                    // by-value `Option<T>` opaque → nullable consume
-                    ParamMode::ConsumeNullable
-                } else if leaf.reading.borrow_target().is_some() {
-                    ParamMode::Borrow
-                } else {
-                    ParamMode::Consume
-                }
-            }
+            InputKind::Handle { mode, .. } => match mode {
+                HandleMode::Borrow => ParamMode::Borrow,
+                HandleMode::Consume => ParamMode::Consume,
+                HandleMode::BorrowNullable => ParamMode::BorrowNullable,
+                HandleMode::ConsumeNullable => ParamMode::ConsumeNullable,
+            },
             InputKind::Unsigned64 { niche } => ParamMode::Unsigned64 {
                 niche: niche.clone(),
             },
@@ -1405,12 +1387,10 @@ fn classify_params(
 /// unchanged).
 fn classify_output(
     ext: &Declarations,
-    f: &prebindgen_registry::flat::Function,
     fplan: &JniFunctionPlan,
-    registry: &Registry,
     imports: &mut BTreeSet<String>,
 ) -> Option<OutputPlan> {
-    let unfold = registry.unfold_plans().get(&f.name);
+    let unfold = fplan.unfold.as_ref();
     // `builder_param` is the trailing **lambda** param (build / fold) as a
     // `(name, function-type)` pair. For the `Iterable` shape, the non-lambda
     // accumulator (`acc: A`) goes in `builder_lead` — it must precede
@@ -1752,9 +1732,7 @@ fn collect_opaques(params: &[Param]) -> Vec<Opaque> {
 /// separate SAM param; the wrapper passes a per-thread capture to the extern,
 /// then after the native call redispatches to whichever channel fired.
 fn error_sink_parts(
-    f: &prebindgen_registry::flat::Function,
     fplan: &JniFunctionPlan,
-    registry: &Registry,
     imports: &mut BTreeSet<String>,
     r_ty: &KtType,
 ) -> Option<ErrorSink> {
@@ -1767,10 +1745,10 @@ fn error_sink_parts(
     // The typed domain channel exists only for a fallible fn with an error
     // plan; when present, both the interface spec and the error plan are.
     let domain = if let Some(domain_spec) = &ifaces.domain {
-        let error_plan = registry
-            .error_plans()
-            .get(&f.name)
-            .expect("domain handler ⇒ error plan");
+        let error_plan = fplan
+            .error
+            .as_ref()
+            .expect("domain handler ⇒ frozen error plan");
         // Per ze leaf: (raw capture Kotlin type, raw→typed wrap). The CAPTURE
         // is the raw twin (what the native side calls); the user's handler is
         // the TYPED interface — the redispatch wraps each raw slot.
@@ -2361,9 +2339,12 @@ pub(crate) fn kt_param_name(rust_ident: &str) -> String {
 /// documenting the REAL prototype after all expansions — one note per
 /// position a plan reshaped, phrased for the caller. `None` for an
 /// undocumented, unshaped fn.
-fn wrapper_kdoc(f: &prebindgen_registry::flat::Function, registry: &Registry) -> Option<String> {
+fn wrapper_kdoc(
+    f: &prebindgen_registry::flat::Function,
+    fplan: &JniFunctionPlan,
+) -> Option<String> {
     let prose = f.docs();
-    let notes = shape_notes(f, registry);
+    let notes = shape_notes(fplan);
     match (prose, notes) {
         (Some(p), Some(n)) => Some(format!("{p}\n\n{n}")),
         (Some(p), None) => Some(p),
@@ -2375,17 +2356,18 @@ fn wrapper_kdoc(f: &prebindgen_registry::flat::Function, registry: &Registry) ->
 /// Caller-facing notes for every boundary position an expansion reshaped:
 /// expanded params (what to pass instead of the Rust argument), decomposed
 /// returns (what the builder/fold receives), and error decompositions
-/// (what `onError` receives). Reads the same resolved plan maps the C7
-/// report uses.
-fn shape_notes(f: &prebindgen_registry::flat::Function, registry: &Registry) -> Option<String> {
-    let fn_ident = &f.name;
+/// (what `onError` receives). Reads the same frozen function plan the report
+/// uses.
+fn shape_notes(fplan: &JniFunctionPlan) -> Option<String> {
     let mut notes: Vec<String> = Vec::new();
 
-    let mut plans: Vec<(&syn::Ident, &prebindgen_registry::expand::FoldPlan)> = registry
-        .expansion_plans()
+    let mut plans: Vec<(&syn::Ident, &prebindgen_registry::expand::FoldPlan)> = fplan
+        .params
         .iter()
-        .filter(|((func, _), _)| func == fn_ident)
-        .map(|((_, param), plan)| (param, plan))
+        .filter_map(|param| match &param.form {
+            ParamForm::Expanded { plan, .. } => Some((&param.ident, plan.as_ref())),
+            ParamForm::Single(_) => None,
+        })
         .collect();
     plans.sort_by_key(|(p, _)| p.to_string());
     for (param, plan) in plans {
@@ -2425,7 +2407,7 @@ fn shape_notes(f: &prebindgen_registry::flat::Function, registry: &Registry) -> 
         ));
     }
 
-    if let Some(plan) = registry.unfold_plans().get(fn_ident) {
+    if let Some(plan) = &fplan.unfold {
         let source = plan.source.to_string();
         let leaves: Vec<&str> = plan.leaves.iter().map(|l| l.name.as_str()).collect();
         match plan.delivery {
@@ -2445,7 +2427,7 @@ fn shape_notes(f: &prebindgen_registry::flat::Function, registry: &Registry) -> 
         }
     }
 
-    if let Some(plan) = registry.error_plans().get(fn_ident) {
+    if let Some(plan) = &fplan.error {
         let source = plan.source.to_string();
         let leaves: Vec<&str> = plan.leaves.iter().map(|l| l.name.as_str()).collect();
         notes.push(format!(

--- a/prebindgen-jni/src/jni/report.rs
+++ b/prebindgen-jni/src/jni/report.rs
@@ -204,15 +204,20 @@ impl super::JniGen {
         let Some(f) = render_wrapper_fn(ext, item_fn, registry, kotlin_name, receiver_key) else {
             return;
         };
+        let fplan = ext
+            .fn_plan(registry, item_fn)
+            .expect("resolved function has a frozen JNI plan");
         out.push_str(&format!("- `{}` — `{}`\n", rust_ident, signature(&f)));
 
         // Param expansions.
         let mut shaped: Vec<String> = Vec::new();
-        let mut plans: Vec<(&syn::Ident, &prebindgen_registry::expand::FoldPlan)> = registry
-            .expansion_plans()
+        let mut plans: Vec<(&syn::Ident, &prebindgen_registry::expand::FoldPlan)> = fplan
+            .params
             .iter()
-            .filter(|((func, _), _)| func == rust_ident)
-            .map(|((_, param), plan)| (param, plan))
+            .filter_map(|param| match &param.form {
+                crate::jni::ParamForm::Expanded { plan, .. } => Some((&param.ident, plan.as_ref())),
+                crate::jni::ParamForm::Single(_) => None,
+            })
             .collect();
         plans.sort_by_key(|(p, _)| p.to_string());
         for (param, plan) in plans {
@@ -230,7 +235,7 @@ impl super::JniGen {
                 variants.join(", ")
             ));
         }
-        if let Some(plan) = registry.unfold_plans().get(rust_ident) {
+        if let Some(plan) = &fplan.unfold {
             let leaves: Vec<&str> = plan.leaves.iter().map(|l| l.name.as_str()).collect();
             shaped.push(format!(
                 "return `{}` decomposed → [{}] ({:?} delivery)",
@@ -239,7 +244,7 @@ impl super::JniGen {
                 plan.delivery
             ));
         }
-        if let Some(plan) = registry.error_plans().get(rust_ident) {
+        if let Some(plan) = &fplan.error {
             let leaves: Vec<&str> = plan.leaves.iter().map(|l| l.name.as_str()).collect();
             shaped.push(format!(
                 "domain error `{}` decomposed → onError [{}] (binding failures → onBindingError)",

--- a/prebindgen-jni/src/jni/struct_plan.rs
+++ b/prebindgen-jni/src/jni/struct_plan.rs
@@ -207,6 +207,30 @@ pub(crate) fn build_struct_plan(
     Some(StructPlan { fields })
 }
 
+impl Declarations {
+    /// The one whole-value struct layout used by Rust encoding and Kotlin
+    /// declaration/factory emission. During resolution it is memoized; after
+    /// resolution the lookup is served exclusively by
+    /// [`crate::jni::generation::JniGenerationPlan`].
+    pub(crate) fn struct_plan(
+        &self,
+        registry: &impl Conversions,
+        s: &prebindgen_registry::flat::Struct,
+        depth: usize,
+    ) -> Option<std::rc::Rc<StructPlan>> {
+        let key = s.type_ref().key();
+        if let Some(generation) = &self.generation {
+            return generation.struct_plan(&key);
+        }
+        if let Some(hit) = self.struct_plans.borrow().get(&key) {
+            return hit.clone();
+        }
+        let plan = build_struct_plan(self, registry, s, depth).map(std::rc::Rc::new);
+        self.struct_plans.borrow_mut().insert(key, plan.clone());
+        plan
+    }
+}
+
 /// True when this plan's flattened `fromParts` takes at least one **raw
 /// native pointer** leaf — an opaque-handle projection, whose wire slot is a
 /// bare `jlong` the factory mints a handle from.

--- a/prebindgen-jni/src/jni/tests/callbacks.rs
+++ b/prebindgen-jni/src/jni/tests/callbacks.rs
@@ -687,12 +687,12 @@ fn iface_spec_memo_shares_one_derivation() {
 }
 
 // ────────────────────────────────────────────────────────────────────────
-// Function-plan memo (the #90 "build once, store" capstone): validation
-// and every emitter share ONE `JniFunctionPlan` per function ident.
+// Frozen generation-plan boundary: resolution drains every mutable planning
+// memo, and every emitter shares the immutable allocations thereafter.
 // ────────────────────────────────────────────────────────────────────────
 
 #[test]
-fn fn_plan_memo_shares_one_derivation() {
+fn generation_plan_freezes_and_drains_derivations() {
     use prebindgen::SourceLocation;
     let loc = myflat_loc();
     let items: Vec<(syn::Item, SourceLocation)> = vec![(
@@ -708,21 +708,31 @@ fn fn_plan_memo_shares_one_derivation() {
     let jni = JniGenBuilder::new()
         .set_package_prefix("io.test.jni")
         .package(crate::package!("thing").fun(prebindgen_registry::fun!(z_do_thing)));
-    // resolve runs validation, which builds and stores every function's plan.
+    // Resolve runs validation, builds every function plan, then freezes and
+    // drains the mutable planning memos before returning the generator.
     let gen = jni.build_with(registry).expect("resolve");
     let (ext, registry) = (gen.declarations(), gen.registry());
     let f = registry.flat().function("z_do_thing").expect("indexed");
 
-    // The plan is already in the memo (populated at resolve by validation) —
-    // repeated lookups return the SAME allocation, and it equals what a fresh
-    // `JniFunctionPlan::build` derives.
+    assert!(ext.fn_plans.borrow().is_empty());
+    assert!(ext.iface_specs.borrow().is_empty());
+    assert!(ext.struct_plans.borrow().is_empty());
+    assert!(ext.sum_plans.borrow().is_empty());
+    assert!(ext.vec_build_plans.borrow().is_empty());
+    let (functions, interfaces, structs, sums, vec_builds) = gen.generation_plan().counts();
+    assert_eq!(functions, 1);
+    assert!(interfaces >= 1, "the binding error interface is frozen");
+    assert_eq!(structs, 0);
+    assert_eq!(sums, 0);
+    assert_eq!(vec_builds, 0);
+
+    // Repeated writer-facing lookups return the same frozen allocation. A
+    // post-freeze fallback derivation would repopulate a memo and fail above.
     let a = ext.fn_plan(registry, f).expect("plan");
     let b = ext.fn_plan(registry, f).expect("plan");
     assert!(std::rc::Rc::ptr_eq(&a, &b), "one plan per function ident");
     assert_eq!(a.native_symbol, b.native_symbol);
-    let fresh = JniFunctionPlan::build(ext, registry, f).expect("fresh build");
-    assert_eq!(a.native_symbol, fresh.native_symbol);
-    assert_eq!(a.jni_method, fresh.jni_method);
+    assert!(ext.fn_plans.borrow().is_empty());
 }
 
 /// A callback identity is the same whether its args come from the **reading**

--- a/prebindgen-jni/src/jni/tests/callbacks.rs
+++ b/prebindgen-jni/src/jni/tests/callbacks.rs
@@ -695,19 +695,43 @@ fn iface_spec_memo_shares_one_derivation() {
 fn generation_plan_freezes_and_drains_derivations() {
     use prebindgen::SourceLocation;
     let loc = myflat_loc();
-    let items: Vec<(syn::Item, SourceLocation)> = vec![(
-        syn::Item::Fn(syn::parse_quote!(
-            pub fn z_do_thing(x: i64) -> i64 {
-                unimplemented!()
-            }
-        )),
-        loc.clone(),
-    )];
+    let items: Vec<(syn::Item, SourceLocation)> = vec![
+        (
+            syn::Item::Struct(syn::parse_quote!(
+                pub struct Record {
+                    pub value: i64,
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Enum(syn::parse_quote!(
+                pub enum Outcome {
+                    Empty,
+                    Value { record: Record },
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn z_do_thing(records: Vec<Record>, outcome: Outcome) -> Outcome {
+                    unimplemented!()
+                }
+            )),
+            loc.clone(),
+        ),
+    ];
     let registry =
         crate::test_util::reg_from_items(declare_referenced(items)).expect("index items");
     let jni = JniGenBuilder::new()
         .set_package_prefix("io.test.jni")
-        .package(crate::package!("thing").fun(prebindgen_registry::fun!(z_do_thing)));
+        .package(
+            crate::package!("thing")
+                .class(crate::data_class!(Record))
+                .class(crate::sealed_class!(Outcome))
+                .fun(prebindgen_registry::fun!(z_do_thing)),
+        );
     // Resolve runs validation, builds every function plan, then freezes and
     // drains the mutable planning memos before returning the generator.
     let gen = jni.build_with(registry).expect("resolve");
@@ -722,17 +746,33 @@ fn generation_plan_freezes_and_drains_derivations() {
     let (functions, interfaces, structs, sums, vec_builds) = gen.generation_plan().counts();
     assert_eq!(functions, 1);
     assert!(interfaces >= 1, "the binding error interface is frozen");
-    assert_eq!(structs, 0);
-    assert_eq!(sums, 0);
-    assert_eq!(vec_builds, 0);
+    assert_eq!(structs, 1);
+    assert_eq!(sums, 1);
+    assert_eq!(vec_builds, 1);
 
     // Repeated writer-facing lookups return the same frozen allocation. A
-    // post-freeze fallback derivation would repopulate a memo and fail above.
+    // post-freeze fallback derivation would repopulate a memo and fail the
+    // final assertions below.
     let a = ext.fn_plan(registry, f).expect("plan");
     let b = ext.fn_plan(registry, f).expect("plan");
     assert!(std::rc::Rc::ptr_eq(&a, &b), "one plan per function ident");
     assert_eq!(a.native_symbol, b.native_symbol);
+
+    // Exercise both artifact writers. None of the recursively used struct,
+    // sum, interface, function, or Vec-helper lookups may resume planning.
+    let dir = unique_test_dir("jnigen_frozen_generation");
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).expect("create generation directory");
+    gen.write_rust(dir.join("generated.rs"))
+        .expect("write frozen Rust plan");
+    gen.write_kotlin(&dir.join("kotlin"))
+        .expect("write frozen Kotlin plan");
+
     assert!(ext.fn_plans.borrow().is_empty());
+    assert!(ext.iface_specs.borrow().is_empty());
+    assert!(ext.struct_plans.borrow().is_empty());
+    assert!(ext.sum_plans.borrow().is_empty());
+    assert!(ext.vec_build_plans.borrow().is_empty());
 }
 
 /// A callback identity is the same whether its args come from the **reading**

--- a/prebindgen-jni/src/jni/trait_impl.rs
+++ b/prebindgen-jni/src/jni/trait_impl.rs
@@ -1607,6 +1607,8 @@ impl JniGenBuilder {
                 )
             })
             .collect();
+        let generation = crate::jni::generation::JniGenerationPlan::freeze(&mut decls, &registry);
+        decls.generation = Some(std::rc::Rc::new(generation));
         Ok(JniGen { decls, registry })
     }
 }
@@ -2226,7 +2228,7 @@ impl Prebindgen for Declarations {
         // Rust-side `Vec` by pushing each element's decoupled leaves, then passes
         // the handle (see `ParamMode::VecBuild`), avoiding per-element
         // `env.get_field(...)` upcalls on the Rust side.
-        items.extend(build_vec_build_helper_items(self, registry, emit));
+        items.extend(build_vec_build_helper_items(self, emit));
         // Expression constants — one nullary JNI getter extern per
         // `PackageDecl::constant_expr`, its value the binding-defined
         // expression evaluated with a glob import of every source module (so


### PR DESCRIPTION
## Summary

- add an immutable `JniGenerationPlan` at the end of JNI resolution and drain the mutable planning memos into it
- make Rust wrappers, Kotlin wrappers and externs, callback interfaces, data/sealed classes, split overloads, reports, and synthetic `Vec` helpers consume the same frozen decisions
- retain the resolved expansion, output/error decomposition, callback ABI, handle mode, struct layout, sealed payload, and helper ABI instead of rescanning registry tables during rendering

## Why

JniGen still had several artifact writers that independently queried or rebuilt resolved information. That left Rust, Kotlin, callback, and report generation able to drift after resolution even though the registry had already selected the conversion chains. Freezing one cross-artifact plan makes resolution the only planning phase and leaves rendering as deterministic assembly.

## Boundary scope

This PR freezes decision ownership, but it deliberately does not yet remove `&Registry` from JNI renderer signatures: phase-dual helpers still branch between planning and frozen lookup. Stages 5 and 6 migrate ordinary and callback representation paths onto registry fragment/site plans; stage 8 removes registry-bearing renderer callbacks and makes the boundary a compile-time signature, matching the C renderer.

This is an internal phase-boundary change. The public generator API is unchanged, and the committed generated Rust and Kotlin output remains byte-for-byte identical.

Part of #513.

## Validation

- `cargo test --workspace`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`
- `bash examples/regen-check.sh`
- `(cd examples/covertest-kotlin && ./gradlew run --console=plain)` — 57 sections passed
