### PR TITLE
Compose owned optional handles in registry plans

### DIFF
--- a/examples/covertest-kotlin/README.md
+++ b/examples/covertest-kotlin/README.md
@@ -93,8 +93,9 @@ for the full table; in brief:
   proves the synthetic `Option<u16>` selects the registry pair recipe and
   crosses as `Boolean + Int`, without `JObject` allocation or `intValue()`.
 - **type mappings:** primitives, `String`/`&str` (incl. a bare `String`
-  return), `Option<T>` (param / return / **field**, incl. `Option<enum>` in
-  all three positions and `Option<Payload>` in both directions),
+  return), `Option<T>` (param / return / **field**, incl.
+  consuming `Option<opaque>`, `Option<enum>` in all three positions, and
+  `Option<Payload>` in both directions),
   `Vec<T>`/`&[T]`, `Vec<String>`, `Vec<Stamp>` → `List<Stamp>`,
   `Vec<handle>` / `Option<Vec<handle>>` (Kotlin-side handle fold),
   borrowed-opaque returns (`Option<&T>` → cloned owned handle),

--- a/examples/covertest-kotlin/build.rs
+++ b/examples/covertest-kotlin/build.rs
@@ -58,6 +58,7 @@
 //! | `Result<_, E>` → typed domain `onError` | `storage_try_with_label` |
 //! | two-caller split (#45): `onBindingError` + `onError` on one fallible wrapper | `storage_try_from_stamp` (wrong-length `tag` → binding; bad `secs` → domain) |
 //! | fixed-width unsigned scalars (#108) | `Unsigned` + direct/optional/callback/collection max-value round trips |
+//! | owned `Option<opaque>` input         | `ingot_optional_grams`: null niche or consuming handle through the shared registry Optional chain |
 //! | `Option<T>`                          | `Option<Payload>` (in + out) / `Option<Vec>` / `Option<i64>` / `Option<enum>` (param + return + field) |
 //! | non-null enum field under nullable-context (#144) | `Option<CacheConfig>` → nested `RepliesConfig.priority` (single Elvis default) |
 //! | `impl Fn` callbacks (single + slice) | `payload_handler_new` / `payload_vec_handler_new` |
