### PR TITLE
Render JNI value codecs from frozen plans

### DIFF
--- a/examples/emitcheck/src/generated_bindings.rs
+++ b/examples/emitcheck/src/generated_bindings.rs
@@ -153,6 +153,32 @@ pub(crate) unsafe fn Box_String_to_JString_027f6250<'a>(
     clippy::nonminimal_bool,
     clippy::eq_op
 )]
+pub(crate) unsafe fn Cow_static_str_to_JString_47272020<'a>(
+    env: &mut jni::JNIEnv<'a>,
+    v: ::std::borrow::Cow<'static, str>,
+) -> ::core::result::Result<jni::objects::JString<'a>, __JniErr> {
+    Ok({
+        env.new_string(&*v)
+            .map_err(|e| {
+                <__JniErr as ::core::convert::From<
+                    String,
+                >>::from(format!("encode_str: {}", e))
+            })?
+    })
+}
+#[allow(
+    non_snake_case,
+    unused_mut,
+    unused_variables,
+    unused_braces,
+    unused_parens,
+    dead_code,
+    clippy::useless_conversion,
+    clippy::needless_question_mark,
+    clippy::let_and_return,
+    clippy::nonminimal_bool,
+    clippy::eq_op
+)]
 pub(crate) unsafe fn JObject_to_impl_Fn_ZSample_Send_Sync_static_24e97b15<'env, 'v>(
     env: &mut jni::JNIEnv<'env>,
     v: &jni::objects::JObject<'v>,
@@ -309,7 +335,7 @@ pub(crate) unsafe fn JObject_to_impl_Fn_ZSample_Send_Sync_static_24e97b15<'env, 
                         __enc5.into()
                     };
                     let __cb0_obj6: jni::objects::JObject = {
-                        let __enc6 = match std_borrow_Cow_str_to_JString_df3f677f(
+                        let __enc6 = match Cow_static_str_to_JString_47272020(
                             &mut env,
                             __vf0.text_cow.clone(),
                         ) {
@@ -463,32 +489,6 @@ pub(crate) unsafe fn ZSample_to_jlong_757bca9c<'a>(
     v: myflat::ZSample,
 ) -> ::core::result::Result<jni::sys::jlong, __JniErr> {
     Ok(std::boxed::Box::into_raw(std::boxed::Box::new(v)) as i64)
-}
-#[allow(
-    non_snake_case,
-    unused_mut,
-    unused_variables,
-    unused_braces,
-    unused_parens,
-    dead_code,
-    clippy::useless_conversion,
-    clippy::needless_question_mark,
-    clippy::let_and_return,
-    clippy::nonminimal_bool,
-    clippy::eq_op
-)]
-pub(crate) unsafe fn std_borrow_Cow_str_to_JString_df3f677f<'a>(
-    env: &mut jni::JNIEnv<'a>,
-    v: ::std::borrow::Cow<'_, str>,
-) -> ::core::result::Result<jni::objects::JString<'a>, __JniErr> {
-    Ok({
-        env.new_string(&*v)
-            .map_err(|e| {
-                <__JniErr as ::core::convert::From<
-                    String,
-                >>::from(format!("encode_str: {}", e))
-            })?
-    })
 }
 #[allow(
     non_snake_case,

