### PR TITLE
Render C field terminals from frozen plans

### DIFF
--- a/prebindgen-c/src/chain.rs
+++ b/prebindgen-c/src/chain.rs
@@ -199,6 +199,28 @@ impl CFunction {
     }
 
     #[cfg(test)]
+    pub(crate) fn is_string_field_terminal(&self) -> bool {
+        matches!(
+            &self.body,
+            CBody::InputTerminal(InputTerminalPlan {
+                operation: InputTerminalOperation::StringField,
+                ..
+            })
+        )
+    }
+
+    #[cfg(test)]
+    pub(crate) fn is_bool_field_terminal(&self) -> bool {
+        matches!(
+            &self.body,
+            CBody::OutputTerminal(OutputTerminalPlan {
+                operation: OutputTerminalOperation::BoolField,
+                ..
+            })
+        )
+    }
+
+    #[cfg(test)]
     pub(crate) fn is_payload(&self) -> bool {
         matches!(self.body, CBody::Payload(_))
     }
@@ -320,7 +342,7 @@ impl PayloadPlan {
     }
 }
 
-/// One whole-value C input operation selected without spelling its source.
+/// One C input terminal operation selected without spelling its source.
 #[derive(Clone)]
 pub(crate) enum InputTerminalOperation {
     OwnedHandle {
@@ -339,6 +361,7 @@ pub(crate) enum InputTerminalOperation {
         align_message: String,
     },
     String,
+    StringField,
     StrMarker,
     Bool,
     Scalar,
@@ -382,7 +405,7 @@ impl InputTerminalOperation {
     }
 }
 
-/// A whole-value C input retained until the final writer owns [`Emit`].
+/// A C input terminal retained until the final writer owns [`Emit`].
 #[derive(Clone)]
 pub(crate) struct InputTerminalPlan {
     pub(crate) ident: syn::Ident,
@@ -497,6 +520,16 @@ impl InputTerminalPlan {
                     }
                 }
             ),
+            InputTerminalOperation::StringField => syn::parse_quote!(
+                #[allow(non_snake_case, unused_variables, dead_code)]
+                pub(crate) unsafe fn #name(v: #wire) -> #source {
+                    if v.is_null() {
+                        ::std::string::String::new()
+                    } else {
+                        ::std::ffi::CStr::from_ptr(v).to_string_lossy().into_owned()
+                    }
+                }
+            ),
             InputTerminalOperation::StrMarker => syn::parse_quote!(
                 #[allow(non_snake_case, dead_code, unused_variables)]
                 pub(crate) fn #name() {}
@@ -520,11 +553,12 @@ impl InputTerminalPlan {
     }
 }
 
-/// One whole-value C output operation selected without spelling its source.
+/// One C output terminal operation selected without spelling its source.
 #[derive(Clone)]
 pub(crate) enum OutputTerminalOperation {
     Unit,
     String,
+    BoolField,
     Scalar,
     OwnedHandle {
         c_struct: syn::Ident,
@@ -539,7 +573,7 @@ pub(crate) enum OutputTerminalOperation {
     },
 }
 
-/// A whole-value C output retained until the final writer owns `Emit`.
+/// A C output terminal retained until the final writer owns `Emit`.
 #[derive(Clone)]
 pub(crate) struct OutputTerminalPlan {
     pub(crate) ident: syn::Ident,
@@ -565,6 +599,15 @@ impl OutputTerminalPlan {
                     __cbg_alloc_cstr(v)
                 }
             ),
+            OutputTerminalOperation::BoolField => {
+                let wrap = bool_out_expr(quote!(v));
+                syn::parse_quote!(
+                    #[allow(non_snake_case, unused_variables, dead_code)]
+                    pub(crate) fn #name(v: #source) -> #wire {
+                        #wrap
+                    }
+                )
+            }
             OutputTerminalOperation::Scalar => syn::parse_quote!(
                 #[allow(non_snake_case, unused_variables, dead_code)]
                 pub(crate) fn #name(v: #source) -> #wire {

--- a/prebindgen-c/src/compile.rs
+++ b/prebindgen-c/src/compile.rs
@@ -710,13 +710,20 @@ impl<R: Conversions> Compile for CCompile<'_, R> {
                     .expect("bool has an ordinary input-terminal plan");
                 return Ok(CFrag::from_input_terminal(at, plan));
             }
