### PR TITLE
Freeze JNI parameter ABI in site plans

### DIFF
--- a/prebindgen-jni/src/jni/compile.rs
+++ b/prebindgen-jni/src/jni/compile.rs
@@ -2147,7 +2147,9 @@ impl<R: Conversions> Compile for JCompile<'_, R> {
     /// leaf, and the diagnostic for an unresolved leaf names the parameter that
     /// expanded.
     fn plan(&mut self, _cx: &mut Cx<'_>, bound: &Bound, root: &JFrag) -> Result<JPlan, JErr> {
-        use crate::jni::fn_plan::{plan_error, InputKind, PlanLeaf};
+        use crate::jni::fn_plan::{
+            kotlin_jvm_slots, plan_error, KotlinParamOp, NativeParam, PlanLeaf, RustParamOp,
+        };
         let site = self
             .site
             .as_ref()
@@ -2190,7 +2192,7 @@ impl<R: Conversions> Compile for JCompile<'_, R> {
         let flat_plan = crate::jni::emit::build_flat_input_plan(ext, registry, ident, reading)
             .map_err(|e| plan_error(crate::jni::fn_plan::PlanError::UnflattenableDataClass(e)))?;
         let mut site_pipeline = None;
-        let kind = if let Some(v) = (!expanded)
+        let kotlin = if let Some(v) = (!expanded)
             .then(|| crate::jni::emit::vec_build_elem(ext, registry, reading))
             .flatten()
         {
@@ -2200,7 +2202,7 @@ impl<R: Conversions> Compile for JCompile<'_, R> {
                 v.by_ref,
                 v.elem_wrappers,
             ));
-            InputKind::VecBuild { helpers: v.helpers }
+            KotlinParamOp::VecBuild { helpers: v.helpers }
         } else if bound.recipe.name() == &crate::jni::recipes::pair() {
             let plan = optional_pair_plan(ext, ident, reading, root).ok_or_else(|| {
                 JErr::Refused(format!(
@@ -2208,12 +2210,12 @@ impl<R: Conversions> Compile for JCompile<'_, R> {
                     bound.site
                 ))
             })?;
-            InputKind::OptionalPair(Box::new(plan))
+            KotlinParamOp::OptionalPair(std::rc::Rc::new(plan))
         } else if let Some(plan) = flat_plan {
-            InputKind::FlattenStruct(plan)
+            KotlinParamOp::FlattenStruct(std::rc::Rc::new(plan))
         } else {
             match entry.metadata.projection.as_ref().map(|p| p.kind.clone()) {
-                Some(ProjectionKind::Handle) => InputKind::Handle {
+                Some(ProjectionKind::Handle) => KotlinParamOp::Handle {
                     mode: if reading
                         .optional_inner()
                         .is_some_and(|inner| inner.borrow_target().is_some())
@@ -2227,7 +2229,7 @@ impl<R: Conversions> Compile for JCompile<'_, R> {
                         crate::jni::HandleMode::Consume
                     },
                 },
-                Some(ProjectionKind::Unsigned64) => InputKind::Unsigned64 {
+                Some(ProjectionKind::Unsigned64) => KotlinParamOp::Unsigned64 {
                     niche: entry.metadata.projection.as_ref().and_then(|p| {
                         reading
                             .optional_inner()
@@ -2236,7 +2238,7 @@ impl<R: Conversions> Compile for JCompile<'_, R> {
                             .flatten()
                     }),
                 },
-                None => InputKind::Plain,
+                None => KotlinParamOp::Plain,
             }
         };
 
@@ -2247,8 +2249,8 @@ impl<R: Conversions> Compile for JCompile<'_, R> {
         // Other leaf parameter plans still consume their root conversion.
         if matches!(root.layout, Some(JLayout::Leaf))
             && !matches!(
-                &kind,
-                InputKind::VecBuild { .. } | InputKind::FlattenStruct(_)
+                &kotlin,
+                KotlinParamOp::VecBuild { .. } | KotlinParamOp::FlattenStruct(_)
             )
         {
             root.rust.mark_reachable();
@@ -2262,19 +2264,122 @@ impl<R: Conversions> Compile for JCompile<'_, R> {
             Some(p) => crate::jni::projection_leaf_kt(ext, p),
             None => kt_meta.clone(),
         };
+        let pipeline = site_pipeline.unwrap_or_else(|| {
+            Self::planned_pipeline(Direction::Construct, bound.crossing.mode(), root)
+        });
+
+        // Freeze the exact native ABI independently from both target-side
+        // operations. The declaration and slot validator consume only this
+        // ordered list; the Rust emitter consumes only its Rust spelling.
+        let (native, rust) = match &kotlin {
+            KotlinParamOp::VecBuild { .. } => {
+                let wire_ident = format_ident!("{}_handle", ident);
+                let wire = annotate_jobject_with_lifetime(pipeline.wire(), "a").to_token_stream();
+                (
+                    vec![NativeParam {
+                        rust_ident: wire_ident.clone(),
+                        rust_wire: wire,
+                        kt_name: kt_name.clone(),
+                        kt_wire: Some(KtType::long()),
+                        jvm_slots: 2,
+                    }],
+                    RustParamOp::Pipeline { wire_ident },
+                )
+            }
+            KotlinParamOp::OptionalPair(plan) => (
+                vec![
+                    NativeParam {
+                        rust_ident: plan.present_ident.clone(),
+                        rust_wire: quote!(jni::sys::jboolean),
+                        kt_name: plan.present_kt.clone(),
+                        kt_wire: Some(KtType::boolean()),
+                        jvm_slots: 1,
+                    },
+                    NativeParam {
+                        rust_ident: plan.value_ident.clone(),
+                        rust_wire: plan.value_wire.to_token_stream(),
+                        kt_name: plan.value_kt.clone(),
+                        kt_wire: Some(KtType::cls(plan.value_kt_type.clone())),
+                        jvm_slots: kotlin_jvm_slots(&plan.value_kt_type),
+                    },
+                ],
+                RustParamOp::OptionalPair(plan.clone()),
+            ),
+            KotlinParamOp::FlattenStruct(plan) => (
+                plan.leaves
+                    .iter()
+                    .map(|leaf| NativeParam {
+                        rust_ident: leaf.native_ident.clone(),
+                        rust_wire: leaf.native_wire_ty(),
+                        kt_name: leaf.kt_name.clone(),
+                        kt_wire: Some(KtType::cls(leaf.kt_wire_ty().to_string())),
+                        jvm_slots: kotlin_jvm_slots(leaf.kt_wire_ty()),
+                    })
+                    .collect(),
+                RustParamOp::FlattenStruct(plan.clone()),
+            ),
+            KotlinParamOp::Handle { .. }
+            | KotlinParamOp::Unsigned64 { .. }
+            | KotlinParamOp::Plain => {
+                let wire_ident = if matches!(pipeline.wire(), syn::Type::Ptr(_)) {
+                    format_ident!("{}_ptr", ident)
+                } else {
+                    ident.clone()
+                };
+                let kt_wire = if matches!(&kotlin, KotlinParamOp::Handle { .. }) {
+                    Some(KtType::long())
+                } else {
+                    let ty = if as_enum_value {
+                        Some(KtType::int())
+                    } else {
+                        kt_meta.clone()
+                    };
+                    let niche_primitive = enum_niche.is_some()
+                        || matches!(&kotlin, KotlinParamOp::Unsigned64 { niche: Some(_) });
+                    ty.map(|ty| {
+                        if optional && !niche_primitive {
+                            ty.nullable()
+                        } else {
+                            ty
+                        }
+                    })
+                };
+                let jvm_slots = if matches!(&kotlin, KotlinParamOp::Handle { .. }) {
+                    2
+                } else {
+                    JniPrim::from_wire(&entry.destination).map_or(1, |prim| match prim {
+                        JniPrim::Long | JniPrim::Double => 2,
+                        _ => 1,
+                    })
+                };
+                (
+                    vec![NativeParam {
+                        rust_ident: wire_ident.clone(),
+                        rust_wire: annotate_jobject_with_lifetime(pipeline.wire(), "a")
+                            .to_token_stream(),
+                        kt_name: kt_name.clone(),
+                        kt_wire,
+                        jvm_slots,
+                    }],
+                    RustParamOp::Pipeline { wire_ident },
+                )
+            }
+            KotlinParamOp::Callback { .. } => {
+                unreachable!("callback parameters bypass registry site planning")
+            }
+        };
 
         Ok(JPlan::Param(Box::new(PlanLeaf {
             reading: reading.clone(),
             kt_name,
             kt_public,
-            kt_meta,
             optional,
             as_enum_value,
             enum_niche,
-            pipeline: site_pipeline.unwrap_or_else(|| {
-                Self::planned_pipeline(Direction::Construct, bound.crossing.mode(), root)
-            }),
-            kind,
+            pipeline,
+            native,
+            rust,
+            kotlin,
         })))
     }
 }