--- a/prebindgen-jni/src/jni/chain.rs
+++ b/prebindgen-jni/src/jni/chain.rs
@@ -18,7 +18,7 @@ pub(crate) struct JFunction(JBody);
 enum JBody {
     Complete(Box<syn::ItemFn>),
     Marker(syn::Ident),
-    Scalar(Box<JScalarPlan>),
+    ValueCodec(Box<JValueCodecPlan>),
     OwnedHandle(Box<JOwnedHandlePlan>),
     BorrowedOptionalHandle(Box<JBorrowedOptionalHandlePlan>),
     Product(Box<JProductPlan>),
@@ -45,8 +45,8 @@ impl JFunction {
         Self(JBody::OwnedHandle(Box::new(plan)))
     }
 
-    pub(crate) fn scalar(plan: JScalarPlan) -> Self {
-        Self(JBody::Scalar(Box::new(plan)))
+    pub(crate) fn value_codec(plan: JValueCodecPlan) -> Self {
+        Self(JBody::ValueCodec(Box::new(plan)))
     }
 
     pub(crate) fn borrowed_optional_handle(plan: JBorrowedOptionalHandlePlan) -> Self {
@@ -79,8 +79,8 @@ impl JFunction {
     }
 
     #[cfg(test)]
-    pub(crate) fn is_scalar(&self) -> bool {
-        matches!(self.0, JBody::Scalar(_))
+    pub(crate) fn is_value_codec(&self) -> bool {
+        matches!(self.0, JBody::ValueCodec(_))
     }
 
     #[cfg(test)]
@@ -103,7 +103,7 @@ impl JFunction {
     pub(crate) fn mark_reachable(&self) {
         match &self.0 {
             JBody::Complete(_) => {}
-            JBody::Marker(_) | JBody::Scalar(_) => {}
+            JBody::Marker(_) | JBody::ValueCodec(_) => {}
             JBody::OwnedHandle(plan) => plan.reachable.set(true),
             JBody::BorrowedOptionalHandle(plan) => plan.reachable.set(true),
             JBody::Product(plan) => {
@@ -144,7 +144,7 @@ impl RustFunction for JFunction {
         match &self.0 {
             JBody::Complete(function) => &function.sig.ident,
             JBody::Marker(ident) => ident,
-            JBody::Scalar(plan) => &plan.ident,
+            JBody::ValueCodec(plan) => &plan.ident,
             JBody::OwnedHandle(plan) => &plan.ident,
             JBody::BorrowedOptionalHandle(plan) => &plan.ident,
             JBody::Product(plan) => &plan.ident,
@@ -161,8 +161,8 @@ impl RustFunction for JFunction {
             JBody::Marker(_) => false,
             // Complete compatibility parents do not yet propagate
             // reachability to the children they call. Until those parents are
-            // planned too, every compiled scalar remains an emitted leaf.
-            JBody::Scalar(_) => true,
+            // planned too, every compiled value codec remains an emitted leaf.
+            JBody::ValueCodec(_) => true,
             JBody::OwnedHandle(plan) => plan.reachable.get(),
             JBody::BorrowedOptionalHandle(plan) => plan.reachable.get(),
             JBody::Product(plan) => plan.reachable.get(),
@@ -179,7 +179,7 @@ impl RustFunction for JFunction {
         match &self.0 {
             JBody::Complete(function) => (**function).clone(),
             JBody::Marker(ident) => planned_marker(ident),
-            JBody::Scalar(plan) => plan.render(emit),
+            JBody::ValueCodec(plan) => plan.render(emit),
             JBody::OwnedHandle(plan) => plan.render(emit),
             JBody::BorrowedOptionalHandle(plan) => plan.render(emit),
             JBody::Product(plan) => plan.render(emit),
@@ -191,14 +191,16 @@ impl RustFunction for JFunction {
     }
 }
 
-/// One bare Flat scalar crossing, retained without source Rust syntax.
+/// One terminal value crossing, retained without source Rust syntax.
 ///
-/// The scalar's JNI representation and conversion expression are adapter
-/// policy and are safe to freeze during recipe compilation. Its Rust spelling
-/// is not: the plan keeps the Flat reading opaque until the writer supplies
-/// [`Emit`].
+/// The JNI representation and conversion expression are adapter policy and
+/// are safe to freeze during recipe compilation. The source Rust spelling is
+/// not: the plan keeps the Flat reading opaque until the writer supplies
+/// [`Emit`]. This covers values whose converter signature names the crossing
+/// itself; deliberately composed signatures such as bare `str -> String`
+/// remain separate.
 #[derive(Clone)]
-pub(crate) struct JScalarPlan {
+pub(crate) struct JValueCodecPlan {
     ident: syn::Ident,
     direction: Direction,
     source: TypeRef,
@@ -206,7 +208,7 @@ pub(crate) struct JScalarPlan {
     body: syn::Expr,
 }
 
-impl JScalarPlan {
+impl JValueCodecPlan {
     pub(crate) fn new(
         direction: Direction,
         source: TypeRef,
@@ -1154,7 +1156,9 @@ pub(crate) fn planned_name(
     let source_key = key.as_str();
     let source_id = crate::jni::emit::sanitize_for_ident(source_key);
     let wire_id = match intermediate {
-        syn::Type::Tuple(tuple) => format!("tuple{}", tuple.elems.len()),
+        syn::Type::Tuple(tuple) if !tuple.elems.is_empty() => {
+            format!("tuple{}", tuple.elems.len())
+        }
         _ => crate::jni::emit::wire_short(intermediate),
     };
     let suffix = crate::jni::emit::hash_name_pair(source_key, intermediate) & 0xffff_ffff;

--- a/prebindgen-jni/src/jni/compile.rs
+++ b/prebindgen-jni/src/jni/compile.rs
@@ -873,30 +873,69 @@ impl<R: Conversions> JCompile<'_, R> {
             .ok_or_else(|| refuse(at, why))
     }
 
-    /// Freeze a bare scalar codec without asking `Emit` to spell its source.
-    fn planned_scalar(&self, at: At<'_>) -> Option<JFrag> {
+    /// Freeze a terminal value codec without asking `Emit` to spell its source.
+    fn planned_value_codec(&self, at: At<'_>) -> Option<JFrag> {
         let source = at.crossing.spelled();
-        if !matches!(source.unwrapped().kind(), TypeKind::Scalar(_)) {
+        let direction = at.crossing.direction();
+        let (wire, body, niches, metadata) = if matches!(source.kind(), TypeKind::Scalar(_)) {
+            let (wire, body) = match direction {
+                Direction::Construct => crate::jni::emit::primitive_input(&source.key()),
+                Direction::Deconstruct => crate::jni::emit::primitive_output(&source.key()),
+            }?;
+            let niches = default_niches_for_wire(&wire);
+            let kotlin_name = kotlin_for_wire(&wire);
+            let metadata = if source.key().as_str() == "u64" {
+                self.decls.unsigned64_leaf_meta()
+            } else {
+                self.decls.framework_meta(kotlin_name)
+            };
+            (wire, body, niches, metadata)
+        } else if !matches!(source.kind(), TypeKind::Str)
+            && matches!(source.unwrapped().kind(), TypeKind::Str | TypeKind::String)
+        {
+            let wire: syn::Type = syn::parse_quote!(jni::objects::JString);
+            let body = match direction {
+                Direction::Construct => syn::parse_quote!({
+                    let s = env.get_string(v).map_err(|e| {
+                        <__JniErr as ::core::convert::From<String>>::from(format!(
+                            "decode_string: {}",
+                            e
+                        ))
+                    })?;
+                    ::std::string::String::from(s).into()
+                }),
+                Direction::Deconstruct => syn::parse_quote!({
+                    env.new_string(&*v).map_err(|e| {
+                        <__JniErr as ::core::convert::From<String>>::from(format!(
+                            "encode_str: {}",
+                            e
+                        ))
+                    })?
+                }),
+            };
+            let niches = default_niches_for_wire(&wire);
+            let kotlin_name = self
+                .decls
+                .override_kotlin_name(&source.key(), Some(KtType::string()));
+            let metadata = self.decls.framework_meta(kotlin_name);
+            (wire, body, niches, metadata)
+        } else if direction == Direction::Deconstruct && matches!(source.kind(), TypeKind::Unit) {
+            (
+                syn::parse_quote!(()),
+                syn::parse_quote!(v),
+                Niches::empty(),
+                KotlinMeta::default(),
+            )
+        } else {
             return None;
-        }
-        let (wire, body) = match at.crossing.direction() {
-            Direction::Construct => crate::jni::emit::primitive_input(&source.key()),
-            Direction::Deconstruct => crate::jni::emit::primitive_output(&source.key()),
-        }?;
-        let plan = crate::jni::chain::JScalarPlan::new(
+        };
+        let plan = crate::jni::chain::JValueCodecPlan::new(
             at.crossing.direction(),
             source.clone(),
             wire.clone(),
             body,
         );
         let ident = plan.name().clone();
-        let niches = default_niches_for_wire(&wire);
-        let kotlin_name = kotlin_for_wire(&wire);
-        let metadata = if source.key().as_str() == "u64" {
-            self.decls.unsigned64_leaf_meta()
-        } else {
-            self.decls.framework_meta(kotlin_name)
-        };
         let conv = ConverterImpl {
             subs: vec![],
             pre_stages: vec![],
@@ -908,7 +947,7 @@ impl<R: Conversions> JCompile<'_, R> {
         Some(JFrag::planned(
             at,
             conv,
-            crate::jni::chain::JFunction::scalar(plan),
+            crate::jni::chain::JFunction::value_codec(plan),
         ))
     }
 
@@ -2003,7 +2042,7 @@ impl<R: Conversions> Compile for JCompile<'_, R> {
 
     fn atomic(&mut self, cx: &mut Cx<'_>, at: At<'_>) -> Frag<Self> {
         let ty = at.crossing.spelled();
-        if let Some(frag) = self.planned_scalar(at) {
+        if let Some(frag) = self.planned_value_codec(at) {
             return Ok(frag);
         }
         if let Some(frag) = self.planned_owned_handle(at) {
@@ -2731,8 +2770,8 @@ impl Conv {
     }
 
     #[cfg(test)]
-    pub(crate) fn is_scalar_plan(&self) -> bool {
-        self.0.rust.is_scalar()
+    pub(crate) fn is_value_codec_plan(&self) -> bool {
+        self.0.rust.is_value_codec()
     }
 }
 

--- a/prebindgen-jni/src/jni/tests/values.rs
+++ b/prebindgen-jni/src/jni/tests/values.rs
@@ -28,16 +28,104 @@ fn bare_scalars_retain_late_registry_plans_in_both_directions() {
             .decls
             .in_frag(&reading)
             .expect("u32 input")
-            .is_scalar_plan(),
-        "the input scalar must retain an unrendered scalar plan"
+            .is_value_codec_plan(),
+        "the input scalar must retain an unrendered value codec plan"
     );
     assert!(
         generation
             .decls
             .out_frag(&reading)
             .expect("u32 output")
-            .is_scalar_plan(),
-        "the output scalar must retain an unrendered scalar plan"
+            .is_value_codec_plan(),
+        "the output scalar must retain an unrendered value codec plan"
+    );
+}
+
+#[test]
+fn owned_strings_and_unit_retain_late_value_codec_plans() {
+    let registry = crate::test_util::reg_from_items(declare_referenced(vec![
+        (
+            syn::parse_quote!(
+                pub fn string_echo(value: String) -> String {
+                    value
+                }
+            ),
+            myflat_loc(),
+        ),
+        (
+            syn::parse_quote!(
+                pub fn boxed_string_echo(value: Box<String>) -> Box<String> {
+                    value
+                }
+            ),
+            myflat_loc(),
+        ),
+        (
+            syn::parse_quote!(
+                pub fn cow_string_echo(value: Cow<'static, str>) -> Cow<'static, str> {
+                    value
+                }
+            ),
+            myflat_loc(),
+        ),
+        (
+            syn::parse_quote!(
+                pub fn unit_result() {}
+            ),
+            myflat_loc(),
+        ),
+    ]))
+    .expect("index value-codec fixture");
+    let generation = JniGenBuilder::new()
+        .set_package_prefix("io.test.jni")
+        .package(
+            crate::package!()
+                .fun(prebindgen_registry::fun!(string_echo))
+                .fun(prebindgen_registry::fun!(boxed_string_echo))
+                .fun(prebindgen_registry::fun!(cow_string_echo))
+                .fun(prebindgen_registry::fun!(unit_result)),
+        )
+        .build_with(registry)
+        .expect("resolve value-codec fixture");
+
+    for ty in [
+        syn::parse_quote!(String),
+        syn::parse_quote!(Box<String>),
+        syn::parse_quote!(Cow<'static, str>),
+    ] {
+        let reading = generation
+            .registry
+            .reading(&TypeKey::from_type(&ty))
+            .expect("owned-string reading");
+        assert!(
+            generation
+                .decls
+                .in_frag(&reading)
+                .expect("owned-string input")
+                .is_value_codec_plan(),
+            "the owned-string input must retain an unrendered value codec: {ty:?}"
+        );
+        assert!(
+            generation
+                .decls
+                .out_frag(&reading)
+                .expect("owned-string output")
+                .is_value_codec_plan(),
+            "the owned-string output must retain an unrendered value codec: {ty:?}"
+        );
+    }
+
+    let unit = generation
+        .registry
+        .reading(&TypeKey::from_type(&syn::parse_quote!(())))
+        .expect("unit reading");
+    assert!(
+        generation
+            .decls
+            .out_frag(&unit)
+            .expect("unit output")
+            .is_value_codec_plan(),
+        "the unit output must retain an unrendered value codec"
     );
 }
 

--- a/prebindgen-jni/src/jni/trait_impl.rs
+++ b/prebindgen-jni/src/jni/trait_impl.rs
@@ -1853,9 +1853,12 @@ impl Prebindgen for Declarations {
 impl Declarations {
     // ── Input converters ─────────────────────────────────────────────
 
-    /// Whole-type **input** terminal categories (opaque handle, enum,
-    /// `convert!`, `str`, primitive, struct) — depends on nothing, `subs`
-    /// empty.
+    /// Remaining whole-type **input** compatibility categories (opaque
+    /// handle, enum, `convert!`, unsized `str`, byte run, struct) — depends on
+    /// nothing, `subs` empty.
+    ///
+    /// Bare scalars and owned strings are compiled as `JValueCodecPlan`s
+    /// before this fallback is entered.
     pub(crate) fn input_terminal(
         &self,
         reading: &prebindgen_registry::flat::TypeRef,
@@ -1956,45 +1959,12 @@ impl Declarations {
                 metadata: self.framework_meta(kotlin_name),
             });
         }
-        // Any OWNED string, however Rust spells it — `String`, `Box<String>`,
-        // `Cow<'_, str>`. The model classifies each of them `Str`; the spelling is
-        // the source's business, and `.into()` constructs it from the decoded
-        // `String`. This used to be one hardcoded `TypeKey == "Box < String >"`
-        // arm, which is what a spelling-keyed converter table costs: one
-        // hand-written case per representation anyone happened to write (#270).
-        //
-        // `str` is handled above, separately and deliberately: it is unsized,
-        // so its converter yields an owned `String` the call site borrows —
-        // a different contract, not a different spelling.
-        if matches!(
-            reading.unwrapped().kind(),
-            prebindgen_registry::flat::TypeKind::Str | prebindgen_registry::flat::TypeKind::String
-        ) {
-            let wire: syn::Type = syn::parse_quote!(jni::objects::JString);
-            let body: syn::Expr = syn::parse_quote!({
-                let s = env.get_string(v).map_err(|e| {
-                    <__JniErr as ::core::convert::From<String>>::from(format!(
-                        "decode_string: {}",
-                        e
-                    ))
-                })?;
-                // The canonical value, then the spelling.
-                ::std::string::String::from(s).into()
-            });
-            let kotlin_name = self.override_kotlin_name(&reading.key(), Some(KtType::string()));
-            let niches = default_niches_for_wire(&wire);
-            return Some(ConverterImpl {
-                subs: vec![],
-                pre_stages: vec![],
-                function: self.build_input_fn_of(reading, &wire, &body, None, emit),
-                destination: wire,
-                niches,
-                metadata: self.framework_meta(kotlin_name),
-            });
-        }
         if let Some((wire, body)) = (!matches!(
             reading.unwrapped().kind(),
             prebindgen_registry::flat::TypeKind::Scalar(_)
+                | prebindgen_registry::flat::TypeKind::Str
+                | prebindgen_registry::flat::TypeKind::String
+                | prebindgen_registry::flat::TypeKind::Unit
         ))
         .then(|| primitive_input(&reading.key()))
         .flatten()
@@ -2235,9 +2205,12 @@ impl Declarations {
 
     // ── Output converters ────────────────────────────────────────────
 
-    /// Whole-type **output** terminal categories (the dual of
-    /// [`Self::input_terminal`]: opaque handle, enum, user table,
-    /// `str`, `Cow<[u8]>`, unit, primitive, struct) — `subs` empty.
+    /// Remaining whole-type **output** compatibility categories (the dual of
+    /// [`Self::input_terminal`]: opaque handle, enum, user table, unsized
+    /// `str`, byte runs, struct) — `subs` empty.
+    ///
+    /// Bare scalars, owned strings, and unit are compiled as
+    /// `JValueCodecPlan`s before this fallback is entered.
     pub(crate) fn output_terminal(
         &self,
         reading: &prebindgen_registry::flat::TypeRef,
@@ -2308,49 +2281,6 @@ impl Declarations {
         if reading.key().as_str() == "str" {
             return Some(self.str_ref_output());
         }
-        // An owned string in any representation the model erases — `Box<String>`,
-        // `Cow<'_, str>`. It classifies each of them `Str`, and the body is
-        // representation-agnostic: `&*v` reaches through any of them by `Deref`
-        // to something `new_string` accepts (`&String` through a `Box`, `&str`
-        // through a `Cow`). Only the *dispatch* was spelling-keyed, as one
-        // hardcoded `TypeKey == "Box < String >"` arm (#270).
-        //
-        // Plain `String` keeps its own earlier arm in `primitive_output`, whose
-        // body this matches exactly; this one is reached for the wrapped
-        // spellings that arm's key cannot name.
-        if matches!(
-            reading.unwrapped().kind(),
-            prebindgen_registry::flat::TypeKind::Str | prebindgen_registry::flat::TypeKind::String
-        ) {
-            let wire: syn::Type = syn::parse_quote!(jni::objects::JString);
-            let body: syn::Expr = syn::parse_quote!({
-                env.new_string(&*v).map_err(|e| {
-                    <__JniErr as ::core::convert::From<String>>::from(format!("encode_str: {}", e))
-                })?
-            });
-            let kotlin_name = self.override_kotlin_name(&reading.key(), Some(KtType::string()));
-            let niches = default_niches_for_wire(&wire);
-            // A `Cow` accessor may spell its own path any way it likes, but the
-            // generated fn's param type has to resolve with no imports in the
-            // consumer crate — normalize it, exactly as the `Cow<'_, [u8]>` arm
-            // below does. Every other spelling here (`String`, `Box<String>`)
-            // is already prelude-resolvable, so it keeps its own.
-            let function = match reading.kind() {
-                prebindgen_registry::flat::TypeKind::Cow { .. } => {
-                    let norm: syn::Type = syn::parse_quote!(::std::borrow::Cow<'_, str>);
-                    self.build_output_fn(&norm, &wire, &body, None)
-                }
-                _ => self.build_output_fn_of(reading, &wire, &body, None, emit),
-            };
-            return Some(ConverterImpl {
-                subs: vec![],
-                pre_stages: vec![],
-                function,
-                destination: wire,
-                niches,
-                metadata: self.framework_meta(kotlin_name),
-            });
-        }
         // `Cow<'_, [u8]>` (any lifetime): a borrow-or-owned byte container —
         // one copy into the JVM array straight off the `Deref<[u8]>`, no
         // intermediate owned `Vec` (the zero-copy dual of the `Vec<u8>`
@@ -2359,29 +2289,12 @@ impl Declarations {
         if let Some(conv) = self.cow_bytes_output(reading) {
             return Some(conv);
         }
-        // `()` — identity converter so `fn foo()` and `fn foo() -> ()`
-        // funnel through the same uniform output path as everything else.
-        // Wire is `()`. Body just returns `v`. No Kotlin name — Unit
-        // returns are dropped from emitted signatures, so metadata stays
-        // empty.
-        if matches!(
-            reading.unwrapped().kind(),
-            prebindgen_registry::flat::TypeKind::Unit
-        ) {
-            let wire: syn::Type = syn::parse_quote!(());
-            let body: syn::Expr = syn::parse_quote!(v);
-            return Some(ConverterImpl {
-                subs: vec![],
-                function: self.build_output_fn_of(reading, &wire, &body, None, emit),
-                destination: wire,
-                pre_stages: vec![],
-                niches: Niches::empty(),
-                metadata: KotlinMeta::default(),
-            });
-        }
         if let Some((wire, body)) = (!matches!(
             reading.unwrapped().kind(),
             prebindgen_registry::flat::TypeKind::Scalar(_)
+                | prebindgen_registry::flat::TypeKind::Str
+                | prebindgen_registry::flat::TypeKind::String
+                | prebindgen_registry::flat::TypeKind::Unit
         ))
         .then(|| primitive_output(&reading.key()))
         .flatten()


### PR DESCRIPTION
## Summary

- generalize the late JNI scalar carrier into a terminal-value codec plan that keeps the source `TypeRef` opaque until final Rust rendering
- compile bare scalars, owned `String` forms (`String`, `Box<String>`, and `Cow<str>`), and unit output through that plan, removing their eager function construction from the compatibility terminal selector
- add a deletion fence proving those crossings retain unrendered plans in both applicable directions

Bare unsized `str` remains a separate compatibility path because its input converter deliberately returns owned `String`, not the crossing's own unsized type.

The refreshed emitcheck golden has one semantic-only Rust change: `Cow<'static, str>` now retains and finally renders its captured lifetime instead of being eagerly normalized to `Cow<'_, str>`; its private converter name changes accordingly. Kotlin, JNI ABI, and the other generated artifacts are unchanged.

Stacked on #513.

## Verification

- `cargo test --workspace` — passed
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` — passed
- `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps` — passed
- `cargo fmt --all -- --check` — passed
- `./examples/regen-check.sh` — passed; committed generated output is reproducible
- `examples/covertest-kotlin/gradlew run --console=plain` — passed all 61 JVM sections
