### PR TITLE
Drive JNI Sequence conversion from registry plans

### DIFF
--- a/docs/crate-split.md
+++ b/docs/crate-split.md
@@ -127,7 +127,7 @@ registry-key construction, and the hidden registry-to-flat protocol path.
 
 The other widened methods are intentional flat-model API rather than emission
 doors. `Flat::classify`, `Flat::add_local_function`,
-`TypeRef::{borrowed, optional, scalar}`, and `types_util::ident` let an
+`TypeRef::{borrowed, optional, vector, scalar}`, and `types_util::ident` let an
 independent parser or collector build and compose the representation without
 depending on the registry.
 

--- a/examples/covertest-kotlin/README.md
+++ b/examples/covertest-kotlin/README.md
@@ -97,7 +97,8 @@ for the full table; in brief:
   consuming `Option<opaque>`, `Option<enum>` in all three positions, and
   `Option<Payload>` in both directions), borrowed `Option<&data_class>`
   (Kotlin-side leaf deconstruction and registry-owned recomposition),
-  `Vec<T>`/`&[T]`, `Vec<String>`, `Vec<Stamp>` → `List<Stamp>`,
+  `Vec<T>`/`&[T]` (including the registry-planned owned `Vec<T>` carrier for a
+  borrowed slice input), `Vec<String>`, `Vec<Stamp>` → `List<Stamp>`,
   `Vec<handle>` / `Option<Vec<handle>>` (Kotlin-side handle fold),
   borrowed-opaque returns (`Option<&T>` → cloned owned handle),
   `Result<_, E>` → `onError`, enums, data/sealed classes, fixed-size primitive arrays, `impl Fn` callbacks

--- a/examples/covertest-kotlin/build.rs
+++ b/examples/covertest-kotlin/build.rs
@@ -61,6 +61,7 @@
 //! | owned `Option<opaque>` input         | `ingot_optional_grams`: null niche or consuming handle through the shared registry Optional chain |
 //! | `Option<T>`                          | `Option<Payload>` (in + out) / `Option<Vec>` / `Option<i64>` / `Option<enum>` (param + return + field) |
 //! | borrowed `Option<&data_class>`       | `payload_optional_borrow_id`: Kotlin-side flattening → registry-owned `Option<Payload>` carrier → final borrow |
+//! | borrowed `&[T]` Sequence input      | `label_borrowed_concat`: registry Sequence chain builds an owned `Vec<Label>` carrier → final borrow |
 //! | non-null enum field under nullable-context (#144) | `Option<CacheConfig>` → nested `RepliesConfig.priority` (single Elvis default) |
 //! | `impl Fn` callbacks (single + slice) | `payload_handler_new` / `payload_vec_handler_new` |
 //! | owned-handle callback (`Fn(Storage)`)| `storage_handler_new` / `storage_emit` |
@@ -591,6 +592,7 @@ fn main() {
                 .fun(fun!(percent_invalid_output))
                 .fun(fun!(label_reverse))
                 .fun(fun!(label_series_echo))
+                .fun(fun!(label_borrowed_concat))
                 .fun(fun!(annotated_new))
                 .fun(fun!(annotated_alternate_value))
                 .fun(fun!(annotated_ttl))

--- a/examples/covertest-kotlin/kotlin/REPORT.md
+++ b/examples/covertest-kotlin/kotlin/REPORT.md
@@ -91,6 +91,7 @@ Base package: `io.prebindgen.covertest`
 - `hold_policy_echo` — `fun holdPolicyEcho(p: HoldPolicy, onError: JniErrorHandler<HoldPolicy?>): HoldPolicy?`
 - `holder_tag_or` — `fun holderTagOr(h: Holder?, fallback: Long, onError: JniErrorHandler<Long>): Long`
 - `ingot_optional_grams` — `fun ingotOptionalGrams(i: Ingot?, onError: JniErrorHandler<Long>): Long`
+- `label_borrowed_concat` — `fun labelBorrowedConcat(labels: List<String>, onError: JniErrorHandler<String?>): String?`
 - `label_reverse` — `fun labelReverse(l: String, onError: JniErrorHandler<String?>): String?`
 - `label_series_echo` — `fun labelSeriesEcho(labels: List<String>, onError: JniErrorHandler<List<String>?>): List<String>?`
 - `layered_of` — `fun layeredOf(which: Int, onError: JniErrorHandler<Layered?>): Layered?`

--- a/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest.kt
+++ b/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest.kt
@@ -1324,6 +1324,9 @@ internal object CovNative {
     external fun ingotOptionalGrams(i: Long, errorSink: Any): Long
 
     @JvmSynthetic
+    external fun labelBorrowedConcat(labels: List<String>, errorSink: Any): String
+
+    @JvmSynthetic
     external fun labelReverse(l: String, errorSink: Any): String
 
     @JvmSynthetic

--- a/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest/model.kt
+++ b/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest/model.kt
@@ -1782,6 +1782,17 @@ public fun labelSeriesEcho(
 }
 
 /**
+ * Join a borrowed run of converted elements. JNI decodes the Java list into
+ * an owned `Vec<Label>` carrier and lends it here only for this call.
+ */
+public fun labelBorrowedConcat(labels: List<String>, onError: JniErrorHandler<String?>): String? {
+    val __bcap = JniErrorHandlerCapture.acquire()
+    val __ret = CovNative.labelBorrowedConcat(labels, __bcap)
+    if (__bcap.failed) return onError.run(__bcap.ze0)
+    return __ret
+}
+
+/**
  * Assemble an [`Annotated`] (nested data-class **output** + bare
  * `Option<scalar>` / `Option<enum>` inputs).
  */

--- a/examples/covertest-kotlin/kotlin/io/prebindgen/covertest/Test.kt
+++ b/examples/covertest-kotlin/kotlin/io/prebindgen/covertest/Test.kt
@@ -77,6 +77,7 @@ import io.prebindgen.covertest.model.durationEmit
 import io.prebindgen.covertest.model.durationOutOfRange
 import io.prebindgen.covertest.model.holdEcho
 import io.prebindgen.covertest.model.holdPolicyEcho
+import io.prebindgen.covertest.model.labelBorrowedConcat
 import io.prebindgen.covertest.model.labelReverse
 import io.prebindgen.covertest.model.labelSeriesEcho
 import io.prebindgen.covertest.model.percentInvalidOutput
@@ -1697,6 +1698,11 @@ fun main() {
         // is a primitive `Long`, so it is refused at resolve time.)
         check(labelSeriesEcho(listOf("alpha", "beta"), boom) == listOf("alpha", "beta"))
         check(labelSeriesEcho(emptyList(), boom) == emptyList<String>())
+        // A borrowed slice uses the registry Sequence loop too. Its converter
+        // returns an owned Vec<Label> carrier; only the final source call adds
+        // the borrow.
+        check(labelBorrowedConcat(listOf("alpha", "beta"), boom) == "alphabeta")
+        check(labelBorrowedConcat(emptyList(), boom) == "")
     }
 
     // ── Vec<opaque-handle> return: the Kotlin-side handle fold ───────────────

--- a/examples/covertest-kotlin/src/generated_bindings.rs
+++ b/examples/covertest-kotlin/src/generated_bindings.rs
@@ -2497,6 +2497,64 @@ pub(crate) unsafe fn JObject_to_Holder_c36a9705<'env, 'v>(
     clippy::nonminimal_bool,
     clippy::eq_op
 )]
+pub(crate) unsafe fn JObject_to_Label_0284d056<'env, 'a>(
+    env: &mut jni::JNIEnv<'env>,
+    v: &jni::objects::JObject<'a>,
+) -> ::core::result::Result<::std::vec::Vec<perftest_flat::Label>, __JniErr> {
+    ::core::result::Result::Ok({
+        let __sequence_list = jni::objects::JList::from_env(env, v)
+            .map_err(|e| <__JniErr as ::core::convert::From<
+                String,
+            >>::from(format!("Vec<_>: list-from-env: {}", e)))?;
+        let mut __sequence_iter = __sequence_list
+            .iter(env)
+            .map_err(|e| <__JniErr as ::core::convert::From<
+                String,
+            >>::from(format!("Vec<_>: list-iter: {}", e)))?;
+        let mut __sequence_values: ::std::vec::Vec<perftest_flat::Label> = ::std::vec::Vec::new();
+        while let ::core::option::Option::Some(__sequence_part) = match __sequence_iter
+            .next(env)
+            .map_err(|e| <__JniErr as ::core::convert::From<
+                String,
+            >>::from(format!("Vec<_>: list-next: {}", e)))?
+        {
+            ::core::option::Option::Some(__sequence_object) => {
+                let __sequence_part: jni::objects::JString = __sequence_object.into();
+                ::core::option::Option::Some(__sequence_part)
+            }
+            ::core::option::Option::None => ::core::option::Option::None,
+        } {
+            __sequence_values
+                .push(
+                    {
+                        let __chain_s0 = JString_to_String_c7f3ca43(
+                            env,
+                            &__sequence_part,
+                        )?;
+                        let __chain_s1 = String_to_Label_c1a79668(env, __chain_s0)
+                            .map_err(|__e| <__JniErr as ::core::convert::From<
+                                String,
+                            >>::from(__e.to_string()))?;
+                        ::core::result::Result::<_, __JniErr>::Ok(__chain_s1)
+                    }?,
+                );
+        }
+        __sequence_values
+    })
+}
+#[allow(
+    non_snake_case,
+    unused_mut,
+    unused_variables,
+    unused_braces,
+    unused_parens,
+    dead_code,
+    clippy::useless_conversion,
+    clippy::needless_question_mark,
+    clippy::let_and_return,
+    clippy::nonminimal_bool,
+    clippy::eq_op
+)]
 pub(crate) unsafe fn JObject_to_Lookup_94ada15e<'env, 'v>(
     env: &mut jni::JNIEnv<'env>,
     v: &jni::objects::JObject<'v>,
@@ -3795,91 +3853,6 @@ pub(crate) unsafe fn JObject_to_Vec_Label_3fdf860d<'env, 'a>(
                 );
         }
         __sequence_values