-            let conv = match at.crossing.direction() {
-                Direction::Construct => self.gen.in_string_field(ty),
+            return match at.crossing.direction() {
+                Direction::Construct => self
+                    .gen
+                    .in_string_field_plan(ty)
+                    .map(|plan| CFrag::from_input_terminal(at, plan))
+                    .ok_or_else(|| refuse(at, "no field reading for this type")),
                 // Only `bool` reads differently on the way out; a `String`
                 // field is allocated exactly as a `String` return is.
-                Direction::Deconstruct => self.gen.out_bool_field(ty),
+                Direction::Deconstruct => self
+                    .gen
+                    .out_bool_field_plan(ty)
+                    .map(|plan| CFrag::from_output_terminal(at, plan))
+                    .ok_or_else(|| refuse(at, "no field reading for this type")),
             };
-            return self.wrap(at, "no field reading for this type", conv);
         }
         if let Some((plan, niches)) =
             self.gen

--- a/prebindgen-c/src/tests/lowering.rs
+++ b/prebindgen-c/src/tests/lowering.rs
@@ -354,6 +354,43 @@ fn tagged_union_payloads_stay_unrendered_until_final_write() {
     );
 }
 
+#[test]
+fn specialized_field_terminals_stay_unrendered_until_final_write() {
+    let loc = SourceLocation::default();
+    let items: Vec<(syn::Item, SourceLocation)> = [
+        "pub struct Record { pub text: String, pub flag: bool }",
+        "pub fn record_roundtrip(v: Record) -> Record { unimplemented!() }",
+    ]
+    .into_iter()
+    .map(|source| (syn::parse_str(source).unwrap(), loc.clone()))
+    .collect();
+    let registry = crate::test_util::reg_from_items(items).unwrap();
+    let generated = CbindgenBuilder::new()
+        .free_memory_function("binding_free")
+        .data_struct(syn::parse_quote!(Record))
+        .function(syn::parse_quote!(record_roundtrip))
+        .build_with(registry)
+        .expect("resolve");
+
+    let functions = &generated.gen.compiled_fns;
+    assert_eq!(
+        functions
+            .iter()
+            .filter(|function| function.is_string_field_terminal())
+            .count(),
+        1,
+        "lenient String input must retain its field plan"
+    );
+    assert_eq!(
+        functions
+            .iter()
+            .filter(|function| function.is_bool_field_terminal())
+            .count(),
+        1,
+        "normalized bool output must retain its distinct field plan"
+    );
+}
+
 /// An adapter with no declarations writes an empty (whitespace-only) file.
 #[test]
 fn empty_adapter_writes_empty_file() {

--- a/prebindgen-c/src/trait_impl.rs
+++ b/prebindgen-c/src/trait_impl.rs
@@ -525,30 +525,19 @@ impl CbindgenBuilder {
     /// Lossy on invalid UTF-8 for the same reason. This is the reading the
     /// hand-written field walk had; stating it as a recipe is what makes it
     /// visible rather than buried.
-    pub(crate) fn in_string_field(&self, ty: &TypeRef) -> Option<ConverterImpl> {
+    pub(crate) fn in_string_field_plan(
+        &self,
+        ty: &TypeRef,
+    ) -> Option<crate::chain::InputTerminalPlan> {
         if !r_is_string(ty) {
             return None;
         }
-        let name = format_ident!("{}_field", Self::in_name_of(&ty.key()));
-        let function: syn::ItemFn = syn::parse_quote!(
-            #[allow(non_snake_case, unused_variables, dead_code)]
-            pub(crate) unsafe fn #name(
-                v: *const ::core::ffi::c_char,
-            ) -> ::std::string::String {
-                if v.is_null() {
-                    ::std::string::String::new()
-                } else {
-                    ::std::ffi::CStr::from_ptr(v).to_string_lossy().into_owned()
-                }
-            }
-        );
-        Some(ConverterImpl {
-            subs: vec![],
-            destination: syn::parse_quote!(*const ::core::ffi::c_char),
-            function,
-            pre_stages: vec![],
-            niches: Niches::empty(),
-            metadata: (),
+        Some(crate::chain::InputTerminalPlan {
+            ident: format_ident!("{}_field", Self::in_name_of(&ty.key())),
+            source: ty.clone(),
+            source_module: self.source_module.clone(),
+            wire: syn::parse_quote!(*const ::core::ffi::c_char),
+            operation: crate::chain::InputTerminalOperation::StringField,
         })
     }
 
@@ -560,26 +549,19 @@ impl CbindgenBuilder {
     /// `bool` **return** is always already one of two values and crosses as
     /// itself, while a field shares one mirror with the decode that has to
     /// normalise it.
-    pub(crate) fn out_bool_field(&self, ty: &TypeRef) -> Option<ConverterImpl> {
+    pub(crate) fn out_bool_field_plan(
+        &self,
+        ty: &TypeRef,
+    ) -> Option<crate::chain::OutputTerminalPlan> {
         if !r_is_bool(ty) {
             return None;
         }
-        let name = format_ident!("{}_field", Self::out_name_of(&ty.key()));
-        let wire = bool_wire();
-        let wrap = bool_out_expr(quote!(v));
-        let function: syn::ItemFn = syn::parse_quote!(
-            #[allow(non_snake_case, unused_variables, dead_code)]
-            pub(crate) fn #name(v: bool) -> #wire {
-                #wrap
-            }
-        );
-        Some(ConverterImpl {
-            subs: vec![],
-            destination: wire,
-            function,
-            pre_stages: vec![],
-            niches: Niches::empty(),
-            metadata: (),
+        Some(crate::chain::OutputTerminalPlan {
+            ident: format_ident!("{}_field", Self::out_name_of(&ty.key())),
+            source: ty.clone(),
+            source_module: self.source_module.clone(),
+            wire: bool_wire(),
+            operation: crate::chain::OutputTerminalOperation::BoolField,
         })
     }
 }


### PR DESCRIPTION
## Summary

- replace the eager lenient String-field input converter with a frozen input-terminal operation
- replace the eager normalized bool-field output converter with a frozen output-terminal operation
- route the field recipe directly into typed terminal plans instead of ConverterImpl
- spell each retained source TypeRef only from the final writer-owned Emit

## Design

C has exactly two specialized field readings:

- a String inside a data-struct mirror treats NULL as empty and decodes invalid UTF-8 lossily, keeping the containing Product input infallible
- a bool written into a mirror or tagged-union arm is normalized into the MaybeUninit<bool> wire instead of being passed through as an ordinary bool return

These are now distinct StringField and BoolField terminal operations in the existing input/output plan family. Their builders retain only the TypeRef, wire type, source-module policy, identifier, and operation kind. Final rendering materializes the source type and body.

The seam fixture compiles a Record { text: String, flag: bool } round trip and independently asserts exactly one retained StringField input and one retained BoolField output before final writing.

## Compatibility

This is an internal code-generation change. Regenerated Rust, C headers, and Kotlin artifacts remain byte-for-byte unchanged.

## Verification

- cargo test -p prebindgen-c (104 tests)
- cargo test --workspace --all-features
- cargo clippy --workspace --all-targets --all-features -- -D warnings
- RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps
- cargo fmt --all -- --check
- git diff --check
- ./examples/regen-check.sh

The branch also includes the current umbrella head after merging main, so validation runs with the build-script debug stripping from #545.

## Follow-up scope

Borrow/slice terminals, payload cleanup and prerequisite declarations, arity/result markers, and the Choice compatibility marker remain for later umbrella stages.