### PR TITLE
Freeze C tagged-union artifacts

### DIFF
--- a/examples/example-cbindgen/generated/example_flat_aarch64.rs
+++ b/examples/example-cbindgen/generated/example_flat_aarch64.rs
@@ -92,6 +92,41 @@ pub enum operation_t {
 }
 #[repr(C)]
 #[allow(non_camel_case_types)]
+pub enum shape_t {
+    Empty,
+    Circle(f64),
+    Rect { width: f64, height: f64 },
+    Labeled(*mut ::core::ffi::c_char, ::core::mem::MaybeUninit<operation_t>),
+}
+#[no_mangle]
+#[allow(non_snake_case, unused_variables)]
+pub unsafe extern "C" fn shape_drop(this_: *mut ::core::mem::MaybeUninit<shape_t>) {
+    if this_.is_null() {
+        return;
+    }
+    const _: () = {
+        assert!(
+            ::core::mem::size_of:: < shape_t > () >= ::core::mem::size_of:: <
+            ::core::ffi::c_int > (),
+            "`shape_t`: a #[repr(C)] enum with payload variants must be at least as large as its C `int` discriminant"
+        );
+    };
+    let __tag: ::core::ffi::c_int = ::core::ptr::read(
+        (*this_).as_ptr() as *const ::core::ffi::c_int,
+    );
+    if !((__tag as i64) >= 0 && (__tag as i64) < 4i64) {
+        return;
+    }
+    match (*this_).assume_init_mut() {
+        shape_t::Labeled(__f0, __f1) => {
+            free(*__f0 as *mut ::core::ffi::c_void);
+            *__f0 = ::core::ptr::null_mut();
+        }
+        _ => {}
+    }
+}
+#[repr(C)]
+#[allow(non_camel_case_types)]
 pub enum note_t {
     Silent,
     Titled(caption_t),
@@ -125,41 +160,6 @@ pub unsafe extern "C" fn note_drop(this_: *mut ::core::mem::MaybeUninit<note_t>)
         }
         note_t::Sketched(__f0) => {
             shape_drop(&mut (*__f0).shape);
-        }
-        _ => {}
-    }
-}
-#[repr(C)]
-#[allow(non_camel_case_types)]
-pub enum shape_t {
-    Empty,
-    Circle(f64),
-    Rect { width: f64, height: f64 },
-    Labeled(*mut ::core::ffi::c_char, ::core::mem::MaybeUninit<operation_t>),
-}
-#[no_mangle]
-#[allow(non_snake_case, unused_variables)]
-pub unsafe extern "C" fn shape_drop(this_: *mut ::core::mem::MaybeUninit<shape_t>) {
-    if this_.is_null() {
-        return;
-    }
-    const _: () = {
-        assert!(
-            ::core::mem::size_of:: < shape_t > () >= ::core::mem::size_of:: <
-            ::core::ffi::c_int > (),
-            "`shape_t`: a #[repr(C)] enum with payload variants must be at least as large as its C `int` discriminant"
-        );
-    };
-    let __tag: ::core::ffi::c_int = ::core::ptr::read(
-        (*this_).as_ptr() as *const ::core::ffi::c_int,
-    );
-    if !((__tag as i64) >= 0 && (__tag as i64) < 4i64) {
-        return;
-    }
-    match (*this_).assume_init_mut() {
-        shape_t::Labeled(__f0, __f1) => {
-            free(*__f0 as *mut ::core::ffi::c_void);
-            *__f0 = ::core::ptr::null_mut();
         }
         _ => {}
     }

--- a/examples/example-cbindgen/generated/example_flat_aarch64_internal_unstable.rs
+++ b/examples/example-cbindgen/generated/example_flat_aarch64_internal_unstable.rs
@@ -92,6 +92,41 @@ pub enum operation_t {
 }
 #[repr(C)]
 #[allow(non_camel_case_types)]
+pub enum shape_t {
+    Empty,
+    Circle(f64),
+    Rect { width: f64, height: f64 },
+    Labeled(*mut ::core::ffi::c_char, ::core::mem::MaybeUninit<operation_t>),
+}
+#[no_mangle]
+#[allow(non_snake_case, unused_variables)]
+pub unsafe extern "C" fn shape_drop(this_: *mut ::core::mem::MaybeUninit<shape_t>) {
+    if this_.is_null() {
+        return;
+    }
+    const _: () = {
+        assert!(
+            ::core::mem::size_of:: < shape_t > () >= ::core::mem::size_of:: <
+            ::core::ffi::c_int > (),
+            "`shape_t`: a #[repr(C)] enum with payload variants must be at least as large as its C `int` discriminant"
+        );
+    };
+    let __tag: ::core::ffi::c_int = ::core::ptr::read(
+        (*this_).as_ptr() as *const ::core::ffi::c_int,
+    );
+    if !((__tag as i64) >= 0 && (__tag as i64) < 4i64) {
+        return;
+    }
+    match (*this_).assume_init_mut() {
+        shape_t::Labeled(__f0, __f1) => {
+            free(*__f0 as *mut ::core::ffi::c_void);
+            *__f0 = ::core::ptr::null_mut();
+        }
+        _ => {}
+    }
+}
+#[repr(C)]
+#[allow(non_camel_case_types)]
 pub enum note_t {
     Silent,
     Titled(caption_t),
@@ -125,41 +160,6 @@ pub unsafe extern "C" fn note_drop(this_: *mut ::core::mem::MaybeUninit<note_t>)
         }
         note_t::Sketched(__f0) => {
             shape_drop(&mut (*__f0).shape);
-        }
-        _ => {}
-    }
-}
-#[repr(C)]
-#[allow(non_camel_case_types)]
-pub enum shape_t {
-    Empty,
-    Circle(f64),
-    Rect { width: f64, height: f64 },
-    Labeled(*mut ::core::ffi::c_char, ::core::mem::MaybeUninit<operation_t>),
-}
-#[no_mangle]
-#[allow(non_snake_case, unused_variables)]
-pub unsafe extern "C" fn shape_drop(this_: *mut ::core::mem::MaybeUninit<shape_t>) {
-    if this_.is_null() {
-        return;
-    }
-    const _: () = {
-        assert!(
-            ::core::mem::size_of:: < shape_t > () >= ::core::mem::size_of:: <
-            ::core::ffi::c_int > (),
-            "`shape_t`: a #[repr(C)] enum with payload variants must be at least as large as its C `int` discriminant"
-        );
-    };
-    let __tag: ::core::ffi::c_int = ::core::ptr::read(
-        (*this_).as_ptr() as *const ::core::ffi::c_int,
-    );
-    if !((__tag as i64) >= 0 && (__tag as i64) < 4i64) {
-        return;
-    }
-    match (*this_).assume_init_mut() {
-        shape_t::Labeled(__f0, __f1) => {
-            free(*__f0 as *mut ::core::ffi::c_void);
-            *__f0 = ::core::ptr::null_mut();
         }
         _ => {}
     }

--- a/examples/example-cbindgen/generated/example_flat_aarch64_unstable.rs
+++ b/examples/example-cbindgen/generated/example_flat_aarch64_unstable.rs
@@ -92,6 +92,41 @@ pub enum operation_t {
 }
 #[repr(C)]
 #[allow(non_camel_case_types)]
+pub enum shape_t {
+    Empty,
+    Circle(f64),
+    Rect { width: f64, height: f64 },
+    Labeled(*mut ::core::ffi::c_char, ::core::mem::MaybeUninit<operation_t>),
+}
+#[no_mangle]
+#[allow(non_snake_case, unused_variables)]
+pub unsafe extern "C" fn shape_drop(this_: *mut ::core::mem::MaybeUninit<shape_t>) {
+    if this_.is_null() {
+        return;
+    }
+    const _: () = {
+        assert!(
+            ::core::mem::size_of:: < shape_t > () >= ::core::mem::size_of:: <
+            ::core::ffi::c_int > (),
+            "`shape_t`: a #[repr(C)] enum with payload variants must be at least as large as its C `int` discriminant"
+        );
+    };
+    let __tag: ::core::ffi::c_int = ::core::ptr::read(
+        (*this_).as_ptr() as *const ::core::ffi::c_int,
+    );
+    if !((__tag as i64) >= 0 && (__tag as i64) < 4i64) {
+        return;
+    }
+    match (*this_).assume_init_mut() {
+        shape_t::Labeled(__f0, __f1) => {
+            free(*__f0 as *mut ::core::ffi::c_void);
+            *__f0 = ::core::ptr::null_mut();
+        }
+        _ => {}
+    }
+}
+#[repr(C)]
+#[allow(non_camel_case_types)]
 pub enum note_t {
     Silent,
     Titled(caption_t),
@@ -125,41 +160,6 @@ pub unsafe extern "C" fn note_drop(this_: *mut ::core::mem::MaybeUninit<note_t>)
         }
         note_t::Sketched(__f0) => {
             shape_drop(&mut (*__f0).shape);
-        }
-        _ => {}
-    }
-}
-#[repr(C)]
-#[allow(non_camel_case_types)]
-pub enum shape_t {
-    Empty,
-    Circle(f64),
-    Rect { width: f64, height: f64 },
-    Labeled(*mut ::core::ffi::c_char, ::core::mem::MaybeUninit<operation_t>),
-}
-#[no_mangle]
-#[allow(non_snake_case, unused_variables)]
-pub unsafe extern "C" fn shape_drop(this_: *mut ::core::mem::MaybeUninit<shape_t>) {
-    if this_.is_null() {
-        return;
-    }
-    const _: () = {
-        assert!(
-            ::core::mem::size_of:: < shape_t > () >= ::core::mem::size_of:: <
-            ::core::ffi::c_int > (),
-            "`shape_t`: a #[repr(C)] enum with payload variants must be at least as large as its C `int` discriminant"
-        );
-    };
-    let __tag: ::core::ffi::c_int = ::core::ptr::read(
-        (*this_).as_ptr() as *const ::core::ffi::c_int,
-    );
-    if !((__tag as i64) >= 0 && (__tag as i64) < 4i64) {
-        return;
-    }
-    match (*this_).assume_init_mut() {
-        shape_t::Labeled(__f0, __f1) => {
-            free(*__f0 as *mut ::core::ffi::c_void);
-            *__f0 = ::core::ptr::null_mut();
         }
         _ => {}
     }

--- a/examples/example-cbindgen/generated/example_flat_x86_64.rs
+++ b/examples/example-cbindgen/generated/example_flat_x86_64.rs
@@ -92,6 +92,41 @@ pub enum operation_t {
 }
 #[repr(C)]
 #[allow(non_camel_case_types)]
+pub enum shape_t {
+    Empty,
+    Circle(f64),
+    Rect { width: f64, height: f64 },
+    Labeled(*mut ::core::ffi::c_char, ::core::mem::MaybeUninit<operation_t>),
+}
+#[no_mangle]
+#[allow(non_snake_case, unused_variables)]
+pub unsafe extern "C" fn shape_drop(this_: *mut ::core::mem::MaybeUninit<shape_t>) {
+    if this_.is_null() {
+        return;
+    }
+    const _: () = {
+        assert!(
+            ::core::mem::size_of:: < shape_t > () >= ::core::mem::size_of:: <
+            ::core::ffi::c_int > (),
+            "`shape_t`: a #[repr(C)] enum with payload variants must be at least as large as its C `int` discriminant"
+        );
+    };
+    let __tag: ::core::ffi::c_int = ::core::ptr::read(
+        (*this_).as_ptr() as *const ::core::ffi::c_int,
+    );
+    if !((__tag as i64) >= 0 && (__tag as i64) < 4i64) {
+        return;
+    }
+    match (*this_).assume_init_mut() {
+        shape_t::Labeled(__f0, __f1) => {
+            free(*__f0 as *mut ::core::ffi::c_void);
+            *__f0 = ::core::ptr::null_mut();
+        }
+        _ => {}
+    }
+}
+#[repr(C)]
+#[allow(non_camel_case_types)]
 pub enum note_t {
     Silent,
     Titled(caption_t),
@@ -125,41 +160,6 @@ pub unsafe extern "C" fn note_drop(this_: *mut ::core::mem::MaybeUninit<note_t>)
         }
         note_t::Sketched(__f0) => {
             shape_drop(&mut (*__f0).shape);
-        }
-        _ => {}
-    }
-}
-#[repr(C)]
-#[allow(non_camel_case_types)]
-pub enum shape_t {
-    Empty,
-    Circle(f64),
-    Rect { width: f64, height: f64 },
-    Labeled(*mut ::core::ffi::c_char, ::core::mem::MaybeUninit<operation_t>),
-}
-#[no_mangle]
-#[allow(non_snake_case, unused_variables)]
-pub unsafe extern "C" fn shape_drop(this_: *mut ::core::mem::MaybeUninit<shape_t>) {
-    if this_.is_null() {
-        return;
-    }
-    const _: () = {
-        assert!(
-            ::core::mem::size_of:: < shape_t > () >= ::core::mem::size_of:: <
-            ::core::ffi::c_int > (),
-            "`shape_t`: a #[repr(C)] enum with payload variants must be at least as large as its C `int` discriminant"
-        );
-    };
-    let __tag: ::core::ffi::c_int = ::core::ptr::read(
-        (*this_).as_ptr() as *const ::core::ffi::c_int,
-    );
-    if !((__tag as i64) >= 0 && (__tag as i64) < 4i64) {
-        return;
-    }
-    match (*this_).assume_init_mut() {
-        shape_t::Labeled(__f0, __f1) => {
-            free(*__f0 as *mut ::core::ffi::c_void);
-            *__f0 = ::core::ptr::null_mut();
         }
         _ => {}
     }

--- a/examples/example-cbindgen/generated/example_flat_x86_64_internal_unstable.rs
+++ b/examples/example-cbindgen/generated/example_flat_x86_64_internal_unstable.rs
@@ -92,6 +92,41 @@ pub enum operation_t {
 }
 #[repr(C)]
 #[allow(non_camel_case_types)]
+pub enum shape_t {
+    Empty,
+    Circle(f64),
+    Rect { width: f64, height: f64 },
+    Labeled(*mut ::core::ffi::c_char, ::core::mem::MaybeUninit<operation_t>),
+}
+#[no_mangle]
+#[allow(non_snake_case, unused_variables)]
+pub unsafe extern "C" fn shape_drop(this_: *mut ::core::mem::MaybeUninit<shape_t>) {
+    if this_.is_null() {
+        return;
+    }
+    const _: () = {
+        assert!(
+            ::core::mem::size_of:: < shape_t > () >= ::core::mem::size_of:: <
+            ::core::ffi::c_int > (),
+            "`shape_t`: a #[repr(C)] enum with payload variants must be at least as large as its C `int` discriminant"
+        );
+    };
+    let __tag: ::core::ffi::c_int = ::core::ptr::read(
+        (*this_).as_ptr() as *const ::core::ffi::c_int,
+    );
+    if !((__tag as i64) >= 0 && (__tag as i64) < 4i64) {
+        return;
+    }
+    match (*this_).assume_init_mut() {
+        shape_t::Labeled(__f0, __f1) => {
+            free(*__f0 as *mut ::core::ffi::c_void);
+            *__f0 = ::core::ptr::null_mut();
+        }
+        _ => {}
+    }
+}
+#[repr(C)]
+#[allow(non_camel_case_types)]
 pub enum note_t {
     Silent,
     Titled(caption_t),
@@ -125,41 +160,6 @@ pub unsafe extern "C" fn note_drop(this_: *mut ::core::mem::MaybeUninit<note_t>)
         }
         note_t::Sketched(__f0) => {
             shape_drop(&mut (*__f0).shape);
-        }
-        _ => {}
-    }
-}
-#[repr(C)]
-#[allow(non_camel_case_types)]
-pub enum shape_t {
-    Empty,
-    Circle(f64),
-    Rect { width: f64, height: f64 },
-    Labeled(*mut ::core::ffi::c_char, ::core::mem::MaybeUninit<operation_t>),
-}
-#[no_mangle]
-#[allow(non_snake_case, unused_variables)]
-pub unsafe extern "C" fn shape_drop(this_: *mut ::core::mem::MaybeUninit<shape_t>) {
-    if this_.is_null() {
-        return;
-    }
-    const _: () = {
-        assert!(
-            ::core::mem::size_of:: < shape_t > () >= ::core::mem::size_of:: <
-            ::core::ffi::c_int > (),
-            "`shape_t`: a #[repr(C)] enum with payload variants must be at least as large as its C `int` discriminant"
-        );
-    };
-    let __tag: ::core::ffi::c_int = ::core::ptr::read(
-        (*this_).as_ptr() as *const ::core::ffi::c_int,
-    );
-    if !((__tag as i64) >= 0 && (__tag as i64) < 4i64) {
-        return;
-    }
-    match (*this_).assume_init_mut() {
-        shape_t::Labeled(__f0, __f1) => {
-            free(*__f0 as *mut ::core::ffi::c_void);
-            *__f0 = ::core::ptr::null_mut();
         }
         _ => {}
     }

--- a/examples/example-cbindgen/include/example_flat_aarch64.h
+++ b/examples/example-cbindgen/include/example_flat_aarch64.h
@@ -33,12 +33,6 @@ typedef struct calculator_t {
   uint8_t _private[0];
 } calculator_t;
 
-typedef struct caption_t {
-  uint64_t id;
-  char *text;
-  bool emphatic;
-} caption_t;
-
 typedef enum shape_t_Tag {
   Empty,
   Circle,
@@ -66,6 +60,12 @@ typedef struct shape_t {
     Labeled_Body labeled;
   };
 } shape_t;
+
+typedef struct caption_t {
+  uint64_t id;
+  char *text;
+  bool emphatic;
+} caption_t;
 
 typedef struct drawing_t {
   uint64_t id;
@@ -136,9 +136,9 @@ void example_free(void *p);
 
 void calculator_drop(struct calculator_t *this_);
 
-void note_drop(struct note_t *this_);
-
 void shape_drop(struct shape_t *this_);
+
+void note_drop(struct note_t *this_);
 
 bool calculator_absorb(struct calculator_t *a, const struct calculator_t *b, double *out, char **e);
 

--- a/examples/example-cbindgen/include/example_flat_aarch64_internal_unstable.h
+++ b/examples/example-cbindgen/include/example_flat_aarch64_internal_unstable.h
@@ -33,12 +33,6 @@ typedef struct calculator_t {
   uint8_t _private[0];
 } calculator_t;
 
-typedef struct caption_t {
-  uint64_t id;
-  char *text;
-  bool emphatic;
-} caption_t;
-
 typedef enum shape_t_Tag {
   Empty,
   Circle,
@@ -66,6 +60,12 @@ typedef struct shape_t {
     Labeled_Body labeled;
   };
 } shape_t;
+
+typedef struct caption_t {
+  uint64_t id;
+  char *text;
+  bool emphatic;
+} caption_t;
 
 typedef struct drawing_t {
   uint64_t id;
@@ -136,9 +136,9 @@ void example_free(void *p);
 
 void calculator_drop(struct calculator_t *this_);
 
-void note_drop(struct note_t *this_);
-
 void shape_drop(struct shape_t *this_);
+
+void note_drop(struct note_t *this_);
 
 bool calculator_absorb(struct calculator_t *a, const struct calculator_t *b, double *out, char **e);
 

--- a/examples/example-cbindgen/include/example_flat_aarch64_unstable.h
+++ b/examples/example-cbindgen/include/example_flat_aarch64_unstable.h
@@ -33,12 +33,6 @@ typedef struct calculator_t {
   uint8_t _private[0];
 } calculator_t;
 
-typedef struct caption_t {
-  uint64_t id;
-  char *text;
-  bool emphatic;
-} caption_t;
-
 typedef enum shape_t_Tag {
   Empty,
   Circle,
@@ -66,6 +60,12 @@ typedef struct shape_t {
     Labeled_Body labeled;
   };
 } shape_t;
+
+typedef struct caption_t {
+  uint64_t id;
+  char *text;
+  bool emphatic;
+} caption_t;
 
 typedef struct drawing_t {
   uint64_t id;
@@ -136,9 +136,9 @@ void example_free(void *p);
 
 void calculator_drop(struct calculator_t *this_);
 
-void note_drop(struct note_t *this_);
-
 void shape_drop(struct shape_t *this_);
+
+void note_drop(struct note_t *this_);
 
 bool calculator_absorb(struct calculator_t *a, const struct calculator_t *b, double *out, char **e);
 

--- a/examples/example-cbindgen/include/example_flat_x86_64.h
+++ b/examples/example-cbindgen/include/example_flat_x86_64.h
@@ -33,12 +33,6 @@ typedef struct calculator_t {
   uint8_t _private[0];
 } calculator_t;
 
-typedef struct caption_t {
-  uint64_t id;
-  char *text;
-  bool emphatic;
-} caption_t;
-
 typedef enum shape_t_Tag {
   Empty,
   Circle,
@@ -66,6 +60,12 @@ typedef struct shape_t {
     Labeled_Body labeled;
   };
 } shape_t;
+
+typedef struct caption_t {
+  uint64_t id;
+  char *text;
+  bool emphatic;
+} caption_t;
 
 typedef struct drawing_t {
   uint64_t id;
@@ -136,9 +136,9 @@ void example_free(void *p);
 
 void calculator_drop(struct calculator_t *this_);
 
-void note_drop(struct note_t *this_);
-
 void shape_drop(struct shape_t *this_);
+
+void note_drop(struct note_t *this_);
 
 bool calculator_absorb(struct calculator_t *a, const struct calculator_t *b, double *out, char **e);
 

--- a/examples/example-cbindgen/include/example_flat_x86_64_internal_unstable.h
+++ b/examples/example-cbindgen/include/example_flat_x86_64_internal_unstable.h
@@ -33,12 +33,6 @@ typedef struct calculator_t {
   uint8_t _private[0];
 } calculator_t;
 
-typedef struct caption_t {
-  uint64_t id;
-  char *text;
-  bool emphatic;
-} caption_t;
-
 typedef enum shape_t_Tag {
   Empty,
   Circle,
@@ -66,6 +60,12 @@ typedef struct shape_t {
     Labeled_Body labeled;
   };
 } shape_t;
+
+typedef struct caption_t {
+  uint64_t id;
+  char *text;
+  bool emphatic;
+} caption_t;
 
 typedef struct drawing_t {
   uint64_t id;
@@ -136,9 +136,9 @@ void example_free(void *p);
 
 void calculator_drop(struct calculator_t *this_);
 
-void note_drop(struct note_t *this_);
-
 void shape_drop(struct shape_t *this_);
+
+void note_drop(struct note_t *this_);
 
 bool calculator_absorb(struct calculator_t *a, const struct calculator_t *b, double *out, char **e);
 

--- a/prebindgen-c/src/builder.rs
+++ b/prebindgen-c/src/builder.rs
@@ -653,21 +653,6 @@ impl CbindgenBuilder {
         qualify_source_type(ty, self.source_module.as_ref())
     }
 
-    /// [`Self::src_ty`] off the **identity** — the type peer of
-    /// [`Self::src_fn`], for the emitters that hold a declared type's key or a
-    /// declaration's own `Origin` rather than a node.
-    ///
-    /// A `TypeKey` is a normalized type, so re-parsing it is the reverse of
-    /// `from_type` and the qualification policy stays in one place: `String`
-    /// still resolves to `::std::string::String` (it can be declared
-    /// `opaque_ptr`), scalars are still left bare, and only a bare
-    /// single-segment path is prefixed.
-    pub(super) fn src_ty_of(&self, key: &TypeKey) -> syn::Type {
-        let spelled: syn::Type = syn::parse_str(key.as_str())
-            .expect("a `TypeKey` is a normalized `syn::Type`, so it re-parses");
-        self.src_ty(&spelled)
-    }
-
     /// Path to a source function (e.g. `zenoh_flat::z_keyexpr_try_from`).
     pub(super) fn src_fn(&self, ident: &syn::Ident) -> syn::Path {
         match &self.source_module {

--- a/prebindgen-c/src/chain.rs
+++ b/prebindgen-c/src/chain.rs
@@ -9,7 +9,7 @@
 use prebindgen_registry::{
     chain::{self, Chain as _},
     flat::{Alternative, TypeRef},
-    generation::{GenerationPlan, SiteId},
+    generation::{ArtifactId, GenerationPlan, SiteId},
     recipe::Mode,
     write::RustFunction,
     Emit,
@@ -1205,6 +1205,7 @@ impl CallbackArtifact {
 pub(crate) enum CArtifact {
     Callback(CallbackArtifact),
     OpaqueHandle(OpaqueHandleArtifact),
+    TaggedUnion(TaggedUnionArtifact),
     ValueOpaque(ValueOpaqueArtifact),
 }
 
@@ -1213,6 +1214,7 @@ impl CArtifact {
         match self {
             Self::Callback(callback) => callback.render(emit),
             Self::OpaqueHandle(handle) => handle.render(emit),
+            Self::TaggedUnion(tagged_union) => tagged_union.render(emit),
             Self::ValueOpaque(value) => value.render(emit),
         }
     }
@@ -1392,6 +1394,178 @@ impl ValueOpaqueArtifact {
             ));
         }
         items
+    }
+}
+
+/// One recursively composed cleanup operation for an owning union payload.
+pub(crate) enum PayloadCleanup {
+    AllocatedString,
+    BoxedPointer {
+        source: Box<TypeRef>,
+    },
+    NestedUnion {
+        artifact: ArtifactId,
+        drop_ident: syn::Ident,
+    },
+    Fields(Vec<(syn::Ident, PayloadCleanup)>),
+}
+
+impl PayloadCleanup {
+    pub(crate) fn prerequisites(&self, out: &mut Vec<ArtifactId>) {
+        match self {
+            Self::NestedUnion { artifact, .. } => out.push(artifact.clone()),
+            Self::Fields(fields) => {
+                for (_, cleanup) in fields {
+                    cleanup.prerequisites(out);
+                }
+            }
+            Self::AllocatedString | Self::BoxedPointer { .. } => {}
+        }
+    }
+
+    fn render(
+        &self,
+        emit: &Emit,
+        source_module: Option<&syn::Path>,
+        slot: TokenStream,
+    ) -> TokenStream {
+        match self {
+            Self::AllocatedString => quote!(
+                free(#slot as *mut ::core::ffi::c_void);
+                #slot = ::core::ptr::null_mut();
+            ),
+            Self::BoxedPointer { source } => {
+                let source = qualify_source_type(&emit.spell_ty(source), source_module);
+                quote!(
+                    if !(#slot).is_null() {
+                        drop(::std::boxed::Box::from_raw(#slot as *mut #source));
+                        #slot = ::core::ptr::null_mut();
+                    }
+                )
+            }
+            Self::NestedUnion { drop_ident, .. } => quote!(#drop_ident(&mut #slot);),
+            Self::Fields(fields) => {
+                let cleanups = fields.iter().map(|(field, cleanup)| {
+                    cleanup.render(emit, source_module, quote!((#slot).#field))
+                });
+                quote!(#(#cleanups)*)
+            }
+        }
+    }
+}
+
+/// One payload field's target wire and optional ownership cleanup.
+pub(crate) struct TaggedUnionFieldArtifact {
+    pub(crate) wire: syn::Type,
+    pub(crate) cleanup: Option<PayloadCleanup>,
+}
+
+/// One alternative of a frozen C tagged-union declaration.
+pub(crate) struct TaggedUnionArmArtifact {
+    pub(crate) alternative: Alternative,
+    pub(crate) fields: Vec<TaggedUnionFieldArtifact>,
+}
+
+/// A tagged-union mirror and its optional typed destructor.
+pub(crate) struct TaggedUnionArtifact {
+    pub(crate) source_module: Option<syn::Path>,
+    pub(crate) c_name: syn::Ident,
+    pub(crate) arms: Vec<TaggedUnionArmArtifact>,
+    pub(crate) drop_ident: Option<syn::Ident>,
+}
+
+impl TaggedUnionArtifact {
+    fn render(&self, emit: &Emit) -> Vec<syn::Item> {
+        let c_name = &self.c_name;
+        let variants = self.arms.iter().map(|arm| {
+            let alternative = &arm.alternative;
+            let variant = &alternative.name;
+            let fields: Vec<_> = alternative
+                .fields
+                .iter()
+                .zip(&arm.fields)
+                .map(|(field, planned)| field.bind(&planned.wire))
+                .collect();
+            emit.shape_alternative(alternative, quote!(#variant), &fields)
+        });
+        let declaration = syn::parse_quote!(
+            #[repr(C)]
+            #[allow(non_camel_case_types)]
+            pub enum #c_name {
+                #(#variants),*
+            }
+        );
+        let Some(drop_ident) = &self.drop_ident else {
+            return vec![declaration];
+        };
+
+        let drop_arms: Vec<_> = self
+            .arms
+            .iter()
+            .filter(|arm| arm.fields.iter().any(|field| field.cleanup.is_some()))
+            .map(|arm| {
+                let alternative = &arm.alternative;
+                let variant = &alternative.name;
+                let bindings: Vec<_> = (0..arm.fields.len())
+                    .map(|index| format_ident!("__f{}", index))
+                    .collect();
+                let parts: Vec<_> = alternative
+                    .fields
+                    .iter()
+                    .zip(&bindings)
+                    .map(|(field, binding)| field.bind(binding))
+                    .collect();
+                let pattern =
+                    emit.shape_alternative(alternative, quote!(#c_name::#variant), &parts);
+                let cleanups = arm
+                    .fields
+                    .iter()
+                    .zip(&bindings)
+                    .filter_map(|(field, binding)| {
+                        field.cleanup.as_ref().map(|cleanup| {
+                            cleanup.render(emit, self.source_module.as_ref(), quote!(*#binding))
+                        })
+                    });
+                quote!(#pattern => { #(#cleanups)* })
+            })
+            .collect();
+        debug_assert!(
+            !drop_arms.is_empty(),
+            "a planned union drop has an owning arm"
+        );
+        let alternatives = self.arms.len() as i64;
+        let bounds_msg = format!(
+            "`{c_name}`: a #[repr(C)] enum with payload variants must be at least as large as \
+             its C `int` discriminant"
+        );
+        let drop = syn::parse_quote!(
+            #[no_mangle]
+            #[allow(non_snake_case, unused_variables)]
+            pub unsafe extern "C" fn #drop_ident(
+                this_: *mut ::core::mem::MaybeUninit<#c_name>,
+            ) {
+                if this_.is_null() {
+                    return;
+                }
+                const _: () = {
+                    assert!(
+                        ::core::mem::size_of::<#c_name>()
+                            >= ::core::mem::size_of::<::core::ffi::c_int>(),
+                        #bounds_msg
+                    );
+                };
+                let __tag: ::core::ffi::c_int =
+                    ::core::ptr::read((*this_).as_ptr() as *const ::core::ffi::c_int);
+                if !((__tag as i64) >= 0 && (__tag as i64) < #alternatives) {
+                    return;
+                }
+                match (*this_).assume_init_mut() {
+                    #(#drop_arms)*
+                    _ => {}
+                }
+            }
+        );
+        vec![declaration, drop]
     }
 }
 

--- a/prebindgen-c/src/emit.rs
+++ b/prebindgen-c/src/emit.rs
@@ -276,8 +276,8 @@ impl CbindgenBuilder {
     ///
     /// A nested `data_struct` payload crosses BY VALUE, so the wire itself is
     /// not a pointer, but its mirror's own fields may be: the union's drop
-    /// then has to reach through and release each of them (see
-    /// [`CbindgenBuilder::payload_free_stmt`]). Without this a `String` or handle
+    /// then has to reach through and release each of them through the recursive
+    /// payload-cleanup artifact plan. Without this a `String` or handle
     /// inside a struct payload would leak, silently, for exactly the shape
     /// zenoh-flat#30 needs.
     pub(super) fn payload_wire_owns(
@@ -323,8 +323,8 @@ impl CbindgenBuilder {
     /// Whether a declared `tagged_union` gets a typed `<base>_drop` — i.e. it is
     /// produced at all, and some arm's payload owns memory.
     ///
-    /// This is the emission condition of that drop
-    /// ([`CbindgenBuilder::prereq_tagged_unions`]) *and* the test for whether a
+    /// This is the emission condition of the tagged-union artifact's drop *and*
+    /// the test for whether a
     /// containing struct has to call it, so a union nested inside a payload
     /// cannot be freed through a symbol that was never emitted. `false` for
     /// anything that is not a declared tagged union.

--- a/prebindgen-c/src/tests/boundary_invariants.rs
+++ b/prebindgen-c/src/tests/boundary_invariants.rs
@@ -511,6 +511,131 @@ fn type_artifacts_retain_source_types_and_fragment_dependencies() {
 }
 
 #[test]
+fn tagged_union_artifacts_retain_cleanup_types_and_dependencies() {
+    use prebindgen_registry::generation::{ArtifactId, ArtifactInput};
+
+    let loc = SourceLocation::default();
+    let items = declare_referenced([
+        (
+            syn::parse_quote!(
+                pub struct Handle;
+            ),
+            loc.clone(),
+        ),
+        (
+            syn::parse_quote!(
+                pub enum Shape {
+                    Empty,
+                    Filled(Box<Handle>),
+                }
+            ),
+            loc.clone(),
+        ),
+        (
+            syn::parse_quote!(
+                pub struct Drawing {
+                    pub shape: Shape,
+                }
+            ),
+            loc.clone(),
+        ),
+        (
+            syn::parse_quote!(
+                pub enum Note {
+                    Silent,
+                    Sketched(Drawing),
+                }
+            ),
+            loc.clone(),
+        ),
+        (
+            syn::parse_quote!(
+                pub fn make_shape() -> Shape {
+                    unimplemented!()
+                }
+            ),
+            loc.clone(),
+        ),
+        (
+            syn::parse_quote!(
+                pub fn make_note() -> Note {
+                    unimplemented!()
+                }
+            ),
+            loc,
+        ),
+    ]);
+    let registry = crate::test_util::reg_from_items(items).expect("index items");
+    let binding = CbindgenBuilder::new()
+        .source_module(syn::parse_quote!(source))
+        .opaque_ptr(syn::parse_quote!(Handle))
+        .tagged_union(syn::parse_quote!(Shape))
+        .data_struct(syn::parse_quote!(Drawing))
+        .tagged_union(syn::parse_quote!(Note))
+        .function(syn::parse_quote!(make_shape))
+        .function(syn::parse_quote!(make_note))
+        .build_with(registry)
+        .expect("resolve");
+    let generation = binding.gen.generation.as_ref().expect("frozen plan");
+    let tagged: Vec<_> = generation
+        .artifacts()
+        .filter(|artifact| artifact.id().kind() == "c-tagged-union")
+        .collect();
+    assert_eq!(tagged.len(), 2);
+    assert_eq!(
+        tagged
+            .iter()
+            .map(|artifact| artifact.id().name())
+            .collect::<Vec<_>>(),
+        ["Shape", "Note"],
+        "the registry orders the inner union before its dependent"
+    );
+    for artifact in &tagged {
+        assert!(
+            !artifact.inputs().is_empty(),
+            "{} must consume reached converter fragments",
+            artifact.id()
+        );
+        assert!(artifact
+            .inputs()
+            .iter()
+            .all(|input| matches!(input, ArtifactInput::Fragment(_))));
+    }
+
+    let shape = tagged
+        .iter()
+        .find(|artifact| artifact.id().name() == "Shape")
+        .expect("Shape artifact");
+    let crate::chain::CArtifact::TaggedUnion(shape_plan) = shape.payload() else {
+        panic!("Shape must be a tagged-union artifact");
+    };
+    assert!(matches!(
+        shape_plan.arms[1].fields[0].cleanup.as_ref(),
+        Some(crate::chain::PayloadCleanup::BoxedPointer { source })
+            if source.key().as_str() == "Handle"
+    ));
+
+    let note = tagged
+        .iter()
+        .find(|artifact| artifact.id().name() == "Note")
+        .expect("Note artifact");
+    let shape_id = ArtifactId::new("c-tagged-union", "Shape").expect("valid artifact id");
+    assert_eq!(note.prerequisites(), std::slice::from_ref(&shape_id));
+    let crate::chain::CArtifact::TaggedUnion(note_plan) = note.payload() else {
+        panic!("Note must be a tagged-union artifact");
+    };
+    assert!(matches!(
+        note_plan.arms[1].fields[0].cleanup.as_ref(),
+        Some(crate::chain::PayloadCleanup::Fields(fields))
+            if matches!(
+                fields.as_slice(),
+                [(field, crate::chain::PayloadCleanup::NestedUnion { artifact, .. })]
+                    if field == "shape" && artifact == &shape_id
+            )
+    ));
+}
+
+#[test]
 fn legacy_c_shape_and_callback_planners_are_deleted() {
     let sources = [
         include_str!("../lib.rs"),
@@ -538,6 +663,10 @@ fn legacy_c_shape_and_callback_planners_are_deleted() {
         "fn prereq_opaque_handles",
         "fn prereq_value_opaque",
         "fn value_opaque_writeback(",
+        "fn prereq_tagged_unions",
+        "fn payload_free_stmt",
+        "fn tag_guard",
+        "fn src_ty_of",
     ] {
         assert!(
             !sources.contains(deleted),

--- a/prebindgen-c/src/tests/tagged_unions.rs
+++ b/prebindgen-c/src/tests/tagged_unions.rs
@@ -472,7 +472,7 @@ fn each_payload_rejection_names_its_own_reason() {
 
     // The other three reasons (no output converter, wire mismatch, fallible
     // output converter) are guards: an undeclared payload type fails at
-    // RESOLVE, before `prereq_tagged_unions` runs, so nothing reaches them
+    // RESOLVE, before tagged-union artifact planning runs, so nothing reaches them
     // from a fixture. Their messages are specific, but unexercised.
 }
 

--- a/prebindgen-c/src/trait_impl.rs
+++ b/prebindgen-c/src/trait_impl.rs
@@ -629,6 +629,20 @@ impl CbindgenBuilder {
         items
     }
 
+    /// Converter fragments consumed by one type-level final artifact.
+    fn artifact_fragment_inputs(
+        &self,
+        reading: &TypeRef,
+    ) -> Vec<prebindgen_registry::generation::ArtifactInput> {
+        [self.in_frag(reading), self.out_frag(reading)]
+            .into_iter()
+            .flatten()
+            .map(|fragment| {
+                prebindgen_registry::generation::ArtifactInput::Fragment(fragment.id.clone())
+            })
+            .collect()
+    }
+
     /// Freeze source-dependent C declaration families as registry artifacts.
     ///
     /// Planning retains source TypeRefs and target-owned wire syntax. Only the
@@ -640,22 +654,15 @@ impl CbindgenBuilder {
         Vec<prebindgen_registry::generation::ArtifactPlan<crate::compile::CRepresentation>>,
         String,
     > {
-        use prebindgen_registry::generation::{ArtifactId, ArtifactInput, ArtifactPlan};
+        use prebindgen_registry::generation::{ArtifactId, ArtifactPlan};
 
-        let inputs = |reading: &TypeRef| {
-            [self.in_frag(reading), self.out_frag(reading)]
-                .into_iter()
-                .flatten()
-                .map(|fragment| ArtifactInput::Fragment(fragment.id.clone()))
-                .collect::<Vec<_>>()
-        };
         let mut artifacts = Vec::new();
 
         for (key, _cfg) in sorted_by_key(&self.opaque) {
             let Some(reading) = registry.reading(key) else {
                 continue;
             };
-            let dependencies = inputs(&reading);
+            let dependencies = self.artifact_fragment_inputs(&reading);
             if dependencies.is_empty() {
                 continue;
             }
@@ -679,7 +686,7 @@ impl CbindgenBuilder {
             let Some(reading) = registry.reading(key) else {
                 continue;
             };
-            let dependencies = inputs(&reading);
+            let dependencies = self.artifact_fragment_inputs(&reading);
             if dependencies.is_empty() {
                 continue;
             }
@@ -752,6 +759,101 @@ impl CbindgenBuilder {
                     mirror,
                     drop_ident: self.destructor_symbol(key),
                     take,
+                }),
+            ));
+        }
+        Ok(artifacts)
+    }
+
+    /// Freeze one owning payload's recursive release policy without spelling
+    /// the Rust type used by a boxed-pointer cleanup.
+    fn payload_cleanup_plan(
+        &self,
+        fty: &TypeRef,
+        registry: &Registry,
+    ) -> Result<crate::chain::PayloadCleanup, String> {
+        use prebindgen_registry::generation::ArtifactId;
+
+        if r_is_string(fty) {
+            return Ok(crate::chain::PayloadCleanup::AllocatedString);
+        }
+        if self.tagged_union_has_drop(fty, registry) {
+            return Ok(crate::chain::PayloadCleanup::NestedUnion {
+                artifact: ArtifactId::new("c-tagged-union", fty.key().as_str())
+                    .map_err(|e| e.to_string())?,
+                drop_ident: self.destructor_symbol(&fty.key()),
+            });
+        }
+        let owning = self.owning_data_struct_fields(fty, registry);
+        if !owning.is_empty() {
+            let mut fields = Vec::with_capacity(owning.len());
+            for (name, ty) in owning {
+                fields.push((name, self.payload_cleanup_plan(ty, registry)?));
+            }
+            return Ok(crate::chain::PayloadCleanup::Fields(fields));
+        }
+        Ok(crate::chain::PayloadCleanup::BoxedPointer {
+            source: Box::new(r_boxed_inner(fty).unwrap_or(fty).clone()),
+        })
+    }
+
+    /// Freeze every reached tagged-union declaration and typed destructor.
+    fn tagged_union_artifact_plans(
+        &self,
+        registry: &Registry,
+    ) -> Result<
+        Vec<prebindgen_registry::generation::ArtifactPlan<crate::compile::CRepresentation>>,
+        String,
+    > {
+        use prebindgen_registry::generation::{ArtifactId, ArtifactPlan};
+
+        let mut artifacts = Vec::new();
+        for (key, _cfg) in sorted_by_key(&self.tagged_unions) {
+            let Some(reading) = registry.reading(key) else {
+                continue;
+            };
+            let inputs = self.artifact_fragment_inputs(&reading);
+            if inputs.is_empty() {
+                continue;
+            }
+            let Some(sum) = payload_enum(registry, key) else {
+                continue;
+            };
+            let mut prerequisites = Vec::new();
+            let mut arms = Vec::with_capacity(sum.alternatives.len());
+            for alternative in &sum.alternatives {
+                let mut fields = Vec::with_capacity(alternative.fields.len());
+                for field in &alternative.fields {
+                    let wire = self.payload_wire_of(key, &alternative.name, field);
+                    let cleanup = if self.payload_wire_owns(&field.ty, &wire, registry) {
+                        let cleanup = self.payload_cleanup_plan(&field.ty, registry)?;
+                        cleanup.prerequisites(&mut prerequisites);
+                        Some(cleanup)
+                    } else {
+                        None
+                    };
+                    fields.push(crate::chain::TaggedUnionFieldArtifact { wire, cleanup });
+                }
+                arms.push(crate::chain::TaggedUnionArmArtifact {
+                    alternative: alternative.clone(),
+                    fields,
+                });
+            }
+            prerequisites.sort();
+            prerequisites.dedup();
+            let drop_ident = arms
+                .iter()
+                .any(|arm| arm.fields.iter().any(|field| field.cleanup.is_some()))
+                .then(|| self.destructor_symbol(key));
+            artifacts.push(ArtifactPlan::new(
+                ArtifactId::new("c-tagged-union", key.as_str()).map_err(|e| e.to_string())?,
+                prerequisites,
+                inputs,
+                crate::chain::CArtifact::TaggedUnion(crate::chain::TaggedUnionArtifact {
+                    source_module: self.source_module.clone(),
+                    c_name: self.c_type_ident(key),
+                    arms,
+                    drop_ident,
                 }),
             ));
         }
@@ -853,134 +955,6 @@ impl CbindgenBuilder {
         items
     }
 
-    /// Tagged unions: the `#[repr(C)]` mirror with payload variants, which
-    /// cbindgen renders as a tag enum plus a `union` of the variant bodies —
-    /// the idiomatic C tagged union, with no hand-written header fragment.
-    /// Variant shape is mirrored faithfully (named stays named, tuple stays
-    /// tuple, unit stays unit); each payload field takes the wire chosen by
-    /// [`CbindgenBuilder::payload_field_wire`].
-    ///
-    /// A union whose payload wires own memory also gets a typed
-    /// `<base>_drop(t_t *)` that frees the **active arm** and nulls the freed
-    /// slots, so a second drop is a no-op. A union of plain data owns nothing
-    /// and gets no drop.
-    fn prereq_tagged_unions(
-        &self,
-        registry: &Registry,
-        emit: &prebindgen_registry::Emit,
-    ) -> Vec<syn::Item> {
-        let mut items: Vec<syn::Item> = Vec::new();
-        for (key, _cfg) in sorted_by_key(&self.tagged_unions) {
-            let Some(reading) = registry.reading(key) else {
-                continue;
-            };
-            if self.in_frag(&reading).is_none() && self.out_frag(&reading).is_none() {
-                continue;
-            }
-            let Some(e) = payload_enum(registry, &reading.key()) else {
-                continue;
-            };
-            let cname = self.c_type_ident(&reading.key());
-
-            let mut variant_defs: Vec<TokenStream> = Vec::new();
-            // Per-variant drop arm, collected only for variants that own
-            // something; the rest fall to a single wildcard arm.
-            let mut drop_arms: Vec<TokenStream> = Vec::new();
-            for a in &e.alternatives {
-                let vident = &a.name;
-                let wires: Vec<syn::Type> = a
-                    .fields
-                    .iter()
-                    .map(|f| self.payload_wire_of(&reading.key(), vident, f))
-                    .collect();
-                // `Alternative::spell` writes the delimiters the source wrote,
-                // which is what the three-armed `syn::Fields` match was doing —
-                // and `Field::bind` decides `name: wire` or `wire` per field.
-                let defs: Vec<TokenStream> = a
-                    .fields
-                    .iter()
-                    .zip(&wires)
-                    .map(|(f, w)| f.bind(w))
-                    .collect();
-                variant_defs.push(emit.shape_alternative(a, quote!(#vident), &defs));
-
-                // Drop arm: bind every field, free the owning ones.
-                let owning: Vec<(usize, &Field, &syn::Type)> = a
-                    .fields
-                    .iter()
-                    .zip(&wires)
-                    .enumerate()
-                    .filter(|(_, (f, w))| self.payload_wire_owns(&f.ty, w, registry))
-                    .map(|(i, (f, w))| (i, f, w))
-                    .collect();
-                if owning.is_empty() {
-                    continue;
-                }
-                let binds: Vec<syn::Ident> = (0..a.fields.len())
-                    .map(|i| format_ident!("__f{}", i))
-                    .collect();
-                let parts: Vec<TokenStream> = a
-                    .fields
-                    .iter()
-                    .zip(&binds)
-                    .map(|(f, b)| f.bind(b))
-                    .collect();
-                let pattern = emit.shape_alternative(a, quote!(#cname::#vident), &parts);
-                let frees = owning.iter().map(|(i, f, _)| {
-                    let b = &binds[*i];
-                    self.payload_free_stmt(&f.ty, b, registry)
-                });
-                drop_arms.push(quote!(#pattern => { #(#frees)* }));
-            }
-
-            items.push(syn::parse_quote!(
-                #[repr(C)]
-                #[allow(non_camel_case_types)]
-                pub enum #cname {
-                    #(#variant_defs),*
-                }
-            ));
-
-            // The same predicate a CONTAINING struct uses to decide whether to
-            // call this drop, so a nested union can never be freed through a
-            // symbol that was not emitted.
-            if self.tagged_union_has_drop(&reading, registry) {
-                debug_assert!(!drop_arms.is_empty(), "has_drop implies an owning arm");
-                let drop_ident = self.destructor_symbol(&reading.key());
-                // The drop is a second C entry point into the same bytes, so it
-                // owes the same tag check as the input converter — `&mut *this_`
-                // on an out-of-range tag would be the very UB that check exists
-                // to prevent. It emits that check from the same place, and,
-                // having nowhere to report to, ignores the value (there is no
-                // live arm to release), which keeps `_drop` the always-safe
-                // no-op it is everywhere else.
-                let tag_guard = self.tag_guard(
-                    &cname,
-                    e.alternatives.len(),
-                    quote!((*this_)),
-                    quote!(return;),
-                );
-                items.push(syn::parse_quote!(
-                    #[no_mangle]
-                    #[allow(non_snake_case, unused_variables)]
-                    pub unsafe extern "C" fn #drop_ident(
-                        this_: *mut ::core::mem::MaybeUninit<#cname>,
-                    ) {
-                        if this_.is_null() {
-                            return;
-                        }
-                        #tag_guard
-                        match (*this_).assume_init_mut() {
-                            #(#drop_arms)*
-                            _ => {}
-                        }
-                    }
-                ));
-            }
-        }
-        items
-    }
-
     /// The wire of one payload field, or a generation error naming the
     /// offending variant field and the supported set.
     fn payload_wire_of(&self, key: &TypeKey, variant: &syn::Ident, field: &Field) -> syn::Type {
@@ -997,107 +971,6 @@ impl CbindgenBuilder {
                 reason,
             )
         })
-    }
-
-    /// Release one owning payload slot held behind `binding` (a `&mut` to the
-    /// wire, from a `match &mut *this_` arm) and null it, so a second drop of
-    /// the same union is a no-op. A `char *` block goes back to the C
-    /// allocator; an opaque pointer is re-boxed and dropped, running the Rust
-    /// destructor.
-    fn payload_free_stmt(
-        &self,
-        fty: &TypeRef,
-        binding: &syn::Ident,
-        registry: &Registry,
-    ) -> TokenStream {
-        if r_is_string(fty) {
-            return quote!(
-                free(*#binding as *mut ::core::ffi::c_void);
-                *#binding = ::core::ptr::null_mut();
-            );
-        }
-        // A nested `data_struct` payload crosses BY VALUE, so the arm binds the
-        // mirror itself and what has to be released is each of its OWNING
-        // fields — reached through the binding and nulled in place, exactly as
-        // a directly-owning payload is. This is the shape zenoh-flat#30 needs
-        // (`ReplyResult`'s alternatives are structs whose fields are handles),
-        // and without it those fields would leak silently.
-        let owning = self.owning_data_struct_fields(fty, registry);
-        if !owning.is_empty() {
-            let frees = owning.iter().map(|(fname, fty)| {
-                if r_is_string(fty) {
-                    quote!(
-                        free((*#binding).#fname as *mut ::core::ffi::c_void);
-                        (*#binding).#fname = ::core::ptr::null_mut();
-                    )
-                } else if self.tagged_union_has_drop(fty, registry) {
-                    // The field is ANOTHER union, crossing by value. Its own
-                    // typed drop releases whichever arm is live and nulls the
-                    // slot, so this stays idempotent like every other arm here
-                    // — and the owning pointer is reached even though it is two
-                    // levels down. Nothing else can reach it: a union arm is not
-                    // a top-level struct field the C caller releases by hand.
-                    let drop_ident = self.destructor_symbol(&fty.key());
-                    quote!(#drop_ident(&mut (*#binding).#fname);)
-                } else {
-                    // `owning_data_struct_fields` yields exactly the two shapes
-                    // above (`data_field_owns`), so this is unreachable — and a
-                    // silent fall-through here would be a leak, which is the
-                    // defect this whole path exists to prevent.
-                    panic!(
-                        "Cbindgen: data-struct field `{}` of type `{}` is owning but has no \
-                         release form (expected a `String` or a declared `tagged_union`)",
-                        fname, fty,
-                    )
-                }
-            });
-            return quote!(#(#frees)*);
-        }
-        let src_inner = self.src_ty_of(&r_boxed_inner(fty).unwrap_or(fty).key());
-        quote!(
-            if !(*#binding).is_null() {
-                drop(::std::boxed::Box::from_raw(*#binding as *mut #src_inner));
-                *#binding = ::core::ptr::null_mut();
-            }
-        )
-    }
-
-    /// The statements that make a C-supplied `MaybeUninit<mirror>` safe to
-    /// `assume_init`: read the leading discriminant as a plain `c_int` and
-    /// reject anything outside `0..variants`.
-    ///
-    /// `slot` is an expression for the `MaybeUninit` in scope and `on_bad` is
-    /// what to do with an out-of-range tag — the **only** thing the two C entry
-    /// points into these bytes differ in (the input converter returns `Err`,
-    /// the typed drop returns `()` and so just bails). Passing that difference
-    /// in, rather than letting the drop repeat the check inline, is what keeps
-    /// the two from drifting apart.
-    pub(crate) fn tag_guard(
-        &self,
-        cname: &syn::Ident,
-        variants: usize,
-        slot: TokenStream,
-        on_bad: TokenStream,
-    ) -> TokenStream {
-        let n = variants as i64;
-        let bounds_msg = format!(
-            "`{cname}`: a #[repr(C)] enum with payload variants must be at least as large as \
-             its C `int` discriminant"
-        );
-        quote!(
-            const _: () = {
-                assert!(
-                    ::core::mem::size_of::<#cname>()
-                        >= ::core::mem::size_of::<::core::ffi::c_int>(),
-                    #bounds_msg
-                );
-            };
-            let __tag: ::core::ffi::c_int =
-                ::core::ptr::read(#slot.as_ptr() as *const ::core::ffi::c_int);
-            if !((__tag as i64) >= 0 && (__tag as i64) < #n) {
-                #on_bad
-            }
-        )
     }
 }
 
@@ -1211,6 +1084,10 @@ impl CbindgenBuilder {
         };
         artifacts.extend(
             self.type_artifact_plans(&registry)
+                .map_err(|message| prebindgen_registry::ScanError::AdapterInvariant { message })?,
+        );
+        artifacts.extend(
+            self.tagged_union_artifact_plans(&registry)
                 .map_err(|message| prebindgen_registry::ScanError::AdapterInvariant { message })?,
         );
         let mut generation = prebindgen_registry::generation::GenerationPlanBuilder::new();
@@ -1365,7 +1242,13 @@ impl Prebindgen for CbindgenBuilder {
             emit,
         ));
         items.extend(self.prereq_enums(registry, emit));
-        items.extend(self.prereq_tagged_unions(registry, emit));
+        items.extend(crate::chain::render_artifacts(
+            self.generation
+                .as_ref()
+                .expect("C generation plan was not frozen"),
+            "c-tagged-union",
+            emit,
+        ));
         items.extend(crate::chain::render_artifacts(
             self.generation
                 .as_ref()


### PR DESCRIPTION
## Summary

- freeze each reached C tagged-union mirror and typed destructor as a registry-owned `c-tagged-union` artifact
- retain boxed payload source types as opaque `TypeRef` values until final rendering, and model string, boxed-pointer, nested-union, and record-field cleanup as a recursive frozen plan
- express nested cleanup as an artifact prerequisite so the registry orders an inner union before the outer union that calls its destructor
- delete the eager `prereq_tagged_unions`, `payload_free_stmt`, `tag_guard`, and `src_ty_of` paths and fence them from returning

## Why

Stage 7 of #513 still let C tagged-union prerequisite generation reopen the registry, spell source types during planning, and assemble recursive cleanup directly into syntax. That left a second artifact-ordering and source-spelling path beside the registry generation plan.

This change makes tagged unions consume the same immutable artifact mechanism as C opaque types. The adapter freezes semantic cleanup operations and target wire syntax; only the final artifact renderer receives `Emit` and may spell a retained source type.

## Generated-source compatibility

Exported C symbols, signatures, layouts, ownership behavior, tag validation, and destructor behavior are unchanged.

Committed Rust and C artifacts are reordered semantically: `shape_t` and `shape_drop` now precede the dependent `note_t` and `note_drop`. cbindgen correspondingly moves one supporting struct declaration. This is registry prerequisite order, not an ABI or behavior change.

## Verification

- `cargo test -p prebindgen-c` — 109 passed
- `cargo test --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`
- `cargo fmt --all -- --check`
- `git diff --check`
- `./examples/regen-check.sh` — byte-identical after refreshing committed dependency order
- `./examples/smoke-asan.sh` — ASan/LSan/UBSan clean