### PR TITLE
Render C output terminals from frozen plans

### DIFF
--- a/prebindgen-c/src/chain.rs
+++ b/prebindgen-c/src/chain.rs
@@ -57,6 +57,7 @@ pub(crate) struct CFunction {
 enum CBody {
     Complete(syn::ItemFn),
     Custom(CustomPlan),
+    OutputTerminal(OutputTerminalPlan),
     Product(ProductPlan),
     Optional(OptionalPlan),
     Sequence(SequencePlan),
@@ -92,6 +93,14 @@ impl CFunction {
         Self {
             call,
             body: CBody::Custom(plan),
+        }
+    }
+
+    pub(crate) fn output_terminal(plan: OutputTerminalPlan) -> Self {
+        let call = CCall(chain::Call::new(plan.ident.clone(), false, false));
+        Self {
+            call,
+            body: CBody::OutputTerminal(plan),
         }
     }
 
@@ -153,6 +162,11 @@ impl CFunction {
         matches!(self.body, CBody::Custom(_))
     }
 
+    #[cfg(test)]
+    pub(crate) fn is_output_terminal(&self) -> bool {
+        matches!(self.body, CBody::OutputTerminal(_))
+    }
+
     pub(crate) fn call(&self) -> &CCall {
         &self.call
     }
@@ -167,12 +181,97 @@ impl RustFunction for CFunction {
         match &self.body {
             CBody::Complete(function) => function.clone(),
             CBody::Custom(plan) => plan.render(emit),
+            CBody::OutputTerminal(plan) => plan.render(emit),
             CBody::Product(plan) => plan.render(emit),
             CBody::Choice(plan) => plan.render(emit),
             CBody::Sequence(plan) => plan.render(emit),
             CBody::Optional(plan) => plan.render(emit),
             CBody::DeferredInvoke => {
                 unreachable!("a deferred C Invoke helper is rendered by its callback artifact")
+            }
+        }
+    }
+}
+
+/// One whole-value C output operation selected without spelling its source.
+#[derive(Clone)]
+pub(crate) enum OutputTerminalOperation {
+    Unit,
+    String,
+    Scalar,
+    OwnedHandle {
+        c_struct: syn::Ident,
+    },
+    OpaqueError {
+        message_path: syn::Path,
+    },
+    ValueOpaque,
+    Enum {
+        c_name: syn::Ident,
+        variants: Vec<syn::Ident>,
+    },
+}
+
+/// A whole-value C output retained until the final writer owns `Emit`.
+#[derive(Clone)]
+pub(crate) struct OutputTerminalPlan {
+    pub(crate) ident: syn::Ident,
+    pub(crate) source: TypeRef,
+    pub(crate) source_module: Option<syn::Path>,
+    pub(crate) wire: syn::Type,
+    pub(crate) operation: OutputTerminalOperation,
+}
+
+impl OutputTerminalPlan {
+    fn render(&self, emit: &Emit) -> syn::ItemFn {
+        let name = &self.ident;
+        let source = qualify_source_type(&emit.spell_ty(&self.source), self.source_module.as_ref());
+        let wire = &self.wire;
+        match &self.operation {
+            OutputTerminalOperation::Unit => syn::parse_quote!(
+                #[allow(non_snake_case, dead_code, unused_variables)]
+                pub(crate) fn #name(v: #source) {}
+            ),
+            OutputTerminalOperation::String => syn::parse_quote!(
+                #[allow(non_snake_case, unused_variables, dead_code)]
+                pub(crate) fn #name(v: #source) -> #wire {
+                    __cbg_alloc_cstr(v)
+                }
+            ),
+            OutputTerminalOperation::Scalar => syn::parse_quote!(
+                #[allow(non_snake_case, unused_variables, dead_code)]
+                pub(crate) fn #name(v: #source) -> #wire {
+                    v
+                }
+            ),
+            OutputTerminalOperation::OwnedHandle { c_struct } => syn::parse_quote!(
+                #[allow(non_snake_case, unused_variables, dead_code)]
+                pub(crate) fn #name(v: #source) -> #wire {
+                    ::std::boxed::Box::into_raw(::std::boxed::Box::new(v)) as *mut #c_struct
+                }
+            ),
+            OutputTerminalOperation::OpaqueError { message_path } => syn::parse_quote!(
+                #[allow(non_snake_case, unused_variables, dead_code)]
+                pub(crate) fn #name(v: #source) -> #wire {
+                    __cbg_alloc_cstr(#message_path(&v))
+                }
+            ),
+            OutputTerminalOperation::ValueOpaque => syn::parse_quote!(
+                #[allow(non_snake_case, unused_variables, dead_code)]
+                pub(crate) fn #name(v: #source) -> #wire {
+                    <#wire as ::prebindgen_c_runtime::Transmute>::from_rust(v)
+                }
+            ),
+            OutputTerminalOperation::Enum { c_name, variants } => {
+                let arms = variants
+                    .iter()
+                    .map(|variant| quote!(#source::#variant => #c_name::#variant,));
+                syn::parse_quote!(
+                    #[allow(non_snake_case, unused_variables, dead_code)]
+                    pub(crate) fn #name(v: #source) -> #wire {
+                        match v { #(#arms)* }
+                    }
+                )
             }
         }
     }

