### PR TITLE
Freeze C opaque type artifacts

### DIFF
--- a/prebindgen-c/src/chain.rs
+++ b/prebindgen-c/src/chain.rs
@@ -1204,30 +1204,195 @@ impl CallbackArtifact {
 /// Adapter-owned final artifacts stored and ordered by the registry plan.
 pub(crate) enum CArtifact {
     Callback(CallbackArtifact),
+    OpaqueHandle(OpaqueHandleArtifact),
+    ValueOpaque(ValueOpaqueArtifact),
 }
 
 impl CArtifact {
     pub(crate) fn render(&self, emit: &Emit) -> Vec<syn::Item> {
         match self {
             Self::Callback(callback) => callback.render(emit),
+            Self::OpaqueHandle(handle) => handle.render(emit),
+            Self::ValueOpaque(value) => value.render(emit),
         }
     }
 }
 
-/// Render the C callback artifacts from the frozen registry plan.
+/// Render one class of C artifacts from the frozen registry plan.
 ///
-/// The deliberately narrow signature is the callback-rendering boundary: final
-/// emission can spell retained source types through [`Emit`], but it cannot
+/// The deliberately narrow signature is the artifact-rendering boundary: final
+/// emission can spell retained source types through Emit, but it cannot
 /// reopen the registry or the adapter's mutable compilation cache.
-pub(crate) fn render_callback_artifacts(
+pub(crate) fn render_artifacts(
     generation: &GenerationPlan<crate::compile::CRepresentation>,
+    kind: &str,
     emit: &Emit,
 ) -> Vec<syn::Item> {
     generation
         .artifacts()
-        .filter(|artifact| artifact.id().kind() == "c-callback")
+        .filter(|artifact| artifact.id().kind() == kind)
         .flat_map(|artifact| artifact.payload().render(emit))
         .collect()
+}
+
+/// One opaque C handle declaration and its typed destructor.
+pub(crate) struct OpaqueHandleArtifact {
+    pub(crate) source: TypeRef,
+    pub(crate) source_module: Option<syn::Path>,
+    pub(crate) c_struct: syn::Ident,
+    pub(crate) drop_ident: syn::Ident,
+}
+
+impl OpaqueHandleArtifact {
+    fn render(&self, emit: &Emit) -> Vec<syn::Item> {
+        let source = qualify_source_type(&emit.spell_ty(&self.source), self.source_module.as_ref());
+        let c_struct = &self.c_struct;
+        let drop_ident = &self.drop_ident;
+        vec![
+            syn::parse_quote!(
+                #[repr(C)]
+                #[allow(non_camel_case_types)]
+                pub struct #c_struct {
+                    _private: [u8; 0],
+                }
+            ),
+            syn::parse_quote!(
+                #[no_mangle]
+                #[allow(non_snake_case, unused_variables)]
+                pub unsafe extern "C" fn #drop_ident(this_: *mut #c_struct) {
+                    if !this_.is_null() {
+                        drop(::std::boxed::Box::from_raw(this_ as *mut #source));
+                    }
+                }
+            ),
+        ]
+    }
+}
+
+/// A generated visible mirror and whether it needs a full gravestone.
+pub(crate) struct ValueOpaqueMirror {
+    pub(crate) ident: syn::Ident,
+    pub(crate) fields: Vec<(syn::Ident, syn::Type)>,
+    pub(crate) gravestone: bool,
+}
+
+/// The optional public move helper for a takeable value-opaque type.
+pub(crate) struct ValueOpaqueTake {
+    pub(crate) ident: syn::Ident,
+    pub(crate) writeback: ValueOpaqueWriteback,
+}
+
+/// One value-opaque declaration family retained until final source spelling.
+pub(crate) struct ValueOpaqueArtifact {
+    pub(crate) source: TypeRef,
+    pub(crate) source_module: Option<syn::Path>,
+    pub(crate) opaque: syn::Type,
+    pub(crate) mirror: Option<ValueOpaqueMirror>,
+    pub(crate) drop_ident: syn::Ident,
+    pub(crate) take: Option<ValueOpaqueTake>,
+}
+
+impl ValueOpaqueArtifact {
+    fn render(&self, emit: &Emit) -> Vec<syn::Item> {
+        let source = qualify_source_type(&emit.spell_ty(&self.source), self.source_module.as_ref());
+        let opaque = &self.opaque;
+        let mut items = Vec::new();
+        if let Some(mirror) = &self.mirror {
+            let ident = &mirror.ident;
+            let fields = mirror
+                .fields
+                .iter()
+                .map(|(name, wire)| quote!(pub #name: #wire));
+            items.push(syn::parse_quote!(
+                #[repr(C)]
+                #[allow(non_camel_case_types)]
+                pub struct #ident {
+                    #(#fields,)*
+                }
+            ));
+            if mirror.gravestone {
+                items.push(syn::parse_quote!(
+                    impl ::prebindgen_c_runtime::Gravestone for #ident {
+                        #[inline]
+                        fn rust_gravestone() -> #source {
+                            <#source as ::core::default::Default>::default()
+                        }
+                    }
+                ));
+            }
+        }
+        items.push(syn::parse_quote!(
+            const _: () = {
+                assert!(
+                    ::core::mem::size_of::<#source>() == ::core::mem::size_of::<#opaque>(),
+                    "value_opaque: Rust type and opaque counterpart differ in size"
+                );
+                assert!(
+                    ::core::mem::align_of::<#source>() == ::core::mem::align_of::<#opaque>(),
+                    "value_opaque: Rust type and opaque counterpart differ in alignment"
+                );
+            };
+        ));
+        items.push(syn::parse_quote!(
+            impl ::prebindgen_c_runtime::Transmute for #opaque {
+                type Rust = #source;
+                #[inline]
+                fn from_rust(value: Self::Rust) -> Self {
+                    let __v = ::core::mem::ManuallyDrop::new(value);
+                    unsafe {
+                        ::core::ptr::read(&*__v as *const Self::Rust as *const Self)
+                    }
+                }
+                #[inline]
+                fn into_rust(self) -> Self::Rust {
+                    let __v = ::core::mem::ManuallyDrop::new(self);
+                    unsafe {
+                        ::core::ptr::read(&*__v as *const Self as *const Self::Rust)
+                    }
+                }
+                #[inline]
+                fn as_rust(&self) -> &Self::Rust {
+                    unsafe { &*(self as *const Self as *const Self::Rust) }
+                }
+                #[inline]
+                fn as_rust_mut(&mut self) -> &mut Self::Rust {
+                    unsafe { &mut *(self as *mut Self as *mut Self::Rust) }
+                }
+            }
+        ));
+        let drop_ident = &self.drop_ident;
+        items.push(syn::parse_quote!(
+            #[no_mangle]
+            #[allow(non_snake_case, unused_variables)]
+            pub unsafe extern "C" fn #drop_ident(this_: *mut #opaque) {
+                if !this_.is_null() {
+                    ::core::ptr::drop_in_place(
+                        <#opaque as ::prebindgen_c_runtime::Transmute>::as_rust_mut(&mut *this_),
+                    );
+                }
+            }
+        ));
+        if let Some(take) = &self.take {
+            let take_ident = &take.ident;
+            let src = format_ident!("src");
+            let writeback = take.writeback.render(&src, opaque);
+            items.push(syn::parse_quote!(
+                #[no_mangle]
+                #[allow(non_snake_case, unused_variables)]
+                pub unsafe extern "C" fn #take_ident(
+                    dst: *mut #opaque,
+                    src: *mut #opaque,
+                ) {
+                    if dst.is_null() || src.is_null() {
+                        return;
+                    }
+                    ::core::ptr::write(dst, ::core::ptr::read(src));
+                    #writeback
+                }
+            ));
+        }
+        items
+    }
 }
 
 /// One C callback argument's already-resolved wire delivery.

