### PR TITLE
Freeze C slice input terminals

### DIFF
--- a/prebindgen-c/src/chain.rs
+++ b/prebindgen-c/src/chain.rs
@@ -61,6 +61,7 @@ enum CBody {
     OutputTerminal(OutputTerminalPlan),
     Payload(PayloadPlan),
     Borrow(BorrowPlan),
+    SliceInput(SliceInputPlan),
     Product(ProductPlan),
     Optional(OptionalPlan),
     Sequence(SequencePlan),
@@ -140,6 +141,14 @@ impl CFunction {
         Self {
             call,
             body: CBody::Borrow(plan),
+        }
+    }
+
+    pub(crate) fn slice_input(plan: SliceInputPlan) -> Self {
+        let call = CCall(chain::Call::new(plan.ident.clone(), false, false));
+        Self {
+            call,
+            body: CBody::SliceInput(plan),
         }
     }
 
@@ -246,6 +255,14 @@ impl CFunction {
         }
     }
 
+    #[cfg(test)]
+    pub(crate) fn slice_input_operation(&self) -> Option<(&TypeRef, bool)> {
+        match &self.body {
+            CBody::SliceInput(plan) => Some((&plan.element, plan.reinterpret)),
+            _ => None,
+        }
+    }
+
     pub(crate) fn call(&self) -> &CCall {
         &self.call
     }
@@ -264,6 +281,7 @@ impl RustFunction for CFunction {
             CBody::OutputTerminal(plan) => plan.render(emit),
             CBody::Payload(plan) => plan.render(emit),
             CBody::Borrow(plan) => plan.render(emit),
+            CBody::SliceInput(plan) => plan.render(),
             CBody::Product(plan) => plan.render(emit),
             CBody::Choice(plan) => plan.render(emit),
             CBody::Sequence(plan) => plan.render(emit),
@@ -272,6 +290,25 @@ impl RustFunction for CFunction {
                 unreachable!("a deferred C Invoke helper is rendered by its callback artifact")
             }
         }
+    }
+}
+
+/// A zero-copy shared-slice input retained without a legacy converter body.
+#[derive(Clone)]
+pub(crate) struct SliceInputPlan {
+    pub(crate) ident: syn::Ident,
+    pub(crate) element: TypeRef,
+    pub(crate) wire: syn::Type,
+    pub(crate) reinterpret: bool,
+}
+
+impl SliceInputPlan {
+    fn render(&self) -> syn::ItemFn {
+        let name = &self.ident;
+        syn::parse_quote!(
+            #[allow(non_snake_case, dead_code, unused)]
+            pub(crate) fn #name() {}
+        )
     }
 }
 

--- a/prebindgen-c/src/compile.rs
+++ b/prebindgen-c/src/compile.rs
@@ -23,7 +23,7 @@ use prebindgen_registry::{
 use super::*;
 use crate::chain::{
     CCall, CFunction, ChoicePlan, OptionalPlan, OptionalRepr, ProductField, ProductPlan,
-    SequencePlan,
+    SequencePlan, SliceInputPlan,
 };
 
 /// The shape selected by the recipe compiler, retaining semantic child edges.
@@ -599,6 +599,39 @@ impl CFrag {
             value,
         }
     }
+
+    /// A shared-slice marker retained as semantic data until final emission.
+    fn from_slice_input(at: At<'_>, plan: SliceInputPlan) -> Self {
+        let destination = plan.wire.clone();
+        let element = plan.element.clone();
+        let reinterpret = plan.reinterpret;
+        let subs = vec![element.key()];
+        let function = CFunction::slice_input(plan);
+        let niches = Niches::empty();
+        let value = CValue::BorrowedInput {
+            element,
+            wire: destination.clone(),
+            reinterpret,
+        };
+        Self {
+            id: FragmentId::new(at.crossing.spelled().key(), at.recipe.clone()),
+            source: at.crossing.spelled().clone(),
+            destination,
+            function,
+            niches,
+            subs,
+            arm: None,
+            yields: Yield {
+                ty: at.crossing.value().stripped_key(),
+                mode: at.crossing.mode(),
+                // Preserve the legacy marker's classification. The actual
+                // borrowed wire is explicit in CValue::BorrowedInput.
+                validity: Validity::SelfSufficient,
+            },
+            shape: CShape::Atomic,
+            value,
+        }
+    }
 }
 
 /// How long what this conversion produces stays usable.