--- a/prebindgen-c/src/compile.rs
+++ b/prebindgen-c/src/compile.rs
@@ -486,6 +486,34 @@ impl CFrag {
             value,
         }
     }
+
+    /// A whole-value output retained as an operation until final Rust emission.
+    fn from_output_terminal(at: At<'_>, plan: crate::chain::OutputTerminalPlan) -> Self {
+        let destination = plan.wire.clone();
+        let function = CFunction::output_terminal(plan);
+        let niches = Niches::empty();
+        let value = CValue::Direct {
+            wire: destination.clone(),
+            converter: function.call().clone(),
+            niches: niches.clone(),
+        };
+        Self {
+            id: FragmentId::new(at.crossing.spelled().key(), at.recipe.clone()),
+            source: at.crossing.spelled().clone(),
+            destination,
+            function,
+            niches,
+            subs: vec![],
+            arm: None,
+            yields: Yield {
+                ty: at.crossing.value().stripped_key(),
+                mode: at.crossing.mode(),
+                validity: Validity::SelfSufficient,
+            },
+            shape: CShape::Atomic,
+            value,
+        }
+    }
 }
 
 /// How long what this conversion produces stays usable.
@@ -596,7 +624,7 @@ impl<R: Conversions> Compile for CCompile<'_, R> {
     type Plan = SitePlan<CRepresentation>;
     type Error = String;
 
