### PR TITLE
Strip debug info from dev-profile build script binaries

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,3 +57,10 @@ itertools = "0.14.0"
 if_rust_version = "1.0"
 konst = "0.3.0" # consumer crates need konst too: the generated file emits a konst::assertc_eq! guard
 toml = "0.9.5"
+
+# Build scripts (and proc-macros/their deps) don't need debug info: cargo
+# runs them once and reads what they print. Without this, build-hash
+# directories accumulate ~100 MB debug binaries per script. See #543.
+[profile.dev.build-override]
+debug = false
+strip = true


### PR DESCRIPTION
## Summary
- `[profile.dev.build-override]` with `debug = false` and `strip = true` in the workspace `Cargo.toml`, so build scripts, proc-macros and their dependencies compile without debug info under `cargo build`/`cargo test`.
- Cargo applies `build-override` only to build scripts, proc-macros and their dependencies, so debug info for the workspace crates under test is untouched.
- Verified on `covertest-kotlin`, the largest offender: `build-script-build` dropped from ~115 MB to 15 MB in this build.

Fixes #543.

## Test plan
- [x] `cargo build --workspace` succeeds and generates identical Kotlin/C bindings (only `Cargo.toml` changed in `git status` after the build)
- [x] `cargo test --workspace`: 28 test suites, 0 failures

https://claude.ai/code/session_01STUTVRnzv9kc8wMjatb9nz