### PR TITLE
Drive borrowed optional handles from registry plans

### DIFF
--- a/prebindgen-jni/src/jni/chain.rs
+++ b/prebindgen-jni/src/jni/chain.rs
@@ -18,6 +18,7 @@ pub(crate) struct JFunction(JBody);
 enum JBody {
     Complete(Box<syn::ItemFn>),
     OwnedHandle(Box<JOwnedHandlePlan>),
+    BorrowedOptionalHandle(Box<JBorrowedOptionalHandlePlan>),
     Product(Box<JProductPlan>),
     Choice(Box<JChoicePlan>),
     Sequence(Box<JSequencePlan>),
@@ -32,6 +33,10 @@ impl JFunction {
 
     pub(crate) fn owned_handle(plan: JOwnedHandlePlan) -> Self {
         Self(JBody::OwnedHandle(Box::new(plan)))
+    }
+
+    pub(crate) fn borrowed_optional_handle(plan: JBorrowedOptionalHandlePlan) -> Self {
+        Self(JBody::BorrowedOptionalHandle(Box::new(plan)))
     }
 
     pub(crate) fn product(plan: JProductPlan) -> Self {
@@ -59,10 +64,16 @@ impl JFunction {
         matches!(self.0, JBody::Invoke(_))
     }
 
+    #[cfg(test)]
+    pub(crate) fn is_borrowed_optional_handle(&self) -> bool {
+        matches!(self.0, JBody::BorrowedOptionalHandle(_))
+    }
+
     pub(crate) fn mark_reachable(&self) {
         match &self.0 {
             JBody::Complete(_) => {}
             JBody::OwnedHandle(plan) => plan.reachable.set(true),
+            JBody::BorrowedOptionalHandle(plan) => plan.reachable.set(true),
             JBody::Product(plan) => {
                 plan.reachable.set(true);
                 for dependency in &plan.dependencies {
@@ -101,6 +112,7 @@ impl RustFunction for JFunction {
         match &self.0 {
             JBody::Complete(function) => &function.sig.ident,
             JBody::OwnedHandle(plan) => &plan.ident,
+            JBody::BorrowedOptionalHandle(plan) => &plan.ident,
             JBody::Product(plan) => &plan.ident,
             JBody::Choice(plan) => &plan.ident,
             JBody::Sequence(plan) => &plan.ident,
@@ -113,6 +125,7 @@ impl RustFunction for JFunction {
         match &self.0 {
             JBody::Complete(_) => true,
             JBody::OwnedHandle(plan) => plan.reachable.get(),
+            JBody::BorrowedOptionalHandle(plan) => plan.reachable.get(),
             JBody::Product(plan) => plan.reachable.get(),
             JBody::Optional(plan) => plan.reachable.get(),
             JBody::Sequence(plan) => plan.reachable.get(),
@@ -127,6 +140,7 @@ impl RustFunction for JFunction {
         match &self.0 {
             JBody::Complete(function) => (**function).clone(),
             JBody::OwnedHandle(plan) => plan.render(emit),
+            JBody::BorrowedOptionalHandle(plan) => plan.render(emit),
             JBody::Product(plan) => plan.render(emit),
             JBody::Optional(plan) => plan.render(emit),
             JBody::Choice(plan) => plan.render(emit),
@@ -491,6 +505,52 @@ impl JOwnedHandlePlan {
                 ::core::result::Result::Ok(unsafe {
                     *::std::boxed::Box::from_raw(*v as *mut #source)
                 })
+            }
+        )
+    }
+}
+
+/// Optional borrowed opaque-handle input, kept syntax-free until final emission.
+///
+/// The converter deliberately returns a non-owning `OwnedObject<T>` carrier,
+/// not the crossing's `Option<&T>` spelling. The wrapper borrows through that
+/// carrier with `.as_deref()` / `.as_deref_mut()` while Kotlin's handle lock
+/// keeps the allocation alive for the native call.
+#[derive(Clone)]
+pub(crate) struct JBorrowedOptionalHandlePlan {
+    pub(crate) ident: syn::Ident,
+    pub(crate) reachable: std::rc::Rc<std::cell::Cell<bool>>,
+    pub(crate) target: TypeRef,
+    pub(crate) module: syn::Path,
+}
+
+impl JBorrowedOptionalHandlePlan {
+    fn render(&self, emit: &Emit) -> syn::ItemFn {
+        let name = &self.ident;
+        let target = shared::Source::spell(
+            &JSource {
+                wrappers: Vec::new(),
+                module: Some(self.module.clone()),
+            },
+            &self.target,
+            emit,
+        );
+        let allow = crate::jni::trait_impl::generated_converter_attr();
+        syn::parse_quote!(
+            #allow
+            pub(crate) unsafe fn #name<'env, 'v>(
+                env: &mut jni::JNIEnv<'env>,
+                v: &jni::sys::jlong,
+            ) -> ::core::result::Result<Option<OwnedObject<#target>>, __JniErr> {
+                if *v == 0 {
+                    Ok(None)
+                } else if (*v & 1) == 1 {
+                    Err(<__JniErr as ::core::convert::From<String>>::from(
+                        "Operation on a closed native handle.".to_string(),
+                    ))
+                } else {
+                    Ok(Some(unsafe { OwnedObject::from_raw(*v as *const #target) }))
+                }
             }
         )
     }

--- a/prebindgen-jni/src/jni/compile.rs
+++ b/prebindgen-jni/src/jni/compile.rs
@@ -1395,16 +1395,99 @@ impl<R: Conversions> JCompile<'_, R> {
         })
     }
 
+    /// Plan the soundness carrier for an optional borrowed opaque handle.
+    ///
+    /// The model crossing is `Option<&T>`, but the converter must keep only a
+    /// non-owning pointer carrier until the wrapper immediately borrows it. This
+    /// is therefore a frozen adapter plan rather than ordinary Optional-child
+    /// composition: calling the child owned-handle converter would consume `T`.
+    fn planned_borrowed_optional_handle(&self, at: At<'_>, inner: &JFrag) -> Option<JFrag> {
+        if at.crossing.direction() != Direction::Construct {
+            return None;
+        }
+        let source = at.crossing.spelled();
+        if !source.erased_wrappers().is_empty() {
+            return None;
+        }
+        let element = source.optional_inner()?;
+        let target = element.borrow_target()?;
+        let cfg = self.decls.types.get(&target.key())?;
+        if !cfg.is_opaque() || !inner.conv.metadata.is_direct_handle() {
+            return None;
+        }
+        let TypeKind::Named { id, .. } = target.unwrapped().kind() else {
+            return None;
+        };
+        let source_ident = id.ident()?;
+        let module = self.decls.fn_module(self.registry, &source_ident);
+        let wire: syn::Type = syn::parse_quote!(jni::sys::jlong);
+        let ident = crate::jni::chain::planned_name(Direction::Construct, source, &wire);
+        let marker = crate::jni::chain::planned_marker(&ident);
+        let rust = crate::jni::chain::JFunction::borrowed_optional_handle(
+            crate::jni::chain::JBorrowedOptionalHandlePlan {
+                ident,
+                reachable: std::rc::Rc::new(std::cell::Cell::new(false)),
+                target: target.clone(),
+                module,
+            },
+        );
+        let kotlin_name = self
+            .decls
+            .override_kotlin_name(&source.key(), inner.conv.metadata.kotlin_name.clone());
+        let projection = inner
+            .conv
+            .metadata
+            .projection
+            .clone()
+            .map(|projection| Projection {
+                owned: false,
+                strategy: FoldStrategy::Optional(
+                    NullableKind::Niche,
+                    Box::new(projection.strategy),
+                ),
+                ..projection
+            });
+        Some(JFrag {
+            conv: ConverterImpl {
+                destination: wire,
+                function: marker,
+                pre_stages: Vec::new(),
+                niches: Niches::empty(),
+                metadata: KotlinMeta {
+                    kotlin_name,
+                    value_rust_type: None,
+                    projection,
+                    niche_sentinels: Vec::new(),
+                },
+                subs: vec![target.key()],
+            },
+            rust,
+            layout: Some(JLayout::Leaf),
+            choice_arm: None,
+            nested_chain: None,
+            wires: None,
+            out_wires: None,
+            composed_only: false,
+            yields: Yield {
+                ty: at.crossing.value().stripped_key(),
+                mode: at.crossing.mode(),
+                validity: Validity::SelfSufficient,
+            },
+        })
+    }
+
     /// Plan an Optional over one already-composed child intermediate without
     /// spelling its source type or generating its Rust body.
     ///
-    /// The deep input recipe for `Option<&opaque>` remains terminal because it
-    /// deliberately yields `OwnedObject<T>` and clones the Java-owned handle.
+    /// Borrowed opaque handles use a dedicated frozen soundness-carrier plan;
     /// Choice layouts remain with the legacy parts compiler.
     fn planned_optional(&self, at: At<'_>, inner: &JFrag, decoupled: bool) -> Option<JFrag> {
         let source = at.crossing.spelled();
         let element = source.optional_inner()?;
         let direction = at.crossing.direction();
+        if let Some(plan) = self.planned_borrowed_optional_handle(at, inner) {
+            return Some(plan);
+        }
         let composed_child =
             !inner.composed_only && inner.layout.as_ref().is_some_and(JLayout::is_composed);
         match direction {
@@ -1420,9 +1503,7 @@ impl<R: Conversions> JCompile<'_, R> {
             }
             _ => {}
         }
-        if direction == Direction::Construct
-            && (element.borrow_target().is_some() || inner.conv.metadata.is_direct_handle())
-        {
+        if direction == Direction::Construct && inner.conv.metadata.is_direct_handle() {
             return None;
         }
 

--- a/prebindgen-jni/src/jni/compile.rs
+++ b/prebindgen-jni/src/jni/compile.rs
@@ -1503,7 +1503,9 @@ impl<R: Conversions> JCompile<'_, R> {
             }
             _ => {}
         }
-        if direction == Direction::Construct && inner.conv.metadata.is_direct_handle() {
+        if direction == Direction::Construct
+            && (element.borrow_target().is_some() || inner.conv.metadata.is_direct_handle())
+        {
             return None;
         }
 

--- a/prebindgen-jni/src/jni/mod.rs
+++ b/prebindgen-jni/src/jni/mod.rs
@@ -791,6 +791,22 @@ impl JniGen {
             .clone()
     }
 
+    /// Whether an ordinary input crossing retained the borrowed-Optional-handle plan.
+    ///
+    /// Test support for the late-render seam: rendering this plan and storing a
+    /// completed function produce identical Rust, so output assertions alone cannot
+    /// prove resolution did not regain direct type access.
+    #[cfg(test)]
+    pub(crate) fn borrowed_optional_handle_plan_for_test(&self, spelling: &str) -> Option<bool> {
+        use prebindgen_registry::recipe::Direction;
+
+        let ty: syn::Type = syn::parse_str(spelling).ok()?;
+        let reading = prebindgen_registry::Conversions::reading_of(&self.registry, &ty)?;
+        let compiled = self.decls.compiled.borrow();
+        let fragment = compiled.fragment(&reading.key(), Direction::Construct)?;
+        Some(fragment.rust.is_borrowed_optional_handle())
+    }
+
     /// The whole-value callback compatibility row, when one was required.
     ///
     /// Recipe-built callbacks occupy their ordinary crossing row. Only the

--- a/prebindgen-jni/src/jni/selector.rs
+++ b/prebindgen-jni/src/jni/selector.rs
@@ -41,9 +41,9 @@ fn is_unsized_spelling(ty: &prebindgen_registry::flat::TypeRef) -> bool {
 impl Declarations {
     /// The `Option<X>` **input** shape.
     ///
-    /// `Option<&T>` tries the deep `OptionRef` — a borrowed handle decoded to
-    /// `Option<OwnedObject<T>>` — before the shallow `Optional`; the shape that
-    /// resolves correctly wins.
+    /// Borrowed opaque handles are intercepted by the registry compiler and kept as
+    /// a frozen non-owning-carrier plan; this legacy selector now handles only the
+    /// structural Optional fallback.
     pub(crate) fn input_optional(
         &self,
         ty: &prebindgen_registry::flat::TypeRef,
@@ -53,24 +53,9 @@ impl Declarations {
         // `Box<Option<T>>` crossing produces a `Box<Option<T>>`.
         let produced = crate::jni::trait_impl::Produced::Reading(ty);
         let inner = ty.optional_inner()?;
-        if let Some(target) = inner.borrow_target() {
-            let mutable = inner.is_exclusive_borrow();
-            if let Some(mut c) = self.input_wrapper_shape(
-                WrapperShape::OptionRef { mutable },
-                &produced,
-                target,
-                emit,
-            ) {
-                c.subs = vec![target.key()];
-                return Some(c);
-            }
-        }
-        // An optional BORROW is the deep handler's alone. It declined — either
-        // the inner is not a handle (then the shallow handler below is right,
-        // and only for the canonical spelling) or the spelling carries a
-        // wrapper it cannot bridge. The shallow handler cannot tell those apart
-        // and would decode the jlong as a `*mut &T`, so a wrapped optional
-        // borrow stops here rather than resolving wrong.
+        // A wrapped optional borrow has no value the fallback can rebuild. Letting
+        // the shallow handler decode it would treat the jlong as a `*mut &T`, so
+        // it still stops here rather than resolving wrong.
         if inner.borrow_target().is_some() && !ty.erased_wrappers().is_empty() {
             return None;
         }

--- a/prebindgen-jni/src/jni/tests/value_form.rs
+++ b/prebindgen-jni/src/jni/tests/value_form.rs
@@ -3226,7 +3226,7 @@ fn a_wrapped_borrow_has_nothing_to_bridge_and_refuses() {
             Ok(g) => {
                 let planned = g
                     .borrowed_optional_handle_plan_for_test(&spelling)
-                    .unwrap_or(false);
+                    .expect("compiled input crossing");
                 Ok((
                     std::fs::read_to_string(g.write_rust(dir.join("g.rs")).expect("write_rust"))
                         .expect("read rust"),

--- a/prebindgen-jni/src/jni/tests/value_form.rs
+++ b/prebindgen-jni/src/jni/tests/value_form.rs
@@ -3190,7 +3190,8 @@ fn an_erased_wrapper_over_a_terminal_crosses_both_ways() {
 #[test]
 fn a_wrapped_borrow_has_nothing_to_bridge_and_refuses() {
     let loc = myflat_loc();
-    let build = |param_ty: syn::Type| -> Result<String, String> {
+    let build = |param_ty: syn::Type| -> Result<(String, bool), String> {
+        let spelling = param_ty.to_token_stream().to_string();
         let items = vec![
             (
                 syn::Item::Struct(syn::parse_quote!(
@@ -3222,24 +3223,52 @@ fn a_wrapped_borrow_has_nothing_to_bridge_and_refuses() {
         let _ = std::fs::remove_dir_all(&dir);
         std::fs::create_dir_all(&dir).unwrap();
         match jni.build_with(registry) {
-            Ok(g) => Ok(std::fs::read_to_string(
-                g.write_rust(dir.join("g.rs")).expect("write_rust"),
-            )
-            .expect("read rust")),
+            Ok(g) => {
+                let planned = g
+                    .borrowed_optional_handle_plan_for_test(&spelling)
+                    .unwrap_or(false);
+                Ok((
+                    std::fs::read_to_string(g.write_rust(dir.join("g.rs")).expect("write_rust"))
+                        .expect("read rust"),
+                    planned,
+                ))
+            }
             Err(e) => Err(format!("{e}")),
         }
     };
 
     // The canonical borrows still resolve, and still adapt at the call site.
-    let borrowed = build(syn::parse_quote!(&ZThing)).expect("a plain borrow resolves");
+    let (borrowed, borrowed_is_plan) =
+        build(syn::parse_quote!(&ZThing)).expect("a plain borrow resolves");
+    assert!(!borrowed_is_plan, "a plain borrow is not the Optional plan");
     assert!(
         borrowed.contains("myflat::z_take(&t)"),
         "the call site adds the borrow:\n{borrowed}"
     );
-    let opt = build(syn::parse_quote!(Option<&ZThing>)).expect("an optional borrow resolves");
+    let (opt, opt_is_plan) =
+        build(syn::parse_quote!(Option<&ZThing>)).expect("an optional borrow resolves");
+    assert!(
+        opt_is_plan,
+        "the optional borrow must retain an unrendered borrowed-handle plan"
+    );
     assert!(
         opt.contains("myflat::z_take(t.as_deref())"),
         "the call site derefs the OwnedObject:\n{opt}"
+    );
+    assert!(
+        opt.contains("OwnedObject::from_raw"),
+        "the plan renders the non-owning carrier:\n{opt}"
+    );
+
+    let (mutable, mutable_is_plan) =
+        build(syn::parse_quote!(Option<&mut ZThing>)).expect("an optional mutable borrow resolves");
+    assert!(
+        mutable_is_plan,
+        "the optional mutable borrow must retain the same late plan"
+    );
+    assert!(
+        mutable.contains("myflat::z_take(t.as_deref_mut())"),
+        "the call site mutably derefs the OwnedObject:\n{mutable}"
     );
 
     // Wrapped, they have nothing to bridge and must not resolve.

--- a/prebindgen-jni/src/jni/trait_impl.rs
+++ b/prebindgen-jni/src/jni/trait_impl.rs
@@ -718,9 +718,6 @@ pub(crate) fn build_handle_destructor_items(
 pub(crate) enum WrapperShape {
     /// `Ref` — a borrow of its inner.
     Borrow { mutable: bool },
-    /// `Optional` whose inner is a `Ref` — the deep handle-borrow form, tried
-    /// before [`Self::Optional`].
-    OptionRef { mutable: bool },
     /// `Sequence` — a run of its element.
     Sequence,
     /// `Optional` — its inner, or absent.
@@ -1008,7 +1005,7 @@ pub(crate) fn build_through_wrappers(
     Some(out)
 }
 
-/// Per-shape **input** wrapper converter builders (`&`/`Option<&>`/`Vec`/
+/// Per-shape **input** wrapper converter builders (`&`/`Vec`/
 /// `Option`). Each returns `Some(ConverterImpl)` only for the [`WrapperShape`]
 /// it claims; [`Declarations::input_wrapper_shape`] chains them in priority
 /// order. The shapes are disjoint — except the two `Optional` sub-cases
@@ -1069,82 +1066,6 @@ impl Declarations {
                 value_rust_type: None,
                 projection,
                 niche_sentinels: inner.metadata.niche_sentinels.clone(),
-            },
-        })
-    }
-
-    /// `Option<&T>` / `Option<&mut T>` for opaque T: returns
-    /// `Option<OwnedObject<T>>` (the call site `.as_deref()` coerces back).
-    /// `None` for non-opaque inners — the resolver then offers `Option<_>`
-    /// over `&T` and the general handler takes it.
-    fn input_option_ref(
-        &self,
-        shape: WrapperShape,
-        produced: &Produced<'_>,
-        t1: &prebindgen_registry::flat::TypeRef,
-        emit: &prebindgen_registry::Emit,
-    ) -> Option<ConverterImpl<KotlinMeta>> {
-        // `t1`'s spelling, for the parts that ask spelling questions — the
-        // canonical form a produced spelling is compared against, and the
-        // type ascriptions the generated body writes. Everything else takes
-        // the READING itself (#284).
-        let t1_ty = emit.spell(t1);
-        let WrapperShape::OptionRef { .. } = shape else {
-            return None;
-        };
-        // Produces `Option<OwnedObject<T>>`, which the call site adapts with
-        // `.as_deref()` — again not the spelled type, so a wrapped spelling has
-        // nothing to bridge and must not resolve. See `input_borrow`.
-        if !produced.is_canonical() {
-            return None;
-        }
-        let inner = self.in_frag(t1)?;
-        if !inner.metadata.is_direct_handle() {
-            // Non-opaque: let the general `Option<_>` handler take it.
-            return None;
-        }
-        let inner_wire = inner.destination.clone();
-        let outer_ty = produced.key();
-        let outer_spelled = produced.spell(emit);
-        let name = input_name(&outer_spelled, &inner_wire);
-        let gen_allow = generated_converter_attr();
-        let function: syn::ItemFn = syn::parse_quote!(
-            #gen_allow
-            pub(crate) unsafe fn #name<'env, 'v>(
-                env: &mut jni::JNIEnv<'env>,
-                v: &#inner_wire,
-            ) -> ::core::result::Result<Option<OwnedObject<#t1_ty>>, __JniErr> {
-                if *v == 0 {
-                    Ok(None)
-                } else if (*v & 1) == 1 {
-                    Err(<__JniErr as ::core::convert::From<String>>::from(
-                        "Operation on a closed native handle.".to_string(),
-                    ))
-                } else {
-                    Ok(Some(unsafe { OwnedObject::from_raw(*v as *const #t1_ty) }))
-                }
-            }
-        );
-        let kotlin_name = self.override_kotlin_name(&outer_ty, inner.metadata.kotlin_name.clone());
-        let projection = inner.metadata.projection.clone().map(|h| Projection {
-            owned: false,
-            // `Option<&Handle>` always rides the inner's `*v == 0` niche
-            // (body is `if *v == 0 { None } else { ... }` above), so
-            // null is the `0i64` sentinel — never JVM boxed.
-            strategy: FoldStrategy::Optional(NullableKind::Niche, Box::new(h.strategy)),
-            ..h
-        });
-        Some(ConverterImpl {
-            subs: vec![],
-            pre_stages: vec![],
-            function,
-            destination: inner_wire,
-            niches: Niches::empty(),
-            metadata: KotlinMeta {
-                kotlin_name,
-                value_rust_type: None,
-                projection,
-                niche_sentinels: Vec::new(),
             },
         })
     }
@@ -2737,10 +2658,9 @@ impl Declarations {
         emit: &prebindgen_registry::Emit,
     ) -> Option<ConverterImpl<KotlinMeta>> {
         // Disjoint shapes (see [`WrapperShape`]), tried in priority order. The
-        // borrow/option-ref/vec shapes are mutually exclusive; the two
+        // borrow/vec shapes are mutually exclusive; the two
         // `Optional` sub-cases share a method.
         self.input_borrow(shape, produced, t1)
-            .or_else(|| self.input_option_ref(shape, produced, t1, emit))
             .or_else(|| self.input_vec(shape, produced, t1, emit))
             .or_else(|| self.input_option(shape, produced, t1, emit))
     }


### PR DESCRIPTION
## Summary

- retain `Option<&T>` and `Option<&mut T>` opaque-handle inputs as a frozen registry plan that keeps `TypeRef` opaque until final Rust emission
- preserve the non-owning `OwnedObject<T>` carrier: Kotlin locks the handle for the native call, and the wrapper adapts it with `.as_deref()` or `.as_deref_mut()` without consuming or cloning `T`
- delete the eager `input_option_ref` converter builder and its `WrapperShape::OptionRef` dispatch

This is a dedicated Optional-handle plan rather than ordinary Optional-child composition because the child opaque-handle input converter consumes `T`, while a borrowed crossing must only create a temporary pointer carrier. The seam test inspects the retained plan directly so replacing it with an eagerly rendered complete function cannot pass merely by producing identical text.

Generated Rust, Kotlin, C bindings, and headers remain byte-identical.

Part of #513.

## Verification

- `cargo test --workspace` — passed
- `cargo clippy --workspace --all-targets -- -D warnings` — passed
- `bash examples/regen-check.sh` — passed; committed generated output is byte-identical
- `cd examples/covertest-kotlin && ./gradlew run` — passed all 59 JVM sections