### PR TITLE
Render JNI primitive arrays from frozen plans

### DIFF
--- a/examples/covertest-helpers/src/lib.rs
+++ b/examples/covertest-helpers/src/lib.rs
@@ -28,6 +28,24 @@ pub const PREBINDGEN_OUT_DIR: &str = prebindgen_proc_macro::prebindgen_out_dir!(
 /// `konst` feature guard, like every prebindgen source crate).
 pub const FEATURES: &str = features!();
 
+/// Non-literal fixed-array length used to pin final-emission qualification.
+#[prebindgen]
+pub const CONST_ARRAY_LEN: usize = 3;
+
+/// A covertest-only fixed array whose length must render as
+/// `cov_helpers::CONST_ARRAY_LEN` in the binding crate.
+#[prebindgen]
+#[derive(Clone, Debug, PartialEq)]
+pub struct ConstArray {
+    pub bytes: [u8; CONST_ARRAY_LEN],
+}
+
+/// Round-trip the const-sized array in both converter directions.
+#[prebindgen]
+pub fn const_array_echo(value: ConstArray) -> ConstArray {
+    value
+}
+
 /// Canonical input conversion for [`Millis`]: build it from the raw
 /// millisecond count. Referenced by covertest's
 /// `convert!(Millis).input(fun!(millis_from_long))`.

--- a/examples/covertest-kotlin/README.md
+++ b/examples/covertest-kotlin/README.md
@@ -101,7 +101,8 @@ for the full table; in brief:
   borrowed slice input), `Vec<String>`, `Vec<Stamp>` → `List<Stamp>`,
   `Vec<handle>` / `Option<Vec<handle>>` (Kotlin-side handle fold),
   borrowed-opaque returns (`Option<&T>` → cloned owned handle),
