### PR TITLE
Keep expanded JNI scalars off boxed fallback

### DIFF
--- a/examples/covertest-kotlin/README.md
+++ b/examples/covertest-kotlin/README.md
@@ -31,7 +31,7 @@ re-runs `build.rs` to regenerate both sides of the binding
 the Kotlin asserts. Expected output ends with:
 
 ```
-PASS - 35 sections, every JniGen feature exercised
+PASS - 58 sections, every JniGen feature exercised
 ```
 
 (One section deliberately provokes callback exceptions; the stack traces it
@@ -87,6 +87,11 @@ for the full table; in brief:
   raw `TryFrom::Error` input stage and a raw `String` output stage. The runtime
   checks null/value round trips and verifies both stage errors normalize to
   `JniErrorHandler`.
+- **expanded selector scalar leaves:** `Option<&SelectorCode>` has a build arm
+  with a required `u16` that is nullable on the public selector surface. The
+  runtime exercises absent, build, and identity arms; the committed native ABI
+  proves the synthetic `Option<u16>` selects the registry pair recipe and
+  crosses as `Boolean + Int`, without `JObject` allocation or `intValue()`.
 - **type mappings:** primitives, `String`/`&str` (incl. a bare `String`
   return), `Option<T>` (param / return / **field**, incl. `Option<enum>` in
   all three positions and `Option<Payload>` in both directions),

--- a/examples/covertest-kotlin/build.rs
+++ b/examples/covertest-kotlin/build.rs
@@ -29,7 +29,7 @@
 //! | bounded conversion domains + niches | `Option<Duration>` ⇄ bounded millisecond `ULong?`; raw JNI remains primitive `Long`, `None` uses an invalid `u64`, invalid input/output routes to `onError`; `DurationBoundary` composes the niche through a data-class field and whole-object decode |
 //! | `.method()` / `.constructor()`       | `Storage` + `Summary` + `Stamp` members |
 //! | `expand_param!` `.variant()` (+`_self`)| `Summary` default input (splittable, checked #52) |
-//! | Optional combined-selector expansion  | `summary_total_opt(Option<&Summary>)` — selector `-1` = absent, borrow-identity arm clones |
+//! | Optional combined-selector expansion  | `summary_total_opt(Option<&Summary>)` — selector `-1` = absent, borrow-identity arm clones; `selector_code_score(Option<&SelectorCode>)` lowers its synthetic `Option<u16>` build-arm leaf to a primitive presence/value pair |
 //! | `FunctionDecl::split_on_param` (#52)  | single: `archiveStore`/`storageMatchesSummary` (class-default) + `storageExpectSummary` (per-fn); cartesian product: `summaryPrefer` (2 params); manual same-named overload in `ManualOverloads.kt` |
 //! | split × builder-delivered return (#87) | `summaryMerge` — cartesian split + generic `<R>` wrapper; every overload re-declares `<R>` |
 //! | JNI native-symbol escaping (#86)      | `esc_pkg.Esc_Probe` — underscored subpackage + class (escaped `freePtr` symbol) + hook-mangled `escape_probe_value` harness extern |
@@ -422,6 +422,12 @@ fn main() {
                                 .sig(sig!((count: i64, mean: f64) -> Result<Summary, String>)),
                         ),
                 )
+                // A multi-variant Optional input whose required `u16` build-arm
+                // leaf is nullable on the public surface. Its synthetic
+                // `Option<u16>` reading must still select the allocation-free
+                // registry pair recipe at the native ABI (#525 follow-up).
+                .class(ptr_class!(SelectorCode).constructor(fun!(selector_code_new)))
+                .fun(fun!(selector_code_score))
                 // `Archive` holds the latest `Summary` and returns it BORROWED
                 // (`Option<&Summary>`) — the JVM binding clones it into a fresh owned
                 // handle (the zenoh-flat borrowed-accessor shape). Its Kotlin class is