-    })
-}
-#[allow(
-    non_snake_case,
-    unused_mut,
-    unused_variables,
-    unused_braces,
-    unused_parens,
-    dead_code,
-    clippy::useless_conversion,
-    clippy::needless_question_mark,
-    clippy::let_and_return,
-    clippy::nonminimal_bool,
-    clippy::eq_op
-)]
-pub(crate) unsafe fn JObject_to_Vec_Option_u64_a34190e7<'env, 'v>(
-    env: &mut jni::JNIEnv<'env>,
-    v: &jni::objects::JObject<'v>,
-) -> ::core::result::Result<Vec<Option<u64>>, __JniErr> {
-    Ok({
-        let __list = jni::objects::JList::from_env(env, v)
-            .map_err(|e| <__JniErr as ::core::convert::From<
-                String,
-            >>::from(format!("Vec<_>: list-from-env: {}", e)))?;
-        let mut __it = __list
-            .iter(env)
-            .map_err(|e| <__JniErr as ::core::convert::From<
-                String,
-            >>::from(format!("Vec<_>: list-iter: {}", e)))?;
-        let mut __out: Vec<Option<u64>> = Vec::new();
-        while let Some(__obj) = __it
-            .next(env)
-            .map_err(|e| <__JniErr as ::core::convert::From<
-                String,
-            >>::from(format!("Vec<_>: list-next: {}", e)))?
-        {
-            let __elem_wire: jni::objects::JObject = __obj.into();
-            let __elem: Option<u64> = JObject_to_Option_u64_32be16a2(env, &__elem_wire)?;
-            __out.push(__elem);
-        }
-        __out
-    })
-}
-#[allow(
-    non_snake_case,
-    unused_mut,
-    unused_variables,
-    unused_braces,
-    unused_parens,
-    dead_code,
-    clippy::useless_conversion,
-    clippy::needless_question_mark,
-    clippy::let_and_return,
-    clippy::nonminimal_bool,
-    clippy::eq_op
-)]
-pub(crate) unsafe fn JObject_to_Vec_Payload_8b7084d2<'env, 'v>(
-    env: &mut jni::JNIEnv<'env>,
-    v: &jni::objects::JObject<'v>,
-) -> ::core::result::Result<Vec<perftest_flat::Payload>, __JniErr> {
-    Ok({
-        let __list = jni::objects::JList::from_env(env, v)
-            .map_err(|e| <__JniErr as ::core::convert::From<
-                String,
-            >>::from(format!("Vec<_>: list-from-env: {}", e)))?;
-        let mut __it = __list
-            .iter(env)
-            .map_err(|e| <__JniErr as ::core::convert::From<
-                String,
-            >>::from(format!("Vec<_>: list-iter: {}", e)))?;
-        let mut __out: Vec<perftest_flat::Payload> = Vec::new();
-        while let Some(__obj) = __it
-            .next(env)
-            .map_err(|e| <__JniErr as ::core::convert::From<
-                String,
-            >>::from(format!("Vec<_>: list-next: {}", e)))?
-        {
-            let __elem_wire: jni::objects::JObject = __obj.into();
-            let __elem: perftest_flat::Payload = JObject_to_Payload_98f64326(
-                env,
-                &__elem_wire,
-            )?;
-            __out.push(__elem);
-        }
-        __out
     })
 }
 #[allow(
@@ -9978,48 +9951,6 @@ pub(crate) unsafe fn PayloadVecHandler_to_jlong_b32d2812<'a>(
     v: perftest_flat::PayloadVecHandler,
 ) -> ::core::result::Result<jni::sys::jlong, __JniErr> {
     Ok(std::boxed::Box::into_raw(std::boxed::Box::new(v)) as i64)
-}
-#[allow(
-    non_snake_case,
-    unused_mut,
-    unused_variables,
-    unused_braces,
-    unused_parens,
-    dead_code,
-    clippy::useless_conversion,
-    clippy::needless_question_mark,
-    clippy::let_and_return,
-    clippy::nonminimal_bool,
-    clippy::eq_op
-)]
-pub(crate) unsafe fn Payload_to_JObject_25cd94ea<'a>(
-    env: &mut jni::JNIEnv<'a>,
-    v: &[perftest_flat::Payload],
-) -> ::core::result::Result<jni::objects::JObject<'a>, __JniErr> {
-    Ok({
-        let __list_obj = env
-            .new_object("java/util/ArrayList", "()V", &[])
-            .map_err(|e| <__JniErr as ::core::convert::From<
-                String,
-            >>::from(format!("&[_]: new ArrayList: {}", e)))?;
-        let __list = jni::objects::JList::from_env(env, &__list_obj)
-            .map_err(|e| <__JniErr as ::core::convert::From<
-                String,
-            >>::from(format!("&[_]: list-from-env: {}", e)))?;
-        for __elem in v.iter() {
-            let __elem_wire = Payload_to_JObject_98f64326(
-                env,
-                ::core::clone::Clone::clone(__elem),
-            )?;
-            let __elem_obj: jni::objects::JObject = __elem_wire.into();
-            __list
-                .add(env, &__elem_obj)
-                .map_err(|e| <__JniErr as ::core::convert::From<
-                    String,
-                >>::from(format!("&[_]: list-add: {}", e)))?;
-        }
-        __list_obj
-    })
 }
 #[allow(
     non_snake_case,
@@ -16217,6 +16148,56 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_ingotOptionalGra
                 &__e.to_string(),
             );
             0 as jni::sys::jlong
+        }
+    }
+}
+#[no_mangle]
+#[allow(non_snake_case, unused_mut, unused_variables, dead_code)]
+pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_labelBorrowedConcat<'a>(
+    mut env: jni::JNIEnv<'a>,
+    _class: jni::objects::JClass<'a>,
+    labels: jni::objects::JObject<'a>,
+    __error_sink: jni::objects::JObject<'a>,
+) -> jni::objects::JString<'a> {
+    #[allow(non_upper_case_globals)]
+    static __SINK_MID: ::prebindgen_jni_runtime::CachedIfaceMethod = ::prebindgen_jni_runtime::CachedIfaceMethod::new();
+    const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
+    const __SINK_DESCR: &str = "(Ljava/lang/String;)Ljava/lang/Object;";
+    let labels = match JObject_to_Label_0284d056(&mut env, &labels) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__e) => {
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e.to_string(),
+            );
+            return jni::objects::JObject::null().into();
+        }
+    };
+    let __out = perftest_flat::label_borrowed_concat(&labels);
+    match (|| -> ::core::result::Result<_, __JniErr> {
+        {
+            let __chain_s0 = Label_to_String_63dec766(&mut env, __out)
+                .map_err(|__e| <__JniErr as ::core::convert::From<
+                    String,
+                >>::from(__e.to_string()))?;
+            String_to_JString_c7f3ca43(&mut env, __chain_s0)
+        }
+    })() {
+        ::core::result::Result::Ok(__w) => __w,
+        ::core::result::Result::Err(__e) => {
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e.to_string(),
+            );
+            jni::objects::JObject::null().into()
         }
     }
 }

--- a/examples/covertest-kotlin/src/generated_bindings.rs
+++ b/examples/covertest-kotlin/src/generated_bindings.rs
@@ -2497,64 +2497,6 @@ pub(crate) unsafe fn JObject_to_Holder_c36a9705<'env, 'v>(
     clippy::nonminimal_bool,
     clippy::eq_op
 )]
