### PR TITLE
Render C borrow terminals from frozen plans

### DIFF
--- a/prebindgen-c/src/chain.rs
+++ b/prebindgen-c/src/chain.rs
@@ -60,6 +60,7 @@ enum CBody {
     InputTerminal(InputTerminalPlan),
     OutputTerminal(OutputTerminalPlan),
     Payload(PayloadPlan),
+    Borrow(BorrowPlan),
     Product(ProductPlan),
     Optional(OptionalPlan),
     Sequence(SequencePlan),
@@ -127,6 +128,18 @@ impl CFunction {
         Self {
             call,
             body: CBody::Payload(plan),
+        }
+    }
+
+    pub(crate) fn borrow(plan: BorrowPlan) -> Self {
+        let call = CCall(chain::Call::new(
+            plan.ident.clone(),
+            plan.operation.fallible(),
+            true,
+        ));
+        Self {
+            call,
+            body: CBody::Borrow(plan),
         }
     }
 
@@ -225,6 +238,14 @@ impl CFunction {
         matches!(self.body, CBody::Payload(_))
     }
 
+    #[cfg(test)]
+    pub(crate) fn borrow_operation(&self) -> Option<&BorrowOperation> {
+        match &self.body {
+            CBody::Borrow(plan) => Some(&plan.operation),
+            _ => None,
+        }
+    }
+
     pub(crate) fn call(&self) -> &CCall {
         &self.call
     }
@@ -242,6 +263,7 @@ impl RustFunction for CFunction {
             CBody::InputTerminal(plan) => plan.render(emit),
             CBody::OutputTerminal(plan) => plan.render(emit),
             CBody::Payload(plan) => plan.render(emit),
+            CBody::Borrow(plan) => plan.render(emit),
             CBody::Product(plan) => plan.render(emit),
             CBody::Choice(plan) => plan.render(emit),
             CBody::Sequence(plan) => plan.render(emit),
@@ -249,6 +271,116 @@ impl RustFunction for CFunction {
             CBody::DeferredInvoke => {
                 unreachable!("a deferred C Invoke helper is rendered by its callback artifact")
             }
+        }
+    }
+}
+
+/// One source borrow crossing retained without spelling its referent.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) enum BorrowOperation {
+    StrInput,
+    SharedInput,
+    MutableInput,
+    MutableUninitInput,
+    SharedOutput,
+}
+
+impl BorrowOperation {
+    fn fallible(&self) -> bool {
+        !matches!(self, Self::SharedOutput)
+    }
+}
+
+/// A borrow terminal whose referent is materialized only during final emission.
+#[derive(Clone)]
+pub(crate) struct BorrowPlan {
+    pub(crate) ident: syn::Ident,
+    pub(crate) source_inner: TypeRef,
+    pub(crate) source_module: Option<syn::Path>,
+    pub(crate) wire: syn::Type,
+    pub(crate) operation: BorrowOperation,
+    pub(crate) null_message: String,
+}
+
+impl BorrowPlan {
+    fn render(&self, emit: &Emit) -> syn::ItemFn {
+        let name = &self.ident;
+        let source_inner = qualify_source_type(
+            &emit.spell_ty(&self.source_inner),
+            self.source_module.as_ref(),
+        );
+        let wire = &self.wire;
+        let null_message = &self.null_message;
+
+        match self.operation {
+            BorrowOperation::StrInput => syn::parse_quote!(
+                #[allow(non_snake_case, unused_variables, dead_code)]
+                pub(crate) unsafe fn #name<'a>(
+                    v: #wire,
+                ) -> ::core::result::Result<&'a str, ::std::string::String> {
+                    if v.is_null() {
+                        return ::core::result::Result::Err(
+                            ::std::string::String::from(#null_message),
+                        );
+                    }
+                    match ::std::ffi::CStr::from_ptr(v).to_str() {
+                        ::core::result::Result::Ok(s) => ::core::result::Result::Ok(s),
+                        ::core::result::Result::Err(_) => ::core::result::Result::Err(
+                            ::std::string::String::from("invalid UTF-8 in str argument"),
+                        ),
+                    }
+                }
+            ),
+            BorrowOperation::SharedInput => syn::parse_quote!(
+                #[allow(non_snake_case, unused_variables, dead_code)]
+                pub(crate) unsafe fn #name<'a>(
+                    v: #wire,
+                ) -> ::core::result::Result<&'a #source_inner, ::std::string::String> {
+                    if v.is_null() {
+                        return ::core::result::Result::Err(
+                            ::std::string::String::from(#null_message),
+                        );
+                    }
+                    ::core::result::Result::Ok(&*(v as *const #source_inner))
+                }
+            ),
+            BorrowOperation::MutableInput => syn::parse_quote!(
+                #[allow(non_snake_case, unused_variables, dead_code)]
+                pub(crate) unsafe fn #name<'a>(
+                    v: #wire,
+                ) -> ::core::result::Result<&'a mut #source_inner, ::std::string::String> {
+                    if v.is_null() {
+                        return ::core::result::Result::Err(
+                            ::std::string::String::from(#null_message),
+                        );
+                    }
+                    ::core::result::Result::Ok(&mut *(v as *mut #source_inner))
+                }
+            ),
+            BorrowOperation::MutableUninitInput => syn::parse_quote!(
+                #[allow(non_snake_case, unused_variables, dead_code)]
+                pub(crate) unsafe fn #name<'a>(
+                    v: #wire,
+                ) -> ::core::result::Result<
+                    &'a mut ::core::mem::MaybeUninit<#source_inner>,
+                    ::std::string::String,
+                > {
+                    if v.is_null() {
+                        return ::core::result::Result::Err(
+                            ::std::string::String::from(#null_message),
+                        );
+                    }
+                    ::core::result::Result::Ok(
+                        &mut *(v as *mut ::core::mem::MaybeUninit<#source_inner>)
+                    )
+                }
+            ),
+            BorrowOperation::SharedOutput => syn::parse_quote!(
+                #[allow(non_snake_case, dead_code, unused)]
+                pub(crate) unsafe fn #name(v: &#source_inner) -> #wire {
+                    v as *const #source_inner as #wire
+                }
+            ),
         }
     }
 }

--- a/prebindgen-c/src/compile.rs
+++ b/prebindgen-c/src/compile.rs
@@ -570,6 +570,35 @@ impl CFrag {
             value,
         }
     }
