### PR TITLE
Freeze registry-planned JNI error delivery

### DIFF
--- a/prebindgen-jni/src/jni/compile.rs
+++ b/prebindgen-jni/src/jni/compile.rs
@@ -493,9 +493,10 @@ pub(crate) struct OutWire {
     /// form reached through an `Option` puts every value under it in doubt —
     /// and the site that splices is what sets it.
     pub(crate) nullable: bool,
-    /// JNI-specific operation frozen when a return site selects this
-    /// registry-composed wire. Legacy callback/error deliveries synthesized
-    /// directly from `UnfoldLeaf` leave this absent until the Invoke stage.
+    /// JNI-specific operation frozen when a return, callback, or error site
+    /// selects this registry-composed wire. `None` is valid only while a
+    /// structural recipe/interface is being described; Rust delivery rejects
+    /// a reached wire whose operation was not frozen during planning.
     pub(crate) abi: Option<OutAbi>,
 }
 

--- a/prebindgen-jni/src/jni/emit/delivery.rs
+++ b/prebindgen-jni/src/jni/emit/delivery.rs
@@ -548,20 +548,7 @@ pub(crate) struct Delivered<'a> {
 }
 
 impl<'a> Delivered<'a> {
-    /// The site one expansion plan describes.
-    pub(crate) fn of(plan: &'a prebindgen_registry::unfold::UnfoldPlan) -> Self {
-        Self {
-            wires: crate::jni::compile::OutWire::from_leaves(&plan.leaves),
-            hoists: &plan.hoists,
-            by_ref: plan.by_ref,
-            chain: None,
-            fixed_product: plan.fixed_builder,
-            optional: plan.is_optional_base(),
-        }
-    }
-
-    /// Ordinary return delivery from the registry-compiled return site. Unlike
-    /// `of`, this does not reconstruct wires from the legacy unfold leaves.
+    /// Delivery from a registry-compiled return, callback, or error site.
     pub(crate) fn planned(
         plan: &'a prebindgen_registry::unfold::UnfoldPlan,
         wires: Vec<crate::jni::compile::OutWire>,
@@ -918,8 +905,8 @@ fn reach_leaf(
 /// null leaf) — see [`reach_leaf`]. Error arms are produced by `fail` (see
 /// [`cast_wire_to_jobject`]). Shared by the return-delivery site
 /// ([`emit_unfold_delivery`]), the callback trampoline, and the domain-error
-/// arm of fallible externs (whose `fail` falls back to a binding-error
-/// `signal_error` with default ze values).
+/// arm of fallible externs (whose `fail` routes an encoding failure to the
+/// binding-error channel).
 pub(crate) fn encode_plan_leaves(
     ext: &Declarations,
     registry: &impl Conversions,
@@ -1221,88 +1208,29 @@ pub(crate) fn encode_plan_leaves(
         let value = &value;
         let (frozen_pipeline, frozen_projection) = match &leaf.abi {
             Some(crate::jni::compile::OutAbi::Value(value)) => {
-                (Some(&value.pipeline), value.projection.as_ref())
+                (&value.pipeline, value.projection.as_ref())
             }
             Some(crate::jni::compile::OutAbi::Tag) => {
                 unreachable!("sum selector segments are encoded above")
             }
-            None => (None, None),
+            None => panic!(
+                "jnigen delivery: leaf `{}` reached Rust rendering without a frozen output ABI",
+                leaf.name
+            ),
         };
-        // Callback/error delivery still arrives through legacy synthesized
-        // leaves until the Invoke stage. Ordinary return delivery always has a
-        // frozen ABI and never enters this compatibility branch.
-        let legacy_entry = frozen_pipeline.is_none().then(|| {
-            ext.out_frag(&leaf.out_ty).unwrap_or_else(|| {
-                panic!(
-                    "jnigen unfold: leaf `{}` has no registered output converter",
-                    leaf.out_ty.key()
-                )
-            })
-        });
-        if let Some(entry) = &legacy_entry {
-            entry.activate();
-        }
-        let projection = frozen_projection.or_else(|| {
-            legacy_entry
-                .as_ref()
-                .and_then(|entry| entry.metadata.projection.as_ref())
-        });
-        let wire = frozen_pipeline.map_or_else(
-            || {
-                legacy_entry
-                    .as_ref()
-                    .expect("legacy output leaf has an entry")
-                    .destination
-                    .clone()
-            },
-            |pipeline| pipeline.wire().clone(),
-        );
+        let projection = frozen_projection;
+        let wire = frozen_pipeline.wire().clone();
         let conv_fail = fail(quote!(__e.to_string()));
         let conv = |input: TokenStream| -> TokenStream {
-            if let Some(pipeline) = frozen_pipeline {
-                let call = pipeline.invoke(input, emit);
-                return quote! {
-                    match #call {
-                        ::core::result::Result::Ok(__w) => __w,
-                        ::core::result::Result::Err(__e) => {
-                            #conv_fail
-                        }
-                    }
-                };
-            }
-            let out_entry = legacy_entry
-                .as_ref()
-                .expect("compatibility output leaf has an entry");
-            // Legacy callback/error leaf: reconstruct its semantic stages until
-            // those paths retain the same registry site result.
-            let conv_stages: Vec<syn::Ident> = out_entry
-                .output_stage_order()
-                .map(|(_, stage)| stage.function.sig.ident.clone())
-                .collect();
-            let conv_fn = out_entry.converter_ident().clone();
-            let step = |f: &syn::Ident, arg: TokenStream| {
-                quote! {
-                    match #f(&mut env, #arg) {
-                        ::core::result::Result::Ok(__w) => __w,
-                        ::core::result::Result::Err(__e) => {
-                            #conv_fail
-                        }
+            let call = frozen_pipeline.invoke(input, emit);
+            quote! {
+                match #call {
+                    ::core::result::Result::Ok(__w) => __w,
+                    ::core::result::Result::Err(__e) => {
+                        #conv_fail
                     }
                 }
-            };
-            if conv_stages.is_empty() {
-                return step(&conv_fn, input);
             }
-            let mut body = TokenStream::new();
-            let mut previous = input;
-            for (order, stage_fn) in conv_stages.iter().enumerate() {
-                let next = format_ident!("__cs{}_{}", idx, order);
-                let call = step(stage_fn, previous);
-                body.extend(quote! { let #next = #call; });
-                previous = quote!(#next);
-            }
-            let last = step(&conv_fn, previous);
-            quote!({ #body #last })
         };
 
         // Bind `obj_ident` to a JObject-yielding `expr`.
@@ -1652,9 +1580,10 @@ pub(crate) fn leaf_is_prim(ext: &Declarations, leaf: &crate::jni::compile::OutWi
     leaf_ty_is_prim(ext, &leaf.out_ty)
 }
 
-/// Final JNI wire for one outgoing leaf. Ordinary return sites retain it in
-/// their frozen ABI; callback/error compatibility leaves still resolve it from
-/// the adapter until the Invoke stage.
+/// Final JNI wire for one outgoing leaf. Every Rust delivery site retains this
+/// in its frozen ABI. The `None` branch serves only structural interface
+/// derivation, which describes raw recipe leaves before a concrete site is
+/// frozen and never emits their conversion.
 pub(crate) fn leaf_wire(ext: &Declarations, leaf: &crate::jni::compile::OutWire) -> syn::Type {
     match &leaf.abi {
         Some(crate::jni::compile::OutAbi::Tag) => syn::parse_quote!(jni::sys::jint),

--- a/prebindgen-jni/src/jni/emit/sum_out.rs
+++ b/prebindgen-jni/src/jni/emit/sum_out.rs
@@ -319,70 +319,28 @@ fn encode_group_leaf(
     emit: &prebindgen_registry::Emit,
 ) -> TokenStream {
     let frozen_pipeline = match &leaf.abi {
-        Some(crate::jni::compile::OutAbi::Value(value)) => Some(&value.pipeline),
+        Some(crate::jni::compile::OutAbi::Value(value)) => &value.pipeline,
         Some(crate::jni::compile::OutAbi::Tag) => {
             unreachable!("a Choice payload is not its selector")
         }
-        None => None,
+        None => panic!(
+            "jnigen sum delivery: payload leaf `{}` reached Rust rendering without a frozen output ABI",
+            leaf.name
+        ),
     };
-    // Callback/error delivery still synthesizes compatibility leaves. An
-    // ordinary return's Choice payload always carries the frozen pipeline.
-    let legacy_entry = frozen_pipeline.is_none().then(|| {
-        ext.out_frag(&leaf.out_ty).unwrap_or_else(|| {
-            panic!(
-                "jnigen sum unfold: payload leaf `{}` (`{}`) has no registered output converter",
-                leaf.name,
-                leaf.out_ty.key()
-            )
-        })
-    });
-    if let Some(entry) = &legacy_entry {
-        entry.activate();
-    }
     let wire = leaf_wire(ext, leaf);
     let conv_fail = fail(quote!(__e.to_string()));
     let enc = format_ident!("__enc_{}", obj_ident);
     let mut encode = TokenStream::new();
-    if let Some(pipeline) = frozen_pipeline {
-        let call = pipeline.invoke(quote!(#bind.clone()), emit);
-        encode.extend(quote! {
-            let #enc = match #call {
-                ::core::result::Result::Ok(__w) => __w,
-                ::core::result::Result::Err(__e) => {
-                    #conv_fail
-                }
-            };
-        });
-    } else {
-        let out_entry = legacy_entry
-            .as_ref()
-            .expect("compatibility Choice payload has an output entry");
-        // Legacy callback/error payload: reconstruct its semantic stages until
-        // those paths retain the same registry site result.
-        let mut previous = quote!(#bind.clone());
-        for (order, (_, stage)) in out_entry.output_stage_order().enumerate() {
-            let stage_fn = &stage.function.sig.ident;
-            let next = format_ident!("__enc_{}_s{}", obj_ident, order);
-            encode.extend(quote! {
-                let #next = match #stage_fn(&mut env, #previous) {
-                    ::core::result::Result::Ok(__w) => __w,
-                    ::core::result::Result::Err(__e) => {
-                        #conv_fail
-                    }
-                };
-            });
-            previous = quote!(#next);
-        }
-        let conv = out_entry.converter_ident();
-        encode.extend(quote! {
-            let #enc = match #conv(&mut env, #previous) {
-                ::core::result::Result::Ok(__w) => __w,
-                ::core::result::Result::Err(__e) => {
-                    #conv_fail
-                }
-            };
-        });
-    }
+    let call = frozen_pipeline.invoke(quote!(#bind.clone()), emit);
+    encode.extend(quote! {
+        let #enc = match #call {
+            ::core::result::Result::Ok(__w) => __w,
+            ::core::result::Result::Err(__e) => {
+                #conv_fail
+            }
+        };
+    });
     if prim {
         let letter = jni_field_access(&wire)
             .expect("leaf_is_prim guarantees a primitive wire")

--- a/prebindgen-jni/src/jni/emit/wrapper.rs
+++ b/prebindgen-jni/src/jni/emit/wrapper.rs
@@ -329,7 +329,7 @@ pub(crate) fn emit_jni_function_wrapper_with_callee(
         let (ze_stmts, ze_args, _) = encode_plan_leaves(
             ext,
             registry,
-            crate::jni::emit::Delivered::of(ep),
+            crate::jni::emit::Delivered::planned(&ep.unfold, ep.wires.clone(), ep.chain.clone()),
             &eze_idents,
             &quote!(__de),
             &ze_fail,

--- a/prebindgen-jni/src/jni/fn_plan.rs
+++ b/prebindgen-jni/src/jni/fn_plan.rs
@@ -43,11 +43,31 @@ pub(crate) struct JniFunctionPlan {
     /// Rust delivery, Kotlin surface/KDoc, and the report all consume this
     /// owned plan after the registry phase is closed.
     pub unfold: Option<prebindgen_registry::unfold::UnfoldPlan>,
-    /// Registry-resolved domain-error decomposition selected for this
-    /// function. Rust encoding and every Kotlin artifact share this value.
-    pub error: Option<prebindgen_registry::unfold::UnfoldPlan>,
+    /// Registry-resolved domain-error delivery selected for this function.
+    /// The structural decomposition, exact outgoing JNI operations, and any
+    /// composed converter are frozen together before either writer runs.
+    pub error: Option<ErrorOutputPlan>,
     pub params: Vec<PlanParam>,
     pub output: FnOutputPlan,
+}
+
+/// Frozen delivery of a fallible function's `Err(E)` arm.
+///
+/// Kotlin and report generation read [`Self::unfold`]. Rust delivery consumes
+/// [`Self::wires`] and [`Self::chain`], so it cannot reconstruct converters
+/// from `TypeRef` while rendering the wrapper.
+pub(crate) struct ErrorOutputPlan {
+    pub unfold: prebindgen_registry::unfold::UnfoldPlan,
+    pub wires: Vec<crate::jni::compile::OutWire>,
+    pub chain: Option<crate::jni::compile::ComposedChain>,
+}
+
+impl std::ops::Deref for ErrorOutputPlan {
+    type Target = prebindgen_registry::unfold::UnfoldPlan;
+
+    fn deref(&self) -> &Self::Target {
+        &self.unfold
+    }
 }
 
 /// One source parameter: the ident/type as written plus its lowered form.
@@ -639,6 +659,9 @@ impl JniFunctionPlan {
         // before the inputs, so an unresolved-output failure takes precedence
         // over an unresolved-input one.
         let output = build_output(ext, registry, f, unfold.as_ref(), error.as_ref())?;
+        let error = error
+            .map(|plan| build_error_output(ext, registry, plan))
+            .transpose()?;
         let mut params = Vec::new();
         // The element's parameters: each already a name and a `TypeRef`, so
         // there is no `FnArg`/`Pat` destructuring and no position that could
@@ -902,6 +925,49 @@ pub(crate) fn decomposed_return_for_test(
     let ret = ret.sequence_elem().unwrap_or(ret);
     let ret = ret.borrow_target().unwrap_or(ret);
     return_site(ext, registry, func, ret, None).and_then(|p| p.decomposed())
+}
+
+/// Freeze the exact Rust-to-JNI delivery selected for one domain-error plan.
+///
+/// Error decompositions may be function-unique value-form walks, so their
+/// leaves are always compiled directly through the registry. A model-derived
+/// Product/Optional/Choice additionally retains its composed converter; the
+/// renderer may use it only when its layout matches the declared error leaves.
+fn build_error_output(
+    ext: &Declarations,
+    registry: &Registry,
+    unfold: prebindgen_registry::unfold::UnfoldPlan,
+) -> Result<ErrorOutputPlan, PlanError> {
+    let wires =
+        crate::jni::compile::freeze_out_wires(ext, registry, &unfold.leaves).map_err(|_| {
+            PlanError::UnresolvedOutput {
+                ty: Box::new(unfold.source.clone()),
+            }
+        })?;
+    let delivered = if unfold.by_ref {
+        unfold.source.borrowed()
+    } else {
+        unfold.source.clone()
+    };
+    let delivered = if unfold.is_optional_base() {
+        delivered.optional()
+    } else {
+        delivered
+    };
+    let chain = if unfold.fixed_builder && unfold.hoists.is_empty() {
+        crate::jni::compile::freeze_output_chain(ext, registry, &delivered).map_err(|_| {
+            PlanError::UnresolvedOutput {
+                ty: Box::new(delivered),
+            }
+        })?
+    } else {
+        None
+    };
+    Ok(ErrorOutputPlan {
+        unfold,
+        wires,
+        chain,
+    })
 }
 
 /// Lower the output side. Mirrors the historical derivations exactly:

--- a/prebindgen-jni/src/jni/mod.rs
+++ b/prebindgen-jni/src/jni/mod.rs
@@ -735,6 +735,20 @@ impl JniGen {
         ))
     }
 
+    /// Frozen domain-error operation coverage for one fallible function:
+    /// `(wire count, every wire has an ABI, composed chain present)`.
+    #[cfg(test)]
+    pub(crate) fn error_freeze_for_test(&self, func: &str) -> Option<(usize, bool, bool)> {
+        let ident = syn::Ident::new(func, proc_macro2::Span::call_site());
+        let plan = self.decls.generation.as_ref()?.function(&ident)?;
+        let error = plan.error.as_ref()?;
+        Some((
+            error.wires.len(),
+            error.wires.iter().all(|wire| wire.abi.is_some()),
+            error.chain.is_some(),
+        ))
+    }
+
     /// The leaves the registry's own expansion plans for one function, in the
     /// form [`Self::out_lines_for_test`] renders a recipe in.
     ///

--- a/prebindgen-jni/src/jni/tests/flatten.rs
+++ b/prebindgen-jni/src/jni/tests/flatten.rs
@@ -165,6 +165,11 @@ fn error_unwrap_universal_records() {
     let _ = std::fs::remove_dir_all(&dir);
     std::fs::create_dir_all(&dir).unwrap();
     let gen = jni.build_with(registry).expect("resolve");
+    assert_eq!(
+        gen.error_freeze_for_test("z_fallible"),
+        Some((3, true, false)),
+        "the function-unique error walk must freeze every delivered leaf before rendering",
+    );
     let rust_path = gen.write_rust(dir.join("gen.rs")).expect("write_rust");
     let rust = std::fs::read_to_string(&rust_path).unwrap();
     let rc: String = rust.split_whitespace().collect();


### PR DESCRIPTION
## Summary

Finish the domain-error side of JNI output migration by freezing each fallible function's exact Rust-to-JNI error delivery before rendering.

## Why

After #538, callback Invoke delivery consumed retained registry fragments, but typed `Err(E)` delivery still reconstructed `OutWire` values from `UnfoldPlan` during wrapper rendering. Those wires had no frozen ABI, so generic and Choice encoders could re-query `Declarations::out_frag` and manually replay `output_stage_order`.

That was the final callback/error compatibility boundary in stage 6 and left the same output encoder with both planned and legacy execution modes.

## What changed

- Replace the raw function error decomposition with an `ErrorOutputPlan` that retains the structural unfold plan, every exact outgoing wire operation, and any matching Product/Optional/Choice composed chain.
- Compile and activate each error leaf's registry-selected pipeline, projection, dependency, and final wire before rendering begins.
- Make the domain-error wrapper use `Delivered::planned` with those retained operations.
- Delete the ABI-less `Delivered::of` constructor.
- Make generic leaf and Choice-payload Rust delivery require a frozen ABI.
- Delete their renderer-time converter lookup and handwritten stage-order assembly.
- Preserve the established output-first resolution/diagnostic precedence.
- Add a seam assertion that the function-unique three-leaf error walk is fully frozen.

## Compatibility

All committed generated Rust, Kotlin, JNI names/descriptors, callback interfaces, and reports are byte-identical after regeneration. This is an internal planning/rendering simplification only.

## Validation

- `cargo test -p prebindgen-jni` — 283 tests plus doctests
- `cargo test --workspace`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps`
- `cargo fmt --all --check`
- `git diff --check`
- `bash examples/regen-check.sh` — byte-identical
- `cd examples/covertest-kotlin && ./gradlew run` — all 61 sections passed

## Relationship

Child of #513. Together with #538, this completes the callback/error delivery deletion unit in stage 6.