@@ -896,27 +929,31 @@ impl<R: Conversions> Compile for CCompile<'_, R> {
                 }
             }
         }
-        let conv = match at.crossing.direction() {
+        let mut fragment = match at.crossing.direction() {
             // A `&[E]` is the only run C builds a Rust value out of, and it does
             // it zero-copy from the caller's own block.
-            Direction::Construct => self.gen.in_slice(ty),
+            Direction::Construct => {
+                let plan = self
+                    .gen
+                    .in_slice_plan(ty)
+                    .ok_or_else(|| refuse(at, "no C representation for this run"))?;
+                CFrag::from_slice_input(at, plan)
+            }
             // A deconstructed run has no single wire of its own. The frozen
             // CValue below carries its pointer-plus-length ABI and encoder.
-            Direction::Deconstruct => Some(self.gen.out_arity_marker("vec", &inner.source)),
+            Direction::Deconstruct => self.wrap(
+                at,
+                "no C representation for this run",
+                Some(self.gen.out_arity_marker("vec", &inner.source)),
+            )?,
         };
-        let mut fragment = self.wrap(at, "no C representation for this run", conv)?;
         fragment.shape = CShape::Sequence(fragment_use(inner));
-        fragment.value = match at.crossing.direction() {
-            Direction::Construct => CValue::BorrowedInput {
-                element: inner.source.clone(),
-                wire: fragment.destination.clone(),
-                reinterpret: scalar_ty(&inner.source).is_none(),
-            },
-            Direction::Deconstruct => CValue::BorrowedSequence {
+        if at.crossing.direction() == Direction::Deconstruct {
+            fragment.value = CValue::BorrowedSequence {
                 element_wire: inner.destination.clone(),
                 converter: inner.function.call().clone(),
-            },
-        };
+            };
+        }
         Ok(fragment)
     }
 

--- a/prebindgen-c/src/tests/lowering.rs
+++ b/prebindgen-c/src/tests/lowering.rs
@@ -442,6 +442,46 @@ fn borrow_terminals_stay_unrendered_until_final_write() {
     }
 }
 