@@ -308,7 +309,12 @@ fn main() {
                 // while both halves still compile.
                 .class(ptr_class!(Vault))
                 .class(ptr_class!(VaultHolder))
-                .class(ptr_class!(Ingot).method(fun!(ingot_grams)))
+                .class(
+                    ptr_class!(Ingot)
+                        .constructor(fun!(ingot_new))
+                        .method(fun!(ingot_grams)),
+                )
+                .fun(fun!(ingot_optional_grams))
                 // `Hold`'s payload is a CONVERTED type, so its leaf crosses
                 // through the `convert!(Duration)` chain; `HoldPolicy` puts
                 // that same payload in the data-class-field position.

--- a/examples/covertest-kotlin/kotlin/REPORT.md
+++ b/examples/covertest-kotlin/kotlin/REPORT.md
@@ -89,6 +89,7 @@ Base package: `io.prebindgen.covertest`
   - shaped by: return `Hold` decomposed → [tag, for_v0] (Callback delivery)
 - `hold_policy_echo` — `fun holdPolicyEcho(p: HoldPolicy, onError: JniErrorHandler<HoldPolicy?>): HoldPolicy?`
 - `holder_tag_or` — `fun holderTagOr(h: Holder?, fallback: Long, onError: JniErrorHandler<Long>): Long`
+- `ingot_optional_grams` — `fun ingotOptionalGrams(i: Ingot?, onError: JniErrorHandler<Long>): Long`
 - `label_reverse` — `fun labelReverse(l: String, onError: JniErrorHandler<String?>): String?`
 - `label_series_echo` — `fun labelSeriesEcho(labels: List<String>, onError: JniErrorHandler<List<String>?>): List<String>?`
 - `layered_of` — `fun layeredOf(which: Int, onError: JniErrorHandler<Layered?>): Layered?`
@@ -187,6 +188,7 @@ Base package: `io.prebindgen.covertest`
 ## class `io.prebindgen.covertest.model.Ingot` (ptr_class, Rust `Ingot`)
 
 - `ingot_grams` — `fun grams(onError: JniErrorHandler<Long>): Long`
+- `ingot_new` — `fun new(grams: Long, onError: JniErrorHandler<Ingot?>): Ingot?`
 
 ## class `io.prebindgen.covertest.Payload` (data_class, Rust `Payload`)
 

--- a/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest.kt
+++ b/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest.kt
@@ -1297,6 +1297,12 @@ internal object CovNative {
     external fun ingotGrams(i: Long, errorSink: Any): Long
 
     @JvmSynthetic
+    external fun ingotNew(grams: Long, errorSink: Any): Long
+
+    @JvmSynthetic
+    external fun ingotOptionalGrams(i: Long, errorSink: Any): Long
+
+    @JvmSynthetic
     external fun labelReverse(l: String, errorSink: Any): String
 
     @JvmSynthetic

--- a/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest/model.kt
+++ b/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest/model.kt
@@ -1068,6 +1068,14 @@ public class Ingot private constructor(initialPtr: Long) : NativeHandle(initialP
         /** Wrap a pointer a generated native call returned. Passing anything else — a literal, a stale pointer, one belonging to another handle — is undefined behaviour, which is why this is not part of the public API. */
         @JvmSynthetic
         internal fun fromRawPtr(initialPtr: Long): Ingot = Ingot(initialPtr)
+
+        /** Construct an [`Ingot`] for direct owned-handle input tests. */
+        public fun new(grams: Long, onError: JniErrorHandler<Ingot?>): Ingot? {
+            val __bcap = JniErrorHandlerCapture.acquire()
+            val __ret = CovNative.ingotNew(grams, __bcap)
+            if (__bcap.failed) return onError.run(__bcap.ze0)
+            return Ingot.fromRawPtr(__ret)
+        }
     }
 }
 
@@ -1587,6 +1595,29 @@ internal object __StampFolderRawHolder {
     @JvmField
     val instance: StampFolderRaw<ArrayList<Stamp>> =
     StampFolderRaw { acc, secs, nanos -> acc.add(Stamp.fromParts(secs, nanos)); acc }
+}
+
+/**
+ * Consume an optional opaque handle. `Some` transfers the allocation and
+ * `None` rides the null-pointer niche without constructing a value.
+ */
+public fun ingotOptionalGrams(i: Ingot?, onError: JniErrorHandler<Long>): Long {
+    if (i?.isClosed() == true) return onError.run("Operation on a closed native handle.")
+    val __bcap = JniErrorHandlerCapture.acquire()
+    val __ret = run {
+        val __locks = ArrayList<NativeHandle>()
+        i?.let { __locks.add(it) }
+        withSortedHandleLocks(__locks) {
+            val i_ptr = i?.ptr ?: 0L
+            try {
+                CovNative.ingotOptionalGrams(i_ptr, __bcap)
+            } finally {
+                i?.markConsumed()
+            }
+        }
+    }
+    if (__bcap.failed) return onError.run(__bcap.ze0)
+    return __ret
 }
 
 /** Classify a payload by magnitude of its `value` (enum **return**). */

--- a/examples/covertest-kotlin/kotlin/io/prebindgen/covertest/Test.kt
+++ b/examples/covertest-kotlin/kotlin/io/prebindgen/covertest/Test.kt
@@ -36,6 +36,7 @@ import io.prebindgen.covertest.model.ObjectBoundary16
 import io.prebindgen.covertest.model.ObjectBoundary32
 import io.prebindgen.covertest.model.ObjectBoundary63
 import io.prebindgen.covertest.model.Ingot
+import io.prebindgen.covertest.model.ingotOptionalGrams
 import io.prebindgen.covertest.model.ObjectBoundary64
 import io.prebindgen.covertest.model.ObjectBoundaryLeaf
 import io.prebindgen.covertest.model.Priority
@@ -1436,6 +1437,15 @@ fun main() {
         val code = SelectorCode.new(50, byteArrayOf(1, 2, 3), boom).orThrow()
         check(selectorCodeScore(1, null, null, code, boom) == 53L)
         code.close()
+    }
+
+    // ── owned Option<handle>: shared registry Optional chain ──────────────
+    section("owned optional handle input consumes only the present arm") {
+        check(ingotOptionalGrams(null, boom) == -1L)
+
+        val ingot = Ingot.new(37L, boom).orThrow()
+        check(ingotOptionalGrams(ingot, boom) == 37L)
+        check(ingot.isClosed())
     }
 
     // ── recursive constructor expansion: nested build and identity arms ─────

--- a/examples/covertest-kotlin/src/generated_bindings.rs
+++ b/examples/covertest-kotlin/src/generated_bindings.rs
@@ -12041,6 +12041,32 @@ pub(crate) unsafe fn jlong_to_Option_Duration_1cfa4d44<'env, 'v>(
     clippy::nonminimal_bool,
     clippy::eq_op
 )]
