### PR TITLE
Delete the C complete function carrier

### DIFF
--- a/prebindgen-c/src/chain.rs
+++ b/prebindgen-c/src/chain.rs
@@ -46,7 +46,7 @@ impl chain::Child for CCall {
     }
 }
 
-/// A complete legacy function or a chain waiting for final rendering.
+/// A typed converter plan waiting for final rendering.
 #[derive(Clone)]
 pub(crate) struct CFunction {
     call: CCall,
@@ -55,7 +55,6 @@ pub(crate) struct CFunction {
 
 #[derive(Clone)]
 enum CBody {
-    Complete(syn::ItemFn),
     Custom(CustomPlan),
     InputTerminal(InputTerminalPlan),
     OutputTerminal(OutputTerminalPlan),
@@ -73,14 +72,6 @@ enum CBody {
 }
 
 impl CFunction {
-    pub(crate) fn complete(function: syn::ItemFn) -> Self {
-        let call = CCall(chain::Call::complete(&function));
-        Self {
-            call,
-            body: CBody::Complete(function),
-        }
-    }
-
     pub(crate) fn product(plan: ProductPlan) -> Self {
         let call = CCall(chain::Call::new(
             plan.ident.clone(),
@@ -292,7 +283,6 @@ impl RustFunction for CFunction {
 
     fn render(&self, emit: &Emit) -> syn::ItemFn {
         match &self.body {
-            CBody::Complete(function) => function.clone(),
             CBody::Custom(plan) => plan.render(emit),
             CBody::InputTerminal(plan) => plan.render(emit),
             CBody::OutputTerminal(plan) => plan.render(emit),
@@ -311,9 +301,10 @@ impl RustFunction for CFunction {
     }
 }
 
-/// A multi-wire crossing whose ABI lives in its frozen site value.
+/// A syntax-free marker whose real ABI or payload assembly lives elsewhere.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) enum MarkerOperation {
+    ChoiceArm,
     Optional,
     Sequence,
     Result,
@@ -330,6 +321,13 @@ pub(crate) struct MarkerPlan {
 impl MarkerPlan {
     fn render(&self) -> syn::ItemFn {
         match self.operation {
+            MarkerOperation::ChoiceArm => {
+                let name = &self.ident;
+                syn::parse_quote!(
+                    #[allow(dead_code)]
+                    fn #name() {}
+                )
+            }
             MarkerOperation::Optional | MarkerOperation::Sequence | MarkerOperation::Result => {
                 render_marker(&self.ident)
             }

--- a/prebindgen-c/src/compile.rs
+++ b/prebindgen-c/src/compile.rs
@@ -1020,10 +1020,13 @@ impl<R: Conversions> Compile for CCompile<'_, R> {
                 })
                 .map(|(p, _)| p.ty.key())
                 .collect();
-            let function = CFunction::complete(syn::parse_quote!(
-                #[allow(dead_code)]
-                fn __cbg_arm() {}
-            ));
+            let function = CFunction::marker(MarkerPlan {
+                ident: format_ident!("__cbg_arm"),
+                operation: MarkerOperation::ChoiceArm,
+                // Choice retains the exact part FragmentUse edges; this
+                // transient bridge has no independent dependency.
+                subs: Vec::new(),
+            });
             let destination: syn::Type = syn::parse_quote!(());
             let value = CValue::Direct {
                 wire: destination.clone(),

--- a/prebindgen-c/src/lib.rs
+++ b/prebindgen-c/src/lib.rs
@@ -445,12 +445,11 @@ pub struct CbindgenBuilder {
     /// argument sites, and callback artifacts.
     pub(crate) generation:
         Option<prebindgen_registry::generation::GenerationPlan<crate::compile::CRepresentation>>,
-    /// Every converter artifact this binding planned.
+    /// Every reached converter function plan this binding retained.
     ///
     /// Filled once by [`Self::build_with`] and handed to `write_rust` directly.
-    /// A legacy terminal may still contain a complete function; composed
-    /// Product and inbound Optional fragments contain syntax-free chains that
-    /// the shared writer renders only after resolution and validation.
+    /// Every entry is a typed terminal or composed shape plan that the shared
+    /// writer renders only after resolution and validation.
     /// The writer sorts and de-duplicates by function name, so the order here
     /// decides which of two same-named functions wins and not where any of them
     /// lands.

--- a/prebindgen-c/src/tests/boundary_invariants.rs
+++ b/prebindgen-c/src/tests/boundary_invariants.rs
@@ -675,11 +675,11 @@ fn legacy_c_shape_and_callback_planners_are_deleted() {
             "deleted C compatibility planner returned through {deleted}"
         );
     }
+    let compact: String = sources.chars().filter(|c| !c.is_whitespace()).collect();
     assert!(
-        sources.contains("operation: MarkerOperation::ChoiceArm"),
+        compact.contains("operation:MarkerOperation::ChoiceArm"),
         "Product-to-Choice composition must use its typed transient marker"
     );
-    let compact: String = sources.chars().filter(|c| !c.is_whitespace()).collect();
     assert!(
         !compact.contains("Option<ConverterImpl>"),
         "a C production path accepts the deleted generic converter carrier"

--- a/prebindgen-c/src/tests/boundary_invariants.rs
+++ b/prebindgen-c/src/tests/boundary_invariants.rs
@@ -667,12 +667,18 @@ fn legacy_c_shape_and_callback_planners_are_deleted() {
         "fn payload_free_stmt",
         "fn tag_guard",
         "fn src_ty_of",
+        "Complete(syn::ItemFn)",
+        "CFunction::complete",
     ] {
         assert!(
             !sources.contains(deleted),
             "deleted C compatibility planner returned through {deleted}"
         );
     }
+    assert!(
+        sources.contains("operation: MarkerOperation::ChoiceArm"),
+        "Product-to-Choice composition must use its typed transient marker"
+    );
     let compact: String = sources.chars().filter(|c| !c.is_whitespace()).collect();
     assert!(
         !compact.contains("Option<ConverterImpl>"),

--- a/prebindgen-c/src/trait_impl.rs
+++ b/prebindgen-c/src/trait_impl.rs
@@ -1581,6 +1581,7 @@ impl CbindgenBuilder {
         subject: &TypeRef,
     ) -> Option<crate::chain::MarkerPlan> {
         let (ident, subs) = match operation {
+            crate::chain::MarkerOperation::ChoiceArm => return None,
             crate::chain::MarkerOperation::Optional => (
                 format_ident!("__cbg_outmark_option_{}", sanitize(&subject.key())),
                 vec![subject.clone()],


### PR DESCRIPTION
## Summary

- replace the transient Product-arm dummy `syn::ItemFn` with a typed `MarkerOperation::ChoiceArm` plan
- remove `CBody::Complete`, `CFunction::complete`, and the final C render branch that accepted an already-rendered function
- keep Choice-arm dependencies solely in the composed Choice's exact `FragmentUse` edges instead of retaining duplicate source types
- add structural fences requiring the typed Product→Choice marker and forbidding the complete-function carrier from returning

## Why

After #551, the only C caller of `CFunction::complete` was a zero-argument placeholder required while `Compile::fields` passes an arm Product directly into `Compile::choice`. The shared compiler does not freeze or emit that transient arm fragment; Choice consumes its payload parts and owns the actual dependency graph.

Keeping an already-rendered `syn::ItemFn` for that placeholder nevertheless left the C representation capable of bypassing late rendering. This closes that final known C stage-7 carrier without widening the output-marker API: `ChoiceArm` is constructed only by Product→Choice composition and is explicitly rejected by the Optional/Sequence/Result marker factory.

## Generated-source compatibility

Generated Rust, C headers, exported ABI, and behavior are byte-for-byte unchanged.

## Verification

- `cargo test --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`
- `cargo fmt --all -- --check`
- `git diff --check`
- `./examples/regen-check.sh` — byte-identical
- `./examples/smoke-asan.sh` — ASan/LSan/UBSan clean