+#[test]
+fn slice_input_terminals_stay_unrendered_until_final_write() {
+    let loc = SourceLocation::default();
+    let items: Vec<(syn::Item, SourceLocation)> = [
+        "pub struct Record { pub value: u64 }",
+        "pub fn scalar_slice(v: &[u8]) { unimplemented!() }",
+        "pub fn record_slice(v: &[Record]) { unimplemented!() }",
+    ]
+    .into_iter()
+    .map(|source| (syn::parse_str(source).unwrap(), loc.clone()))
+    .collect();
+    let registry = crate::test_util::reg_from_items(items).unwrap();
+    let generated = CbindgenBuilder::new()
+        .repr_c_struct(syn::parse_quote!(Record))
+        .function(syn::parse_quote!(scalar_slice))
+        .panic()
+        .function(syn::parse_quote!(record_slice))
+        .panic()
+        .build_with(registry)
+        .expect("resolve");
+
+    let mut operations: Vec<(TypeKey, bool)> = generated
+        .gen
+        .compiled_fns
+        .iter()
+        .filter_map(|function| function.slice_input_operation())
+        .map(|(element, reinterpret)| (element.key(), reinterpret))
+        .collect();
+    operations.sort_by(|a, b| a.0.cmp(&b.0));
+
+    assert_eq!(
+        operations,
+        [
+            (TypeKey::from_type(&syn::parse_quote!(Record)), true),
+            (TypeKey::from_type(&syn::parse_quote!(u8)), false),
+        ],
+        "scalar and value-opaque slices must retain their exact final-decode operation"
+    );
+}
+
 /// An adapter with no declarations writes an empty (whitespace-only) file.
 #[test]
 fn empty_adapter_writes_empty_file() {

--- a/prebindgen-c/src/trait_impl.rs
+++ b/prebindgen-c/src/trait_impl.rs
@@ -1637,10 +1637,10 @@ impl CbindgenBuilder {
 /// peels `ty`'s outermost layer and composes the inner's converter; `subs`
 /// lists the immediate inner(s) it looked up.
 impl CbindgenBuilder {
-    /// `&[E]` slice **input**: marker only for converter-artifact compatibility.
+    /// `&[E]` slice **input** retained without a rendered converter body.
     /// The frozen site plan owns the two-parameter (`*const E_wire`, `usize`)
     /// ABI and zero-copy decode.
-    pub(crate) fn in_slice(&self, ty: &TypeRef) -> Option<ConverterImpl> {
+    pub(crate) fn in_slice_plan(&self, ty: &TypeRef) -> Option<crate::chain::SliceInputPlan> {
         let e = r_shared_slice_elem(ty)?;
         // #170, the slice instance. The two-param lowering builds the
         // `&[E]` zero-copy from C's own block, so there is nowhere to
@@ -1658,24 +1658,19 @@ impl CbindgenBuilder {
                  `opaque_ptr` handle."
             );
         }
-        let wire: syn::Type = if let Some(e_ty) = scalar_ty(e) {
-            syn::parse_quote!(*const #e_ty)
-        } else {
-            let counterpart = self.value_opaque_ty_of(&e.key())?.clone();
-            syn::parse_quote!(*const #counterpart)
+        let scalar = scalar_ty(e);
+        let wire: syn::Type = match &scalar {
+            Some(e_ty) => syn::parse_quote!(*const #e_ty),
+            None => {
+                let counterpart = self.value_opaque_ty_of(&e.key())?.clone();
+                syn::parse_quote!(*const #counterpart)
+            }
         };
-        let name = format_ident!("__cbg_inmark_slice_{}", sanitize(&e.key()));
-        let function: syn::ItemFn = syn::parse_quote!(
-            #[allow(non_snake_case, dead_code, unused)]
-            pub(crate) fn #name() {}
-        );
-        Some(ConverterImpl {
-            subs: vec![e.key()],
-            destination: wire,
-            function,
-            pre_stages: vec![],
-            niches: Niches::empty(),
-            metadata: (),
+        Some(crate::chain::SliceInputPlan {
+            ident: format_ident!("__cbg_inmark_slice_{}", sanitize(&e.key())),
+            element: e.clone(),
+            wire,
+            reinterpret: scalar.is_none(),
         })
     }
 


### PR DESCRIPTION
## Summary

- replace the C `&[E]` input marker's eager `ConverterImpl` with a typed `SliceInputPlan`
- retain the element `TypeRef`, exact pointer wire, and scalar-versus-value-opaque reinterpretation decision in the frozen fragment
- keep pointer-plus-length decoding in the final wrapper renderer, where source element spelling already belongs
- cover both scalar and value-opaque slice operations at the planning/rendering seam

## Design

The real slice conversion was already registry-driven: `CValue::BorrowedInput` owns the two-slot ABI, and final wrapper emission reconstructs the zero-copy slice while holding the element as an opaque `TypeRef`. The remaining legacy object was a dummy zero-argument function wrapped in `ConverterImpl` solely to carry identity, reachability, and a renderable artifact.

`SliceInputPlan` now carries those facts directly. Its final renderer preserves the existing private marker artifact, while fragment construction records the exact element, pointer wire, and whether the wrapper must reinterpret a value-opaque mirror.

## Compatibility

This is an internal carrier simplification. The pointer-plus-length ABI, null-as-empty policy, zero-copy behavior, and generated artifacts are byte-for-byte unchanged.

## Verification

- `cargo test -p prebindgen-c` (106 tests)
- `cargo test --workspace --all-features`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps`
- `cargo fmt --all -- --check`
- `git diff --check`
- `./examples/regen-check.sh`

## Follow-up

The remaining C complete-function carriers are payload cleanup/prerequisite declarations, arity/result markers, and Choice's compatibility arm marker.