--- a/prebindgen-jni/src/jni/emit/vec_build.rs
+++ b/prebindgen-jni/src/jni/emit/vec_build.rs
@@ -36,7 +36,7 @@ pub(crate) struct VecBuildElem {
     /// The wrappers taken off the element, outermost first — empty for the
     /// ordinary case. Applied per element where the Vec is consumed, since the
     /// storage holds the canonical type. A list and not a `TypeRef`: it is the
-    /// only part a rebuild uses, and it rides in [`InputKind::VecBuild`], whose
+    /// only part a rebuild uses, and it rides in [`KotlinParamOp::VecBuild`], whose
     /// size every variant pays.
     pub elem_wrappers: Vec<&'static str>,
     /// The canonical helper ABI shared by every function using this element

--- a/prebindgen-jni/src/jni/emit/wrapper.rs
+++ b/prebindgen-jni/src/jni/emit/wrapper.rs
@@ -499,7 +499,8 @@ fn unfold_builder_param(iterable_fold: bool) -> TokenStream {
 /// Render the Rust-side decode for one source-fn parameter from its lowered
 /// [`PlanParam`]: the wire params, prelude decode statements, and the call
 /// argument. The classification (which crossing form) lives in the plan; this
-/// site only renders each [`InputKind`]'s decode.
+/// site renders the frozen Rust decode operation over the leaf's exact native
+/// ABI.
 #[allow(clippy::type_complexity)]
 fn emit_input_param(
     param: &PlanParam,
@@ -518,24 +519,25 @@ fn emit_input_param(
     let arg_ident = &param.ident;
     let arg_ty = &param.ty;
 
-    let mut wire_params: Vec<TokenStream> = Vec::new();
-    let mut prelude: Vec<TokenStream> = Vec::new();
+    let wire_params: Vec<TokenStream> = leaf
+        .native
+        .iter()
+        .map(|native| {
+            let ident = &native.rust_ident;
+            let wire = &native.rust_wire;
+            quote!(#ident: #wire)
+        })
+        .collect();
 
-    match &leaf.kind {
+    match &leaf.rust {
         // Flattenable data_class param: cross its fields as separate wire
         // params and reconstruct the struct inline — no per-call
         // `env.get_field(...)` reflection. The `JNINative` extern and the
         // Kotlin call-site destructure read the same plan so the three
         // sites can't drift.
-        InputKind::FlattenStruct(plan) => {
-            for leaf in &plan.leaves {
-                let pid = &leaf.native_ident;
-                let pty = &leaf.native_wire_ty();
-                wire_params.push(quote!(#pid: #pty));
-            }
+        RustParamOp::FlattenStruct(plan) => {
             let (decode, call_arg) = render_flat_input_decode(plan, arg_ident, on_err);
-            prelude.push(decode);
-            (wire_params, prelude, call_arg)
+            (wire_params, vec![decode], call_arg)
         }
 
         // Bare `Option<primitive>` / `Option<enum>` param: cross as a
@@ -543,14 +545,11 @@ fn emit_input_param(
         // `java.lang.*` `JObject`. The registry's selected Optional fragment
         // rebuilds the value from two raw scalars — no
         // `env.call_method("intValue", …)` unbox.
-        InputKind::OptionalPair(sp) => {
+        RustParamOp::OptionalPair(sp) => {
             let pid = &sp.present_ident;
             let vid = &sp.value_ident;
-            let vwire = &sp.value_wire;
-            wire_params.push(quote!(#pid: jni::sys::jboolean));
-            wire_params.push(quote!(#vid: #vwire));
             let converter = &sp.chain.ident;
-            prelude.push(quote! {
+            let decode = quote! {
                 let #arg_ident = match #converter(&mut env, (#pid, #vid)) {
                     ::core::result::Result::Ok(__value) => __value,
                     ::core::result::Result::Err(__error) => {
@@ -565,30 +564,17 @@ fn emit_input_param(
                         return #on_err;
                     }
                 };
-            });
-            (wire_params, prelude, quote!(#arg_ident))
+            };
+            (wire_params, vec![decode], quote!(#arg_ident))
         }
 
-        // The helper ABI still distinguishes Vec-build inputs for Kotlin, but
-        // Rust reconstruction is the frozen site pipeline's operation.
-        InputKind::VecBuild { .. } => emit_plain_decode(
-            &leaf.pipeline,
-            arg_ident,
-            arg_ty,
-            on_err,
-            emit,
-            Some(format_ident!("{}_handle", arg_ident)),
-        ),
-
-        // Handles, value projections, callbacks, and plain types all decode
-        // through the frozen site pipeline. In particular, a direct owned
-        // handle now reaches the registry-planned `JOwnedHandlePlan`; wrapper
-        // emission no longer repeats its null/tag guard and `Box::from_raw`.
-        InputKind::Callback { .. }
-        | InputKind::Handle { .. }
-        | InputKind::Unsigned64 { .. }
-        | InputKind::Plain => {
-            emit_plain_decode(&leaf.pipeline, arg_ident, arg_ty, on_err, emit, None)
+        // Handles, value projections, callbacks, Vec-build inputs, and plain
+        // values all execute the registry-planned pipeline. The plan already
+        // fixed the sole native leaf's name and type.
+        RustParamOp::Pipeline { wire_ident } => {
+            let (prelude, call_arg) =
+                emit_plain_decode(&leaf.pipeline, arg_ident, arg_ty, on_err, emit, wire_ident);
+            (wire_params, prelude, call_arg)
         }
     }
 }
@@ -602,8 +588,8 @@ fn emit_plain_decode(
     arg_ty: &prebindgen_registry::flat::TypeRef,
     on_err: &TokenStream,
     emit: &prebindgen_registry::Emit,
-    wire_name: Option<syn::Ident>,
-) -> (Vec<TokenStream>, Vec<TokenStream>, TokenStream) {
+    wire_ident: &syn::Ident,
+) -> (Vec<TokenStream>, TokenStream) {
     use prebindgen_registry::flat::TypeKind;
     /// `&mut T`, read off the kind — and off `kind()` rather than through
     /// `is_exclusive_borrow`, which also sees through a `Box` and refuses an
@@ -622,19 +608,7 @@ fn emit_plain_decode(
             _ => None,
         }
     }
-    let mut wire_params: Vec<TokenStream> = Vec::new();
     let mut prelude: Vec<TokenStream> = Vec::new();
-    let wire = pipeline.wire();
-    let wire_ident = wire_name.unwrap_or_else(|| {
-        if matches!(wire, syn::Type::Ptr(_)) {
-            format_ident!("{}_ptr", arg_ident)
-        } else {
-            arg_ident.clone()
-        }
-    });
-
-    let wire_with_lifetime = annotate_jobject_with_lifetime(wire, "a");
-    wire_params.push(quote!(#wire_ident: #wire_with_lifetime));
     // Binding for the final `arg_ident` needs `mut` when the source
     // fn takes `&mut T` — the call site below emits `&mut arg_ident`,
     // which requires a mutable binding. Also for `Option<&mut T>`
@@ -681,7 +655,7 @@ fn emit_plain_decode(
         }
         _ => quote!(#arg_ident),
     };
-    (wire_params, prelude, call_arg)
+    (prelude, call_arg)
 }
 
 /// Emit the wire params, decode prelude, and call argument for one
@@ -709,78 +683,59 @@ pub(crate) fn emit_expanded_param(
         // The ascription generated Rust writes for this leaf's local.
         let leaf_ty_tokens = emit.spell(leaf_ty);
         let local = format_ident!("__exp_{}", leaf.name);
+        wire_params.extend(classified.native.iter().map(|native| {
+            let ident = &native.rust_ident;
+            let wire = &native.rust_wire;
+            quote!(#ident: #wire)
+        }));
 
-        // An expansion leaf can itself be a data class. Reuse the recursive
-        // plan instead of allowing that leaf to fall back to a JObject, so
-        // expansion and ordinary parameters have the same boundary rule.
-        if let InputKind::FlattenStruct(flat) = &classified.kind {
-            for flat_leaf in &flat.leaves {
-                let ident = &flat_leaf.native_ident;
-                let wire = &flat_leaf.native_wire_ty();
-                wire_params.push(quote!(#ident: #wire));
+        match &classified.rust {
+            // An expansion leaf can itself be a data class. Reuse the
+            // recursive rebuild operation used by an ordinary parameter.
+            RustParamOp::FlattenStruct(flat) => {
+                let (decode, _) = render_flat_input_decode(flat, &local, on_err);
+                prelude.push(decode);
             }
-            let (decode, _) = render_flat_input_decode(flat, &local, on_err);
-            prelude.push(decode);
-            leaf_locals.push(local);
-            continue;
+            // Selector-dispatched Optional leaf: rebuild from its already
+            // frozen `(present, value)` native pair.
+            RustParamOp::OptionalPair(sp) => {
+                let present_ident = &sp.present_ident;
+                let value_ident = &sp.value_ident;
+                let converter = &sp.chain.ident;
+                prelude.push(quote!(
+                    let #local: #leaf_ty_tokens = match #converter(
+                        &mut env,
+                        (#present_ident, #value_ident),
+                    ) {
+                        ::core::result::Result::Ok(__value) => __value,
+                        ::core::result::Result::Err(__error) => {
+                            signal_binding_error(
+                                &mut env,
+                                &__error_sink,
+                                &__SINK_MID,
+                                __SINK_FQN,
+                                __SINK_DESCR,
+                                &__error.to_string(),
+                            );
+                            return #on_err;
+                        }
+                    };
+                ));
+            }
+            RustParamOp::Pipeline { wire_ident } => {
+                let pipeline = &classified.pipeline;
+                let decode_call = pipeline.invoke(quote!(#wire_ident), emit);
+                prelude.push(quote!(
+                    let #local = match #decode_call {
+                        ::core::result::Result::Ok(__v) => __v,
+                        ::core::result::Result::Err(__e) => {
+                            signal_binding_error(&mut env, &__error_sink, &__SINK_MID, __SINK_FQN, __SINK_DESCR, &__e.to_string());
+                            return #on_err;
+                        }
+                    };
+                ));
+            }
         }
-
-        // `Option<scalar>` / `Option<enum>` leaf (only produced by a
-        // selector-dispatched constructor variant, where each arm's args are
-        // `Option`-wrapped by presence): cross as a decoupled
-        // `(present: jboolean, value: <wire>)` pair instead of a boxed
-        // `java.lang.*` `JObject`. The Kotlin extern and call site consume
-        // the same classified plan, so the JNI arity/types agree on both
-        // sides of the wire.
-        if let InputKind::OptionalPair(sp) = &classified.kind {
-            let present_ident = &sp.present_ident;
-            let value_ident = &sp.value_ident;
-            let value_wire = &sp.value_wire;
-            let converter = &sp.chain.ident;
-            wire_params.push(quote!(#present_ident: jni::sys::jboolean));
-            wire_params.push(quote!(#value_ident: #value_wire));
-            prelude.push(quote!(
-                let #local: #leaf_ty_tokens = match #converter(
-                    &mut env,
-                    (#present_ident, #value_ident),
-                ) {
-                    ::core::result::Result::Ok(__value) => __value,
-                    ::core::result::Result::Err(__error) => {
-                        signal_binding_error(
-                            &mut env,
-                            &__error_sink,
-                            &__SINK_MID,
-                            __SINK_FQN,
-                            __SINK_DESCR,
-                            &__error.to_string(),
-                        );
-                        return #on_err;
-                    }
-                };
-            ));
-            leaf_locals.push(local);
-            continue;
-        }
-
-        let pipeline = &classified.pipeline;
-        let wire = pipeline.wire();
-        let wire_ident = if matches!(wire, syn::Type::Ptr(_)) {
-            format_ident!("{}_ptr", leaf.name)
-        } else {
-            leaf.name.clone()
-        };
-        let wire_with_lifetime = annotate_jobject_with_lifetime(wire, "a");
-        wire_params.push(quote!(#wire_ident: #wire_with_lifetime));
-        let decode_call = pipeline.invoke(quote!(#wire_ident), emit);
-        prelude.push(quote!(
-            let #local = match #decode_call {
-                ::core::result::Result::Ok(__v) => __v,
-                ::core::result::Result::Err(__e) => {
-                    signal_binding_error(&mut env, &__error_sink, &__SINK_MID, __SINK_FQN, __SINK_DESCR, &__e.to_string());
-                    return #on_err;
-                }
-            };
-        ));
         leaf_locals.push(local);
     }
 

--- a/prebindgen-jni/src/jni/fn_plan.rs
+++ b/prebindgen-jni/src/jni/fn_plan.rs
@@ -670,7 +670,7 @@ impl JniFunctionPlan {
             params,
             output,
         };
-        let slots = result.jvm_parameter_slots(ext);
+        let slots = result.jvm_parameter_slots();
         if slots > 255 {
             return Err(PlanError::JvmParameterLimit { slots });
         }
@@ -686,7 +686,7 @@ impl JniFunctionPlan {
         })
     }
 
-    fn jvm_parameter_slots(&self, _ext: &Declarations) -> usize {
+    fn jvm_parameter_slots(&self) -> usize {
         // `JNINative` is a Kotlin object, so its external methods are instance
         // methods and the JVM counts the implicit receiver as one unit.
         let mut slots = 1usize;

--- a/prebindgen-jni/src/jni/fn_plan.rs
+++ b/prebindgen-jni/src/jni/fn_plan.rs
@@ -1,14 +1,13 @@
 //! Input side of the per-function lowered binding plan (issue #90).
 //!
-//! [`JniFunctionPlan`] classifies every input parameter of a bound function
-//! ONCE, deterministically over `(ext, registry, f)`. The three coordinated
-//! emission sites — the Rust `extern "C"` wrapper (`emit_input_param`), the
-//! Kotlin wrapper classifier (`classify_params`), and the `JNINative`
-//! `external fun` declaration (`render_extern_decl`) — all consume the same
-//! [`InputKind`] decision instead of re-running their own copies of the
-//! probe cascade, so the wire arity, types, and call forms agree by
-//! construction. The pattern generalizes [`build_struct_plan`]'s field-level
-//! plan to function granularity; the output side follows in a later stage.
+//! [`JniFunctionPlan`] lowers every input parameter of a bound function ONCE,
+//! deterministically over `(ext, registry, f)`. Each leaf freezes three
+//! independent answers: its exact ordered native ABI leaves, its Rust decode
+//! operation, and its Kotlin call/locking operation. The Rust `extern "C"`
+//! wrapper, Kotlin wrapper, `JNINative` declaration, and JVM-slot validator
+//! consume those answers without reconstructing them from a source-shape tag.
+//! The pattern generalizes [`build_struct_plan`]'s field-level plan to function
+//! granularity; the output side follows in a later stage.
 
 use kotlin_codegen::KtType;
 use prebindgen_registry::{flat::TypeRef, Conversions};
@@ -163,13 +162,9 @@ pub(crate) struct PlanLeaf {
     /// Typed-wrapper surface type: the projection's Kotlin FQN for
     /// handle/value projections, else the resolved entry's Kotlin name.
     /// `None` when the metadata lacks a name (the Kotlin wrapper renderer
-    /// skips the function — the escape-hatch path) and for [`InputKind::
-    /// Callback`] (typed from the interface spec at render time).
+    /// skips the function — the escape-hatch path) and for callback operations
+    /// (typed from the interface spec at render time).
     pub kt_public: Option<KtType>,
-    /// The resolved entry's raw `metadata.kotlin_name` — the type the
-    /// `JNINative` extern declares for pass-through leaves (for projections
-    /// this is the erased wire name, not the typed surface).
-    pub kt_meta: Option<KtType>,
     /// Whether the leaf crosses as optional, **per the model** — so a wrapped
     /// spelling (`Box<Option<T>>`) answers exactly as the bare one does. Each
     /// site applies its own nullability rule on top (handles stay non-null
@@ -190,13 +185,42 @@ pub(crate) struct PlanLeaf {
     /// supply several site wires instead, but ordinary parameters and
     /// constructor-expansion leaves call this pipeline directly.
     pub pipeline: crate::jni::chain::JPipeline,
-    pub kind: InputKind,
+    /// Exact ordered parameters shared by the Rust extern, `JNINative`
+    /// declaration, and JVM descriptor-slot validation.
+    pub native: Vec<NativeParam>,
+    /// How the Rust wrapper obtains this leaf's source value from `native`.
+    pub rust: RustParamOp,
+    /// How the typed Kotlin wrapper supplies `native`, including handle
+    /// locking/consumption policy.
+    pub kotlin: KotlinParamOp,
 }
 
-/// The classified crossing form. Branches are mutually exclusive by
-/// construction (each probe rejects the shapes the others accept), so the
-/// probe order is canonical, not load-bearing.
-pub(crate) enum InputKind {
+/// One exact JNI parameter in a leaf's ordered native ABI.
+pub(crate) struct NativeParam {
+    pub rust_ident: syn::Ident,
+    /// Final Rust spelling, including the JNI object lifetime when required.
+    pub rust_wire: TokenStream,
+    pub kt_name: String,
+    /// `None` preserves the unresolved-name escape hatch: Kotlin emission
+    /// skips the containing function.
+    pub kt_wire: Option<KtType>,
+    pub jvm_slots: usize,
+}
+
+/// Frozen Rust-side operation for one effective parameter.
+pub(crate) enum RustParamOp {
+    /// Invoke the registry-planned pipeline with this single native leaf.
+    Pipeline { wire_ident: syn::Ident },
+    /// Rebuild an allocation-free optional from its two native leaves.
+    OptionalPair(std::rc::Rc<crate::jni::compile::OptionalPairPlan>),
+    /// Rebuild a data class from its recursively flattened native leaves.
+    FlattenStruct(std::rc::Rc<FlatInputPlan>),
+}
+
+/// Frozen typed-Kotlin call and ownership operation for one effective
+/// parameter. These variants are target operations, not a source-type
+/// classification; native ABI and Rust decoding are stored independently.
+pub(crate) enum KotlinParamOp {
     /// `impl Fn(args)` callback: erased `Any` on the wire. `iface` is the
     /// typed `fun interface` spec (memoized under [`SpecKey::Callback`] —
     /// the same allocation the trampoline and the declaration emitter read);
@@ -211,9 +235,9 @@ pub(crate) enum InputKind {
     },
     /// Bare `Option<primitive>` / `Option<enum>`: a decoupled
     /// `(present: jboolean, value: <wire>)` pair.
-    OptionalPair(Box<crate::jni::compile::OptionalPairPlan>),
+    OptionalPair(std::rc::Rc<crate::jni::compile::OptionalPairPlan>),
     /// Flattenable data_class: the field leaves cross as separate wire params.
-    FlattenStruct(FlatInputPlan),
+    FlattenStruct(std::rc::Rc<FlatInputPlan>),
     /// Lockable opaque-handle projection (`jlong` wire). Ownership and
     /// nullability are Kotlin locking policy; Rust conversion is already
     /// frozen in the leaf pipeline.
@@ -662,28 +686,16 @@ impl JniFunctionPlan {
         })
     }
 
-    fn jvm_parameter_slots(&self, ext: &Declarations) -> usize {
+    fn jvm_parameter_slots(&self, _ext: &Declarations) -> usize {
         // `JNINative` is a Kotlin object, so its external methods are instance
         // methods and the JVM counts the implicit receiver as one unit.
         let mut slots = 1usize;
         for leaf in self.leaves() {
-            slots += match &leaf.kind {
-                InputKind::FlattenStruct(plan) => plan
-                    .leaves
-                    .iter()
-                    .map(|l| kotlin_jvm_slots(l.kt_wire_ty()))
-                    .sum(),
-                InputKind::OptionalPair(plan) => 1 + kotlin_jvm_slots(&plan.value_kt_type),
-                InputKind::Handle { .. } | InputKind::VecBuild { .. } => 2,
-                InputKind::Callback { .. } => 1,
-                InputKind::Unsigned64 { .. } | InputKind::Plain => ext
-                    .in_frag(&leaf.reading)
-                    .and_then(|entry| JniPrim::from_wire(&entry.destination))
-                    .map_or(1, |prim| match prim {
-                        JniPrim::Long | JniPrim::Double => 2,
-                        _ => 1,
-                    }),
-            };
+            slots += leaf
+                .native
+                .iter()
+                .map(|param| param.jvm_slots)
+                .sum::<usize>();
         }
         slots += match &self.output {
             FnOutputPlan::Unfold(plan) if plan.iterable_fold => 2,
@@ -698,7 +710,7 @@ impl JniFunctionPlan {
     }
 }
 
-fn kotlin_jvm_slots(ty: &str) -> usize {
+pub(crate) fn kotlin_jvm_slots(ty: &str) -> usize {
     if !ty.ends_with('?') && matches!(ty, "Long" | "Double") {
         2
     } else {
@@ -729,13 +741,18 @@ fn classify_leaf(
         // `SpecKey` is a memo key and holds `TypeKey`s, so the args reach it as
         // each arg reading's own identity.
         let iface = ext.iface_spec(registry, &SpecKey::callback(args));
+        let entry = ext.in_frag(reading).ok_or_else(|| PlanError::Unresolved {
+            ty: Box::new(reading.clone()),
+        })?;
+        let pipeline = entry.pipeline(
+            prebindgen_registry::recipe::Direction::Construct,
+            prebindgen_registry::recipe::Mode::Owned,
+        );
+        let wire_ident = ident.clone();
         return Ok(PlanLeaf {
             reading: reading.clone(),
             kt_name: kt_param_name(&ident.to_string()),
             kt_public: None,
-            kt_meta: ext
-                .in_frag(reading)
-                .and_then(|e| e.metadata.kotlin_name.clone()),
             optional: reading.optional_inner().is_some(),
             as_enum_value: ext.is_kotlin_enum_reading(reading),
             enum_niche: crate::jni::compile::option_enum_niche(
@@ -743,16 +760,16 @@ fn classify_leaf(
                 reading,
                 prebindgen_registry::recipe::Direction::Construct,
             ),
-            pipeline: ext
-                .in_frag(reading)
-                .ok_or_else(|| PlanError::Unresolved {
-                    ty: Box::new(reading.clone()),
-                })?
-                .pipeline(
-                    prebindgen_registry::recipe::Direction::Construct,
-                    prebindgen_registry::recipe::Mode::Owned,
-                ),
-            kind: InputKind::Callback { iface },
+            native: vec![NativeParam {
+                rust_ident: wire_ident.clone(),
+                rust_wire: annotate_jobject_with_lifetime(pipeline.wire(), "a").to_token_stream(),
+                kt_name: kt_param_name(&ident.to_string()),
+                kt_wire: entry.metadata.kotlin_name.clone(),
+                jvm_slots: 1,
+            }],
+            pipeline,
+            rust: RustParamOp::Pipeline { wire_ident },
+            kotlin: KotlinParamOp::Callback { iface },
         });
     }
     // The compiler, resumed over what the build already compiled. Every

--- a/prebindgen-jni/src/jni/kotlin_emit.rs
+++ b/prebindgen-jni/src/jni/kotlin_emit.rs
@@ -1211,7 +1211,7 @@ impl Declarations {
             .expect("callback-interface emission requires a frozen JNI plan");
         for fplan in generation.functions() {
             for leaf in fplan.leaves() {
-                if let InputKind::Callback { iface: Some(spec) } = &leaf.kind {
+                if let KotlinParamOp::Callback { iface: Some(spec) } = &leaf.kotlin {
                     let args = leaf
                         .reading
                         .callback_args()

--- a/prebindgen-jni/src/jni/render.rs
+++ b/prebindgen-jni/src/jni/render.rs
@@ -523,59 +523,11 @@ pub(crate) fn render_extern_decl(
     let jni_call = &fplan.jni_method;
     let mut params: Vec<KtParam> = Vec::new();
     for leaf in fplan.leaves() {
-        let name = leaf.kt_name.clone();
-        match &leaf.kind {
-            // Flattenable data_class param → its leaf wire params.
-            InputKind::FlattenStruct(plan) => {
-                for l in &plan.leaves {
-                    params.push(KtParam::new(
-                        l.kt_name.clone(),
-                        KtType::cls(l.kt_wire_ty().to_string()),
-                    ));
-                }
-            }
-            // Bare `Option<primitive>` / `Option<enum>` param → a `(present:
-            // Boolean, value: <Prim>)` pair (no boxed `java.lang.*` wire).
-            InputKind::OptionalPair(sp) => {
-                params.push(KtParam::new(sp.present_kt.clone(), KtType::boolean()));
-                params.push(KtParam::new(
-                    sp.value_kt.clone(),
-                    KtType::cls(sp.value_kt_type.clone()),
-                ));
-            }
-            // Slice/Vec of a flattenable data_class → a single `jlong`
-            // Vec-handle param (the Rust extern decodes the boxed `Vec<T>`).
-            // Elements cross through the synthetic `…VecPush` extern.
-            InputKind::VecBuild { .. } => {
-                params.push(KtParam::new(name, KtType::long()));
-            }
-            // An opaque-**handle** projection (direct `&T`/`T`, `Option<&T>`,
-            // or by-value `Option<T>`) crosses the JNI wire as a primitive
-            // `jlong` with `0` encoding `None` — a non-null `Long`; the `?`
-            // lives only on the typed-wrapper surface.
-            InputKind::Handle { .. } => {
-                params.push(KtParam::new(name, KtType::long()));
-            }
-            InputKind::Callback { .. } | InputKind::Unsigned64 { .. } | InputKind::Plain => {
-                let ty = if leaf.as_enum_value {
-                    // Enum (incl. `Option<enum>`) crosses as jint → Kotlin
-                    // `Int`; the wrapper passes `.value` / `?.value`. The Rust
-                    // converter consumes that discriminant directly when a
-                    // niche exists, and boxes only as a fallback. The extern
-                    // never declares the enum object.
-                    KtType::int()
-                } else {
-                    leaf.kt_meta.clone()?
-                };
-                let niche_primitive = leaf.enum_niche.is_some()
-                    || matches!(&leaf.kind, InputKind::Unsigned64 { niche: Some(_) });
-                let ty = if leaf.optional && !niche_primitive {
-                    ty.nullable()
-                } else {
-                    ty
-                };
-                params.push(KtParam::new(name, ty));
-            }
+        for native in &leaf.native {
+            params.push(KtParam::new(
+                native.kt_name.clone(),
+                native.kt_wire.clone()?,
+            ));
         }
     }
     // Output (data) expansion: a **callback** delivery appends the lambda(s)
@@ -1216,9 +1168,9 @@ struct DomainSink {
 
 /// Type every effective input of the lowered [`JniFunctionPlan`] into a
 /// [`Param`] (Kotlin name/type + call-site [`ParamMode`]). The crossing-form
-/// classification comes from the plan — the same decision the Rust extern and
-/// `external fun` renderers consume — this site only maps each [`InputKind`]
-/// to its Kotlin surface. Returns the params plus the index of the
+/// operation comes from the plan; this site only renders each
+/// [`KotlinParamOp`] into its Kotlin surface and call form. Returns the params
+/// plus the index of the
 /// instance-method receiver (the first param whose peeled type matches
 /// `receiver_key`), which is bound to `this` and dropped from the signature.
 fn classify_params(
@@ -1250,7 +1202,7 @@ fn classify_params(
         // The extern receives it erased (`Any`) and the native trampoline
         // calls the typed `run`, so no call-site adapter exists.
         // Lambda-literal call sites SAM-convert unchanged.
-        if let InputKind::Callback { iface, .. } = &leaf.kind {
+        if let KotlinParamOp::Callback { iface, .. } = &leaf.kotlin {
             let spec = iface.as_deref()?;
             let kt_type = spec.kt_ref(vec![]);
             // The extern receives the RAW twin: the generated `asRaw()`
@@ -1280,8 +1232,8 @@ fn classify_params(
         let kt_type_raw = leaf.kt_public.clone()?;
 
         // Map the plan's crossing form to the Kotlin call-site mode.
-        let mode = match &leaf.kind {
-            InputKind::VecBuild { helpers, .. } => {
+        let mode = match &leaf.kotlin {
+            KotlinParamOp::VecBuild { helpers, .. } => {
                 // Slice/Vec of a flattenable data_class: build the Rust-side
                 // Vec by pushing each element's leaves, pass the handle (see
                 // the body direction + `build_vec_build_helper_items`). The
@@ -1298,7 +1250,7 @@ fn classify_params(
                     elem_accesses,
                 }
             }
-            InputKind::OptionalPair(sp) => {
+            KotlinParamOp::OptionalPair(sp) => {
                 // Bare `Option<primitive>` / `Option<enum>`: cross as a
                 // `(present, value)` pair (no boxed object). The high-level
                 // signature keeps `T?`; only the call-site args split in two.
@@ -1313,7 +1265,7 @@ fn classify_params(
                     value_expr,
                 }
             }
-            InputKind::FlattenStruct(plan) => {
+            KotlinParamOp::FlattenStruct(plan) => {
                 let handles = plan
                     .leaves
                     .iter()
@@ -1352,17 +1304,17 @@ fn classify_params(
                     handles,
                 }
             }
-            InputKind::Handle { mode, .. } => match mode {
+            KotlinParamOp::Handle { mode, .. } => match mode {
                 HandleMode::Borrow => ParamMode::Borrow,
                 HandleMode::Consume => ParamMode::Consume,
                 HandleMode::BorrowNullable => ParamMode::BorrowNullable,
                 HandleMode::ConsumeNullable => ParamMode::ConsumeNullable,
             },
-            InputKind::Unsigned64 { niche } => ParamMode::Unsigned64 {
+            KotlinParamOp::Unsigned64 { niche } => ParamMode::Unsigned64 {
                 niche: niche.clone(),
             },
-            InputKind::Plain => ParamMode::PassThrough,
-            InputKind::Callback { .. } => unreachable!("callback params handled above"),
+            KotlinParamOp::Plain => ParamMode::PassThrough,
+            KotlinParamOp::Callback { .. } => unreachable!("callback params handled above"),
         };
 
         // Full-FQN surface type — the render-time `ImportSet` shortens it and

--- a/prebindgen-jni/src/jni/tests/callbacks.rs
+++ b/prebindgen-jni/src/jni/tests/callbacks.rs
@@ -757,6 +757,23 @@ fn generation_plan_freezes_and_drains_derivations() {
     let b = ext.fn_plan(registry, f).expect("plan");
     assert!(std::rc::Rc::ptr_eq(&a, &b), "one plan per function ident");
     assert_eq!(a.native_symbol, b.native_symbol);
+    let records = a.leaves().next().expect("records parameter leaf");
+    assert!(
+        matches!(&records.kotlin, KotlinParamOp::VecBuild { .. }),
+        "the Kotlin operation remains independently frozen"
+    );
+    let RustParamOp::Pipeline { wire_ident } = &records.rust else {
+        panic!("Vec-build Rust operation must execute its registry pipeline");
+    };
+    assert_eq!(wire_ident, "records_handle");
+    assert_eq!(records.native.len(), 1);
+    assert_eq!(records.native[0].rust_ident, "records_handle");
+    assert_eq!(
+        records.native[0].rust_wire.to_string(),
+        "jni :: sys :: jlong"
+    );
+    assert_eq!(records.native[0].kt_name, "records");
+    assert_eq!(records.native[0].jvm_slots, 2);
 
     // Exercise both artifact writers. None of the recursively used struct,
     // sum, interface, function, or Vec-helper lookups may resume planning.

--- a/prebindgen-jni/src/jni/tests/values.rs
+++ b/prebindgen-jni/src/jni/tests/values.rs
@@ -1613,6 +1613,56 @@ fn recursive_flattening_counts_long_as_two_and_rejects_jvm_parameter_slot_overfl
     assert!(error.contains("uses 256 JVM parameter slots"), "{error}");
     assert!(error.contains("jobject_input"), "{error}");
 
+    // Pin the two other two-slot paths independently. An ordinary i64 reads
+    // its width from the frozen converter wire, while a handle stores its
+    // primitive jlong width directly in the native parameter plan.
+    let plain_params = (0..127)
+        .map(|index| format!("p{index}: i64"))
+        .collect::<Vec<_>>()
+        .join(",");
+    let use_plain_wide: syn::ItemFn = syn::parse_str(&format!(
+        "pub fn use_plain_wide({plain_params}) -> i64 {{ unimplemented!() }}"
+    ))
+    .expect("parse wide plain function");
+    let registry = crate::test_util::reg_from_items(declare_referenced([(
+        syn::Item::Fn(use_plain_wide),
+        loc.clone(),
+    )]))
+    .expect("index plain function");
+    let error = JniGenBuilder::new()
+        .package(crate::package!().fun(prebindgen_registry::fun!(use_plain_wide)))
+        .build_with(registry)
+        .expect_err("127 ordinary Long parameters plus infrastructure must fail")
+        .to_string();
+    assert!(error.contains("uses 256 JVM parameter slots"), "{error}");
+
+    let handle_params = (0..127)
+        .map(|index| format!("p{index}: &Token"))
+        .collect::<Vec<_>>()
+        .join(",");
+    let token: syn::ItemStruct = syn::parse_quote!(
+        pub struct Token;
+    );
+    let use_handle_wide: syn::ItemFn = syn::parse_str(&format!(
+        "pub fn use_handle_wide({handle_params}) -> i64 {{ unimplemented!() }}"
+    ))
+    .expect("parse wide handle function");
+    let registry = crate::test_util::reg_from_items(declare_referenced([
+        (syn::Item::Struct(token), loc.clone()),
+        (syn::Item::Fn(use_handle_wide), loc.clone()),
+    ]))
+    .expect("index handle function");
+    let error = JniGenBuilder::new()
+        .package(
+            crate::package!()
+                .class(crate::ptr_class!(Token))
+                .fun(prebindgen_registry::fun!(use_handle_wide)),
+        )
+        .build_with(registry)
+        .expect_err("127 handle Long parameters plus infrastructure must fail")
+        .to_string();
+    assert!(error.contains("uses 256 JVM parameter slots"), "{error}");
+
     // The explicit object boundary keeps the same public Kotlin data class,
     // but the native method receives it in one slot and performs the legacy
     // whole-object field decode instead of producing an illegal signature.

--- a/prebindgen-jni/src/jni/tests/values.rs
+++ b/prebindgen-jni/src/jni/tests/values.rs
@@ -1580,7 +1580,10 @@ fn whole_object_handle_field_calls_its_reached_owned_plan() {
 }
 
 #[test]
-fn recursive_flattening_rejects_jvm_parameter_slot_overflow() {
+fn recursive_flattening_counts_long_as_two_and_rejects_jvm_parameter_slot_overflow() {
+    // 127 non-null Long leaves occupy 254 descriptor slots. Together with the
+    // JNINative object receiver and binding-error sink, this is exactly 256:
+    // both the two-slot Long rule and the 255-slot rejection are load-bearing.
     let fields = (0..127)
         .map(|index| format!("pub f{index}: i64"))
         .collect::<Vec<_>>()

--- a/prebindgen-jni/src/jni/trait_impl.rs
+++ b/prebindgen-jni/src/jni/trait_impl.rs
@@ -841,7 +841,7 @@ pub(crate) fn build_through_erased_wrappers(
 ///
 /// The list is the only part of the reading a rebuild uses, and it is two
 /// pointers instead of a `TypeRef`'s ~264 bytes. That matters because these
-/// plans live in `InputKind`, whose size every variant pays.
+/// plans live in `KotlinParamOp`, whose size every variant pays.
 pub(crate) fn build_through_wrappers(
     names: &[&'static str],
     value: TokenStream,


### PR DESCRIPTION
## Why

Ordinary JNI parameters were lowered once to an `InputKind`, but the Rust wrapper, `JNINative` declaration, Kotlin wrapper, and JVM-slot validator still independently reconstructed native arity, wire types, parameter names, and call behavior from that tag. That left three render-time pipelines coupled to the same source-shape classification and made ABI agreement an emitter convention.

This is the next child of #513. Callback composition remains an explicit later stage; generated Rust and Kotlin behavior should not change here.

## What changed

- replace `InputKind` with three independent frozen answers on each parameter leaf:
  - an ordered `NativeParam` ABI containing the final Rust wire spelling, Kotlin wire type/name, and JVM slot width;
  - a `RustParamOp` describing how registry-planned conversion consumes those wires;
  - a `KotlinParamOp` describing typed call arguments and handle locking/consumption;
- make Rust wrapper signatures and expanded-parameter signatures iterate the frozen native ABI directly;
- make `JNINative` declarations and JVM parameter-limit validation consume the same native ABI instead of reclassifying parameter shapes;
- keep callback-specific interface planning isolated in `KotlinParamOp::Callback` for the callback stage;
- extend the frozen-generation seam test to pin the independent Vec-build native ABI, registry pipeline, Kotlin operation, and JVM width.

The one-time compiler-side freeze grows because it now owns the former renderer decisions. The Rust and Kotlin renderers lose their duplicated ABI branch tables, and the legacy `InputKind` type is removed.

## Validation

- `cargo test --workspace --all-targets`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `./examples/regen-check.sh` — all committed generated output byte-identical
- `examples/covertest-kotlin/gradlew run` — 61 sections passed