### PR TITLE
Render JNI scalar codecs from frozen plans

### DIFF
--- a/prebindgen-jni/src/jni/chain.rs
+++ b/prebindgen-jni/src/jni/chain.rs
@@ -17,6 +17,8 @@ pub(crate) struct JFunction(JBody);
 #[derive(Clone)]
 enum JBody {
     Complete(Box<syn::ItemFn>),
+    Marker(syn::Ident),
+    Scalar(Box<JScalarPlan>),
     OwnedHandle(Box<JOwnedHandlePlan>),
     BorrowedOptionalHandle(Box<JBorrowedOptionalHandlePlan>),
     Product(Box<JProductPlan>),
@@ -31,8 +33,20 @@ impl JFunction {
         Self(JBody::Complete(Box::new(function)))
     }
 
+    pub(crate) fn retained(function: syn::ItemFn) -> Self {
+        if is_planned_marker(&function) {
+            Self(JBody::Marker(function.sig.ident))
+        } else {
+            Self::complete(function)
+        }
+    }
+
     pub(crate) fn owned_handle(plan: JOwnedHandlePlan) -> Self {
         Self(JBody::OwnedHandle(Box::new(plan)))
+    }
+
+    pub(crate) fn scalar(plan: JScalarPlan) -> Self {
+        Self(JBody::Scalar(Box::new(plan)))
     }
 
     pub(crate) fn borrowed_optional_handle(plan: JBorrowedOptionalHandlePlan) -> Self {
@@ -65,6 +79,11 @@ impl JFunction {
     }
 
     #[cfg(test)]
+    pub(crate) fn is_scalar(&self) -> bool {
+        matches!(self.0, JBody::Scalar(_))
+    }
+
+    #[cfg(test)]
     pub(crate) fn is_borrowed_optional_handle(&self) -> bool {
         matches!(self.0, JBody::BorrowedOptionalHandle(_))
     }
@@ -84,6 +103,7 @@ impl JFunction {
     pub(crate) fn mark_reachable(&self) {
         match &self.0 {
             JBody::Complete(_) => {}
+            JBody::Marker(_) | JBody::Scalar(_) => {}
             JBody::OwnedHandle(plan) => plan.reachable.set(true),
             JBody::BorrowedOptionalHandle(plan) => plan.reachable.set(true),
             JBody::Product(plan) => {
@@ -123,6 +143,8 @@ impl RustFunction for JFunction {
     fn ident(&self) -> &syn::Ident {
         match &self.0 {
             JBody::Complete(function) => &function.sig.ident,
+            JBody::Marker(ident) => ident,
+            JBody::Scalar(plan) => &plan.ident,
             JBody::OwnedHandle(plan) => &plan.ident,
             JBody::BorrowedOptionalHandle(plan) => &plan.ident,
             JBody::Product(plan) => &plan.ident,
@@ -136,6 +158,11 @@ impl RustFunction for JFunction {
     fn should_emit(&self) -> bool {
         match &self.0 {
             JBody::Complete(_) => true,
+            JBody::Marker(_) => false,
+            // Complete compatibility parents do not yet propagate
+            // reachability to the children they call. Until those parents are
+            // planned too, every compiled scalar remains an emitted leaf.
+            JBody::Scalar(_) => true,
             JBody::OwnedHandle(plan) => plan.reachable.get(),
             JBody::BorrowedOptionalHandle(plan) => plan.reachable.get(),
             JBody::Product(plan) => plan.reachable.get(),
@@ -151,6 +178,8 @@ impl RustFunction for JFunction {
     fn render(&self, emit: &Emit) -> syn::ItemFn {
         match &self.0 {
             JBody::Complete(function) => (**function).clone(),
+            JBody::Marker(ident) => planned_marker(ident),
+            JBody::Scalar(plan) => plan.render(emit),
             JBody::OwnedHandle(plan) => plan.render(emit),
             JBody::BorrowedOptionalHandle(plan) => plan.render(emit),
             JBody::Product(plan) => plan.render(emit),
@@ -158,6 +187,77 @@ impl RustFunction for JFunction {
             JBody::Choice(plan) => plan.render(emit),
             JBody::Sequence(plan) => plan.render(emit),
             JBody::Invoke(plan) => plan.render(emit),
+        }
+    }
+}
+
+/// One bare Flat scalar crossing, retained without source Rust syntax.
+///
+/// The scalar's JNI representation and conversion expression are adapter
+/// policy and are safe to freeze during recipe compilation. Its Rust spelling
+/// is not: the plan keeps the Flat reading opaque until the writer supplies
+/// [`Emit`].
+#[derive(Clone)]
+pub(crate) struct JScalarPlan {
+    ident: syn::Ident,
+    direction: Direction,
+    source: TypeRef,
+    wire: syn::Type,
+    body: syn::Expr,
+}
+
+impl JScalarPlan {
+    pub(crate) fn new(
+        direction: Direction,
+        source: TypeRef,
+        wire: syn::Type,
+        body: syn::Expr,
+    ) -> Self {
+        let ident = planned_name(direction, &source, &wire);
+        Self {
+            ident,
+            direction,
+            source,
+            wire,
+            body,
+        }
+    }
+
+    pub(crate) fn name(&self) -> &syn::Ident {
+        &self.ident
+    }
+
+    fn render(&self, emit: &Emit) -> syn::ItemFn {
+        let name = &self.ident;
+        let source = emit.spell(&self.source);
+        let wire = &self.wire;
+        let body = super::builder::body_for_exc(&self.body, None);
+        let allow = super::trait_impl::generated_converter_attr();
+        match self.direction {
+            Direction::Construct => {
+                let wire = annotate_jobject_with_lifetime(wire, "v");
+                syn::parse_quote!(
+                    #allow
+                    pub(crate) unsafe fn #name<'env, 'v>(
+                        env: &mut jni::JNIEnv<'env>,
+                        v: &#wire,
+                    ) -> ::core::result::Result<#source, __JniErr> {
+                        #body
+                    }
+                )
+            }
+            Direction::Deconstruct => {
+                let wire = annotate_jobject_with_lifetime(wire, "a");
+                syn::parse_quote!(
+                    #allow
+                    pub(crate) unsafe fn #name<'a>(
+                        env: &mut jni::JNIEnv<'a>,
+                        v: #source,
+                    ) -> ::core::result::Result<#wire, __JniErr> {
+                        #body
+                    }
+                )
+            }
         }
     }
 }
@@ -1028,6 +1128,19 @@ impl JOptionalPlan {
 /// prevents callers from mistaking the marker for executable generated code.
 pub(crate) fn planned_marker(ident: &syn::Ident) -> syn::ItemFn {
     syn::parse_quote!(fn #ident() {})
+}
+
+fn is_planned_marker(function: &syn::ItemFn) -> bool {
+    function.attrs.is_empty()
+        && function.vis == syn::Visibility::Inherited
+        && function.sig.constness.is_none()
+        && function.sig.asyncness.is_none()
+        && function.sig.unsafety.is_none()
+        && function.sig.abi.is_none()
+        && function.sig.generics.params.is_empty()
+        && function.sig.inputs.is_empty()
+        && matches!(function.sig.output, syn::ReturnType::Default)
+        && function.block.stmts.is_empty()
 }
 
 /// Stable private name for a converter whose source spelling is deliberately

--- a/prebindgen-jni/src/jni/compile.rs
+++ b/prebindgen-jni/src/jni/compile.rs
@@ -697,8 +697,16 @@ impl Carrier for JFrag {
 
 impl JFrag {
     fn new(at: At<'_>, conv: ConverterImpl<KotlinMeta>) -> Self {
+        let rust = crate::jni::chain::JFunction::retained(conv.function.clone());
+        Self::planned(at, conv, rust)
+    }
+
+    fn planned(
+        at: At<'_>,
+        conv: ConverterImpl<KotlinMeta>,
+        rust: crate::jni::chain::JFunction,
+    ) -> Self {
         let validity = validity_of(&conv, at.crossing.direction());
-        let rust = crate::jni::chain::JFunction::complete(conv.function.clone());
         Self {
             conv,
             rust,
@@ -863,6 +871,45 @@ impl<R: Conversions> JCompile<'_, R> {
     fn wrap(&self, at: At<'_>, why: &str, conv: Option<ConverterImpl<KotlinMeta>>) -> Frag<Self> {
         conv.map(|c| JFrag::new(at, c))
             .ok_or_else(|| refuse(at, why))
+    }
+
+    /// Freeze a bare scalar codec without asking `Emit` to spell its source.
+    fn planned_scalar(&self, at: At<'_>) -> Option<JFrag> {
+        let source = at.crossing.spelled();
+        if !matches!(source.unwrapped().kind(), TypeKind::Scalar(_)) {
+            return None;
+        }
+        let (wire, body) = match at.crossing.direction() {
+            Direction::Construct => crate::jni::emit::primitive_input(&source.key()),
+            Direction::Deconstruct => crate::jni::emit::primitive_output(&source.key()),
+        }?;
+        let plan = crate::jni::chain::JScalarPlan::new(
+            at.crossing.direction(),
+            source.clone(),
+            wire.clone(),
+            body,
+        );
+        let ident = plan.name().clone();
+        let niches = default_niches_for_wire(&wire);
+        let kotlin_name = kotlin_for_wire(&wire);
+        let metadata = if source.key().as_str() == "u64" {
+            self.decls.unsigned64_leaf_meta()
+        } else {
+            self.decls.framework_meta(kotlin_name)
+        };
+        let conv = ConverterImpl {
+            subs: vec![],
+            pre_stages: vec![],
+            function: crate::jni::chain::planned_marker(&ident),
+            destination: wire,
+            niches,
+            metadata,
+        };
+        Some(JFrag::planned(
+            at,
+            conv,
+            crate::jni::chain::JFunction::scalar(plan),
+        ))
     }
 
     /// The borrow arms, which are neither a terminal nor an arity layer.
@@ -1956,10 +2003,13 @@ impl<R: Conversions> Compile for JCompile<'_, R> {
 
     fn atomic(&mut self, cx: &mut Cx<'_>, at: At<'_>) -> Frag<Self> {
         let ty = at.crossing.spelled();
-        let emit = cx.emit();
+        if let Some(frag) = self.planned_scalar(at) {
+            return Ok(frag);
+        }
         if let Some(frag) = self.planned_owned_handle(at) {
             return Ok(frag);
         }
+        let emit = cx.emit();
         let conv = match at.crossing.direction() {
             Direction::Construct => self
                 .decls
@@ -2678,6 +2728,11 @@ impl Conv {
     /// Freeze this exact compiled fragment as one outgoing ABI operation.
     pub(crate) fn output_abi(&self) -> OutAbi {
         self.0.output_abi()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn is_scalar_plan(&self) -> bool {
+        self.0.rust.is_scalar()
     }
 }
 

--- a/prebindgen-jni/src/jni/tests/values.rs
+++ b/prebindgen-jni/src/jni/tests/values.rs
@@ -3,6 +3,45 @@ use prebindgen_registry::Conversions;
 use super::*;
 
 #[test]
+fn bare_scalars_retain_late_registry_plans_in_both_directions() {
+    let registry = crate::test_util::reg_from_items(declare_referenced(vec![(
+        syn::parse_quote!(
+            pub fn scalar_echo(value: u32) -> u32 {
+                value
+            }
+        ),
+        myflat_loc(),
+    )]))
+    .expect("index scalar fixture");
+    let generation = JniGenBuilder::new()
+        .set_package_prefix("io.test.jni")
+        .package(crate::package!().fun(prebindgen_registry::fun!(scalar_echo)))
+        .build_with(registry)
+        .expect("resolve scalar fixture");
+    let reading = generation
+        .registry
+        .reading(&TypeKey::from_type(&syn::parse_quote!(u32)))
+        .expect("u32 reading");
+
+    assert!(
+        generation
+            .decls
+            .in_frag(&reading)
+            .expect("u32 input")
+            .is_scalar_plan(),
+        "the input scalar must retain an unrendered scalar plan"
+    );
+    assert!(
+        generation
+            .decls
+            .out_frag(&reading)
+            .expect("u32 output")
+            .is_scalar_plan(),
+        "the output scalar must retain an unrendered scalar plan"
+    );
+}
+
+#[test]
 fn bounded_duration_option_uses_u64_niche_without_boxing() {
     let loc = myflat_loc();
     let items: Vec<(syn::Item, SourceLocation)> = [

--- a/prebindgen-jni/src/jni/trait_impl.rs
+++ b/prebindgen-jni/src/jni/trait_impl.rs
@@ -367,7 +367,7 @@ impl Declarations {
     /// Leaf metadata for Rust `u64`: the JNI value-context stays `Long`, while
     /// projection-aware Kotlin emitters surface `ULong` and insert the
     /// bit-preserving `toLong()` / `toULong()` bridge.
-    fn unsigned64_leaf_meta(&self) -> KotlinMeta {
+    pub(crate) fn unsigned64_leaf_meta(&self) -> KotlinMeta {
         KotlinMeta {
             projection: Some(Projection {
                 leaf_key: TypeKey::parse("u64").expect("builtin type key"),
@@ -1992,7 +1992,13 @@ impl Declarations {
                 metadata: self.framework_meta(kotlin_name),
             });
         }
-        if let Some((wire, body)) = primitive_input(&reading.key()) {
+        if let Some((wire, body)) = (!matches!(
+            reading.unwrapped().kind(),
+            prebindgen_registry::flat::TypeKind::Scalar(_)
+        ))
+        .then(|| primitive_input(&reading.key()))
+        .flatten()
+        {
             let niches = default_niches_for_wire(&wire);
             let kotlin_name = kotlin_for_wire(&wire);
             let metadata = if reading.key().as_str() == "u64" {
@@ -2373,7 +2379,13 @@ impl Declarations {
                 metadata: KotlinMeta::default(),
             });
         }
-        if let Some((wire, body)) = primitive_output(&reading.key()) {
+        if let Some((wire, body)) = (!matches!(
+            reading.unwrapped().kind(),
+            prebindgen_registry::flat::TypeKind::Scalar(_)
+        ))
+        .then(|| primitive_output(&reading.key()))
+        .flatten()
+        {
             let niches = default_niches_for_wire(&wire);
             let kotlin_name = kotlin_for_wire(&wire);
             let metadata = if reading.key().as_str() == "u64" {


### PR DESCRIPTION
## Goal

Move bare JNI scalar codecs onto frozen registry-composed Rust plans, so their source `TypeRef` is not spelled until final emission.

## What changes

- add a typed `JScalarPlan` for `bool`, signed and unsigned integer, and `f64` crossings in both directions;
- select that plan in the registry compiler before it obtains `Emit`;
- keep the Flat reading opaque during planning and spell it only from `RustFunction::render`;
- remove bare scalars from the eager `input_terminal` and `output_terminal` function builders;
- represent compatibility `planned_marker` functions as non-emitting `JFunction::Marker` values, so copied name carriers cannot win writer de-duplication over the executable typed plan;
- add a seam test proving both directions retain `JScalarPlan`.

## Why the marker change is part of this slice

Legacy composed fragments can still copy a child converter's `ConverterImpl` while the migration is in progress. For a planned scalar that field contains only a dummy name carrier. Treating the carrier as a complete function caused regeneration to emit `fn scalar_codec() {}` instead of the typed plan. Classifying planned markers as non-emitting closes that mixed-pipeline seam without adding a fallback.

Scalar plans remain emitted once compiled for now because complete compatibility parents do not yet propagate child reachability. That constraint disappears with the remaining JNI terminal/stage migration.

## Compatibility

Generated Rust, JNI ABI, and generated Kotlin are byte-for-byte unchanged.

This is a focused stage-7 child of #513. Strings, arrays, enums, structs, transparent bridges, custom conversions, and semantic `Stage` functions remain separate migration units.

## Verification

- `cargo test --workspace`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`
- `cargo fmt --all --check`
- `git diff --check`
- `bash examples/regen-check.sh`
- `cd examples/covertest-kotlin && ./gradlew run` — 61/61 sections passed
