### PR TITLE
Freeze registry-planned JNI output delivery

### DIFF
--- a/examples/covertest-kotlin/src/generated_bindings.rs
+++ b/examples/covertest-kotlin/src/generated_bindings.rs
@@ -19573,37 +19573,29 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_spanHolderNew<'a
     let (__obj0, __obj1): (jni::objects::JObject, jni::objects::JObject) = match __vf0 {
         ::core::option::Option::Some(__u0) => {
             let __obj0: jni::objects::JObject = {
-                let __enc0 = {
-                    let __cs0_0 = match Duration_to_u64_e3980876(
-                        &mut env,
-                        __u0.required.clone(),
-                    ) {
-                        ::core::result::Result::Ok(__w) => __w,
-                        ::core::result::Result::Err(__e) => {
-                            signal_binding_error(
+                let __enc0 = match (|| -> ::core::result::Result<_, __JniErr> {
+                    {
+                        let __chain_s0 = Duration_to_u64_e3980876(
                                 &mut env,
-                                &__error_sink,
-                                &__SINK_MID,
-                                __SINK_FQN,
-                                __SINK_DESCR,
-                                &__e.to_string(),
-                            );
-                            return jni::objects::JObject::null().into();
-                        }
-                    };
-                    match u64_to_jlong_4384a5d6(&mut env, __cs0_0) {
-                        ::core::result::Result::Ok(__w) => __w,
-                        ::core::result::Result::Err(__e) => {
-                            signal_binding_error(
-                                &mut env,
-                                &__error_sink,
-                                &__SINK_MID,
-                                __SINK_FQN,
-                                __SINK_DESCR,
-                                &__e.to_string(),
-                            );
-                            return jni::objects::JObject::null().into();
-                        }
+                                __u0.required.clone(),
+                            )
+                            .map_err(|__e| <__JniErr as ::core::convert::From<
+                                String,
+                            >>::from(__e.to_string()))?;
+                        u64_to_jlong_4384a5d6(&mut env, __chain_s0)
+                    }
+                })() {
+                    ::core::result::Result::Ok(__w) => __w,
+                    ::core::result::Result::Err(__e) => {
+                        signal_binding_error(
+                            &mut env,
+                            &__error_sink,
+                            &__SINK_MID,
+                            __SINK_FQN,
+                            __SINK_DESCR,
+                            &__e.to_string(),
+                        );
+                        return jni::objects::JObject::null().into();
                     }
                 };
                 match ::prebindgen_jni_runtime::box_jlong(&mut env, __enc0) {
@@ -20703,20 +20695,18 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_storageLabels<'a
     let __vec = perftest_flat::storage_labels(&s);
     let mut __acc = __acc;
     for __elem in __vec.into_iter() {
-        let __enc = {
-            match String_to_JString_c7f3ca43(&mut env, __elem) {
-                ::core::result::Result::Ok(__w) => __w,
-                ::core::result::Result::Err(__e) => {
-                    signal_binding_error(
-                        &mut env,
-                        &__error_sink,
-                        &__SINK_MID,
-                        __SINK_FQN,
-                        __SINK_DESCR,
-                        &__e.to_string(),
-                    );
-                    return jni::objects::JObject::null().into();
-                }
+        let __enc = match String_to_JString_c7f3ca43(&mut env, __elem) {
+            ::core::result::Result::Ok(__w) => __w,
+            ::core::result::Result::Err(__e) => {
+                signal_binding_error(
+                    &mut env,
+                    &__error_sink,
+                    &__SINK_MID,
+                    __SINK_FQN,
+                    __SINK_DESCR,
+                    &__e.to_string(),
+                );
+                return jni::objects::JObject::null().into();
             }
         };
         let __obj: jni::objects::JObject = __enc.into();
@@ -21284,20 +21274,18 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_storageShards<'a
     let __vec = perftest_flat::storage_shards(count, each);
     let mut __acc = __acc;
     for __elem in __vec.into_iter() {
-        let __enc = {
-            match Storage_to_jlong_1b233abd(&mut env, __elem) {
-                ::core::result::Result::Ok(__w) => __w,
-                ::core::result::Result::Err(__e) => {
-                    signal_binding_error(
-                        &mut env,
-                        &__error_sink,
-                        &__SINK_MID,
-                        __SINK_FQN,
-                        __SINK_DESCR,
-                        &__e.to_string(),
-                    );
-                    return jni::objects::JObject::null().into();
-                }
+        let __enc = match Storage_to_jlong_1b233abd(&mut env, __elem) {
+            ::core::result::Result::Ok(__w) => __w,
+            ::core::result::Result::Err(__e) => {
+                signal_binding_error(
+                    &mut env,
+                    &__error_sink,
+                    &__SINK_MID,
+                    __SINK_FQN,
+                    __SINK_DESCR,
+                    &__e.to_string(),
+                );
+                return jni::objects::JObject::null().into();
             }
         };
         __acc = match __CB_MID
@@ -21387,20 +21375,18 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_storageShardsOpt
         ::core::option::Option::Some(__vec) => {
             let mut __acc = __acc;
             for __elem in __vec.into_iter() {
-                let __enc = {
-                    match Storage_to_jlong_1b233abd(&mut env, __elem) {
-                        ::core::result::Result::Ok(__w) => __w,
-                        ::core::result::Result::Err(__e) => {
-                            signal_binding_error(
-                                &mut env,
-                                &__error_sink,
-                                &__SINK_MID,
-                                __SINK_FQN,
-                                __SINK_DESCR,
-                                &__e.to_string(),
-                            );
-                            return jni::objects::JObject::null().into();
-                        }
+                let __enc = match Storage_to_jlong_1b233abd(&mut env, __elem) {
+                    ::core::result::Result::Ok(__w) => __w,
+                    ::core::result::Result::Err(__e) => {
+                        signal_binding_error(
+                            &mut env,
+                            &__error_sink,
+                            &__SINK_MID,
+                            __SINK_FQN,
+                            __SINK_DESCR,
+                            &__e.to_string(),
+                        );
+                        return jni::objects::JObject::null().into();
                     }
                 };
                 __acc = match __CB_MID
@@ -24368,20 +24354,18 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_unsignedSeries<'
     let __vec = perftest_flat::unsigned_series();
     let mut __acc = __acc;
     for __elem in __vec.into_iter() {
-        let __enc = {
-            match u64_to_jlong_4384a5d6(&mut env, __elem) {
-                ::core::result::Result::Ok(__w) => __w,
-                ::core::result::Result::Err(__e) => {
-                    signal_binding_error(
-                        &mut env,
-                        &__error_sink,
-                        &__SINK_MID,
-                        __SINK_FQN,
-                        __SINK_DESCR,
-                        &__e.to_string(),
-                    );
-                    return jni::objects::JObject::null().into();
-                }
+        let __enc = match u64_to_jlong_4384a5d6(&mut env, __elem) {
+            ::core::result::Result::Ok(__w) => __w,
+            ::core::result::Result::Err(__e) => {
+                signal_binding_error(
+                    &mut env,
+                    &__error_sink,
+                    &__SINK_MID,
+                    __SINK_FQN,
+                    __SINK_DESCR,
+                    &__e.to_string(),
+                );
+                return jni::objects::JObject::null().into();
             }
         };
         __acc = match __CB_MID

--- a/prebindgen-jni/src/jni/compile.rs
+++ b/prebindgen-jni/src/jni/compile.rs
@@ -31,10 +31,8 @@ pub(crate) enum JPlan {
     /// A return the binding takes apart: the values it hands out, in the order
     /// the builder receives them.
     ///
-    /// Read only by the equivalence fixture until the encode side takes it —
-    /// `reach_leaf_flat` and `encode_plan_leaves` still read the plan, because
-    /// where the Rust side reaches a value is the plan's and not the wire's.
-    #[cfg_attr(not(test), allow(dead_code))]
+    /// Consumed by ordinary decomposed-return delivery. Callback delivery
+    /// takes the same result in the following Invoke stage.
     Decomposed(Vec<OutWire>),
 }
 
@@ -56,7 +54,6 @@ impl JPlan {
     }
 
     /// The values a decomposed return hands out, or `None` if it is not one.
-    #[cfg(test)]
     pub(crate) fn decomposed(self) -> Option<Vec<OutWire>> {
         match self {
             JPlan::Decomposed(wires) => Some(wires),
@@ -496,6 +493,36 @@ pub(crate) struct OutWire {
     /// form reached through an `Option` puts every value under it in doubt —
     /// and the site that splices is what sets it.
     pub(crate) nullable: bool,
+    /// JNI-specific operation frozen when a return site selects this
+    /// registry-composed wire. Legacy callback/error deliveries synthesized
+    /// directly from `UnfoldLeaf` leave this absent until the Invoke stage.
+    pub(crate) abi: Option<OutAbi>,
+}
+
+/// Frozen JNI operation for one registry-composed outgoing wire.
+#[derive(Clone)]
+pub(crate) enum OutAbi {
+    /// Synthesized Choice selector: raw `jint`, with no converter.
+    Tag,
+    /// One value encoded through its registry-planned pipeline. Projection is
+    /// retained because handle/unsigned delivery owns special jvalue policy.
+    Value(Box<OutValueAbi>),
+}
+
+#[derive(Clone)]
+pub(crate) struct OutValueAbi {
+    pub(crate) pipeline: crate::jni::chain::JPipeline,
+    pub(crate) projection: Option<Projection>,
+    /// Converter dependency activated only when a site retains this wire.
+    dependency: crate::jni::chain::JFunction,
+}
+
+impl OutAbi {
+    fn activate(&self) {
+        if let Self::Value(value) = self {
+            value.dependency.mark_reachable();
+        }
+    }
 }
 
 impl OutWire {
@@ -522,12 +549,32 @@ impl OutWire {
             reach: leaf.path.clone(),
             identity: leaf.identity,
             nullable: leaf.nullable,
+            abi: None,
         }
     }
 
     /// A whole plan's leaves in the recipe's vocabulary.
     pub(crate) fn from_leaves(leaves: &[prebindgen_registry::unfold::UnfoldLeaf]) -> Vec<Self> {
         leaves.iter().map(Self::from_leaf).collect()
+    }
+
+    /// Whether two wires name the same delivered value. The ABI is excluded:
+    /// this compares a reusable recipe row with the function-unique unfold
+    /// plan before choosing which registry compilation supplies that ABI.
+    pub(crate) fn same_delivery(&self, other: &Self) -> bool {
+        self.name == other.name
+            && self.out_ty.key() == other.out_ty.key()
+            && self.group == other.group
+            && self.from == other.from
+            && self.reach == other.reach
+            && self.identity == other.identity
+            && self.nullable == other.nullable
+    }
+
+    fn activate(&self) {
+        if let Some(abi) = &self.abi {
+            abi.activate();
+        }
     }
 
     /// The steps from the crossed value down to this one, or empty for a value
@@ -818,6 +865,18 @@ fn refuse(at: At<'_>, why: &str) -> JErr {
 }
 
 impl<R: Conversions> JCompile<'_, R> {
+    /// Freeze the exact child operation while the registry is composing the
+    /// structural row. A later lookup by `TypeRef` cannot recover binding-local
+    /// field conversions and may select the structural row itself instead of
+    /// the child recipe that produced this leaf.
+    fn output_abi(&self, frag: &JFrag) -> OutAbi {
+        OutAbi::Value(Box::new(OutValueAbi {
+            pipeline: Self::planned_pipeline(Direction::Deconstruct, Mode::Owned, frag),
+            projection: frag.conv.metadata.projection.clone(),
+            dependency: frag.rust.clone(),
+        }))
+    }
+
     fn wrap(&self, at: At<'_>, why: &str, conv: Option<ConverterImpl<KotlinMeta>>) -> Frag<Self> {
         conv.map(|c| JFrag::new(at, c))
             .ok_or_else(|| refuse(at, why))
@@ -1784,6 +1843,87 @@ impl<R: Conversions> JCompile<'_, R> {
     }
 }
 
+/// Freeze each leaf of a function-unique unfold plan through the registry's
+/// selected default crossing. Per-function `expand_return(...)` declarations
+/// can describe a walk for which no reusable type recipe exists; the registry
+/// still owns that walk in `UnfoldPlan`, and this compiles rather than looks up
+/// each converter operation before rendering begins.
+pub(crate) fn freeze_out_wires(
+    ext: &Declarations,
+    registry: &Registry,
+    leaves: &[prebindgen_registry::unfold::UnfoldLeaf],
+) -> Result<Vec<OutWire>, JErr> {
+    let mut compiler = prebindgen_registry::recipe::Compiler::resume(
+        registry.flat(),
+        ext.recipe_table(),
+        ext.site_bindings(),
+        ext.compiled.borrow().clone(),
+    );
+    let mut adapter = JCompile {
+        decls: ext,
+        registry,
+        declared_return: None,
+        site: None,
+    };
+    let result = leaves
+        .iter()
+        .map(|leaf| {
+            let mut wire = OutWire::from_leaf(leaf);
+            wire.abi = Some(if wire.is_tag() {
+                OutAbi::Tag
+            } else {
+                let crossing = prebindgen_registry::recipe::Crossing::new(
+                    wire.out_ty.clone(),
+                    Direction::Deconstruct,
+                );
+                let fragment = compiler
+                    .crossing(&mut adapter, &crossing)
+                    .map_err(|error| JErr::Refused(error.to_string()))?;
+                adapter.output_abi(&fragment)
+            });
+            wire.activate();
+            Ok(wire)
+        })
+        .collect();
+    *ext.compiled.borrow_mut() = compiler.finish();
+    result
+}
+
+/// Freeze one whole-element output conversion through the registry before the
+/// iterable-fold renderer runs.
+pub(crate) fn freeze_output_pipeline(
+    ext: &Declarations,
+    registry: &Registry,
+    ty: &TypeRef,
+) -> Result<crate::jni::chain::JPipeline, JErr> {
+    let mut compiler = prebindgen_registry::recipe::Compiler::resume(
+        registry.flat(),
+        ext.recipe_table(),
+        ext.site_bindings(),
+        ext.compiled.borrow().clone(),
+    );
+    let mut adapter = JCompile {
+        decls: ext,
+        registry,
+        declared_return: None,
+        site: None,
+    };
+    let crossing = prebindgen_registry::recipe::Crossing::new(ty.clone(), Direction::Deconstruct);
+    let result = compiler
+        .crossing(&mut adapter, &crossing)
+        .map(|fragment| {
+            let abi = adapter.output_abi(&fragment);
+            abi.activate();
+            let OutAbi::Value(value) = abi else {
+                unreachable!("a whole element is never a synthesized selector")
+            };
+            value.pipeline
+        })
+        .map_err(|error| JErr::Refused(error.to_string()));
+    *ext.compiled.borrow_mut() = compiler.finish();
+    result
+}
+
 impl<R: Conversions> Compile for JCompile<'_, R> {
     type Fragment = JFrag;
     /// One site of one exported function, classified.
@@ -2164,7 +2304,10 @@ impl<R: Conversions> Compile for JCompile<'_, R> {
                 // recipe states. Nothing else distinguishes the two cases, and
                 // nothing needs to.
                 return Ok(match &root.out_wires {
-                    Some(wires) => JPlan::Decomposed(wires.clone()),
+                    Some(wires) => {
+                        wires.iter().for_each(OutWire::activate);
+                        JPlan::Decomposed(wires.clone())
+                    }
                     None => JPlan::Return(Box::new(self.return_plan(bound, root))),
                 });
             }
@@ -2677,7 +2820,7 @@ impl<R: Conversions> JCompile<'_, R> {
     fn out_arm(&self, at: At<'_>, parts: Parts<'_, Self>) -> JFrag {
         let wires = parts
             .iter()
-            .filter_map(|(part, _)| {
+            .filter_map(|(part, child)| {
                 Some(OutWire {
                     // Named by `choice`, which knows the alternative the name
                     // is built from.
@@ -2691,6 +2834,7 @@ impl<R: Conversions> JCompile<'_, R> {
                     nullable: false,
                     identity: false,
                     reach: Vec::new(),
+                    abi: Some(self.output_abi(child)),
                 })
             })
             .collect();
@@ -2729,12 +2873,32 @@ impl<R: Conversions> JCompile<'_, R> {
     /// Describe a `data_class` as one tuple intermediate while retaining the
     /// independently flattened ABI leaves used by Kotlin signatures.
     fn out_product(&self, at: At<'_>, parts: Parts<'_, Self>) -> JFrag {
-        let Some(wires) = self
+        let Some(mut wires) = self
             .decls
             .struct_out_wires(self.registry, at.crossing.value())
         else {
             return JFrag::new(at, self.parts_marker(Vec::new()));
         };
+        let abis: Vec<OutAbi> = parts
+            .iter()
+            .flat_map(|(_, child)| match &child.out_wires {
+                Some(inner) => inner
+                    .iter()
+                    .map(|wire| {
+                        wire.abi
+                            .clone()
+                            .expect("a composed Product child freezes every outgoing leaf")
+                    })
+                    .collect::<Vec<_>>(),
+                None => vec![self.output_abi(child)],
+            })
+            .collect();
+        if wires.len() != abis.len() {
+            return JFrag::new(at, self.parts_marker(Vec::new()));
+        }
+        for (wire, abi) in wires.iter_mut().zip(abis) {
+            wire.abi = Some(abi);
+        }
         let mut frag = self.planned_product(at, parts).unwrap_or_else(|| {
             let mut marker = JFrag::new(
                 at,
@@ -2767,7 +2931,7 @@ impl<R: Conversions> JCompile<'_, R> {
             return declined;
         };
         let mut wires = Vec::new();
-        for (part, _) in parts {
+        for (part, child) in parts {
             let Some(field) = part_field(part) else {
                 return declined;
             };
@@ -2788,6 +2952,7 @@ impl<R: Conversions> JCompile<'_, R> {
                 reach: vec![field_step(&ident)],
                 nullable: false,
                 identity: false,
+                abi: Some(self.output_abi(child)),
             });
         }
         let mut frag = JFrag::new(
@@ -2817,15 +2982,32 @@ impl<R: Conversions> JCompile<'_, R> {
         let ident = id
             .ident()
             .ok_or_else(|| refuse(at, "a choice recipe over a type that is not one identifier"))?;
-        // The composition is the declaration's and the model's, so the same
-        // answer serves the leaf synthesis that runs before `resolve`. The arm
-        // fragments the driver built are not read at all — a sum hands its
-        // payloads out through their own conversions, and which those are is
-        // the emitter's question rather than this recipe's.
-        let wires = self
+        // The layout is the declaration's and the model's, so the same answer
+        // serves leaf synthesis before `resolve`. The selected child operation
+        // is different: only the arm fragments handed here can state it, so
+        // splice their already-frozen payload ABIs into that shared layout.
+        let mut wires = self
             .decls
             .sum_out_wires(self.registry, &ident, at.crossing.value())
             .ok_or_else(|| refuse(at, "a choice recipe over an undeclared sum"))?;
+        let abis: Vec<OutAbi> = std::iter::once(OutAbi::Tag)
+            .chain(arms.iter().flat_map(|(_, arm)| {
+                arm.out_wires.as_ref().into_iter().flatten().map(|wire| {
+                    wire.abi
+                        .clone()
+                        .expect("a Choice arm freezes every payload operation")
+                })
+            }))
+            .collect();
+        if wires.len() != abis.len() {
+            return Err(refuse(
+                at,
+                "a choice recipe whose payload operations do not match its slots",
+            ));
+        }
+        for (wire, abi) in wires.iter_mut().zip(abis) {
+            wire.abi = Some(abi);
+        }
         let mut frag = JFrag::new(at, self.parts_marker(parts_subs(arms)));
         frag.out_wires = Some(wires);
         frag.composed_only = true;
@@ -3150,6 +3332,7 @@ impl Declarations {
                 reach: field_path.iter().map(field_step).collect(),
                 nullable: false,
                 identity: false,
+                abi: None,
             });
         }
         Some(wires)
@@ -3189,6 +3372,7 @@ impl Declarations {
             nullable: false,
             identity: false,
             reach: Vec::new(),
+            abi: None,
         }];
         for alt in &sum.alternatives {
             let kotlin = self.sum_variant_class_name(cfg, &alt.name);
@@ -3208,6 +3392,7 @@ impl Declarations {
                     nullable: false,
                     identity: false,
                     reach: Vec::new(),
+                    abi: None,
                 });
             }
         }

--- a/prebindgen-jni/src/jni/emit/delivery.rs
+++ b/prebindgen-jni/src/jni/emit/delivery.rs
@@ -35,7 +35,7 @@ pub(crate) fn emit_unfold_delivery(
     ext: &Declarations,
     registry: &Registry,
     plan: &prebindgen_registry::unfold::UnfoldPlan,
-    iface: Option<&IfaceSpec>,
+    output: &crate::jni::fn_plan::UnfoldOutputPlan,
     call_expr: &TokenStream,
     on_err: &TokenStream,
     emit: &prebindgen_registry::Emit,
@@ -63,7 +63,7 @@ pub(crate) fn emit_unfold_delivery(
     // `__elem`) into `__obj0…__objN` (shared with the callback trampoline),
     // yielding the per-leaf typed jvalue arg expressions.
     let encode_leaves = |value: &TokenStream, optional: bool| {
-        let mut delivered = Delivered::of(plan);
+        let mut delivered = Delivered::planned(plan, output.wires.clone());
         delivered.optional = optional;
         encode_plan_leaves(ext, registry, delivered, &obj_idents, value, &fail, emit)
     };
@@ -123,8 +123,12 @@ pub(crate) fn emit_unfold_delivery(
         _ => None,
     };
     if let Some(optional) = opt_iterable {
-        let statics =
-            iface_statics(iface.expect("folder interface spec derivable for a resolved plan"));
+        let statics = iface_statics(
+            output
+                .iface
+                .as_deref()
+                .expect("folder interface spec derivable for a resolved plan"),
+        );
         let fold_invoke = |arg_exprs: &[TokenStream]| -> TokenStream {
             quote! {
                 __acc = match __CB_MID.call_object(
@@ -142,50 +146,26 @@ pub(crate) fn emit_unfold_delivery(
             }
         };
 
-        let loop_body = if let Some(element) = plan.element.as_ref() {
+        let loop_body = if plan.element.is_some() {
             // Whole-element (M4): encode the element via its own converter —
             // a raw typed jvalue for a primitive-wire element, a JObject
             // otherwise (mirrors `leaf_is_prim`; the folder interface
             // declares the matching typed param).
-            let out_entry = registry
-                .reading(&element.key())
-                .and_then(|tr| ext.out_frag(&tr))
-                .unwrap_or_else(|| {
-                    panic!(
-                        "emit_unfold_delivery: Vec element `{}` has no registered output converter",
-                        element.key()
-                    )
-                });
-            // The element's COMPLETE Rust -> wire chain. No `convert!` type is
-            // known to reach THIS path today (a fold element is single-leaf and
-            // whole, and the collection converters claim the shapes a converted
-            // element can take), but composing keeps the invariant uniform: a
-            // chain-less entry emits exactly the same call it did before. This
-            // is an extern body, so errors route to the sink rather than `?`.
-            let elem_conv = {
-                let step = |f: &syn::Ident, arg: TokenStream| {
-                    quote! {
-                        match #f(&mut env, #arg) {
-                            ::core::result::Result::Ok(__w) => __w,
-                            ::core::result::Result::Err(__e) => {
-                                signal_binding_error(&mut env, &__error_sink, &__SINK_MID, __SINK_FQN, __SINK_DESCR, &__e.to_string());
-                                return #on_err;
-                            }
-                        }
+            let pipeline = output
+                .element_pipeline
+                .as_ref()
+                .expect("whole-element fold carries its frozen output pipeline");
+            let elem_call = pipeline.invoke(quote!(__elem), emit);
+            let elem_conv = quote! {
+                match #elem_call {
+                    ::core::result::Result::Ok(__w) => __w,
+                    ::core::result::Result::Err(__e) => {
+                        signal_binding_error(&mut env, &__error_sink, &__SINK_MID, __SINK_FQN, __SINK_DESCR, &__e.to_string());
+                        return #on_err;
                     }
-                };
-                let mut body = TokenStream::new();
-                let mut previous = quote!(__elem);
-                for (order, (_, stage)) in out_entry.output_stage_order().enumerate() {
-                    let next = format_ident!("__es{}", order);
-                    let call = step(&stage.function.sig.ident, previous);
-                    body.extend(quote! { let #next = #call; });
-                    previous = quote!(#next);
                 }
-                let last = step(out_entry.converter_ident(), previous);
-                quote!({ #body #last })
             };
-            let elem_wire = out_entry.destination.clone();
+            let elem_wire = pipeline.wire().clone();
             // Primitive-wire elements (including an opaque **handle**, whose wire
             // is `jlong`) cross as a raw typed jvalue; object wires (String,
             // arrays) cross as a `JObject`. Keyed purely on the wire shape —
@@ -253,7 +233,10 @@ pub(crate) fn emit_unfold_delivery(
     match &plan.shape {
         UnfoldShape::Base => {
             let statics = iface_statics(
-                iface.expect("builder interface spec derivable for a registered declaration"),
+                output
+                    .iface
+                    .as_deref()
+                    .expect("builder interface spec derivable for a registered declaration"),
             );
             let body = emit_decompose(&quote!(__out));
             quote! {
@@ -271,7 +254,10 @@ pub(crate) fn emit_unfold_delivery(
                 ),
             }
             let statics = iface_statics(
-                iface.expect("builder interface spec derivable for a registered declaration"),
+                output
+                    .iface
+                    .as_deref()
+                    .expect("builder interface spec derivable for a registered declaration"),
             );
             let (leaves, arg_exprs, present) = encode_leaves(&quote!(__out), true);
             if let Some(present) = present {
@@ -568,6 +554,23 @@ impl<'a> Delivered<'a> {
     pub(crate) fn of(plan: &'a prebindgen_registry::unfold::UnfoldPlan) -> Self {
         Self {
             wires: crate::jni::compile::OutWire::from_leaves(&plan.leaves),
+            hoists: &plan.hoists,
+            by_ref: plan.by_ref,
+            source: &plan.source,
+            chain: None,
+            fixed_product: plan.fixed_builder,
+            optional: plan.is_optional_base(),
+        }
+    }
+
+    /// Ordinary return delivery from the registry-compiled return site. Unlike
+    /// `of`, this does not reconstruct wires from the legacy unfold leaves.
+    pub(crate) fn planned(
+        plan: &'a prebindgen_registry::unfold::UnfoldPlan,
+        wires: Vec<crate::jni::compile::OutWire>,
+    ) -> Self {
+        Self {
+            wires,
             hoists: &plan.hoists,
             by_ref: plan.by_ref,
             source: &plan.source,
@@ -1026,20 +1029,15 @@ pub(crate) fn encode_plan_leaves(
                     });
                     continue;
                 }
-                let out_entry = ext.out_frag(&leaf.out_ty).unwrap_or_else(|| {
-                    panic!(
-                        "jnigen composed leaf `{}` has no registered output converter",
-                        leaf.out_ty.key()
-                    )
-                });
+                let wire = leaf_wire(ext, leaf);
                 if leaf_is_prim(ext, leaf) {
-                    let (_, member, _) = jni_field_access(&out_entry.destination)
+                    let (_, member, _) = jni_field_access(&wire)
                         .expect("a primitive Product leaf has a JNI jvalue member");
                     stmts.extend(quote! {
                         let #object = jni::sys::jvalue { #member: #encoded };
                     });
                 } else {
-                    let cast = cast_wire_to_jobject(encoded, &out_entry.destination, fail);
+                    let cast = cast_wire_to_jobject(encoded, &wire, fail);
                     stmts.extend(quote! {
                         let #object: jni::objects::JObject = #cast;
                     });
@@ -1253,26 +1251,67 @@ pub(crate) fn encode_plan_leaves(
         };
         let (value, by_ref, path, consuming) = rebase(leaf);
         let value = &value;
-        let out_entry = ext.out_frag(&leaf.out_ty).unwrap_or_else(|| {
-            panic!(
-                "jnigen unfold: leaf `{}` has no registered output converter",
-                leaf.out_ty.key()
-            )
+        let (frozen_pipeline, frozen_projection) = match &leaf.abi {
+            Some(crate::jni::compile::OutAbi::Value(value)) => {
+                (Some(&value.pipeline), value.projection.as_ref())
+            }
+            Some(crate::jni::compile::OutAbi::Tag) => {
+                unreachable!("sum selector segments are encoded above")
+            }
+            None => (None, None),
+        };
+        // Callback/error delivery still arrives through legacy synthesized
+        // leaves until the Invoke stage. Ordinary return delivery always has a
+        // frozen ABI and never enters this compatibility branch.
+        let legacy_entry = frozen_pipeline.is_none().then(|| {
+            ext.out_frag(&leaf.out_ty).unwrap_or_else(|| {
+                panic!(
+                    "jnigen unfold: leaf `{}` has no registered output converter",
+                    leaf.out_ty.key()
+                )
+            })
         });
-        out_entry.activate();
+        if let Some(entry) = &legacy_entry {
+            entry.activate();
+        }
+        let projection = frozen_projection.or_else(|| {
+            legacy_entry
+                .as_ref()
+                .and_then(|entry| entry.metadata.projection.as_ref())
+        });
+        let wire = frozen_pipeline.map_or_else(
+            || {
+                legacy_entry
+                    .as_ref()
+                    .expect("legacy output leaf has an entry")
+                    .destination
+                    .clone()
+            },
+            |pipeline| pipeline.wire().clone(),
+        );
         let conv_fail = fail(quote!(__e.to_string()));
-        // The leaf's COMPLETE Rust -> wire chain: the rust-side stages a custom
-        // `convert!` declaration inserts (`Duration -> u64`), then the
-        // wire-facing converter (`u64 -> jlong`). Calling only the latter would
-        // hand it the semantic value where it expects the representation.
-        // Stage locals are keyed on the leaf index, so sibling leaves of the
-        // same type cannot collide.
-        let conv_stages: Vec<syn::Ident> = out_entry
-            .output_stage_order()
-            .map(|(_, stage)| stage.function.sig.ident.clone())
-            .collect();
-        let conv_fn = out_entry.converter_ident().clone();
         let conv = |input: TokenStream| -> TokenStream {
+            if let Some(pipeline) = frozen_pipeline {
+                let call = pipeline.invoke(input, emit);
+                return quote! {
+                    match #call {
+                        ::core::result::Result::Ok(__w) => __w,
+                        ::core::result::Result::Err(__e) => {
+                            #conv_fail
+                        }
+                    }
+                };
+            }
+            let out_entry = legacy_entry
+                .as_ref()
+                .expect("compatibility output leaf has an entry");
+            // Legacy callback/error leaf: reconstruct its semantic stages until
+            // those paths retain the same registry site result.
+            let conv_stages: Vec<syn::Ident> = out_entry
+                .output_stage_order()
+                .map(|(_, stage)| stage.function.sig.ident.clone())
+                .collect();
+            let conv_fn = out_entry.converter_ident().clone();
             let step = |f: &syn::Ident, arg: TokenStream| {
                 quote! {
                     match #f(&mut env, #arg) {
@@ -1316,7 +1355,7 @@ pub(crate) fn encode_plan_leaves(
             // path) boxes to `java.lang.Long` / null. The whole path is `Option`-unwrapped
             // (`unwrap_last`): an optional nesting step makes the leaf null
             // when the value is absent.
-            let proj = out_entry.metadata.projection.as_ref().unwrap_or_else(|| {
+            let proj = projection.unwrap_or_else(|| {
                 panic!(
                     "jnigen unfold: identity leaf `{}` has no projection — \
                      `.accessor_record_id()` requires a ptr_class type",
@@ -1556,7 +1595,6 @@ pub(crate) fn encode_plan_leaves(
         // declares the primitive). Everything else (object wires, and nullable
         // leaves whose `None` arm must yield a JVM null) encodes the reached
         // value with the leaf's output converter and casts to JObject.
-        let wire = out_entry.destination.clone();
         let enc_ident = format_ident!("__enc{}", idx);
         if leaf_is_prim(ext, leaf) {
             let letter = jni_field_access(&wire)
@@ -1636,7 +1674,34 @@ pub(crate) fn leaf_is_prim(ext: &Declarations, leaf: &crate::jni::compile::OutWi
     if leaf.nullable {
         return false;
     }
+    if let Some(crate::jni::compile::OutAbi::Value(value)) = &leaf.abi {
+        let proj_ok = match &value.projection {
+            None => true,
+            Some(p) => matches!(p.kind, ProjectionKind::Handle | ProjectionKind::Unsigned64),
+        };
+        return proj_ok && matches!(jni_field_access(value.pipeline.wire()), Some((_, _, false)));
+    }
     leaf_ty_is_prim(ext, &leaf.out_ty)
+}
+
+/// Final JNI wire for one outgoing leaf. Ordinary return sites retain it in
+/// their frozen ABI; callback/error compatibility leaves still resolve it from
+/// the adapter until the Invoke stage.
+pub(crate) fn leaf_wire(ext: &Declarations, leaf: &crate::jni::compile::OutWire) -> syn::Type {
+    match &leaf.abi {
+        Some(crate::jni::compile::OutAbi::Tag) => syn::parse_quote!(jni::sys::jint),
+        Some(crate::jni::compile::OutAbi::Value(value)) => value.pipeline.wire().clone(),
+        None => ext
+            .out_frag(&leaf.out_ty)
+            .unwrap_or_else(|| {
+                panic!(
+                    "jnigen output leaf `{}` has no registered output converter",
+                    leaf.out_ty.key()
+                )
+            })
+            .destination
+            .clone(),
+    }
 }
 
 /// The wire half of [`leaf_is_prim`]: does a leaf of this type occupy a **raw

--- a/prebindgen-jni/src/jni/emit/sum_out.rs
+++ b/prebindgen-jni/src/jni/emit/sum_out.rs
@@ -99,11 +99,7 @@ pub(crate) fn leaf_slot(ext: &Declarations, leaf: &crate::jni::compile::OutWire)
     let (sig, letter) = if leaf.is_tag() {
         ("I", format_ident!("i"))
     } else {
-        let wire = ext
-            .out_frag(&leaf.out_ty)
-            .expect("leaf_is_prim implies a resolved output entry")
-            .destination
-            .clone();
+        let wire = leaf_wire(ext, leaf);
         let (sig, letter, _) =
             jni_field_access(&wire).expect("leaf_is_prim guarantees a primitive wire");
         (sig, letter)
@@ -262,6 +258,7 @@ pub(crate) fn encode_sum_group(
                         slots[idx].prim,
                         bind,
                         fail,
+                        emit,
                     )
                 })
                 .collect();
@@ -319,46 +316,73 @@ fn encode_group_leaf(
     prim: bool,
     bind: &syn::Ident,
     fail: &dyn Fn(TokenStream) -> TokenStream,
+    emit: &prebindgen_registry::Emit,
 ) -> TokenStream {
-    let out_entry = ext.out_frag(&leaf.out_ty).unwrap_or_else(|| {
-        panic!(
-            "jnigen sum unfold: payload leaf `{}` (`{}`) has no registered output converter",
-            leaf.name,
-            leaf.out_ty.key()
-        )
+    let frozen_pipeline = match &leaf.abi {
+        Some(crate::jni::compile::OutAbi::Value(value)) => Some(&value.pipeline),
+        Some(crate::jni::compile::OutAbi::Tag) => {
+            unreachable!("a Choice payload is not its selector")
+        }
+        None => None,
+    };
+    // Callback/error delivery still synthesizes compatibility leaves. An
+    // ordinary return's Choice payload always carries the frozen pipeline.
+    let legacy_entry = frozen_pipeline.is_none().then(|| {
+        ext.out_frag(&leaf.out_ty).unwrap_or_else(|| {
+            panic!(
+                "jnigen sum unfold: payload leaf `{}` (`{}`) has no registered output converter",
+                leaf.name,
+                leaf.out_ty.key()
+            )
+        })
     });
-    out_entry.activate();
-    let wire = out_entry.destination.clone();
+    if let Some(entry) = &legacy_entry {
+        entry.activate();
+    }
+    let wire = leaf_wire(ext, leaf);
     let conv_fail = fail(quote!(__e.to_string()));
     let enc = format_ident!("__enc_{}", obj_ident);
-    // The payload's COMPLETE chain: a `convert!`-declared type reaches the
-    // wire through its rust-side stages first (`Duration → u64 → jlong`).
-    // Stopping at the wire-facing converter would hand it the semantic value
-    // where it expects the representation.
     let mut encode = TokenStream::new();
-    let mut previous = quote!(#bind.clone());
-    for (order, (_, stage)) in out_entry.output_stage_order().enumerate() {
-        let stage_fn = &stage.function.sig.ident;
-        let next = format_ident!("__enc_{}_s{}", obj_ident, order);
+    if let Some(pipeline) = frozen_pipeline {
+        let call = pipeline.invoke(quote!(#bind.clone()), emit);
         encode.extend(quote! {
-            let #next = match #stage_fn(&mut env, #previous) {
+            let #enc = match #call {
                 ::core::result::Result::Ok(__w) => __w,
                 ::core::result::Result::Err(__e) => {
                     #conv_fail
                 }
             };
         });
-        previous = quote!(#next);
+    } else {
+        let out_entry = legacy_entry
+            .as_ref()
+            .expect("compatibility Choice payload has an output entry");
+        // Legacy callback/error payload: reconstruct its semantic stages until
+        // those paths retain the same registry site result.
+        let mut previous = quote!(#bind.clone());
+        for (order, (_, stage)) in out_entry.output_stage_order().enumerate() {
+            let stage_fn = &stage.function.sig.ident;
+            let next = format_ident!("__enc_{}_s{}", obj_ident, order);
+            encode.extend(quote! {
+                let #next = match #stage_fn(&mut env, #previous) {
+                    ::core::result::Result::Ok(__w) => __w,
+                    ::core::result::Result::Err(__e) => {
+                        #conv_fail
+                    }
+                };
+            });
+            previous = quote!(#next);
+        }
+        let conv = out_entry.converter_ident();
+        encode.extend(quote! {
+            let #enc = match #conv(&mut env, #previous) {
+                ::core::result::Result::Ok(__w) => __w,
+                ::core::result::Result::Err(__e) => {
+                    #conv_fail
+                }
+            };
+        });
     }
-    let conv = out_entry.converter_ident();
-    encode.extend(quote! {
-        let #enc = match #conv(&mut env, #previous) {
-            ::core::result::Result::Ok(__w) => __w,
-            ::core::result::Result::Err(__e) => {
-                #conv_fail
-            }
-        };
-    });
     if prim {
         let letter = jni_field_access(&wire)
             .expect("leaf_is_prim guarantees a primitive wire")

--- a/prebindgen-jni/src/jni/emit/wrapper.rs
+++ b/prebindgen-jni/src/jni/emit/wrapper.rs
@@ -394,15 +394,7 @@ pub(crate) fn emit_jni_function_wrapper_with_callee(
                     delivered.erased_wrappers().join("<"),
                 )
             });
-        emit_unfold_delivery(
-            ext,
-            registry,
-            uplan,
-            u.iface.as_deref(),
-            &call_expr,
-            &on_err,
-            emit,
-        )
+        emit_unfold_delivery(ext, registry, uplan, u, &call_expr, &on_err, emit)
     } else {
         let output = match &plan.output {
             FnOutputPlan::Value(value) => value,

--- a/prebindgen-jni/src/jni/fn_plan.rs
+++ b/prebindgen-jni/src/jni/fn_plan.rs
@@ -7,7 +7,8 @@
 //! wrapper, Kotlin wrapper, `JNINative` declaration, and JVM-slot validator
 //! consume those answers without reconstructing them from a source-shape tag.
 //! The pattern generalizes [`build_struct_plan`]'s field-level plan to function
-//! granularity; the output side follows in a later stage.
+//! granularity. Ordinary decomposed outputs likewise retain their ordered
+//! outgoing wires and converter pipelines before either writer runs.
 
 use kotlin_codegen::KtType;
 use prebindgen_registry::{flat::TypeRef, Conversions};
@@ -262,7 +263,7 @@ pub(crate) enum HandleMode {
 /// `Unfold` = callback delivery (builder/fold lambda, erased `Any?` wire);
 /// `Value` = everything else, including the `Return`-delivery convert.
 pub(crate) enum FnOutputPlan {
-    Unfold(UnfoldOutputPlan),
+    Unfold(Box<UnfoldOutputPlan>),
     Value(Box<ValueOutputPlan>),
 }
 
@@ -270,6 +271,13 @@ pub(crate) enum FnOutputPlan {
 /// Rust builder param, the erased extern params, and the typed Kotlin
 /// builder/fold surface all branch on the same booleans.
 pub(crate) struct UnfoldOutputPlan {
+    /// Registry-composed values the return site hands to its builder/folder,
+    /// with each target ABI and output pipeline frozen. Empty only for a
+    /// whole-element iterable fold.
+    pub wires: Vec<crate::jni::compile::OutWire>,
+    /// Whole-element iterable conversion, when `wires` is empty because the
+    /// fold receives each element through its ordinary one-value converter.
+    pub element_pipeline: Option<crate::jni::chain::JPipeline>,
     /// `is_iterable_fold(shape)` — a bare `Iterable` OR one wrapped in an
     /// `Optional` layer (`Option<Vec<T>>`). Selects the fold surface
     /// (`acc` + `fold`) over a scalar builder on every tier.
@@ -944,7 +952,35 @@ fn build_output(
                     .clone(),
             )
         });
-        return Ok(FnOutputPlan::Unfold(UnfoldOutputPlan {
+        let (wires, element_pipeline) = if let Some(element) = &plan.element {
+            let pipeline = crate::jni::compile::freeze_output_pipeline(ext, registry, element)
+                .map_err(|_| PlanError::UnresolvedOutput {
+                    ty: Box::new(element.clone()),
+                })?;
+            (Vec::new(), Some(pipeline))
+        } else {
+            let expected = crate::jni::compile::OutWire::from_leaves(&plan.leaves);
+            let composed = return_site(ext, registry, ident, &plan.source, None)
+                .and_then(|site| site.decomposed())
+                .filter(|wires| {
+                    wires.len() == expected.len()
+                        && wires
+                            .iter()
+                            .zip(&expected)
+                            .all(|(left, right)| left.same_delivery(right))
+                });
+            let wires = match composed {
+                Some(wires) => wires,
+                None => crate::jni::compile::freeze_out_wires(ext, registry, &plan.leaves)
+                    .map_err(|_| PlanError::UnresolvedOutput {
+                        ty: Box::new(plan.source.clone()),
+                    })?,
+            };
+            (wires, None)
+        };
+        return Ok(FnOutputPlan::Unfold(Box::new(UnfoldOutputPlan {
+            wires,
+            element_pipeline,
             iterable_fold,
             optional,
             fixed_builder,
@@ -952,7 +988,7 @@ fn build_output(
             decon,
             generic,
             iface,
-        }));
+        })));
     }
 
     // Value return. The conversion target: the converted single value for a

--- a/prebindgen-jni/src/jni/mod.rs
+++ b/prebindgen-jni/src/jni/mod.rs
@@ -719,6 +719,22 @@ impl JniGen {
         )
     }
 
+    /// Frozen ordinary-output operation coverage for one function:
+    /// `(wire count, every wire has an ABI, whole-element pipeline present)`.
+    #[cfg(test)]
+    pub(crate) fn output_freeze_for_test(&self, func: &str) -> Option<(usize, bool, bool)> {
+        let ident = syn::Ident::new(func, proc_macro2::Span::call_site());
+        let plan = self.decls.generation.as_ref()?.function(&ident)?;
+        let crate::jni::fn_plan::FnOutputPlan::Unfold(output) = &plan.output else {
+            return None;
+        };
+        Some((
+            output.wires.len(),
+            output.wires.iter().all(|wire| wire.abi.is_some()),
+            output.element_pipeline.is_some(),
+        ))
+    }
+
     /// The leaves the registry's own expansion plans for one function, in the
     /// form [`Self::out_lines_for_test`] renders a recipe in.
     ///

--- a/prebindgen-jni/src/jni/render.rs
+++ b/prebindgen-jni/src/jni/render.rs
@@ -1377,16 +1377,11 @@ fn classify_output(
         // extern returns the real wire and `build_call` applies the
         // projection wrap (handle) below.
         render_return_surface(&v.surface)?
-    } else if let (
-        FnOutputPlan::Unfold(
-            u @ UnfoldOutputPlan {
-                fixed_builder: true,
-                ..
-            },
-        ),
-        Some(plan),
-    ) = (&fplan.output, unfold)
-    {
+    } else if matches!(&fplan.output, FnOutputPlan::Unfold(u) if u.fixed_builder) {
+        let FnOutputPlan::Unfold(u) = &fplan.output else {
+            unreachable!()
+        };
+        let plan = unfold?;
         // Synthesized by-value `data_class` delivery via a **fixed, hoisted
         // singleton** — the wrapper takes no caller `build`/`fold` param and is
         // not generic over `R`/`A`. The native side still receives the singleton

--- a/prebindgen-jni/src/jni/tests/flatten.rs
+++ b/prebindgen-jni/src/jni/tests/flatten.rs
@@ -59,6 +59,16 @@ fn inline_output_gets_own_builder() {
     let _ = std::fs::remove_dir_all(&dir);
     std::fs::create_dir_all(&dir).unwrap();
     let gen = jni.build_with(registry).expect("resolve");
+    assert_eq!(
+        gen.output_freeze_for_test("z_make_a"),
+        Some((2, true, false)),
+        "the type-level return must freeze every delivered leaf",
+    );
+    assert_eq!(
+        gen.output_freeze_for_test("z_make_b"),
+        Some((3, true, false)),
+        "the function-unique return must freeze its own leaf operations",
+    );
     let rust_path = gen.write_rust(dir.join("gen.rs")).expect("write_rust");
     let rust = std::fs::read_to_string(&rust_path).unwrap();
     let rc: String = rust.split_whitespace().collect();


### PR DESCRIPTION
## Summary

- freeze the exact registry-composed output pipeline and JNI wire for every ordinary decomposed return leaf
- retain whole-element iterable-fold conversion as a resolved pipeline instead of rebuilding it while rendering
- preserve callback and error delivery as the explicit compatibility boundary for the following migration stage

## Implementation

Product, Choice, and value-form recipe composition now carries each child output operation into `OutWire`. Return-site planning activates and stores those operations before either Rust or Kotlin rendering begins.

Reusable type-level return recipes reuse the composed wires directly. A per-function `expand_return(...)` may describe a unique leaf walk with no reusable type recipe row; in that case, planning compiles each registry-owned `UnfoldLeaf` crossing once and freezes the resulting operation. Renderers receive the same immutable answer in both cases and perform no ordinary-path converter selection.

Whole-element iterable folds similarly retain their registry-compiled element pipeline. The committed generated Rust changes only inside private `Java_*` wrapper bodies; the JNI ABI and generated Kotlin surface remain semantically unchanged.

Part of #513.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test -p prebindgen-jni` (283 tests)
- `cargo test --workspace`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`
- `bash examples/regen-check.sh`
- `examples/covertest-kotlin/gradlew run` (61 sections)