-    fn atomic(&mut self, cx: &mut Cx<'_>, at: At<'_>) -> Frag<Self> {
+    fn atomic(&mut self, _cx: &mut Cx<'_>, at: At<'_>) -> Frag<Self> {
         let ty = at.crossing.spelled();
         // The field recipe, where a value crosses differently **inside a
         // `data_struct`'s mirror** than it does on its own. Two types have one:
@@ -636,6 +664,11 @@ impl<R: Conversions> Compile for CCompile<'_, R> {
         {
             return Ok(CFrag::from_custom(at, plan, niches));
         }
+        if at.crossing.direction() == Direction::Deconstruct {
+            if let Some(plan) = self.gen.out_terminal(ty, self.registry) {
+                return Ok(CFrag::from_output_terminal(at, plan));
+            }
+        }
         let conv = match at.crossing.direction() {
             Direction::Construct => self
                 .gen
@@ -647,10 +680,7 @@ impl<R: Conversions> Compile for CCompile<'_, R> {
                 .or_else(|| self.gen.in_bool(ty))
                 .or_else(|| self.gen.in_scalar(ty))
                 .or_else(|| self.gen.in_borrow(ty)),
-            Direction::Deconstruct => self
-                .gen
-                .out_terminal(ty, self.registry, cx.emit())
-                .or_else(|| self.gen.out_borrow_or_result(ty)),
+            Direction::Deconstruct => self.gen.out_borrow_or_result(ty),
         };
         self.wrap(at, "no C representation for this type", conv)
     }

--- a/prebindgen-c/src/tests/lowering.rs
+++ b/prebindgen-c/src/tests/lowering.rs
@@ -217,9 +217,17 @@ fn trait_backed_custom_conversion_renders_from_the_late_plan() {
 fn output_terminals_stay_unrendered_until_final_write() {
     let loc = SourceLocation::default();
     let items: Vec<(syn::Item, SourceLocation)> = [
+        "pub struct Handle;",
+        "pub struct Error;",
+        "pub struct Payload;",
+        "pub enum Mode { First, Second }",
         "pub fn output_unit() {}",
         "pub fn output_string() -> String { unimplemented!() }",
         "pub fn output_scalar() -> u64 { unimplemented!() }",
+        "pub fn output_handle() -> Handle { unimplemented!() }",
+        "pub fn output_error() -> Error { unimplemented!() }",
+        "pub fn output_value_opaque() -> Payload { unimplemented!() }",
+        "pub fn output_enum() -> Mode { unimplemented!() }",
     ]
     .into_iter()
     .map(|source| (syn::parse_str(source).unwrap(), loc.clone()))
@@ -227,9 +235,17 @@ fn output_terminals_stay_unrendered_until_final_write() {
     let registry = crate::test_util::reg_from_items(items).unwrap();
     let generated = CbindgenBuilder::new()
         .free_memory_function("binding_free")
+        .opaque_ptr(syn::parse_quote!(Handle))
+        .opaque_error(syn::parse_quote!(Error), syn::parse_quote!(error_message))
+        .opaque_owned_struct(syn::parse_quote!(Payload), syn::parse_quote!(OpaquePayload))
+        .enum_type(syn::parse_quote!(Mode))
         .function(syn::parse_quote!(output_unit))
         .function(syn::parse_quote!(output_string))
         .function(syn::parse_quote!(output_scalar))
+        .function(syn::parse_quote!(output_handle))
+        .function(syn::parse_quote!(output_error))
+        .function(syn::parse_quote!(output_value_opaque))
+        .function(syn::parse_quote!(output_enum))
         .build_with(registry)
         .expect("resolve");
 
@@ -240,8 +256,8 @@ fn output_terminals_stay_unrendered_until_final_write() {
             .iter()
             .filter(|function| function.is_output_terminal())
             .count(),
-        3,
-        "unit, String, and scalar outputs must retain semantic plans before final writing"
+        7,
+        "every whole-value output operation must retain a semantic plan before final writing"
     );
 }
 

--- a/prebindgen-c/src/tests/lowering.rs
+++ b/prebindgen-c/src/tests/lowering.rs
@@ -213,6 +213,38 @@ fn trait_backed_custom_conversion_renders_from_the_late_plan() {
     );
 }
 
+#[test]
+fn output_terminals_stay_unrendered_until_final_write() {
+    let loc = SourceLocation::default();
+    let items: Vec<(syn::Item, SourceLocation)> = [
+        "pub fn output_unit() {}",
+        "pub fn output_string() -> String { unimplemented!() }",
+        "pub fn output_scalar() -> u64 { unimplemented!() }",
+    ]
+    .into_iter()
+    .map(|source| (syn::parse_str(source).unwrap(), loc.clone()))
+    .collect();
+    let registry = crate::test_util::reg_from_items(items).unwrap();
+    let generated = CbindgenBuilder::new()
+        .free_memory_function("binding_free")
+        .function(syn::parse_quote!(output_unit))
+        .function(syn::parse_quote!(output_string))
+        .function(syn::parse_quote!(output_scalar))
+        .build_with(registry)
+        .expect("resolve");
+
+    assert_eq!(
+        generated
+            .gen
+            .compiled_fns
+            .iter()
+            .filter(|function| function.is_output_terminal())
+            .count(),
+        3,
+        "unit, String, and scalar outputs must retain semantic plans before final writing"
+    );
+}
+
 /// An adapter with no declarations writes an empty (whitespace-only) file.
 #[test]
 fn empty_adapter_writes_empty_file() {

--- a/prebindgen-c/src/trait_impl.rs
+++ b/prebindgen-c/src/trait_impl.rs
@@ -1785,26 +1785,25 @@ impl CbindgenBuilder {
     pub(crate) fn out_terminal(
         &self,
         ty: &TypeRef,
-        _r: &impl Conversions,
-        _emit: &prebindgen_registry::Emit,
-    ) -> Option<ConverterImpl> {
+        registry: &impl Conversions,
+    ) -> Option<crate::chain::OutputTerminalPlan> {
+        let plan = |ident, wire, operation| crate::chain::OutputTerminalPlan {
+            ident,
+            source: ty.clone(),
+            source_module: self.source_module.clone(),
+            wire,
+            operation,
+        };
         // Unit return: trivial converter so `()` (and `Result<(), _>`) resolves.
         // Never actually called — void-returning wrappers ignore it, and
         // `emit_fallible_wrapper` special-cases `Result<(), E>` to drop the
         // out-param entirely (it exists only to satisfy the resolver).
         if matches!(ty.kind(), TypeKind::Unit) {
-            let function: syn::ItemFn = syn::parse_quote!(
-                #[allow(non_snake_case, dead_code, unused_variables)]
-                pub(crate) fn __cbg_out_unit(v: ()) {}
-            );
-            return Some(ConverterImpl {
-                subs: vec![],
-                destination: syn::parse_quote!(()),
-                function,
-                pre_stages: vec![],
-                niches: Niches::empty(),
-                metadata: (),
-            });
+            return Some(plan(
+                format_ident!("__cbg_out_unit"),
+                syn::parse_quote!(()),
+                crate::chain::OutputTerminalOperation::Unit,
+            ));
         }
 
         // `String` output: a `malloc`'d `char*` raw block freed via the
@@ -1813,40 +1812,22 @@ impl CbindgenBuilder {
         // owns it then (mirroring the input side, where `in_opaque_handle` wins).
         if r_is_string(ty) && !self.opaque.contains_key(&ty.key()) {
             let name = Self::out_name_of(&ty.key());
-            let function: syn::ItemFn = syn::parse_quote!(
-                #[allow(non_snake_case, unused_variables, dead_code)]
-                pub(crate) fn #name(v: ::std::string::String) -> *mut ::core::ffi::c_char {
-                    __cbg_alloc_cstr(v)
-                }
-            );
-            return Some(ConverterImpl {
-                subs: vec![],
-                destination: syn::parse_quote!(*mut ::core::ffi::c_char),
-                function,
-                pre_stages: vec![],
-                niches: Niches::empty(),
-                metadata: (),
-            });
+            return Some(plan(
+                name,
+                syn::parse_quote!(*mut ::core::ffi::c_char),
+                crate::chain::OutputTerminalOperation::String,
+            ));
         }
 
         // FFI-safe scalar (`bool`, integers, floats): identity pass-through.
         if r_is_scalar(ty) {
             let name = Self::out_name_of(&ty.key());
             let spelled = scalar_ty(ty)?;
-            let function: syn::ItemFn = syn::parse_quote!(
-                #[allow(non_snake_case, unused_variables, dead_code)]
-                pub(crate) fn #name(v: #spelled) -> #spelled {
-                    v
-                }
-            );
-            return Some(ConverterImpl {
-                subs: vec![],
-                destination: spelled.clone(),
-                function,
-                pre_stages: vec![],
-                niches: Niches::empty(),
-                metadata: (),
-            });
+            return Some(plan(
+                name,
+                spelled,
+                crate::chain::OutputTerminalOperation::Scalar,
+            ));
         }
 
         let key = ty.key();
@@ -1855,21 +1836,11 @@ impl CbindgenBuilder {
         if self.opaque.contains_key(&key) {
             let name = Self::out_name_of(&ty.key());
             let c_struct = self.c_type_ident(&ty.key());
-            let src = self.src_ty_of(&ty.key());
-            let function: syn::ItemFn = syn::parse_quote!(
-                #[allow(non_snake_case, unused_variables, dead_code)]
-                pub(crate) fn #name(v: #src) -> *mut #c_struct {
-                    ::std::boxed::Box::into_raw(::std::boxed::Box::new(v)) as *mut #c_struct
-                }
-            );
-            return Some(ConverterImpl {
-                subs: vec![],
-                destination: syn::parse_quote!(*mut #c_struct),
-                function,
-                pre_stages: vec![],
-                niches: Niches::empty(),
-                metadata: (),
-            });
+            return Some(plan(
+                name,
+                syn::parse_quote!(*mut #c_struct),
+                crate::chain::OutputTerminalOperation::OwnedHandle { c_struct },
+            ));
         }
 
         // Opaque error output (e.g. `ZError`): not a by-value struct — marshal it
@@ -1878,22 +1849,13 @@ impl CbindgenBuilder {
         // `char **e`. Freed by the universal `free_memory_function`.
         if let Some(msg_fn) = self.opaque_errors.get(&key) {
             let name = Self::out_name_of(&ty.key());
-            let src = self.src_ty_of(&ty.key());
-            let msg_path = self.src_fn(msg_fn);
-            let function: syn::ItemFn = syn::parse_quote!(
-                #[allow(non_snake_case, unused_variables, dead_code)]
-                pub(crate) fn #name(v: #src) -> *mut ::core::ffi::c_char {
-                    __cbg_alloc_cstr(#msg_path(&v))
-                }
-            );
-            return Some(ConverterImpl {
-                subs: vec![],
-                destination: syn::parse_quote!(*mut ::core::ffi::c_char),
-                function,
-                pre_stages: vec![],
-                niches: Niches::empty(),
-                metadata: (),
-            });
+            return Some(plan(
+                name,
+                syn::parse_quote!(*mut ::core::ffi::c_char),
+                crate::chain::OutputTerminalOperation::OpaqueError {
+                    message_path: self.src_fn(msg_fn),
+                },
+            ));
         }
 
         // Value-opaque output: move the Rust value's bytes into the opaque
@@ -1902,47 +1864,26 @@ impl CbindgenBuilder {
         if let Some(opaque) = self.value_opaque_ty_of(&ty.key()) {
             let opaque = opaque.clone();
             let name = Self::out_name_of(&ty.key());
-            let src = self.src_ty_of(&ty.key());
-            let function: syn::ItemFn = syn::parse_quote!(
-                #[allow(non_snake_case, unused_variables, dead_code)]
-                pub(crate) fn #name(v: #src) -> #opaque {
-                    <#opaque as ::prebindgen_c_runtime::Transmute>::from_rust(v)
-                }
-            );
-            return Some(ConverterImpl {
-                subs: vec![],
-                destination: opaque,
-                function,
-                pre_stages: vec![],
-                niches: Niches::empty(),
-                metadata: (),
-            });
+            return Some(plan(
+                name,
+                opaque,
+                crate::chain::OutputTerminalOperation::ValueOpaque,
+            ));
         }
 
         // Enum output: `match` the source enum to the C enum.
         if self.enums.contains_key(&key) {
-            let e = unit_enum(_r, &ty.key())?;
+            let e = unit_enum(registry, &ty.key())?;
             let name = Self::out_name_of(&ty.key());
             let cname = self.c_type_ident(&ty.key());
-            let src = self.src_ty_of(&ty.key());
-            let arms = e.values.iter().map(|v| {
-                let id = &v.name;
-                quote!(#src::#id => #cname::#id,)
-            });
-            let function: syn::ItemFn = syn::parse_quote!(
-                #[allow(non_snake_case, unused_variables, dead_code)]
-                pub(crate) fn #name(v: #src) -> #cname {
-                    match v { #(#arms)* }
-                }
-            );
-            return Some(ConverterImpl {
-                subs: vec![],
-                destination: syn::parse_quote!(#cname),
-                function,
-                pre_stages: vec![],
-                niches: Niches::empty(),
-                metadata: (),
-            });
+            return Some(plan(
+                name,
+                syn::parse_quote!(#cname),
+                crate::chain::OutputTerminalOperation::Enum {
+                    c_name: cname,
+                    variants: e.values.iter().map(|value| value.name.clone()).collect(),
+                },
+            ));
         }
 
         None


### PR DESCRIPTION
## Summary

- replace Cbindgen’s seven eager whole-value output converters with one frozen `OutputTerminalPlan`
- cover unit, String, scalar, owned-handle, opaque-error, value-opaque, and fieldless-enum outputs
- retain each source as an opaque `TypeRef` and spell/qualify it only when the final writer calls `RustFunction::render`
- remove the last `Cx::emit()` use from C recipe compilation and add a non-vacuous pre-render seam test

## Why

Stage 7 of #513 requires terminal codecs to retain semantic operations instead of complete Rust syntax, and requires source spelling to happen only at final file assembly.

After #540, Cbindgen’s canonical `convert!` terminals met that rule, but `out_terminal` still reconstructed source types from `TypeKey` and returned complete `syn::ItemFn` values through `ConverterImpl`. Its `Emit` argument was unused, which made the path a particularly clear case of planning carrying syntax it did not need.

## Design

`out_terminal` now selects an adapter-owned operation and freezes:

- converter identity and C wire type;
- the opaque source `TypeRef` plus source-module qualification policy;
- operation-specific facts such as the C handle type, error-message accessor, or enum variants.

The resulting fragment derives its callable contract immediately, so registry composition, reachability, niches, and ABI layout do not change. Final rendering spells the stored source and assembles the private helper.

C input/specialized terminals and the Choice arm marker still use complete-function carriers; those remain subsequent stage-7 work.

## Validation

- `cargo test -p prebindgen-c` (101 tests)
- `cargo test --workspace --all-features`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --all-features --no-deps`
- `./examples/regen-check.sh`
- `cargo fmt --all -- --check`
- `git diff --check`

The committed generated Rust, C headers, JNI Rust, and Kotlin artifacts remain byte-identical.