### PR TITLE
Freeze registry-planned JNI Invoke delivery

### DIFF
--- a/examples/covertest-kotlin/src/generated_bindings.rs
+++ b/examples/covertest-kotlin/src/generated_bindings.rs
@@ -4015,13 +4015,18 @@ pub(crate) unsafe fn JObject_to_impl_Fn_Duration_Send_Sync_static_98c9f460<'env,
                         format!("push local frame for {}: {}", "Fn(Duration)", e),
                     ))?;
                 let __frame_res = (|| -> ::core::result::Result<(), __JniErr> {
-                    let __cb0_enc = {
-                        let __cb0_s0 = Duration_to_u64_e3980876(&mut env, __cb_arg0)
-                            .map_err(|__e| <__JniErr as ::core::convert::From<
-                                String,
-                            >>::from(__e.to_string()))?;
-                        u64_to_jlong_4384a5d6(&mut env, __cb0_s0)?
-                    };
+                    let __cb0_enc = (|| -> ::core::result::Result<_, __JniErr> {
+                        {
+                            let __chain_s0 = Duration_to_u64_e3980876(
+                                    &mut env,
+                                    __cb_arg0,
+                                )
+                                .map_err(|__e| <__JniErr as ::core::convert::From<
+                                    String,
+                                >>::from(__e.to_string()))?;
+                            u64_to_jlong_4384a5d6(&mut env, __chain_s0)
+                        }
+                    })()?;
                     let __call_res: ::core::result::Result<(), __JniErr> = unsafe {
                         env.call_method_unchecked(
                             &callback_global_ref,
@@ -9613,6 +9618,108 @@ pub(crate) unsafe fn Option_Priority_to_jint_3d9b4399<'a>(
     clippy::nonminimal_bool,
     clippy::eq_op
 )]
+pub(crate) unsafe fn Option_Reading_to_tuple2_550e9a70<'a>(
+    env: &mut jni::JNIEnv<'a>,
+    v: Option<perftest_flat::Reading>,
+) -> ::core::result::Result<
+    (
+        jni::sys::jboolean,
+        (
+            jni::sys::jint,
+            (),
+            (jni::sys::jlong,),
+            (jni::sys::jlong, jni::sys::jlong),
+            (jni::objects::JString<'a>, jni::sys::jint),
+            (jni::sys::jlong,),
+        ),
+    ),
+    __JniErr,
+> {
+    ::core::result::Result::Ok({
+        match v {
+            ::core::option::Option::Some(__value) => {
+                (1u8, Reading_to_tuple6_69702d1f(env, __value)?)
+            }
+            ::core::option::Option::None => {
+                (
+                    0u8,
+                    (
+                        0 as jni::sys::jint,
+                        (),
+                        (0 as jni::sys::jlong,),
+                        (0 as jni::sys::jlong, 0 as jni::sys::jlong),
+                        (jni::objects::JObject::null().into(), 0 as jni::sys::jint),
+                        (0 as jni::sys::jlong,),
+                    ),
+                )
+            }
+        }
+    })
+}
+#[allow(
+    non_snake_case,
+    unused_mut,
+    unused_variables,
+    unused_braces,
+    unused_parens,
+    dead_code,
+    clippy::useless_conversion,
+    clippy::needless_question_mark,
+    clippy::let_and_return,
+    clippy::nonminimal_bool,
+    clippy::eq_op
+)]
+pub(crate) unsafe fn Option_Reading_to_tuple2_62404c22<'a>(
+    env: &mut jni::JNIEnv<'a>,
+    v: Option<&perftest_flat::Reading>,
+) -> ::core::result::Result<
+    (
+        jni::sys::jboolean,
+        (
+            jni::sys::jint,
+            (),
+            (jni::sys::jlong,),
+            (jni::sys::jlong, jni::sys::jlong),
+            (jni::objects::JString<'a>, jni::sys::jint),
+            (jni::sys::jlong,),
+        ),
+    ),
+    __JniErr,
+> {
+    ::core::result::Result::Ok({
+        match v {
+            ::core::option::Option::Some(__value) => {
+                (1u8, Reading_to_tuple6_4cad5c2d(env, __value)?)
+            }
+            ::core::option::Option::None => {
+                (
+                    0u8,
+                    (
+                        0 as jni::sys::jint,
+                        (),
+                        (0 as jni::sys::jlong,),
+                        (0 as jni::sys::jlong, 0 as jni::sys::jlong),
+                        (jni::objects::JObject::null().into(), 0 as jni::sys::jint),
+                        (0 as jni::sys::jlong,),
+                    ),
+                )
+            }
+        }
+    })
+}
+#[allow(
+    non_snake_case,
+    unused_mut,
+    unused_variables,
+    unused_braces,
+    unused_parens,
+    dead_code,
+    clippy::useless_conversion,
+    clippy::needless_question_mark,
+    clippy::let_and_return,
+    clippy::nonminimal_bool,
+    clippy::eq_op
+)]
 pub(crate) unsafe fn Option_Stamp_to_JObject_6375b503<'a>(
     env: &mut jni::JNIEnv<'a>,
     v: Option<perftest_flat::Stamp>,
