### PR TITLE
Type C multi-wire output markers

### DIFF
--- a/prebindgen-c/src/chain.rs
+++ b/prebindgen-c/src/chain.rs
@@ -62,6 +62,7 @@ enum CBody {
     Payload(PayloadPlan),
     Borrow(BorrowPlan),
     SliceInput(SliceInputPlan),
+    Marker(MarkerPlan),
     Product(ProductPlan),
     Optional(OptionalPlan),
     Sequence(SequencePlan),
@@ -149,6 +150,14 @@ impl CFunction {
         Self {
             call,
             body: CBody::SliceInput(plan),
+        }
+    }
+
+    pub(crate) fn marker(plan: MarkerPlan) -> Self {
+        let call = CCall(chain::Call::new(plan.ident.clone(), false, false));
+        Self {
+            call,
+            body: CBody::Marker(plan),
         }
     }
 
@@ -263,6 +272,14 @@ impl CFunction {
         }
     }
 
+    #[cfg(test)]
+    pub(crate) fn marker_operation(&self) -> Option<&MarkerOperation> {
+        match &self.body {
+            CBody::Marker(plan) => Some(&plan.operation),
+            _ => None,
+        }
+    }
+
     pub(crate) fn call(&self) -> &CCall {
         &self.call
     }
@@ -282,12 +299,39 @@ impl RustFunction for CFunction {
             CBody::Payload(plan) => plan.render(emit),
             CBody::Borrow(plan) => plan.render(emit),
             CBody::SliceInput(plan) => plan.render(),
+            CBody::Marker(plan) => plan.render(),
             CBody::Product(plan) => plan.render(emit),
             CBody::Choice(plan) => plan.render(emit),
             CBody::Sequence(plan) => plan.render(emit),
             CBody::Optional(plan) => plan.render(emit),
             CBody::DeferredInvoke => {
                 unreachable!("a deferred C Invoke helper is rendered by its callback artifact")
+            }
+        }
+    }
+}
+
+/// A multi-wire crossing whose ABI lives in its frozen site value.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) enum MarkerOperation {
+    Optional,
+    Sequence,
+    Result,
+}
+
+/// A typed replacement for one legacy zero-argument marker converter.
+#[derive(Clone)]
+pub(crate) struct MarkerPlan {
+    pub(crate) ident: syn::Ident,
+    pub(crate) operation: MarkerOperation,
+    pub(crate) subs: Vec<TypeRef>,
+}
+
+impl MarkerPlan {
+    fn render(&self) -> syn::ItemFn {
+        match self.operation {
+            MarkerOperation::Optional | MarkerOperation::Sequence | MarkerOperation::Result => {
+                render_marker(&self.ident)
             }
         }
     }
@@ -304,12 +348,15 @@ pub(crate) struct SliceInputPlan {
 
 impl SliceInputPlan {
     fn render(&self) -> syn::ItemFn {
-        let name = &self.ident;
-        syn::parse_quote!(
-            #[allow(non_snake_case, dead_code, unused)]
-            pub(crate) fn #name() {}
-        )
+        render_marker(&self.ident)
     }
+}
+
+fn render_marker(name: &syn::Ident) -> syn::ItemFn {
+    syn::parse_quote!(
+        #[allow(non_snake_case, dead_code, unused)]
+        pub(crate) fn #name() {}
+    )
 }
 
 /// One source borrow crossing retained without spelling its referent.

--- a/prebindgen-c/src/compile.rs
+++ b/prebindgen-c/src/compile.rs
@@ -22,8 +22,8 @@ use prebindgen_registry::{
 
 use super::*;
 use crate::chain::{
-    CCall, CFunction, ChoicePlan, OptionalPlan, OptionalRepr, ProductField, ProductPlan,
-    SequencePlan, SliceInputPlan,
+    CCall, CFunction, ChoicePlan, MarkerOperation, MarkerPlan, OptionalPlan, OptionalRepr,
+    ProductField, ProductPlan, SequencePlan, SliceInputPlan,
 };
 
 /// The shape selected by the recipe compiler, retaining semantic child edges.
@@ -429,12 +429,12 @@ impl CFrag {
         )
     }
 
-    /// One of the adapter's existing converter builders, as a fragment.
-    fn from_converter(at: At<'_>, conv: ConverterImpl) -> Self {
-        let validity = validity_of(&conv, at.crossing.direction());
-        let destination = conv.destination;
-        let niches = conv.niches;
-        let function = CFunction::complete(conv.function);
+    /// A multi-wire crossing whose exact ABI is carried by its frozen value.
+    fn from_marker(at: At<'_>, plan: MarkerPlan) -> Self {
+        let destination: syn::Type = syn::parse_quote!(());
+        let subs = plan.subs.iter().map(TypeRef::key).collect();
+        let function = CFunction::marker(plan);
+        let niches = Niches::empty();
         let value = CValue::Direct {
             wire: destination.clone(),
             converter: function.call().clone(),
@@ -446,12 +446,12 @@ impl CFrag {
             destination,
             function,
             niches,
-            subs: conv.subs,
+            subs,
             arm: None,
             yields: Yield {
                 ty: at.crossing.value().stripped_key(),
                 mode: at.crossing.mode(),
-                validity,
+                validity: Validity::SelfSufficient,
             },
             shape: CShape::Atomic,
             value,
@@ -634,42 +634,6 @@ impl CFrag {
     }
 }
 
-/// How long what this conversion produces stays usable.
-///
-/// A property of the **conversion**, not of how the crossing was spelled.
-/// Reading the spelling is wrong in both directions: a conversion may clone or
-/// allocate out of a borrow, and — the case C actually has — a conversion may
-/// hand C a pointer *into* a Rust value from a crossing that looks owned.
-fn validity_of(conv: &ConverterImpl, direction: Direction) -> Validity {
-    match direction {
-        // Rust to C. A `*const T` is the zero-copy borrow: the late borrow plan
-        // casts the Rust value's own address, and `repr_c_struct`'s reinterpret
-        // does the same, so the pointer dies with the value it points into. A
-        // `*mut` is a handle C now owns (`Box::into_raw`) or a block C must free
-        // (`__cbg_alloc_cstr`), and every by-value wire is a copy.
-        Direction::Deconstruct => match &conv.destination {
-            syn::Type::Ptr(p) if p.mutability.is_none() => Validity::Borrowed,
-            _ => Validity::SelfSufficient,
-        },
-        // C to Rust: what the converter's own function hands back. A decode
-        // yielding `&'a T` borrows the caller's memory, which is right at a
-        // parameter and refused at a return.
-        Direction::Construct => match &conv.function.sig.output {
-            syn::ReturnType::Type(_, ty) if produces_borrow(ty) => Validity::Borrowed,
-            _ => Validity::SelfSufficient,
-        },
-    }
-}
-
-/// Whether a converter's return type hands back a borrow — `&T`, or a
-/// `Result<&T, E>` whose success arm is one.
-fn produces_borrow(ty: &syn::Type) -> bool {
-    match ty {
-        syn::Type::Reference(_) => true,
-        _ => result_parts(ty).is_some_and(|(ok, _)| matches!(ok, syn::Type::Reference(_))),
-    }
-}
-
 /// The adapter, for the length of one crossing's compilation.
 ///
 /// Holds the binding's declarations and the registry view the emission helpers
@@ -726,13 +690,6 @@ fn held_uninit(declared: &syn::Type, produced: &syn::Type) -> bool {
 /// A refusal naming the crossing that could not be answered.
 fn refuse(at: At<'_>, why: &str) -> String {
     format!("Cbindgen: {} ({why})", at.crossing.key())
-}
-
-impl<R: Conversions> CCompile<'_, R> {
-    fn wrap(&self, at: At<'_>, why: &str, conv: Option<ConverterImpl>) -> Frag<Self> {
-        conv.map(|c| CFrag::from_converter(at, c))
-            .ok_or_else(|| refuse(at, why))
-    }
 }
 
 impl<R: Conversions> Compile for CCompile<'_, R> {
@@ -806,11 +763,12 @@ impl<R: Conversions> Compile for CCompile<'_, R> {
         if let Some(plan) = self.gen.borrow_plan(ty, at.crossing.direction()) {
             return Ok(CFrag::from_borrow(at, plan));
         }
-        let conv = match at.crossing.direction() {
-            Direction::Construct => None,
-            Direction::Deconstruct => self.gen.out_result_marker(ty),
-        };
-        self.wrap(at, "no C representation for this type", conv)
+        if at.crossing.direction() == Direction::Deconstruct {
+            if let Some(plan) = self.gen.out_marker_plan(MarkerOperation::Result, ty) {
+                return Ok(CFrag::from_marker(at, plan));
+            }
+        }
+        Err(refuse(at, "no C representation for this type"))
     }
 
     fn optional(&mut self, _cx: &mut Cx<'_>, at: At<'_>, inner: &CFrag) -> Frag<Self> {
@@ -821,8 +779,11 @@ impl<R: Conversions> Compile for CCompile<'_, R> {
             ));
         };
         if at.crossing.direction() == Direction::Deconstruct {
-            let marker = self.gen.out_arity_marker("option", elem);
-            let mut fragment = CFrag::from_converter(at, marker);
+            let marker = self
+                .gen
+                .out_marker_plan(MarkerOperation::Optional, elem)
+                .expect("Optional output markers accept every resolved inner");
+            let mut fragment = CFrag::from_marker(at, marker);
             let absent = inner.value.effective_niches().carve().map(|(slot, _)| slot);
             fragment.shape = CShape::Optional(fragment_use(inner));
             fragment.value = CValue::Optional {
@@ -941,11 +902,12 @@ impl<R: Conversions> Compile for CCompile<'_, R> {
             }
             // A deconstructed run has no single wire of its own. The frozen
             // CValue below carries its pointer-plus-length ABI and encoder.
-            Direction::Deconstruct => self.wrap(
+            Direction::Deconstruct => CFrag::from_marker(
                 at,
-                "no C representation for this run",
-                Some(self.gen.out_arity_marker("vec", &inner.source)),
-            )?,
+                self.gen
+                    .out_marker_plan(MarkerOperation::Sequence, &inner.source)
+                    .expect("Sequence output markers accept every resolved element"),
+            ),
         };
         fragment.shape = CShape::Sequence(fragment_use(inner));
         if at.crossing.direction() == Direction::Deconstruct {

--- a/prebindgen-c/src/lib.rs
+++ b/prebindgen-c/src/lib.rs
@@ -103,12 +103,12 @@ use std::collections::{HashMap, HashSet};
 // `TypeRef` now, so what is left here serves the two node populations that
 // remain — a build-script declaration, and a converter's own generated
 // signature.
-pub(crate) use prebindgen_registry::types_util::{path_tail_ident as type_path_tail, result_parts};
+pub(crate) use prebindgen_registry::types_util::path_tail_ident as type_path_tail;
 use prebindgen_registry::{
     decl::{ConvertDecl, ConvertSpec},
     flat::{extract_fn_trait_args, Field, Origin, ScalarKind, TypeKind, TypeRef},
     recipe::{Bound, Direction},
-    Conversions, ConverterImpl, NicheSlot, Niches, Prebindgen, Registry, TypeKey,
+    Conversions, NicheSlot, Niches, Prebindgen, Registry, TypeKey,
 };
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote, ToTokens};

--- a/prebindgen-c/src/tests/boundary_invariants.rs
+++ b/prebindgen-c/src/tests/boundary_invariants.rs
@@ -441,7 +441,9 @@ fn legacy_c_shape_and_callback_planners_are_deleted() {
         include_str!("../builder.rs"),
         include_str!("../chain.rs"),
         include_str!("../compile.rs"),
+        include_str!("../convert.rs"),
         include_str!("../emit.rs"),
+        include_str!("../recipes.rs"),
         include_str!("../trait_impl.rs"),
     ]
     .join("\n");
@@ -457,11 +459,15 @@ fn legacy_c_shape_and_callback_planners_are_deleted() {
         "fn from_converter",
         "fn validity_of",
         "fn produces_borrow",
-        "fn wrap(",
     ] {
         assert!(
             !sources.contains(deleted),
             "deleted C compatibility planner returned through {deleted}"
         );
     }
+    let compact: String = sources.chars().filter(|c| !c.is_whitespace()).collect();
+    assert!(
+        !compact.contains("fnwrap(&self,at:At<'_>,why:&str,conv:Option<ConverterImpl>)"),
+        "the deleted generic ConverterImpl fragment wrapper returned"
+    );
 }

--- a/prebindgen-c/src/tests/boundary_invariants.rs
+++ b/prebindgen-c/src/tests/boundary_invariants.rs
@@ -467,7 +467,7 @@ fn legacy_c_shape_and_callback_planners_are_deleted() {
     }
     let compact: String = sources.chars().filter(|c| !c.is_whitespace()).collect();
     assert!(
-        !compact.contains("fnwrap(&self,at:At<'_>,why:&str,conv:Option<ConverterImpl>)"),
-        "the deleted generic ConverterImpl fragment wrapper returned"
+        !compact.contains("Option<ConverterImpl>"),
+        "a C production path accepts the deleted generic converter carrier"
     );
 }

