### PR TITLE
Route owned JNI handles through frozen site pipelines

### DIFF
--- a/examples/covertest-kotlin/src/generated_bindings.rs
+++ b/examples/covertest-kotlin/src/generated_bindings.rs
@@ -23906,19 +23906,19 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_summaryTotalRaw<
     static __SINK_MID: ::prebindgen_jni_runtime::CachedIfaceMethod = ::prebindgen_jni_runtime::CachedIfaceMethod::new();
     const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
     const __SINK_DESCR: &str = "(Ljava/lang/String;)Ljava/lang/Object;";
-    if s == 0 || (s & 1) == 1 {
-        signal_binding_error(
-            &mut env,
-            &__error_sink,
-            &__SINK_MID,
-            __SINK_FQN,
-            __SINK_DESCR,
-            "Operation on a closed native handle.",
-        );
-        return 0.0 as jni::sys::jdouble;
-    }
-    let s: perftest_flat::Summary = unsafe {
-        *std::boxed::Box::from_raw(s as *mut perftest_flat::Summary)
+    let s = match jlong_to_Summary_3cb103b9_owned(&mut env, &s) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__e) => {
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e.to_string(),
+            );
+            return 0.0 as jni::sys::jdouble;
+        }
     };
     let __out = perftest_flat::summary_total_raw(s);
     match f64_to_jdouble_9e4a8f70(&mut env, __out) {

--- a/examples/covertest-kotlin/src/generated_bindings.rs
+++ b/examples/covertest-kotlin/src/generated_bindings.rs
@@ -2212,16 +2212,7 @@ pub(crate) unsafe fn JObject_to_CallbackToken_432e8cc0<'env, 'v>(
                     String,
                 >>::from(format!("CallbackToken.ingot: {}", e)))?
         };
-        if __ingot_raw == 0 || (__ingot_raw & 1) == 1 {
-            return ::core::result::Result::Err(
-                <__JniErr as ::core::convert::From<
-                    String,
-                >>::from("Operation on a closed native handle.".to_string()),
-            );
-        }
-        let ingot: perftest_flat::Ingot = unsafe {
-            *std::boxed::Box::from_raw(__ingot_raw as *mut perftest_flat::Ingot)
-        };
+        let ingot = jlong_to_Ingot_020c3a86_owned(env, &__ingot_raw)?;
         perftest_flat::CallbackToken {
             ingot,
         }
@@ -2473,16 +2464,7 @@ pub(crate) unsafe fn JObject_to_Holder_c36a9705<'env, 'v>(
                     String,
                 >>::from(format!("Holder.summary: {}", e)))?
         };
-        if __summary_raw == 0 || (__summary_raw & 1) == 1 {
-            return ::core::result::Result::Err(
-                <__JniErr as ::core::convert::From<
-                    String,
-                >>::from("Operation on a closed native handle.".to_string()),
-            );
-        }
-        let summary: perftest_flat::Summary = unsafe {
-            *std::boxed::Box::from_raw(__summary_raw as *mut perftest_flat::Summary)
-        };
+        let summary = jlong_to_Summary_3cb103b9_owned(env, &__summary_raw)?;
         perftest_flat::Holder {
             tag,
             summary,
@@ -2561,16 +2543,7 @@ pub(crate) unsafe fn JObject_to_Lookup_94ada15e<'env, 'v>(
                             String,
                         >>::from(format!("Lookup.Found.v0: {}", e)))?
                 };
-                if __p_v0_raw == 0 || (__p_v0_raw & 1) == 1 {
-                    return ::core::result::Result::Err(
-                        <__JniErr as ::core::convert::From<
-                            String,
-                        >>::from("Operation on a closed native handle.".to_string()),
-                    );
-                }
-                let __p_v0: perftest_flat::Summary = unsafe {
-                    *std::boxed::Box::from_raw(__p_v0_raw as *mut perftest_flat::Summary)
-                };
+                let __p_v0 = jlong_to_Summary_3cb103b9_owned(env, &__p_v0_raw)?;
                 return ::core::result::Result::Ok(perftest_flat::Lookup::Found(__p_v0));
             }
             if env