@@ -10070,6 +10177,95 @@ pub(crate) unsafe fn Probe_to_jlong_76f3d10e<'a>(
     v: perftest_flat::Probe,
 ) -> ::core::result::Result<jni::sys::jlong, __JniErr> {
     Ok(std::boxed::Box::into_raw(std::boxed::Box::new(v)) as i64)
+}
+#[allow(
+    non_snake_case,
+    unused_mut,
+    unused_variables,
+    unused_braces,
+    unused_parens,
+    dead_code,
+    clippy::useless_conversion,
+    clippy::needless_question_mark,
+    clippy::let_and_return,
+    clippy::nonminimal_bool,
+    clippy::eq_op
+)]
+#[inline(always)]
+pub(crate) unsafe fn Reading_to_tuple6_4cad5c2d<'a>(
+    env: &mut jni::JNIEnv<'a>,
+    v: &perftest_flat::Reading,
+) -> ::core::result::Result<
+    (
+        jni::sys::jint,
+        (),
+        (jni::sys::jlong,),
+        (jni::sys::jlong, jni::sys::jlong),
+        (jni::objects::JString<'a>, jni::sys::jint),
+        (jni::sys::jlong,),
+    ),
+    __JniErr,
+> {
+    ::core::result::Result::Ok({
+        match v {
+            perftest_flat::Reading::Missing => {
+                (
+                    0i32,
+                    (),
+                    (0 as jni::sys::jlong,),
+                    (0 as jni::sys::jlong, 0 as jni::sys::jlong),
+                    (jni::objects::JObject::null().into(), 0 as jni::sys::jint),
+                    (0 as jni::sys::jlong,),
+                )
+            }
+            perftest_flat::Reading::Exact(__part0) => {
+                (
+                    1i32,
+                    (),
+                    (i64_to_jlong_fbf9a9bc(env, (*&*__part0).clone())?,),
+                    (0 as jni::sys::jlong, 0 as jni::sys::jlong),
+                    (jni::objects::JObject::null().into(), 0 as jni::sys::jint),
+                    (0 as jni::sys::jlong,),
+                )
+            }
+            perftest_flat::Reading::Range { low: __part0, high: __part1 } => {
+                (
+                    2i32,
+                    (),
+                    (0 as jni::sys::jlong,),
+                    (
+                        i64_to_jlong_fbf9a9bc(env, (*&*__part0).clone())?,
+                        i64_to_jlong_fbf9a9bc(env, (*&*__part1).clone())?,
+                    ),
+                    (jni::objects::JObject::null().into(), 0 as jni::sys::jint),
+                    (0 as jni::sys::jlong,),
+                )
+            }
+            perftest_flat::Reading::Labeled(__part0, __part1) => {
+                (
+                    3i32,
+                    (),
+                    (0 as jni::sys::jlong,),
+                    (0 as jni::sys::jlong, 0 as jni::sys::jlong),
+                    (
+                        String_to_JString_c7f3ca43(env, (*&*__part0).clone())?,
+                        Priority_to_jint_447102d2(env, (*&*__part1).clone())?,
+                    ),
+                    (0 as jni::sys::jlong,),
+                )
+            }
+            perftest_flat::Reading::Companion(__part0) => {
+                (
+                    4i32,
+                    (),
+                    (0 as jni::sys::jlong,),
+                    (0 as jni::sys::jlong, 0 as jni::sys::jlong),
+                    (jni::objects::JObject::null().into(), 0 as jni::sys::jint),
+                    (i64_to_jlong_fbf9a9bc(env, (*&*__part0).clone())?,),
+                )
+            }
+        }
+    })
 }
 #[allow(
     non_snake_case,
@@ -13808,157 +14004,46 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_archiveReading<'
     const __CB_FQN: &str = "io/prebindgen/covertest/model/ReadingBuilder";
     const __CB_DESCR: &str = "(IJJJLjava/lang/String;IJ)Ljava/lang/Object;";
     let __out = perftest_flat::archive_reading(&a);
-    let __obj0: jni::sys::jvalue;
-    let __obj1: jni::sys::jvalue;
-    let __obj2: jni::sys::jvalue;
-    let __obj3: jni::sys::jvalue;
-    let __obj4: jni::objects::JObject;
-    let __obj5: jni::sys::jvalue;
-    let __obj6: jni::sys::jvalue;
-    match __out {
-        perftest_flat::Reading::Missing => {
-            __obj0 = jni::sys::jvalue { i: 0 };
-            __obj1 = jni::sys::jvalue { j: 0i64 };
-            __obj2 = jni::sys::jvalue { j: 0i64 };
-            __obj3 = jni::sys::jvalue { j: 0i64 };
-            __obj4 = jni::objects::JObject::null();
-            __obj5 = jni::sys::jvalue { i: 0i32 };
-            __obj6 = jni::sys::jvalue { j: 0i64 };
-        }
-        perftest_flat::Reading::Exact(__sv0) => {
-            let __enc___obj1 = match i64_to_jlong_fbf9a9bc(&mut env, __sv0.clone()) {
-                ::core::result::Result::Ok(__w) => __w,
-                ::core::result::Result::Err(__e) => {
-                    signal_binding_error(
-                        &mut env,
-                        &__error_sink,
-                        &__SINK_MID,
-                        __SINK_FQN,
-                        __SINK_DESCR,
-                        &__e.to_string(),
-                    );
-                    return jni::objects::JObject::null().into();
-                }
-            };
-            __obj1 = jni::sys::jvalue {
-                j: __enc___obj1,
-            };
-            __obj0 = jni::sys::jvalue { i: 1 };
-            __obj2 = jni::sys::jvalue { j: 0i64 };
-            __obj3 = jni::sys::jvalue { j: 0i64 };
-            __obj4 = jni::objects::JObject::null();
-            __obj5 = jni::sys::jvalue { i: 0i32 };
-            __obj6 = jni::sys::jvalue { j: 0i64 };
-        }
-        perftest_flat::Reading::Range { low: __sv0, high: __sv1 } => {
-            let __enc___obj2 = match i64_to_jlong_fbf9a9bc(&mut env, __sv0.clone()) {
-                ::core::result::Result::Ok(__w) => __w,
-                ::core::result::Result::Err(__e) => {
-                    signal_binding_error(
-                        &mut env,
-                        &__error_sink,
-                        &__SINK_MID,
-                        __SINK_FQN,
-                        __SINK_DESCR,
-                        &__e.to_string(),
-                    );
-                    return jni::objects::JObject::null().into();
-                }
-            };
-            __obj2 = jni::sys::jvalue {
-                j: __enc___obj2,
-            };
-            let __enc___obj3 = match i64_to_jlong_fbf9a9bc(&mut env, __sv1.clone()) {
-                ::core::result::Result::Ok(__w) => __w,
-                ::core::result::Result::Err(__e) => {
-                    signal_binding_error(
-                        &mut env,
-                        &__error_sink,
-                        &__SINK_MID,
-                        __SINK_FQN,
-                        __SINK_DESCR,
-                        &__e.to_string(),
-                    );
-                    return jni::objects::JObject::null().into();
-                }
-            };
-            __obj3 = jni::sys::jvalue {
-                j: __enc___obj3,
-            };
-            __obj0 = jni::sys::jvalue { i: 2 };
-            __obj1 = jni::sys::jvalue { j: 0i64 };
-            __obj4 = jni::objects::JObject::null();
-            __obj5 = jni::sys::jvalue { i: 0i32 };
-            __obj6 = jni::sys::jvalue { j: 0i64 };
-        }
-        perftest_flat::Reading::Labeled(__sv0, __sv1) => {
-            let __enc___obj4 = match String_to_JString_c7f3ca43(
+    let (
+        __chain_wire0,
+        (),
+        (__chain_wire1,),
+        (__chain_wire2, __chain_wire3),
+        (__chain_wire4, __chain_wire5),
+        (__chain_wire6,),
+    ) = match Reading_to_tuple6_4cad5c2d(&mut env, __out) {
+        ::core::result::Result::Ok(__intermediate) => __intermediate,
+        ::core::result::Result::Err(__chain_error) => {
+            signal_binding_error(
                 &mut env,
-                __sv0.clone(),
-            ) {
-                ::core::result::Result::Ok(__w) => __w,
-                ::core::result::Result::Err(__e) => {
-                    signal_binding_error(
-                        &mut env,
-                        &__error_sink,
-                        &__SINK_MID,
-                        __SINK_FQN,
-                        __SINK_DESCR,
-                        &__e.to_string(),
-                    );
-                    return jni::objects::JObject::null().into();
-                }
-            };
-            __obj4 = __enc___obj4.into();
-            let __enc___obj5 = match Priority_to_jint_447102d2(&mut env, __sv1.clone()) {
-                ::core::result::Result::Ok(__w) => __w,
-                ::core::result::Result::Err(__e) => {
-                    signal_binding_error(
-                        &mut env,
-                        &__error_sink,
-                        &__SINK_MID,
-                        __SINK_FQN,
-                        __SINK_DESCR,
-                        &__e.to_string(),
-                    );
-                    return jni::objects::JObject::null().into();
-                }
-            };
-            __obj5 = jni::sys::jvalue {
-                i: __enc___obj5,
-            };
-            __obj0 = jni::sys::jvalue { i: 3 };
-            __obj1 = jni::sys::jvalue { j: 0i64 };
-            __obj2 = jni::sys::jvalue { j: 0i64 };
-            __obj3 = jni::sys::jvalue { j: 0i64 };
-            __obj6 = jni::sys::jvalue { j: 0i64 };
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__chain_error.to_string(),
+            );
+            return jni::objects::JObject::null().into();
         }
-        perftest_flat::Reading::Companion(__sv0) => {
-            let __enc___obj6 = match i64_to_jlong_fbf9a9bc(&mut env, __sv0.clone()) {
-                ::core::result::Result::Ok(__w) => __w,
-                ::core::result::Result::Err(__e) => {
-                    signal_binding_error(
-                        &mut env,
-                        &__error_sink,
-                        &__SINK_MID,
-                        __SINK_FQN,
-                        __SINK_DESCR,
-                        &__e.to_string(),
-                    );
-                    return jni::objects::JObject::null().into();
-                }
-            };
-            __obj6 = jni::sys::jvalue {
-                j: __enc___obj6,
-            };
-            __obj0 = jni::sys::jvalue { i: 4 };
-            __obj1 = jni::sys::jvalue { j: 0i64 };
-            __obj2 = jni::sys::jvalue { j: 0i64 };
-            __obj3 = jni::sys::jvalue { j: 0i64 };
-            __obj4 = jni::objects::JObject::null();
-            __obj5 = jni::sys::jvalue { i: 0i32 };
-        }
-    }
+    };
+    let __obj0 = jni::sys::jvalue {
+        i: __chain_wire0,
+    };
+    let __obj1 = jni::sys::jvalue {
+        j: __chain_wire1,
+    };
+    let __obj2 = jni::sys::jvalue {
+        j: __chain_wire2,
+    };
+    let __obj3 = jni::sys::jvalue {
+        j: __chain_wire3,
+    };
+    let __obj4: jni::objects::JObject = __chain_wire4.into();
+    let __obj5 = jni::sys::jvalue {
+        i: __chain_wire5,
+    };
+    let __obj6 = jni::sys::jvalue {
+        j: __chain_wire6,
+    };
     match __CB_MID
         .call_object(
             &mut env,
@@ -14029,213 +14114,89 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_archiveReadingMa
     const __CB_FQN: &str = "io/prebindgen/covertest/model/ReadingBuilder";
     const __CB_DESCR: &str = "(IJJJLjava/lang/String;IJ)Ljava/lang/Object;";
     let __out = perftest_flat::archive_reading_maybe(&a);
-    match __out {
-        ::core::option::Option::Some(__inner) => {
-            let __obj0: jni::sys::jvalue;
-            let __obj1: jni::sys::jvalue;
-            let __obj2: jni::sys::jvalue;
-            let __obj3: jni::sys::jvalue;
-            let __obj4: jni::objects::JObject;
-            let __obj5: jni::sys::jvalue;
-            let __obj6: jni::sys::jvalue;
-            match __inner {
-                perftest_flat::Reading::Missing => {
-                    __obj0 = jni::sys::jvalue { i: 0 };
-                    __obj1 = jni::sys::jvalue { j: 0i64 };
-                    __obj2 = jni::sys::jvalue { j: 0i64 };
-                    __obj3 = jni::sys::jvalue { j: 0i64 };
-                    __obj4 = jni::objects::JObject::null();
-                    __obj5 = jni::sys::jvalue { i: 0i32 };
-                    __obj6 = jni::sys::jvalue { j: 0i64 };
-                }
-                perftest_flat::Reading::Exact(__sv0) => {
-                    let __enc___obj1 = match i64_to_jlong_fbf9a9bc(
-                        &mut env,
-                        __sv0.clone(),
-                    ) {
-                        ::core::result::Result::Ok(__w) => __w,
-                        ::core::result::Result::Err(__e) => {
-                            signal_binding_error(
-                                &mut env,
-                                &__error_sink,
-                                &__SINK_MID,
-                                __SINK_FQN,
-                                __SINK_DESCR,
-                                &__e.to_string(),
-                            );
-                            return jni::objects::JObject::null().into();
-                        }
-                    };
-                    __obj1 = jni::sys::jvalue {
-                        j: __enc___obj1,
-                    };
-                    __obj0 = jni::sys::jvalue { i: 1 };
-                    __obj2 = jni::sys::jvalue { j: 0i64 };
-                    __obj3 = jni::sys::jvalue { j: 0i64 };
-                    __obj4 = jni::objects::JObject::null();
-                    __obj5 = jni::sys::jvalue { i: 0i32 };
-                    __obj6 = jni::sys::jvalue { j: 0i64 };
-                }
-                perftest_flat::Reading::Range { low: __sv0, high: __sv1 } => {
-                    let __enc___obj2 = match i64_to_jlong_fbf9a9bc(
-                        &mut env,
-                        __sv0.clone(),
-                    ) {
-                        ::core::result::Result::Ok(__w) => __w,
-                        ::core::result::Result::Err(__e) => {
-                            signal_binding_error(
-                                &mut env,
-                                &__error_sink,
-                                &__SINK_MID,
-                                __SINK_FQN,
-                                __SINK_DESCR,
-                                &__e.to_string(),
-                            );
-                            return jni::objects::JObject::null().into();
-                        }
-                    };
-                    __obj2 = jni::sys::jvalue {
-                        j: __enc___obj2,
-                    };
-                    let __enc___obj3 = match i64_to_jlong_fbf9a9bc(
-                        &mut env,
-                        __sv1.clone(),
-                    ) {
-                        ::core::result::Result::Ok(__w) => __w,
-                        ::core::result::Result::Err(__e) => {
-                            signal_binding_error(
-                                &mut env,
-                                &__error_sink,
-                                &__SINK_MID,
-                                __SINK_FQN,
-                                __SINK_DESCR,
-                                &__e.to_string(),
-                            );
-                            return jni::objects::JObject::null().into();
-                        }
-                    };
-                    __obj3 = jni::sys::jvalue {
-                        j: __enc___obj3,
-                    };
-                    __obj0 = jni::sys::jvalue { i: 2 };
-                    __obj1 = jni::sys::jvalue { j: 0i64 };
-                    __obj4 = jni::objects::JObject::null();
-                    __obj5 = jni::sys::jvalue { i: 0i32 };
-                    __obj6 = jni::sys::jvalue { j: 0i64 };
-                }
-                perftest_flat::Reading::Labeled(__sv0, __sv1) => {
-                    let __enc___obj4 = match String_to_JString_c7f3ca43(
-                        &mut env,
-                        __sv0.clone(),
-                    ) {
-                        ::core::result::Result::Ok(__w) => __w,
-                        ::core::result::Result::Err(__e) => {
-                            signal_binding_error(
-                                &mut env,
-                                &__error_sink,
-                                &__SINK_MID,
-                                __SINK_FQN,
-                                __SINK_DESCR,
-                                &__e.to_string(),
-                            );
-                            return jni::objects::JObject::null().into();
-                        }
-                    };
-                    __obj4 = __enc___obj4.into();
-                    let __enc___obj5 = match Priority_to_jint_447102d2(
-                        &mut env,
-                        __sv1.clone(),
-                    ) {
-                        ::core::result::Result::Ok(__w) => __w,
-                        ::core::result::Result::Err(__e) => {
-                            signal_binding_error(
-                                &mut env,
-                                &__error_sink,
-                                &__SINK_MID,
-                                __SINK_FQN,
-                                __SINK_DESCR,
-                                &__e.to_string(),
-                            );
-                            return jni::objects::JObject::null().into();
-                        }
-                    };
-                    __obj5 = jni::sys::jvalue {
-                        i: __enc___obj5,
-                    };
-                    __obj0 = jni::sys::jvalue { i: 3 };
-                    __obj1 = jni::sys::jvalue { j: 0i64 };
-                    __obj2 = jni::sys::jvalue { j: 0i64 };
-                    __obj3 = jni::sys::jvalue { j: 0i64 };
-                    __obj6 = jni::sys::jvalue { j: 0i64 };
-                }
-                perftest_flat::Reading::Companion(__sv0) => {
-                    let __enc___obj6 = match i64_to_jlong_fbf9a9bc(
-                        &mut env,
-                        __sv0.clone(),
-                    ) {
-                        ::core::result::Result::Ok(__w) => __w,
-                        ::core::result::Result::Err(__e) => {
-                            signal_binding_error(
-                                &mut env,
-                                &__error_sink,
-                                &__SINK_MID,
-                                __SINK_FQN,
-                                __SINK_DESCR,
-                                &__e.to_string(),
-                            );
-                            return jni::objects::JObject::null().into();
-                        }
-                    };
-                    __obj6 = jni::sys::jvalue {
-                        j: __enc___obj6,
-                    };
-                    __obj0 = jni::sys::jvalue { i: 4 };
-                    __obj1 = jni::sys::jvalue { j: 0i64 };
-                    __obj2 = jni::sys::jvalue { j: 0i64 };
-                    __obj3 = jni::sys::jvalue { j: 0i64 };
-                    __obj4 = jni::objects::JObject::null();
-                    __obj5 = jni::sys::jvalue { i: 0i32 };
-                }
-            }
-            match __CB_MID
-                .call_object(
+    let (
+        __chain_present,
+        (
+            __chain_wire0,
+            (),
+            (__chain_wire1,),
+            (__chain_wire2, __chain_wire3),
+            (__chain_wire4, __chain_wire5),
+            (__chain_wire6,),
+        ),
+    ) = match Option_Reading_to_tuple2_62404c22(&mut env, __out) {
+        ::core::result::Result::Ok(__intermediate) => __intermediate,
+        ::core::result::Result::Err(__chain_error) => {
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__chain_error.to_string(),
+            );
+            return jni::objects::JObject::null().into();
+        }
+    };
+    let __obj0 = jni::sys::jvalue {
+        i: __chain_wire0,
+    };
+    let __obj1 = jni::sys::jvalue {
+        j: __chain_wire1,
+    };
+    let __obj2 = jni::sys::jvalue {
+        j: __chain_wire2,
+    };
+    let __obj3 = jni::sys::jvalue {
+        j: __chain_wire3,
+    };
+    let __obj4: jni::objects::JObject = __chain_wire4.into();
+    let __obj5 = jni::sys::jvalue {
+        i: __chain_wire5,
+    };
+    let __obj6 = jni::sys::jvalue {
+        j: __chain_wire6,
+    };
+    if __chain_present != 0 {
+        match __CB_MID
+            .call_object(
+                &mut env,
+                __CB_FQN,
+                "run",
+                __CB_DESCR,
+                &__builder,
+                &[
+                    __obj0,
+                    __obj1,
+                    __obj2,
+                    __obj3,
+                    jni::sys::jvalue {
+                        l: __obj4.as_raw(),
+                    },
+                    __obj5,
+                    __obj6,
+                ],
+            )
+        {
+            ::core::result::Result::Ok(__o) => __o,
+            ::core::result::Result::Err(__e) => {
+                let _ = env.exception_describe();
+                let __e2 = <__JniErr as ::core::convert::From<
+                    String,
+                >>::from(__e.to_string());
+                signal_binding_error(
                     &mut env,
-                    __CB_FQN,
-                    "run",
-                    __CB_DESCR,
-                    &__builder,
-                    &[
-                        __obj0,
-                        __obj1,
-                        __obj2,
-                        __obj3,
-                        jni::sys::jvalue {
-                            l: __obj4.as_raw(),
-                        },
-                        __obj5,
-                        __obj6,
-                    ],
-                )
-            {
-                ::core::result::Result::Ok(__o) => __o,
-                ::core::result::Result::Err(__e) => {
-                    let _ = env.exception_describe();
-                    let __e2 = <__JniErr as ::core::convert::From<
-                        String,
-                    >>::from(__e.to_string());
-                    signal_binding_error(
-                        &mut env,
-                        &__error_sink,
-                        &__SINK_MID,
-                        __SINK_FQN,
-                        __SINK_DESCR,
-                        &__e2.to_string(),
-                    );
-                    jni::objects::JObject::null().into()
-                }
+                    &__error_sink,
+                    &__SINK_MID,
+                    __SINK_FQN,
+                    __SINK_DESCR,
+                    &__e2.to_string(),
+                );
+                jni::objects::JObject::null().into()
             }
         }
-        ::core::option::Option::None => jni::objects::JObject::null().into(),
+    } else {
+        jni::objects::JObject::null().into()
     }
 }
 #[no_mangle]
@@ -18860,87 +18821,89 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_readingMaybe<'a>
     const __CB_FQN: &str = "io/prebindgen/covertest/model/ReadingBuilder";
     const __CB_DESCR: &str = "(IJJJLjava/lang/String;IJ)Ljava/lang/Object;";
     let __out = perftest_flat::reading_maybe(which);
-    match __out {
-        ::core::option::Option::Some(__inner) => {
-            let (
-                __chain_wire0,
-                (),
-                (__chain_wire1,),
-                (__chain_wire2, __chain_wire3),
-                (__chain_wire4, __chain_wire5),
-                (__chain_wire6,),
-            ) = match Reading_to_tuple6_69702d1f(&mut env, __inner) {
-                ::core::result::Result::Ok(__intermediate) => __intermediate,
-                ::core::result::Result::Err(__chain_error) => {
-                    signal_binding_error(
-                        &mut env,
-                        &__error_sink,
-                        &__SINK_MID,
-                        __SINK_FQN,
-                        __SINK_DESCR,
-                        &__chain_error.to_string(),
-                    );
-                    return jni::objects::JObject::null().into();
-                }
-            };
-            let __obj0 = jni::sys::jvalue {
-                i: __chain_wire0,
-            };
-            let __obj1 = jni::sys::jvalue {
-                j: __chain_wire1,
-            };
-            let __obj2 = jni::sys::jvalue {
-                j: __chain_wire2,
-            };
-            let __obj3 = jni::sys::jvalue {
-                j: __chain_wire3,
-            };
-            let __obj4: jni::objects::JObject = __chain_wire4.into();
-            let __obj5 = jni::sys::jvalue {
-                i: __chain_wire5,
-            };
-            let __obj6 = jni::sys::jvalue {
-                j: __chain_wire6,
-            };
-            match __CB_MID
-                .call_object(
+    let (
+        __chain_present,
+        (
+            __chain_wire0,
+            (),
+            (__chain_wire1,),
+            (__chain_wire2, __chain_wire3),
+            (__chain_wire4, __chain_wire5),
+            (__chain_wire6,),
+        ),
+    ) = match Option_Reading_to_tuple2_550e9a70(&mut env, __out) {
+        ::core::result::Result::Ok(__intermediate) => __intermediate,
+        ::core::result::Result::Err(__chain_error) => {
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__chain_error.to_string(),
+            );
+            return jni::objects::JObject::null().into();
+        }
+    };
+    let __obj0 = jni::sys::jvalue {
+        i: __chain_wire0,
+    };
+    let __obj1 = jni::sys::jvalue {
+        j: __chain_wire1,
+    };
+    let __obj2 = jni::sys::jvalue {
+        j: __chain_wire2,
+    };
+    let __obj3 = jni::sys::jvalue {
+        j: __chain_wire3,
+    };
+    let __obj4: jni::objects::JObject = __chain_wire4.into();
+    let __obj5 = jni::sys::jvalue {
+        i: __chain_wire5,
+    };
+    let __obj6 = jni::sys::jvalue {
+        j: __chain_wire6,
+    };
+    if __chain_present != 0 {
+        match __CB_MID
+            .call_object(
+                &mut env,
+                __CB_FQN,
+                "run",
+                __CB_DESCR,
+                &__builder,
+                &[
+                    __obj0,
+                    __obj1,
+                    __obj2,
+                    __obj3,
+                    jni::sys::jvalue {
+                        l: __obj4.as_raw(),
+                    },
+                    __obj5,
+                    __obj6,
+                ],
+            )
+        {
+            ::core::result::Result::Ok(__o) => __o,
+            ::core::result::Result::Err(__e) => {
+                let _ = env.exception_describe();
+                let __e2 = <__JniErr as ::core::convert::From<
+                    String,
+                >>::from(__e.to_string());
+                signal_binding_error(
                     &mut env,
-                    __CB_FQN,
-                    "run",
-                    __CB_DESCR,
-                    &__builder,
-                    &[
-                        __obj0,
-                        __obj1,
-                        __obj2,
-                        __obj3,
-                        jni::sys::jvalue {
-                            l: __obj4.as_raw(),
-                        },
-                        __obj5,
-                        __obj6,
-                    ],
-                )
-            {
-                ::core::result::Result::Ok(__o) => __o,
-                ::core::result::Result::Err(__e) => {
-                    let _ = env.exception_describe();
-                    let __e2 = <__JniErr as ::core::convert::From<
-                        String,
-                    >>::from(__e.to_string());
-                    signal_binding_error(
-                        &mut env,
-                        &__error_sink,
-                        &__SINK_MID,
-                        __SINK_FQN,
-                        __SINK_DESCR,
-                        &__e2.to_string(),
-                    );
-                    jni::objects::JObject::null().into()
-                }
+                    &__error_sink,
+                    &__SINK_MID,
+                    __SINK_FQN,
+                    __SINK_DESCR,
+                    &__e2.to_string(),
+                );
+                jni::objects::JObject::null().into()
             }
         }
-        ::core::option::Option::None => jni::objects::JObject::null().into(),
+    } else {
+        jni::objects::JObject::null().into()
     }
 }
 #[no_mangle]

--- a/prebindgen-jni/src/jni/compile.rs
+++ b/prebindgen-jni/src/jni/compile.rs
@@ -518,7 +518,7 @@ pub(crate) struct OutValueAbi {
 }
 
 impl OutAbi {
-    fn activate(&self) {
+    pub(crate) fn activate(&self) {
         if let Self::Value(value) = self {
             value.dependency.mark_reachable();
         }
@@ -571,7 +571,7 @@ impl OutWire {
             && self.nullable == other.nullable
     }
 
-    fn activate(&self) {
+    pub(crate) fn activate(&self) {
         if let Some(abi) = &self.abi {
             abi.activate();
         }
@@ -695,33 +695,6 @@ impl Carrier for JFrag {
 }
 
 impl JFrag {
-    /// A callback conversion built by the legacy fallback.
-    ///
-    /// Registry recipes handle composable callback products. Irregular layouts
-    /// still enter through this compatibility path and are indexed as fragments
-    /// so downstream emitters use the same lookup in either case.
-    pub(crate) fn by_hand_with_rust(
-        ty: TypeKey,
-        conv: ConverterImpl<KotlinMeta>,
-        rust: crate::jni::chain::JFunction,
-    ) -> Self {
-        Self {
-            conv,
-            rust,
-            layout: Some(JLayout::Leaf),
-            choice_arm: None,
-            nested_chain: None,
-            wires: None,
-            out_wires: None,
-            composed_only: false,
-            yields: Yield {
-                ty,
-                mode: Mode::Owned,
-                validity: Validity::SelfSufficient,
-            },
-        }
-    }
-
     fn new(at: At<'_>, conv: ConverterImpl<KotlinMeta>) -> Self {
         let validity = validity_of(&conv, at.crossing.direction());
         let rust = crate::jni::chain::JFunction::complete(conv.function.clone());
@@ -753,6 +726,19 @@ impl JFrag {
             }
         }
         self.nested_chain.clone()
+    }
+
+    /// Exact Rust-value-to-JNI operation selected for this fragment.
+    pub(crate) fn output_abi(&self) -> OutAbi {
+        OutAbi::Value(Box::new(OutValueAbi {
+            pipeline: JCompile::<Registry>::planned_pipeline(
+                Direction::Deconstruct,
+                Mode::Owned,
+                self,
+            ),
+            projection: self.conv.metadata.projection.clone(),
+            dependency: self.rust.clone(),
+        }))
     }
 }
 
@@ -870,11 +856,7 @@ impl<R: Conversions> JCompile<'_, R> {
     /// field conversions and may select the structural row itself instead of
     /// the child recipe that produced this leaf.
     fn output_abi(&self, frag: &JFrag) -> OutAbi {
-        OutAbi::Value(Box::new(OutValueAbi {
-            pipeline: Self::planned_pipeline(Direction::Deconstruct, Mode::Owned, frag),
-            projection: frag.conv.metadata.projection.clone(),
-            dependency: frag.rust.clone(),
-        }))
+        frag.output_abi()
     }
 
     fn wrap(&self, at: At<'_>, why: &str, conv: Option<ConverterImpl<KotlinMeta>>) -> Frag<Self> {
@@ -1924,6 +1906,47 @@ pub(crate) fn freeze_output_pipeline(
     result
 }
 
+/// Compile and retain the exact composed deconstructor for a delivery crossing.
+/// Product composition lives in its explicit `parts` row; Optional and Choice
+/// composition may be the crossing's derived/default row. Selection happens
+/// here, while the registry compiler and site mode are still available.
+pub(crate) fn freeze_output_chain(
+    ext: &Declarations,
+    registry: &Registry,
+    ty: &TypeRef,
+) -> Result<Option<ComposedChain>, JErr> {
+    let mut compiler = prebindgen_registry::recipe::Compiler::resume(
+        registry.flat(),
+        ext.recipe_table(),
+        ext.site_bindings(),
+        ext.compiled.borrow().clone(),
+    );
+    let mut adapter = JCompile {
+        decls: ext,
+        registry,
+        declared_return: None,
+        site: None,
+    };
+    let crossing = prebindgen_registry::recipe::Crossing::new(ty.clone(), Direction::Deconstruct);
+    let fragment = if ext
+        .recipe_table()
+        .key_of(&crossing.key(), &crate::jni::recipes::parts())
+        .is_some()
+    {
+        compiler.recipe_of(&mut adapter, &crossing, &crate::jni::recipes::parts())
+    } else {
+        compiler.crossing(&mut adapter, &crossing)
+    };
+    let result = fragment
+        .map(|fragment| fragment.composed_chain())
+        .map_err(|error| JErr::Refused(error.to_string()));
+    if let Ok(Some(chain)) = &result {
+        chain.activate();
+    }
+    *ext.compiled.borrow_mut() = compiler.finish();
+    result
+}
+
 impl<R: Conversions> Compile for JCompile<'_, R> {
     type Fragment = JFrag;
     /// One site of one exported function, classified.
@@ -1935,18 +1958,6 @@ impl<R: Conversions> Compile for JCompile<'_, R> {
         let emit = cx.emit();
         if let Some(frag) = self.planned_owned_handle(at) {
             return Ok(frag);
-        }
-        if at.crossing.direction() == Direction::Construct {
-            if let TypeKind::Callback { args } = ty.unwrapped().kind() {
-                if let Some((conv, rust)) =
-                    self.decls
-                        .dispatch_fn_input(ty, args, self.registry, None, emit)
-                {
-                    let mut fragment = JFrag::new(at, conv);
-                    fragment.rust = rust;
-                    return Ok(fragment);
-                }
-            }
         }
         let conv = match at.crossing.direction() {
             Direction::Construct => self
@@ -1964,6 +1975,32 @@ impl<R: Conversions> Compile for JCompile<'_, R> {
                         .output_transparent_bridge(ty, self.registry, emit)
                 }),
         };
+        if conv.is_none()
+            && at.crossing.direction() == Direction::Deconstruct
+            && !self
+                .decls
+                .types
+                .contains_key(&at.crossing.value().stripped_key())
+        {
+            // A type-level output expansion is already a registry-owned
+            // deconstruction plan. Some deliberately Rust-only types have no
+            // whole JNI representation at all: only the plan's leaves cross.
+            // Retain that as an ordinary composed-only fragment so an Invoke
+            // recipe receives the same plan as ordinary output delivery instead
+            // of escaping through a callback-specific compatibility converter.
+            if let Some(plan) = crate::jni::iface::effective_callback_plan(
+                self.decls,
+                self.registry,
+                at.crossing.spelled(),
+            ) {
+                let mut fragment = JFrag::new(
+                    at,
+                    self.parts_marker(plan.leaves.iter().map(|leaf| leaf.out_ty.key()).collect()),
+                );
+                fragment.composed_only = true;
+                return Ok(fragment);
+            }
+        }
         self.wrap(at, "no JNI representation for this type", conv)
     }
 
@@ -2269,7 +2306,7 @@ impl<R: Conversions> Compile for JCompile<'_, R> {
         };
         let planned =
             self.decls
-                .dispatch_fn_input(ty, args, self.registry, Some(arg_fragments), cx.emit());
+                .dispatch_fn_input(ty, args, self.registry, arg_fragments, cx.emit());
         let (conv, rust) = planned.ok_or_else(|| refuse(at, "undeclared callback signature"))?;
         let mut fragment = JFrag::new(at, conv);
         fragment.rust = rust;
@@ -2635,6 +2672,11 @@ impl Conv {
     ) -> crate::jni::chain::JPipeline {
         self.activate();
         JCompile::<Registry>::planned_pipeline(direction, mode, &self.0)
+    }
+
+    /// Freeze this exact compiled fragment as one outgoing ABI operation.
+    pub(crate) fn output_abi(&self) -> OutAbi {
+        self.0.output_abi()
     }
 }
 

--- a/prebindgen-jni/src/jni/emit/callback.rs
+++ b/prebindgen-jni/src/jni/emit/callback.rs
@@ -41,6 +41,59 @@ fn callback_argument_name(index: usize) -> syn::Ident {
     format_ident!("__cb_arg{}", index)
 }
 
+/// Freeze one callback argument's deconstructed delivery before the retained
+/// Invoke plan is rendered. A composable recipe contributes its exact child
+/// wires and chain; an irregular registry-owned unfold walk freezes each
+/// already-resolved leaf crossing once at this resolution seam.
+fn freeze_callback_delivery(
+    ext: &Declarations,
+    plan: &prebindgen_registry::unfold::UnfoldPlan,
+    fragment: &crate::jni::compile::JFrag,
+) -> Option<(
+    Vec<crate::jni::compile::OutWire>,
+    Option<crate::jni::compile::ComposedChain>,
+)> {
+    let expected = crate::jni::compile::OutWire::from_leaves(&plan.leaves);
+    let composed = fragment.out_wires.clone().filter(|wires| {
+        wires.len() == expected.len()
+            && wires
+                .iter()
+                .zip(&expected)
+                .all(|(left, right)| left.same_delivery(right))
+    });
+    let wires = match composed {
+        Some(wires) => wires,
+        None => expected
+            .into_iter()
+            .map(|mut wire| {
+                wire.abi = Some(if wire.is_tag() {
+                    crate::jni::compile::OutAbi::Tag
+                } else {
+                    ext.out_frag(&wire.out_ty)?.output_abi()
+                });
+                if wire.identity
+                    && matches!(
+                        wire.abi,
+                        Some(crate::jni::compile::OutAbi::Value(ref value))
+                            if value.projection.is_none()
+                    )
+                {
+                    return None;
+                }
+                Some(wire)
+            })
+            .collect::<Option<Vec<_>>>()?,
+    };
+    wires
+        .iter()
+        .for_each(crate::jni::compile::OutWire::activate);
+    let chain = fragment.composed_chain();
+    if let Some(chain) = &chain {
+        chain.activate();
+    }
+    Some((wires, chain))
+}
+
 /// A registry-composed callback retained until the final Rust writer runs.
 #[derive(Clone)]
 pub(crate) struct JInvokePlan {
@@ -193,7 +246,7 @@ pub(crate) fn callback_input(
     source: &prebindgen_registry::flat::TypeRef,
     args: &[prebindgen_registry::flat::TypeRef],
     registry: &impl Conversions,
-    arg_fragments: Option<&[&crate::jni::compile::JFrag]>,
+    arg_fragments: &[&crate::jni::compile::JFrag],
     emit: &prebindgen_registry::Emit,
 ) -> Option<(syn::Type, JInvokePlan)> {
     // Human-readable tag for attach/log messages.
@@ -245,11 +298,8 @@ pub(crate) fn callback_input(
             .callback_arg_plan(&arg_ty.key())
             .filter(|p| super::render::is_iterable_fold(&p.shape))
         {
-            // Every leaf converter must already be resolved (deferral safety).
-            // A synthesized leaf (a sum's tag) has no converter to wait for.
-            for leaf in plan.leaves.iter().filter(|l| l.has_converter()) {
-                ext.out_frag(&leaf.out_ty)?;
-            }
+            let fragment = *arg_fragments.get(i)?;
+            let (wires, chain) = freeze_callback_delivery(ext, plan, fragment)?;
             let spec = folder_iface_for_plan(ext, registry, plan)?;
             let holder_slash =
                 syn::LitStr::new(&spec.singleton_holder_slash_fqn(), Span::call_site());
@@ -292,12 +342,7 @@ pub(crate) fn callback_input(
             let (leaf_stmts, leaf_args, _) = encode_plan_leaves(
                 ext,
                 registry,
-                crate::jni::emit::Delivered::with_chain(
-                    plan,
-                    arg_fragments
-                        .and_then(|fragments| fragments.get(i))
-                        .and_then(|fragment| fragment.composed_chain()),
-                ),
+                crate::jni::emit::Delivered::planned(plan, wires, chain),
                 &obj_idents,
                 &quote!(__cb_elem),
                 &fail,
@@ -349,30 +394,15 @@ pub(crate) fn callback_input(
         // Decomposed arg: deliver the leaves of its type-level canonical
         // output, exactly like a return delivery.
         if let Some(plan) = effective_callback_plan(ext, registry, arg_ty) {
-            // Deferral safety: every leaf converter (and identity-leaf
-            // projection) must already be resolved — return None so the rank
-            // resolver retries this converter later otherwise. A synthesized
-            // leaf (a sum's tag) has no converter to wait for: requiring one
-            // would make the trampoline wait forever on an `i32` crossing the
-            // binding may not have.
-            for leaf in plan.leaves.iter().filter(|l| l.has_converter()) {
-                let e = ext.out_frag(&leaf.out_ty)?;
-                if leaf.identity && e.metadata.projection.is_none() {
-                    return None;
-                }
-            }
+            let fragment = *arg_fragments.get(i)?;
+            let (wires, chain) = freeze_callback_delivery(ext, plan, fragment)?;
             let obj_idents: Vec<syn::Ident> = (0..plan.leaves.len())
                 .map(|k| format_ident!("__cb{}_obj{}", i, k))
                 .collect();
             let (stmts, mut arg_exprs, present) = encode_plan_leaves(
                 ext,
                 registry,
-                crate::jni::emit::Delivered::with_chain(
-                    plan,
-                    arg_fragments
-                        .and_then(|fragments| fragments.get(i))
-                        .and_then(|fragment| fragment.composed_chain()),
-                ),
+                crate::jni::emit::Delivered::planned(plan, wires, chain),
                 &obj_idents,
                 &quote!(#cb_arg),
                 &fail,
@@ -397,72 +427,24 @@ pub(crate) fn callback_input(
             continue;
         }
 
-        // Whole-value delivery. A by-value arg (`impl Fn(T)`) has a `T` output
-        // converter and is passed by move. A borrowed whole-value arg
-        // (`impl Fn(&T)` for a type with no accessor plan — e.g. a field-based
-        // `data_class` like `Payload`) has no `&T` converter, so fall back to `T`'s
-        // converter and clone the borrow (the callback only borrows the value). The
-        // `data_class` converter composes the whole object via `fromParts`, so the
-        // Kotlin `run(t: T)` receives a ready-made `T`.
-        let (cb_val, arg_entry) = match ext.out_frag(arg_ty) {
-            Some(e) => (quote!(#cb_arg), e),
-            // A borrow: the callback hands out a reference, and the value is
-            // cloned for the JVM.
-            //
-            // That this is a borrow is the model's answer (`borrow_target`) —
-            // no spelling is inspected here, which is the point of #229.
-            //
-            // `(#cb_arg).clone()` is nonetheless only well-typed for a
-            // DIRECTLY-spelled `&T`: `#cb_arg` carries the source's spelling,
-            // so a transparent wrapper — `Box<&T>`, `Ref` all the same —
-            // would clone to `Box<&T>`, which the `T` converter rejects. That
-            // case is refused before it reaches here: a callback arg's
-            // whole-value output converter is a *required* type, and
-            // `output_wrapper_shape`'s borrowed-opaque arm matches
-            // `syn::Type::Reference` on `produced` structurally, so `Box<&T>`
-            // (a `Type::Path`) never gets one.
-            //
-            // MEASURED, not assumed — `a_wrapped_borrow_callback_arg_declines`
-            // fails, on exactly this clone, if that arm is made
-            // spelling-blind. A local re-check here was tried (#279 review)
-            // and dropped: it changed no output on `Box<&String>` or
-            // `Box<&ZThing>`, and added a classification that never fires.
-            None => {
-                let core = arg_ty.borrow_target()?;
-                (quote!((#cb_arg).clone()), ext.out_frag(core)?)
-            }
+        // Whole-value delivery consumes the exact deconstruct fragment the
+        // registry's Invoke recipe compiled for this argument. Its retained
+        // pipeline already decides move versus borrow cloning, stage order,
+        // projection, and the final JNI wire; rendering does not look the type
+        // up again or reconstruct any of those decisions.
+        let fragment = *arg_fragments.get(i)?;
+        let cb_val = quote!(#cb_arg);
+        let arg_abi = fragment.output_abi();
+        arg_abi.activate();
+        let crate::jni::compile::OutAbi::Value(arg_value) = arg_abi else {
+            unreachable!("a whole callback argument is not a synthesized selector")
         };
-        arg_entry.activate();
-        let arg_wire = arg_entry.destination.clone();
+        let arg_wire = arg_value.pipeline.wire().clone();
         let enc_ident = format_ident!("__cb{}_enc", i);
         let obj_ident = format_ident!("__cb{}_obj", i);
 
-        // The arg's COMPLETE Rust -> wire chain: the rust-side stages a custom
-        // `convert!` declaration inserts (`Duration -> u64`), then the
-        // wire-facing converter (`u64 -> jlong`). A whole-value callback arg
-        // has no leaf plan, so this is its own encoder path — calling only the
-        // wire-facing converter would hand it the semantic value where it
-        // expects the representation. Stage locals are keyed on the arg index.
-        let conv = {
-            let converter = arg_entry.converter_ident();
-            if arg_entry.pre_stages.is_empty() {
-                quote!(#converter(&mut env, #cb_val)?)
-            } else {
-                let mut body = TokenStream::new();
-                let mut previous = cb_val.clone();
-                for (order, (_, stage)) in arg_entry.output_stage_order().enumerate() {
-                    let stage_fn = &stage.function.sig.ident;
-                    let next = format_ident!("__cb{}_s{}", i, order);
-                    body.extend(quote! {
-                        let #next = #stage_fn(&mut env, #previous)
-                            .map_err(|__e| <__JniErr as ::core::convert::From<String>>::from(
-                                __e.to_string()))?;
-                    });
-                    previous = quote!(#next);
-                }
-                quote!({ #body #converter(&mut env, #previous)? })
-            }
-        };
+        let conversion = arg_value.pipeline.invoke(cb_val, emit);
+        let conv = quote!(#conversion?);
 
         // Plan-less opaque-handle arg: encode to a raw `jlong` (`Box::into_raw`)
         // and deliver it as-is. The typed handle class is constructed Kotlin-side
@@ -472,7 +454,7 @@ pub(crate) fn callback_input(
         // consumer reply through the handle inside the callback (a consuming
         // reply zeroes the slot, making the proxy's `close` a no-op). See
         // `owned_handle_iface_param`.
-        if let Some(h) = &arg_entry.metadata.projection {
+        if let Some(h) = &arg_value.projection {
             if matches!(h.kind, ProjectionKind::Handle) {
                 preludes.push(quote! {
                     let #enc_ident = #conv;
@@ -494,8 +476,7 @@ pub(crate) fn callback_input(
         // passes its raw primitive; everything else casts to JObject. Output
         // converters take the value by move; `cb_arg` is the closure
         // parameter, so pass it directly.
-        let arg_is_prim = arg_entry
-            .metadata
+        let arg_is_prim = arg_value
             .projection
             .as_ref()
             .is_none_or(|p| p.kind == ProjectionKind::Unsigned64)

--- a/prebindgen-jni/src/jni/emit/delivery.rs
+++ b/prebindgen-jni/src/jni/emit/delivery.rs
@@ -63,7 +63,7 @@ pub(crate) fn emit_unfold_delivery(
     // `__elem`) into `__obj0…__objN` (shared with the callback trampoline),
     // yielding the per-leaf typed jvalue arg expressions.
     let encode_leaves = |value: &TokenStream, optional: bool| {
-        let mut delivered = Delivered::planned(plan, output.wires.clone());
+        let mut delivered = Delivered::planned(plan, output.wires.clone(), output.chain.clone());
         delivered.optional = optional;
         encode_plan_leaves(ext, registry, delivered, &obj_idents, value, &fail, emit)
     };
@@ -538,8 +538,6 @@ pub(crate) struct Delivered<'a> {
     pub(crate) hoists: &'a [prebindgen_registry::unfold::Hoist],
     /// Whether the delivered value is reached through a borrow.
     pub(crate) by_ref: bool,
-    /// Core source whose exact deconstructing crossing can be selected.
-    pub(crate) source: &'a prebindgen_registry::flat::TypeRef,
     /// True when these leaves are the model-derived data-class Product itself.
     pub(crate) fixed_product: bool,
     /// Whether the fixed Product is wrapped in one outer Optional shape.
@@ -556,7 +554,6 @@ impl<'a> Delivered<'a> {
             wires: crate::jni::compile::OutWire::from_leaves(&plan.leaves),
             hoists: &plan.hoists,
             by_ref: plan.by_ref,
-            source: &plan.source,
             chain: None,
             fixed_product: plan.fixed_builder,
             optional: plan.is_optional_base(),
@@ -568,28 +565,15 @@ impl<'a> Delivered<'a> {
     pub(crate) fn planned(
         plan: &'a prebindgen_registry::unfold::UnfoldPlan,
         wires: Vec<crate::jni::compile::OutWire>,
+        chain: Option<crate::jni::compile::ComposedChain>,
     ) -> Self {
         Self {
             wires,
             hoists: &plan.hoists,
             by_ref: plan.by_ref,
-            source: &plan.source,
-            chain: None,
+            chain,
             fixed_product: plan.fixed_builder,
             optional: plan.is_optional_base(),
-        }
-    }
-
-    /// The same delivery with the composed fragment the registry handed to a
-    /// callback's `Invoke` recipe. This is available before the compilation
-    /// store is committed, so callbacks do not need an adapter-side re-query.
-    pub(crate) fn with_chain(
-        plan: &'a prebindgen_registry::unfold::UnfoldPlan,
-        chain: Option<crate::jni::compile::ComposedChain>,
-    ) -> Self {
-        Self {
-            chain,
-            ..Self::of(plan)
         }
     }
 }
@@ -949,7 +933,6 @@ pub(crate) fn encode_plan_leaves(
         wires,
         hoists,
         by_ref,
-        source,
         chain,
         fixed_product,
         optional,
@@ -979,22 +962,7 @@ pub(crate) fn encode_plan_leaves(
     // call ABI. Callback and ordinary output delivery therefore share the
     // same Rust-value walk; only the final delivery remains JNI-specific.
     if fixed_product && hoists.is_empty() {
-        let crossing = if by_ref {
-            source.borrowed()
-        } else {
-            source.clone()
-        };
-        let crossing = if optional {
-            crossing.optional()
-        } else {
-            crossing
-        };
-        let chain = chain.or_else(|| {
-            ext.composed_chain(
-                &crossing,
-                prebindgen_registry::recipe::Direction::Deconstruct,
-            )
-        });
+        let chain = chain;
         if let Some(chain) = chain.filter(|chain| match &chain.layout {
             crate::jni::compile::JLayout::Optional(inner) => optional && inner.leaf_count() == n,
             layout => !optional && layout.leaf_count() == n,

--- a/prebindgen-jni/src/jni/fn_plan.rs
+++ b/prebindgen-jni/src/jni/fn_plan.rs
@@ -275,6 +275,8 @@ pub(crate) struct UnfoldOutputPlan {
     /// with each target ABI and output pipeline frozen. Empty only for a
     /// whole-element iterable fold.
     pub wires: Vec<crate::jni::compile::OutWire>,
+    /// Exact composed converter for a fixed Product/Optional/Choice return.
+    pub chain: Option<crate::jni::compile::ComposedChain>,
     /// Whole-element iterable conversion, when `wires` is empty because the
     /// fold receives each element through its ordinary one-value converter.
     pub element_pipeline: Option<crate::jni::chain::JPipeline>,
@@ -952,14 +954,28 @@ fn build_output(
                     .clone(),
             )
         });
-        let (wires, element_pipeline) = if let Some(element) = &plan.element {
+        let (wires, chain, element_pipeline) = if let Some(element) = &plan.element {
             let pipeline = crate::jni::compile::freeze_output_pipeline(ext, registry, element)
                 .map_err(|_| PlanError::UnresolvedOutput {
                     ty: Box::new(element.clone()),
                 })?;
-            (Vec::new(), Some(pipeline))
+            (Vec::new(), None, Some(pipeline))
         } else {
             let expected = crate::jni::compile::OutWire::from_leaves(&plan.leaves);
+            let delivered = if plan.by_ref {
+                plan.source.borrowed()
+            } else {
+                plan.source.clone()
+            };
+            // Only an Optional directly around the decomposed base belongs in
+            // the converter chain. `optional` also covers
+            // `Option<Vec<T>>`, whose presence gates the fold outside the
+            // per-element `T` chain.
+            let delivered = if plan.is_optional_base() {
+                delivered.optional()
+            } else {
+                delivered
+            };
             let composed = return_site(ext, registry, ident, &plan.source, None)
                 .and_then(|site| site.decomposed())
                 .filter(|wires| {
@@ -976,10 +992,23 @@ fn build_output(
                         ty: Box::new(plan.source.clone()),
                     })?,
             };
-            (wires, None)
+            // Chain availability depends on the exact value the delivery owns,
+            // including borrow and outer Optional mode. Freeze that answer now;
+            // the site binding itself intentionally names the core Product.
+            let chain = if fixed_builder && plan.hoists.is_empty() {
+                crate::jni::compile::freeze_output_chain(ext, registry, &delivered).map_err(
+                    |_| PlanError::UnresolvedOutput {
+                        ty: Box::new(delivered),
+                    },
+                )?
+            } else {
+                None
+            };
+            (wires, chain, None)
         };
         return Ok(FnOutputPlan::Unfold(Box::new(UnfoldOutputPlan {
             wires,
+            chain,
             element_pipeline,
             iterable_fold,
             optional,

--- a/prebindgen-jni/src/jni/mod.rs
+++ b/prebindgen-jni/src/jni/mod.rs
@@ -835,23 +835,16 @@ impl JniGen {
         Some(fragment.rust.is_optional())
     }
 
-    /// The whole-value callback compatibility row, when one was required.
-    ///
-    /// Recipe-built callbacks occupy their ordinary crossing row. Only the
-    /// adapter-refusal fallback records this deliberately named row, so asking
-    /// for it pins the compatibility seam rather than callback generation in
-    /// general. The boolean distinguishes the retained late plan from a
-    /// complete function rendered during resolution.
+    /// Whether a callback crossing retained the registry's late Invoke plan.
     #[cfg(test)]
-    pub(crate) fn compatibility_callback_for_test(&self, spelling: &str) -> Option<(String, bool)> {
-        use prebindgen_registry::recipe::{Crossing, Direction};
+    pub(crate) fn callback_invoke_for_test(&self, spelling: &str) -> Option<(String, bool)> {
+        use prebindgen_registry::recipe::Direction;
 
         let ty: syn::Type = syn::parse_str(spelling).ok()?;
         let reading = prebindgen_registry::Conversions::reading_of(&self.registry, &ty)?;
         let key = reading.key();
-        let row = Crossing::new(reading, Direction::Construct).row(crate::jni::recipes::callback());
         let compiled = self.decls.compiled.borrow();
-        let fragment = compiled.recipe_fragment(&key, &row)?;
+        let fragment = compiled.fragment(&key, Direction::Construct)?;
         Some((
             fragment.conv.converter_ident().to_string(),
             fragment.rust.is_invoke(),

--- a/prebindgen-jni/src/jni/recipes.rs
+++ b/prebindgen-jni/src/jni/recipes.rs
@@ -260,11 +260,6 @@ pub(crate) fn pair() -> RecipeName {
     RecipeName::new("pair")
 }
 
-/// The compatibility row for a callback whose arguments cannot be composed.
-pub(crate) fn callback() -> RecipeName {
-    RecipeName::new("callback")
-}
-
 impl Declarations {
     /// Every recipe this binding's declarations state.
     ///

--- a/prebindgen-jni/src/jni/tests/callbacks.rs
+++ b/prebindgen-jni/src/jni/tests/callbacks.rs
@@ -241,12 +241,11 @@ fn declared_optional_conversion_callback_falls_back_to_whole_value() {
 
 /// `Ledger` has an output expansion but is deliberately not a declared Kotlin
 /// class. Its fields reach a consuming `Report` value form through two
-/// conditional (`Option`) accessors. The recipe compiler cannot turn that
-/// irregular callback argument into a reusable parts converter, so callback
-/// delivery takes the whole-value compatibility seam. That seam must keep the
-/// `Invoke` plan late and pair it with the conversion the resolver returns.
+/// conditional (`Option`) accessors. The registry's deconstruction plan is its
+/// only JNI representation, and Invoke must retain that plan without a
+/// callback-specific compatibility row.
 #[test]
-fn undeclared_expanded_callback_retains_its_late_compatibility_plan() {
+fn undeclared_expanded_callback_retains_its_registry_invoke_plan() {
     let loc = myflat_loc();
     let items: Vec<(syn::Item, SourceLocation)> = [
         "pub struct ReportStruct { pub label: String }",
@@ -283,11 +282,11 @@ fn undeclared_expanded_callback_retains_its_late_compatibility_plan() {
     let generation = jni.build_with(registry).expect("resolve");
     let callback = "impl Fn(Ledger) + Send + Sync + 'static";
     let (converter, is_late_invoke) = generation
-        .compatibility_callback_for_test(callback)
-        .expect("Ledger callback uses the whole-value compatibility row");
+        .callback_invoke_for_test(callback)
+        .expect("Ledger callback is compiled through its ordinary crossing");
     assert!(
         is_late_invoke,
-        "the compatibility row must retain an unrendered Invoke plan"
+        "the ordinary callback fragment must retain an unrendered Invoke plan"
     );
 
     let rust = std::fs::read_to_string(generation.write_rust(dir.join("gen.rs")).unwrap()).unwrap();

--- a/prebindgen-jni/src/jni/tests/sealed.rs
+++ b/prebindgen-jni/src/jni/tests/sealed.rs
@@ -1156,9 +1156,10 @@ fn sum_return_emits_one_match_with_wire_defaults() {
 
 /// A sum returned **borrowed** (`&E`, `Option<&E>`). `unfold::returns_type`
 /// peels the leading `&` and `wire_fixed_returns` records `by_ref`, so the
-/// encoder matches THROUGH the reference rather than moving the value out of
-/// the owner. Each live group then clones what it needs, and Kotlin receives an
-/// ordinary value with no borrow to track — the borrow never crosses (#161).
+/// registry Choice chain matches THROUGH the reference rather than moving the
+/// value out of the owner. Each live group then clones what it needs, and
+/// Kotlin receives an ordinary value with no borrow to track — the borrow never
+/// crosses (#161).
 #[test]
 fn borrowed_sum_return_matches_through_the_reference() {
     let (rust, kotlin) = sum_returns("jnigen_sum_borrowed");
@@ -1168,30 +1169,23 @@ fn borrowed_sum_return_matches_through_the_reference() {
             .find(&format!("fn Java_io_test_jni_JNINative_{extern_fn}"))
             .unwrap_or_else(|| panic!("{extern_fn} extern missing:\n{rust}"));
         let body = &rust[at..at + 4000];
-        // The value is borrowed from its owner, so the encoder matches the
-        // binding DIRECTLY — `by_ref` is already reflected in `__out`'s type.
-        // Asserted exactly: a bare `contains("match __out")` would also accept
-        // `match __out2`, and accepting `match &__out` as an alternative would
-        // let a regression to double-referencing the borrow pass silently.
+        // The exact borrowed Choice crossing is frozen during planning, so the
+        // wrapper delegates rather than rebuilding the match locally.
         assert!(
-            body.contains("match __out {"),
-            "{extern_fn}: one match over the borrowed value:\n{body}"
+            body.contains("Reading_to_tuple"),
+            "{extern_fn}: delegates to the borrowed Choice chain:\n{body}"
         );
         assert!(
             !body.contains("match &__out"),
             "{extern_fn}: a borrowed return must not take a second reference:\n{body}"
         );
-        assert!(
-            body.contains("myflat::Reading::Missing =>"),
-            "{extern_fn}: arms bind each variant through the reference:\n{body}"
-        );
-        // A payload reached through a borrow cannot be moved out, so the live
-        // group clones it.
-        assert!(
-            body.contains(".clone()"),
-            "{extern_fn}: a borrowed group's payload is cloned, not moved:\n{body}"
-        );
     }
+
+    let rc: String = rust.split_whitespace().collect();
+    assert!(
+        rc.contains("v:&myflat::Reading") && rc.contains("matchv{") && rc.contains(".clone()"),
+        "the retained Choice chain matches through the borrow and clones payloads:\n{rust}"
+    );
 
     // Kotlin sees a plain value / nullable value — a borrowed sum is not a
     // handle, so there is nothing to close and no lifetime to track.

--- a/prebindgen-jni/src/jni/trait_impl.rs
+++ b/prebindgen-jni/src/jni/trait_impl.rs
@@ -1016,15 +1016,11 @@ impl JniGenBuilder {
         // built out of the conversions for its inners, which are compiled
         // first. That is the same order the converter table was filled in, so
         // a fragment is there exactly when a table entry would have been.
-        // Callback layouts whose arguments have no composable deconstructor
-        // still use the shared Invoke composer, but enter it without child
-        // fragments. Their late plan is recorded beside the compatibility
-        // fragment below, so neither path renders during resolution.
         // Compositions that refused. See `compile_crossing`: these are adapter
         // invariants, reported together once the walk is done.
         let mut refusals: Vec<String> = Vec::new();
         let registry = declared
-            .convert_with(|crossing, built, emit| {
+            .convert_with(|crossing, built, _emit| {
                 let mut compiler = prebindgen_registry::recipe::Compiler::resume(
                     &model,
                     decls.recipe_table(),
@@ -1032,30 +1028,9 @@ impl JniGenBuilder {
                     decls.compiled.borrow().clone(),
                 );
                 let compiled =
-                    decls.compile_crossing(&mut compiler, crossing, built, emit, &mut refusals);
+                    decls.compile_crossing(&mut compiler, crossing, built, &mut refusals);
                 *decls.compiled.borrow_mut() = compiler.finish();
-                let (conv, compatibility) = compiled?;
-                let (dir, key) = crossing;
-                let compiled_by_recipe = decls.compiled.borrow().fragment(key, *dir).is_some();
-                if decls.is_callback_crossing(crossing, built) && !compiled_by_recipe {
-                    let rust = compatibility.expect(
-                        "a callback outside the recipe compiler retains its late Invoke plan",
-                    );
-                    // Index the whole-value compatibility plan with the same
-                    // lookup and late renderer used for recipe-built callbacks.
-                    decls.compiled.borrow_mut().record(
-                        prebindgen_registry::recipe::CrossingKey {
-                            ty: key.clone(),
-                            direction: *dir,
-                        }
-                        .row(crate::jni::recipes::callback()),
-                        crate::jni::compile::JFrag::by_hand_with_rust(
-                            key.clone(),
-                            conv.clone(),
-                            rust,
-                        ),
-                    );
-                }
+                let conv = compiled?;
                 // The conversion stays here; what the registry gets back is
                 // which other crossings this one delegates to, which is what
                 // its reachability walk needs.
@@ -1186,19 +1161,6 @@ impl Declarations {
     ///
     /// `None` is *cannot*, never *not yet*: the crossings arrive inner-first,
     /// so everything this could compose from is already in `built`.
-    /// Whether this crossing is the callback shape `compile_crossing` answers
-    /// without the compiler.
-    fn is_callback_crossing<R: Conversions>(&self, crossing: &Crossing, built: &R) -> bool {
-        let (dir, key) = crossing;
-        matches!(dir, Direction::Construct)
-            && built.reading(key).is_some_and(|r| {
-                matches!(
-                    r.unwrapped().kind(),
-                    prebindgen_registry::flat::TypeKind::Callback { .. }
-                )
-            })
-    }
-
     fn compile_crossing<'v, R: Conversions>(
         &'v self,
         compiler: &mut prebindgen_registry::recipe::Compiler<
@@ -1207,12 +1169,8 @@ impl Declarations {
         >,
         crossing: &Crossing,
         built: &'v R,
-        emit: &prebindgen_registry::Emit,
         refusals: &mut Vec<String>,
-    ) -> Option<(
-        ConverterImpl<KotlinMeta>,
-        Option<crate::jni::chain::JFunction>,
-    )> {
+    ) -> Option<ConverterImpl<KotlinMeta>> {
         let (dir, key) = crossing;
         // The reading the scan already took for this crossing, fetched by the
         // key the crossing IS.
@@ -1225,22 +1183,7 @@ impl Declarations {
             site: None,
         };
         let crossing = prebindgen_registry::recipe::Crossing::new(reading, direction);
-        let fragment = match compiler.crossing(&mut adapter, &crossing) {
-            Ok(fragment) => fragment,
-            Err(prebindgen_registry::recipe::CompileError::Adapter(
-                crate::jni::compile::JErr::Refused(_),
-            )) => {
-                let prebindgen_registry::flat::TypeKind::Callback { args } =
-                    crossing.spelled().unwrapped().kind()
-                else {
-                    return None;
-                };
-                return self
-                    .dispatch_fn_input(crossing.spelled(), args, built, None, emit)
-                    .map(|(conv, rust)| (conv, Some(rust)));
-            }
-            Err(_) => return None,
-        };
+        let fragment = compiler.crossing(&mut adapter, &crossing).ok()?;
         // A `data_class` also states a recipe that says what it is made of.
         // Compiling that named recipe equips whole-value input, output and
         // callback paths with the same registry-owned Product descriptor.
@@ -1281,7 +1224,7 @@ impl Declarations {
                 ));
             }
         }
-        Some(((*fragment).clone().conv, None))
+        Some((*fragment).clone().conv)
     }
 
     pub fn declare_into(
@@ -1525,7 +1468,7 @@ impl Declarations {
         source: &prebindgen_registry::flat::TypeRef,
         args: &[prebindgen_registry::flat::TypeRef],
         registry: &impl Conversions,
-        arg_fragments: Option<&[&crate::jni::compile::JFrag]>,
+        arg_fragments: &[&crate::jni::compile::JFrag],
         emit: &prebindgen_registry::Emit,
     ) -> Option<(ConverterImpl<KotlinMeta>, crate::jni::chain::JFunction)> {
         let (wire, plan) = callback_input(self, source, args, registry, arg_fragments, emit)?;


### PR DESCRIPTION
## Summary

Finish the Invoke-side JNI migration by retaining each callback argument's registry-compiled deconstruct fragment and freezing its exact outgoing ABI operation before Rust rendering.

## Why

Invoke already owned callback capture and invocation, but JniGen still had two ways to prepare arguments:

- recipe-built callbacks received child fragments;
- callbacks whose Rust-only argument had no whole JNI representation escaped through a named compatibility row and rebuilt converters from the legacy tables.

Callback rendering also reconstructed output stage order and could look a converter up again by `TypeRef`. That left callback behavior outside the registry fragment graph and made the old pipeline non-removable.

## What changed

- Remove the callback atomic bypass, the `callback` compatibility recipe row, the handwritten fragment constructor, and fallback callback compilation.
- Require Invoke to supply one compiled child fragment for every callback argument.
- Retain the exact outgoing pipeline, projection, dependency, wires, and composed Product/Optional/Choice chain while the registry compiler is active.
- Represent a Rust-only output expansion with no whole JNI representation as an ordinary composed-only deconstruct fragment, so its registry `UnfoldPlan` remains usable by Invoke.
- Make whole-value callback delivery invoke the frozen pipeline instead of rebuilding `pre_stages` and converter order.
- Freeze ordinary fixed-builder output chains as part of the same delivery contract; this removes the final renderer-time chain lookup exposed by the callback work.
- Preserve Product reuse for `Option<Vec<T>>`: the outer optional gates the fold and does not change the per-element chain.
- Update the committed covertest Rust fixture and seam tests.

## Compatibility

Generated Kotlin, the JNI native names and descriptors, callback interfaces, and the report are unchanged.

The committed generated Rust changes are private restructuring: callbacks and fixed Choice/Optional returns delegate to retained converter pipelines instead of expanding the same stage or match logic at the wrapper site. Exported behavior and ABI are unchanged.

## Validation

- `cargo test --workspace`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps`
- `cargo fmt --all --check`
- `git diff --check`
- `bash examples/regen-check.sh` — the committed fixture is current; relative to the base, only `examples/covertest-kotlin/src/generated_bindings.rs` changes
- `cd examples/covertest-kotlin && ./gradlew run` — all 61 sections passed

## Relationship

Child of #513, stage 6. Error-handler delivery remains the next explicit slice.