### PR TITLE
Freeze JNI expansion folds before rendering

### DIFF
--- a/examples/covertest-kotlin/build.rs
+++ b/examples/covertest-kotlin/build.rs
@@ -29,6 +29,7 @@
 //! | bounded conversion domains + niches | `Option<Duration>` ⇄ bounded millisecond `ULong?`; raw JNI remains primitive `Long`, `None` uses an invalid `u64`, invalid input/output routes to `onError`; `DurationBoundary` composes the niche through a data-class field and whole-object decode |
 //! | `.method()` / `.constructor()`       | `Storage` + `Summary` + `Stamp` members |
 //! | `expand_param!` `.variant()` (+`_self`)| `Summary` default input (splittable, checked #52) |
+//! | recursive `expand_param!` constructor input | `SummaryEnvelope` folds the nested Summary build/identity selector before its outer constructor |
 //! | Optional combined-selector expansion  | `summary_total_opt(Option<&Summary>)` — selector `-1` = absent, borrow-identity arm clones; `selector_code_score(Option<&SelectorCode>)` lowers its synthetic `Option<u16>` build-arm leaf to a primitive presence/value pair |
 //! | `FunctionDecl::split_on_param` (#52)  | single: `archiveStore`/`storageMatchesSummary` (class-default) + `storageExpectSummary` (per-fn); cartesian product: `summaryPrefer` (2 params); manual same-named overload in `ManualOverloads.kt` |
 //! | split × builder-delivered return (#87) | `summaryMerge` — cartesian split + generic `<R>` wrapper; every overload re-declares `<R>` |