--- a/prebindgen-c/src/lib.rs
+++ b/prebindgen-c/src/lib.rs
@@ -185,7 +185,7 @@ struct ValueOpaqueCfg {
     kind: OpaqueKind,
     /// When `true`, the `opaque` counterpart is **not** supplied externally but is
     /// an auto-generated **visible-field** `#[repr(C)]` mirror of the source struct,
-    /// emitted by [`CbindgenBuilder::prereq_value_opaque`]. Set by
+    /// retained in the registry generation plan. Set by
     /// [`CbindgenBuilder::repr_c_struct`]; `false` for `opaque_data_struct` /
     /// `opaque_owned_struct` (counterpart defined elsewhere).
     generate_mirror: bool,

--- a/prebindgen-c/src/tests/boundary_invariants.rs
+++ b/prebindgen-c/src/tests/boundary_invariants.rs
@@ -429,9 +429,85 @@ fn ordinary_wrapper_rendering_cannot_resume_legacy_planning() {
 fn callback_renderer_accepts_only_the_frozen_plan() {
     let renderer: fn(
         &prebindgen_registry::generation::GenerationPlan<crate::compile::CRepresentation>,
+        &str,
         &prebindgen_registry::Emit,
-    ) -> Vec<syn::Item> = crate::chain::render_callback_artifacts;
+    ) -> Vec<syn::Item> = crate::chain::render_artifacts;
     let _ = renderer;
+}
+
+#[test]
+fn type_artifacts_retain_source_types_and_fragment_dependencies() {
+    use prebindgen_registry::generation::ArtifactInput;
+
+    let loc = SourceLocation::default();
+    let items = declare_referenced([
+        (
+            syn::parse_quote!(
+                pub struct Handle;
+            ),
+            loc.clone(),
+        ),
+        (
+            syn::parse_quote!(
+                pub struct Payload {
+                    pub bytes: Vec<u8>,
+                }
+            ),
+            loc.clone(),
+        ),
+        (
+            syn::parse_quote!(
+                pub fn make_handle() -> Handle {
+                    unimplemented!()
+                }
+            ),
+            loc.clone(),
+        ),
+        (
+            syn::parse_quote!(
+                pub fn make_payload() -> Payload {
+                    unimplemented!()
+                }
+            ),
+            loc,
+        ),
+    ]);
+    let registry = crate::test_util::reg_from_items(items).expect("index items");
+    let binding = CbindgenBuilder::new()
+        .source_module(syn::parse_quote!(source))
+        .opaque_ptr(syn::parse_quote!(Handle))
+        .opaque_owned_struct(syn::parse_quote!(Payload), syn::parse_quote!(PayloadOpaque))
+        .function(syn::parse_quote!(make_handle))
+        .function(syn::parse_quote!(make_payload))
+        .build_with(registry)
+        .expect("resolve");
+    let generation = binding.gen.generation.as_ref().expect("frozen plan");
+
+    let handle = generation
+        .artifacts()
+        .find(|artifact| artifact.id().kind() == "c-opaque-handle")
+        .expect("opaque handle artifact");
+    assert!(handle
+        .inputs()
+        .iter()
+        .all(|input| matches!(input, ArtifactInput::Fragment(_))));
+    assert!(matches!(
+        handle.payload(),
+        crate::chain::CArtifact::OpaqueHandle(plan) if plan.source.key().as_str() == "Handle"
+    ));
+
+    let value = generation
+        .artifacts()
+        .find(|artifact| artifact.id().kind() == "c-value-opaque")
+        .expect("value opaque artifact");
+    assert!(value
+        .inputs()
+        .iter()
+        .all(|input| matches!(input, ArtifactInput::Fragment(_))));
+    assert!(matches!(
+        value.payload(),
+        crate::chain::CArtifact::ValueOpaque(plan) if plan.source.key().as_str() == "Payload"
+    ));
 }
 
 #[test]
@@ -459,6 +535,9 @@ fn legacy_c_shape_and_callback_planners_are_deleted() {
         "fn from_converter",
         "fn validity_of",
         "fn produces_borrow",
+        "fn prereq_opaque_handles",
+        "fn prereq_value_opaque",
+        "fn value_opaque_writeback(",
     ] {
         assert!(
             !sources.contains(deleted),

--- a/prebindgen-c/src/trait_impl.rs
+++ b/prebindgen-c/src/trait_impl.rs
@@ -171,28 +171,6 @@ impl CbindgenBuilder {
         Some(idents)
     }
 
-    /// The gravestone write-back statements for a by-value **consume** / `_take` of a
-    /// value-opaque type, writing into the slot pointed to by `slot` (a `*mut #opaque`).
-    /// `None` ⇒ no write-back needed (plain data — the moved-from bitwise copy drops
-    /// harmlessly). Owned-ness is **inferred** for a `repr_c_struct` mirror (the
-    /// generator knows the fields): nullable owned-pointer fields are nulled in place
-    /// (cheap, no `Default`); a bare `Box<T>` field falls back to the full `gravestone()`
-    /// write. A non-mirror (`opaque_data_struct`/`opaque_owned_struct`) uses its explicit
-    /// declared `kind` (its fields are an opaque blob the generator can't introspect).
-    fn value_opaque_writeback(
-        &self,
-        registry: &impl Conversions,
-        key: &TypeKey,
-        slot: &syn::Ident,
-    ) -> Option<TokenStream> {
-        let opaque = &self.value_opaque.get(key)?.opaque;
-        let plan = self.value_opaque_writeback_plan(registry, key)?;
-        match plan {
-            crate::chain::ValueOpaqueWriteback::None => None,
-            _ => Some(plan.render(slot, opaque)),
-        }
-    }
-
     /// The semantic write-back policy shared by late input rendering and the
     /// emitted public `_take` helper.
     fn value_opaque_writeback_plan(
@@ -651,42 +629,133 @@ impl CbindgenBuilder {
         items
     }
 
-    /// Opaque handles: bare-pointer C type (`z_*_t*` = `Box::into_raw`) + typed
-    /// `_drop`. The C type is an opaque/incomplete struct.
-    fn prereq_opaque_handles(&self, registry: &Registry) -> Vec<syn::Item> {
-        let mut items: Vec<syn::Item> = Vec::new();
+    /// Freeze source-dependent C declaration families as registry artifacts.
+    ///
+    /// Planning retains source TypeRefs and target-owned wire syntax. Only the
+    /// final artifact renderer may ask Emit to spell a source type.
+    fn type_artifact_plans(
+        &self,
+        registry: &Registry,
+    ) -> Result<
+        Vec<prebindgen_registry::generation::ArtifactPlan<crate::compile::CRepresentation>>,
+        String,
+    > {
+        use prebindgen_registry::generation::{ArtifactId, ArtifactInput, ArtifactPlan};
+
+        let inputs = |reading: &TypeRef| {
+            [self.in_frag(reading), self.out_frag(reading)]
+                .into_iter()
+                .flatten()
+                .map(|fragment| ArtifactInput::Fragment(fragment.id.clone()))
+                .collect::<Vec<_>>()
+        };
+        let mut artifacts = Vec::new();
+
         for (key, _cfg) in sorted_by_key(&self.opaque) {
-            // Keyed directly: this used to spell the key into tokens purely so
-            // `reading_of` could re-key them, twice (#291).
             let Some(reading) = registry.reading(key) else {
                 continue;
             };
-            if self.in_frag(&reading).is_none() && self.out_frag(&reading).is_none() {
+            let dependencies = inputs(&reading);
+            if dependencies.is_empty() {
                 continue;
             }
-            let c_struct = self.c_type_ident(&reading.key());
-            // Opaque/incomplete C type: the handle is `#c_struct *`, which IS the
-            // `Box::into_raw` pointer to the source value.
-            items.push(syn::parse_quote!(
-                #[repr(C)]
-                #[allow(non_camel_case_types)]
-                pub struct #c_struct {
-                    _private: [u8; 0],
-                }
-            ));
-            let src = self.src_ty_of(&reading.key());
-            let drop_ident = self.destructor_symbol(&reading.key());
-            items.push(syn::parse_quote!(
-                #[no_mangle]
-                #[allow(non_snake_case, unused_variables)]
-                pub unsafe extern "C" fn #drop_ident(this_: *mut #c_struct) {
-                    if !this_.is_null() {
-                        drop(::std::boxed::Box::from_raw(this_ as *mut #src));
-                    }
-                }
+            artifacts.push(ArtifactPlan::new(
+                ArtifactId::new("c-opaque-handle", key.as_str()).map_err(|e| e.to_string())?,
+                Vec::new(),
+                dependencies,
+                crate::chain::CArtifact::OpaqueHandle(crate::chain::OpaqueHandleArtifact {
+                    source: reading,
+                    source_module: self.source_module.clone(),
+                    c_struct: self.c_type_ident(key),
+                    drop_ident: self.destructor_symbol(key),
+                }),
             ));
         }
-        items
+
+        let takeable_keys = self.takeable_type_keys();
+        let mut values: Vec<(&TypeKey, &ValueOpaqueCfg)> = self.value_opaque.iter().collect();
+        values.sort_by(|a, b| a.0.as_str().cmp(b.0.as_str()));
+        for (key, cfg) in values {
+            let Some(reading) = registry.reading(key) else {
+                continue;
+            };
+            let dependencies = inputs(&reading);
+            if dependencies.is_empty() {
+                continue;
+            }
+            let mirror = if cfg.generate_mirror {
+                let fields = self.struct_fields(registry, key).unwrap_or_else(|| {
+                    panic!(
+                        "Cbindgen::repr_c_struct: `{}` is not a named struct",
+                        type_short(key)
+                    )
+                });
+                let restricted = self.restricted_validity_fields(registry, key);
+                if !restricted.is_empty() && !cfg.assume_c_field_validity {
+                    let listed: Vec<String> = restricted
+                        .iter()
+                        .map(|(fname, reason)| format!("  `{fname}`: {reason}"))
+                        .collect();
+                    panic!(
+                        "Cbindgen::repr_c_struct: `{}` crosses C's memory by whole-struct \
+                         reinterpret, but these fields have restricted-validity Rust types:\n\
+                         {}\n\
+                         A C caller can write a byte outside those domains, and the reinterpret \
+                         materialises it with no hook to normalise or validate it first (#170, \
+                         #158). Move the field to a `data_struct` (per-field wires), pass it as \
+                         a separate parameter, or widen it to an integer. If this binding's C \
+                         side is trusted to write only in-domain bytes — or never hands the \
+                         mirror back at all — acknowledge it with `.assume_c_field_validity()`.",
+                        type_short(key),
+                        listed.join("\n"),
+                    );
+                }
+                Some(crate::chain::ValueOpaqueMirror {
+                    ident: self.c_type_ident(key),
+                    fields: fields
+                        .iter()
+                        .map(|(name, ty)| {
+                            let wire = self.mirror_field_wire(ty).unwrap_or_else(|| {
+                                panic!(
+                                    "Cbindgen::repr_c_struct: field `{}` of `{}` has unsupported \
+                                     type `{}` (expected a scalar, a declared `enum_type`, or an \
+                                     opaque pointer `Option<Box<T>>`/`Box<T>` with `T` an `opaque_ptr`)",
+                                    name,
+                                    type_short(key),
+                                    ty
+                                )
+                            });
+                            (name.clone(), wire)
+                        })
+                        .collect(),
+                    gravestone: self.mirror_needs_gravestone_impl(registry, key),
+                })
+            } else {
+                None
+            };
+            let take = takeable_keys
+                .contains(key)
+                .then(|| crate::chain::ValueOpaqueTake {
+                    ident: self.take_symbol(key),
+                    writeback: self
+                        .value_opaque_writeback_plan(registry, key)
+                        .expect("value-opaque declaration has a write-back policy"),
+                });
+            artifacts.push(ArtifactPlan::new(
+                ArtifactId::new("c-value-opaque", key.as_str()).map_err(|e| e.to_string())?,
+                Vec::new(),
+                dependencies,
+                crate::chain::CArtifact::ValueOpaque(crate::chain::ValueOpaqueArtifact {
+                    source: reading,
+                    source_module: self.source_module.clone(),
+                    opaque: cfg.opaque.clone(),
+                    mirror,
+                    drop_ident: self.destructor_symbol(key),
+                    take,
+                }),
+            ));
+        }
+        Ok(artifacts)
     }
 
     /// Data structs: `#[repr(C)]` mirror only. Heap (`String`) fields are
@@ -724,199 +793,6 @@ impl CbindgenBuilder {
                     #(#field_defs,)*
                 }
             ));
-        }
-        items
-    }
-
-    /// Value-opaque types: the opaque `#[repr(C, align(_))]` counterpart is
-    /// defined elsewhere (e.g. a size/align probe generator). Here we emit only
-    /// the fail-closed size+align equality asserts and the typed `_drop` (drops
-    /// the live Rust value in place; NULL/gravestone ⇒ no-op), plus a `_take`
-    /// for types delivered as takeable callback params.
-    fn prereq_value_opaque(&self, registry: &Registry) -> Vec<syn::Item> {
-        let mut items: Vec<syn::Item> = Vec::new();
-        let takeable_keys = self.takeable_type_keys();
-        let mut vo: Vec<(&TypeKey, &ValueOpaqueCfg)> = self.value_opaque.iter().collect();
-        vo.sort_by(|a, b| a.0.as_str().cmp(b.0.as_str()));
-        for (key, cfg) in vo {
-            let Some(reading) = registry.reading(key) else {
-                continue;
-            };
-            if self.in_frag(&reading).is_none() && self.out_frag(&reading).is_none() {
-                continue;
-            }
-            let src = self.src_ty_of(&reading.key());
-            let opaque = &cfg.opaque;
-            // `repr_c_struct`: the opaque counterpart is an auto-generated
-            // **visible-field** `#[repr(C)]` mirror (so C reads the fields directly),
-            // not an externally-provided blob. Each field is lowered by
-            // `mirror_field_wire` (scalar / enum / opaque pointer). The size/align
-            // assert below then proves the whole-struct reinterpret sound.
-            if cfg.generate_mirror {
-                let mirror_ident = self.c_type_ident(&reading.key());
-                let fields = self
-                    .struct_fields(registry, &reading.key())
-                    .unwrap_or_else(|| {
-                        panic!(
-                            "Cbindgen::repr_c_struct: `{}` is not a named struct",
-                            type_short(&reading.key())
-                        )
-                    });
-                // Restricted-validity audit (#170 instance 3, #158 instance 3):
-                // a mirror is reinterpreted whole, so a field whose Rust type
-                // rejects some bit patterns is UB the moment C writes one and
-                // hands the struct back.
-                //
-                // Not narrowed to inbound mirrors, though only those are
-                // reachable: converter reachability is not derived from use
-                // today (a declared type resolves BOTH directions whether or
-                // not either is called — the accounting #194/#196 replace), so
-                // "does it cross in" has no truthful answer here. Over-
-                // reporting is the safe direction, and the acknowledgement
-                // below is the escape for a genuinely write-only mirror.
-                let restricted = self.restricted_validity_fields(registry, &reading.key());
-                if !restricted.is_empty() && !cfg.assume_c_field_validity {
-                    let listed: Vec<String> = restricted
-                        .iter()
-                        .map(|(fname, reason)| format!("  `{fname}`: {reason}"))
-                        .collect();
-                    panic!(
-                        "Cbindgen::repr_c_struct: `{}` crosses C's memory by whole-struct \
-                         reinterpret, but these fields have restricted-validity Rust types:\n\
-                         {}\n\
-                         A C caller can write a byte outside those domains, and the reinterpret \
-                         materialises it with no hook to normalise or validate it first (#170, \
-                         #158). Move the field to a `data_struct` (per-field wires), pass it as \
-                         a separate parameter, or widen it to an integer. If this binding's C \
-                         side is trusted to write only in-domain bytes — or never hands the \
-                         mirror back at all — acknowledge it with `.assume_c_field_validity()`.",
-                        type_short(&reading.key()),
-                        listed.join("\n"),
-                    );
-                }
-                let field_defs: Vec<TokenStream> = fields
-                    .iter()
-                    .map(|(fname, fty)| {
-                        let wire = self.mirror_field_wire(fty).unwrap_or_else(|| {
-                            panic!(
-                                "Cbindgen::repr_c_struct: field `{}` of `{}` has unsupported \
-                                 type `{}` (expected a scalar, a declared `enum_type`, or an \
-                                 opaque pointer `Option<Box<T>>`/`Box<T>` with `T` an `opaque_ptr`)",
-                                fname,
-                                type_short(&reading.key()),
-                                fty
-                            )
-                        });
-                        quote!(pub #fname: #wire)
-                    })
-                    .collect();
-                items.push(syn::parse_quote!(
-                    #[repr(C)]
-                    #[allow(non_camel_case_types)]
-                    pub struct #mirror_ident {
-                        #(#field_defs,)*
-                    }
-                ));
-                // A mirror that needs `gravestone()` (only the bare-`Box<T>` fallback —
-                // nullable owned-pointer fields are nulled in place) gets an
-                // auto-generated `Gravestone` from the source type's `Default`. Nullable
-                // mirrors emit nothing here, so they impose no `Default` requirement.
-                if self.mirror_needs_gravestone_impl(registry, &reading.key()) {
-                    items.push(syn::parse_quote!(
-                        impl ::prebindgen_c_runtime::Gravestone for #mirror_ident {
-                            #[inline]
-                            fn rust_gravestone() -> #src {
-                                <#src as ::core::default::Default>::default()
-                            }
-                        }
-                    ));
-                }
-            }
-            // Fail-closed size/align equality guard (proves the transmute sound).
-            items.push(syn::parse_quote!(
-                const _: () = {
-                    assert!(
-                        ::core::mem::size_of::<#src>() == ::core::mem::size_of::<#opaque>(),
-                        "value_opaque: Rust type and opaque counterpart differ in size"
-                    );
-                    assert!(
-                        ::core::mem::align_of::<#src>() == ::core::mem::align_of::<#opaque>(),
-                        "value_opaque: Rust type and opaque counterpart differ in alignment"
-                    );
-                };
-            ));
-            // Autogenerated transmute glue: the single place that owns the
-            // unsafe rust<->opaque reinterpretation. `Gravestone` (user logic)
-            // and the converters below are all expressed via these methods.
-            items.push(syn::parse_quote!(
-                impl ::prebindgen_c_runtime::Transmute for #opaque {
-                    type Rust = #src;
-                    #[inline]
-                    fn from_rust(value: Self::Rust) -> Self {
-                        let __v = ::core::mem::ManuallyDrop::new(value);
-                        unsafe {
-                            ::core::ptr::read(&*__v as *const Self::Rust as *const Self)
-                        }
-                    }
-                    #[inline]
-                    fn into_rust(self) -> Self::Rust {
-                        let __v = ::core::mem::ManuallyDrop::new(self);
-                        unsafe {
-                            ::core::ptr::read(&*__v as *const Self as *const Self::Rust)
-                        }
-                    }
-                    #[inline]
-                    fn as_rust(&self) -> &Self::Rust {
-                        unsafe { &*(self as *const Self as *const Self::Rust) }
-                    }
-                    #[inline]
-                    fn as_rust_mut(&mut self) -> &mut Self::Rust {
-                        unsafe { &mut *(self as *mut Self as *mut Self::Rust) }
-                    }
-                }
-            ));
-            let drop_ident = self.destructor_symbol(&reading.key());
-            // Unconditional drop: safe because a moved-from slot holds a
-            // gravestone (a valid, safely-droppable empty value), so dropping
-            // it is a harmless no-op; a live slot drops normally.
-            items.push(syn::parse_quote!(
-                #[no_mangle]
-                #[allow(non_snake_case, unused_variables)]
-                pub unsafe extern "C" fn #drop_ident(this_: *mut #opaque) {
-                    if !this_.is_null() {
-                        ::core::ptr::drop_in_place(
-                            <#opaque as ::prebindgen_c_runtime::Transmute>::as_rust_mut(&mut *this_),
-                        );
-                    }
-                }
-            ));
-            // For a type delivered as a takeable callback param, also emit a
-            // public `<base>_take(dst, src)`: move `src`'s value into `dst`. For
-            // an `opaque_owned_struct` type, leave `src` a gravestone (so the
-            // trampoline's post-call drop is a no-op); an `opaque_data_struct` type owns
-            // nothing, so the leftover bitwise copy in `src` drops harmlessly and
-            // no write-back is needed. This is the C user's "take" operation.
-            if takeable_keys.contains(key) {
-                let take_ident = self.take_symbol(&reading.key());
-                // Same inferred write-back as a consume (field-null for a nullable
-                // mirror, `gravestone()` for a bare-`Box` mirror / non-mirror owned).
-                let writeback =
-                    self.value_opaque_writeback(registry, &reading.key(), &format_ident!("src"));
-                items.push(syn::parse_quote!(
-                    #[no_mangle]
-                    #[allow(non_snake_case, unused_variables)]
-                    pub unsafe extern "C" fn #take_ident(
-                        dst: *mut #opaque,
-                        src: *mut #opaque,
-                    ) {
-                        if dst.is_null() || src.is_null() {
-                            return;
-                        }
-                        ::core::ptr::write(dst, ::core::ptr::read(src));
-                        #writeback
-                    }
-                ));
-            }
         }
         items
     }