-  `Result<_, E>` → `onError`, enums, data/sealed classes, fixed-size primitive arrays, `impl Fn` callbacks
+  `Result<_, E>` → `onError`, enums, data/sealed classes, fixed-size primitive arrays
+  (including a marked const-path length qualified from a renamed source), `impl Fn` callbacks
   (single + slice + **owned-handle**), N-ary sorted handle locking (3 handles,
   hammered from 4 threads), the `je != null` binding-error channel (malformed
   wrong-length fixed-size arrays), the callback no-throw contract (exceptions described +

--- a/examples/covertest-kotlin/build.rs
+++ b/examples/covertest-kotlin/build.rs
@@ -71,6 +71,7 @@
 //! | N-ary sorted handle locking          | `storage_total_len` (3 handles) + a 4-thread smoke |
 //! | `Vec<String>` return                 | `storage_labels` (single-leaf string fold) |
 //! | `String` return                      | `string_new` |
+//! | fixed-size primitive arrays          | every JNI scalar element + `[u8; CONST_ARRAY_LEN]` from the renamed helper source |
 //! | binding-error channel (`JniErrorHandler`) | wrong-length `[u8; 2]` (fixed-size array length guard) |
 //! | callback no-throw contract           | a throwing `PayloadCallback` (described + cleared per upcall) |
 //! | `data_class` instance member          | `Payload.labelLen()` (receiver crosses as `this` field leaves) |
@@ -209,6 +210,14 @@ fn main() {
         // verify callback cleanup through an Optional(Product) chain.
         .convert(convert!(CallbackToken).output(fun!(callback_token_into_ingot)))
         .ignore(ty!(CallbackToken))
+        // The helper source is private to this JVM covertest. Its array length
+        // is a marked const, so final Rust emission must qualify the path with
+        // the helper crate's configured `cov_helpers` name.
+        .package(
+            package!("model")
+                .class(data_class!(ConstArray))
+                .fun(fun!(const_array_echo)),
+        )
         // ── Base-package types ──────────────────────────────────────────────
         // `Payload` as a Kotlin `data class` (fields cross as decoupled leaves,
         // reassembled via a generated `fromParts`). A data class can carry

--- a/examples/covertest-kotlin/kotlin/REPORT.md
+++ b/examples/covertest-kotlin/kotlin/REPORT.md
@@ -80,6 +80,8 @@ Base package: `io.prebindgen.covertest`
 - `boxed_run_id_sum` — `fun boxedRunIdSum(ps: List<Payload>, onError: JniErrorHandler<Long>): Long`
 - `cache_config_weight` — `fun cacheConfigWeight(cache: CacheConfig?, onError: JniErrorHandler<Int>): Int`
 - `celsius_double` — `fun celsiusDouble(c: Int, onError: JniErrorHandler<Int>): Int`
+- `const_array_echo` — `fun constArrayEcho(value: ConstArray, onError: JniErrorHandler<ConstArray?>): ConstArray?`
+  - shaped by: return `ConstArray` decomposed → [bytes] (Callback delivery)
 - `dossier_new` — `fun dossierNew(note: Long, tag: Long, count: Long, total: Double, onError: JniErrorHandler<Dossier?>): Dossier?`
 - `duration_boundary_echo` — `fun durationBoundaryEcho(value: DurationBoundary, onError: JniErrorHandler<DurationBoundary?>): DurationBoundary?`
   - shaped by: return `DurationBoundary` decomposed → [required, delay] (Callback delivery)
@@ -232,6 +234,7 @@ Base package: `io.prebindgen.covertest`
 - `BlobValue`: data_class → `io.prebindgen.covertest.model.BlobValue` (wire `jni :: objects :: JObject`, input `JObject` opt-in)
 - `CacheConfig`: data_class → `io.prebindgen.covertest.model.CacheConfig` (wire `jni :: objects :: JObject`)
 - `CallbackHolder`: data_class → `io.prebindgen.covertest.CallbackHolder` (wire `jni :: objects :: JObject`)
+- `ConstArray`: data_class → `io.prebindgen.covertest.model.ConstArray` (wire `jni :: objects :: JObject`)
 - `Dossier`: data_class → `io.prebindgen.covertest.Dossier` (wire `jni :: objects :: JObject`)
 - `DurationBoundary`: data_class → `io.prebindgen.covertest.model.DurationBoundary` (wire `jni :: objects :: JObject`, input `JObject` opt-in)
 - `EscapeProbe`: ptr_class → `io.prebindgen.covertest.esc_pkg.Esc_Probe` (wire `jni :: sys :: jlong`)

--- a/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest.kt
+++ b/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest.kt
@@ -1266,6 +1266,9 @@ internal object CovNative {
     external fun celsiusDouble(c: Int, errorSink: Any): Int
 
     @JvmSynthetic
+    external fun constArrayEcho(valueBytes: ByteArray, build: Any, errorSink: Any): Any?
+
+    @JvmSynthetic
     external fun coverTagRuntime(errorSink: Any): String
 
     @JvmSynthetic

--- a/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest/model.kt
+++ b/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest/model.kt
@@ -461,6 +461,29 @@ public data class CacheConfig(val replies: RepliesConfig, val ttl: Long) {
 }
 
 /**
+ * A covertest-only fixed array whose length must render as
+ * `cov_helpers::CONST_ARRAY_LEN` in the binding crate.
+ */
+public data class ConstArray(val bytes: ByteArray) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is ConstArray) return false
+        return bytes.contentEquals(other.bytes)
+    }
+
+    override fun hashCode(): Int {
+        return bytes.contentHashCode()
+    }
+
+    override fun toString(): String = "ConstArray(bytes=${bytes.contentToString()})"
+
+    public companion object {
+        @JvmStatic
+        public fun fromParts(bytes: ByteArray): ConstArray = ConstArray(bytes)
+    }
+}
+
+/**
  * Data-class composition probe for the bounded duration representation.
  * The coverage binding deliberately marks this class `.jobject_input()` so
  * its echo executes both the whole-object input decoder and the `fromParts`
@@ -1404,6 +1427,14 @@ public fun interface BlobValueBuilder<out R> {
 internal val __BlobValueBuilder: BlobValueBuilder<BlobValue> =
 BlobValueBuilder { stamp__secs, stamp__nanos, id, chunks -> BlobValue.fromParts(stamp__secs, stamp__nanos, id, chunks) }
 
+public fun interface ConstArrayBuilder<out R> {
+    public fun run(bytes: ByteArray): R
+}
+
+@get:JvmSynthetic
+internal val __ConstArrayBuilder: ConstArrayBuilder<ConstArray> =
+ConstArrayBuilder { bytes -> ConstArray.fromParts(bytes) }
+
 internal fun interface DurationBoundaryBuilderRaw<out R> {
     public fun run(required: Long, delay: Long): R
 }
@@ -1595,6 +1626,19 @@ internal object __StampFolderRawHolder {
     @JvmField
     val instance: StampFolderRaw<ArrayList<Stamp>> =
     StampFolderRaw { acc, secs, nanos -> acc.add(Stamp.fromParts(secs, nanos)); acc }
+}
+
+/**
+ * Round-trip the const-sized array in both converter directions.
+ *
+ * The Rust `ConstArray` result is delivered decomposed: the builder callback receives (`bytes`).
+ */
+@Suppress("UNCHECKED_CAST")
+public fun constArrayEcho(value: ConstArray, onError: JniErrorHandler<ConstArray?>): ConstArray? {
+    val __bcap = JniErrorHandlerCapture.acquire()
+    val __ret = CovNative.constArrayEcho(value.bytes, __ConstArrayBuilder, __bcap)
+    if (__bcap.failed) return onError.run(__bcap.ze0)
+    return __ret as ConstArray
 }
 
 /**

--- a/examples/covertest-kotlin/kotlin/io/prebindgen/covertest/Test.kt
+++ b/examples/covertest-kotlin/kotlin/io/prebindgen/covertest/Test.kt
@@ -26,6 +26,7 @@ import io.prebindgen.covertest.esc_pkg.Esc_Probe
 import io.prebindgen.covertest.model.Annotated
 import io.prebindgen.covertest.model.Arrays
 import io.prebindgen.covertest.model.CacheConfig
+import io.prebindgen.covertest.model.ConstArray
 import io.prebindgen.covertest.model.RepliesConfig
 import io.prebindgen.covertest.model.DurationBoundary
 import io.prebindgen.covertest.model.ObjectBoundary
@@ -49,6 +50,7 @@ import io.prebindgen.covertest.model.Stamp
 import io.prebindgen.covertest.model.Unsigned
 import io.prebindgen.covertest.model.annotatedNew
 import io.prebindgen.covertest.model.arraysEcho
+import io.prebindgen.covertest.model.constArrayEcho
 import io.prebindgen.covertest.model.blobValueEcho
 import io.prebindgen.covertest.Holder
 import io.prebindgen.covertest.WrappedFields
@@ -1181,6 +1183,14 @@ fun main() {
             "flags must matter"
         }
         check(a1.toString().contains("flags=[true, false, true]")) { "got $a1" }
+
+        // This separate source-stream fixture uses `[u8; CONST_ARRAY_LEN]`.
+        // The generated Rust must qualify that const as
+        // `cov_helpers::CONST_ARRAY_LEN`; the binding crate has no bare import.
+        val constArray = ConstArray(byteArrayOf(8, 9, 10))
+        val constEcho = constArrayEcho(constArray, boom)
+        check(constEcho == constArray)
+        check(constEcho.bytes.contentEquals(byteArrayOf(8, 9, 10)))
 
         // Wrong length is a BINDING ERROR, not a panic — the decode's `try_into`
         // is the fixed-size-array length check.

--- a/examples/covertest-kotlin/src/generated_bindings.rs
+++ b/examples/covertest-kotlin/src/generated_bindings.rs
@@ -1127,6 +1127,65 @@ pub(crate) unsafe fn Celsius_to_i32_88c8e884<'a>(
     clippy::nonminimal_bool,
     clippy::eq_op
 )]
+pub(crate) unsafe fn ConstArray_to_JObject_d4812b36<'a>(
+    env: &mut jni::JNIEnv<'a>,
+    v: cov_helpers::ConstArray,
+) -> ::core::result::Result<jni::objects::JObject<'a>, __JniErr> {
+    Ok({
+        let ___bytes: jni::objects::JObject = u8_CONST_ARRAY_LEN_to_JByteArray_417a13ac(
+                env,
+                v.bytes.clone(),
+            )?
+            .into();
+        let __obj = env
+            .call_static_method(
+                "io/prebindgen/covertest/model/ConstArray",
+                "fromParts",
+                "([B)Lio/prebindgen/covertest/model/ConstArray;",
+                &[jni::objects::JValue::Object(&___bytes)],
+            )
+            .and_then(|__v| __v.l())
+            .map_err(|e| <__JniErr as ::core::convert::From<
+                String,
+            >>::from(format!("encode struct via fromParts: {}", e)))?;
+        __obj
+    })
+}
+#[allow(
+    non_snake_case,
+    unused_mut,
+    unused_variables,
+    unused_braces,
+    unused_parens,
+    dead_code,
+    clippy::useless_conversion,
+    clippy::needless_question_mark,
+    clippy::let_and_return,
+    clippy::nonminimal_bool,
+    clippy::eq_op
+)]
+#[inline(always)]
+pub(crate) unsafe fn ConstArray_to_tuple1_7d60a1f4<'a>(
+    env: &mut jni::JNIEnv<'a>,
+    v: cov_helpers::ConstArray,
+) -> ::core::result::Result<(jni::objects::JByteArray<'a>,), __JniErr> {
+    ::core::result::Result::Ok((
+        u8_CONST_ARRAY_LEN_to_JByteArray_417a13ac(env, v.bytes)?,
+    ))
+}
+#[allow(
+    non_snake_case,
+    unused_mut,
+    unused_variables,
+    unused_braces,
+    unused_parens,
+    dead_code,
+    clippy::useless_conversion,
+    clippy::needless_question_mark,
+    clippy::let_and_return,
+    clippy::nonminimal_bool,
+    clippy::eq_op
+)]
 pub(crate) unsafe fn Dossier_to_JObject_eabbdbfa<'a>(
     env: &mut jni::JNIEnv<'a>,
     v: perftest_flat::Dossier,
@@ -1659,6 +1718,45 @@ pub(crate) unsafe fn JByteArray_to_u8_4_39abedfa<'env, 'v>(
                     String,
                 >>::from(
                     "fixed-size array decode: `[u8 ; 4]` expects a different length"
+                        .to_string(),
+                )
+            })?;
+        __arr
+    })
+}
+#[allow(
+    non_snake_case,
+    unused_mut,
+    unused_variables,
+    unused_braces,
+    unused_parens,
+    dead_code,
+    clippy::useless_conversion,
+    clippy::needless_question_mark,
+    clippy::let_and_return,
+    clippy::nonminimal_bool,
+    clippy::eq_op
+)]
+pub(crate) unsafe fn JByteArray_to_u8_CONST_ARRAY_LEN_417a13ac<'env, 'v>(
+    env: &mut jni::JNIEnv<'env>,
+    v: &jni::objects::JByteArray<'v>,
+) -> ::core::result::Result<[u8; cov_helpers::CONST_ARRAY_LEN], __JniErr> {
+    Ok({
+        let __buf = env
+            .convert_byte_array(v)
+            .map_err(|e| {
+                <__JniErr as ::core::convert::From<
+                    String,
+                >>::from(format!("fixed-size array decode: {}", e))
+            })?;
+        let __arr: [u8; cov_helpers::CONST_ARRAY_LEN] = __buf
+            .as_slice()
+            .try_into()
+            .map_err(|_| {
+                <__JniErr as ::core::convert::From<
+                    String,
+                >>::from(
+                    "fixed-size array decode: `[u8 ; CONST_ARRAY_LEN]` expects a different length"
                         .to_string(),
                 )
             })?;
@@ -2229,6 +2327,35 @@ pub(crate) unsafe fn JObject_to_CallbackToken_432e8cc0<'env, 'v>(
         perftest_flat::CallbackToken {
             ingot,
         }
+    })
+}
+#[allow(
+    non_snake_case,
+    unused_mut,
+    unused_variables,
+    unused_braces,
+    unused_parens,
+    dead_code,
+    clippy::useless_conversion,
+    clippy::needless_question_mark,
+    clippy::let_and_return,
+    clippy::nonminimal_bool,
+    clippy::eq_op
+)]
+pub(crate) unsafe fn JObject_to_ConstArray_d4812b36<'env, 'v>(
+    env: &mut jni::JNIEnv<'env>,
+    v: &jni::objects::JObject<'v>,
+) -> ::core::result::Result<cov_helpers::ConstArray, __JniErr> {
+    Ok({
+        let __bytes_jobj: jni::objects::JObject = env
+            .get_field(v, "bytes", "[B")
+            .and_then(|val| val.l())
+            .map_err(|e| <__JniErr as ::core::convert::From<
+                String,
+            >>::from(format!("ConstArray.bytes: {}", e)))?;
+        let __bytes_raw: jni::objects::JByteArray = __bytes_jobj.into();
+        let bytes = JByteArray_to_u8_CONST_ARRAY_LEN_417a13ac(env, &__bytes_raw)?;
+        cov_helpers::ConstArray { bytes }
     })
 }
 #[allow(
@@ -12442,6 +12569,28 @@ pub(crate) unsafe fn str_to_JString_7b77dc67<'a>(
     clippy::nonminimal_bool,
     clippy::eq_op
 )]
+#[inline(always)]
+pub(crate) unsafe fn tuple1_to_ConstArray_7d60a1f4<'env, 'a>(
+    env: &mut jni::JNIEnv<'env>,
+    v: (jni::objects::JByteArray<'a>,),
+) -> ::core::result::Result<cov_helpers::ConstArray, __JniErr> {
+    ::core::result::Result::Ok(cov_helpers::ConstArray {
+        bytes: JByteArray_to_u8_CONST_ARRAY_LEN_417a13ac(env, &((v).0))?,
+    })
+}
+#[allow(
+    non_snake_case,
+    unused_mut,
+    unused_variables,
+    unused_braces,
+    unused_parens,
+    dead_code,
+    clippy::useless_conversion,
+    clippy::needless_question_mark,
+    clippy::let_and_return,
+    clippy::nonminimal_bool,
+    clippy::eq_op
+)]
 pub(crate) unsafe fn tuple2_to_Box_Option_Payload_0aa97b23<'env, 'v>(
     env: &mut jni::JNIEnv<'env>,
     v: (
@@ -13459,6 +13608,32 @@ pub(crate) unsafe fn u64_to_jlong_4384a5d6<'a>(
 pub(crate) unsafe fn u8_4_to_JByteArray_39abedfa<'a>(
     env: &mut jni::JNIEnv<'a>,
     v: [u8; 4],
+) -> ::core::result::Result<jni::objects::JByteArray<'a>, __JniErr> {
+    Ok({
+        env.byte_array_from_slice(&v)
+            .map_err(|e| {
+                <__JniErr as ::core::convert::From<
+                    String,
+                >>::from(format!("fixed-size array encode: {}", e))
+            })?
+    })
+}
+#[allow(
+    non_snake_case,
+    unused_mut,
+    unused_variables,
+    unused_braces,
+    unused_parens,
+    dead_code,
+    clippy::useless_conversion,
+    clippy::needless_question_mark,
+    clippy::let_and_return,
+    clippy::nonminimal_bool,
+    clippy::eq_op
+)]
+pub(crate) unsafe fn u8_CONST_ARRAY_LEN_to_JByteArray_417a13ac<'a>(
+    env: &mut jni::JNIEnv<'a>,
+    v: [u8; cov_helpers::CONST_ARRAY_LEN],
 ) -> ::core::result::Result<jni::objects::JByteArray<'a>, __JniErr> {
     Ok({
         env.byte_array_from_slice(&v)
@@ -15321,6 +15496,85 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_celsiusDouble<'a
                 &__e.to_string(),
             );
             0 as jni::sys::jint
+        }
+    }
+}
+#[no_mangle]
+#[allow(non_snake_case, unused_mut, unused_variables, dead_code)]
+pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_constArrayEcho<'a>(
+    mut env: jni::JNIEnv<'a>,
+    _class: jni::objects::JClass<'a>,
+    value_bytes: jni::objects::JByteArray<'a>,
+    __builder: jni::objects::JObject<'a>,
+    __error_sink: jni::objects::JObject<'a>,
+) -> jni::objects::JObject<'a> {
+    #[allow(non_upper_case_globals)]
+    static __SINK_MID: ::prebindgen_jni_runtime::CachedIfaceMethod = ::prebindgen_jni_runtime::CachedIfaceMethod::new();
+    const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
+    const __SINK_DESCR: &str = "(Ljava/lang/String;)Ljava/lang/Object;";
+    let value = match tuple1_to_ConstArray_7d60a1f4(&mut env, (value_bytes,)) {
+        ::core::result::Result::Ok(__value) => __value,
+        ::core::result::Result::Err(__error) => {
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__error.to_string(),
+            );
+            return jni::objects::JObject::null().into();
+        }
+    };
+    #[allow(non_upper_case_globals)]
+    static __CB_MID: ::prebindgen_jni_runtime::CachedIfaceMethod = ::prebindgen_jni_runtime::CachedIfaceMethod::new();
+    const __CB_FQN: &str = "io/prebindgen/covertest/model/ConstArrayBuilder";
+    const __CB_DESCR: &str = "([B)Ljava/lang/Object;";
+    let __out = cov_helpers::const_array_echo(value);
+    let (__chain_wire0,) = match ConstArray_to_tuple1_7d60a1f4(&mut env, __out) {
+        ::core::result::Result::Ok(__intermediate) => __intermediate,
+        ::core::result::Result::Err(__chain_error) => {
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__chain_error.to_string(),
+            );
+            return jni::objects::JObject::null().into();
+        }
+    };
+    let __obj0: jni::objects::JObject = __chain_wire0.into();
+    match __CB_MID
+        .call_object(
+            &mut env,
+            __CB_FQN,
+            "run",
+            __CB_DESCR,
+            &__builder,
+            &[
+                jni::sys::jvalue {
+                    l: __obj0.as_raw(),
+                },
+            ],
+        )
+    {
+        ::core::result::Result::Ok(__o) => __o,
+        ::core::result::Result::Err(__e) => {
+            let _ = env.exception_describe();
+            let __e2 = <__JniErr as ::core::convert::From<
+                String,
+            >>::from(__e.to_string());
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e2.to_string(),
+            );
+            jni::objects::JObject::null().into()
         }
     }
 }

--- a/prebindgen-jni/src/jni/chain.rs
+++ b/prebindgen-jni/src/jni/chain.rs
@@ -191,14 +191,24 @@ impl RustFunction for JFunction {
     }
 }
 
+#[derive(Clone)]
+enum JValueBody {
+    Ready(syn::Expr),
+    /// Array classification and JNI method selection are adapter policy. The
+    /// decoder's element and full-array type ascriptions are source spelling,
+    /// so its body is built only during final rendering.
+    PrimitiveArray(Box<crate::jni::prim_array::PrimArray>),
+}
+
 /// One terminal value crossing, retained without source Rust syntax.
 ///
-/// The JNI representation and conversion expression are adapter policy and
-/// are safe to freeze during recipe compilation. The source Rust spelling is
-/// not: the plan keeps the Flat reading opaque until the writer supplies
-/// [`Emit`]. This covers values whose converter signature names the crossing
-/// itself; deliberately composed signatures such as bare `str -> String`
-/// remain separate.
+/// The JNI representation and source-independent conversion policy are safe
+/// to freeze during recipe compilation. Source Rust spelling is not: the plan
+/// keeps the Flat reading opaque until the writer supplies [`Emit`]. Most
+/// codecs retain a ready expression; fixed-size arrays retain their JNI policy
+/// and build the source-typed expression only while rendering. Bare `str`
+/// records its adapter-authored `String`/`&str` signature explicitly without
+/// deriving either spelling from the crossing.
 #[derive(Clone)]
 pub(crate) struct JValueCodecPlan {
     ident: syn::Ident,
@@ -206,7 +216,7 @@ pub(crate) struct JValueCodecPlan {
     source: TypeRef,
     adapter_source: Option<syn::Type>,
     wire: syn::Type,
-    body: syn::Expr,
+    body: JValueBody,
 }
 
 impl JValueCodecPlan {
@@ -223,7 +233,7 @@ impl JValueCodecPlan {
             source,
             adapter_source: None,
             wire,
-            body,
+            body: JValueBody::Ready(body),
         }
     }
 
@@ -253,7 +263,23 @@ impl JValueCodecPlan {
             source,
             adapter_source: Some(adapter_source),
             wire,
-            body,
+            body: JValueBody::Ready(body),
+        }
+    }
+
+    pub(crate) fn primitive_array(
+        direction: Direction,
+        source: TypeRef,
+        spec: crate::jni::prim_array::PrimArray,
+    ) -> Self {
+        let ident = planned_name(direction, &source, &spec.wire);
+        Self {
+            ident,
+            direction,
+            source,
+            adapter_source: None,
+            wire: spec.wire.clone(),
+            body: JValueBody::PrimitiveArray(Box::new(spec)),
         }
     }
 
@@ -269,7 +295,16 @@ impl JValueCodecPlan {
             .map(|source| quote::quote!(#source))
             .unwrap_or_else(|| emit.spell(&self.source));
         let wire = &self.wire;
-        let body = super::builder::body_for_exc(&self.body, None);
+        let body = match &self.body {
+            JValueBody::Ready(body) => body.clone(),
+            JValueBody::PrimitiveArray(spec) => match self.direction {
+                Direction::Construct => {
+                    crate::jni::prim_array::input_body(&self.source, spec, emit)
+                }
+                Direction::Deconstruct => crate::jni::prim_array::output_body(spec),
+            },
+        };
+        let body = super::builder::body_for_exc(&body, None);
         let allow = super::trait_impl::generated_converter_attr();
         match self.direction {
             Direction::Construct => {

--- a/prebindgen-jni/src/jni/compile.rs
+++ b/prebindgen-jni/src/jni/compile.rs
@@ -1039,6 +1039,36 @@ impl<R: Conversions> JCompile<'_, R> {
         ))
     }
 
+    /// Freeze a fixed-size primitive-array codec without spelling its element
+    /// or full array type until final rendering.
+    fn planned_primitive_array(&self, at: At<'_>) -> Option<JFrag> {
+        let source = at.crossing.spelled();
+        let direction = at.crossing.direction();
+        let spec = crate::jni::prim_array::prim_array_of(source)?;
+        let wire = spec.wire.clone();
+        let niches = default_niches_for_wire(&wire);
+        let kotlin_name = self
+            .decls
+            .override_kotlin_name(&source.key(), Some(spec.kotlin.clone()));
+        let metadata = self.decls.framework_meta(kotlin_name);
+        let plan =
+            crate::jni::chain::JValueCodecPlan::primitive_array(direction, source.clone(), spec);
+        let ident = plan.name().clone();
+        let conv = ConverterImpl {
+            subs: vec![],
+            pre_stages: vec![],
+            function: crate::jni::chain::planned_marker(&ident),
+            destination: wire,
+            niches,
+            metadata,
+        };
+        Some(JFrag::planned(
+            at,
+            conv,
+            crate::jni::chain::JFunction::value_codec(plan),
+        ))
+    }
+
     /// The borrow arms, which are neither a terminal nor an arity layer.
     fn borrow(
         &self,
@@ -2131,6 +2161,9 @@ impl<R: Conversions> Compile for JCompile<'_, R> {
     fn atomic(&mut self, cx: &mut Cx<'_>, at: At<'_>) -> Frag<Self> {
         let ty = at.crossing.spelled();
         if let Some(frag) = self.planned_value_codec(at) {
+            return Ok(frag);
+        }
+        if let Some(frag) = self.planned_primitive_array(at) {
             return Ok(frag);
         }
         if let Some(frag) = self.planned_owned_handle(at) {

--- a/prebindgen-jni/src/jni/prim_array.rs
+++ b/prebindgen-jni/src/jni/prim_array.rs
@@ -28,6 +28,7 @@ use kotlin_codegen::KtType;
 use super::*;
 
 /// The JNI/Kotlin array pair for one primitive element type.
+#[derive(Clone)]
 pub(crate) struct PrimArray {
     /// Wire type: `jni::objects::JLongArray`.
     pub wire: syn::Type,

--- a/prebindgen-jni/src/jni/tests/values.rs
+++ b/prebindgen-jni/src/jni/tests/values.rs
@@ -211,6 +211,45 @@ fn unsized_str_retains_adapter_typed_value_codec_plans() {
 }
 
 #[test]
+fn fixed_primitive_arrays_retain_late_registry_plans() {
+    let registry = crate::test_util::reg_from_items(declare_referenced(vec![(
+        syn::parse_quote!(
+            pub fn array_echo(value: [bool; 4]) -> [bool; 4] {
+                value
+            }
+        ),
+        myflat_loc(),
+    )]))
+    .expect("index primitive-array fixture");
+    let generation = JniGenBuilder::new()
+        .set_package_prefix("io.test.jni")
+        .package(crate::package!().fun(prebindgen_registry::fun!(array_echo)))
+        .build_with(registry)
+        .expect("resolve primitive-array fixture");
+    let reading = generation
+        .registry
+        .reading(&TypeKey::from_type(&syn::parse_quote!([bool; 4])))
+        .expect("primitive-array reading");
+
+    assert!(
+        generation
+            .decls
+            .in_frag(&reading)
+            .expect("primitive-array input")
+            .is_value_codec_plan(),
+        "the input array must retain an unrendered primitive-array plan"
+    );
+    assert!(
+        generation
+            .decls
+            .out_frag(&reading)
+            .expect("primitive-array output")
+            .is_value_codec_plan(),
+        "the output array must retain an unrendered primitive-array plan"
+    );
+}
+
+#[test]
 fn bounded_duration_option_uses_u64_niche_without_boxing() {
     let loc = myflat_loc();
     let items: Vec<(syn::Item, SourceLocation)> = [

--- a/prebindgen-jni/src/jni/trait_impl.rs
+++ b/prebindgen-jni/src/jni/trait_impl.rs
@@ -1815,23 +1815,6 @@ impl Declarations {
                 return Some(self.opaque_handle_input(reading, emit));
             }
         }
-        // Fixed-size array of JNI primitives — dual of the output branch.
-        // The `try_into` IS the length check: a JVM array of the wrong size
-        // becomes a binding error naming the type, never a panic.
-        if let Some(spec) = crate::jni::prim_array::prim_array_of(reading) {
-            let body = crate::jni::prim_array::input_body(reading, &spec, emit);
-            let wire = spec.wire.clone();
-            let kotlin_name = self.override_kotlin_name(&reading.key(), Some(spec.kotlin.clone()));
-            let niches = default_niches_for_wire(&wire);
-            return Some(ConverterImpl {
-                subs: vec![],
-                pre_stages: vec![],
-                function: self.build_input_fn_of(reading, &wire, &body, None, emit),
-                destination: wire,
-                niches,
-                metadata: self.framework_meta(kotlin_name),
-            });
-        }
         // `enum_class`-declared enums: jint wire, `TryFrom<i32>` decode.
         // Registered before the user-wrapper lookup so a stray
         // `input_wrapper` registration on the same key would have to be
@@ -2134,23 +2117,6 @@ impl Declarations {
             if cfg.is_opaque() {
                 return Some(self.opaque_handle_output(reading, emit));
             }
-        }
-        // Fixed-size array of JNI primitives: `[u8; N]` -> `ByteArray`,
-        // `[i64; N]` -> `LongArray`, ... Bulk-copied, nothing boxed. See
-        // [`prim_array`]; this replaced the raw-memory value blob.
-        if let Some(spec) = crate::jni::prim_array::prim_array_of(reading) {
-            let body = crate::jni::prim_array::output_body(&spec);
-            let wire = spec.wire.clone();
-            let kotlin_name = self.override_kotlin_name(&reading.key(), Some(spec.kotlin.clone()));
-            let niches = default_niches_for_wire(&wire);
-            return Some(ConverterImpl {
-                subs: vec![],
-                pre_stages: vec![],
-                function: self.build_output_fn_of(reading, &wire, &body, None, emit),
-                destination: wire,
-                niches,
-                metadata: self.framework_meta(kotlin_name),
-            });
         }
         // `enum_class`-declared enums: jint wire, `as jni::sys::jint`
         // encode. Symmetric to the input arm above; relies on


### PR DESCRIPTION
## Summary

- move fixed-size JNI primitive-array codecs into the existing frozen `JValueCodecPlan`
- retain array/JNI policy during registry compilation while deferring full-array and element Rust spelling to final rendering
- delete the eager primitive-array input and output branches from the compatibility terminal selector
- add a deletion-fence test proving both array directions retain an unrendered registry plan
- add a covertest-only `[u8; CONST_ARRAY_LEN]` round trip from the renamed helper source, pinning final qualified spelling in committed Rust

## Design

Array classification, JNI wire selection, Kotlin primitive-array type, and JNI region methods are adapter policy derived from Flat semantic facts. Those decisions are frozen in `PrimArray`. The input decoder still needs the actual element and `[T; N]` spellings for local type ascriptions, so the value-codec plan stores the policy and constructs that expression only after the writer supplies `Emit`.

Primitive arrays reuse the existing terminal value-codec carrier rather than adding another `JFunction` variant. This preserves the established converter identity, metadata, niche, and emission path while removing both eager terminal builders.

Existing generated surfaces remain byte-for-byte unchanged. The only generated-source addition is the new covertest-only `ConstArray` fixture: its Rust converters spell `[u8; cov_helpers::CONST_ARRAY_LEN]`, and its Kotlin data class/runtime round trip pins both directions. The C example is unchanged. Boolean elements remain normalized instead of reinterpreted, and malformed JVM array lengths still return the binding error.

## Validation

- `cargo test --workspace --all-features`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps`
- `cargo fmt --all -- --check`
- `./examples/regen-check.sh`
- `examples/covertest-kotlin/gradlew run --console=plain` (61 sections)
