### PR TITLE
Route JNI Vec-handle inputs through frozen site pipelines

### DIFF
--- a/examples/covertest-kotlin/src/generated_bindings.rs
+++ b/examples/covertest-kotlin/src/generated_bindings.rs
@@ -19593,8 +19593,10 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_refVecIdSum<'a>(
     static __SINK_MID: ::prebindgen_jni_runtime::CachedIfaceMethod = ::prebindgen_jni_runtime::CachedIfaceMethod::new();
     const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
     const __SINK_DESCR: &str = "(Ljava/lang/String;)Ljava/lang/Object;";
-    let ps = unsafe { &*(ps_handle as *const Vec<perftest_flat::Payload>) };
-    let __out = perftest_flat::ref_vec_id_sum(ps);
+    let ps = unsafe {
+        OwnedObject::from_raw(ps_handle as *const Vec<perftest_flat::Payload>)
+    };
+    let __out = perftest_flat::ref_vec_id_sum(&ps);
     match i64_to_jlong_fbf9a9bc(&mut env, __out) {
         ::core::result::Result::Ok(__w) => __w,
         ::core::result::Result::Err(__e) => {
@@ -19682,8 +19684,10 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_sliceIdSum<'a>(
     static __SINK_MID: ::prebindgen_jni_runtime::CachedIfaceMethod = ::prebindgen_jni_runtime::CachedIfaceMethod::new();
     const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
     const __SINK_DESCR: &str = "(Ljava/lang/String;)Ljava/lang/Object;";
-    let ps = unsafe { &*(ps_handle as *const Vec<perftest_flat::Payload>) };
-    let __out = perftest_flat::slice_id_sum(ps);
+    let ps = unsafe {
+        OwnedObject::from_raw(ps_handle as *const Vec<perftest_flat::Payload>)
+    };
+    let __out = perftest_flat::slice_id_sum(&ps);
     match i64_to_jlong_fbf9a9bc(&mut env, __out) {
         ::core::result::Result::Ok(__w) => __w,
         ::core::result::Result::Err(__e) => {
@@ -21408,8 +21412,10 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_storagePutSlice<
             return ();
         }
     };
-    let payloads = unsafe { &*(payloads_handle as *const Vec<perftest_flat::Payload>) };
-    let __out = perftest_flat::storage_put_slice(&mut s, payloads);
+    let payloads = unsafe {
+        OwnedObject::from_raw(payloads_handle as *const Vec<perftest_flat::Payload>)
+    };
+    let __out = perftest_flat::storage_put_slice(&mut s, &payloads);
     match unit_to_unit_9ecccf8e(&mut env, __out) {
         ::core::result::Result::Ok(__w) => __w,
         ::core::result::Result::Err(__e) => {

--- a/examples/covertest-kotlin/src/generated_bindings.rs
+++ b/examples/covertest-kotlin/src/generated_bindings.rs
@@ -7,6 +7,7 @@ pub(crate) struct OwnedObject<T: ?Sized> {
 }
 impl<T: ?Sized> std::ops::Deref for OwnedObject<T> {
     type Target = T;
+    #[inline]
     fn deref(&self) -> &Self::Target {
         unsafe { &*self.ptr }
     }

--- a/examples/emitcheck/src/generated_bindings.rs
+++ b/examples/emitcheck/src/generated_bindings.rs
@@ -7,6 +7,7 @@ pub(crate) struct OwnedObject<T: ?Sized> {
 }
 impl<T: ?Sized> std::ops::Deref for OwnedObject<T> {
     type Target = T;
+    #[inline]
     fn deref(&self) -> &Self::Target {
         unsafe { &*self.ptr }
     }

--- a/examples/perftest-kotlin/src/generated_bindings.rs
+++ b/examples/perftest-kotlin/src/generated_bindings.rs
@@ -4423,8 +4423,10 @@ pub unsafe extern "C" fn Java_io_prebindgen_perftest_JNINative_storagePutSlice<'
             return ();
         }
     };
-    let payloads = unsafe { &*(payloads_handle as *const Vec<perftest_flat::Payload>) };
-    let __out = perftest_flat::storage_put_slice(&mut s, payloads);
+    let payloads = unsafe {
+        OwnedObject::from_raw(payloads_handle as *const Vec<perftest_flat::Payload>)
+    };
+    let __out = perftest_flat::storage_put_slice(&mut s, &payloads);
     match unit_to_unit_9ecccf8e(&mut env, __out) {
         ::core::result::Result::Ok(__w) => __w,
         ::core::result::Result::Err(__e) => {

--- a/examples/perftest-kotlin/src/generated_bindings.rs
+++ b/examples/perftest-kotlin/src/generated_bindings.rs
@@ -7,6 +7,7 @@ pub(crate) struct OwnedObject<T: ?Sized> {
 }
 impl<T: ?Sized> std::ops::Deref for OwnedObject<T> {
     type Target = T;
+    #[inline]
     fn deref(&self) -> &Self::Target {
         unsafe { &*self.ptr }
     }

--- a/prebindgen-jni/src/jni/chain.rs
+++ b/prebindgen-jni/src/jni/chain.rs
@@ -265,26 +265,112 @@ impl JChild {
 #[derive(Clone)]
 pub(crate) struct JPipeline {
     wire: syn::Type,
-    child: JChild,
+    body: JPipelineBody,
+}
+
+#[derive(Clone)]
+enum JPipelineBody {
+    Converter(JChild),
+    VecHandle(Box<JVecHandleInput>),
+}
+
+/// A parameter-site ABI that borrows or consumes the transient `Vec<T>` built
+/// by Kotlin's push-helper trio. The site retains model readings and wrapper
+/// policy only; Rust types are spelled when the final wrapper is rendered.
+#[derive(Clone)]
+struct JVecHandleInput {
+    source: TypeRef,
+    elem: TypeRef,
+    by_ref: bool,
+    elem_wrappers: Vec<&'static str>,
 }
 
 impl JPipeline {
     pub(crate) fn new(wire: syn::Type, child: JChild) -> Self {
-        Self { wire, child }
+        Self {
+            wire,
+            body: JPipelineBody::Converter(child),
+        }
+    }
+
+    pub(crate) fn vec_handle(
+        source: TypeRef,
+        elem: TypeRef,
+        by_ref: bool,
+        elem_wrappers: Vec<&'static str>,
+    ) -> Self {
+        Self {
+            wire: syn::parse_quote!(jni::sys::jlong),
+            body: JPipelineBody::VecHandle(Box::new(JVecHandleInput {
+                source,
+                elem,
+                by_ref,
+                elem_wrappers,
+            })),
+        }
     }
 
     pub(crate) fn wire(&self) -> &syn::Type {
         &self.wire
     }
 
-    /// Render the already-planned call graph around `value`.
-    pub(crate) fn invoke(&self, value: TokenStream) -> TokenStream {
-        let call = self.child.invoke_with_env(quote!(&mut env), value);
-        if self.child.stages.is_empty() {
-            call
-        } else {
-            quote!((|| -> ::core::result::Result<_, __JniErr> { #call })())
+    /// Render a site operation that cannot fail. Terminal converters keep
+    /// their `Result` contract; the transient Vec-handle ABI is a direct
+    /// borrow or move and should not acquire an unreachable error branch just
+    /// because it now shares the ordinary decode scaffold.
+    pub(crate) fn invoke_infallible(&self, value: TokenStream, emit: &Emit) -> Option<TokenStream> {
+        match &self.body {
+            JPipelineBody::VecHandle(plan) => Some(plan.invoke(value, emit)),
+            JPipelineBody::Converter(_) => None,
         }
+    }
+
+    /// Render the already-planned call graph around `value`.
+    pub(crate) fn invoke(&self, value: TokenStream, emit: &Emit) -> TokenStream {
+        match &self.body {
+            JPipelineBody::Converter(child) => {
+                let call = child.invoke_with_env(quote!(&mut env), value);
+                if child.stages.is_empty() {
+                    call
+                } else {
+                    quote!((|| -> ::core::result::Result<_, __JniErr> { #call })())
+                }
+            }
+            JPipelineBody::VecHandle(plan) => {
+                let value = plan.invoke(value, emit);
+                quote!(::core::result::Result::<_, __JniErr>::Ok(#value))
+            }
+        }
+    }
+}
+
+impl JVecHandleInput {
+    fn invoke(&self, handle: TokenStream, emit: &Emit) -> TokenStream {
+        let elem = emit.spell_ty(&self.elem);
+        if self.by_ref {
+            return quote!(unsafe {
+                OwnedObject::from_raw(#handle as *const Vec<#elem>)
+            });
+        }
+
+        let taken = quote!(unsafe {
+            ::core::mem::take(&mut *(#handle as *mut Vec<#elem>))
+        });
+        let taken = if self.elem_wrappers.is_empty() {
+            taken
+        } else {
+            let wrapped =
+                super::trait_impl::build_through_wrappers(&self.elem_wrappers, quote!(__e))
+                    .expect("Vec-handle planning accepted this element spelling");
+            quote!(
+                #taken
+                    .into_iter()
+                    .map(|__e| #wrapped)
+                    .collect::<Vec<_>>()
+            )
+        };
+        super::trait_impl::build_through_erased_wrappers(&self.source, taken)
+            .expect("Vec-handle planning accepted this run spelling")
     }
 }
 

--- a/prebindgen-jni/src/jni/compile.rs
+++ b/prebindgen-jni/src/jni/compile.rs
@@ -2054,16 +2054,18 @@ impl<R: Conversions> Compile for JCompile<'_, R> {
 
         let flat_plan = crate::jni::emit::build_flat_input_plan(ext, registry, ident, reading)
             .map_err(|e| plan_error(crate::jni::fn_plan::PlanError::UnflattenableDataClass(e)))?;
+        let mut site_pipeline = None;
         let kind = if let Some(v) = (!expanded)
             .then(|| crate::jni::emit::vec_build_elem(ext, registry, reading))
             .flatten()
         {
-            InputKind::VecBuild {
-                elem: v.elem,
-                by_ref: v.by_ref,
-                elem_wrappers: v.elem_wrappers,
-                helpers: v.helpers,
-            }
+            site_pipeline = Some(crate::jni::chain::JPipeline::vec_handle(
+                reading.clone(),
+                v.elem,
+                v.by_ref,
+                v.elem_wrappers,
+            ));
+            InputKind::VecBuild { helpers: v.helpers }
         } else if bound.recipe.name() == &crate::jni::recipes::pair() {
             let plan = optional_pair_plan(ext, ident, reading, root).ok_or_else(|| {
                 JErr::Refused(format!(
@@ -2131,7 +2133,9 @@ impl<R: Conversions> Compile for JCompile<'_, R> {
             optional,
             as_enum_value,
             enum_niche,
-            pipeline: Self::planned_pipeline(Direction::Construct, bound.crossing.mode(), root),
+            pipeline: site_pipeline.unwrap_or_else(|| {
+                Self::planned_pipeline(Direction::Construct, bound.crossing.mode(), root)
+            }),
             kind,
         })))
     }

--- a/prebindgen-jni/src/jni/emit/convert.rs
+++ b/prebindgen-jni/src/jni/emit/convert.rs
@@ -547,6 +547,7 @@ pub(crate) fn owned_object_prerequisite_items() -> Vec<syn::Item> {
         syn::parse_quote!(
             impl<T: ?Sized> std::ops::Deref for OwnedObject<T> {
                 type Target = T;
+                #[inline]
                 fn deref(&self) -> &Self::Target {
                     unsafe { &*self.ptr }
                 }

--- a/prebindgen-jni/src/jni/emit/wrapper.rs
+++ b/prebindgen-jni/src/jni/emit/wrapper.rs
@@ -4,9 +4,7 @@
 use prebindgen_registry::{types_util::result_ok_type, Conversions};
 
 use super::*;
-use crate::jni::trait_impl::{
-    build_through_erased_wrappers, build_through_wrappers, read_through_erased_wrappers,
-};
+use crate::jni::trait_impl::read_through_erased_wrappers;
 
 pub(crate) fn emit_jni_function_wrapper(
     ext: &Declarations,
@@ -410,7 +408,7 @@ pub(crate) fn emit_jni_function_wrapper_with_callee(
             FnOutputPlan::Value(value) => value,
             FnOutputPlan::Unfold(_) => unreachable!("normal output has a value plan"),
         };
-        let convert = output.pipeline.invoke(quote!(__out));
+        let convert = output.pipeline.invoke(quote!(__out), emit);
         let mut phase: TokenStream = quote! { let __out = #call_expr; };
         phase.extend(quote! {
             match #convert {
@@ -573,78 +571,16 @@ fn emit_input_param(
             (wire_params, prelude, quote!(#arg_ident))
         }
 
-        // per-element `env.get_field(...)`. A borrowed run — `&[T]` or
-        // `&Vec<T>` — borrows the boxed Vec; by-value `Vec<T>` moves it out
-        // with `mem::take` (leaving an empty Vec the Kotlin `finally` frees).
-        // Decode is infallible, like the by-value-handle consume below.
-        InputKind::VecBuild {
-            elem,
-            by_ref,
-            elem_wrappers,
-            ..
-        } => {
-            // Generated Rust spells the reading's own tokens. This is the
-            // CANONICAL element, which is what the helper trio stores — so the
-            // cast below and `build_vec_build_helper_items` name one type.
-            let elem = emit.spell(elem);
-            let handle_ident = format_ident!("{}_handle", arg_ident);
-            wire_params.push(quote!(#handle_ident: jni::sys::jlong));
-            if *by_ref {
-                // `vec_build_elem` refuses a wrapped run on this path, so the
-                // borrow is the parameter's own spelling and there is nothing
-                // to put back.
-                //
-                // **No ascription**, for the reason the by-value branch below
-                // gives: the expression already produces the local's type, and
-                // naming it here writes the same fact twice — but here it also
-                // got it WRONG. `&*(.. as *const Vec<T>)` is a `&Vec<T>`, and
-                // ascribing `&[T]` coerced it at the `let`, where only one of
-                // the two spellings the model accepts can come out. A
-                // `&Vec<T>` parameter — which `sequence_elem` answers for
-                // exactly as it does for `&[T]` — was then handed a `&[T]`:
-                // `E0308` in the generated crate, since the deref coercion runs
-                // `&Vec<T>` → `&[T]` and not back (#384).
-                //
-                // Unascribed, the coercion moves to the call site and serves
-                // both: exact for `&Vec<T>`, deref for `&[T]`. `&mut Vec<T>`
-                // stays refused, and by `sequence_elem` returning `None` for a
-                // `Ref` kind rather than by the `mutable: false` guard — that
-                // guard is what refuses `&mut [T]`.
-                prelude.push(quote!(
-                    let #arg_ident = unsafe { &*(#handle_ident as *const Vec<#elem>) };
-                ));
-            } else {
-                // By value the local is owned, so the run's wrappers go back on
-                // for free — `Box<Vec<T>>` is `Box::new(mem::take(..))`. The
-                // ascription is dropped rather than restated: the wrapped
-                // spelling is what the expression now produces, and naming it
-                // here would be the same fact written twice.
-                let taken = quote!(unsafe {
-                    ::core::mem::take(&mut *(#handle_ident as *mut Vec<#elem>))
-                });
-                // The ELEMENT's wrappers, which the storage does not carry
-                // (#296). One O(n) pass over a Vec already being moved, and it
-                // goes INSIDE the run wrap: `Box<Vec<Box<Payload>>>` boxes each
-                // element, collects, then boxes the run. Emitted only when there
-                // are wrappers, so every existing shape keeps its exact tokens.
-                let taken = if elem_wrappers.is_empty() {
-                    taken
-                } else {
-                    let wrapped = build_through_wrappers(elem_wrappers, quote!(__e))
-                        .expect("vec_build_elem accepted this element spelling");
-                    quote!(
-                        #taken
-                            .into_iter()
-                            .map(|__e| #wrapped)
-                            .collect::<Vec<_>>()
-                    )
-                };
-                let taken = build_through_erased_wrappers(&leaf.reading, taken)
-                    .expect("vec_build_elem accepted this run spelling");
-                prelude.push(quote!(let #arg_ident = #taken;));
-            }
-            (wire_params, prelude, quote!(#arg_ident))
-        }
+        // The helper ABI still distinguishes Vec-build inputs for Kotlin, but
+        // Rust reconstruction is the frozen site pipeline's operation.
+        InputKind::VecBuild { .. } => emit_plain_decode(
+            &leaf.pipeline,
+            arg_ident,
+            arg_ty,
+            on_err,
+            emit,
+            Some(format_ident!("{}_handle", arg_ident)),
+        ),
 
         // Handles, value projections, callbacks, and plain types all decode
         // through the frozen site pipeline. In particular, a direct owned
@@ -653,7 +589,9 @@ fn emit_input_param(
         InputKind::Callback { .. }
         | InputKind::Handle { .. }
         | InputKind::Unsigned64 { .. }
-        | InputKind::Plain => emit_plain_decode(&leaf.pipeline, arg_ident, arg_ty, on_err),
+        | InputKind::Plain => {
+            emit_plain_decode(&leaf.pipeline, arg_ident, arg_ty, on_err, emit, None)
+        }
     }
 }
 
@@ -665,6 +603,8 @@ fn emit_plain_decode(
     arg_ident: &syn::Ident,
     arg_ty: &prebindgen_registry::flat::TypeRef,
     on_err: &TokenStream,
+    emit: &prebindgen_registry::Emit,
+    wire_name: Option<syn::Ident>,
 ) -> (Vec<TokenStream>, Vec<TokenStream>, TokenStream) {
     use prebindgen_registry::flat::TypeKind;
     /// `&mut T`, read off the kind — and off `kind()` rather than through
@@ -687,15 +627,16 @@ fn emit_plain_decode(
     let mut wire_params: Vec<TokenStream> = Vec::new();
     let mut prelude: Vec<TokenStream> = Vec::new();
     let wire = pipeline.wire();
-    let wire_ident = if matches!(wire, syn::Type::Ptr(_)) {
-        format_ident!("{}_ptr", arg_ident)
-    } else {
-        arg_ident.clone()
-    };
+    let wire_ident = wire_name.unwrap_or_else(|| {
+        if matches!(wire, syn::Type::Ptr(_)) {
+            format_ident!("{}_ptr", arg_ident)
+        } else {
+            arg_ident.clone()
+        }
+    });
 
     let wire_with_lifetime = annotate_jobject_with_lifetime(wire, "a");
     wire_params.push(quote!(#wire_ident: #wire_with_lifetime));
-    let decode_call = pipeline.invoke(quote!(#wire_ident));
     // Binding for the final `arg_ident` needs `mut` when the source
     // fn takes `&mut T` — the call site below emits `&mut arg_ident`,
     // which requires a mutable binding. Also for `Option<&mut T>`
@@ -705,15 +646,20 @@ fn emit_plain_decode(
     } else {
         quote!()
     };
-    prelude.push(quote!(
-        let #arg_mut #arg_ident = match #decode_call {
-            ::core::result::Result::Ok(__v) => __v,
-            ::core::result::Result::Err(__e) => {
-                signal_binding_error(&mut env, &__error_sink, &__SINK_MID, __SINK_FQN, __SINK_DESCR, &__e.to_string());
-                return #on_err;
-            }
-        };
-    ));
+    if let Some(value) = pipeline.invoke_infallible(quote!(#wire_ident), emit) {
+        prelude.push(quote!(let #arg_mut #arg_ident = #value;));
+    } else {
+        let decode_call = pipeline.invoke(quote!(#wire_ident), emit);
+        prelude.push(quote!(
+            let #arg_mut #arg_ident = match #decode_call {
+                ::core::result::Result::Ok(__v) => __v,
+                ::core::result::Result::Err(__e) => {
+                    signal_binding_error(&mut env, &__error_sink, &__SINK_MID, __SINK_FQN, __SINK_DESCR, &__e.to_string());
+                    return #on_err;
+                }
+            };
+        ));
+    }
     let call_arg = match arg_ty.kind() {
         TypeKind::Ref { mutable: true, .. } => quote!(&mut #arg_ident),
         TypeKind::Ref { .. } => quote!(&#arg_ident),
@@ -821,7 +767,7 @@ pub(crate) fn emit_expanded_param(
         };
         let wire_with_lifetime = annotate_jobject_with_lifetime(wire, "a");
         wire_params.push(quote!(#wire_ident: #wire_with_lifetime));
-        let decode_call = pipeline.invoke(quote!(#wire_ident));
+        let decode_call = pipeline.invoke(quote!(#wire_ident), emit);
         prelude.push(quote!(
             let #local = match #decode_call {
                 ::core::result::Result::Ok(__v) => __v,

--- a/prebindgen-jni/src/jni/fn_plan.rs
+++ b/prebindgen-jni/src/jni/fn_plan.rs
@@ -136,16 +136,9 @@ pub(crate) enum InputKind {
     Callback { iface: Option<Arc<IfaceSpec>> },
     /// `&[T]` / `Vec<T>` of a flattenable data_class: a single `jlong`
     /// Vec-handle on the wire, built by pushing element leaves.
-    /// The element as a **reading**, and the CANONICAL one: the vec-helper plan
-    /// and the element key are both taken from it, and generated Rust spells
-    /// `emit.spell(elem)`. `elem_wrappers` is what the storage therefore does not
-    /// carry, put back per element on consumption (#296) — empty for the
-    /// ordinary case, and a list rather than a second `TypeRef` because every
-    /// variant of this enum pays its size.
+    /// Rust reconstruction is frozen in [`PlanLeaf::pipeline`]; this kind keeps
+    /// only the helper ABI that Kotlin and the synthetic externs share.
     VecBuild {
-        elem: TypeRef,
-        by_ref: bool,
-        elem_wrappers: Vec<&'static str>,
         helpers: std::rc::Rc<VecBuildHelpers>,
     },
     /// Bare `Option<primitive>` / `Option<enum>`: a decoupled

--- a/prebindgen-jni/src/jni/tests/snapshots.rs
+++ b/prebindgen-jni/src/jni/tests/snapshots.rs
@@ -623,6 +623,10 @@ fn slice_input_builds_vec_handle() {
         "{rust}"
     );
     assert!(
+        rc.contains("#[inline]fnderef(&self)->&Self::Target"),
+        "the non-owning carrier's dereference must be explicitly inline:\n{rust}"
+    );
+    assert!(
         rc.contains("mem::take(&mut*(v_handleas*mutVec<myflat::Foo>))"),
         "{rust}"
     );

--- a/prebindgen-jni/src/jni/tests/snapshots.rs
+++ b/prebindgen-jni/src/jni/tests/snapshots.rs
@@ -604,7 +604,8 @@ fn slice_input_builds_vec_handle() {
     assert!(kc.contains("}finally{"), "{kotlin}");
     assert!(kc.contains("JNINative.fooVecFree(__vec_v)"), "{kotlin}");
 
-    // Rust: the three helper symbols + both decode shapes (borrow / take).
+    // Rust: the three helper symbols + both frozen site-pipeline operations
+    // (a non-owning carrier for borrow, `mem::take` for consume).
     assert!(
         rc.contains("fnJava_io_test_jni_JNINative_fooVecNew"),
         "{rust}"
@@ -618,7 +619,7 @@ fn slice_input_builds_vec_handle() {
         "{rust}"
     );
     assert!(
-        rc.contains("&*(v_handleas*constVec<myflat::Foo>)"),
+        rc.contains("OwnedObject::from_raw(v_handleas*constVec<myflat::Foo>)"),
         "{rust}"
     );
     assert!(

--- a/prebindgen-jni/src/jni/tests/values.rs
+++ b/prebindgen-jni/src/jni/tests/values.rs
@@ -2886,8 +2886,8 @@ fn an_outer_wrapper_around_a_reference_is_seen_before_the_layers_are_read() {
     );
 }
 
-/// The two spellings of a **borrowed run** get the same local, and it is the
-/// borrow of the `Vec` rather than a slice of it (#384).
+/// The two spellings of a **borrowed run** get the same frozen site operation,
+/// carrying a borrow of the `Vec` rather than coercing it to a slice (#384).
 ///
 /// `sequence_elem` answers for `&[T]` and `&Vec<T>` alike — they are one type to
 /// the model — so both reach the Vec-build path. The emitter was not symmetric
@@ -2896,8 +2896,8 @@ fn an_outer_wrapper_around_a_reference_is_seen_before_the_layers_are_read() {
 /// of the two. A `&Vec<T>` parameter was then handed a `&[T]`, which does not
 /// coerce back — `E0308` in the generated crate.
 ///
-/// Unascribed, the coercion moves to the call site and serves both. What this
-/// test can pin is the **shape**; that it compiles is `covertest-kotlin`'s
+/// The non-owning `OwnedObject<Vec<T>>` carrier leaves coercion at the call site
+/// and serves both. What this test can pin is the **shape**; that it compiles is `covertest-kotlin`'s
 /// `ref_vec_id_sum`/`slice_id_sum` pair, since a lib test emits tokens and never
 /// builds them.
 #[test]
@@ -2973,19 +2973,22 @@ fn both_spellings_of_a_borrowed_run_get_the_vec_borrow() {
         );
     }
 
-    // The finding: ONE local, and it is the `Vec` borrow. Counted rather than
-    // merely found, so a per-spelling form cannot pass.
+    // The finding: both sites invoke the same Vec-handle pipeline operation,
+    // which returns the non-owning carrier the ordinary decode scaffold can
+    // borrow. Counted rather than merely found, so a per-spelling form cannot
+    // pass.
     assert_eq!(
-        rc.matches("letv=unsafe{&*(v_handleas*constVec<myflat::Foo>)};")
+        rc.matches("OwnedObject::from_raw(v_handleas*constVec<myflat::Foo>)")
             .count(),
         2,
-        "both borrowed runs must get the same unascribed `&Vec<Foo>` local:\n{rust}"
+        "both borrowed runs must use the same frozen Vec-handle operation:\n{rust}"
     );
-    // …and no slice ascription survives, which is the thing that broke.
+    // …and neither the old slice ascription nor the wrapper-local direct
+    // reconstruction survives.
     assert!(
-        !rc.contains("letv:&[myflat::Foo]="),
-        "ascribing `&[Foo]` coerces at the `let`, so a `&Vec<Foo>` parameter \
-         gets a `&[Foo]` and the generated crate does not build (E0308):\n{rust}"
+        !rc.contains("letv:&[myflat::Foo]=")
+            && !rc.contains("letv=unsafe{&*(v_handleas*constVec<myflat::Foo>)};"),
+        "borrowed Vec reconstruction must come only from the frozen pipeline:\n{rust}"
     );
 }
 


### PR DESCRIPTION
## Summary

- freeze transient Vec-handle borrow/consume behavior as a `JPipeline` site operation selected during parameter planning
- make Rust wrapper emission use the common pipeline decoder and delete wrapper-local `Vec<T>` spelling, pointer casts, `mem::take`, and wrapper restoration
- retain the Kotlin push-helper ABI and helper ownership while removing Rust reconstruction policy from `InputKind::VecBuild`

## Design

Kotlin still constructs a transient Rust `Vec<T>` through the `{type}VecNew` / `Push` / `Free` helper trio and passes its `jlong` handle. The frozen parameter site now records whether it borrows or consumes that vector, its canonical element reading, and transparent-wrapper restoration. `TypeRef` is spelled only when the final `JPipeline` operation is rendered.

Borrowed sites use the existing non-owning `OwnedObject<Vec<T>>` carrier so the source call performs the final `&Vec<T>` or `&[T]` coercion. Consumed sites retain `mem::take`, leaving an empty vector for the Kotlin `finally` block to free, and restore element/run wrappers inside the frozen operation.

`InputKind::VecBuild` remains only as the cross-artifact helper-ABI classification. The general `JObject -> Vec<T>` converter remains deliberately unreachable for this site-specific ABI.

## Compatibility

Generated Kotlin and JNI names/descriptors are unchanged. Generated Rust changes privately at borrowed Vec sites from a direct wrapper-local pointer borrow to the existing non-owning carrier; owned sites retain the same take and wrapper-restoration semantics.

This private change is visible in the committed covertest and perftest Rust fixtures, including the benchmarked `storagePutSlice` wrapper. `OwnedObject<T>` is a single pointer with an inline `Deref` and no `Drop`; it introduces no ownership or cleanup work and is expected to lower to the same pointer load. Compatibility here is semantic rather than byte-identical generated Rust.

## Verification

- `cargo test --workspace`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- `RUSTDOCFLAGS=-Dwarnings cargo doc --workspace --all-features --no-deps`
- `./examples/regen-check.sh`
- `examples/covertest-kotlin/gradlew run --no-daemon` — 57 sections passed