### PR TITLE
Render C payload terminals from frozen plans

### DIFF
--- a/prebindgen-c/src/chain.rs
+++ b/prebindgen-c/src/chain.rs
@@ -59,6 +59,7 @@ enum CBody {
     Custom(CustomPlan),
     InputTerminal(InputTerminalPlan),
     OutputTerminal(OutputTerminalPlan),
+    Payload(PayloadPlan),
     Product(ProductPlan),
     Optional(OptionalPlan),
     Sequence(SequencePlan),
@@ -114,6 +115,18 @@ impl CFunction {
         Self {
             call,
             body: CBody::InputTerminal(plan),
+        }
+    }
+
+    pub(crate) fn payload(plan: PayloadPlan) -> Self {
+        let call = CCall(chain::Call::new(
+            plan.ident.clone(),
+            plan.direction == Direction::Construct && !plan.optional,
+            plan.direction == Direction::Construct,
+        ));
+        Self {
+            call,
+            body: CBody::Payload(plan),
         }
     }
 
@@ -185,6 +198,11 @@ impl CFunction {
         matches!(self.body, CBody::InputTerminal(_))
     }
 
+    #[cfg(test)]
+    pub(crate) fn is_payload(&self) -> bool {
+        matches!(self.body, CBody::Payload(_))
+    }
+
     pub(crate) fn call(&self) -> &CCall {
         &self.call
     }
@@ -201,12 +219,102 @@ impl RustFunction for CFunction {
             CBody::Custom(plan) => plan.render(emit),
             CBody::InputTerminal(plan) => plan.render(emit),
             CBody::OutputTerminal(plan) => plan.render(emit),
+            CBody::Payload(plan) => plan.render(emit),
             CBody::Product(plan) => plan.render(emit),
             CBody::Choice(plan) => plan.render(emit),
             CBody::Sequence(plan) => plan.render(emit),
             CBody::Optional(plan) => plan.render(emit),
             CBody::DeferredInvoke => {
                 unreachable!("a deferred C Invoke helper is rendered by its callback artifact")
+            }
+        }
+    }
+}
+
+/// A tagged-union pointer payload retained without spelling its source types.
+#[derive(Clone)]
+pub(crate) struct PayloadPlan {
+    pub(crate) ident: syn::Ident,
+    pub(crate) source: TypeRef,
+    pub(crate) source_inner: TypeRef,
+    pub(crate) source_module: Option<syn::Path>,
+    pub(crate) wire: syn::Type,
+    pub(crate) direction: Direction,
+    pub(crate) optional: bool,
+    pub(crate) boxed: bool,
+    pub(crate) null_message: String,
+}
+
+impl PayloadPlan {
+    fn render(&self, emit: &Emit) -> syn::ItemFn {
+        let name = &self.ident;
+        let source = qualify_source_type(&emit.spell_ty(&self.source), self.source_module.as_ref());
+        let source_inner = qualify_source_type(
+            &emit.spell_ty(&self.source_inner),
+            self.source_module.as_ref(),
+        );
+        let wire = &self.wire;
+
+        match self.direction {
+            Direction::Construct => {
+                let owned = if self.boxed {
+                    quote!(::std::boxed::Box::from_raw(v as *mut #source_inner))
+                } else {
+                    quote!(*::std::boxed::Box::from_raw(v as *mut #source_inner))
+                };
+                if self.optional {
+                    syn::parse_quote!(
+                        #[allow(non_snake_case, unused_variables, dead_code)]
+                        pub(crate) unsafe fn #name(v: #wire) -> #source {
+                            if v.is_null() {
+                                ::core::option::Option::None
+                            } else {
+                                ::core::option::Option::Some(#owned)
+                            }
+                        }
+                    )
+                } else {
+                    let null_message = &self.null_message;
+                    syn::parse_quote!(
+                        #[allow(non_snake_case, unused_variables, dead_code)]
+                        pub(crate) unsafe fn #name(
+                            v: #wire,
+                        ) -> ::core::result::Result<#source, ::std::string::String> {
+                            if v.is_null() {
+                                return ::core::result::Result::Err(
+                                    ::std::string::String::from(#null_message),
+                                );
+                            }
+                            ::core::result::Result::Ok(#owned)
+                        }
+                    )
+                }
+            }
+            Direction::Deconstruct => {
+                let encode = |value: TokenStream| {
+                    if self.boxed {
+                        quote!(::std::boxed::Box::into_raw(#value) as #wire)
+                    } else {
+                        quote!(
+                            ::std::boxed::Box::into_raw(::std::boxed::Box::new(#value)) as #wire
+                        )
+                    }
+                };
+                let body = if self.optional {
+                    let some = encode(quote!(__v));
+                    quote!(match v {
+                        ::core::option::Option::Some(__v) => #some,
+                        ::core::option::Option::None => ::core::ptr::null_mut(),
+                    })
+                } else {
+                    encode(quote!(v))
+                };
+                syn::parse_quote!(
+                    #[allow(non_snake_case, unused_variables, dead_code)]
+                    pub(crate) fn #name(v: #source) -> #wire {
+                        #body
+                    }
+                )
             }
         }
     }

--- a/prebindgen-c/src/compile.rs
+++ b/prebindgen-c/src/compile.rs
@@ -542,6 +542,34 @@ impl CFrag {
             value,
         }
     }
+
+    /// A tagged-union pointer payload retained until final Rust emission.
+    fn from_payload(at: At<'_>, plan: crate::chain::PayloadPlan) -> Self {
+        let destination = plan.wire.clone();
+        let function = CFunction::payload(plan);
+        let niches = Niches::empty();
+        let value = CValue::Direct {
+            wire: destination.clone(),
+            converter: function.call().clone(),
+            niches: niches.clone(),
+        };
+        Self {
+            id: FragmentId::new(at.crossing.spelled().key(), at.recipe.clone()),
+            source: at.crossing.spelled().clone(),
+            destination,
+            function,
+            niches,
+            subs: vec![],
+            arm: None,
+            yields: Yield {
+                ty: at.crossing.value().stripped_key(),
+                mode: at.crossing.mode(),
+                validity: Validity::SelfSufficient,
+            },
+            shape: CShape::Atomic,
+            value,
+        }
+    }
 }
 
 /// How long what this conversion produces stays usable.
@@ -668,11 +696,11 @@ impl<R: Conversions> Compile for CCompile<'_, R> {
         // `Blob` share one recipe and could not be told apart there. A fragment is
         // keyed by the spelling, which is exactly the distinction needed.
         if at.recipe.name() == &crate::recipes::payload() {
-            let conv = match at.crossing.direction() {
-                Direction::Construct => self.gen.in_boxed_payload(ty),
-                Direction::Deconstruct => self.gen.out_boxed_payload(ty),
-            };
-            return self.wrap(at, "no payload reading for this handle", conv);
+            let plan = self
+                .gen
+                .payload_plan(ty, at.crossing.direction())
+                .ok_or_else(|| refuse(at, "no payload reading for this handle"))?;
+            return Ok(CFrag::from_payload(at, plan));
         }
         if at.recipe.name() == &crate::recipes::in_field() {
             if at.crossing.direction() == Direction::Construct && r_is_bool(ty) {

--- a/prebindgen-c/src/tests/lowering.rs
+++ b/prebindgen-c/src/tests/lowering.rs
@@ -311,6 +311,49 @@ fn input_terminals_stay_unrendered_until_final_write() {
     );
 }
 
+#[test]
+fn tagged_union_payloads_stay_unrendered_until_final_write() {
+    let count: usize = [
+        "Handle",
+        "Option<Handle>",
+        "Box<Handle>",
+        "Option<Box<Handle>>",
+    ]
+    .into_iter()
+    .map(|payload| {
+        let loc = SourceLocation::default();
+        let variant = format!("pub enum Payloads {{ Value({payload}) }}");
+        let items: Vec<(syn::Item, SourceLocation)> = [
+            "pub struct Handle;".to_owned(),
+            variant,
+            "pub fn payload_roundtrip(v: Payloads) -> Payloads { unimplemented!() }".to_owned(),
+        ]
+        .into_iter()
+        .map(|source| (syn::parse_str(&source).unwrap(), loc.clone()))
+        .collect();
+        let registry = crate::test_util::reg_from_items(items).unwrap();
+        let generated = CbindgenBuilder::new()
+            .opaque_ptr(syn::parse_quote!(Handle))
+            .tagged_union(syn::parse_quote!(Payloads))
+            .function(syn::parse_quote!(payload_roundtrip))
+            .panic()
+            .build_with(registry)
+            .expect("resolve");
+        generated
+            .gen
+            .compiled_fns
+            .iter()
+            .filter(|function| function.is_payload())
+            .count()
+    })
+    .sum();
+
+    assert_eq!(
+        count, 8,
+        "bare, optional, boxed, and optional-boxed payloads must retain plans in both directions"
+    );
+}
+
 /// An adapter with no declarations writes an empty (whitespace-only) file.
 #[test]
 fn empty_adapter_writes_empty_file() {

--- a/prebindgen-c/src/trait_impl.rs
+++ b/prebindgen-c/src/trait_impl.rs
@@ -459,127 +459,55 @@ impl CbindgenBuilder {
             .map(|a| a.name.to_string())
     }
 
-    /// A `Box`-over-handle **payload of a tagged union**, C to Rust.
+    /// Retain a tagged-union pointer payload without spelling its Rust type.
     ///
-    /// The payload rides as a bare `*mut t_t` the C caller gave up ownership
-    /// of, so the pointer is reclaimed. A NULL one is reachable rather than
-    /// hypothetical — the typed drop nulls the arm it frees, so a union passed
-    /// back after being dropped arrives here NULL — and is reported, never
-    /// materialised. An `Option<Box<T>>` reads NULL as `None` instead, which is
-    /// the representation it has room for.
-    pub(crate) fn in_boxed_payload(&self, fty: &TypeRef) -> Option<ConverterImpl> {
-        let name = format_ident!("{}_payload", Self::in_name_of(&fty.key()));
+    /// The C wire owns one heap allocation. A source payload that already says
+    /// `Box<T>` transfers that box directly; a bare declared handle `T` is
+    /// boxed or unboxed at the boundary. Optionality is represented by NULL,
+    /// while a NULL non-optional input is a binding error because it can be
+    /// observed after a union arm has already been dropped.
+    pub(crate) fn payload_plan(
+        &self,
+        fty: &TypeRef,
+        direction: Direction,
+    ) -> Option<crate::chain::PayloadPlan> {
         let optional = fty.optional_inner().is_some();
-        let (wire, src_inner, owned, short) =
+        let (wire, source_inner, boxed, short) =
             if let Some(inner) = self.declared_opaque_payload_inner(fty) {
                 let c = self.c_type_ident(&inner);
-                let src_inner = self.src_ty_of(&inner);
-                let short = type_short(&inner);
-                // The value is moved out of the box the C side owned.
                 (
-                    quote!(*mut #c),
-                    src_inner.clone(),
-                    quote!(*::std::boxed::Box::from_raw(v as *mut #src_inner)),
-                    short,
+                    syn::parse_quote!(*mut #c),
+                    fty.optional_inner().unwrap_or(fty).clone(),
+                    false,
+                    type_short(&inner),
                 )
             } else {
                 let inner = r_boxed_inner(fty)?;
                 let c = self.c_type_ident(&inner.key());
-                let src_inner = self.src_ty_of(&inner.key());
-                let short = type_short(&inner.key());
                 (
-                    quote!(*mut #c),
-                    src_inner.clone(),
-                    quote!(::std::boxed::Box::from_raw(v as *mut #src_inner)),
-                    short,
+                    syn::parse_quote!(*mut #c),
+                    inner.clone(),
+                    true,
+                    type_short(&inner.key()),
                 )
             };
-        let _ = src_inner;
-        let produced = self.src_ty_of(&fty.key());
-        let function: syn::ItemFn = if optional {
-            syn::parse_quote!(
-                #[allow(non_snake_case, unused_variables, dead_code)]
-                pub(crate) unsafe fn #name(v: #wire) -> #produced {
-                    if v.is_null() {
-                        ::core::option::Option::None
-                    } else {
-                        ::core::option::Option::Some(#owned)
-                    }
-                }
-            )
-        } else {
-            let null_msg = format!(
+        let prefix = match direction {
+            Direction::Construct => Self::in_name_of(&fty.key()),
+            Direction::Deconstruct => Self::out_name_of(&fty.key()),
+        };
+        Some(crate::chain::PayloadPlan {
+            ident: format_ident!("{prefix}_payload"),
+            source: fty.clone(),
+            source_inner,
+            source_module: self.source_module.clone(),
+            wire,
+            direction,
+            optional,
+            boxed,
+            null_message: format!(
                 "null payload for `{short}` (a non-optional payload cannot be NULL — the \
                  union may already have been dropped)"
-            );
-            syn::parse_quote!(
-                #[allow(non_snake_case, unused_variables, dead_code)]
-                pub(crate) unsafe fn #name(
-                    v: #wire,
-                ) -> ::core::result::Result<#produced, ::std::string::String> {
-                    if v.is_null() {
-                        return ::core::result::Result::Err(
-                            ::std::string::String::from(#null_msg),
-                        );
-                    }
-                    ::core::result::Result::Ok(#owned)
-                }
-            )
-        };
-        Some(ConverterImpl {
-            subs: vec![],
-            destination: syn::parse_quote!(#wire),
-            function,
-            pre_stages: vec![],
-            niches: Niches::empty(),
-            metadata: (),
-        })
-    }
-
-    /// The peer of [`Self::in_boxed_payload`]: an owned value the C side must
-    /// later release, boxed here rather than having arrived boxed.
-    pub(crate) fn out_boxed_payload(&self, fty: &TypeRef) -> Option<ConverterImpl> {
-        let name = format_ident!("{}_payload", Self::out_name_of(&fty.key()));
-        let optional = fty.optional_inner().is_some();
-        let src = self.src_ty_of(&fty.key());
-        let (wire, some_expr, bare_expr) =
-            if let Some(inner) = self.declared_opaque_payload_inner(fty) {
-                let c = self.c_type_ident(&inner);
-                (
-                    quote!(*mut #c),
-                    quote!(::std::boxed::Box::into_raw(::std::boxed::Box::new(__v)) as *mut #c),
-                    quote!(::std::boxed::Box::into_raw(::std::boxed::Box::new(v)) as *mut #c),
-                )
-            } else {
-                let inner = r_boxed_inner(fty)?;
-                let c = self.c_type_ident(&inner.key());
-                (
-                    quote!(*mut #c),
-                    quote!(::std::boxed::Box::into_raw(__v) as *mut #c),
-                    quote!(::std::boxed::Box::into_raw(v) as *mut #c),
-                )
-            };
-        let body: TokenStream = if optional {
-            quote!(match v {
-                ::core::option::Option::Some(__v) => #some_expr,
-                ::core::option::Option::None => ::core::ptr::null_mut(),
-            })
-        } else {
-            bare_expr
-        };
-        let function: syn::ItemFn = syn::parse_quote!(
-            #[allow(non_snake_case, unused_variables, dead_code)]
-            pub(crate) fn #name(v: #src) -> #wire {
-                #body
-            }
-        );
-        Some(ConverterImpl {
-            subs: vec![],
-            destination: syn::parse_quote!(#wire),
-            function,
-            pre_stages: vec![],
-            niches: Niches::empty(),
-            metadata: (),
+            ),
         })
     }
 
@@ -588,7 +516,7 @@ impl CbindgenBuilder {
     ///
     /// The second reading a `String` has, and the reason it needs a recipe of its
     /// own. A `String` **parameter** is a pointer the caller chose to pass, so
-    /// a null one is a caller error and [`Self::in_string`] says so. A `String`
+    /// a null one is a caller error and the ordinary input-terminal plan says so. A `String`
     /// **field** shares a struct with every other field, and refusing it would
     /// make the whole struct's decode fallible — so a function taking such a
     /// struct by value would need a `Result` return or `.panic()`, for a field


### PR DESCRIPTION
## Summary

- replace eager C tagged-union payload converters with a frozen PayloadPlan
- retain the full and inner TypeRef plus semantic optional/boxed ownership flags until final Rust emission
- render bare, optional, boxed, and optional-boxed pointer payloads in both directions through writer-owned Emit
- route payload recipes directly into CFrag without constructing a legacy ConverterImpl

## Design

A tagged-union pointer payload has one of four source shapes: T, Option<T>, Box<T>, or Option<Box<T>>. The plan stores those semantics without spelling either source type. At final emission, the writer spells and qualifies both TypeRefs and renders the same ownership behavior as before:

- construct moves a bare T out of the C-owned allocation or restores an existing Box<T>
- deconstruct allocates a bare T or transfers an existing Box<T>
- optional payloads map NULL to and from None
- non-optional NULL input remains a binding error

The seam test builds all four shapes independently and proves that both construct and deconstruct recipes retain eight unrendered payload plans.

## Compatibility

This is an internal code-generation change. Regenerated Rust, C headers, and Kotlin artifacts remain byte-for-byte unchanged.

## Verification

- cargo test -p prebindgen-c (103 tests)
- cargo test --workspace --all-features
- cargo clippy --workspace --all-targets --all-features -- -D warnings
- RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps
- cargo fmt --all -- --check
- git diff --check
- ./examples/regen-check.sh

## Follow-up scope

Payload cleanup/prerequisite declarations, specialized field converters, borrow/slice converters, arity/result markers, and the Choice compatibility marker remain for later umbrella stages.