@@ -428,6 +429,10 @@ fn main() {
                 // registry pair recipe at the native ABI (#525 follow-up).
                 .class(ptr_class!(SelectorCode).constructor(fun!(selector_code_new)))
                 .fun(fun!(selector_code_score))
+                // `SummaryEnvelope` has no Kotlin class. Its sole constructor
+                // takes `Summary`, so the registry recursively folds Summary's
+                // own selector expansion before building the outer Rust value.
+                .fun(fun!(summary_envelope_score))
                 // `Archive` holds the latest `Summary` and returns it BORROWED
                 // (`Option<&Summary>`) — the JVM binding clones it into a fresh owned
                 // handle (the zenoh-flat borrowed-accessor shape). Its Kotlin class is
@@ -446,6 +451,7 @@ fn main() {
                 .variant(fun!(summary_new))
                 .variant_self(),
         )
+        .expand(expand_param!(SummaryEnvelope).variant(fun!(summary_envelope_new)))
         .expand(
             expand_param!(SelectorCode)
                 .variant(fun!(selector_code_new))

--- a/examples/covertest-kotlin/kotlin/REPORT.md
+++ b/examples/covertest-kotlin/kotlin/REPORT.md
@@ -33,6 +33,8 @@ Base package: `io.prebindgen.covertest`
   - shaped by: return `Summary` decomposed → [count, total, handle] (Callback delivery)
 - `summary_describe` — `fun describeSummary(sSel: Int, s00: Long?, s01: Double?, s1: Summary?, verbose: Boolean, onError: JniErrorHandler<String?>): String?`
   - shaped by: param `s` expanded from `Summary` — variants [summary_new, self]
+- `summary_envelope_score` — `fun summaryEnvelopeScore(valueSummarySel: Int, valueSummary00: Long?, valueSummary01: Double?, valueSummary1: Summary?, valueBonus: Long, onError: JniErrorHandler<Long>): Long`
+  - shaped by: param `value` expanded from `SummaryEnvelope` — variants [summary_envelope_new]
 - `summary_merge` — `fun <R> summaryMerge(primarySel: Int, primary00: Long?, primary01: Double?, primary1: Summary?, fallbackSel: Int, fallback00: Long?, fallback01: Double?, fallback1: Summary?, onError: JniErrorHandler<R?>, build: SummaryBuilder<R>): R?`
   - shaped by: param `fallback` expanded from `Summary` — variants [summary_new, self]
   - shaped by: param `primary` expanded from `Summary` — variants [summary_new, self]
@@ -283,3 +285,4 @@ Base package: `io.prebindgen.covertest`
 ## rust-side-only types
 
 - `Ledger` (never materializes in Kotlin)
+- `SummaryEnvelope` (never materializes in Kotlin)

--- a/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest.kt
+++ b/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest.kt
@@ -1636,6 +1636,18 @@ internal object CovNative {
     ): String
 
     @JvmSynthetic
+    external fun summaryEnvelopeScore(
+        valueSummarySel: Int,
+        valueSummary00Present: Boolean,
+        valueSummary00Value: Long,
+        valueSummary01Present: Boolean,
+        valueSummary01Value: Double,
+        valueSummary1: Long,
+        valueBonus: Long,
+        errorSink: Any,
+    ): Long
+
+    @JvmSynthetic
     external fun summaryFromMean(count: Long, mean: Double, errorSink: Any): Long
 
     @JvmSynthetic

--- a/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest/analytics.kt
+++ b/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest/analytics.kt
@@ -264,6 +264,48 @@ public fun selectorCodeScore(
 }
 
 /**
+ * Observe a recursively reconstructed [`SummaryEnvelope`].
+ *
+ * Parameter `value` is the Rust `SummaryEnvelope` argument, expanded: its `summary_envelope_new` inputs (crosses as `valueSummarySel`, `valueSummary00`, `valueSummary01`, `valueSummary1`, `valueBonus`).
+ */
+public fun summaryEnvelopeScore(
+    valueSummarySel: Int,
+    valueSummary00: Long?,
+    valueSummary01: Double?,
+    valueSummary1: Summary?,
+    valueBonus: Long,
+    onError: JniErrorHandler<Long>,
+): Long {
+    if (valueSummary1?.isClosed() == true) return onError.run(
+        "Operation on a closed native handle.",
+    )
+    val __bcap = JniErrorHandlerCapture.acquire()
+    val __ret = run {
+        val __locks = ArrayList<NativeHandle>()
+        valueSummary1?.let { __locks.add(it) }
+        withSortedHandleLocks(__locks) {
+            val valueSummary1_ptr = valueSummary1?.ptr ?: 0L
+            try {
+                CovNative.summaryEnvelopeScore(
+                    valueSummarySel,
+                    valueSummary00 != null,
+                    valueSummary00 ?: 0L,
+                    valueSummary01 != null,
+                    valueSummary01 ?: 0.0,
+                    valueSummary1_ptr,
+                    valueBonus,
+                    __bcap,
+                )
+            } finally {
+                valueSummary1?.markConsumed()
+            }
+        }
+    }
+    if (__bcap.failed) return onError.run(__bcap.ze0)
+    return __ret
+}
+
+/**
  * Summarize a storage (returns a `Summary`; the binding's **default
  * flatten-output** turns it into `(count, total)` leaves).
  *

--- a/examples/covertest-kotlin/kotlin/io/prebindgen/covertest/Test.kt
+++ b/examples/covertest-kotlin/kotlin/io/prebindgen/covertest/Test.kt
@@ -20,6 +20,7 @@ import io.prebindgen.covertest.analytics.summarySeriesOpt
 import io.prebindgen.covertest.analytics.summaryTotalOpt
 import io.prebindgen.covertest.analytics.summaryTotalRaw
 import io.prebindgen.covertest.analytics.selectorCodeScore
+import io.prebindgen.covertest.analytics.summaryEnvelopeScore
 import io.prebindgen.covertest.errors.StorageErrorHandler
 import io.prebindgen.covertest.esc_pkg.Esc_Probe
 import io.prebindgen.covertest.model.Annotated
@@ -1435,6 +1436,15 @@ fun main() {
         val code = SelectorCode.new(50, byteArrayOf(1, 2, 3), boom).orThrow()
         check(selectorCodeScore(1, null, null, code, boom) == 53L)
         code.close()
+    }
+
+    // ── recursive constructor expansion: nested build and identity arms ─────
+    section("recursive constructor expansion freezes nested constructors") {
+        // The outer SummaryEnvelope constructor receives a Summary. Exercise
+        // both variants of that nested Summary build before the outer call.
+        check(summaryEnvelopeScore(0, 4L, 10.0, null, 3L, boom) == 17L)
+        val nested = Summary.of(5L, 12.0, boom).orThrow()
+        check(summaryEnvelopeScore(1, null, null, nested, 2L, boom) == 19L)
     }
 
     // ── flatten input on Summary: default + with, both selectors ─────────────

--- a/examples/covertest-kotlin/src/generated_bindings.rs
+++ b/examples/covertest-kotlin/src/generated_bindings.rs
@@ -22360,6 +22360,189 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_summaryDescribe<
 }
 #[no_mangle]
 #[allow(non_snake_case, unused_mut, unused_variables, dead_code)]
+pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_summaryEnvelopeScore<'a>(
+    mut env: jni::JNIEnv<'a>,
+    _class: jni::objects::JClass<'a>,
+    value_summary_sel: jni::sys::jint,
+    value_summary_0_0_present: jni::sys::jboolean,
+    value_summary_0_0_value: jni::sys::jlong,
+    value_summary_0_1_present: jni::sys::jboolean,
+    value_summary_0_1_value: jni::sys::jdouble,
+    value_summary_1: jni::sys::jlong,
+    value_bonus: jni::sys::jlong,
+    __error_sink: jni::objects::JObject<'a>,
+) -> jni::sys::jlong {
+    #[allow(non_upper_case_globals)]
+    static __SINK_MID: ::prebindgen_jni_runtime::CachedIfaceMethod = ::prebindgen_jni_runtime::CachedIfaceMethod::new();
+    const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
+    const __SINK_DESCR: &str = "(Ljava/lang/String;)Ljava/lang/Object;";
+    let __exp_value_summary_sel = match jint_to_i32_a3e3b6ef(
+        &mut env,
+        &value_summary_sel,
+    ) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__e) => {
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e.to_string(),
+            );
+            return 0 as jni::sys::jlong;
+        }
+    };
+    let __exp_value_summary_0_0: Option<i64> = match tuple2_to_Option_i64_b2611839(
+        &mut env,
+        (value_summary_0_0_present, value_summary_0_0_value),
+    ) {
+        ::core::result::Result::Ok(__value) => __value,
+        ::core::result::Result::Err(__error) => {
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__error.to_string(),
+            );
+            return 0 as jni::sys::jlong;
+        }
+    };
+    let __exp_value_summary_0_1: Option<f64> = match tuple2_to_Option_f64_49db5632(
+        &mut env,
+        (value_summary_0_1_present, value_summary_0_1_value),
+    ) {
+        ::core::result::Result::Ok(__value) => __value,
+        ::core::result::Result::Err(__error) => {
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__error.to_string(),
+            );
+            return 0 as jni::sys::jlong;
+        }
+    };
+    let __exp_value_summary_1 = match jlong_to_Option_Summary_252ef2ba(
+        &mut env,
+        &value_summary_1,
+    ) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__e) => {
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e.to_string(),
+            );
+            return 0 as jni::sys::jlong;
+        }
+    };
+    let __exp_value_bonus = match jlong_to_i64_fbf9a9bc(&mut env, &value_bonus) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__e) => {
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e.to_string(),
+            );
+            return 0 as jni::sys::jlong;
+        }
+    };
+    let __folded_value = match {
+        (|| -> ::core::result::Result<_, ::std::string::String> {
+            let __a0 = {
+                let __r: ::core::result::Result<_, ::std::string::String> = {
+                    match __exp_value_summary_sel {
+                        0i32 => {
+                            match (__exp_value_summary_0_0, __exp_value_summary_0_1) {
+                                (
+                                    ::core::option::Option::Some(__p0),
+                                    ::core::option::Option::Some(__p1),
+                                ) => {
+                                    ::core::result::Result::Ok(
+                                        perftest_flat::summary_new(__p0, __p1),
+                                    )
+                                }
+                                _ => {
+                                    ::core::result::Result::Err(
+                                        ::std::string::String::from(
+                                            "constructor variant input missing",
+                                        ),
+                                    )
+                                }
+                            }
+                        }
+                        1i32 => {
+                            match __exp_value_summary_1 {
+                                ::core::option::Option::Some(__v) => {
+                                    ::core::result::Result::Ok(__v)
+                                }
+                                ::core::option::Option::None => {
+                                    ::core::result::Result::Err(
+                                        ::std::string::String::from(
+                                            "identity variant value missing",
+                                        ),
+                                    )
+                                }
+                            }
+                        }
+                        __sel => {
+                            ::core::result::Result::Err(
+                                ::std::format!("invalid constructor selector: {}", __sel),
+                            )
+                        }
+                    }
+                };
+                __r?
+            };
+            let __a1 = __exp_value_bonus;
+            ::core::result::Result::Ok(perftest_flat::summary_envelope_new(__a0, __a1))
+        })()
+    } {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__e) => {
+            let __je = <__JniErr as ::core::convert::From<
+                ::std::string::String,
+            >>::from(__e);
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__je.to_string(),
+            );
+            return 0 as jni::sys::jlong;
+        }
+    };
+    let __out = perftest_flat::summary_envelope_score(__folded_value);
+    match i64_to_jlong_fbf9a9bc(&mut env, __out) {
+        ::core::result::Result::Ok(__w) => __w,
+        ::core::result::Result::Err(__e) => {
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e.to_string(),
+            );
+            0 as jni::sys::jlong
+        }
+    }
+}
+#[no_mangle]
+#[allow(non_snake_case, unused_mut, unused_variables, dead_code)]
 pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_summaryFromMean<'a>(
     mut env: jni::JNIEnv<'a>,
     _class: jni::objects::JClass<'a>,

--- a/examples/perftest-flat/src/ext.rs
+++ b/examples/perftest-flat/src/ext.rs
@@ -42,6 +42,11 @@ mod handles {
         pub(super) total: f64,
     }
 
+    pub struct SummaryEnvelope {
+        pub(super) summary: Summary,
+        pub(super) bonus: i64,
+    }
+
     #[derive(Clone)]
     pub struct SelectorCode {
         pub(super) id: u16,
@@ -806,6 +811,24 @@ pub fn summary_count(s: &Summary) -> i64 {
 #[prebindgen]
 pub fn summary_total(s: &Summary) -> f64 {
     s.total
+}
+
+/// Rust-side-only aggregate used to exercise recursive input expansion: its
+/// constructor receives a [`Summary`], whose own default constructor expansion
+/// must be folded before this outer constructor is called.
+#[prebindgen]
+pub type SummaryEnvelope = handles::SummaryEnvelope;
+
+/// Construct the outer half of the recursive input-expansion fixture.
+#[prebindgen]
+pub fn summary_envelope_new(summary: Summary, bonus: i64) -> SummaryEnvelope {
+    SummaryEnvelope { summary, bonus }
+}
+
+/// Observe a recursively reconstructed [`SummaryEnvelope`].
+#[prebindgen]
+pub fn summary_envelope_score(value: SummaryEnvelope) -> i64 {
+    value.summary.count + value.summary.total as i64 + value.bonus
 }
 
 /// Total scaled by a factor (an instance **method**: `&Self` receiver + arg).

--- a/prebindgen-jni/src/jni/emit/wrapper.rs
+++ b/prebindgen-jni/src/jni/emit/wrapper.rs
@@ -229,7 +229,7 @@ pub(crate) fn emit_jni_function_wrapper_with_callee(
     let on_err = sentinel_for_wire(&wire_ty);
 
     for param in &plan.params {
-        let (wp, pre, call_arg) = emit_input_param(ext, registry, param, &on_err, emit);
+        let (wp, pre, call_arg) = emit_input_param(param, &on_err, emit);
         wire_params.extend(wp);
         prelude.extend(pre);
         call_args.push(call_arg);
@@ -502,8 +502,6 @@ fn unfold_builder_param(iterable_fold: bool) -> TokenStream {
 /// site only renders each [`InputKind`]'s decode.
 #[allow(clippy::type_complexity)]
 fn emit_input_param(
-    ext: &Declarations,
-    registry: &Registry,
     param: &PlanParam,
     on_err: &TokenStream,
     emit: &prebindgen_registry::Emit,
@@ -513,7 +511,7 @@ fn emit_input_param(
     // (pure-Rust) fold to build the value, then pass it to the call.
     let leaf = match &param.form {
         ParamForm::Expanded { plan: fold, leaves } => {
-            return emit_expanded_param(ext, registry, fold, leaves, &param.ident, on_err, emit);
+            return emit_expanded_param(fold, leaves, &param.ident, on_err, emit);
         }
         ParamForm::Single(leaf) => &**leaf,
     };
@@ -687,20 +685,19 @@ fn emit_plain_decode(
 /// through the same error sink as any fallible input. The returned call
 /// argument is the built value (`&value` when the original parameter was `&T`).
 pub(crate) fn emit_expanded_param(
-    ext: &Declarations,
-    registry: &Registry,
-    plan: &prebindgen_registry::expand::FoldPlan,
+    plan: &ExpandedParamPlan,
     leaves: &[PlanLeaf],
     orig_param: &syn::Ident,
     on_err: &TokenStream,
     emit: &prebindgen_registry::Emit,
 ) -> (Vec<TokenStream>, Vec<TokenStream>, TokenStream) {
     let mut wire_params: Vec<TokenStream> = Vec::new();
+    let fold = plan.fold();
     let mut prelude: Vec<TokenStream> = Vec::new();
     let mut leaf_locals: Vec<syn::Ident> = Vec::new();
 
-    debug_assert_eq!(plan.leaves.len(), leaves.len());
-    for (leaf, classified) in plan.leaves.iter().zip(leaves) {
+    debug_assert_eq!(fold.leaves.len(), leaves.len());
+    for (leaf, classified) in fold.leaves.iter().zip(leaves) {
         let leaf_ty = &leaf.ty;
         // The ascription generated Rust writes for this leaf's local.
         let leaf_ty_tokens = emit.spell(leaf_ty);
@@ -782,11 +779,7 @@ pub(crate) fn emit_expanded_param(
 
     // The fold itself (language-agnostic). Its `Err(String)` is lifted into
     // `__JniErr` and routed through the same sink as fallible inputs.
-    let qualify = |id: &syn::Ident| -> syn::Path {
-        let m = ext.fn_module(registry, id);
-        syn::parse_quote!(#m::#id)
-    };
-    let fold_expr = prebindgen_registry::expand::emit_fold(plan, &leaf_locals, &qualify);
+    let fold_expr = plan.emit(&leaf_locals);
     let folded = format_ident!("__folded_{}", orig_param);
     prelude.push(quote!(
         let #folded = match #fold_expr {
@@ -801,7 +794,7 @@ pub(crate) fn emit_expanded_param(
 
     // `Option<&T>` ⇒ `folded.as_ref()`; `&T` ⇒ `&folded`; by-value (incl.
     // `Option<T>`) ⇒ `folded`.
-    let call_arg = match (plan.produces_option(), plan.by_ref) {
+    let call_arg = match (fold.produces_option(), fold.by_ref) {
         (true, true) => quote!(#folded.as_ref()),
         (false, true) => quote!(&#folded),
         (_, false) => quote!(#folded),

--- a/prebindgen-jni/src/jni/fn_plan.rs
+++ b/prebindgen-jni/src/jni/fn_plan.rs
@@ -74,12 +74,80 @@ pub(crate) enum ParamForm {
     /// remains a source-parameter-only collection optimization), so all three
     /// sites agree on the leaf wire.
     Expanded {
-        /// The registry-built constructor plan. Keeping it beside its lowered
-        /// leaves lets Rust reconstruction and Kotlin/report descriptions use
-        /// the same decision after resolution.
-        plan: Box<prebindgen_registry::expand::FoldPlan>,
+        /// The frozen constructor fold and qualified call paths. Keeping it
+        /// beside its lowered leaves lets Rust reconstruction and Kotlin/report
+        /// descriptions use the same decision after resolution.
+        plan: Box<ExpandedParamPlan>,
         leaves: Vec<PlanLeaf>,
     },
+}
+
+/// Registry-built expansion fold plus every Rust constructor path it may call.
+///
+/// The core [`prebindgen_registry::expand::FoldPlan`] owns constructor
+/// selection and recursive argument assembly. JNI freezes origin qualification
+/// beside it while the registry is still available, so final wrapper emission
+/// only supplies decoded leaf locals and never resumes a registry lookup.
+pub(crate) struct ExpandedParamPlan {
+    fold: prebindgen_registry::expand::FoldPlan,
+    constructors: BTreeMap<String, syn::Path>,
+}
+
+impl ExpandedParamPlan {
+    fn new(
+        ext: &Declarations,
+        registry: &Registry,
+        fold: &prebindgen_registry::expand::FoldPlan,
+    ) -> Self {
+        let mut constructors = BTreeMap::new();
+        Self::freeze_variants(ext, registry, &fold.variants, &mut constructors);
+        Self {
+            fold: fold.clone(),
+            constructors,
+        }
+    }
+
+    fn freeze_variants(
+        ext: &Declarations,
+        registry: &Registry,
+        variants: &[prebindgen_registry::expand::FoldVariant],
+        constructors: &mut BTreeMap<String, syn::Path>,
+    ) {
+        for variant in variants {
+            if let Some(ctor) = &variant.ctor {
+                let module = ext.fn_module(registry, ctor);
+                let path = syn::parse_quote!(#module::#ctor);
+                constructors.entry(ctor.to_string()).or_insert(path);
+            }
+            for input in &variant.inputs {
+                if let prebindgen_registry::expand::FoldArg::Build(build) = input {
+                    Self::freeze_variants(ext, registry, &build.variants, constructors);
+                }
+            }
+        }
+    }
+
+    /// The core fold shared with Kotlin overload and report consumers.
+    pub(crate) fn fold(&self) -> &prebindgen_registry::expand::FoldPlan {
+        &self.fold
+    }
+
+    /// Assemble the fold expression from already-decoded leaf locals.
+    pub(crate) fn emit(&self, leaf_locals: &[syn::Ident]) -> syn::Expr {
+        prebindgen_registry::expand::emit_fold(&self.fold, leaf_locals, &|ident| {
+            self.constructors
+                .get(&ident.to_string())
+                .unwrap_or_else(|| {
+                    panic!("frozen JNI expansion plan has no constructor path for `{ident}`")
+                })
+                .clone()
+        })
+    }
+
+    #[cfg(test)]
+    pub(crate) fn constructor_path(&self, ident: &str) -> Option<&syn::Path> {
+        self.constructors.get(ident)
+    }
 }
 
 /// One classified effective parameter (a source param, or one expansion leaf).
@@ -559,7 +627,7 @@ impl JniFunctionPlan {
                     )?);
                 }
                 ParamForm::Expanded {
-                    plan: Box::new(plan.clone()),
+                    plan: Box::new(ExpandedParamPlan::new(ext, registry, plan)),
                     leaves,
                 }
             } else {

--- a/prebindgen-jni/src/jni/overloads.rs
+++ b/prebindgen-jni/src/jni/overloads.rs
@@ -325,7 +325,7 @@ fn resolve_split<'a>(
         .iter()
         .find(|planned| planned.ident == param)
         .and_then(|planned| match &planned.form {
-            ParamForm::Expanded { plan, .. } => Some(plan.as_ref()),
+            ParamForm::Expanded { plan, .. } => Some(plan.fold()),
             ParamForm::Single(_) => None,
         })
         .unwrap_or_else(|| {

--- a/prebindgen-jni/src/jni/render.rs
+++ b/prebindgen-jni/src/jni/render.rs
@@ -2395,7 +2395,7 @@ fn shape_notes(fplan: &JniFunctionPlan) -> Option<String> {
         .params
         .iter()
         .filter_map(|param| match &param.form {
-            ParamForm::Expanded { plan, .. } => Some((&param.ident, plan.as_ref())),
+            ParamForm::Expanded { plan, .. } => Some((&param.ident, plan.fold())),
             ParamForm::Single(_) => None,
         })
         .collect();

--- a/prebindgen-jni/src/jni/report.rs
+++ b/prebindgen-jni/src/jni/report.rs
@@ -215,7 +215,7 @@ impl super::JniGen {
             .params
             .iter()
             .filter_map(|param| match &param.form {
-                crate::jni::ParamForm::Expanded { plan, .. } => Some((&param.ident, plan.as_ref())),
+                crate::jni::ParamForm::Expanded { plan, .. } => Some((&param.ident, plan.fold())),
                 crate::jni::ParamForm::Single(_) => None,
             })
             .collect();

--- a/prebindgen-jni/src/jni/tests/flatten.rs
+++ b/prebindgen-jni/src/jni/tests/flatten.rs
@@ -1130,6 +1130,21 @@ fn binding_local_functions_all_positions() {
     let _ = std::fs::remove_dir_all(&dir);
     std::fs::create_dir_all(&dir).unwrap();
     let gen = jni.build_with(registry).expect("resolve");
+    let function_plan = gen
+        .generation_plan()
+        .function(&syn::parse_quote!(z_use))
+        .expect("frozen z_use plan");
+    let ParamForm::Expanded { plan, .. } = &function_plan.params[0].form else {
+        panic!("z_use primary parameter must be expanded");
+    };
+    assert_eq!(
+        plan.constructor_path("z_thing_from_len")
+            .expect("frozen local constructor path")
+            .to_token_stream()
+            .to_string(),
+        "crate :: z_thing_from_len"
+    );
+
     let rust_path = gen.write_rust(dir.join("gen.rs")).expect("write_rust");
     let rust = std::fs::read_to_string(&rust_path).unwrap();
     let rc: String = rust.split_whitespace().collect();
@@ -1932,8 +1947,32 @@ fn optional_selector_dispatch_end_to_end() {
             loc.clone(),
         ),
         (
+            syn::Item::Struct(syn::parse_quote!(
+                pub struct ZReq {
+                    _p: u8,
+                }
+            )),
+            loc.clone(),
+        ),
+        (
             syn::Item::Fn(syn::parse_quote!(
                 pub fn z_enc_from_id(id: u16, schema: Option<Vec<u8>>) -> ZEnc {
+                    unimplemented!()
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn z_req_new(enc: ZEnc, bonus: i64) -> ZReq {
+                    unimplemented!()
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn z_score(req: ZReq) -> i64 {
                     unimplemented!()
                 }
             )),
@@ -1957,17 +1996,58 @@ fn optional_selector_dispatch_end_to_end() {
                 .class(
                     crate::ptr_class!(ZEnc).constructor(prebindgen_registry::fun!(z_enc_from_id)),
                 )
+                .fun(prebindgen_registry::fun!(z_score))
                 .fun(prebindgen_registry::fun!(z_put)),
         )
         .expand(
             prebindgen_registry::expand_param!(ZEnc)
                 .variant(prebindgen_registry::fun!(z_enc_from_id))
                 .variant_self(),
+        )
+        .expand(
+            prebindgen_registry::expand_param!(ZReq).variant(prebindgen_registry::fun!(z_req_new)),
         );
     let dir = unique_test_dir("jnigen_opt_selector");
     let _ = std::fs::remove_dir_all(&dir);
     std::fs::create_dir_all(&dir).unwrap();
     let gen = jni.build_with(registry).expect("resolve");
+    let function_plan = gen
+        .generation_plan()
+        .function(&syn::parse_quote!(z_put))
+        .expect("frozen z_put plan");
+    let ParamForm::Expanded { plan, .. } = &function_plan.params[0].form else {
+        panic!("z_put encoding parameter must be expanded");
+    };
+    assert_eq!(
+        plan.constructor_path("z_enc_from_id")
+            .expect("frozen source constructor path")
+            .to_token_stream()
+            .to_string(),
+        "myflat :: z_enc_from_id"
+    );
+
+    let nested_plan = gen
+        .generation_plan()
+        .function(&syn::parse_quote!(z_score))
+        .expect("frozen z_score plan");
+    let ParamForm::Expanded { plan, .. } = &nested_plan.params[0].form else {
+        panic!("z_score request parameter must be expanded");
+    };
+    assert_eq!(
+        plan.constructor_path("z_req_new")
+            .expect("frozen outer constructor path")
+            .to_token_stream()
+            .to_string(),
+        "myflat :: z_req_new"
+    );
+    assert_eq!(
+        plan.constructor_path("z_enc_from_id")
+            .expect("frozen nested constructor path")
+            .to_token_stream()
+            .to_string(),
+        "myflat :: z_enc_from_id"
+    );
+
     let rust_path = gen.write_rust(dir.join("gen.rs")).expect("write_rust");
     let rust = std::fs::read_to_string(&rust_path).unwrap();
     let rc: String = rust.split_whitespace().collect();


### PR DESCRIPTION
## Summary

- Freeze each expanded JNI parameter as one adapter plan containing the registry-built constructor fold and every recursively qualified Rust constructor path.
- Make final expanded-parameter rendering consume only that immutable plan plus decoded leaf locals; it no longer queries `Registry` or `Declarations` to rebuild constructor calls.
- Keep Kotlin overloads, shape notes, and reports on the same core fold decision.

This advances stage 5 of #513. It does not expose captured Rust types during planning: the plan retains Flat `TypeRef` readings and constructor paths, while source type spelling remains confined to final emission through `Emit`.

The implementation leaves every pre-existing generated Rust, Kotlin, and report artifact byte-for-byte unchanged. The review follow-up intentionally adds one covertest-only `SummaryEnvelope` binding to exercise recursive constructor input: a nested `Summary` is built through either its scalar constructor arm or identity-handle arm before the outer constructor runs.

## Verification

- `cargo test -p prebindgen-jni binding_local_functions_all_positions` — passed
- `cargo test -p prebindgen-jni optional_selector_dispatch_end_to_end` — passed, including frozen outer and nested constructor paths
- `cargo check -p prebindgen-jni --all-targets` — passed
- `cargo test --workspace` — passed
- `cargo clippy --workspace --all-targets -- -D warnings` — passed
- `cargo fmt --all -- --check` — passed
- `git diff --check` — passed
- `bash examples/regen-check.sh` — passed; committed generated output is reproducible byte-for-byte
- `cd examples/covertest-kotlin && ./gradlew run` — passed all 59 runtime sections