+pub(crate) unsafe fn jlong_to_Option_Ingot_a76a8f2f<'env, 'v>(
+    env: &mut jni::JNIEnv<'env>,
+    v: &jni::sys::jlong,
+) -> ::core::result::Result<Option<perftest_flat::Ingot>, __JniErr> {
+    ::core::result::Result::Ok({
+        if *v == 0 {
+            ::core::option::Option::None
+        } else {
+            let __present = v;
+            ::core::option::Option::Some(jlong_to_Ingot_020c3a86_owned(env, __present)?)
+        }
+    })
+}
+#[allow(
+    non_snake_case,
+    unused_mut,
+    unused_variables,
+    unused_braces,
+    unused_parens,
+    dead_code,
+    clippy::useless_conversion,
+    clippy::needless_question_mark,
+    clippy::let_and_return,
+    clippy::nonminimal_bool,
+    clippy::eq_op
+)]
 pub(crate) unsafe fn jlong_to_Option_SelectorCode_b3d1576b<'env, 'v>(
     env: &mut jni::JNIEnv<'env>,
     v: &jni::sys::jlong,
@@ -12078,19 +12104,15 @@ pub(crate) unsafe fn jlong_to_Option_Summary_252ef2ba<'env, 'v>(
     env: &mut jni::JNIEnv<'env>,
     v: &jni::sys::jlong,
 ) -> ::core::result::Result<Option<perftest_flat::Summary>, __JniErr> {
-    Ok({
-        let __v: ::core::option::Option<perftest_flat::Summary> = if *v == 0 {
-            None
-        } else if (*v & 1) == 1 {
-            return ::core::result::Result::Err(
-                <__JniErr as ::core::convert::From<
-                    String,
-                >>::from("Operation on a closed native handle.".to_string()),
-            );
+    ::core::result::Result::Ok({
+        if *v == 0 {
+            ::core::option::Option::None
         } else {
-            Some(*std::boxed::Box::from_raw(*v as *mut perftest_flat::Summary))
-        };
-        __v
+            let __present = v;
+            ::core::option::Option::Some(
+                jlong_to_Summary_3cb103b9_owned(env, __present)?,
+            )
+        }
     })
 }
 #[allow(
@@ -16148,6 +16170,90 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_ingotGrams<'a>(
         }
     };
     let __out = perftest_flat::ingot_grams(&i);
+    match i64_to_jlong_fbf9a9bc(&mut env, __out) {
+        ::core::result::Result::Ok(__w) => __w,
+        ::core::result::Result::Err(__e) => {
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e.to_string(),
+            );
+            0 as jni::sys::jlong
+        }
+    }
+}
+#[no_mangle]
+#[allow(non_snake_case, unused_mut, unused_variables, dead_code)]
+pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_ingotNew<'a>(
+    mut env: jni::JNIEnv<'a>,
+    _class: jni::objects::JClass<'a>,
+    grams: jni::sys::jlong,
+    __error_sink: jni::objects::JObject<'a>,
+) -> jni::sys::jlong {
+    #[allow(non_upper_case_globals)]
+    static __SINK_MID: ::prebindgen_jni_runtime::CachedIfaceMethod = ::prebindgen_jni_runtime::CachedIfaceMethod::new();
+    const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
+    const __SINK_DESCR: &str = "(Ljava/lang/String;)Ljava/lang/Object;";
+    let grams = match jlong_to_i64_fbf9a9bc(&mut env, &grams) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__e) => {
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e.to_string(),
+            );
+            return 0 as jni::sys::jlong;
+        }
+    };
+    let __out = perftest_flat::ingot_new(grams);
+    match Ingot_to_jlong_020c3a86(&mut env, __out) {
+        ::core::result::Result::Ok(__w) => __w,
+        ::core::result::Result::Err(__e) => {
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e.to_string(),
+            );
+            0 as jni::sys::jlong
+        }
+    }
+}
+#[no_mangle]
+#[allow(non_snake_case, unused_mut, unused_variables, dead_code)]
+pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_ingotOptionalGrams<'a>(
+    mut env: jni::JNIEnv<'a>,
+    _class: jni::objects::JClass<'a>,
+    i: jni::sys::jlong,
+    __error_sink: jni::objects::JObject<'a>,
+) -> jni::sys::jlong {
+    #[allow(non_upper_case_globals)]
+    static __SINK_MID: ::prebindgen_jni_runtime::CachedIfaceMethod = ::prebindgen_jni_runtime::CachedIfaceMethod::new();
+    const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
+    const __SINK_DESCR: &str = "(Ljava/lang/String;)Ljava/lang/Object;";
+    let i = match jlong_to_Option_Ingot_a76a8f2f(&mut env, &i) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__e) => {
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e.to_string(),
+            );
+            return 0 as jni::sys::jlong;
+        }
+    };
+    let __out = perftest_flat::ingot_optional_grams(i);
     match i64_to_jlong_fbf9a9bc(&mut env, __out) {
         ::core::result::Result::Ok(__w) => __w,
         ::core::result::Result::Err(__e) => {

--- a/examples/perftest-flat/src/ext.rs
+++ b/examples/perftest-flat/src/ext.rs
@@ -1106,6 +1106,19 @@ pub type Vault = handles::Vault;
 #[prebindgen]
 pub type Ingot = handles::Ingot;
 
+/// Construct an [`Ingot`] for direct owned-handle input tests.
+#[prebindgen]
+pub fn ingot_new(grams: i64) -> Ingot {
+    Ingot { grams }
+}
+
+/// Consume an optional opaque handle. `Some` transfers the allocation and
+/// `None` rides the null-pointer niche without constructing a value.
+#[prebindgen]
+pub fn ingot_optional_grams(i: Option<Ingot>) -> i64 {
+    i.map_or(-1, |i| i.grams)
+}
+
 /// What an [`Ingot`] weighs — enough to prove the handle delivered to the JVM
 /// points at the right object.
 #[prebindgen]

--- a/prebindgen-jni/src/jni/chain.rs
+++ b/prebindgen-jni/src/jni/chain.rs
@@ -69,6 +69,11 @@ impl JFunction {
         matches!(self.0, JBody::BorrowedOptionalHandle(_))
     }
 
+    #[cfg(test)]
+    pub(crate) fn is_optional(&self) -> bool {
+        matches!(self.0, JBody::Optional(_))
+    }
+
     pub(crate) fn mark_reachable(&self) {
         match &self.0 {
             JBody::Complete(_) => {}

--- a/prebindgen-jni/src/jni/compile.rs
+++ b/prebindgen-jni/src/jni/compile.rs
@@ -1503,9 +1503,7 @@ impl<R: Conversions> JCompile<'_, R> {
             }
             _ => {}
         }
-        if direction == Direction::Construct
-            && (element.borrow_target().is_some() || inner.conv.metadata.is_direct_handle())
-        {
+        if direction == Direction::Construct && element.borrow_target().is_some() {
             return None;
         }
 

--- a/prebindgen-jni/src/jni/mod.rs
+++ b/prebindgen-jni/src/jni/mod.rs
@@ -807,6 +807,18 @@ impl JniGen {
         Some(fragment.rust.is_borrowed_optional_handle())
     }
 
+    /// Whether an ordinary input crossing retained the shared Optional plan.
+    #[cfg(test)]
+    pub(crate) fn optional_chain_plan_for_test(&self, spelling: &str) -> Option<bool> {
+        use prebindgen_registry::recipe::Direction;
+
+        let ty: syn::Type = syn::parse_str(spelling).ok()?;
+        let reading = prebindgen_registry::Conversions::reading_of(&self.registry, &ty)?;
+        let compiled = self.decls.compiled.borrow();
+        let fragment = compiled.fragment(&reading.key(), Direction::Construct)?;
+        Some(fragment.rust.is_optional())
+    }
+
     /// The whole-value callback compatibility row, when one was required.
     ///
     /// Recipe-built callbacks occupy their ordinary crossing row. Only the

--- a/prebindgen-jni/src/jni/tests/values.rs
+++ b/prebindgen-jni/src/jni/tests/values.rs
@@ -1327,6 +1327,11 @@ fn recursive_flattened_owned_handles_join_lock_and_consume_scaffold() {
     let _ = std::fs::remove_dir_all(&dir);
     std::fs::create_dir_all(&dir).unwrap();
     let generation = jni.build_with(registry).expect("resolve");
+    assert_eq!(
+        generation.optional_chain_plan_for_test("Option<Token>"),
+        Some(true),
+        "the owned optional handle must retain the shared Optional plan"
+    );
     let rust = std::fs::read_to_string(generation.write_rust(dir.join("gen.rs")).unwrap()).unwrap();
     let kotlin = generation
         .write_kotlin(&dir.join("kotlin"))
@@ -1363,6 +1368,31 @@ fn recursive_flattened_owned_handles_join_lock_and_consume_scaffold() {
     assert!(
         rc.contains("spare:jlong_to_Option_Token_") && rc.contains("env,&((v).1))?"),
         "the registry chain must own the optional field conversion:\n{rust}"
+    );
+    let file = syn::parse_file(&rust).expect("generated Rust parses");
+    let optional_helper = file
+        .items
+        .iter()
+        .filter_map(|item| match item {
+            syn::Item::Fn(function) => Some(function),
+            _ => None,
+        })
+        .find(|function| {
+            function
+                .sig
+                .ident
+                .to_string()
+                .starts_with("jlong_to_Option_Token_")
+        })
+        .expect("the reached Optional plan must be emitted");
+    let optional_body = quote::ToTokens::to_token_stream(&optional_helper.block).to_string();
+    assert!(
+        optional_body.contains("jlong_to_Token_") && optional_body.contains("_owned"),
+        "the Optional plan must delegate its present arm to the owned child plan:\n{rust}"
+    );
+    assert!(
+        !optional_body.contains("Box :: from_raw"),
+        "the Optional composer must not reconstruct the owned handle itself:\n{rust}"
     );
 }
 

--- a/prebindgen-jni/src/jni/trait_impl.rs
+++ b/prebindgen-jni/src/jni/trait_impl.rs
@@ -836,14 +836,6 @@ impl Produced<'_> {
         self.bridge_layers().is_some_and(|l| l.is_empty())
     }
 
-    /// The tokens generated Rust spells for this type.
-    fn spell(&self, emit: &prebindgen_registry::Emit) -> TokenStream {
-        match self {
-            Produced::Reading(r) => emit.spell(r),
-            Produced::Composed(t) => t.to_token_stream(),
-        }
-    }
-
     /// This type's identity.
     fn key(&self) -> TypeKey {
         match self {
@@ -1140,11 +1132,8 @@ impl Declarations {
         })
     }
 
-    /// `Option<T>`: first the direct-opaque-handle by-value consume (wire
-    /// `jlong`, `0` = `None`, `Box` reconstructed and `T` moved out), then —
-    /// when the inner isn't a direct handle — the general nullable fold. The
-    /// two share the `Option<_>` pattern, so they stay in one method to keep
-    /// the original sequential fall-through.
+    /// Legacy `Option<T>` nullable fold for intermediates the registry Optional
+    /// composer cannot represent yet.
     fn input_option(
         &self,
         shape: WrapperShape,
@@ -1157,65 +1146,6 @@ impl Declarations {
         // type ascriptions the generated body writes. Everything else takes
         // the READING itself (#284).
         let t1_ty = emit.spell(t1);
-        if shape == WrapperShape::Optional {
-            let inner = self.in_frag(t1)?;
-            if inner.metadata.is_direct_handle() {
-                let inner_wire = inner.destination.clone();
-                let outer_ty = produced.key();
-                let outer_spelled = produced.spell(emit);
-                let build = build_from_canonical(produced, quote::quote!(__v))?;
-                let name = input_name(&outer_spelled, &inner_wire);
-                let gen_allow = generated_converter_attr();
-                let function: syn::ItemFn = syn::parse_quote!(
-                    #gen_allow
-                    pub(crate) unsafe fn #name<'env, 'v>(
-                        env: &mut jni::JNIEnv<'env>,
-                        v: &#inner_wire,
-                    ) -> ::core::result::Result<#outer_spelled, __JniErr> {
-                        Ok({
-                            let __v: ::core::option::Option<#t1_ty> = if *v == 0 {
-                                None
-                            } else if (*v & 1) == 1 {
-                                // Tagged (closed) handle raced past the Kotlin
-                                // pre-lock guard — present-but-closed is an
-                                // error, absent is None.
-                                return ::core::result::Result::Err(
-                                    <__JniErr as ::core::convert::From<String>>::from(
-                                        "Operation on a closed native handle.".to_string(),
-                                    ),
-                                );
-                            } else {
-                                Some(*std::boxed::Box::from_raw(*v as *mut #t1_ty))
-                            };
-                            #build
-                        })
-                    }
-                );
-                let kotlin_name =
-                    self.override_kotlin_name(&outer_ty, inner.metadata.kotlin_name.clone());
-                let projection = inner.metadata.projection.clone().map(|h| Projection {
-                    owned: true,
-                    // Rides the inner's `*v == 0` niche, so the wire stays
-                    // `jlong` and `None` is the `0` sentinel (never JVM boxed).
-                    strategy: FoldStrategy::Optional(NullableKind::Niche, Box::new(h.strategy)),
-                    ..h
-                });
-                return Some(ConverterImpl {
-                    subs: vec![],
-                    pre_stages: vec![],
-                    function,
-                    destination: inner_wire,
-                    niches: Niches::empty(),
-                    metadata: KotlinMeta {
-                        kotlin_name,
-                        value_rust_type: None,
-                        projection,
-                        niche_sentinels: Vec::new(),
-                    },
-                });
-            }
-            // Non-opaque inner: fall through to the general Option handler.
-        }
         if shape == WrapperShape::Optional {
             let outer_ty = produced.key();
             let build = build_from_canonical(produced, quote::quote!(__v))?;


### PR DESCRIPTION
## Summary

- Route owned `Option<opaque>` inputs through the shared registry `Optional` plan; its absent arm uses the existing null `jlong` niche, while its present arm delegates to the frozen owned-handle child converter.
- Remove the eager JniGen direct-handle `Option<T>` converter and the now-unused type-spelling helper. Reachability-driven composition also stops emitting orphaned owned-optional converters; regenerating zenoh-flat-jni removes its uncalled `Option<ZBytes>` helper while preserving every call to `Option<KeyExpr>`.
- Seam coverage verifies that the retained `JFunction` is `Optional`, delegates to the `_owned` child, and contains no local `Box::from_raw` reconstruction. A Kotlin/JNI covertest covers absent and present inputs and verifies that a present handle is consumed.

## Compatibility

Existing generated Kotlin behavior and the JNI application binary interface remain semantically unchanged. The private generated Rust implementation now composes the same null/closed-handle/ownership behavior from registry plans. The only new public names are confined to the covertest fixture.

## Verification

- `cargo test --workspace` — passed
- `cargo clippy --workspace --all-targets -- -D warnings` — passed
- `bash examples/regen-check.sh` — passed; committed generated output is byte-identical after regeneration
- `examples/covertest-kotlin/gradlew run` — passed all 60 sections
- zenoh-flat-jni at `49b93e5` regenerated and compiled in review; its Kotlin surface was unchanged