--- a/prebindgen-c/src/tests/boundary_invariants.rs
+++ b/prebindgen-c/src/tests/boundary_invariants.rs
@@ -454,6 +454,10 @@ fn legacy_c_shape_and_callback_planners_are_deleted() {
         "shape_is_lowerable",
         "is_lowered_composite",
         "has_own_wire",
+        "fn from_converter",
+        "fn validity_of",
+        "fn produces_borrow",
+        "fn wrap(",
     ] {
         assert!(
             !sources.contains(deleted),

--- a/prebindgen-c/src/tests/lowering.rs
+++ b/prebindgen-c/src/tests/lowering.rs
@@ -482,6 +482,47 @@ fn slice_input_terminals_stay_unrendered_until_final_write() {
     );
 }
 
+#[test]
+fn multi_wire_markers_stay_typed_until_final_write() {
+    use crate::chain::MarkerOperation;
+
+    let loc = SourceLocation::default();
+    let items: Vec<(syn::Item, SourceLocation)> = [
+        "pub fn maybe() -> Option<u64> { unimplemented!() }",
+        "pub fn values() -> &'static [u64] { &[] }",
+        "pub fn fallible() -> Result<u64, Error> { unimplemented!() }",
+        "pub struct Error { pub message: String }",
+    ]
+    .into_iter()
+    .map(|source| (syn::parse_str(source).unwrap(), loc.clone()))
+    .collect();
+    let registry = crate::test_util::reg_from_items(items).unwrap();
+    let generated = CbindgenBuilder::new()
+        .free_memory_function("free")
+        .data_struct(syn::parse_quote!(Error))
+        .error()
+        .function(syn::parse_quote!(maybe))
+        .function(syn::parse_quote!(values))
+        .function(syn::parse_quote!(fallible))
+        .build_with(registry)
+        .expect("resolve");
+
+    for operation in [
+        MarkerOperation::Optional,
+        MarkerOperation::Sequence,
+        MarkerOperation::Result,
+    ] {
+        assert!(
+            generated
+                .gen
+                .compiled_fns
+                .iter()
+                .any(|function| function.marker_operation() == Some(&operation)),
+            "{operation:?} must retain its own semantic marker before final writing"
+        );
+    }
+}
+
 /// An adapter with no declarations writes an empty (whitespace-only) file.
 #[test]
 fn empty_adapter_writes_empty_file() {

--- a/prebindgen-c/src/trait_impl.rs
+++ b/prebindgen-c/src/trait_impl.rs
@@ -1792,43 +1792,36 @@ impl CbindgenBuilder {
         ))
     }
 