+
+    /// A source borrow retained until final Rust emission.
+    fn from_borrow(at: At<'_>, plan: crate::chain::BorrowPlan) -> Self {
+        let destination = plan.wire.clone();
+        let subs = vec![plan.source_inner.key()];
+        let function = CFunction::borrow(plan);
+        let niches = Niches::empty();
+        let value = CValue::Direct {
+            wire: destination.clone(),
+            converter: function.call().clone(),
+            niches: niches.clone(),
+        };
+        Self {
+            id: FragmentId::new(at.crossing.spelled().key(), at.recipe.clone()),
+            source: at.crossing.spelled().clone(),
+            destination,
+            function,
+            niches,
+            subs,
+            arm: None,
+            yields: Yield {
+                ty: at.crossing.value().stripped_key(),
+                mode: at.crossing.mode(),
+                validity: Validity::Borrowed,
+            },
+            shape: CShape::Atomic,
+            value,
+        }
+    }
 }
 
 /// How long what this conversion produces stays usable.
@@ -580,7 +609,7 @@ impl CFrag {
 /// hand C a pointer *into* a Rust value from a crossing that looks owned.
 fn validity_of(conv: &ConverterImpl, direction: Direction) -> Validity {
     match direction {
-        // Rust to C. A `*const T` is the zero-copy borrow: `out_borrow_or_result`
+        // Rust to C. A `*const T` is the zero-copy borrow: the late borrow plan
         // casts the Rust value's own address, and `repr_c_struct`'s reinterpret
         // does the same, so the pointer dies with the value it points into. A
         // `*mut` is a handle C now owns (`Box::into_raw`) or a block C must free
@@ -741,9 +770,12 @@ impl<R: Conversions> Compile for CCompile<'_, R> {
                 return Ok(CFrag::from_input_terminal(at, plan));
             }
         }
+        if let Some(plan) = self.gen.borrow_plan(ty, at.crossing.direction()) {
+            return Ok(CFrag::from_borrow(at, plan));
+        }
         let conv = match at.crossing.direction() {
-            Direction::Construct => self.gen.in_borrow(ty),
-            Direction::Deconstruct => self.gen.out_borrow_or_result(ty),
+            Direction::Construct => None,
+            Direction::Deconstruct => self.gen.out_result_marker(ty),
         };
         self.wrap(at, "no C representation for this type", conv)
     }

