### PR TITLE
Render C custom terminals from frozen plans

### DIFF
--- a/prebindgen-c/src/chain.rs
+++ b/prebindgen-c/src/chain.rs
@@ -56,6 +56,7 @@ pub(crate) struct CFunction {
 #[derive(Clone)]
 enum CBody {
     Complete(syn::ItemFn),
+    Custom(CustomPlan),
     Product(ProductPlan),
     Optional(OptionalPlan),
     Sequence(SequencePlan),
@@ -83,6 +84,14 @@ impl CFunction {
         Self {
             call,
             body: CBody::Product(plan),
+        }
+    }
+
+    pub(crate) fn custom(plan: CustomPlan) -> Self {
+        let call = CCall(chain::Call::new(plan.ident.clone(), plan.fallible(), false));
+        Self {
+            call,
+            body: CBody::Custom(plan),
         }
     }
 
@@ -139,6 +148,11 @@ impl CFunction {
         matches!(self.body, CBody::DeferredInvoke)
     }
 
+    #[cfg(test)]
+    pub(crate) fn is_custom(&self) -> bool {
+        matches!(self.body, CBody::Custom(_))
+    }
+
     pub(crate) fn call(&self) -> &CCall {
         &self.call
     }
@@ -152,6 +166,7 @@ impl RustFunction for CFunction {
     fn render(&self, emit: &Emit) -> syn::ItemFn {
         match &self.body {
             CBody::Complete(function) => function.clone(),
+            CBody::Custom(plan) => plan.render(emit),
             CBody::Product(plan) => plan.render(emit),
             CBody::Choice(plan) => plan.render(emit),
             CBody::Sequence(plan) => plan.render(emit),
@@ -159,6 +174,154 @@ impl RustFunction for CFunction {
             CBody::DeferredInvoke => {
                 unreachable!("a deferred C Invoke helper is rendered by its callback artifact")
             }
+        }
+    }
+}
+
+/// The operation behind one canonical scalar `convert!` declaration.
+///
+/// The callable path and wire type belong to the adapter and are safe to freeze
+/// during planning. The Rust value type remains a [`TypeRef`] in
+/// [`CustomPlan`] until final rendering.
+#[derive(Clone)]
+pub(crate) enum CustomOperation {
+    Function {
+        path: syn::Path,
+        by_ref: bool,
+        fallible: bool,
+    },
+    Trait {
+        fallible: bool,
+    },
+}
+
+impl CustomOperation {
+    fn fallible(&self) -> bool {
+        match self {
+            Self::Function { fallible, .. } | Self::Trait { fallible } => *fallible,
+        }
+    }
+
+    fn expression(&self, direction: Direction, source: &syn::Type, wire: &syn::Type) -> syn::Expr {
+        match self {
+            Self::Function { path, by_ref, .. } => {
+                if *by_ref {
+                    syn::parse_quote!(#path(&v))
+                } else {
+                    syn::parse_quote!(#path(v))
+                }
+            }
+            Self::Trait { fallible: true } => match direction {
+                Direction::Construct => syn::parse_quote!(
+                    <#wire as ::core::convert::TryInto<#source>>::try_into(v)
+                ),
+                Direction::Deconstruct => syn::parse_quote!(
+                    <#source as ::core::convert::TryInto<#wire>>::try_into(v)
+                ),
+            },
+            Self::Trait { fallible: false } => match direction {
+                Direction::Construct => syn::parse_quote!(
+                    <#wire as ::core::convert::Into<#source>>::into(v)
+                ),
+                Direction::Deconstruct => syn::parse_quote!(
+                    <#source as ::core::convert::Into<#wire>>::into(v)
+                ),
+            },
+        }
+    }
+}
+
+/// One canonical scalar conversion, frozen before source spelling is allowed.
+#[derive(Clone)]
+pub(crate) struct CustomPlan {
+    pub(crate) ident: syn::Ident,
+    pub(crate) source: TypeRef,
+    pub(crate) source_module: Option<syn::Path>,
+    pub(crate) wire: syn::Type,
+    pub(crate) direction: Direction,
+    pub(crate) operation: CustomOperation,
+    pub(crate) valid: Option<syn::Expr>,
+    pub(crate) invalid_message: String,
+}
+
+impl CustomPlan {
+    pub(crate) fn fallible(&self) -> bool {
+        self.valid.is_some() || self.operation.fallible()
+    }
+
+    fn render(&self, emit: &Emit) -> syn::ItemFn {
+        let name = &self.ident;
+        let source = qualify_source_type(&emit.spell_ty(&self.source), self.source_module.as_ref());
+        let wire = &self.wire;
+        let conversion = self.operation.expression(self.direction, &source, wire);
+        let conversion_fallible = self.operation.fallible();
+
+        match self.direction {
+            Direction::Construct if self.fallible() => {
+                let valid = self
+                    .valid
+                    .as_ref()
+                    .cloned()
+                    .unwrap_or_else(|| syn::parse_quote!(true));
+                let message = &self.invalid_message;
+                let converted = if conversion_fallible {
+                    quote!((#conversion).map_err(|e| e.to_string()))
+                } else {
+                    quote!(::core::result::Result::Ok(#conversion))
+                };
+                syn::parse_quote!(
+                    #[allow(non_snake_case, unused_variables, dead_code)]
+                    pub(crate) fn #name(v: #wire)
+                        -> ::core::result::Result<#source, ::std::string::String>
+                    {
+                        if !(#valid) {
+                            return ::core::result::Result::Err(
+                                ::std::string::String::from(#message)
+                            );
+                        }
+                        #converted
+                    }
+                )
+            }
+            Direction::Construct => syn::parse_quote!(
+                #[allow(non_snake_case, unused_variables, dead_code)]
+                pub(crate) fn #name(v: #wire) -> #source {
+                    #conversion
+                }
+            ),
+            Direction::Deconstruct if self.fallible() => {
+                let valid = self
+                    .valid
+                    .as_ref()
+                    .cloned()
+                    .unwrap_or_else(|| syn::parse_quote!(true));
+                let message = &self.invalid_message;
+                let repr_expr = if conversion_fallible {
+                    quote!((#conversion).map_err(|error| error.to_string())?)
+                } else {
+                    quote!(#conversion)
+                };
+                syn::parse_quote!(
+                    #[allow(non_snake_case, unused_variables, dead_code)]
+                    pub(crate) fn #name(v: #source)
+                        -> ::core::result::Result<#wire, ::std::string::String>
+                    {
+                        let __repr: #wire = #repr_expr;
+                        if !(#valid) {
+                            return ::core::result::Result::Err(
+                                ::std::string::String::from(#message)
+                            );
+                        }
+                        ::core::result::Result::Ok(__repr)
+                    }
+                )
+            }
+            Direction::Deconstruct => syn::parse_quote!(
+                #[allow(non_snake_case, unused_variables, dead_code)]
+                pub(crate) fn #name(v: #source) -> #wire {
+                    #conversion
+                }
+            ),
         }
     }
 }

--- a/prebindgen-c/src/compile.rs
+++ b/prebindgen-c/src/compile.rs
@@ -457,6 +457,35 @@ impl CFrag {
             value,
         }
     }
+
+    /// A canonical scalar conversion retained as an operation until final
+    /// Rust emission rather than routed through `ConverterImpl::function`.
+    fn from_custom(at: At<'_>, plan: crate::chain::CustomPlan, niches: Niches) -> Self {
+        let destination = plan.wire.clone();
+        let subs = vec![TypeKey::from_type(&destination)];
+        let function = CFunction::custom(plan);
+        let value = CValue::Direct {
+            wire: destination.clone(),
+            converter: function.call().clone(),
+            niches: niches.clone(),
+        };
+        Self {
+            id: FragmentId::new(at.crossing.spelled().key(), at.recipe.clone()),
+            source: at.crossing.spelled().clone(),
+            destination,
+            function,
+            niches,
+            subs,
+            arm: None,
+            yields: Yield {
+                ty: at.crossing.value().stripped_key(),
+                mode: at.crossing.mode(),
+                validity: Validity::SelfSufficient,
+            },
+            shape: CShape::Atomic,
+            value,
+        }
+    }
 }
 
 /// How long what this conversion produces stays usable.
@@ -601,11 +630,16 @@ impl<R: Conversions> Compile for CCompile<'_, R> {
             };
             return self.wrap(at, "no field reading for this type", conv);
         }
+        if let Some((plan, niches)) =
+            self.gen
+                .custom_plan(ty, self.registry, at.crossing.direction())
+        {
+            return Ok(CFrag::from_custom(at, plan, niches));
+        }
         let conv = match at.crossing.direction() {
             Direction::Construct => self
                 .gen
-                .in_custom(ty, self.registry, cx.emit())
-                .or_else(|| self.gen.in_opaque_handle(ty))
+                .in_opaque_handle(ty)
                 .or_else(|| self.gen.in_value_opaque(ty, self.registry))
                 .or_else(|| self.gen.in_enum(ty, self.registry))
                 .or_else(|| self.gen.in_string(ty))
@@ -615,8 +649,7 @@ impl<R: Conversions> Compile for CCompile<'_, R> {
                 .or_else(|| self.gen.in_borrow(ty)),
             Direction::Deconstruct => self
                 .gen
-                .out_custom(ty, self.registry, cx.emit())
-                .or_else(|| self.gen.out_terminal(ty, self.registry, cx.emit()))
+                .out_terminal(ty, self.registry, cx.emit())
                 .or_else(|| self.gen.out_borrow_or_result(ty)),
         };
         self.wrap(at, "no C representation for this type", conv)

--- a/prebindgen-c/src/convert.rs
+++ b/prebindgen-c/src/convert.rs
@@ -52,16 +52,19 @@ impl CbindgenBuilder {
         items
     }
 
-    pub(crate) fn in_custom(
+    pub(crate) fn custom_plan(
         &self,
         ty: &TypeRef,
         registry: &impl Conversions,
-        emit: &prebindgen_registry::Emit,
-    ) -> Option<ConverterImpl> {
+        direction: Direction,
+    ) -> Option<(crate::chain::CustomPlan, Niches)> {
         let key = ty.key();
         let decl = self.convert_decls.iter().find(|d| *d.key() == key)?;
-        let spec = decl.input_spec().as_ref()?;
-        let (repr, conversion, fallible) = self.input_conversion(decl, spec, registry, emit);
+        let spec = match direction {
+            Direction::Construct => decl.input_spec().as_ref()?,
+            Direction::Deconstruct => decl.output_spec().as_ref()?,
+        };
+        let (repr, operation) = self.custom_operation(decl, spec, registry, direction);
         assert!(
             is_scalar(&repr),
             "Cbindgen custom representations must be C scalar types"
@@ -70,212 +73,96 @@ impl CbindgenBuilder {
             assert_eq!(
                 TypeKey::from_type(domain.ty()),
                 TypeKey::from_type(&repr),
-                "Cbindgen conversion domain type does not match its input representation"
+                "Cbindgen conversion domain type does not match its {} representation",
+                match direction {
+                    Direction::Construct => "input",
+                    Direction::Deconstruct => "output",
+                }
             );
         }
-        let src = self.src_ty_of(&key);
-        let wire = repr.clone();
-        let name = Self::in_name_of(&key);
+        let ident = match direction {
+            Direction::Construct => Self::in_name_of(&key),
+            Direction::Deconstruct => Self::out_name_of(&key),
+        };
         let valid = decl
             .domain()
             .as_ref()
-            .map(|d| d.contains_expr(quote!(v)))
-            .unwrap_or_else(|| quote!(true));
-        let msg = format!("{} representation is outside its declared domain", key);
-        let function: syn::ItemFn = if decl.domain().is_some() || fallible {
-            let converted = if fallible {
-                quote!((#conversion).map_err(|e| e.to_string()))
-            } else {
-                quote!(::core::result::Result::Ok(#conversion))
-            };
-            syn::parse_quote!(
-                #[allow(non_snake_case, unused_variables, dead_code)]
-                pub(crate) fn #name(v: #wire)
-                    -> ::core::result::Result<#src, ::std::string::String>
-                {
-                    if !(#valid) {
-                        return ::core::result::Result::Err(
-                            ::std::string::String::from(#msg)
-                        );
-                    }
-                    #converted
-                }
-            )
-        } else {
-            syn::parse_quote!(
-                #[allow(non_snake_case, unused_variables, dead_code)]
-                pub(crate) fn #name(v: #wire) -> #src {
-                    #conversion
-                }
-            )
-        };
-        let niches = self.c_domain_niches(decl, registry, Direction::Construct);
-        Some(ConverterImpl {
-            subs: vec![TypeKey::from_type(&repr)],
-            destination: wire,
-            function,
-            pre_stages: vec![],
+            .map(|domain| match direction {
+                Direction::Construct => domain.contains_expr(quote!(v)),
+                Direction::Deconstruct => domain.contains_expr(quote!(__repr)),
+            })
+            .map(|tokens| {
+                syn::parse2(tokens).expect("a representation-domain predicate is an expression")
+            });
+        let invalid_message = format!("{} representation is outside its declared domain", key);
+        let niches = self.c_domain_niches(decl, registry, direction);
+        Some((
+            crate::chain::CustomPlan {
+                ident,
+                source: ty.clone(),
+                source_module: self.source_module.clone(),
+                wire: repr,
+                direction,
+                operation,
+                valid,
+                invalid_message,
+            },
             niches,
-            metadata: (),
-        })
+        ))
     }
 
-    pub(crate) fn out_custom(
-        &self,
-        ty: &TypeRef,
-        registry: &impl Conversions,
-        emit: &prebindgen_registry::Emit,
-    ) -> Option<ConverterImpl> {
-        let key = ty.key();
-        let decl = self.convert_decls.iter().find(|d| *d.key() == key)?;
-        let spec = decl.output_spec().as_ref()?;
-        let (repr, conversion, fallible) = self.output_conversion(decl, spec, registry, emit);
-        assert!(
-            is_scalar(&repr),
-            "Cbindgen custom representations must be C scalar types"
-        );
-        if let Some(domain) = decl.domain() {
-            assert_eq!(
-                TypeKey::from_type(domain.ty()),
-                TypeKey::from_type(&repr),
-                "Cbindgen conversion domain type does not match its output representation"
-            );
-        }
-        let src = self.src_ty_of(&key);
-        let wire = repr.clone();
-        let name = Self::out_name_of(&key);
-        let valid = decl
-            .domain()
-            .as_ref()
-            .map(|d| d.contains_expr(quote!(__repr)))
-            .unwrap_or_else(|| quote!(true));
-        let msg = format!("{} representation is outside its declared domain", key);
-        let function: syn::ItemFn = if decl.domain().is_some() || fallible {
-            let repr_expr = if fallible {
-                quote!((#conversion).map_err(|error| error.to_string())?)
-            } else {
-                quote!(#conversion)
-            };
-            syn::parse_quote!(
-                #[allow(non_snake_case, unused_variables, dead_code)]
-                pub(crate) fn #name(v: #src)
-                    -> ::core::result::Result<#wire, ::std::string::String>
-                {
-                    let __repr: #repr = #repr_expr;
-                    if !(#valid) {
-                        return ::core::result::Result::Err(
-                            ::std::string::String::from(#msg)
-                        );
-                    }
-                    ::core::result::Result::Ok(__repr)
-                }
-            )
-        } else {
-            syn::parse_quote!(
-                #[allow(non_snake_case, unused_variables, dead_code)]
-                pub(crate) fn #name(v: #src) -> #wire {
-                    #conversion
-                }
-            )
-        };
-        let niches = self.c_domain_niches(decl, registry, Direction::Deconstruct);
-        Some(ConverterImpl {
-            subs: vec![TypeKey::from_type(&repr)],
-            destination: wire,
-            function,
-            pre_stages: vec![],
-            niches,
-            metadata: (),
-        })
-    }
-
-    fn input_conversion(
+    fn custom_operation(
         &self,
         decl: &ConvertDecl,
         spec: &ConvertSpec,
         registry: &impl Conversions,
-        emit: &prebindgen_registry::Emit,
-    ) -> (syn::Type, syn::Expr, bool) {
-        let target = self.src_ty_of(&decl.rust_type().key());
+        direction: Direction,
+    ) -> (syn::Type, crate::chain::CustomOperation) {
         match spec {
             ConvertSpec::PrebindgenFn(f) => {
                 let item = registry
                     .flat()
                     .function(&f)
                     .unwrap_or_else(|| panic!("Cbindgen conversion function {} was not found", f));
-                let (repr_reading, by_ref) = one_param(item);
-                let repr = emit.spell_ty(repr_reading);
-                // The element normalizes an elided return to `Unit`, and
-                // `TypeKind::Fallible` is the `Result` `result_parts` looked for
-                // in a path.
-                let (ok, fallible) = match item.ret.fallible_parts() {
-                    Some((ok, _)) => (ok, true),
-                    None => (&item.ret, false),
+                let (repr, by_ref, fallible) = match direction {
+                    Direction::Construct => {
+                        let (repr, by_ref) = one_param(item);
+                        let (ok, fallible) = match item.ret.fallible_parts() {
+                            Some((ok, _)) => (ok, true),
+                            None => (&item.ret, false),
+                        };
+                        assert_eq!(ok.key(), *decl.key());
+                        (repr, by_ref, fallible)
+                    }
+                    Direction::Deconstruct => {
+                        let (param, by_ref) = one_param(item);
+                        assert_eq!(param.key(), *decl.key());
+                        let (repr, fallible) = match item.ret.fallible_parts() {
+                            Some((ok, _)) => (ok, true),
+                            None => (&item.ret, false),
+                        };
+                        (repr, by_ref, fallible)
+                    }
                 };
-                assert_eq!(ok.key(), *decl.key());
+                let repr = scalar_ty(repr).unwrap_or_else(|| {
+                    panic!("Cbindgen custom representations must be C scalar types")
+                });
                 let path = self.conversion_fn_path(registry, f);
-                let expr = if by_ref {
-                    syn::parse_quote!(#path(&v))
-                } else {
-                    syn::parse_quote!(#path(v))
-                };
-                (repr, expr, fallible)
+                (
+                    repr,
+                    crate::chain::CustomOperation::Function {
+                        path,
+                        by_ref,
+                        fallible,
+                    },
+                )
             }
-            ConvertSpec::Trait { repr, fallible } => {
-                let expr = if *fallible {
-                    syn::parse_quote!(
-                        <#repr as ::core::convert::TryInto<#target>>::try_into(v)
-                    )
-                } else {
-                    syn::parse_quote!(
-                        <#repr as ::core::convert::Into<#target>>::into(v)
-                    )
-                };
-                (repr.clone(), expr, *fallible)
-            }
-        }
-    }
-
-    fn output_conversion(
-        &self,
-        decl: &ConvertDecl,
-        spec: &ConvertSpec,
-        registry: &impl Conversions,
-        emit: &prebindgen_registry::Emit,
-    ) -> (syn::Type, syn::Expr, bool) {
-        let target = self.src_ty_of(&decl.rust_type().key());
-        match spec {
-            ConvertSpec::PrebindgenFn(f) => {
-                let item = registry
-                    .flat()
-                    .function(&f)
-                    .unwrap_or_else(|| panic!("Cbindgen conversion function {} was not found", f));
-                let (param, by_ref) = one_param(item);
-                assert_eq!(param.key(), *decl.key());
-                let (repr, fallible) = match item.ret.fallible_parts() {
-                    Some((ok, _)) => (emit.spell_ty(ok), true),
-                    None => (emit.spell_ty(&item.ret), false),
-                };
-                let path = self.conversion_fn_path(registry, f);
-                let expr = if by_ref {
-                    syn::parse_quote!(#path(&v))
-                } else {
-                    syn::parse_quote!(#path(v))
-                };
-                (repr, expr, fallible)
-            }
-            ConvertSpec::Trait { repr, fallible } => {
-                let expr = if *fallible {
-                    syn::parse_quote!(
-                        <#target as ::core::convert::TryInto<#repr>>::try_into(v)
-                    )
-                } else {
-                    syn::parse_quote!(
-                        <#target as ::core::convert::Into<#repr>>::into(v)
-                    )
-                };
-                (repr.clone(), expr, *fallible)
-            }
+            ConvertSpec::Trait { repr, fallible } => (
+                repr.clone(),
+                crate::chain::CustomOperation::Trait {
+                    fallible: *fallible,
+                },
+            ),
         }
     }
 

--- a/prebindgen-c/src/tests/lowering.rs
+++ b/prebindgen-c/src/tests/lowering.rs
@@ -148,6 +148,71 @@ fn custom_conversion_without_domain_stays_infallible() {
     );
 }
 
+#[test]
+fn custom_conversion_stays_unrendered_until_final_write() {
+    let loc = SourceLocation::default();
+    let items: Vec<(syn::Item, SourceLocation)> = [
+        "pub fn ratio_from_f64(v: f64) -> Ratio { unimplemented!() }",
+        "pub fn ratio_to_f64(v: Ratio) -> f64 { unimplemented!() }",
+        "pub fn ratio_echo(v: Ratio) -> Ratio { unimplemented!() }",
+    ]
+    .into_iter()
+    .map(|source| (syn::parse_str(source).unwrap(), loc.clone()))
+    .collect();
+    let registry = crate::test_util::reg_from_items(declare_referenced(items)).unwrap();
+    let generated = CbindgenBuilder::new()
+        .source_module(syn::parse_quote!(myflat))
+        .convert(
+            prebindgen_registry::convert!(Ratio)
+                .input(prebindgen_registry::fun!(ratio_from_f64))
+                .output(prebindgen_registry::fun!(ratio_to_f64)),
+        )
+        .function(syn::parse_quote!(ratio_echo))
+        .build_with(registry)
+        .expect("resolve");
+
+    assert_eq!(
+        generated
+            .gen
+            .compiled_fns
+            .iter()
+            .filter(|function| function.is_custom())
+            .count(),
+        2,
+        "both custom directions must retain semantic plans before final writing"
+    );
+}
+
+#[test]
+fn trait_backed_custom_conversion_renders_from_the_late_plan() {
+    let loc = SourceLocation::default();
+    let items: Vec<(syn::Item, SourceLocation)> =
+        ["pub fn ratio_echo(v: Ratio) -> Ratio { unimplemented!() }"]
+            .into_iter()
+            .map(|source| (syn::parse_str(source).unwrap(), loc.clone()))
+            .collect();
+    let registry = crate::test_util::reg_from_items(declare_referenced(items)).unwrap();
+    let cbindgen = CbindgenBuilder::new()
+        .source_module(syn::parse_quote!(myflat))
+        .convert(
+            prebindgen_registry::convert!(Ratio)
+                .input(prebindgen_registry::from!(f64))
+                .output(prebindgen_registry::into!(f64)),
+        )
+        .function(syn::parse_quote!(ratio_echo));
+
+    let src = write(cbindgen, registry, "trait_custom_conversion");
+    let compact: String = src.split_whitespace().collect();
+    assert!(
+        compact.contains("<f64as::core::convert::Into<myflat::Ratio>>::into(v)"),
+        "{src}"
+    );
+    assert!(
+        compact.contains("<myflat::Ratioas::core::convert::Into<f64>>::into(v)"),
+        "{src}"
+    );
+}
+
 /// An adapter with no declarations writes an empty (whitespace-only) file.
 #[test]
 fn empty_adapter_writes_empty_file() {


### PR DESCRIPTION
## Summary

- replace Cbindgen's planning-time construction of complete Rust functions for canonical scalar `convert!` terminals with a frozen `CustomPlan`
- retain the source value as an opaque `TypeRef` until the writer calls `RustFunction::render`, while freezing only adapter-owned wire, callable/trait, direction, domain, and niche facts
- route both function-backed and `Into`/`TryInto` conversions through the late plan, including callback and nested composition reuse
- add a seam test proving both converter directions remain semantic plans before final writing, plus direct trait-backed rendering coverage

## Why

Stage 7 of #513 requires terminal codecs and source spelling to move to final emission. Cbindgen's canonical scalar conversion path still called `Cx::emit()` while compiling a crossing and stored a complete `syn::ItemFn` in `ConverterImpl`. That made a terminal adapter path an exception to the source-opacity rule even though its planning decisions need only the Flat signature and adapter-owned wire facts.

This PR removes that exception for canonical C `convert!` declarations. Other legacy C/JNI terminal families remain for subsequent stage-7 PRs.

## Design

Planning now records one `CustomOperation`:

- a resolved conversion function path, borrow mode, and fallibility; or
- an `Into`/`TryInto` operation and fallibility.

The plan also owns the scalar wire type, direction, optional domain predicate, error text, source-module policy, and the source `TypeRef`. It derives the callable contract immediately so registry composition remains unchanged. Only final rendering receives `Emit`, spells and qualifies the source type, and assembles the Rust function body.

## Validation

- `cargo test -p prebindgen-c` (100 tests)
- `cargo test --workspace --all-features`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --all-features --no-deps`
- `./examples/regen-check.sh`
- `cargo fmt --all -- --check`
- `git diff --check`

The committed generated Rust, C headers, JNI Rust, and Kotlin artifacts remain byte-identical.