-pub(crate) unsafe fn JObject_to_Label_0284d056<'env, 'a>(
-    env: &mut jni::JNIEnv<'env>,
-    v: &jni::objects::JObject<'a>,
-) -> ::core::result::Result<::std::vec::Vec<perftest_flat::Label>, __JniErr> {
-    ::core::result::Result::Ok({
-        let __sequence_list = jni::objects::JList::from_env(env, v)
-            .map_err(|e| <__JniErr as ::core::convert::From<
-                String,
-            >>::from(format!("Vec<_>: list-from-env: {}", e)))?;
-        let mut __sequence_iter = __sequence_list
-            .iter(env)
-            .map_err(|e| <__JniErr as ::core::convert::From<
-                String,
-            >>::from(format!("Vec<_>: list-iter: {}", e)))?;
-        let mut __sequence_values: ::std::vec::Vec<perftest_flat::Label> = ::std::vec::Vec::new();
-        while let ::core::option::Option::Some(__sequence_part) = match __sequence_iter
-            .next(env)
-            .map_err(|e| <__JniErr as ::core::convert::From<
-                String,
-            >>::from(format!("Vec<_>: list-next: {}", e)))?
-        {
-            ::core::option::Option::Some(__sequence_object) => {
-                let __sequence_part: jni::objects::JString = __sequence_object.into();
-                ::core::option::Option::Some(__sequence_part)
-            }
-            ::core::option::Option::None => ::core::option::Option::None,
-        } {
-            __sequence_values
-                .push(
-                    {
-                        let __chain_s0 = JString_to_String_c7f3ca43(
-                            env,
-                            &__sequence_part,
-                        )?;
-                        let __chain_s1 = String_to_Label_c1a79668(env, __chain_s0)
-                            .map_err(|__e| <__JniErr as ::core::convert::From<
-                                String,
-                            >>::from(__e.to_string()))?;
-                        ::core::result::Result::<_, __JniErr>::Ok(__chain_s1)
-                    }?,
-                );
-        }
-        __sequence_values
-    })
-}
-#[allow(
-    non_snake_case,
-    unused_mut,
-    unused_variables,
-    unused_braces,
-    unused_parens,
-    dead_code,
-    clippy::useless_conversion,
-    clippy::needless_question_mark,
-    clippy::let_and_return,
-    clippy::nonminimal_bool,
-    clippy::eq_op
-)]
 pub(crate) unsafe fn JObject_to_Lookup_94ada15e<'env, 'v>(
     env: &mut jni::JNIEnv<'env>,
     v: &jni::objects::JObject<'v>,
@@ -16163,7 +16105,7 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_labelBorrowedCon
     static __SINK_MID: ::prebindgen_jni_runtime::CachedIfaceMethod = ::prebindgen_jni_runtime::CachedIfaceMethod::new();
     const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
     const __SINK_DESCR: &str = "(Ljava/lang/String;)Ljava/lang/Object;";
-    let labels = match JObject_to_Label_0284d056(&mut env, &labels) {
+    let labels = match JObject_to_Vec_Label_3fdf860d(&mut env, &labels) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__e) => {
             signal_binding_error(

--- a/examples/perftest-flat/src/ext.rs
+++ b/examples/perftest-flat/src/ext.rs
@@ -1321,6 +1321,13 @@ pub fn label_series_echo(labels: Vec<Label>) -> Vec<Label> {
     labels
 }
 
+/// Join a borrowed run of converted elements. JNI decodes the Java list into
+/// an owned `Vec<Label>` carrier and lends it here only for this call.
+#[prebindgen]
+pub fn label_borrowed_concat(labels: &[Label]) -> Label {
+    Label(labels.iter().map(|label| label.0.as_str()).collect())
+}
+
 // ─────────────────────────────────────────────────────────────────────────────
 // Option<scalar> — a nullable primitive return.
 // ─────────────────────────────────────────────────────────────────────────────

--- a/examples/perftest-kotlin/src/generated_bindings.rs
+++ b/examples/perftest-kotlin/src/generated_bindings.rs
@@ -642,50 +642,6 @@ pub(crate) unsafe fn JObject_to_Payload_98f64326<'env, 'v>(
     clippy::nonminimal_bool,
     clippy::eq_op
 )]
-pub(crate) unsafe fn JObject_to_Vec_Payload_8b7084d2<'env, 'v>(
-    env: &mut jni::JNIEnv<'env>,
-    v: &jni::objects::JObject<'v>,
-) -> ::core::result::Result<Vec<perftest_flat::Payload>, __JniErr> {
-    Ok({
-        let __list = jni::objects::JList::from_env(env, v)
-            .map_err(|e| <__JniErr as ::core::convert::From<
-                String,
-            >>::from(format!("Vec<_>: list-from-env: {}", e)))?;
-        let mut __it = __list
-            .iter(env)
-            .map_err(|e| <__JniErr as ::core::convert::From<
-                String,
-            >>::from(format!("Vec<_>: list-iter: {}", e)))?;
-        let mut __out: Vec<perftest_flat::Payload> = Vec::new();
-        while let Some(__obj) = __it
-            .next(env)
-            .map_err(|e| <__JniErr as ::core::convert::From<
-                String,
-            >>::from(format!("Vec<_>: list-next: {}", e)))?
-        {
-            let __elem_wire: jni::objects::JObject = __obj.into();
-            let __elem: perftest_flat::Payload = JObject_to_Payload_98f64326(
-                env,
-                &__elem_wire,
-            )?;
-            __out.push(__elem);
-        }
-        __out
-    })
-}
-#[allow(
-    non_snake_case,
-    unused_mut,
-    unused_variables,
-    unused_braces,
-    unused_parens,
-    dead_code,
-    clippy::useless_conversion,
-    clippy::needless_question_mark,
-    clippy::let_and_return,
-    clippy::nonminimal_bool,
-    clippy::eq_op
-)]
 pub(crate) unsafe fn JObject_to_impl_Fn_Payload_Send_Sync_static_95073668<'env, 'v>(
     env: &mut jni::JNIEnv<'env>,
     v: &jni::objects::JObject<'v>,
@@ -2573,48 +2529,6 @@ pub(crate) unsafe fn PayloadVecHandler_to_jlong_b32d2812<'a>(
     v: perftest_flat::PayloadVecHandler,
 ) -> ::core::result::Result<jni::sys::jlong, __JniErr> {
     Ok(std::boxed::Box::into_raw(std::boxed::Box::new(v)) as i64)
-}
-#[allow(
-    non_snake_case,
-    unused_mut,
-    unused_variables,
-    unused_braces,
-    unused_parens,
-    dead_code,
-    clippy::useless_conversion,
-    clippy::needless_question_mark,
-    clippy::let_and_return,
-    clippy::nonminimal_bool,
-    clippy::eq_op
-)]
-pub(crate) unsafe fn Payload_to_JObject_25cd94ea<'a>(
-    env: &mut jni::JNIEnv<'a>,
-    v: &[perftest_flat::Payload],
-) -> ::core::result::Result<jni::objects::JObject<'a>, __JniErr> {
-    Ok({
-        let __list_obj = env
-            .new_object("java/util/ArrayList", "()V", &[])
-            .map_err(|e| <__JniErr as ::core::convert::From<
-                String,
-            >>::from(format!("&[_]: new ArrayList: {}", e)))?;
-        let __list = jni::objects::JList::from_env(env, &__list_obj)
-            .map_err(|e| <__JniErr as ::core::convert::From<
-                String,
-            >>::from(format!("&[_]: list-from-env: {}", e)))?;
-        for __elem in v.iter() {
-            let __elem_wire = Payload_to_JObject_98f64326(
-                env,
-                ::core::clone::Clone::clone(__elem),
-            )?;
-            let __elem_obj: jni::objects::JObject = __elem_wire.into();
-            __list
-                .add(env, &__elem_obj)
-                .map_err(|e| <__JniErr as ::core::convert::From<
-                    String,
-                >>::from(format!("&[_]: list-add: {}", e)))?;
-        }
-        __list_obj
-    })
 }
 #[allow(
     non_snake_case,

--- a/prebindgen-flat/src/flat/tests/acceptance.rs
+++ b/prebindgen-flat/src/flat/tests/acceptance.rs
@@ -1971,6 +1971,13 @@ fn a_composed_type_keys_as_its_spelling() {
     );
     assert_eq!(optional.optional_inner().expect("optional").key(), t.key());
 
