### PR TITLE
Render JNI str codecs from frozen plans

### DIFF
--- a/prebindgen-jni/src/jni/chain.rs
+++ b/prebindgen-jni/src/jni/chain.rs
@@ -204,6 +204,7 @@ pub(crate) struct JValueCodecPlan {
     ident: syn::Ident,
     direction: Direction,
     source: TypeRef,
+    adapter_source: Option<syn::Type>,
     wire: syn::Type,
     body: syn::Expr,
 }
@@ -220,6 +221,37 @@ impl JValueCodecPlan {
             ident,
             direction,
             source,
+            adapter_source: None,
+            wire,
+            body,
+        }
+    }
+
+    /// A codec whose Rust signature deliberately differs from its crossing.
+    ///
+    /// The supplied type is adapter-authored syntax, not syntax extracted from
+    /// `source`: bare `str` is unsized, so JNI decodes it into `String` and
+    /// encodes it through `&str`. Keeping that exception explicit lets the
+    /// crossing remain opaque while preserving the actual converter contract.
+    pub(crate) fn with_adapter_source(
+        direction: Direction,
+        source: TypeRef,
+        adapter_source: syn::Type,
+        wire: syn::Type,
+        body: syn::Expr,
+    ) -> Self {
+        use quote::ToTokens as _;
+
+        let source_tokens = adapter_source.to_token_stream();
+        let ident = match direction {
+            Direction::Construct => crate::jni::emit::input_name(&source_tokens, &wire),
+            Direction::Deconstruct => crate::jni::emit::output_name(&source_tokens, &wire),
+        };
+        Self {
+            ident,
+            direction,
+            source,
+            adapter_source: Some(adapter_source),
             wire,
             body,
         }
@@ -231,7 +263,11 @@ impl JValueCodecPlan {
 
     fn render(&self, emit: &Emit) -> syn::ItemFn {
         let name = &self.ident;
-        let source = emit.spell(&self.source);
+        let source = self
+            .adapter_source
+            .as_ref()
+            .map(|source| quote::quote!(#source))
+            .unwrap_or_else(|| emit.spell(&self.source));
         let wire = &self.wire;
         let body = super::builder::body_for_exc(&self.body, None);
         let allow = super::trait_impl::generated_converter_attr();

--- a/prebindgen-jni/src/jni/compile.rs
+++ b/prebindgen-jni/src/jni/compile.rs
@@ -877,64 +877,152 @@ impl<R: Conversions> JCompile<'_, R> {
     fn planned_value_codec(&self, at: At<'_>) -> Option<JFrag> {
         let source = at.crossing.spelled();
         let direction = at.crossing.direction();
-        let (wire, body, niches, metadata) = if matches!(source.kind(), TypeKind::Scalar(_)) {
-            let (wire, body) = match direction {
-                Direction::Construct => crate::jni::emit::primitive_input(&source.key()),
-                Direction::Deconstruct => crate::jni::emit::primitive_output(&source.key()),
-            }?;
-            let niches = default_niches_for_wire(&wire);
-            let kotlin_name = kotlin_for_wire(&wire);
-            let metadata = if source.key().as_str() == "u64" {
-                self.decls.unsigned64_leaf_meta()
-            } else {
-                self.decls.framework_meta(kotlin_name)
-            };
-            (wire, body, niches, metadata)
-        } else if !matches!(source.kind(), TypeKind::Str)
-            && matches!(source.unwrapped().kind(), TypeKind::Str | TypeKind::String)
-        {
-            let wire: syn::Type = syn::parse_quote!(jni::objects::JString);
-            let body = match direction {
-                Direction::Construct => syn::parse_quote!({
-                    let s = env.get_string(v).map_err(|e| {
-                        <__JniErr as ::core::convert::From<String>>::from(format!(
-                            "decode_string: {}",
-                            e
-                        ))
-                    })?;
-                    ::std::string::String::from(s).into()
-                }),
-                Direction::Deconstruct => syn::parse_quote!({
-                    env.new_string(&*v).map_err(|e| {
+        let (wire, body, niches, metadata, adapter_source) =
+            if matches!(source.kind(), TypeKind::Scalar(_)) {
+                let (wire, body) = match direction {
+                    Direction::Construct => crate::jni::emit::primitive_input(&source.key()),
+                    Direction::Deconstruct => crate::jni::emit::primitive_output(&source.key()),
+                }?;
+                let niches = default_niches_for_wire(&wire);
+                let kotlin_name = kotlin_for_wire(&wire);
+                let metadata = if source.key().as_str() == "u64" {
+                    self.decls.unsigned64_leaf_meta()
+                } else {
+                    self.decls.framework_meta(kotlin_name)
+                };
+                (wire, body, niches, metadata, None)
+            } else if matches!(source.kind(), TypeKind::Str) {
+                let wire: syn::Type = syn::parse_quote!(jni::objects::JString);
+                let (adapter_source, body, kotlin_key) = match direction {
+                    Direction::Construct => (
+                        syn::parse_quote!(String),
+                        syn::parse_quote!({
+                            let s = env.get_string(v).map_err(|e| {
+                                <__JniErr as ::core::convert::From<String>>::from(format!(
+                                    "decode_string: {}",
+                                    e
+                                ))
+                            })?;
+                            s.into()
+                        }),
+                        source.key(),
+                    ),
+                    Direction::Deconstruct => {
+                        let rust: syn::Type = syn::parse_quote!(&str);
+                        (
+                            rust.clone(),
+                            syn::parse_quote!({
+                                env.new_string(v).map_err(|e| {
+                                    <__JniErr as ::core::convert::From<String>>::from(format!(
+                                        "encode_str: {}",
+                                        e
+                                    ))
+                                })?
+                            }),
+                            TypeKey::from_type(&rust),
+                        )
+                    }
+                };
+                let niches = default_niches_for_wire(&wire);
+                let kotlin_name = self
+                    .decls
+                    .override_kotlin_name(&kotlin_key, Some(KtType::string()));
+                let metadata = self.decls.framework_meta(kotlin_name);
+                (wire, body, niches, metadata, Some(adapter_source))
+            } else if direction == Direction::Deconstruct
+                && matches!(
+                    source.kind(),
+                    TypeKind::Ref {
+                        mutable: false,
+                        inner,
+                        ..
+                    } if matches!(inner.kind(), TypeKind::Str)
+                )
+            {
+                let adapter_source: syn::Type = syn::parse_quote!(&str);
+                let wire: syn::Type = syn::parse_quote!(jni::objects::JString);
+                let body = syn::parse_quote!({
+                    env.new_string(v).map_err(|e| {
                         <__JniErr as ::core::convert::From<String>>::from(format!(
                             "encode_str: {}",
                             e
                         ))
                     })?
-                }),
+                });
+                let niches = default_niches_for_wire(&wire);
+                let kotlin_name = self.decls.override_kotlin_name(
+                    &TypeKey::from_type(&adapter_source),
+                    Some(KtType::string()),
+                );
+                let metadata = self.decls.framework_meta(kotlin_name);
+                (wire, body, niches, metadata, Some(adapter_source))
+            } else if !matches!(source.kind(), TypeKind::Str)
+                && matches!(source.unwrapped().kind(), TypeKind::Str | TypeKind::String)
+            {
+                let wire: syn::Type = syn::parse_quote!(jni::objects::JString);
+                let body = match direction {
+                    Direction::Construct if matches!(source.kind(), TypeKind::String) => {
+                        syn::parse_quote!({
+                            let s = env.get_string(v).map_err(|e| {
+                                <__JniErr as ::core::convert::From<String>>::from(format!(
+                                    "decode_string: {}",
+                                    e
+                                ))
+                            })?;
+                            s.into()
+                        })
+                    }
+                    Direction::Construct => syn::parse_quote!({
+                        let s = env.get_string(v).map_err(|e| {
+                            <__JniErr as ::core::convert::From<String>>::from(format!(
+                                "decode_string: {}",
+                                e
+                            ))
+                        })?;
+                        ::std::string::String::from(s).into()
+                    }),
+                    Direction::Deconstruct => syn::parse_quote!({
+                        env.new_string(&*v).map_err(|e| {
+                            <__JniErr as ::core::convert::From<String>>::from(format!(
+                                "encode_str: {}",
+                                e
+                            ))
+                        })?
+                    }),
+                };
+                let niches = default_niches_for_wire(&wire);
+                let kotlin_name = self
+                    .decls
+                    .override_kotlin_name(&source.key(), Some(KtType::string()));
+                let metadata = self.decls.framework_meta(kotlin_name);
+                (wire, body, niches, metadata, None)
+            } else if direction == Direction::Deconstruct && matches!(source.kind(), TypeKind::Unit)
+            {
+                (
+                    syn::parse_quote!(()),
+                    syn::parse_quote!(v),
+                    Niches::empty(),
+                    KotlinMeta::default(),
+                    None,
+                )
+            } else {
+                return None;
             };
-            let niches = default_niches_for_wire(&wire);
-            let kotlin_name = self
-                .decls
-                .override_kotlin_name(&source.key(), Some(KtType::string()));
-            let metadata = self.decls.framework_meta(kotlin_name);
-            (wire, body, niches, metadata)
-        } else if direction == Direction::Deconstruct && matches!(source.kind(), TypeKind::Unit) {
-            (
-                syn::parse_quote!(()),
-                syn::parse_quote!(v),
-                Niches::empty(),
-                KotlinMeta::default(),
-            )
-        } else {
-            return None;
+        let plan = match adapter_source {
+            Some(adapter_source) => crate::jni::chain::JValueCodecPlan::with_adapter_source(
+                direction,
+                source.clone(),
+                adapter_source,
+                wire.clone(),
+                body,
+            ),
+            None => crate::jni::chain::JValueCodecPlan::new(
+                direction,
+                source.clone(),
+                wire.clone(),
+                body,
+            ),
         };
-        let plan = crate::jni::chain::JValueCodecPlan::new(
-            at.crossing.direction(),
-            source.clone(),
-            wire.clone(),
-            body,
-        );
         let ident = plan.name().clone();
         let conv = ConverterImpl {
             subs: vec![],

--- a/prebindgen-jni/src/jni/tests/values.rs
+++ b/prebindgen-jni/src/jni/tests/values.rs
@@ -130,6 +130,87 @@ fn owned_strings_and_unit_retain_late_value_codec_plans() {
 }
 
 #[test]
+fn unsized_str_retains_adapter_typed_value_codec_plans() {
+    let loc = myflat_loc();
+    let registry = crate::test_util::reg_from_items(declare_referenced(vec![
+        (
+            syn::parse_quote!(
+                pub struct Text {
+                    pub value: String,
+                }
+            ),
+            loc.clone(),
+        ),
+        (
+            syn::parse_quote!(
+                pub fn text_as_str(value: &Text) -> &str {
+                    unimplemented!()
+                }
+            ),
+            loc.clone(),
+        ),
+        (
+            syn::parse_quote!(
+                pub fn text_len(value: &str) -> i64 {
+                    value.len() as i64
+                }
+            ),
+            loc.clone(),
+        ),
+        (
+            syn::parse_quote!(
+                pub fn text_emit(cb: impl Fn(Text) + Send + Sync + 'static) {
+                    unimplemented!()
+                }
+            ),
+            loc,
+        ),
+    ]))
+    .expect("index unsized-str fixture");
+    let generation = JniGenBuilder::new()
+        .set_package_prefix("io.test.jni")
+        .package(
+            crate::package!()
+                .class(crate::ptr_class!(Text))
+                .fun(prebindgen_registry::fun!(text_len))
+                .fun(prebindgen_registry::fun!(text_emit)),
+        )
+        .expand(
+            prebindgen_registry::expand_return!(Text).field(prebindgen_registry::fun!(text_as_str)),
+        )
+        .build_with(registry)
+        .expect("resolve unsized-str fixture");
+    let str_reading = generation
+        .registry
+        .reading(&TypeKey::from_type(&syn::parse_quote!(str)))
+        .expect("str reading");
+    let ref_reading = generation
+        .registry
+        .reading(&TypeKey::from_type(&syn::parse_quote!(&str)))
+        .expect("&str reading");
+
+    let input = generation.decls.in_frag(&str_reading).expect("str input");
+    let bare_output = generation.decls.out_frag(&str_reading).expect("str output");
+    let ref_output = generation
+        .decls
+        .out_frag(&ref_reading)
+        .expect("&str output");
+    assert!(
+        input.is_value_codec_plan(),
+        "the unsized input must retain a plan whose adapter type is String"
+    );
+    assert!(
+        bare_output.is_value_codec_plan() && ref_output.is_value_codec_plan(),
+        "both output crossings must retain the adapter-typed &str plan"
+    );
+    assert_eq!(
+        bare_output.converter_ident(),
+        ref_output.converter_ident(),
+        "rank-0 str and rank-1 &str must share one normalized converter"
+    );
+}
+
+#[test]
 fn bounded_duration_option_uses_u64_niche_without_boxing() {
     let loc = myflat_loc();
     let items: Vec<(syn::Item, SourceLocation)> = [

--- a/prebindgen-jni/src/jni/trait_impl.rs
+++ b/prebindgen-jni/src/jni/trait_impl.rs
@@ -46,38 +46,6 @@ pub(crate) fn generated_converter_attr() -> syn::Attribute {
 // ──────────────────────────────────────────────────────────────────────
 
 impl Declarations {
-    /// Build the standard JNI input-converter `fn` for a Rust type this
-    /// **adapter composed**. Body assumes in-scope `env: &mut JNIEnv` and
-    /// `v: &<wire>` (or `v: <wire>` for raw-pointer wires); produces a value of
-    /// `rust`. Returned function has its name already set per the JNI plugin's
-    /// naming convention.
-    ///
-    /// There are three composed types: `impl Fn(..)` for a callback, `String`
-    /// for the `str` terminal (which yields an owned value the call site
-    /// borrows), and `Vec<T>` for the `&[T]` parameter, likewise. None is a
-    /// borrow, which is why this spells its input verbatim — there is no `&_`
-    /// to splice `'env` into. [`Self::build_input_fn_of`] is the door that
-    /// annotates, and it does so off `TypeKind::Ref`, where
-    /// `annotate_borrow_with_lifetime` matched a `syn::Type::Reference` and
-    /// rebuilt it.
-    ///
-    /// `exc` ties the body convention to the `Result`'s Rust error type:
-    /// * `None` → signature `Result<rust, __JniErr>` and the body is
-    ///   wrapped `Ok(<body>)`; `?` inside propagates the framework error.
-    /// * `Some(E)` → signature `Result<rust, E>` and the body is emitted
-    ///   as-is — `<body>` already evaluates to that `Result`, so no `Ok`
-    ///   wrap. `E` is the raw error type peeled from a `Result<T, E>`.
-    pub(crate) fn build_input_fn_composed(
-        &self,
-        rust: &syn::Type,
-        wire: &syn::Type,
-        body: &syn::Expr,
-        exc: Option<&syn::Type>,
-    ) -> syn::ItemFn {
-        let spelled = rust.to_token_stream();
-        self.build_input_fn_parts(&spelled, &spelled, wire, body, exc)
-    }
-
     /// [`Self::build_input_fn`] for a caller holding the **reading** of the Rust
     /// type this converter yields — the terminals and the transparent bridges.
     ///
@@ -189,37 +157,6 @@ impl Declarations {
                 #ret_body
             }
         )
-    }
-
-    /// Borrowed string-slice output converter (`&str → jstring`, a single
-    /// copy — the dual of the `str` input arm). Shared by two resolver arms so
-    /// they emit the SAME-named fn (write.rs dedups by `sig.ident`):
-    /// * the rank-1 `&str` arm — the converter actually used for a reference
-    ///   accessor leaf (`f(&T) -> &str`, output expansion);
-    /// * the rank-0 `str` arm — resolves the unsized `str` reached as the sub
-    ///   of `&str` (so required-propagation doesn't flag `str` unresolved).
-    ///
-    /// Surfaces as Kotlin `String`. Built from a normalized (lifetime-free)
-    /// `&str` so both arms produce an identical [`output_name`].
-    fn str_ref_output(&self) -> ConverterImpl<KotlinMeta> {
-        let outer_ty: syn::Type = syn::parse_quote!(&str);
-        let wire: syn::Type = syn::parse_quote!(jni::objects::JString);
-        let body: syn::Expr = syn::parse_quote!({
-            env.new_string(v).map_err(|e| {
-                <__JniErr as ::core::convert::From<String>>::from(format!("encode_str: {}", e))
-            })?
-        });
-        let kotlin_name =
-            self.override_kotlin_name(&TypeKey::from_type(&outer_ty), Some(KtType::string()));
-        let niches = default_niches_for_wire(&wire);
-        ConverterImpl {
-            subs: vec![],
-            pre_stages: vec![],
-            function: self.build_output_fn(&outer_ty, &wire, &body, None),
-            destination: wire,
-            niches,
-            metadata: self.framework_meta(kotlin_name),
-        }
     }
 
     /// `Cow<[u8]>` output converter (any lifetime form) — see the call site
@@ -1854,11 +1791,11 @@ impl Declarations {
     // ── Input converters ─────────────────────────────────────────────
 
     /// Remaining whole-type **input** compatibility categories (opaque
-    /// handle, enum, `convert!`, unsized `str`, byte run, struct) — depends on
-    /// nothing, `subs` empty.
+    /// handle, enum, `convert!`, byte run, struct) — depends on nothing,
+    /// `subs` empty.
     ///
-    /// Bare scalars and owned strings are compiled as `JValueCodecPlan`s
-    /// before this fallback is entered.
+    /// Bare scalars and all string terminals are compiled as
+    /// `JValueCodecPlan`s before this fallback is entered.
     pub(crate) fn input_terminal(
         &self,
         reading: &prebindgen_registry::flat::TypeRef,
@@ -1929,35 +1866,6 @@ impl Declarations {
         }
         if let Some(conv) = self.lookup_input(reading, registry, emit) {
             return Some(conv);
-        }
-        // `str` is unsized, so converters can't return it directly.
-        // Still register a rank-0 entry to satisfy resolution for
-        // borrowed `&str` parameters: decode `JString` to owned `String`
-        // and let call sites borrow as needed.
-        if reading.key().as_str() == "str" {
-            let wire: syn::Type = syn::parse_quote!(jni::objects::JString);
-            let body: syn::Expr = syn::parse_quote!({
-                let s = env.get_string(v).map_err(|e| {
-                    <__JniErr as ::core::convert::From<String>>::from(format!(
-                        "decode_string: {}",
-                        e
-                    ))
-                })?;
-                s.into()
-            });
-            // The unsized `str` yields an OWNED `String` the call site borrows,
-            // so this converter's Rust type is not the reading's spelling.
-            let rust_ty: syn::Type = syn::parse_quote!(String);
-            let kotlin_name = self.override_kotlin_name(&reading.key(), Some(KtType::string()));
-            let niches = default_niches_for_wire(&wire);
-            return Some(ConverterImpl {
-                subs: vec![],
-                pre_stages: vec![],
-                function: self.build_input_fn_composed(&rust_ty, &wire, &body, None),
-                destination: wire,
-                niches,
-                metadata: self.framework_meta(kotlin_name),
-            });
         }
         if let Some((wire, body)) = (!matches!(
             reading.unwrapped().kind(),
@@ -2206,10 +2114,10 @@ impl Declarations {
     // ── Output converters ────────────────────────────────────────────
 
     /// Remaining whole-type **output** compatibility categories (the dual of
-    /// [`Self::input_terminal`]: opaque handle, enum, user table, unsized
-    /// `str`, byte runs, struct) — `subs` empty.
+    /// [`Self::input_terminal`]: opaque handle, enum, user table, byte runs,
+    /// struct) — `subs` empty.
     ///
-    /// Bare scalars, owned strings, and unit are compiled as
+    /// Bare scalars, all string terminals, and unit are compiled as
     /// `JValueCodecPlan`s before this fallback is entered.
     pub(crate) fn output_terminal(
         &self,
@@ -2274,13 +2182,6 @@ impl Declarations {
         if let Some(conv) = self.lookup_output(reading, registry, emit) {
             return Some(conv);
         }
-        // `str` is unsized, so it has no by-value output converter — but it is
-        // reached as the sub of a `&str` reference accessor leaf. Resolve it to
-        // the same `&str → jstring` fn the rank-1 `&str` arm uses (deduped by
-        // name) so required-propagation doesn't flag it unresolved.
-        if reading.key().as_str() == "str" {
-            return Some(self.str_ref_output());
-        }
         // `Cow<'_, [u8]>` (any lifetime): a borrow-or-owned byte container —
         // one copy into the JVM array straight off the `Deref<[u8]>`, no
         // intermediate owned `Vec` (the zero-copy dual of the `Vec<u8>`
@@ -2337,7 +2238,7 @@ impl Declarations {
         None
     }
 
-    /// Borrowed-handle and borrowed-string output terminals.
+    /// Borrowed-handle output terminals.
     pub(crate) fn output_borrow(
         &self,
         produced: &prebindgen_registry::flat::TypeRef,
@@ -2370,18 +2271,6 @@ impl Declarations {
                 niches: Niches::one(syn::parse_quote!(0i64), syn::parse_quote!(*v == 0)),
                 metadata: self.opaque_leaf_meta(t1.key()),
             });
-        }
-        // Borrowed string slice output (`&str` / `&'a str`): the converter used
-        // for a zero-copy reference accessor return (`f(&T) -> &str`, output
-        // expansion). The single copy into the JVM is `&str → jstring` (no
-        // intermediate owned `String`). The unsized `str` sub resolves via the
-        // rank-0 arm to the same fn (see [`Self::str_ref_output`]).
-        if matches!(
-            produced.kind(),
-            prebindgen_registry::flat::TypeKind::Ref { mutable: false, .. }
-        ) && t1.key().as_str() == "str"
-        {
-            return Some(self.str_ref_output());
         }
         None
     }


### PR DESCRIPTION
## Summary

- retain bare `str` input/output and borrowed `&str` output converters as frozen `JValueCodecPlan` values
- let a value-codec plan declare an adapter-authored Rust signature when an unsized crossing cannot be used as the converter's value type
- delete the legacy eager `str` converter builders and compatibility-selector branches
- add a deletion-fence test covering input `str`, rank-0 output `str`, and rank-1 output `&str`

## Design

Bare `str` is the remaining string exception to an exact crossing signature: JNI input decoding produces an owned `String`, while output encoding accepts `&str`. The frozen plan now records that adapter-authored signature explicitly. It does not extract or render Rust syntax from the crossing `TypeRef`; the crossing remains opaque until final rendering.

Rank-0 `str` and rank-1 `&str` output plans retain the same normalized converter identity, preserving the existing deduplication contract. Both plans have identical adapter signatures, wire types, and bodies, so name-based deduplication cannot silently discard a different function. Exact `String` input uses the same legacy body, so committed generated Rust and Kotlin remain byte-for-byte unchanged.

## Validation

- `cargo test --workspace --all-features`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps`
- `cargo fmt --all -- --check`
- `./examples/regen-check.sh`
- `examples/covertest-kotlin/gradlew run --console=plain` (61 sections)