-    /// The `Option<X>` / `Vec<X>` / `Cow<'_, [X]>` **output** marker.
+    /// A typed Optional, Sequence, or Result output marker.
     ///
-    /// Carries a `()` destination: the frozen [`crate::compile::CValue`] owns the
-    /// real multi-leaf ABI, and this legacy converter carrier remains only until
-    /// terminal operations move into final emission.
-    pub(crate) fn out_arity_marker(&self, kind: &str, inner: &TypeRef) -> ConverterImpl {
-        let name = format_ident!("__cbg_outmark_{}_{}", kind, sanitize(&inner.key()));
-        let function: syn::ItemFn = syn::parse_quote!(
-            #[allow(non_snake_case, dead_code, unused)]
-            pub(crate) fn #name() {}
-        );
-        ConverterImpl {
-            subs: vec![inner.key()],
-            destination: syn::parse_quote!(()),
-            function,
-            pre_stages: vec![],
-            niches: Niches::empty(),
-            metadata: (),
-        }
-    }
-
-    /// The `Result<T, E>` output marker. Real lowering (bool + out-param +
-    /// error-param) is in `on_function`.
-    pub(crate) fn out_result_marker(&self, ty: &TypeRef) -> Option<ConverterImpl> {
-        let (ok, err) = ty.fallible_parts()?;
-        let name = format_ident!("__cbg_result_{}", sanitize(&ty.key()));
-        let function: syn::ItemFn = syn::parse_quote!(
-            #[allow(non_snake_case, dead_code, unused)]
-            pub(crate) fn #name() {}
-        );
-        Some(ConverterImpl {
-            subs: vec![ok.key(), err.key()],
-            destination: syn::parse_quote!(()),
-            function,
-            pre_stages: vec![],
-            niches: Niches::empty(),
-            metadata: (),
+    /// Its frozen C value or function site owns the real multi-leaf ABI; the
+    /// marker retains semantic identity and dependency edges for emission.
+    pub(crate) fn out_marker_plan(
+        &self,
+        operation: crate::chain::MarkerOperation,
+        subject: &TypeRef,
+    ) -> Option<crate::chain::MarkerPlan> {
+        let (ident, subs) = match operation {
+            crate::chain::MarkerOperation::Optional => (
+                format_ident!("__cbg_outmark_option_{}", sanitize(&subject.key())),
+                vec![subject.clone()],
+            ),
+            crate::chain::MarkerOperation::Sequence => (
+                format_ident!("__cbg_outmark_vec_{}", sanitize(&subject.key())),
+                vec![subject.clone()],
+            ),
+            crate::chain::MarkerOperation::Result => {
+                let (ok, err) = subject.fallible_parts()?;
+                (
+                    format_ident!("__cbg_result_{}", sanitize(&subject.key())),
+                    vec![ok.clone(), err.clone()],
+                )
+            }
+        };
+        Some(crate::chain::MarkerPlan {
+            ident,
+            operation,
+            subs,
         })
     }
 }


### PR DESCRIPTION
## Summary

- replace Optional-, borrowed-Sequence-, and Result-output dummy `ConverterImpl` functions with one typed `MarkerPlan`
- retain each operation's exact dependency edges as opaque `TypeRef` values while the frozen site/function plan owns its real multi-wire ABI
- delete `CFrag::from_converter`, generic `wrap`, syntax-based `validity_of` / `produces_borrow`, and the adapter's final `ConverterImpl` import
- pin both the three-operation planning seam and deletion of every removed fallback helper

## Design

`MarkerOperation::{Optional, Sequence, Result}` drives one total builder. Optional and Sequence markers retain their inner dependency; Result validates the subject as fallible and retains both success and error dependencies. Final rendering deliberately preserves the existing private zero-argument marker artifacts, while `CValue` and function-site plans continue to own actual pointer/presence/length/error ABI leaves.

This migration forms a deletion unit: after all three former marker users construct `CFrag` directly from typed plans, no production path needs the generic `ConverterImpl` wrapper or its inference from rendered Rust syntax.

## Compatibility

This is an internal carrier simplification. Generated Rust and C artifacts are byte-for-byte unchanged.

## Verification

- `cargo test -p prebindgen-c` (107 tests)
- `cargo test --workspace --all-features`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps`
- `cargo fmt --all -- --check`
- `git diff --check`
- `./examples/regen-check.sh`

## Follow-up

The remaining C complete-function carriers are payload cleanup/prerequisite declarations and Choice's compatibility arm marker.