+    let vector = t.vector();
+    assert_eq!(
+        vector.key(),
+        TypeKey::from_type(&syn::parse_quote!(Vec<u64>))
+    );
+    assert_eq!(vector.sequence_elem().expect("vector").key(), t.key());
+
     // A scalar the binding invented: spelled from its own kind, so the two
     // cannot drift.
     assert_eq!(

--- a/prebindgen-flat/src/flat/ty.rs
+++ b/prebindgen-flat/src/flat/ty.rs
@@ -50,9 +50,9 @@ use super::{
 ///
 /// **Enforced at the representation boundary.** The `kind` and `origin`
 /// fields remain private, so no consumer can assemble a disagreeing pair.
-/// `Flat::classify` and the `borrowed` / `optional` / `scalar`
-/// composers are intentionally public: they are the independent flat layer's
-/// constructors, and each builds the model and its matching origin together.
+/// `Flat::classify` and the `borrowed` / `optional` / `vector` /
+/// `scalar` composers are intentionally public: they are the independent flat
+/// layer's constructors, and each builds the model and its matching origin together.
 /// A collector does not need to depend on `prebindgen-registry` to create or
 /// compose a valid reading.
 ///
@@ -125,10 +125,11 @@ impl TypeRef {
     /// let forged = TypeRef { kind: TypeKind::Unit, origin: todo!() };
     /// ```
     ///
-    /// The public composition constructors (`borrowed`, `optional`, `scalar`) are
-    /// intentional flat-model API: collectors can derive readings without reparsing
-    /// Rust. They construct a matching kind and origin together, but the resulting
-    /// captured spelling still leaves this crate only through `RustEmitter`.
+    /// The public composition constructors (`borrowed`, `optional`, `vector`,
+    /// `scalar`) are intentional flat-model API: collectors can derive readings
+    /// without reparsing Rust. They construct a matching kind and origin together,
+    /// but the resulting captured spelling still leaves this crate only through
+    /// `RustEmitter`.
     pub fn kind(&self) -> &TypeKind {
         &self.kind
     }
@@ -346,6 +347,18 @@ impl TypeRef {
         TypeRef {
             kind: TypeKind::Optional(Box::new(self.clone())),
             origin: self.origin.with(syn::parse_quote!(Option<#inner>)),
+        }
+    }
+
+    /// An owned vector of this type — `Vec<T>` from `T`. Location as
+    /// [`Self::borrowed`]. A converter that materializes an owned carrier for a
+    /// borrowed slice uses this model value as its identity; it never has to
+    /// reconstruct or inspect the corresponding Rust syntax.
+    pub fn vector(&self) -> TypeRef {
+        let inner = self.origin.spell();
+        TypeRef {
+            kind: TypeKind::Vec(Box::new(self.clone())),
+            origin: self.origin.with(syn::parse_quote!(Vec<#inner>)),
         }
     }
 

--- a/prebindgen-jni/src/jni/chain.rs
+++ b/prebindgen-jni/src/jni/chain.rs
@@ -821,6 +821,10 @@ pub(crate) struct JSequencePlan {
     pub(crate) reachable: std::rc::Rc<std::cell::Cell<bool>>,
     pub(crate) dependencies: Vec<JFunction>,
     pub(crate) mode: Mode,
+    /// A borrowed slice input is decoded into an owned `Vec<T>` local; the
+    /// exported wrapper lends that local to the source call. The element stays
+    /// a `TypeRef` until this plan is rendered.
+    pub(crate) construct_vec_carrier: bool,
     pub(crate) chain: shared::Sequence<JSource, JSequenceBridge, JChild>,
 }
 
@@ -833,15 +837,23 @@ impl JSequencePlan {
         let body = &rendered.body;
         let allow = crate::jni::trait_impl::generated_converter_attr();
         match self.chain.direction {
-            Direction::Construct => syn::parse_quote!(
-                #allow
-                pub(crate) unsafe fn #name<'env, 'a>(
-                    env: &mut jni::JNIEnv<'env>,
-                    v: &#intermediate,
-                ) -> ::core::result::Result<#source, __JniErr> {
-                    ::core::result::Result::Ok(#body)
-                }
-            ),
+            Direction::Construct => {
+                let output = if self.construct_vec_carrier {
+                    let element = emit.spell_ty(&self.chain.element);
+                    syn::parse_quote!(::std::vec::Vec<#element>)
+                } else {
+                    source.clone()
+                };
+                syn::parse_quote!(
+                    #allow
+                    pub(crate) unsafe fn #name<'env, 'a>(
+                        env: &mut jni::JNIEnv<'env>,
+                        v: &#intermediate,
+                    ) -> ::core::result::Result<#output, __JniErr> {
+                        ::core::result::Result::Ok(#body)
+                    }
+                )
+            }
             Direction::Deconstruct => {
                 let input = match self.mode {
                     Mode::Owned => quote!(v: #source),

--- a/prebindgen-jni/src/jni/chain.rs
+++ b/prebindgen-jni/src/jni/chain.rs
@@ -821,10 +821,6 @@ pub(crate) struct JSequencePlan {
     pub(crate) reachable: std::rc::Rc<std::cell::Cell<bool>>,
     pub(crate) dependencies: Vec<JFunction>,
     pub(crate) mode: Mode,
-    /// A borrowed slice input is decoded into an owned `Vec<T>` local; the
-    /// exported wrapper lends that local to the source call. The element stays
-    /// a `TypeRef` until this plan is rendered.
-    pub(crate) construct_vec_carrier: bool,
     pub(crate) chain: shared::Sequence<JSource, JSequenceBridge, JChild>,
 }
 
@@ -837,23 +833,15 @@ impl JSequencePlan {
         let body = &rendered.body;
         let allow = crate::jni::trait_impl::generated_converter_attr();
         match self.chain.direction {
-            Direction::Construct => {
-                let output = if self.construct_vec_carrier {
-                    let element = emit.spell_ty(&self.chain.element);
-                    syn::parse_quote!(::std::vec::Vec<#element>)
-                } else {
-                    source.clone()
-                };
-                syn::parse_quote!(
-                    #allow
-                    pub(crate) unsafe fn #name<'env, 'a>(
-                        env: &mut jni::JNIEnv<'env>,
-                        v: &#intermediate,
-                    ) -> ::core::result::Result<#output, __JniErr> {
-                        ::core::result::Result::Ok(#body)
-                    }
-                )
-            }
+            Direction::Construct => syn::parse_quote!(
+                #allow
+                pub(crate) unsafe fn #name<'env, 'a>(
+                    env: &mut jni::JNIEnv<'env>,
+                    v: &#intermediate,
+                ) -> ::core::result::Result<#source, __JniErr> {
+                    ::core::result::Result::Ok(#body)
+                }
+            ),
             Direction::Deconstruct => {
                 let input = match self.mode {
                     Mode::Owned => quote!(v: #source),

--- a/prebindgen-jni/src/jni/compile.rs
+++ b/prebindgen-jni/src/jni/compile.rs
@@ -15,10 +15,7 @@ use prebindgen_registry::{
     Conversions,
 };
 
-use super::{
-    trait_impl::{Produced, WrapperShape},
-    *,
-};
+use super::*;
 
 /// The JNI adapter's answer for one site.
 ///
@@ -845,7 +842,6 @@ impl<R: Conversions> JCompile<'_, R> {
         // The target through the accessor: an out-parameter's `MaybeUninit` is
         // the slot a `T` goes in, and it is the `T` that converts.
         let inner = ty.borrow_target().expect("a borrow");
-        let produced = Produced::Reading(ty);
         if into_rust {
             // An exclusive borrow crosses only when the borrowed value lives on
             // the Rust side — see `input_borrow`'s own note. `mutable` is read
@@ -875,23 +871,11 @@ impl<R: Conversions> JCompile<'_, R> {
                 c.subs = vec![inner.key()];
                 return Some(c);
             }
-            let mutable = ty.is_exclusive_borrow();
-            let mut c = self.decls.input_wrapper_shape(
-                WrapperShape::Borrow { mutable },
-                &produced,
-                inner,
-                emit,
-            )?;
+            let mut c = self.decls.input_borrow(ty, inner)?;
             c.subs = vec![inner.key()];
             Some(c)
         } else {
-            let mutable = ty.is_exclusive_borrow();
-            let mut c = self.decls.output_wrapper_shape(
-                WrapperShape::Borrow { mutable },
-                &produced,
-                inner,
-                emit,
-            )?;
+            let mut c = self.decls.output_borrow(ty, inner, emit)?;
             c.subs = vec![inner.key()];
             Some(c)
         }
@@ -1283,15 +1267,13 @@ impl<R: Conversions> JCompile<'_, R> {
     /// operations. Primitive arrays, handle-vector builders and multi-slot
     /// element folds retain their specialized representations.
     fn planned_sequence(&self, at: At<'_>, elements: Mode, inner: &JFrag) -> Option<JFrag> {
-        if inner.composed_only || inner.wires.is_some() || inner.out_wires.is_some() {
-            return None;
-        }
         let source = at.crossing.value();
         let element = source.sequence_elem()?.clone();
         let direction = at.crossing.direction();
         match (direction, source.unwrapped().kind()) {
-            (Direction::Construct, TypeKind::Vec(_))
-            | (Direction::Deconstruct, TypeKind::Vec(_) | TypeKind::Slice(_)) => {}
+            (Direction::Construct, TypeKind::Vec(_)) => {}
+            (Direction::Construct, TypeKind::Slice(_)) if at.crossing.mode() == Mode::Shared => {}
+            (Direction::Deconstruct, TypeKind::Vec(_) | TypeKind::Slice(_)) => {}
             _ => return None,
         }
         // The same gate the product and choice planners apply. This one used to
@@ -1301,8 +1283,52 @@ impl<R: Conversions> JCompile<'_, R> {
         // the `Box`.
         let wrappers = composable_wrappers(at.crossing)?;
 
+        let inner_kotlin = inner
+            .conv
+            .metadata
+            .kotlin_name
+            .clone()
+            .or_else(|| self.decls.override_kotlin_name(&element.key(), None))?;
+        let kotlin_name = self.decls.override_kotlin_name(
+            &at.crossing.spelled().key(),
+            Some(KtType::generic("List", [inner_kotlin])),
+        );
+        let projection = if direction == Direction::Deconstruct {
+            inner
+                .conv
+                .metadata
+                .projection
+                .clone()
+                .map(|projection| Projection {
+                    strategy: FoldStrategy::Iterable(Box::new(projection.strategy)),
+                    ..projection
+                })
+        } else {
+            None
+        };
+
         let child_wire = inner.conv.destination.clone();
-        if !is_jobject_shaped_wire(&child_wire) {
+        let specialized_site = inner.wires.is_some()
+            || inner.out_wires.is_some()
+            || (!is_jobject_shaped_wire(&child_wire) && inner.conv.metadata.projection.is_some());
+        if specialized_site {
+            // Multi-slot elements cross at a site as a Kotlin-side fold or a
+            // transient Vec handle. The Sequence row still owns the shape and
+            // its surface metadata, but deliberately has no whole-list Rust
+            // converter for those site-specific representations.
+            let mut marker = JFrag::new(at, self.parts_marker(vec![element.key()]));
+            marker.conv.destination = syn::parse_quote!(jni::objects::JObject);
+            marker.conv.metadata = KotlinMeta {
+                kotlin_name,
+                value_rust_type: None,
+                projection,
+                niche_sentinels: Vec::new(),
+            };
+            marker.nested_chain = inner.composed_chain();
+            marker.composed_only = true;
+            return Some(marker);
+        }
+        if inner.composed_only || !is_jobject_shaped_wire(&child_wire) {
             return None;
         }
         if direction == Direction::Construct {
@@ -1323,6 +1349,8 @@ impl<R: Conversions> JCompile<'_, R> {
             reachable: std::rc::Rc::new(std::cell::Cell::new(false)),
             dependencies: vec![inner.rust.clone()],
             mode: at.crossing.mode(),
+            construct_vec_carrier: direction == Direction::Construct
+                && matches!(source.unwrapped().kind(), TypeKind::Slice(_)),
             chain: prebindgen_registry::chain::Sequence {
                 source: source.clone(),
                 element: element.clone(),
@@ -1336,24 +1364,6 @@ impl<R: Conversions> JCompile<'_, R> {
             },
         });
 
-        let inner_kotlin = inner.conv.metadata.kotlin_name.clone()?;
-        let kotlin_name = self.decls.override_kotlin_name(
-            &at.crossing.spelled().key(),
-            Some(KtType::generic("List", [inner_kotlin])),
-        );
-        let projection = if direction == Direction::Deconstruct {
-            inner
-                .conv
-                .metadata
-                .projection
-                .clone()
-                .map(|projection| Projection {
-                    strategy: FoldStrategy::Iterable(Box::new(projection.strategy)),
-                    ..projection
-                })
-        } else {
-            None
-        };
         let niches = match direction {
             Direction::Construct => Niches::empty(),
             Direction::Deconstruct => default_niches_for_wire(&destination),
@@ -1924,13 +1934,11 @@ impl<R: Conversions> Compile for JCompile<'_, R> {
             Direction::Construct => self
                 .decls
                 .input_terminal(ty, self.registry, emit)
-                .or_else(|| self.decls.input_run(ty, emit))
                 .or_else(|| self.borrow(ty, emit, true))
                 .or_else(|| self.decls.input_transparent_bridge(ty, self.registry, emit)),
             Direction::Deconstruct => self
                 .decls
                 .output_terminal(ty, self.registry, emit)
-                .or_else(|| self.decls.output_run(ty, emit))
                 .or_else(|| self.borrow(ty, emit, false))
                 .or_else(|| {
                     self.decls

--- a/prebindgen-jni/src/jni/compile.rs
+++ b/prebindgen-jni/src/jni/compile.rs
@@ -1336,7 +1336,19 @@ impl<R: Conversions> JCompile<'_, R> {
         }
         let child = Self::planned_child_mode(direction, elements, inner);
         let destination: syn::Type = syn::parse_quote!(jni::objects::JObject);
-        let ident = crate::jni::chain::planned_name(direction, at.crossing.spelled(), &destination);
+        // A shared slice input and an owned vector input both materialize the
+        // same `Vec<T>` carrier. Give that produced model type to the plan,
+        // so converter identity, name and emitted body are shared. The wrapper
+        // still owns the crossing mode and adds the final borrow.
+        let produced = if direction == Direction::Construct
+            && matches!(source.kind(), TypeKind::Slice(_))
+            && at.crossing.mode() == Mode::Shared
+        {
+            element.vector()
+        } else {
+            source.clone()
+        };
+        let ident = crate::jni::chain::planned_name(direction, &produced, &destination);
         let marker = crate::jni::chain::planned_marker(&ident);
         let bridge = match direction {
             Direction::Construct => crate::jni::chain::JSequenceBridge::Input {
@@ -1349,10 +1361,8 @@ impl<R: Conversions> JCompile<'_, R> {
             reachable: std::rc::Rc::new(std::cell::Cell::new(false)),
             dependencies: vec![inner.rust.clone()],
             mode: at.crossing.mode(),
-            construct_vec_carrier: direction == Direction::Construct
-                && matches!(source.unwrapped().kind(), TypeKind::Slice(_)),
             chain: prebindgen_registry::chain::Sequence {
-                source: source.clone(),
+                source: produced,
                 element: element.clone(),
                 direction,
                 source_policy: crate::jni::chain::JSource {

--- a/prebindgen-jni/src/jni/selector.rs
+++ b/prebindgen-jni/src/jni/selector.rs
@@ -2,84 +2,9 @@
 
 use prebindgen_registry::Conversions;
 
-use super::{trait_impl::WrapperShape, *};
-
-/// Whether a decoded `Vec<T>` local can be borrowed where `referent` is expected.
-///
-/// A question about the **form**, and it always was: `[T]` is reached by deref
-/// coercion from `&Vec<T>` and `Vec<T>` is the thing itself, while a transparent
-/// wrapper — `Box<Vec<T>>`, `Cow<'_, [T]>` — cannot be rebuilt from the decoded
-/// local.
-///
-/// It asked the spelling because it had to. This doc used to say so: *"Rust
-/// distinguishes forms the boundary classification does not"*, and that was true
-/// when `Vec<T>` and `[T]` were one `Sequence` and a `Box` was erased. `TypeKind`
-/// **is** the accepted syntax now, so the kind draws every distinction this needs
-/// — `Vec`, `Slice`, `Boxed` and `Cow` are four kinds — and the question is
-/// answered by the model instead of by a `match` on `syn`.
-fn decoded_vec_satisfies(referent: &prebindgen_registry::flat::TypeRef) -> bool {
-    matches!(
-        referent.kind(),
-        prebindgen_registry::flat::TypeKind::Slice(_) | prebindgen_registry::flat::TypeKind::Vec(_)
-    )
-}
-
-/// Whether a type has no size, so no by-value converter can name it.
-///
-/// The peer of [`decoded_vec_satisfies`], and it stopped being a *spelling*
-/// question for the same reason: `[T]` and `Vec<T>` were one concept once and
-/// are two kinds now. A bare slice is reached exclusively through a borrow,
-/// whose own arm handles it; claiming it here would generate `fn f(..) -> [T]`.
-///
-/// `str` is the same shape of fact and is handled the same way, one layer up:
-/// its terminal arm resolves it to the borrowed `&str` converter rather than
-/// pretending an owned `str` exists — which is why `Str` is not an arm here.
-fn is_unsized_spelling(ty: &prebindgen_registry::flat::TypeRef) -> bool {
-    matches!(ty.kind(), prebindgen_registry::flat::TypeKind::Slice(_))
-}
+use super::*;
 
 impl Declarations {
-    /// The `Vec<X>` / `&[X]` / `&Vec<X>` **input** shapes.
-    ///
-    /// A shared slice borrow has no owned `[T]` to decode into, so it reuses the
-    /// `Vec<_>` shape: the Java `List<T>` becomes an owned `Vec<T>` and the call
-    /// site borrows it (`&Vec<T>` deref-coerces to `&[T]`). `&mut [T]` is
-    /// deliberately not supported, because the decoded `Vec` is never written
-    /// back.
-    pub(crate) fn input_run(
-        &self,
-        ty: &prebindgen_registry::flat::TypeRef,
-        emit: &prebindgen_registry::Emit,
-    ) -> Option<ConverterImpl<KotlinMeta>> {
-        let produced = crate::jni::trait_impl::Produced::Reading(ty);
-        if let Some(elem) = ty.sequence_elem().filter(|_| !is_unsized_spelling(ty)) {
-            let mut c = self.input_wrapper_shape(WrapperShape::Sequence, &produced, elem, emit)?;
-            c.subs = vec![elem.key()];
-            return Some(c);
-        }
-        // Two questions, and only the first is `kind`'s. That it is a run of
-        // values makes this arm a *candidate*; whether the decoded `Vec<T>` can
-        // be handed to the Rust function is a question about the **spelling**,
-        // because the generated glue is the one consumer that can tell
-        // `&Vec<T>` from `&Box<Vec<T>>`.
-        let prebindgen_registry::flat::TypeKind::Ref { mutable, .. } = ty.unwrapped().kind() else {
-            return None;
-        };
-        let inner = ty.borrow_target().expect("a borrow");
-        if *mutable || !decoded_vec_satisfies(inner) {
-            return None;
-        }
-        let elem = inner.sequence_elem()?;
-        let elem_ty = emit.spell(elem);
-        // The one place `produced` is NOT the crossing's spelling: there is no
-        // owned `[T]` to decode into, so the converter yields an owned `Vec<T>`
-        // and the call site borrows it.
-        let produced = crate::jni::trait_impl::Produced::Composed(syn::parse_quote!(Vec<#elem_ty>));
-        let mut c = self.input_wrapper_shape(WrapperShape::Sequence, &produced, elem, emit)?;
-        c.subs = vec![elem.key()];
-        Some(c)
-    }
-
     /// `Result<T, E>` **output**: succeeds as `T`, routes `E` to the error sink.
     ///
     /// Read off the model, which calls this shape `TypeKind::Fallible`.
@@ -91,35 +16,6 @@ impl Declarations {
     ) -> Option<ConverterImpl<KotlinMeta>> {
         let (ok, err) = fallible_parts(ty, emit)?;
         self.result_peel(ty, &ok, &err, registry, emit)
-    }
-
-    /// The `Vec<X>` / `&[X]` **output** shapes.
-    ///
-    /// A shared slice borrow is a callback argument crossing native to JVM: it
-    /// builds a `List<T>` from the borrowed run. Dual of [`Self::input_run`],
-    /// and split the same way — `kind` says it is a borrow of a run of values,
-    /// and whether the generated Rust can iterate the borrow directly is a
-    /// question about the spelling.
-    pub(crate) fn output_run(
-        &self,
-        ty: &prebindgen_registry::flat::TypeRef,
-        emit: &prebindgen_registry::Emit,
-    ) -> Option<ConverterImpl<KotlinMeta>> {
-        let produced = crate::jni::trait_impl::Produced::Reading(ty);
-        if let Some(elem) = ty.sequence_elem().filter(|_| !is_unsized_spelling(ty)) {
-            let mut c = self.output_wrapper_shape(WrapperShape::Sequence, &produced, elem, emit)?;
-            c.subs = vec![elem.key()];
-            return Some(c);
-        }
-        let prebindgen_registry::flat::TypeKind::Ref { mutable, .. } = ty.unwrapped().kind() else {
-            return None;
-        };
-        let inner = ty.borrow_target().expect("a borrow");
-        if *mutable || !decoded_vec_satisfies(inner) {
-            return None;
-        }
-        let elem = inner.sequence_elem()?;
-        self.output_slice(elem, emit)
     }
 }
 

--- a/prebindgen-jni/src/jni/tests/sealed.rs
+++ b/prebindgen-jni/src/jni/tests/sealed.rs
@@ -2838,6 +2838,79 @@ fn sequence_wrapper_plan(
     gen.crossing_plan_for_test(ty, direction)
 }
 
+/// Sequence composition has two registry-owned outcomes: an executable list
+/// converter for a one-slot element, and a non-rendering shape fragment when a
+/// site already folds a multi-slot element on the Kotlin side.
+#[test]
+fn borrowed_sequences_keep_their_registry_plan_or_specialized_shape() {
+    let loc = myflat_loc();
+    let items: Vec<(syn::Item, SourceLocation)> = vec![
+        (
+            syn::parse_quote!(
+                pub struct Payload {
+                    pub id: i64,
+                    pub label: String,
+                }
+            ),
+            loc.clone(),
+        ),
+        (
+            syn::parse_quote!(
+                pub fn seed(cb: impl Fn(&[Payload]) + Send + Sync + 'static) {
+                    unimplemented!()
+                }
+            ),
+            loc.clone(),
+        ),
+        (
+            syn::parse_quote!(
+                pub fn take_labels(labels: &[String]) {
+                    unimplemented!()
+                }
+            ),
+            loc,
+        ),
+    ];
+    let registry =
+        crate::test_util::reg_from_items(declare_referenced(items)).expect("index items");
+    let gen = JniGenBuilder::new()
+        .set_package_prefix("io.test.jni")
+        .package(
+            crate::package!()
+                .class(crate::data_class!(Payload))
+                .fun(prebindgen_registry::fun!(seed))
+                .fun(prebindgen_registry::fun!(take_labels)),
+        )
+        .build_with(registry)
+        .expect("resolve");
+    let (specialized, ident, rendered) = gen
+        .crossing_plan_for_test(
+            syn::parse_quote!(&[Payload]),
+            prebindgen_registry::recipe::Direction::Deconstruct,
+        )
+        .expect("plan");
+    assert!(
+        specialized && ident == "__jni_parts",
+        "the flattened callback fold needs only its Sequence shape: {ident}\n{rendered}"
+    );
+
+    let (specialized, ident, rendered) = gen
+        .crossing_plan_for_test(
+            syn::parse_quote!(&[String]),
+            prebindgen_registry::recipe::Direction::Construct,
+        )
+        .expect("labels plan");
+    let compact: String = rendered.split_whitespace().collect();
+    assert!(
+        !specialized
+            && ident.starts_with("JObject_to_String_")
+            && compact.contains("Result<::std::vec::Vec<String>,__JniErr>")
+            && compact.contains("letmut__sequence_values")
+            && compact.contains("JString_to_String"),
+        "the borrowed input must retain the executable registry Sequence plan: {ident}\n{rendered}"
+    );
+}
+
 /// Every composed planner refuses a wrapper it cannot peel and put back, and
 /// refuses to read one it does not own.
 ///

--- a/prebindgen-jni/src/jni/tests/sealed.rs
+++ b/prebindgen-jni/src/jni/tests/sealed.rs
@@ -2894,20 +2894,33 @@ fn borrowed_sequences_keep_their_registry_plan_or_specialized_shape() {
         "the flattened callback fold needs only its Sequence shape: {ident}\n{rendered}"
     );
 
-    let (specialized, ident, rendered) = gen
+    let (specialized, borrowed_ident, borrowed_rendered) = gen
         .crossing_plan_for_test(
             syn::parse_quote!(&[String]),
             prebindgen_registry::recipe::Direction::Construct,
         )
         .expect("labels plan");
-    let compact: String = rendered.split_whitespace().collect();
+    let compact: String = borrowed_rendered.split_whitespace().collect();
     assert!(
         !specialized
-            && ident.starts_with("JObject_to_String_")
-            && compact.contains("Result<::std::vec::Vec<String>,__JniErr>")
+            && borrowed_ident.starts_with("JObject_to_Vec_String_")
+            && compact.contains("Result<Vec<String>,__JniErr>")
             && compact.contains("letmut__sequence_values")
             && compact.contains("JString_to_String"),
-        "the borrowed input must retain the executable registry Sequence plan: {ident}\n{rendered}"
+        "the borrowed input must retain the executable registry Sequence plan: {borrowed_ident}\n{borrowed_rendered}"
+    );
+
+    let (specialized, owned_ident, owned_rendered) = gen
+        .crossing_plan_for_test(
+            syn::parse_quote!(Vec<String>),
+            prebindgen_registry::recipe::Direction::Construct,
+        )
+        .expect("owned labels plan");
+    assert!(
+        !specialized
+            && owned_ident == borrowed_ident
+            && owned_rendered == borrowed_rendered,
+        "owned Vec and borrowed slice inputs must share their produced-carrier converter:\nborrowed {borrowed_ident}: {borrowed_rendered}\nowned {owned_ident}: {owned_rendered}"
     );
 }
 

--- a/prebindgen-jni/src/jni/trait_impl.rs
+++ b/prebindgen-jni/src/jni/trait_impl.rs
@@ -702,26 +702,6 @@ pub(crate) fn build_handle_destructor_items(
     named.into_iter().map(|(_, item)| item).collect()
 }
 
-/// Which built-in wrapper a converter is being built for — **the model's
-/// answer, not a guess from the spelling**.
-///
-/// This used to be a `&syn::Type` wildcard pattern (`Option<_>`, `& mut _`)
-/// rebuilt from the type's tokens and compared as a *string*. That made the
-/// dispatch depend on how Rust happened to spell the type: `Box<Option<T>>`
-/// reconstructed as `Box<_>`, matched no pattern, and got no converter at all
-/// (#270) — even though the model classifies it `Optional` and says so.
-///
-/// So the shape comes from [`TypeKind`](prebindgen_registry::flat::TypeKind) and
-/// the spelling comes from `spell()`, which is the same split the rest of
-/// the pipeline follows: classify off `kind`, spell with `spell()`.
-#[derive(Clone, Copy, PartialEq, Eq, Debug)]
-pub(crate) enum WrapperShape {
-    /// `Ref` — a borrow of its inner.
-    Borrow { mutable: bool },
-    /// `Sequence` — a run of its element.
-    Sequence,
-}
-
 /// What generated Rust can do with one wrapper the model
 /// [erases](prebindgen_registry::flat::TRANSPARENT_WRAPPERS).
 ///
@@ -789,128 +769,6 @@ const WRAPPER_OPS: &[WrapperOps] = &[
 
 pub(crate) fn wrapper_ops(name: &str) -> Option<&'static WrapperOps> {
     WRAPPER_OPS.iter().find(|w| w.name == name)
-}
-
-/// What a wrapper arm's converter **yields**.
-///
-/// Two cases, and the code always had both — one of them just had no name:
-///
-/// * `Reading` — the crossing's own type, as the model classified it. Every
-///   arm but one gets this.
-/// * `Composed` — a shape this adapter built. The `&[T]` parameter is the only
-///   instance: it decodes to an owned `Vec<T>` the call site borrows, and #280
-///   leaves `api::lang` no way to mint that reading. A composed shape carries
-///   no erased wrappers by construction — it *is* the canonical form.
-///
-/// The distinction is what the `canonical` argument used to stand in for. A
-/// spelling was compared token-for-token against a reconstructed
-/// `Option<t1>` / `Vec<t1>` / `&t1` to find out what wrappers sat over it —
-/// which is [`TypeRef::erased_wrappers`], asked of the classification instead
-/// of re-derived from tokens.
-pub(crate) enum Produced<'a> {
-    Reading(&'a prebindgen_registry::flat::TypeRef),
-    /// Boxed: a `syn::Type` dwarfs the borrow beside it, and the composed case
-    /// is the rare one (a single arm).
-    Composed(Box<syn::Type>),
-}
-
-impl Produced<'_> {
-    /// The chain of wrappers standing between what this yields and the
-    /// canonical shape its `kind` names, outermost first — empty when the
-    /// source already wrote the canonical form.
-    ///
-    /// `None` when a wrapper has no [`WrapperOps`], so no converter claims it.
-    fn bridge_layers(&self) -> Option<Vec<&'static WrapperOps>> {
-        match self {
-            Produced::Reading(r) => r.erased_wrappers().into_iter().map(wrapper_ops).collect(),
-            Produced::Composed(_) => Some(Vec::new()),
-        }
-    }
-
-    /// True when what this yields IS the canonical shape — no wrapper to
-    /// bridge. The arms that hand back an inner converter verbatim require it:
-    /// there is no value in hand to wrap or unwrap.
-    fn is_canonical(&self) -> bool {
-        self.bridge_layers().is_some_and(|l| l.is_empty())
-    }
-
-    /// This type's identity.
-    fn key(&self) -> TypeKey {
-        match self {
-            Produced::Reading(r) => r.key(),
-            Produced::Composed(t) => TypeKey::from_type(t),
-        }
-    }
-
-    /// The borrow this yields, when the source wrote one — the reading's own
-    /// `TypeKind::Ref`. A composed shape is never a borrow.
-    fn borrow(&self) -> Option<(&prebindgen_registry::flat::TypeRef, bool)> {
-        match self {
-            Produced::Reading(r) => match r.kind() {
-                prebindgen_registry::flat::TypeKind::Ref { mutable, inner, .. } => {
-                    Some((inner, *mutable))
-                }
-                _ => None,
-            },
-            Produced::Composed(_) => None,
-        }
-    }
-}
-
-impl Declarations {
-    /// [`Self::build_input_fn`] over either case.
-    fn build_input_fn_produced(
-        &self,
-        produced: &Produced<'_>,
-        wire: &syn::Type,
-        body: &syn::Expr,
-        exc: Option<&syn::Type>,
-        emit: &prebindgen_registry::Emit,
-    ) -> syn::ItemFn {
-        match produced {
-            Produced::Reading(r) => self.build_input_fn_of(r, wire, body, exc, emit),
-            Produced::Composed(t) => self.build_input_fn_composed(t, wire, body, exc),
-        }
-    }
-
-    /// [`Self::build_output_fn`] over either case.
-    fn build_output_fn_produced(
-        &self,
-        produced: &Produced<'_>,
-        wire: &syn::Type,
-        body: &syn::Expr,
-        exc: Option<&syn::Type>,
-        emit: &prebindgen_registry::Emit,
-    ) -> syn::ItemFn {
-        match produced {
-            Produced::Reading(r) => self.build_output_fn_of(r, wire, body, exc, emit),
-            Produced::Composed(t) => self.build_output_fn(t, wire, body, exc),
-        }
-    }
-}
-
-/// Read the converter's `v` as the canonical shape, undoing each layer
-/// outside-in. `None` when any layer cannot be read through — the crossing then
-/// stays **unresolved**, naming the type, rather than resolving and emitting
-/// Rust the consumer cannot build (#270 review).
-fn read_as_canonical(produced: &Produced<'_>) -> Option<TokenStream> {
-    let layers = produced.bridge_layers()?;
-    let mut e = quote!(v);
-    for w in layers {
-        e = (w.read?)(e);
-    }
-    Some(e)
-}
-
-/// Build the spelling from a canonical value — the input-side peer, applying
-/// each layer inside-out.
-fn build_from_canonical(produced: &Produced<'_>, value: TokenStream) -> Option<TokenStream> {
-    let layers = produced.bridge_layers()?;
-    let mut e = value;
-    for w in layers.into_iter().rev() {
-        e = (w.build?)(e);
-    }
-    Some(e)
 }
 
 /// Move a value the **source** produced out of the transparent wrappers its
@@ -995,33 +853,22 @@ pub(crate) fn build_through_wrappers(
     Some(out)
 }
 
-/// Per-shape **input** wrapper converter builders (`&` and `Vec`). Each returns
-/// `Some(ConverterImpl)` only for the [`WrapperShape`] it claims;
-/// [`Declarations::input_wrapper_shape`] chains the disjoint builders.
-///
-/// Each takes `produced`, the Rust type the converter function yields. This is
-/// normally the crossing spelling; a borrowed slice deliberately decodes to an
-/// owned `Vec<T>` that the call site borrows.
 impl Declarations {
     /// `& _` / `& mut _` borrow: share T's resolved converter — `&T`'s entry
     /// points at the same `ItemFn` (the fn returns owned `T`; the call site in
     /// `emit_jni_function_wrapper` adds `&decoded`). Exists so the
     /// wildcard-substitution machinery marks T required transitively from `&T`.
-    fn input_borrow(
+    pub(crate) fn input_borrow(
         &self,
-        shape: WrapperShape,
-        produced: &Produced<'_>,
+        produced: &prebindgen_registry::flat::TypeRef,
         t1: &prebindgen_registry::flat::TypeRef,
     ) -> Option<ConverterImpl<KotlinMeta>> {
-        let WrapperShape::Borrow { .. } = shape else {
-            return None;
-        };
         // This converter does NOT produce the spelled type: it hands back the
         // inner type's own entry, and the call site adds the `&`. So there is no
         // value in hand to unwrap a representation from, and a wrapped spelling
         // — `Box<&T>` — must not resolve here (it would pass an owned `T` where
         // `Box<&T>` is expected).
-        if !produced.is_canonical() {
+        if !produced.erased_wrappers().is_empty() {
             return None;
         }
         let inner = self.in_frag(t1)?;
@@ -1050,76 +897,6 @@ impl Declarations {
                 value_rust_type: None,
                 projection,
                 niche_sentinels: inner.metadata.niche_sentinels.clone(),
-            },
-        })
-    }
-
-    /// `Vec<T>` (input side): wire is `JObject` carrying a Java
-    /// `List<InnerWire>`; iterate, decode each element via the inner converter,
-    /// collect into a `Vec`. (`Vec<u8>` is special-cased at rank-0.)
-    fn input_vec(
-        &self,
-        shape: WrapperShape,
-        produced: &Produced<'_>,
-        t1: &prebindgen_registry::flat::TypeRef,
-        emit: &prebindgen_registry::Emit,
-    ) -> Option<ConverterImpl<KotlinMeta>> {
-        // `t1`'s spelling, for the parts that ask spelling questions — the
-        // canonical form a produced spelling is compared against, and the
-        // type ascriptions the generated body writes. Everything else takes
-        // the READING itself (#284).
-        let t1_ty = emit.spell(t1);
-        if shape != WrapperShape::Sequence {
-            return None;
-        }
-        let inner = self.in_frag(t1)?;
-        reject_vec_of_handle(&inner.metadata.projection, t1);
-        let inner_wire = inner.destination.clone();
-        if !is_jobject_shaped_wire(&inner_wire) {
-            return None;
-        }
-        inner.activate();
-        // The element's COMPLETE wire -> Rust chain: a `convert!` element
-        // (`Label` -> `String`) reaches its value through the rust-side stages,
-        // not through the wire-facing converter alone.
-        let inner_conv =
-            crate::jni::emit::composed_inner_input(&inner, quote::quote!(&__elem_wire));
-        let outer_ty = produced.key();
-        // Bridgeable first — see `box_layers_to`.
-        let build = build_from_canonical(produced, quote::quote!(__out))?;
-        let wire: syn::Type = syn::parse_quote!(jni::objects::JObject);
-        let body: syn::Expr = syn::parse_quote!({
-            let __list = jni::objects::JList::from_env(env, v)
-                .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(format!("Vec<_>: list-from-env: {}", e)))?;
-            let mut __it = __list.iter(env)
-                .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(format!("Vec<_>: list-iter: {}", e)))?;
-            let mut __out: Vec<#t1_ty> = Vec::new();
-            while let Some(__obj) = __it.next(env)
-                .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(format!("Vec<_>: list-next: {}", e)))?
-            {
-                let __elem_wire: #inner_wire = __obj.into();
-                let __elem: #t1_ty = #inner_conv;
-                __out.push(__elem);
-            }
-            #build
-        });
-        let inner_kotlin = inner.metadata.kotlin_name.clone()?;
-        let kotlin_name = self.override_kotlin_name(
-            &outer_ty,
-            // `List` is auto-imported in Kotlin (default imports).
-            Some(KtType::generic("List", [inner_kotlin])),
-        );
-        Some(ConverterImpl {
-            subs: vec![],
-            pre_stages: vec![],
-            function: self.build_input_fn_produced(produced, &wire, &body, None, emit),
-            destination: wire,
-            niches: Niches::empty(),
-            metadata: KotlinMeta {
-                kotlin_name,
-                value_rust_type: None,
-                projection: None,
-                niche_sentinels: Vec::new(),
             },
         })
     }
@@ -2443,9 +2220,9 @@ impl Declarations {
     /// resolved through the ordinary machinery rather than being resolved here.
     ///
     /// Deliberately tried **after** every layer arm, so nothing that resolves
-    /// today changes route: `Box<Option<T>>` keeps the `Optional` arm (which
-    /// bridges via `build_from_canonical`), and only the shapes that previously
-    /// reached `None` arrive here.
+    /// today changes route: `Box<Option<T>>` keeps the registry-composed
+    /// `Optional` arm, and only the shapes that previously reached `None`
+    /// arrive here.
     pub(crate) fn input_transparent_bridge(
         &self,
         reading: &prebindgen_registry::flat::TypeRef,
@@ -2505,20 +2282,6 @@ impl Declarations {
             // Kotlin class from being lost behind the wrapper.
             metadata: entry.metadata.clone(),
         })
-    }
-
-    /// **Input** wrapper shape: the built-in borrow and sequence handlers.
-    /// The dual of [`Self::output_wrapper_shape`].
-    pub(crate) fn input_wrapper_shape(
-        &self,
-        shape: WrapperShape,
-        produced: &Produced<'_>,
-        t1: &prebindgen_registry::flat::TypeRef,
-        emit: &prebindgen_registry::Emit,
-    ) -> Option<ConverterImpl<KotlinMeta>> {
-        // Disjoint borrow and sequence shapes, tried in priority order.
-        self.input_borrow(shape, produced, t1)
-            .or_else(|| self.input_vec(shape, produced, t1, emit))
     }
 
     // ── Output converters ────────────────────────────────────────────
@@ -2706,20 +2469,13 @@ impl Declarations {
         None
     }
 
-    /// **Output** wrapper shape (the dual of [`Self::input_wrapper_shape`]):
-    /// the built-in borrowed-handle, borrowed-string, and sequence handlers.
-    pub(crate) fn output_wrapper_shape(
+    /// Borrowed-handle and borrowed-string output terminals.
+    pub(crate) fn output_borrow(
         &self,
-        shape: WrapperShape,
-        produced: &Produced<'_>,
+        produced: &prebindgen_registry::flat::TypeRef,
         t1: &prebindgen_registry::flat::TypeRef,
         emit: &prebindgen_registry::Emit,
     ) -> Option<ConverterImpl<KotlinMeta>> {
-        // `t1`'s spelling, for the parts that ask spelling questions — the
-        // canonical form a produced spelling is compared against, and the
-        // type ascriptions the generated body writes. Everything else takes
-        // the READING itself (#284).
-        let t1_ty = emit.spell(t1);
         // Borrowed opaque-handle output (`&T` / `&'static T` where `T` is a
         // declared opaque handle). Canonical zenoh-flat's `z_*` accessors
         // return *borrowed* handles for the C tier's zero-copy borrows, but
@@ -2729,175 +2485,37 @@ impl Declarations {
         // with a `.clone()`; `Option<&T>` then composes through the `Option`
         // arm below (it looks up this `&T` entry as its inner). Matched
         // structurally so the lifetime variant `&'static _` is covered too.
-        if let Some((_, false)) = produced.borrow() {
-            if self.types.get(&t1.key()).is_some_and(|c| c.is_opaque()) {
-                let wire: syn::Type = syn::parse_quote!(jni::sys::jlong);
-                let body: syn::Expr = syn::parse_quote!(std::boxed::Box::into_raw(
-                    std::boxed::Box::new(v.clone())
-                ) as i64);
-                return Some(ConverterImpl {
-                    subs: vec![],
-                    function: self.build_output_fn_produced(produced, &wire, &body, None, emit),
-                    destination: wire,
-                    pre_stages: vec![],
-                    niches: Niches::one(syn::parse_quote!(0i64), syn::parse_quote!(*v == 0)),
-                    metadata: self.opaque_leaf_meta(t1.key()),
-                });
-            }
+        if matches!(
+            produced.kind(),
+            prebindgen_registry::flat::TypeKind::Ref { mutable: false, .. }
+        ) && self.types.get(&t1.key()).is_some_and(|c| c.is_opaque())
+        {
+            let wire: syn::Type = syn::parse_quote!(jni::sys::jlong);
+            let body: syn::Expr = syn::parse_quote!(
+                std::boxed::Box::into_raw(std::boxed::Box::new(v.clone())) as i64
+            );
+            return Some(ConverterImpl {
+                subs: vec![],
+                function: self.build_output_fn_of(produced, &wire, &body, None, emit),
+                destination: wire,
+                pre_stages: vec![],
+                niches: Niches::one(syn::parse_quote!(0i64), syn::parse_quote!(*v == 0)),
+                metadata: self.opaque_leaf_meta(t1.key()),
+            });
         }
         // Borrowed string slice output (`&str` / `&'a str`): the converter used
         // for a zero-copy reference accessor return (`f(&T) -> &str`, output
         // expansion). The single copy into the JVM is `&str → jstring` (no
         // intermediate owned `String`). The unsized `str` sub resolves via the
         // rank-0 arm to the same fn (see [`Self::str_ref_output`]).
-        if let Some((_, false)) = produced.borrow() {
-            if t1.key().as_str() == "str" {
-                return Some(self.str_ref_output());
-            }
-        }
-        // `Vec<T>` (output side): encode as a `java.util.ArrayList<InnerWire>`.
-        // Symmetric to the input handler. `Vec<u8>` is special-cased at
-        // rank-0 (primitive_output → JByteArray) so rank-1 never sees it.
-        if shape == WrapperShape::Sequence {
-            let inner = self.out_frag(t1)?;
-            // `Vec<opaque-handle>` output is delivered by the Kotlin-side leaf
-            // fold (`apply_leaf_vec_folds` → typed-handle wrap), so this
-            // whole-`ArrayList` converter is bypassed for it. A handle's `jlong`
-            // wire isn't JObject-shaped, so it returns `None` below; the
-            // fold-covered return is de-required, so the `None` is not an error.
-            let inner_wire = inner.destination.clone();
-            if !is_jobject_shaped_wire(&inner_wire) {
-                return None;
-            }
-            inner.activate();
-            // The element's COMPLETE Rust -> wire chain (see the input peer).
-            let inner_conv = crate::jni::emit::composed_inner_output(&inner, quote::quote!(__elem));
-            let outer_ty = produced.key();
-            let canonical: syn::Type = syn::parse_quote!(Vec<#t1_ty>);
-            let read = read_as_canonical(produced)?;
-            let wire: syn::Type = syn::parse_quote!(jni::objects::JObject);
-            let body: syn::Expr = syn::parse_quote!({
-                let v: #canonical = #read;
-                let __list_obj = env
-                    .new_object("java/util/ArrayList", "()V", &[])
-                    .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(format!("Vec<_>: new ArrayList: {}", e)))?;
-                let __list = jni::objects::JList::from_env(env, &__list_obj)
-                    .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(format!("Vec<_>: list-from-env: {}", e)))?;
-                for __elem in v.into_iter() {
-                    let __elem_wire = #inner_conv;
-                    let __elem_obj: jni::objects::JObject = __elem_wire.into();
-                    __list.add(env, &__elem_obj)
-                        .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(format!("Vec<_>: list-add: {}", e)))?;
-                }
-                __list_obj
-            });
-            let inner_kotlin = inner.metadata.kotlin_name.clone()?;
-            let kotlin_name = self.override_kotlin_name(
-                &outer_ty,
-                // `List` is auto-imported in Kotlin (default imports). When
-                // the inner carries a projection, this wire-context name
-                // still drives non-projection consumers; projection-aware
-                // sites (classify_return, data-class fields) prefer
-                // `projection` and render the typed `List<TypedShort>`
-                // instead.
-                Some(KtType::generic("List", [inner_kotlin])),
-            );
-            // Fold an Iterable layer over the inner projection (if any), so
-            // `Vec<Handle>` carries the full strategy.
-            let projection = inner.metadata.projection.clone().map(|h| Projection {
-                strategy: FoldStrategy::Iterable(Box::new(h.strategy)),
-                ..h
-            });
-            // The list conversion always builds a fresh non-null `ArrayList`, so
-            // `JObject` null is a free niche — lets `Option<Vec<T>>` ride it
-            // (None ⇒ null list) instead of needing a boxed wrapper.
-            let niches = default_niches_for_wire(&wire);
-            return Some(ConverterImpl {
-                subs: vec![],
-                pre_stages: vec![],
-                function: self.build_output_fn_produced(produced, &wire, &body, None, emit),
-                destination: wire,
-                niches,
-                metadata: KotlinMeta {
-                    kotlin_name,
-                    value_rust_type: None,
-                    projection,
-                    niche_sentinels: Vec::new(),
-                },
-            });
+        if matches!(
+            produced.kind(),
+            prebindgen_registry::flat::TypeKind::Ref { mutable: false, .. }
+        ) && t1.key().as_str() == "str"
+        {
+            return Some(self.str_ref_output());
         }
         None
-    }
-
-    /// `&[T]` borrowed-slice output (used for a **callback argument** that crosses
-    /// native→JVM, e.g. `impl Fn(&[Payload])`). The borrowed dual of the `Vec<T>`
-    /// output handler above: build a `java.util.ArrayList<InnerWire>` by iterating
-    /// the slice **by reference** and cloning each element through its output
-    /// converter (`v.iter()` + `Clone::clone` instead of `into_iter()`). Surfaces
-    /// as Kotlin `List<T>`. The element must have a JObject-shaped output wire
-    /// (struct / String / …) — scalar slices are not handled here.
-    pub(crate) fn output_slice(
-        &self,
-        elem: &prebindgen_registry::flat::TypeRef,
-        emit: &prebindgen_registry::Emit,
-    ) -> Option<ConverterImpl<KotlinMeta>> {
-        let inner = self.out_frag(elem)?;
-        let elem_key = elem.key();
-        // The element as the source spelled it — the slice type this converter
-        // yields is re-emitted, never re-derived.
-        let elem = emit.spell(elem);
-        // A `&[opaque-handle]` callback arg is delivered by the Kotlin-side leaf
-        // fold (typed-handle wrap), bypassing this whole-`ArrayList` converter; a
-        // handle's `jlong` wire isn't JObject-shaped, so it returns `None` here.
-        let inner_wire = inner.destination.clone();
-        if !is_jobject_shaped_wire(&inner_wire) {
-            return None;
-        }
-        inner.activate();
-        // The element's COMPLETE Rust -> wire chain (see the `Vec<_>` peer).
-        let inner_conv = crate::jni::emit::composed_inner_output(
-            &inner,
-            quote::quote!(::core::clone::Clone::clone(__elem)),
-        );
-        let outer_ty: syn::Type = syn::parse_quote!(&[#elem]);
-        let wire: syn::Type = syn::parse_quote!(jni::objects::JObject);
-        let body: syn::Expr = syn::parse_quote!({
-            let __list_obj = env
-                .new_object("java/util/ArrayList", "()V", &[])
-                .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(format!("&[_]: new ArrayList: {}", e)))?;
-            let __list = jni::objects::JList::from_env(env, &__list_obj)
-                .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(format!("&[_]: list-from-env: {}", e)))?;
-            for __elem in v.iter() {
-                let __elem_wire = #inner_conv;
-                let __elem_obj: jni::objects::JObject = __elem_wire.into();
-                __list.add(env, &__elem_obj)
-                    .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(format!("&[_]: list-add: {}", e)))?;
-            }
-            __list_obj
-        });
-        let inner_kotlin = inner.metadata.kotlin_name.clone()?;
-        let kotlin_name = self.override_kotlin_name(
-            &TypeKey::from_type(&outer_ty),
-            Some(KtType::generic("List", [inner_kotlin])),
-        );
-        let projection = inner.metadata.projection.clone().map(|h| Projection {
-            strategy: FoldStrategy::Iterable(Box::new(h.strategy)),
-            ..h
-        });
-        let niches = default_niches_for_wire(&wire);
-        Some(ConverterImpl {
-            subs: vec![elem_key],
-            pre_stages: vec![],
-            function: self.build_output_fn(&outer_ty, &wire, &body, None),
-            destination: wire,
-            niches,
-            metadata: KotlinMeta {
-                kotlin_name,
-                value_rust_type: None,
-                projection,
-                niche_sentinels: Vec::new(),
-            },
-        })
     }
 }
 


### PR DESCRIPTION
## Summary

- make the shared registry Sequence plan own ordinary JNI `Vec<T>` and `&[T]` list conversion in both directions
- model a borrowed slice input as an owned `Vec<T>` carrier, then borrow that carrier only at the final source call
- key plans on the produced carrier so `Vec<T>` and `&[T]` inputs share one converter and one `JObject_to_Vec_*` name
- retain registry-owned composed-only Sequence fragments for specialized Kotlin folds such as multi-slot data values and handle lists
- delete the parallel JNI `WrapperShape::Sequence`, `Produced`, `input_run`, `output_run`, and handwritten list converter pipeline

## Why

Sequence conversion still had two implementations after the earlier chain work. The registry plan handled ordinary composed crossings, while JniGen could fall back to adapter-side loops and an adapter-created `Vec<T>` type for borrowed slices. That fallback duplicated chain mechanics and let the language adapter decide an intermediate Rust type outside the Flat model.

This change makes the registry-selected Sequence fragment the single owner. The Flat model now provides `TypeRef::vector()`, so a shared `&[T]` input can carry the produced `Vec<T>` identity without inspecting or reconstructing Rust syntax. The renderer spells that model value only during final emission, and the wrapper lends the resulting vector to the Rust API.

## What changed

- `TypeRef::vector()` composes a model-valid owned vector reading from an existing element reading.
- Shared-slice construction plans use that vector reading as their source and identity.
- Owned `Vec<T>` and shared `&[T]` input crossings therefore render byte-identical plans under one canonical vector name; generated-function dedup emits the converter once.
- Sequence planning recognizes shared slice construction as well as vector/slice deconstruction.
- Specialized Kotlin-side folds receive a non-rendering Sequence shape fragment with the same metadata and nested chain, instead of falling through to a legacy Rust converter.
- Borrowed handle and string terminals are called directly; the generic wrapper dispatcher and legacy Sequence selector are removed.
- Generated output drops orphan whole-list converters retained only by the compatibility path.
- Covertest adds `label_borrowed_concat(&[Label])` and verifies non-empty and empty Java lists through the generated JNI boundary.
- Focused tests pin the Flat vector composer and prove owned-vector and borrowed-slice crossings have identical names and rendered bodies.

## Compatibility

All existing generated Kotlin declarations, JNI signatures, and live generated Rust function bodies remain unchanged. The generated Rust differences for existing fixtures are removals of unreferenced legacy converters only. The new covertest-only `labelBorrowedConcat` entry point reuses the existing `JObject_to_Vec_Label_3fdf860d` decoder and adds no duplicate list converter.

## Validation

- `cargo test --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `cargo test -p prebindgen-flat a_composed_type_keys_as_its_spelling`
- `cargo test -p prebindgen-jni borrowed_sequences_keep_their_registry_plan_or_specialized_shape`
- `bash examples/regen-check.sh`
- `./gradlew run` in `examples/covertest-kotlin` — PASS, 61 sections
- `git diff --check`