@@ -1317,7 +1193,10 @@ impl CbindgenBuilder {
             .build()?;
         // Freeze every ordinary and callback position plus the callback artifacts
         // that consume those sites.
-        let CPlanParts { sites, artifacts } = {
+        let CPlanParts {
+            sites,
+            mut artifacts,
+        } = {
             let mut compiler = prebindgen_registry::recipe::Compiler::resume(
                 &model,
                 &recipes,
@@ -1330,6 +1209,10 @@ impl CbindgenBuilder {
             *self.compiled.borrow_mut() = compiler.finish();
             parts
         };
+        artifacts.extend(
+            self.type_artifact_plans(&registry)
+                .map_err(|message| prebindgen_registry::ScanError::AdapterInvariant { message })?,
+        );
         let mut generation = prebindgen_registry::generation::GenerationPlanBuilder::new();
         for fragment in self.compiled.borrow().fragments() {
             generation.fragment(fragment.freeze());
@@ -1466,15 +1349,28 @@ impl Prebindgen for CbindgenBuilder {
         let mut items: Vec<syn::Item> = Vec::new();
         items.extend(self.prereq_alloc_free(registry, produces_array));
         items.extend(self.prereq_array_builder(produces_array));
-        items.extend(self.prereq_opaque_handles(registry));
-        items.extend(self.prereq_data_structs(registry));
-        items.extend(self.prereq_value_opaque(registry));
-        items.extend(self.prereq_enums(registry, emit));
-        items.extend(self.prereq_tagged_unions(registry, emit));
-        items.extend(crate::chain::render_callback_artifacts(
+        items.extend(crate::chain::render_artifacts(
             self.generation
                 .as_ref()
                 .expect("C generation plan was not frozen"),
+            "c-opaque-handle",
+            emit,
+        ));
+        items.extend(self.prereq_data_structs(registry));
+        items.extend(crate::chain::render_artifacts(
+            self.generation
+                .as_ref()
+                .expect("C generation plan was not frozen"),
+            "c-value-opaque",
+            emit,
+        ));
+        items.extend(self.prereq_enums(registry, emit));
+        items.extend(self.prereq_tagged_unions(registry, emit));
+        items.extend(crate::chain::render_artifacts(
+            self.generation
+                .as_ref()
+                .expect("C generation plan was not frozen"),
+            "c-callback",
             emit,
         ));
         items.extend(self.prereq_domain_constants(registry));


### PR DESCRIPTION
## Why

Umbrella #513 still lets two C declaration families reopen the registry during prerequisite emission and spell source Rust types before the final rendering boundary:

- opaque handle declarations and typed destructors
- value-opaque mirrors, transmute glue, typed destructors, and take helpers

That keeps source-type knowledge in the old prerequisite pipeline even though their converter fragments are already frozen.

## What changed

- Add typed `OpaqueHandleArtifact` and `ValueOpaqueArtifact` payloads to the registry-owned C generation plan.
- Retain each source `TypeRef`, target-owned C syntax, naming decisions, mirror fields, and value-opaque writeback policy during planning.
- Attach these artifacts to their resolved input/output fragment dependencies.
- Render artifact classes in their existing prerequisite slots, with `Emit::spell_ty` used only at final emission.
- Delete the eager `prereq_opaque_handles`, `prereq_value_opaque`, and token-producing value-opaque writeback path.
- Generalize the callback-only artifact renderer so all C artifact classes consume the frozen generation plan through the same narrow seam.
- Add a boundary test proving both new artifacts retain source `TypeRef` values and depend only on frozen fragments, plus deletion fences for the removed paths.

Generated Rust and C headers remain byte-identical.

## Validation

- `cargo test -p prebindgen-c` (108 tests)
- `cargo test --all`
- `cargo clippy --all-targets --all-features -- --deny warnings`
- exact CI rustfmt check
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps`
- `./examples/regen-check.sh` (byte-identical)
- `./examples/smoke-asan.sh` (ASan/LSan/UBSan clean)

Part of #513.