--- a/prebindgen-c/src/tests/lowering.rs
+++ b/prebindgen-c/src/tests/lowering.rs
@@ -391,6 +391,57 @@ fn specialized_field_terminals_stay_unrendered_until_final_write() {
     );
 }
 
+#[test]
+fn borrow_terminals_stay_unrendered_until_final_write() {
+    use crate::chain::BorrowOperation;
+
+    let loc = SourceLocation::default();
+    let items: Vec<(syn::Item, SourceLocation)> = [
+        "pub struct Handle;",
+        "pub struct Record { pub value: u64 }",
+        "pub fn read_str(v: &str) -> usize { unimplemented!() }",
+        "pub fn share(v: &Handle) -> &Handle { unimplemented!() }",
+        "pub fn mutate(v: &mut Handle) { unimplemented!() }",
+        "pub fn fill(v: &mut std::mem::MaybeUninit<Record>) { unimplemented!() }",
+    ]
+    .into_iter()
+    .map(|source| (syn::parse_str(source).unwrap(), loc.clone()))
+    .collect();
+    let registry = crate::test_util::reg_from_items(items).unwrap();
+    let generated = CbindgenBuilder::new()
+        .opaque_ptr(syn::parse_quote!(Handle))
+        .repr_c_struct(syn::parse_quote!(Record))
+        .function(syn::parse_quote!(read_str))
+        .panic()
+        .function(syn::parse_quote!(share))
+        .panic()
+        .function(syn::parse_quote!(mutate))
+        .panic()
+        .function(syn::parse_quote!(fill))
+        .panic()
+        .build_with(registry)
+        .expect("resolve");
+
+    for operation in [
+        BorrowOperation::StrInput,
+        BorrowOperation::SharedInput,
+        BorrowOperation::MutableInput,
+        BorrowOperation::MutableUninitInput,
+        BorrowOperation::SharedOutput,
+    ] {
+        assert_eq!(
+            generated
+                .gen
+                .compiled_fns
+                .iter()
+                .filter(|function| function.borrow_operation() == Some(&operation))
+                .count(),
+            1,
+            "{operation:?} must retain its own semantic plan before final writing"
+        );
+    }
+}
+
 /// An adapter with no declarations writes an empty (whitespace-only) file.
 #[test]
 fn empty_adapter_writes_empty_file() {

--- a/prebindgen-c/src/trait_impl.rs
+++ b/prebindgen-c/src/trait_impl.rs
@@ -1679,9 +1679,14 @@ impl CbindgenBuilder {
         })
     }
 