--- a/prebindgen-jni/src/jni/compile.rs
+++ b/prebindgen-jni/src/jni/compile.rs
@@ -2077,7 +2077,6 @@ impl<R: Conversions> Compile for JCompile<'_, R> {
         } else {
             match entry.metadata.projection.as_ref().map(|p| p.kind.clone()) {
                 Some(ProjectionKind::Handle) => InputKind::Handle {
-                    direct: entry.metadata.is_direct_handle(),
                     mode: if reading
                         .optional_inner()
                         .is_some_and(|inner| inner.borrow_target().is_some())

--- a/prebindgen-jni/src/jni/emit/flat_input.rs
+++ b/prebindgen-jni/src/jni/emit/flat_input.rs
@@ -69,33 +69,6 @@ pub(crate) fn struct_input_body(
                     let java_path = handle_field_fqn(ext, proj).replace('.', "/");
                     let sig = format!("L{};", java_path);
                     let tmp_ident = format_ident!("__{}_jobj", fname_ident);
-                    // Struct fields are owned, so a non-`Option` handle field
-                    // owns its native object: decode by consuming
-                    // (`Box::from_raw` → owned `T`), mirroring
-                    // `struct_output_body`'s `Box::into_raw`. The borrow
-                    // converter would yield `OwnedObject<T>`, which can't
-                    // populate an owned field. `Option<_>` handle fields keep
-                    // the niche-aware converter (jlong 0 ⇒ `None`).
-                    let field_ty = emit.spell(&field.ty);
-                    let decode = if field_optional {
-                        quote! { let #fname_ident = #field_conv; }
-                    } else {
-                        quote! {
-                            // Null or closed handle in a required field —
-                            // reject before any dereference (`peek()`
-                            // normalizes closed handles to 0).
-                            if #raw_ident == 0 || (#raw_ident & 1) == 1 {
-                                return ::core::result::Result::Err(
-                                    <__JniErr as ::core::convert::From<String>>::from(
-                                        "Operation on a closed native handle.".to_string(),
-                                    ),
-                                );
-                            }
-                            let #fname_ident: #field_ty = unsafe {
-                                *std::boxed::Box::from_raw(#raw_ident as *mut #field_ty)
-                            };
-                        }
-                    };
                     field_preludes.push(quote! {
                         let #tmp_ident: jni::objects::JObject = env.get_field(v, #camel, #sig)
                             .and_then(|val| val.l())
@@ -107,7 +80,7 @@ pub(crate) fn struct_input_body(
                                 .and_then(|val| val.j())
                                 .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(format!(#err_prefix, e)))?
                         };
-                        #decode
+                        let #fname_ident = #field_conv;
                     });
                 }
                 ProjectionKind::Unsigned64 => {
@@ -351,15 +324,8 @@ pub(crate) fn sum_input_body(
             let prop = crate::jni::struct_plan::sum_field_prop_name(&field.member());
             let bind = format_ident!("__p_{}", prop);
             let err_prefix = format!("{enum_name}.{kotlin_name}.{prop}: {{}}");
-            let (pre, value) = read_kotlin_property(
-                ext,
-                &quote!(__obj),
-                &prop,
-                &field.ty,
-                &bind,
-                &err_prefix,
-                emit,
-            )?;
+            let (pre, value) =
+                read_kotlin_property(ext, &quote!(__obj), &prop, &field.ty, &bind, &err_prefix)?;
             preludes.push(pre);
             inits.push(field.bind(&value));
         }
@@ -420,14 +386,13 @@ fn read_kotlin_property(
     reading: &TypeRef,
     bind: &syn::Ident,
     err_prefix: &str,
-    emit: &prebindgen_registry::Emit,
 ) -> Option<(TokenStream, TokenStream)> {
     // The payload's own reading straight to its entry, and the layer questions
     // below asked of it once — `option_inner_type` compared the last path
     // segment, so a payload spelled `Box<Option<T>>` answered "not optional"
     // four separate times here (#289).
     let entry = ext.in_frag(reading)?;
-    let ty = emit.spell(reading);
+    entry.activate();
     let optional = reading.optional_inner().is_some();
     let inner = reading.optional_inner().unwrap_or(reading);
     let wire = entry.destination.clone();
@@ -447,30 +412,6 @@ fn read_kotlin_property(
             let fqn = handle_field_fqn(ext, proj).replace('.', "/");
             let sig = format!("L{fqn};");
             let obj = format_ident!("{}_obj", bind);
-            // A required (non-`Option`) handle payload is OWNED by the variant
-            // it builds, so it is decoded by CONSUMING the native object
-            // (`Box::from_raw`) — the mirror of the output side's
-            // `Box::into_raw`. The borrow converter would yield
-            // `OwnedObject<T>`, which cannot populate an owned field. Same rule
-            // (and same reasoning) as an owned handle field of a data class;
-            // `Option<_>` keeps the niche-aware converter (jlong 0 ⇒ `None`).
-            let closed_msg = "Operation on a closed native handle.";
-            let decode = if optional {
-                quote! { let #bind = #conv; }
-            } else {
-                quote! {
-                    if #raw == 0 || (#raw & 1) == 1 {
-                        return ::core::result::Result::Err(
-                            <__JniErr as ::core::convert::From<String>>::from(
-                                #closed_msg.to_string(),
-                            ),
-                        );
-                    }
-                    let #bind: #ty = unsafe {
-                        *std::boxed::Box::from_raw(#raw as *mut #ty)
-                    };
-                }
-            };
             return Some((
                 quote! {
                     let #obj: jni::objects::JObject = env.get_field(#receiver, #prop, #sig)
@@ -483,7 +424,7 @@ fn read_kotlin_property(
                             .and_then(|val| val.j())
                             .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(format!(#err_prefix, e)))?
                     };
-                    #decode
+                    let #bind = #conv;
                 },
                 quote!(#bind),
             ));

--- a/prebindgen-jni/src/jni/emit/wrapper.rs
+++ b/prebindgen-jni/src/jni/emit/wrapper.rs
@@ -646,45 +646,10 @@ fn emit_input_param(
             (wire_params, prelude, quote!(#arg_ident))
         }
 
-        // By-value `T` opaque-handle parameter: emit the consume
-        // converter inline, bypassing `OwnedObject`. The Java side
-        // holds the handle's monitor and passes the pointer here;
-        // `Box::from_raw` reconstructs the unique owner and `*box`
-        // moves `T` out, dropping the heap allocation. The
-        // unique-ownership invariant is upheld by the Kotlin wrapper
-        // (monitor + tag-bit close in `finally`), which ensures the
-        // same live pointer cannot be passed twice. No `T: Clone`
-        // bound, so non-Clone handles (e.g. `Publisher<'a>`) work too.
-        // A null or tagged (closed) pointer — a close that raced past
-        // the pre-lock guard — is rejected before any dereference.
-        InputKind::Handle { direct: true, .. }
-            if !matches!(
-                arg_ty.kind(),
-                prebindgen_registry::flat::TypeKind::Ref { .. }
-            ) =>
-        {
-            let wire_ident = if matches!(leaf.pipeline.wire(), syn::Type::Ptr(_)) {
-                format_ident!("{}_ptr", arg_ident)
-            } else {
-                arg_ident.clone()
-            };
-            wire_params.push(quote!(#wire_ident: jni::sys::jlong));
-            let arg_ty = emit.spell(arg_ty);
-            prelude.push(quote!(
-                if #wire_ident == 0 || (#wire_ident & 1) == 1 {
-                    signal_binding_error(&mut env, &__error_sink, &__SINK_MID, __SINK_FQN, __SINK_DESCR, "Operation on a closed native handle.");
-                    return #on_err;
-                }
-                let #arg_ident: #arg_ty = unsafe {
-                    *std::boxed::Box::from_raw(#wire_ident as *mut #arg_ty)
-                };
-            ));
-            (wire_params, prelude, quote!(#arg_ident))
-        }
-
-        // Everything else — borrowed/composed handles, value projections,
-        // callbacks, plain types — decodes through the resolved entry's
-        // ordinary converter chain.
+        // Handles, value projections, callbacks, and plain types all decode
+        // through the frozen site pipeline. In particular, a direct owned
+        // handle now reaches the registry-planned `JOwnedHandlePlan`; wrapper
+        // emission no longer repeats its null/tag guard and `Box::from_raw`.
         InputKind::Callback { .. }
         | InputKind::Handle { .. }
         | InputKind::Unsigned64 { .. }
@@ -841,30 +806,6 @@ pub(crate) fn emit_expanded_param(
                         );
                         return #on_err;
                     }
-                };
-            ));
-            leaf_locals.push(local);
-            continue;
-        }
-
-        // Direct owned-handle leaf (e.g. an identity-variant `T`): consume the
-        // jlong handle inline, mirroring the normal by-value-handle path —
-        // including its null/tagged (closed) pointer guard.
-        let is_consume = matches!(classified.kind, InputKind::Handle { direct: true, .. })
-            && !matches!(
-                leaf_ty.kind(),
-                prebindgen_registry::flat::TypeKind::Ref { .. }
-            );
-        if is_consume {
-            let wire_ident = format_ident!("{}_ptr", leaf.name);
-            wire_params.push(quote!(#wire_ident: jni::sys::jlong));
-            prelude.push(quote!(
-                if #wire_ident == 0 || (#wire_ident & 1) == 1 {
-                    signal_binding_error(&mut env, &__error_sink, &__SINK_MID, __SINK_FQN, __SINK_DESCR, "Operation on a closed native handle.");
-                    return #on_err;
-                }
-                let #local: #leaf_ty_tokens = unsafe {
-                    *std::boxed::Box::from_raw(#wire_ident as *mut #leaf_ty_tokens)
                 };
             ));
             leaf_locals.push(local);

--- a/prebindgen-jni/src/jni/fn_plan.rs
+++ b/prebindgen-jni/src/jni/fn_plan.rs
@@ -153,10 +153,10 @@ pub(crate) enum InputKind {
     OptionalPair(crate::jni::compile::OptionalPairPlan),
     /// Flattenable data_class: the field leaves cross as separate wire params.
     FlattenStruct(FlatInputPlan),
-    /// Lockable opaque-handle projection (`jlong` wire). `direct` is
-    /// [`KotlinMeta::is_direct_handle`] — `true` only for the bare
-    /// `T`/`&T` shape, the by-value consume fast-path trigger.
-    Handle { direct: bool, mode: HandleMode },
+    /// Lockable opaque-handle projection (`jlong` wire). Ownership and
+    /// nullability are Kotlin locking policy; Rust conversion is already
+    /// frozen in the leaf pipeline.
+    Handle { mode: HandleMode },
     /// Rust `u64`: typed Kotlin `ULong`, raw JNI `Long`. The wrapper passes
     /// the bit-preserving `toLong()` representation and takes no lock.
     Unsigned64 { niche: Option<String> },

--- a/prebindgen-jni/src/jni/tests/values.rs
+++ b/prebindgen-jni/src/jni/tests/values.rs
@@ -1459,6 +1459,95 @@ fn owned_handle_sites_reuse_the_frozen_pipeline() {
     );
 }
 
+/// A required handle read out of a whole Kotlin object is another owned-input
+/// site. It must call the reached plan instead of emitting a second local
+/// guard and `Box::from_raw`, which also left the reached helper uncalled.
+#[test]
+fn whole_object_handle_field_calls_its_reached_owned_plan() {
+    let loc = myflat_loc();
+    let items = vec![
+        (
+            syn::Item::Struct(syn::parse_quote!(
+                pub struct Token {
+                    _p: u8,
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Struct(syn::parse_quote!(
+                pub struct Container {
+                    pub token: Token,
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn consume_container(container: Container) -> i64 {
+                    unimplemented!()
+                }
+            )),
+            loc,
+        ),
+    ];
+    let registry =
+        crate::test_util::reg_from_items(declare_referenced(items)).expect("index items");
+    let jni = JniGenBuilder::new()
+        .set_package_prefix("io.test.jni")
+        .package(
+            crate::package!()
+                .class(crate::ptr_class!(Token))
+                .class(crate::data_class!(Container).jobject_input())
+                .fun(prebindgen_registry::fun!(consume_container)),
+        );
+    let dir = unique_test_dir("jnigen_whole_object_owned_handle_plan");
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    let generation = jni.build_with(registry).expect("resolve");
+    let rust = std::fs::read_to_string(generation.write_rust(dir.join("gen.rs")).unwrap()).unwrap();
+    let file = syn::parse_file(&rust).expect("generated Rust parses");
+
+    let functions = file.items.iter().filter_map(|item| match item {
+        syn::Item::Fn(function) => Some(function),
+        _ => None,
+    });
+    let helper = functions
+        .clone()
+        .find(|function| {
+            let name = function.sig.ident.to_string();
+            name.starts_with("jlong_to_Token_") && name.ends_with("_owned")
+        })
+        .expect("the reached owned-handle plan must be emitted");
+    let helper_name = helper.sig.ident.to_string();
+    let decoder = functions
+        .clone()
+        .find(|function| {
+            function
+                .sig
+                .ident
+                .to_string()
+                .starts_with("JObject_to_Container_")
+        })
+        .expect("Container whole-object decoder");
+    let decoder_body = quote::ToTokens::to_token_stream(&decoder.block).to_string();
+    assert_eq!(
+        decoder_body.matches(&helper_name).count(),
+        1,
+        "the handle field must call its planned owned converter:\n{rust}"
+    );
+    assert!(
+        !decoder_body.contains("Box :: from_raw"),
+        "whole-object emission must not reconstruct the handle itself:\n{rust}"
+    );
+    let all_rust = quote::ToTokens::to_token_stream(&file).to_string();
+    assert_eq!(
+        all_rust.matches(&helper_name).count(),
+        2,
+        "the emitted helper must have exactly one call site in this fixture:\n{rust}"
+    );
+}
+
 #[test]
 fn recursive_flattening_rejects_jvm_parameter_slot_overflow() {
     let fields = (0..127)

--- a/prebindgen-jni/src/jni/tests/values.rs
+++ b/prebindgen-jni/src/jni/tests/values.rs
@@ -1365,6 +1365,100 @@ fn recursive_flattened_owned_handles_join_lock_and_consume_scaffold() {
     );
 }
 
+/// Direct owned handles in ordinary and constructor-expanded parameter sites
+/// must both call the one registry-planned converter. Reintroducing either
+/// wrapper-local `Box::from_raw` fast path makes this test lose one call.
+#[test]
+fn owned_handle_sites_reuse_the_frozen_pipeline() {
+    let loc = myflat_loc();
+    let items = vec![
+        (
+            syn::Item::Struct(syn::parse_quote!(
+                pub struct Token {
+                    _p: u8,
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn request_new(token: Token) -> Request {
+                    unimplemented!()
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn consume_owned(token: Token, request: Request) -> i64 {
+                    unimplemented!()
+                }
+            )),
+            loc,
+        ),
+    ];
+    let registry =
+        crate::test_util::reg_from_items(declare_referenced(items)).expect("index items");
+    let jni = JniGenBuilder::new()
+        .set_package_prefix("io.test.jni")
+        .package(
+            crate::package!()
+                .class(crate::ptr_class!(Token))
+                .fun(prebindgen_registry::fun!(consume_owned)),
+        )
+        .expand(
+            prebindgen_registry::expand_param!(Request)
+                .variant(prebindgen_registry::fun!(request_new)),
+        );
+    let dir = unique_test_dir("jnigen_owned_handle_site_pipeline");
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    let generation = jni.build_with(registry).expect("resolve");
+    let rust = std::fs::read_to_string(generation.write_rust(dir.join("gen.rs")).unwrap()).unwrap();
+    let file = syn::parse_file(&rust).expect("generated Rust parses");
+
+    let helper = file
+        .items
+        .iter()
+        .filter_map(|item| match item {
+            syn::Item::Fn(function) => Some(function),
+            _ => None,
+        })
+        .find(|function| {
+            let name = function.sig.ident.to_string();
+            name.starts_with("jlong_to_Token_") && name.ends_with("_owned")
+        })
+        .expect("the reached owned-handle plan must be emitted");
+    let helper_name = helper.sig.ident.to_string();
+    let helper_body = quote::ToTokens::to_token_stream(&helper.block).to_string();
+    assert!(
+        helper_body.contains("Box :: from_raw")
+            && helper_body.contains("* v == 0")
+            && helper_body.contains("* v & 1"),
+        "the planned helper owns the consume guard and reconstruction:\n{rust}"
+    );
+
+    let wrapper = file
+        .items
+        .iter()
+        .filter_map(|item| match item {
+            syn::Item::Fn(function) => Some(function),
+            _ => None,
+        })
+        .find(|function| function.sig.ident.to_string().ends_with("_consumeOwned"))
+        .expect("consumeOwned JNI wrapper");
+    let wrapper_body = quote::ToTokens::to_token_stream(&wrapper.block).to_string();
+    assert_eq!(
+        wrapper_body.matches(&helper_name).count(),
+        2,
+        "ordinary and expanded owned-handle sites must call the same planned helper:\n{rust}"
+    );
+    assert!(
+        !wrapper_body.contains("Box :: from_raw"),
+        "wrapper emission must not reconstruct owned handles itself:\n{rust}"
+    );
+}
+
 #[test]
 fn recursive_flattening_rejects_jvm_parameter_slot_overflow() {
     let fields = (0..127)


### PR DESCRIPTION
## Summary

- Route direct owned-handle parameters and constructor-expansion leaves through the frozen `JPipeline` selected during registry-backed site planning.
- Reuse the registry-planned `JOwnedHandlePlan` for null/tag validation and ownership reconstruction; delete both wrapper-local `Box::from_raw` branches and the obsolete `InputKind::Handle.direct` classifier.
- Add seam coverage proving an ordinary owned parameter and an expanded owned leaf call the same emitted helper, while the JNI wrapper performs no ownership reconstruction itself.

This is the next Stage 5 slice of #513 and builds directly on #526.

## Compatibility

- Generated Kotlin and C artifacts, JNI native names/descriptors/signatures, `emitcheck`, and `perftest-kotlin` are byte-for-byte unchanged.
- The only changed generated artifact is `covertest-kotlin/src/generated_bindings.rs`: one JNI extern body now calls the already planned owned-handle helper instead of repeating its guard and `Box::from_raw` inline. The signature, error message, ownership behavior, and sentinel routing are unchanged.
- No benchmarked path changes because the `perftest-kotlin` generated Rust fixture is byte-identical to the base.

## Verification

- `cargo test --workspace --quiet` — passed
- `cargo clippy --workspace --all-targets --all-features -- --deny warnings` — passed
- `cargo +stable fmt --all -- --check` — passed
- `RUSTDOCFLAGS=-Dwarnings cargo doc --workspace --no-deps --quiet` — passed
- `bash examples/regen-check.sh` — passed; committed generated output reproduced byte-for-byte
- `cd examples/covertest-kotlin && ./gradlew run --console=plain` — passed all 57 runtime sections
- `git diff --check` — passed

Related to #506 and #513.