@@ -438,6 +444,11 @@ fn main() {
         .expand(
             expand_param!(Summary)
                 .variant(fun!(summary_new))
+                .variant_self(),
+        )
+        .expand(
+            expand_param!(SelectorCode)
+                .variant(fun!(selector_code_new))
                 .variant_self(),
         )
         // `Summary` default output: decomposed `(count, total)` leaves, names
@@ -857,7 +868,9 @@ fn main() {
         .join("src")
         .join("generated_bindings.rs");
     let jni = binding.build().expect("build failed");
-    let rust_path = jni.write_rust(&rust_dest).expect("write_rust failed");
+    let rust_path = jni
+        .write_rust(&rust_dest)
+        .unwrap_or_else(|error| panic!("write_rust failed: {error}"));
     println!(
         "cargo:warning=Generated bindings at: {}",
         rust_path.display()

--- a/examples/covertest-kotlin/kotlin/REPORT.md
+++ b/examples/covertest-kotlin/kotlin/REPORT.md
@@ -18,6 +18,8 @@ Base package: `io.prebindgen.covertest`
 - `archive_new` — `fun archiveNew(onError: JniErrorHandler<SummaryVault?>): SummaryVault?`
 - `archive_store` — `fun archiveStore(a: SummaryVault, sSel: Int, s00: Long?, s01: Double?, s1: Summary?, onError: JniErrorHandler<Unit>)`
   - shaped by: param `s` expanded from `Summary` — variants [summary_new, self]
+- `selector_code_score` — `fun selectorCodeScore(valueSel: Int, value00: Int?, value01: ByteArray?, value1: SelectorCode?, onError: JniErrorHandler<Long>): Long`
+  - shaped by: param `value` expanded from `SelectorCode` — variants [selector_code_new, self]
 - `storage_expect_summary` — `fun storageExpectSummary(s: Storage, expectedSel: Int, expected00: Long?, expected01: Double?, expected1: Summary?, onError: JniErrorHandler<Boolean>): Boolean`
   - shaped by: param `expected` expanded from `Summary` — variants [summary_new, self]
 - `storage_matches_summary` — `fun storageMatchesSummary(s: Storage, expectedSel: Int, expected00: Long?, expected01: Double?, expected1: Summary?, onError: JniErrorHandler<Boolean>): Boolean`
@@ -188,6 +190,10 @@ Base package: `io.prebindgen.covertest`
 
 - `payload_label_len` — `fun labelLen(onError: JniErrorHandler<Long?>): Long?`
 
+## class `io.prebindgen.covertest.analytics.SelectorCode` (ptr_class, Rust `SelectorCode`)
+
+- `selector_code_new` — `fun new(id: Int, schema: ByteArray?, onError: JniErrorHandler<SelectorCode?>): SelectorCode?`
+
 ## class `io.prebindgen.covertest.model.Stamp` (data_class, Rust `Stamp`)
 
 - `stamp_nanos` — `fun nanos(onError: JniErrorHandler<Long>): Long`
@@ -249,6 +255,7 @@ Base package: `io.prebindgen.covertest`
 - `Reading`: sealed_class → `io.prebindgen.covertest.model.Reading` (wire `?`)
 - `RepliesConfig`: data_class → `io.prebindgen.covertest.model.RepliesConfig` (wire `jni :: objects :: JObject`)
 - `Report`: ptr_class → `io.prebindgen.covertest.model.Report` (wire `jni :: sys :: jlong`)
+- `SelectorCode`: ptr_class → `io.prebindgen.covertest.analytics.SelectorCode` (wire `jni :: sys :: jlong`)
 - `Span`: ptr_class → `io.prebindgen.covertest.model.Span` (wire `jni :: sys :: jlong`)
 - `SpanHolder`: ptr_class → `io.prebindgen.covertest.model.SpanHolder` (wire `jni :: sys :: jlong`)
 - `Stamp`: data_class → `io.prebindgen.covertest.model.Stamp` (wire `jni :: objects :: JObject`)

--- a/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest.kt
+++ b/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest.kt
@@ -1438,6 +1438,19 @@ internal object CovNative {
     external fun reportEach(n: Long, sink: Any, errorSink: Any)
 
     @JvmSynthetic
+    external fun selectorCodeNew(id: Int, schema: ByteArray?, errorSink: Any): Long
+
+    @JvmSynthetic
+    external fun selectorCodeScore(
+        valueSel: Int,
+        value00Present: Boolean,
+        value00Value: Int,
+        value01: ByteArray?,
+        value1: Long,
+        errorSink: Any,
+    ): Long
+
+    @JvmSynthetic
     external fun sliceIdSum(ps: Long, errorSink: Any): Long
 
     @JvmSynthetic

--- a/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest/analytics.kt
+++ b/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest/analytics.kt
@@ -41,6 +41,50 @@ public class SummaryVault private constructor(initialPtr: Long) : NativeHandle(i
     }
 }
 
+/** Typed handle for a native Zenoh `SelectorCode`. */
+public class SelectorCode private constructor(initialPtr: Long) : NativeHandle(initialPtr) {
+    @Synchronized
+    override fun close() {
+        val p = ptr
+        if (p != 0L && (p and 1L) == 0L) {
+            ptr = p or 1L
+            freePtr(p)
+        }
+    }
+
+    @Synchronized
+    public fun take(): SelectorCode {
+        val p = ptr
+        ptr = p or 1L
+        return SelectorCode.fromRawPtr(p)
+    }
+
+    public companion object {
+        @JvmStatic
+        @JvmSynthetic
+        external fun freePtr(ptr: Long)
+
+        /** Wrap a pointer a generated native call returned. Passing anything else — a literal, a stale pointer, one belonging to another handle — is undefined behaviour, which is why this is not part of the public API. */
+        @JvmSynthetic
+        internal fun fromRawPtr(initialPtr: Long): SelectorCode = SelectorCode(initialPtr)
+
+        /**
+         * Construct a [`SelectorCode`] from the same scalar-plus-optional-vector shape
+         * used by zenoh's expanded `Encoding` input.
+         */
+        public fun new(
+            id: Int,
+            schema: ByteArray?,
+            onError: JniErrorHandler<SelectorCode?>,
+        ): SelectorCode? {
+            val __bcap = JniErrorHandlerCapture.acquire()
+            val __ret = CovNative.selectorCodeNew(id, schema, __bcap)
+            if (__bcap.failed) return onError.run(__bcap.ze0)
+            return SelectorCode.fromRawPtr(__ret)
+        }
+    }
+}
+
 /** Typed handle for a native Zenoh `Summary`. */
 public class Summary private constructor(initialPtr: Long) : GcNativeHandle(initialPtr) {
     private val __cleanable = registerGcHandle(this) { freePtr(it) }
@@ -183,6 +227,40 @@ internal fun <R> SummaryStorageSummaryProbeBuilder<R>.asRaw(): SummaryStorageSum
 
 public fun interface SummaryFolder<A> {
     public fun run(acc: A, count: Long, total: Double): A
+}
+
+/**
+ * Observe all three selector states: absent, rebuilt from leaves, and supplied
+ * as an existing handle.
+ *
+ * Parameter `value` is the Rust `SelectorCode` argument, expanded: pass EITHER its `selector_code_new` inputs OR an existing `SelectorCode` — the selector chooses the arm, `-1` = absent (crosses as `valueSel`, `value00`, `value01`, `value1`).
+ */
+public fun selectorCodeScore(
+    valueSel: Int,
+    value00: Int?,
+    value01: ByteArray?,
+    value1: SelectorCode?,
+    onError: JniErrorHandler<Long>,
+): Long {
+    if (value1?.isClosed() == true) return onError.run("Operation on a closed native handle.")
+    val __bcap = JniErrorHandlerCapture.acquire()
+    val __ret = run {
+        val __locks = ArrayList<NativeHandle>()
+        value1?.let { __locks.add(it) }
+        withSortedHandleLocks(__locks) {
+            val value1_ptr = value1?.ptr ?: 0L
+            CovNative.selectorCodeScore(
+                valueSel,
+                value00 != null,
+                value00 ?: 0,
+                value01,
+                value1_ptr,
+                __bcap,
+            )
+        }
+    }
+    if (__bcap.failed) return onError.run(__bcap.ze0)
+    return __ret
 }
 
 /**

--- a/examples/covertest-kotlin/kotlin/io/prebindgen/covertest/Test.kt
+++ b/examples/covertest-kotlin/kotlin/io/prebindgen/covertest/Test.kt
@@ -2,6 +2,7 @@ package io.prebindgen.covertest
 
 import io.prebindgen.covertest.analytics.Summary
 import io.prebindgen.covertest.analytics.SummaryVault
+import io.prebindgen.covertest.analytics.SelectorCode
 import io.prebindgen.covertest.analytics.archiveLatest
 import io.prebindgen.covertest.analytics.archiveNew
 import io.prebindgen.covertest.analytics.archiveStore
@@ -18,6 +19,7 @@ import io.prebindgen.covertest.analytics.summarySeries
 import io.prebindgen.covertest.analytics.summarySeriesOpt
 import io.prebindgen.covertest.analytics.summaryTotalOpt
 import io.prebindgen.covertest.analytics.summaryTotalRaw
+import io.prebindgen.covertest.analytics.selectorCodeScore
 import io.prebindgen.covertest.errors.StorageErrorHandler
 import io.prebindgen.covertest.esc_pkg.Esc_Probe
 import io.prebindgen.covertest.model.Annotated
@@ -1418,6 +1420,21 @@ fun main() {
         check(describeSummary(0, 2L, 8.0, null, false, boom) == "2/8")
         check(describeSummary(1, null, null, m, true, boom) == "summary of 4 payloads totalling 10")
         m.close()
+    }
+
+    // ── expanded nullable u16 leaf: primitive native pair, never JObject ────
+    section("expanded selector keeps nullable scalar off JObject") {
+        // -1 skips every arm; 0 rebuilds from the nullable constructor slots.
+        // The latter crosses JNI as Boolean + Int and executes the registry
+        // Optional chain, without allocating/unboxing java.lang.Integer.
+        check(selectorCodeScore(-1, null, null, null, boom) == -1L)
+        check(selectorCodeScore(0, 41, byteArrayOf(1, 2), null, boom) == 43L)
+
+        // The identity arm uses the same expansion and proves its handle slot
+        // remains independent of the primitive build-arm leaves.
+        val code = SelectorCode.new(50, byteArrayOf(1, 2, 3), boom).orThrow()
+        check(selectorCodeScore(1, null, null, code, boom) == 53L)
+        code.close()
     }
 
     // ── flatten input on Summary: default + with, both selectors ─────────────

--- a/examples/covertest-kotlin/src/generated_bindings.rs
+++ b/examples/covertest-kotlin/src/generated_bindings.rs
@@ -148,6 +148,22 @@ const _: () = {
 };
 #[no_mangle]
 #[allow(non_snake_case, unused_variables)]
+pub(crate) unsafe extern "C" fn Java_io_prebindgen_covertest_analytics_SelectorCode_freePtr(
+    _env: jni::JNIEnv,
+    _class: jni::objects::JClass,
+    ptr: jni::sys::jlong,
+) {
+    if ptr != 0 && (ptr & 1) == 0 {
+        drop(Box::from_raw(ptr as *mut perftest_flat::SelectorCode));
+    }
+}
+const _: () = {
+    if ::core::mem::align_of::<perftest_flat::SelectorCode>() < 2 {
+        panic!("opaque handle types must have alignment >= 2 (bit 0 is the closed tag)");
+    }
+};
+#[no_mangle]
+#[allow(non_snake_case, unused_variables)]
 pub(crate) unsafe extern "C" fn Java_io_prebindgen_covertest_analytics_SummaryVault_freePtr(
     _env: jni::JNIEnv,
     _class: jni::objects::JClass,
@@ -1517,6 +1533,32 @@ pub(crate) unsafe fn JBooleanArray_to_bool_3_3f960c58<'env, 'v>(
                 )
             })?;
         __arr
+    })
+}
+#[allow(
+    non_snake_case,
+    unused_mut,
+    unused_variables,
+    unused_braces,
+    unused_parens,
+    dead_code,
+    clippy::useless_conversion,
+    clippy::needless_question_mark,
+    clippy::let_and_return,
+    clippy::nonminimal_bool,
+    clippy::eq_op
+)]
+pub(crate) unsafe fn JByteArray_to_Option_Vec_u8_6f4428ab<'env, 'v>(
+    env: &mut jni::JNIEnv<'env>,
+    v: &jni::objects::JByteArray<'v>,
+) -> ::core::result::Result<Option<Vec<u8>>, __JniErr> {
+    ::core::result::Result::Ok({
+        if v.is_null() {
+            ::core::option::Option::None
+        } else {
+            let __present = v;
+            ::core::option::Option::Some(JByteArray_to_Vec_u8_7936d5de(env, __present)?)
+        }
     })
 }
 #[allow(
@@ -10442,6 +10484,25 @@ pub(crate) unsafe fn Result_Summary_String_to_Summary_dfdf7f9e<'a>(
     clippy::nonminimal_bool,
     clippy::eq_op
 )]
+pub(crate) unsafe fn SelectorCode_to_jlong_e4059701<'a>(
+    env: &mut jni::JNIEnv<'a>,
+    v: perftest_flat::SelectorCode,
+) -> ::core::result::Result<jni::sys::jlong, __JniErr> {
+    Ok(std::boxed::Box::into_raw(std::boxed::Box::new(v)) as i64)
+}
+#[allow(
+    non_snake_case,
+    unused_mut,
+    unused_variables,
+    unused_braces,
+    unused_parens,
+    dead_code,
+    clippy::useless_conversion,
+    clippy::needless_question_mark,
+    clippy::let_and_return,
+    clippy::nonminimal_bool,
+    clippy::eq_op
+)]
 pub(crate) unsafe fn SpanHolder_to_jlong_7ffe9314<'a>(
     env: &mut jni::JNIEnv<'a>,
     v: perftest_flat::SpanHolder,
@@ -11980,6 +12041,39 @@ pub(crate) unsafe fn jlong_to_Option_Duration_1cfa4d44<'env, 'v>(
     clippy::nonminimal_bool,
     clippy::eq_op
 )]
+pub(crate) unsafe fn jlong_to_Option_SelectorCode_b3d1576b<'env, 'v>(
+    env: &mut jni::JNIEnv<'env>,
+    v: &jni::sys::jlong,
+) -> ::core::result::Result<Option<OwnedObject<perftest_flat::SelectorCode>>, __JniErr> {
+    if *v == 0 {
+        Ok(None)
+    } else if (*v & 1) == 1 {
+        Err(
+            <__JniErr as ::core::convert::From<
+                String,
+            >>::from("Operation on a closed native handle.".to_string()),
+        )
+    } else {
+        Ok(
+            Some(unsafe {
+                OwnedObject::from_raw(*v as *const perftest_flat::SelectorCode)
+            }),
+        )
+    }
+}
+#[allow(
+    non_snake_case,
+    unused_mut,
+    unused_variables,
+    unused_braces,
+    unused_parens,
+    dead_code,
+    clippy::useless_conversion,
+    clippy::needless_question_mark,
+    clippy::let_and_return,
+    clippy::nonminimal_bool,
+    clippy::eq_op
+)]
 pub(crate) unsafe fn jlong_to_Option_Summary_252ef2ba<'env, 'v>(
     env: &mut jni::JNIEnv<'env>,
     v: &jni::sys::jlong,
@@ -12079,6 +12173,32 @@ pub(crate) unsafe fn jlong_to_PayloadVecHandler_b32d2812<'env, 'v>(
         );
     }
     Ok(unsafe { OwnedObject::from_raw(*v as *const perftest_flat::PayloadVecHandler) })
+}
+#[allow(
+    non_snake_case,
+    unused_mut,
+    unused_variables,
+    unused_braces,
+    unused_parens,
+    dead_code,
+    clippy::useless_conversion,
+    clippy::needless_question_mark,
+    clippy::let_and_return,
+    clippy::nonminimal_bool,
+    clippy::eq_op
+)]
+pub(crate) unsafe fn jlong_to_SelectorCode_e4059701<'env, 'v>(
+    env: &mut jni::JNIEnv<'env>,
+    v: &jni::sys::jlong,
+) -> ::core::result::Result<OwnedObject<perftest_flat::SelectorCode>, __JniErr> {
+    if *v == 0 || (*v & 1) == 1 {
+        return ::core::result::Result::Err(
+            <__JniErr as ::core::convert::From<
+                String,
+            >>::from("Operation on a closed native handle.".to_string()),
+        );
+    }
+    Ok(unsafe { OwnedObject::from_raw(*v as *const perftest_flat::SelectorCode) })
 }
 #[allow(
     non_snake_case,
@@ -12608,6 +12728,32 @@ pub(crate) unsafe fn tuple2_to_Option_i64_b2611839<'env, 'v>(
         } else {
             let __present = (v).1;
             ::core::option::Option::Some(jlong_to_i64_fbf9a9bc(env, &__present)?)
+        }
+    })
+}
+#[allow(
+    non_snake_case,
+    unused_mut,
+    unused_variables,
+    unused_braces,
+    unused_parens,
+    dead_code,
+    clippy::useless_conversion,
+    clippy::needless_question_mark,
+    clippy::let_and_return,
+    clippy::nonminimal_bool,
+    clippy::eq_op
+)]
+pub(crate) unsafe fn tuple2_to_Option_u16_f61c9f72<'env, 'v>(
+    env: &mut jni::JNIEnv<'env>,
+    v: (jni::sys::jboolean, jni::sys::jint),
+) -> ::core::result::Result<Option<u16>, __JniErr> {
+    ::core::result::Result::Ok({
+        if (v).0 == 0u8 {
+            ::core::option::Option::None
+        } else {
+            let __present = (v).1;
+            ::core::option::Option::Some(jint_to_u16_28edf527(env, &__present)?)
         }
     })
 }
@@ -19081,6 +19227,219 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_reportEach<'a>(
                 &__e.to_string(),
             );
             ()
+        }
+    }
+}
+#[no_mangle]
+#[allow(non_snake_case, unused_mut, unused_variables, dead_code)]
+pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_selectorCodeNew<'a>(
+    mut env: jni::JNIEnv<'a>,
+    _class: jni::objects::JClass<'a>,
+    id: jni::sys::jint,
+    schema: jni::objects::JByteArray<'a>,
+    __error_sink: jni::objects::JObject<'a>,
+) -> jni::sys::jlong {
+    #[allow(non_upper_case_globals)]
+    static __SINK_MID: ::prebindgen_jni_runtime::CachedIfaceMethod = ::prebindgen_jni_runtime::CachedIfaceMethod::new();
+    const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
+    const __SINK_DESCR: &str = "(Ljava/lang/String;)Ljava/lang/Object;";
+    let id = match jint_to_u16_28edf527(&mut env, &id) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__e) => {
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e.to_string(),
+            );
+            return 0 as jni::sys::jlong;
+        }
+    };
+    let schema = match JByteArray_to_Option_Vec_u8_6f4428ab(&mut env, &schema) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__e) => {
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e.to_string(),
+            );
+            return 0 as jni::sys::jlong;
+        }
+    };
+    let __out = perftest_flat::selector_code_new(id, schema);
+    match SelectorCode_to_jlong_e4059701(&mut env, __out) {
+        ::core::result::Result::Ok(__w) => __w,
+        ::core::result::Result::Err(__e) => {
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e.to_string(),
+            );
+            0 as jni::sys::jlong
+        }
+    }
+}
+#[no_mangle]
+#[allow(non_snake_case, unused_mut, unused_variables, dead_code)]
+pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_selectorCodeScore<'a>(
+    mut env: jni::JNIEnv<'a>,
+    _class: jni::objects::JClass<'a>,
+    value_sel: jni::sys::jint,
+    value_0_0_present: jni::sys::jboolean,
+    value_0_0_value: jni::sys::jint,
+    value_0_1: jni::objects::JByteArray<'a>,
+    value_1: jni::sys::jlong,
+    __error_sink: jni::objects::JObject<'a>,
+) -> jni::sys::jlong {
+    #[allow(non_upper_case_globals)]
+    static __SINK_MID: ::prebindgen_jni_runtime::CachedIfaceMethod = ::prebindgen_jni_runtime::CachedIfaceMethod::new();
+    const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
+    const __SINK_DESCR: &str = "(Ljava/lang/String;)Ljava/lang/Object;";
+    let __exp_value_sel = match jint_to_i32_a3e3b6ef(&mut env, &value_sel) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__e) => {
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e.to_string(),
+            );
+            return 0 as jni::sys::jlong;
+        }
+    };
+    let __exp_value_0_0: Option<u16> = match tuple2_to_Option_u16_f61c9f72(
+        &mut env,
+        (value_0_0_present, value_0_0_value),
+    ) {
+        ::core::result::Result::Ok(__value) => __value,
+        ::core::result::Result::Err(__error) => {
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__error.to_string(),
+            );
+            return 0 as jni::sys::jlong;
+        }
+    };
+    let __exp_value_0_1 = match JByteArray_to_Option_Vec_u8_6f4428ab(
+        &mut env,
+        &value_0_1,
+    ) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__e) => {
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e.to_string(),
+            );
+            return 0 as jni::sys::jlong;
+        }
+    };
+    let __exp_value_1 = match jlong_to_Option_SelectorCode_b3d1576b(&mut env, &value_1) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__e) => {
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e.to_string(),
+            );
+            return 0 as jni::sys::jlong;
+        }
+    };
+    let __folded_value = match if __exp_value_sel < 0 {
+        ::core::result::Result::Ok(::core::option::Option::None)
+    } else {
+        ({
+            match __exp_value_sel {
+                0i32 => {
+                    match __exp_value_0_0 {
+                        ::core::option::Option::Some(__p0) => {
+                            ::core::result::Result::Ok(
+                                perftest_flat::selector_code_new(__p0, __exp_value_0_1),
+                            )
+                        }
+                        ::core::option::Option::None => {
+                            ::core::result::Result::Err(
+                                ::std::string::String::from(
+                                    "constructor variant input missing",
+                                ),
+                            )
+                        }
+                    }
+                }
+                1i32 => {
+                    match __exp_value_1 {
+                        ::core::option::Option::Some(__v) => {
+                            ::core::result::Result::Ok(
+                                ::core::clone::Clone::clone(&*__v),
+                            )
+                        }
+                        ::core::option::Option::None => {
+                            ::core::result::Result::Err(
+                                ::std::string::String::from(
+                                    "identity variant value missing",
+                                ),
+                            )
+                        }
+                    }
+                }
+                __sel => {
+                    ::core::result::Result::Err(
+                        ::std::format!("invalid constructor selector: {}", __sel),
+                    )
+                }
+            }
+        })
+            .map(::core::option::Option::Some)
+    } {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__e) => {
+            let __je = <__JniErr as ::core::convert::From<
+                ::std::string::String,
+            >>::from(__e);
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__je.to_string(),
+            );
+            return 0 as jni::sys::jlong;
+        }
+    };
+    let __out = perftest_flat::selector_code_score(__folded_value.as_ref());
+    match i64_to_jlong_fbf9a9bc(&mut env, __out) {
+        ::core::result::Result::Ok(__w) => __w,
+        ::core::result::Result::Err(__e) => {
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e.to_string(),
+            );
+            0 as jni::sys::jlong
         }
     }
 }

--- a/examples/emitcheck/build.rs
+++ b/examples/emitcheck/build.rs
@@ -97,6 +97,8 @@ fn main() {
     let dest = std::path::Path::new(&manifest_dir)
         .join("src")
         .join("generated_bindings.rs");
-    let written = generation.write_rust(&dest).expect("write_rust failed");
+    let written = generation
+        .write_rust(&dest)
+        .unwrap_or_else(|error| panic!("write_rust failed: {error}"));
     println!("cargo:warning=emitcheck: wrote {}", written.display());
 }

--- a/examples/example-cbindgen/build.rs
+++ b/examples/example-cbindgen/build.rs
@@ -245,7 +245,7 @@ fn generate_ffi_bindings() -> PathBuf {
         .build()
         .expect("build prebindgen items")
         .write_rust("example_flat.rs")
-        .expect("write generated bindings");
+        .unwrap_or_else(|error| panic!("write generated bindings: {error}"));
 
     // Publish the generated Rust into the crate tree under its per-variant name
     // (committed artifact). Write only on change so cargo doesn't rebuild-loop on

--- a/examples/perftest-c/build.rs
+++ b/examples/perftest-c/build.rs
@@ -133,7 +133,7 @@ fn generate_ffi_bindings() -> PathBuf {
         .build()
         .expect("build prebindgen items")
         .write_rust("perftest.rs")
-        .expect("write generated bindings");
+        .unwrap_or_else(|error| panic!("write generated bindings: {error}"));
 
     // Publish the generated Rust into the crate tree (committed artifact `lib.rs`
     // `include!`s; regenerated on every build).

--- a/examples/perftest-flat/src/ext.rs
+++ b/examples/perftest-flat/src/ext.rs
@@ -42,6 +42,12 @@ mod handles {
         pub(super) total: f64,
     }
 
+    #[derive(Clone)]
+    pub struct SelectorCode {
+        pub(super) id: u16,
+        pub(super) schema: Option<Vec<u8>>,
+    }
+
     pub struct Archive {
         pub(super) latest: Option<Summary>,
         /// A sum the archive OWNS, so it can hand one back **borrowed** (`&Reading`)
@@ -742,6 +748,31 @@ pub fn storage_try_from_stamp(s: Stamp, tag: [u8; 2]) -> Result<Storage, Storage
             label: None,
         }],
     })
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// SelectorCode — boxed scalar leaf in a multi-variant input expansion.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Opaque value used to exercise a selector expansion whose required `u16`
+/// constructor leaf becomes nullable when the identity arm is selected.
+#[prebindgen]
+pub type SelectorCode = handles::SelectorCode;
+
+/// Construct a [`SelectorCode`] from the same scalar-plus-optional-vector shape
+/// used by zenoh's expanded `Encoding` input.
+#[prebindgen]
+pub fn selector_code_new(id: u16, schema: Option<Vec<u8>>) -> SelectorCode {
+    SelectorCode { id, schema }
+}
+
+/// Observe all three selector states: absent, rebuilt from leaves, and supplied
+/// as an existing handle.
+#[prebindgen]
+pub fn selector_code_score(value: Option<&SelectorCode>) -> i64 {
+    value
+        .map(|value| i64::from(value.id) + value.schema.as_ref().map_or(0, |v| v.len() as i64))
+        .unwrap_or(-1)
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/examples/perftest-kotlin/build.rs
+++ b/examples/perftest-kotlin/build.rs
@@ -123,7 +123,9 @@ fn main() {
         .join("src")
         .join("generated_bindings.rs");
     let jni = binding.build().expect("build failed");
-    let rust_path = jni.write_rust(&rust_dest).expect("write_rust failed");
+    let rust_path = jni
+        .write_rust(&rust_dest)
+        .unwrap_or_else(|error| panic!("write_rust failed: {error}"));
     println!(
         "cargo:warning=Generated bindings at: {}",
         rust_path.display()

--- a/prebindgen-c/src/chain.rs
+++ b/prebindgen-c/src/chain.rs
@@ -145,6 +145,10 @@ impl CFunction {
 }
 
 impl RustFunction for CFunction {
+    fn ident(&self) -> &syn::Ident {
+        self.call.ident()
+    }
+
     fn render(&self, emit: &Emit) -> syn::ItemFn {
         match &self.body {
             CBody::Complete(function) => function.clone(),

--- a/prebindgen-jni/src/jni/chain.rs
+++ b/prebindgen-jni/src/jni/chain.rs
@@ -97,6 +97,18 @@ impl JFunction {
 }
 
 impl RustFunction for JFunction {
+    fn ident(&self) -> &syn::Ident {
+        match &self.0 {
+            JBody::Complete(function) => &function.sig.ident,
+            JBody::OwnedHandle(plan) => &plan.ident,
+            JBody::Product(plan) => &plan.ident,
+            JBody::Choice(plan) => &plan.ident,
+            JBody::Sequence(plan) => &plan.ident,
+            JBody::Optional(plan) => &plan.ident,
+            JBody::Invoke(plan) => plan.name(),
+        }
+    }
+
     fn should_emit(&self) -> bool {
         match &self.0 {
             JBody::Complete(_) => true,

--- a/prebindgen-jni/src/jni/recipes.rs
+++ b/prebindgen-jni/src/jni/recipes.rs
@@ -274,6 +274,7 @@ impl Declarations {
     pub(crate) fn recipes(
         &self,
         model: &Flat,
+        expansion_leaves: &[TypeRef],
         registry: &impl prebindgen_registry::Conversions,
     ) -> Result<Recipes, Vec<RecipeError>> {
         let mut recipes = Recipes::builder();
@@ -394,8 +395,28 @@ impl Declarations {
         //
         // Product-shaped payloads additionally offer `parts`; that row is
         // selected by the existing flattening bindings below.
-        let implicit = self.implicit_optionals(model);
-        for outer in implicit.values().map(|(outer, _)| *outer) {
+        let mut implicit: BTreeMap<TypeKey, (TypeRef, TypeRef)> = self
+            .implicit_optionals(model)
+            .into_iter()
+            .map(|(key, (outer, inner))| (key, (outer.clone(), inner.clone())))
+            .collect();
+        // A combined constructor expansion represents an inactive arm by
+        // Option-wrapping each required leaf. Those readings are synthesized
+        // after the Flat model was built, so a model walk cannot discover
+        // them. File them in the same table as source-written implicit
+        // Optionals: otherwise a nullable primitive leaf falls back to a boxed
+        // JObject and Rust has to call `intValue()`/`longValue()` across JNI.
+        for leaf in expansion_leaves {
+            let Some(inner) = leaf.optional_inner() else {
+                continue;
+            };
+            if !self.explicitly_declares(leaf) {
+                implicit
+                    .entry(leaf.stripped_key())
+                    .or_insert_with(|| (leaf.clone(), inner.clone()));
+            }
+        }
+        for (outer, _) in implicit.values() {
             recipes
                 .declare_default(outer.clone(), whole(), Constructing::Optional)
                 .declare(outer.clone(), pair(), Constructing::Optional)
@@ -477,13 +498,6 @@ impl Declarations {
         &self,
         model: &'a Flat,
     ) -> BTreeMap<TypeKey, (&'a TypeRef, &'a TypeRef)> {
-        let explicitly_declared = |ty: &TypeRef| {
-            self.types.contains_key(&ty.key())
-                || self
-                    .convert_decls
-                    .iter()
-                    .any(|decl| decl.key() == &ty.key() || decl.key() == &ty.stripped_key())
-        };
         let mut optionals = BTreeMap::new();
         for ty in model
             .elements()
@@ -493,11 +507,19 @@ impl Declarations {
             let Some(inner) = ty.optional_inner() else {
                 continue;
             };
-            if !explicitly_declared(ty) {
+            if !self.explicitly_declares(ty) {
                 optionals.entry(ty.stripped_key()).or_insert((ty, inner));
             }
         }
         optionals
+    }
+
+    fn explicitly_declares(&self, ty: &TypeRef) -> bool {
+        self.types.contains_key(&ty.key())
+            || self
+                .convert_decls
+                .iter()
+                .any(|decl| decl.key() == &ty.key() || decl.key() == &ty.stripped_key())
     }
 
     pub(crate) fn bindings(

--- a/prebindgen-jni/src/jni/tests/flatten.rs
+++ b/prebindgen-jni/src/jni/tests/flatten.rs
@@ -1933,7 +1933,7 @@ fn optional_selector_dispatch_end_to_end() {
         ),
         (
             syn::Item::Fn(syn::parse_quote!(
-                pub fn z_enc_from_id(id: i32, schema: Option<String>) -> ZEnc {
+                pub fn z_enc_from_id(id: u16, schema: Option<Vec<u8>>) -> ZEnc {
                     unimplemented!()
                 }
             )),
@@ -1975,6 +1975,18 @@ fn optional_selector_dispatch_end_to_end() {
     assert!(rc.contains("<0"), "{rust}");
     assert!(rc.contains("Option::None"), "{rust}");
     assert!(rc.contains("z_enc_from_id"), "{rust}");
+    // The required `u16` constructor argument becomes nullable on the public
+    // selector surface because the identity arm does not use it. The native ABI
+    // must nevertheless stay allocation-free: Kotlin sends presence + raw
+    // primitive, and the registry Optional chain gates the scalar conversion.
+    assert_eq!(rc.matches("fntuple2_to_Option_u16_").count(), 1, "{rust}");
+    assert!(
+        rc.contains("encoding_0_0_present:jni::sys::jboolean"),
+        "{rust}"
+    );
+    assert!(rc.contains("encoding_0_0_value:jni::sys::jint"), "{rust}");
+    assert!(!rc.contains("JObject_to_Option_u16"), "{rust}");
+    assert!(!rc.contains("intValue"), "{rust}");
 
     let paths = gen.write_kotlin(&dir.join("kotlin")).expect("write_kotlin");
     let raw = paths
@@ -1986,9 +1998,11 @@ fn optional_selector_dispatch_end_to_end() {
     // Selector Int + nullable build-arm leaves + nullable identity handle.
     assert!(all.contains("encodingSel:Int"), "{raw}");
     assert!(all.contains("encoding1:ZEnc?"), "{raw}");
-    // The already-Option schema arg stays a single-level String?.
-    assert!(all.contains("encoding01:String?"), "{raw}");
-    assert!(!all.contains("String??"), "{raw}");
+    assert!(all.contains("encoding00:Int?"), "{raw}");
+    assert!(all.contains("encoding00!=null,encoding00?:0"), "{raw}");
+    // The already-Option schema arg stays a single-level ByteArray?.
+    assert!(all.contains("encoding01:ByteArray?"), "{raw}");
+    assert!(!all.contains("ByteArray??"), "{raw}");
 }
 
 /// #96: a `.constructor()` member's return is a factory — it must be

--- a/prebindgen-jni/src/jni/trait_impl.rs
+++ b/prebindgen-jni/src/jni/trait_impl.rs
@@ -1420,19 +1420,20 @@ impl JniGenBuilder {
         registry: prebindgen_registry::RegistryBuilder,
     ) -> Result<JniGen, prebindgen_registry::WriteRustError> {
         let mut decls = self.decls;
-        let declared = decls.declare_into(registry)?.validate_with(&decls)?;
+        let mut declared = decls.declare_into(registry)?.validate_with(&decls)?;
         // A second holding of the model: `convert_with` consumes the builder,
         // and the table outlives that call.
         let model = declared.flat().clone();
-        let recipes = decls.recipes(&model, &declared).map_err(|errors| {
-            prebindgen_registry::ScanError::AdapterInvariant {
+        let expansion_leaves: Vec<_> = declared.expansion_leaf_readings()?.cloned().collect();
+        let recipes = decls
+            .recipes(&model, &expansion_leaves, &declared)
+            .map_err(|errors| prebindgen_registry::ScanError::AdapterInvariant {
                 message: errors
                     .iter()
                     .map(|e| e.to_string())
                     .collect::<Vec<_>>()
                     .join("; "),
-            }
-        })?;
+            })?;
         // A `data_class` field that is itself one takes the `parts` recipe rather
         // than its own default — see `Declarations::bindings`.
         let bindings = decls

--- a/prebindgen-registry/src/registry/declare.rs
+++ b/prebindgen-registry/src/registry/declare.rs
@@ -297,6 +297,23 @@ impl RegistryBuilder {
         self.registry.named_item_idents()
     }
 
+    /// Readings introduced as leaves of resolved parameter expansions.
+    ///
+    /// Derives the registry first when necessary, so callers cannot silently
+    /// observe an empty pre-validation plan store. The iterator exposes only
+    /// the readings recipe declaration needs, not the expansion map's storage
+    /// or key representation.
+    pub fn expansion_leaf_readings(
+        &mut self,
+    ) -> Result<impl Iterator<Item = &prebindgen_flat::flat::TypeRef>, WriteRustError> {
+        self.derive()?;
+        Ok(self
+            .registry
+            .expansion_plans
+            .values()
+            .flat_map(|plan| plan.leaves.iter().map(|leaf| &leaf.ty)))
+    }
+
     /// Whether the source declares a type under this name — see
     /// `Registry::declares_type`.
     #[cfg(test)]

--- a/prebindgen-registry/src/registry/tests.rs
+++ b/prebindgen-registry/src/registry/tests.rs
@@ -1772,3 +1772,53 @@ fn a_recursive_type_is_handed_out_once_and_terminates() {
     }
     assert!(revisited, "fixture must actually be recursive");
 }
+
+#[test]
+fn expansion_leaf_readings_derive_before_validation() {
+    let consumer: syn::Ident = syn::parse_quote!(consume);
+    let constructor: syn::Ident = syn::parse_quote!(build);
+    let expansions = crate::expand::Expansions {
+        expands: vec![crate::expand::ExpandDecl {
+            func: consumer.clone(),
+            param: syn::parse_quote!(value),
+            declared_target: Some(TypeKey::parse("Value").expect("test type")),
+            sel: crate::expand::ExpandSel::Subset(vec![
+                crate::expand::Variant::Ctor(constructor.clone()),
+                crate::expand::Variant::Identity,
+            ]),
+        }],
+        ..Default::default()
+    };
+    let mut registry = crate::test_util::reg_with(&[
+        "fn build(id: u16) -> Value { todo!() }",
+        "fn consume(value: &Value) {}",
+    ])
+    .export(&consumer)
+    .export(&constructor)
+    .decompose(Decompositions {
+        expansions: Some(expansions),
+        ..Default::default()
+    });
+
+    // No validate/build call precedes this read. The accessor must trigger
+    // derivation itself instead of silently exposing the builder's empty store.
+    let readings: Vec<_> = registry
+        .expansion_leaf_readings()
+        .expect("derive expansion plans")
+        .cloned()
+        .collect();
+
+    assert_eq!(
+        readings.len(),
+        3,
+        "selector, constructor leaf, identity leaf"
+    );
+    assert_eq!(
+        readings
+            .iter()
+            .filter(|reading| reading.optional_inner().is_some())
+            .count(),
+        2,
+        "both non-selector arms are nullable synthetic readings"
+    );
+}

--- a/prebindgen-registry/src/write.rs
+++ b/prebindgen-registry/src/write.rs
@@ -15,7 +15,7 @@
 //! adapters migrating incrementally.
 
 use std::{
-    collections::BTreeMap,
+    collections::{BTreeMap, BTreeSet},
     path::{Path, PathBuf},
 };
 
@@ -33,6 +33,8 @@ use crate::{
 /// [`RegistryBuilder::build`](crate::RegistryBuilder::build)
 /// (see [`Prebindgen::validate_resolved`]), so an invalid binding fails
 /// before a built generator exists and never reaches a writer.
+/// Emission-integrity checks still run here because reachability is finalized
+/// while per-item output is assembled.
 #[derive(Debug)]
 pub enum WriteError {
     /// A `TokenStream` produced by an `on_*` trait method failed to parse
@@ -40,6 +42,12 @@ pub enum WriteError {
     BadTokens {
         phase: &'static str,
         source: syn::Error,
+    },
+    /// Generated code calls a planned private converter whose function was
+    /// removed by reachability filtering.
+    UnrenderedConverterCalls {
+        /// `(caller, missing converter)` pairs, sorted and de-duplicated.
+        calls: Vec<(String, String)>,
     },
 }
 
@@ -51,6 +59,19 @@ impl std::fmt::Display for WriteError {
                     f,
                     "generated tokens from {} did not parse: {}",
                     phase, source
+                )
+            }
+            WriteError::UnrenderedConverterCalls { calls } => {
+                write!(
+                    f,
+                    "generated code calls private converters that were not rendered:"
+                )?;
+                for (caller, converter) in calls {
+                    write!(f, "\n  - `{caller}` calls `{converter}`")?;
+                }
+                write!(
+                    f,
+                    "\nconverter reachability or dependency planning is incomplete"
                 )
             }
         }
@@ -66,6 +87,11 @@ impl std::error::Error for WriteError {}
 /// validation are complete, with the same [`crate::Emit`] capability used for
 /// the rest of final Rust emission.
 pub trait RustFunction {
+    /// The private function name this plan renders. Naming the plan before
+    /// rendering lets the writer validate reachability without granting source
+    /// spelling capability to planning.
+    fn ident(&self) -> &syn::Ident;
+
     /// Whether this plan is reachable from the generated adapter surface.
     /// Validation-only plans may return false and remain available for diagnostics.
     fn should_emit(&self) -> bool {
@@ -77,6 +103,10 @@ pub trait RustFunction {
 }
 
 impl RustFunction for syn::ItemFn {
+    fn ident(&self) -> &syn::Ident {
+        &self.sig.ident
+    }
+
     fn render(&self, _emit: &crate::Emit) -> syn::ItemFn {
         self.clone()
     }
@@ -105,13 +135,19 @@ pub fn write_rust<P: AsRef<Path>, E: Prebindgen, C: RustFunction>(
 ) -> Result<PathBuf, WriteError> {
     // Validation already ran ONCE in the generator's `build` — a built generator
     // (the only source of a resolved registry) is valid by construction, so
-    // this writer is a pure emission.
+    // this writer does no binding resolution. It does validate the assembled
+    // private call graph before handing the file to the destination.
     // The capability, minted here and nowhere else in this function's reach.
     // Every callback below is handed a borrow; nothing else in the pipeline is.
     // See `prebindgen_flat::flat::emit` for what that buys and what it
     // deliberately does not.
     let emit = crate::Emit::new();
     let mut items: Vec<syn::Item> = Vec::new();
+
+    let converter_names: BTreeSet<String> = conversions
+        .iter()
+        .map(|plan| plan.ident().to_string())
+        .collect();
 
     // 0. Adapter prerequisites — runtime-support items (helper structs,
     //    type aliases) the converter bodies depend on. Emitted first so
@@ -206,6 +242,7 @@ pub fn write_rust<P: AsRef<Path>, E: Prebindgen, C: RustFunction>(
         ext.post_process_item(item, registry, &emit);
     }
 
+    validate_converter_calls(&mut items, &converter_names)?;
     let dest: Destination = items.into_iter().collect();
     Ok(dest.write(out_path))
 }
@@ -240,6 +277,73 @@ fn parse_items_from_tokens<I: IntoIterator<Item = TokenStream>>(
         out.extend(file.items);
     }
     Ok(out)
+}
+
+/// Refuse a generated file whose rendered functions still call a private
+/// converter plan removed by reachability filtering.
+///
+/// This is deliberately an integrity check for planned converter functions,
+/// not a general unresolved-name check. Calls to missing prerequisites or
+/// arbitrary external functions remain rustc's responsibility.
+fn validate_converter_calls(
+    items: &mut [syn::Item],
+    candidates: &BTreeSet<String>,
+) -> Result<(), WriteError> {
+    let rendered: BTreeSet<String> = items
+        .iter()
+        .filter_map(|item| match item {
+            syn::Item::Fn(function) => Some(function.sig.ident.to_string()),
+            _ => None,
+        })
+        .collect();
+    let mut visitor = ConverterCallValidator {
+        candidates,
+        rendered: &rendered,
+        caller: None,
+        calls: BTreeSet::new(),
+    };
+    for item in items {
+        syn::visit_mut::VisitMut::visit_item_mut(&mut visitor, item);
+    }
+    if visitor.calls.is_empty() {
+        Ok(())
+    } else {
+        Err(WriteError::UnrenderedConverterCalls {
+            calls: visitor.calls.into_iter().collect(),
+        })
+    }
+}
+
+struct ConverterCallValidator<'a> {
+    candidates: &'a BTreeSet<String>,
+    rendered: &'a BTreeSet<String>,
+    caller: Option<String>,
+    calls: BTreeSet<(String, String)>,
+}
+
+impl syn::visit_mut::VisitMut for ConverterCallValidator<'_> {
+    fn visit_item_fn_mut(&mut self, function: &mut syn::ItemFn) {
+        let previous = self.caller.replace(function.sig.ident.to_string());
+        syn::visit_mut::visit_item_fn_mut(self, function);
+        self.caller = previous;
+    }
+
+    fn visit_expr_call_mut(&mut self, call: &mut syn::ExprCall) {
+        if let syn::Expr::Path(path) = call.func.as_ref() {
+            if let Some(segment) = path.path.segments.last() {
+                let name = segment.ident.to_string();
+                if self.candidates.contains(&name) && !self.rendered.contains(&name) {
+                    self.calls.insert((
+                        self.caller
+                            .clone()
+                            .unwrap_or_else(|| "<generated item>".to_string()),
+                        name,
+                    ));
+                }
+            }
+        }
+        syn::visit_mut::visit_expr_call_mut(self, call);
+    }
 }
 
 #[cfg(test)]

--- a/prebindgen-registry/src/write/tests.rs
+++ b/prebindgen-registry/src/write/tests.rs
@@ -66,23 +66,31 @@ impl Prebindgen for IdentityExt {
 
 #[derive(Clone)]
 struct LatePlan {
+    ident: syn::Ident,
     reachable: Rc<Cell<bool>>,
 }
 
 impl RustFunction for LatePlan {
+    fn ident(&self) -> &syn::Ident {
+        &self.ident
+    }
+
     fn should_emit(&self) -> bool {
         self.reachable.get()
     }
 
     fn render(&self, _emit: &crate::Emit) -> syn::ItemFn {
+        let ident = &self.ident;
         syn::parse_quote!(
-            fn late_converter() {}
+            fn #ident() {}
         )
     }
 }
 
 struct LateExt {
     reachable: Rc<Cell<bool>>,
+    activate: bool,
+    call_converter: bool,
 }
 
 impl Prebindgen for LateExt {
@@ -92,8 +100,15 @@ impl Prebindgen for LateExt {
         _registry: &Registry,
         emit: &crate::Emit,
     ) -> TokenStream {
-        self.reachable.set(true);
-        emit.verbatim_fn(f)
+        if self.activate {
+            self.reachable.set(true);
+        }
+        if self.call_converter {
+            let ident = &f.name;
+            quote::quote!(fn #ident() { late_converter(); })
+        } else {
+            emit.verbatim_fn(f)
+        }
     }
 
     fn on_struct(
@@ -139,8 +154,13 @@ fn per_item_planning_precedes_late_converter_filtering() {
     let reachable = Rc::new(Cell::new(false));
     let ext = LateExt {
         reachable: reachable.clone(),
+        activate: true,
+        call_converter: false,
     };
-    let plan = LatePlan { reachable };
+    let plan = LatePlan {
+        ident: syn::parse_quote!(late_converter),
+        reachable,
+    };
     let dir = crate::test_util::unique_test_dir("write_late_plan");
     std::fs::create_dir_all(&dir).unwrap();
 
@@ -150,6 +170,51 @@ fn per_item_planning_precedes_late_converter_filtering() {
     assert!(source.contains("fn late_converter()"), "{source}");
     assert!(source.find("fn late_converter").unwrap() < source.find("fn a_fn").unwrap());
 }
+
+#[test]
+fn a_call_to_a_filtered_converter_is_a_writer_error() {
+    let item: syn::ItemFn = syn::parse_quote!(
+        fn a_fn() {}
+    );
+    let ident: syn::Ident = syn::parse_quote!(a_fn);
+    let registry =
+        crate::test_util::reg_from_items(vec![(syn::Item::Fn(item), SourceLocation::default())])
+            .expect("index")
+            .export(&ident)
+            .scanned()
+            .expect("scan");
+    let reachable = Rc::new(Cell::new(false));
+    let ext = LateExt {
+        reachable: reachable.clone(),
+        activate: false,
+        call_converter: true,
+    };
+    let plan = LatePlan {
+        ident: syn::parse_quote!(late_converter),
+        reachable,
+    };
+    let dir = crate::test_util::unique_test_dir("write_missing_converter");
+    std::fs::create_dir_all(&dir).unwrap();
+    let path = dir.join("gen.rs");
+
+    let err = write_rust(&registry, &ext, &[plan], &path)
+        .expect_err("a call to a filtered private converter must fail in the writer");
+
+    match err {
+        WriteError::UnrenderedConverterCalls { calls } => {
+            assert_eq!(
+                calls,
+                vec![("a_fn".to_string(), "late_converter".to_string())]
+            );
+        }
+        other => panic!("unexpected writer error: {other}"),
+    }
+    assert!(
+        !path.exists(),
+        "an invalid generated file must not reach the destination"
+    );
+}
+
 #[test]
 fn dedup_and_sort() {
     // Two crossings can compile the same conversion, and an adapter hands over


### PR DESCRIPTION
## Problem

A multi-variant `expand_param!` makes each constructor leaf nullable while another arm is selected. Those synthetic `Option<T>` readings exist only in the resolved expansion plan, not in the captured Flat model.

JniGen built implicit Optional recipe rows by walking only Flat. An Encoding-shaped required `u16` leaf therefore missed the allocation-free pair row and selected the boxed whole-value fallback: Kotlin passed `Integer`/`JObject`, and generated Rust crossed JNI again with `intValue()`. That fallback could also leave a wrapper calling a converter removed by reachability filtering, which surfaced only as `E0425` when a consumer compiled generated Rust.

## Change

- Add `RegistryBuilder::expansion_leaf_readings()`. It derives expansion plans on demand and exposes only synthetic leaf readings, without publishing the expansion map or its key representation.
- Include expansion-created Optional readings in JniGen recipe declaration while preserving explicit type and conversion declarations.
- Select the existing registry pair row for niche-free nullable primitive leaves. Public Kotlin remains `Int?`; Kotlin decomposes it to `Boolean + Int` before the native call, and the shared Optional chain constructs `Option<u16>` from those primitives.
- Give every `RustFunction` plan its private function identifier. After final assembly and adapter post-processing, the shared writer now rejects calls to planned converters that were not rendered, before writing an invalid destination file.
- Add regressions for pre-validation expansion-leaf access, filtered-converter calls, the exact Encoding-shaped generator path, and absent, constructor, and identity selector arms on the JVM.

For the covered Encoding shape, generated Rust contains `tuple2_to_Option_u16_*` and no `JObject_to_Option_u16_*` or `intValue()`.

## Compatibility

Generated Kotlin public declarations and behavior are unchanged. The private generated Java Native Interface (JNI) descriptor for affected nullable primitive leaves intentionally changes from one boxed object to a presence primitive plus the raw value primitive. Rust and Kotlin sides regenerate together, so the private boundary stays synchronized while avoiding allocation and a nested JNI call.

The real zenoh-flat-jni consumer compiles against this branch. Its generated Rust gains one pair converter and changes the 11 affected extern signatures and bodies; generated Kotlin keeps all 1,019 public declarations unchanged. The boxed whole-value route remains available for shapes that support it, while the writer guard turns any future missing private converter into a generator error.

This does not yet reuse the outer selector as the presence bit. That optimization can be considered when the registry Choice plan owns the complete expansion fold; this PR uses the existing general Optional pair representation.

## Verification

- `cargo test --workspace` — passed
- `cargo clippy --workspace --all-targets -- -D warnings` — passed
- `cargo fmt --all -- --check` — passed
- `git diff --check` — passed
- `cargo test -p prebindgen-registry a_call_to_a_filtered_converter_is_a_writer_error` — passed
- `cargo test -p prebindgen-registry expansion_leaf_readings_derive_before_validation` — passed
- `cargo test -p prebindgen-jni optional_selector_dispatch_end_to_end` — passed
- `bash examples/regen-check.sh` — generated output is byte-identical
- `cd examples/covertest-kotlin && ./gradlew run` — 58/58 sections passed
- zenoh-flat-jni full consumer compile — passed, as independently reproduced in review

Stacked on #513. Follow-up to #525 and the review finding on #529.