-    /// `&str`, `&mut T` and `&T` **input** shapes: a borrow reached through the
-    /// pointer the C caller supplied.
-    pub(crate) fn in_borrow(&self, ty: &TypeRef) -> Option<ConverterImpl> {
+    /// Retain an input or output borrow without spelling its Rust referent.
+    pub(crate) fn borrow_plan(
+        &self,
+        ty: &TypeRef,
+        direction: Direction,
+    ) -> Option<crate::chain::BorrowPlan> {
+        use crate::chain::{BorrowOperation, BorrowPlan};
+
         // `mutable` off the `Ref` itself, NOT `is_exclusive_borrow`: that
         // reading deliberately answers `false` for `&mut MaybeUninit<_>` — an
         // out-param slot is not an exclusive borrow OF A VALUE — and these arms
@@ -1698,35 +1703,44 @@ impl CbindgenBuilder {
         // or its source path, both of which the model answers.
         let elem = rf_inner;
 
+        let plan = |ident, source_inner, wire, operation, null_message| BorrowPlan {
+            ident,
+            source_inner,
+            source_module: self.source_module.clone(),
+            wire,
+            operation,
+            null_message,
+        };
+
+        if direction == Direction::Deconstruct {
+            if *rf_mut {
+                return None;
+            }
+            let key = elem.key();
+            let wire_ty: syn::Type = if self.opaque.contains_key(&key) {
+                let c_struct = self.c_type_ident(&key);
+                syn::parse_quote!(#c_struct)
+            } else {
+                self.value_opaque_ty_of(&key)?.clone()
+            };
+            return Some(plan(
+                format_ident!("__cbg_out_ref_{}", sanitize(&key)),
+                elem.as_ref().clone(),
+                syn::parse_quote!(*const #wire_ty),
+                BorrowOperation::SharedOutput,
+                String::new(),
+            ));
+        }
+
         // `&str`: borrow a UTF-8 C string directly from the caller.
         if !*rf_mut && r_is_str(rf_inner) {
-            let name = Self::in_name_of(&ty.key());
-            let function: syn::ItemFn = syn::parse_quote!(
-                #[allow(non_snake_case, unused_variables, dead_code)]
-                pub(crate) unsafe fn #name<'a>(
-                    v: *const ::core::ffi::c_char,
-                ) -> ::core::result::Result<&'a str, ::std::string::String> {
-                    if v.is_null() {
-                        return ::core::result::Result::Err(
-                            ::std::string::String::from("null pointer passed for str argument"),
-                        );
-                    }
-                    match ::std::ffi::CStr::from_ptr(v).to_str() {
-                        ::core::result::Result::Ok(s) => ::core::result::Result::Ok(s),
-                        ::core::result::Result::Err(_) => ::core::result::Result::Err(
-                            ::std::string::String::from("invalid UTF-8 in str argument"),
-                        ),
-                    }
-                }
-            );
-            return Some(ConverterImpl {
-                subs: vec![elem.key()],
-                destination: syn::parse_quote!(*const ::core::ffi::c_char),
-                function,
-                pre_stages: vec![],
-                niches: Niches::empty(),
-                metadata: (),
-            });
+            return Some(plan(
+                Self::in_name_of(&ty.key()),
+                elem.as_ref().clone(),
+                syn::parse_quote!(*const ::core::ffi::c_char),
+                BorrowOperation::StrInput,
+                "null pointer passed for str argument".to_owned(),
+            ));
         }
         // `&mut T` (mutable borrow). Three sub-cases, all wiring to a `*mut` of the
         // wire (the C memory IS the Rust value for a value-opaque mirror — asserted
@@ -1738,31 +1752,14 @@ impl CbindgenBuilder {
             // reading a path's tail ident.
             if let prebindgen_registry::flat::TypeKind::Uninit(inner) = elem.kind() {
                 let op = self.value_opaque_ty_of(&inner.key())?.clone();
-                let name = Self::in_name_of(&ty.key());
-                let src = self.src_ty_of(&inner.key());
                 let short = type_short(&inner.key());
-                let null_ptr_msg = format!("null {short} pointer");
-                let function: syn::ItemFn = syn::parse_quote!(
-                    #[allow(non_snake_case, unused_variables, dead_code)]
-                    pub(crate) unsafe fn #name<'a>(
-                        v: *mut #op,
-                    ) -> ::core::result::Result<&'a mut ::core::mem::MaybeUninit<#src>, ::std::string::String> {
-                        if v.is_null() {
-                            return ::core::result::Result::Err(
-                                ::std::string::String::from(#null_ptr_msg),
-                            );
-                        }
-                        ::core::result::Result::Ok(&mut *(v as *mut ::core::mem::MaybeUninit<#src>))
-                    }
-                );
-                return Some(ConverterImpl {
-                    subs: vec![inner.key()],
-                    destination: syn::parse_quote!(*mut #op),
-                    function,
-                    pre_stages: vec![],
-                    niches: Niches::empty(),
-                    metadata: (),
-                });
+                return Some(plan(
+                    Self::in_name_of(&ty.key()),
+                    inner.as_ref().clone(),
+                    syn::parse_quote!(*mut #op),
+                    BorrowOperation::MutableUninitInput,
+                    format!("null {short} pointer"),
+                ));
             }
             // `&mut` opaque handle, or `&mut` value-opaque: both reinterpret the C
             // pointer as a mutable Rust reference. The wire is the handle's C struct
@@ -1773,31 +1770,14 @@ impl CbindgenBuilder {
             } else {
                 self.value_opaque_ty_of(&elem.key())?.clone()
             };
-            let name = Self::in_name_of(&ty.key());
-            let src = self.src_ty_of(&elem.key());
             let short = type_short(&elem.key());
-            let null_ptr_msg = format!("null {short} pointer");
-            let function: syn::ItemFn = syn::parse_quote!(
-                #[allow(non_snake_case, unused_variables, dead_code)]
-                pub(crate) unsafe fn #name<'a>(
-                    v: *mut #wire_ty,
-                ) -> ::core::result::Result<&'a mut #src, ::std::string::String> {
-                    if v.is_null() {
-                        return ::core::result::Result::Err(
-                            ::std::string::String::from(#null_ptr_msg),
-                        );
-                    }
-                    ::core::result::Result::Ok(&mut *(v as *mut #src))
-                }
-            );
-            return Some(ConverterImpl {
-                subs: vec![elem.key()],
-                destination: syn::parse_quote!(*mut #wire_ty),
-                function,
-                pre_stages: vec![],
-                niches: Niches::empty(),
-                metadata: (),
-            });
+            return Some(plan(
+                Self::in_name_of(&ty.key()),
+                elem.as_ref().clone(),
+                syn::parse_quote!(*mut #wire_ty),
+                BorrowOperation::MutableInput,
+                format!("null {short} pointer"),
+            ));
         }
         // `&T` (shared borrow) of an opaque handle or value-opaque type.
         let key1 = elem.key();
@@ -1807,29 +1787,14 @@ impl CbindgenBuilder {
         } else {
             self.value_opaque_ty_of(&elem.key())?.clone()
         };
-        let name = Self::in_name_of(&ty.key());
-        let src = self.src_ty_of(&elem.key());
         let short = type_short(&elem.key());
-        let null_ptr_msg = format!("null {short} pointer");
-        let function: syn::ItemFn = syn::parse_quote!(
-            #[allow(non_snake_case, unused_variables, dead_code)]
-            pub(crate) unsafe fn #name<'a>(
-                v: *const #wire_ty,
-            ) -> ::core::result::Result<&'a #src, ::std::string::String> {
-                if v.is_null() {
-                    return ::core::result::Result::Err(::std::string::String::from(#null_ptr_msg));
-                }
-                ::core::result::Result::Ok(&*(v as *const #src))
-            }
-        );
-        Some(ConverterImpl {
-            subs: vec![elem.key()],
-            destination: syn::parse_quote!(*const #wire_ty),
-            function,
-            pre_stages: vec![],
-            niches: Niches::empty(),
-            metadata: (),
-        })
+        Some(plan(
+            Self::in_name_of(&ty.key()),
+            elem.as_ref().clone(),
+            syn::parse_quote!(*const #wire_ty),
+            BorrowOperation::SharedInput,
+            format!("null {short} pointer"),
+        ))
     }
 
     /// The `Option<X>` / `Vec<X>` / `Cow<'_, [X]>` **output** marker.
@@ -1853,40 +1818,9 @@ impl CbindgenBuilder {
         }
     }
 
-    /// The `&T` shared borrow and the `Result<T, E>` marker — the two **output**
-    /// shapes that are neither terminal nor a run.
-    pub(crate) fn out_borrow_or_result(&self, ty: &TypeRef) -> Option<ConverterImpl> {
-        // `&T` shared borrow of an opaque/value-opaque type → non-owning `*const`.
-        if let TypeKind::Ref { mutable, inner, .. } = ty.kind() {
-            if !*mutable {
-                let key = inner.key();
-                let wire_ty: syn::Type = if self.opaque.contains_key(&key) {
-                    let c_struct = self.c_type_ident(&key);
-                    syn::parse_quote!(#c_struct)
-                } else {
-                    self.value_opaque_ty_of(&key)?.clone()
-                };
-                let src = self.src_ty_of(&key);
-                let name = format_ident!("__cbg_out_ref_{}", sanitize(&key));
-                let function: syn::ItemFn = syn::parse_quote!(
-                    #[allow(non_snake_case, dead_code, unused)]
-                    pub(crate) unsafe fn #name(v: &#src) -> *const #wire_ty {
-                        v as *const #src as *const #wire_ty
-                    }
-                );
-                return Some(ConverterImpl {
-                    subs: vec![key],
-                    destination: syn::parse_quote!(*const #wire_ty),
-                    function,
-                    pre_stages: vec![],
-                    niches: Niches::empty(),
-                    metadata: (),
-                });
-            }
-            return None;
-        }
-        // `Result<T, E>` marker — real lowering (bool + out-param + error-param)
-        // is in `on_function`.
+    /// The `Result<T, E>` output marker. Real lowering (bool + out-param +
+    /// error-param) is in `on_function`.
+    pub(crate) fn out_result_marker(&self, ty: &TypeRef) -> Option<ConverterImpl> {
         let (ok, err) = ty.fallible_parts()?;
         let name = format_ident!("__cbg_result_{}", sanitize(&ty.key()));
         let function: syn::ItemFn = syn::parse_quote!(


### PR DESCRIPTION
## Summary

- retain all five C borrow crossings as typed `BorrowPlan` values instead of eagerly rendered `ConverterImpl` functions
- materialize the source referent only in the writer-owned final `Emit` pass
- separate the remaining `Result<T, E>` marker fallback from borrow lowering
- add an operation-specific seam test covering string, shared, mutable, `MaybeUninit`, and shared-output borrows

## Design

A `BorrowOperation` records the exact semantic terminal: `StrInput`, `SharedInput`, `MutableInput`, `MutableUninitInput`, or `SharedOutput`. The plan keeps the referent as an opaque `TypeRef`; source spelling and module qualification happen only when the Rust function is finally emitted.

The compiled fragment retains borrowed validity and the same direct C wire representation. Input variants remain fallible because they reject null pointers; shared output remains infallible.

## Compatibility

This is an internal pipeline simplification. Regenerated Rust and C artifacts are byte-for-byte unchanged.

## Verification

- `cargo test -p prebindgen-c` (105 tests)
- `cargo test --workspace --all-features`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps`
- `cargo fmt --all -- --check`
- `git diff --check`
- `./examples/regen-check.sh`

## Follow-up

The umbrella still needs late plans for slice terminals, payload cleanup/prerequisite declarations, arity/result markers, and the remaining Choice compatibility path.