### PR TITLE
Render JNI Cow byte slices from frozen plans

### DIFF
--- a/examples/covertest-kotlin/src/generated_bindings.rs
+++ b/examples/covertest-kotlin/src/generated_bindings.rs
@@ -6711,6 +6711,34 @@ pub(crate) unsafe fn JString_to_String_c7f3ca43<'env, 'v>(
     clippy::nonminimal_bool,
     clippy::eq_op
 )]
+pub(crate) unsafe fn JString_to_owned_text_220e25c6<'env, 'v>(
+    env: &mut jni::JNIEnv<'env>,
+    v: &jni::objects::JString<'v>,
+) -> ::core::result::Result<String, __JniErr> {
+    Ok({
+        let s = env
+            .get_string(v)
+            .map_err(|e| {
+                <__JniErr as ::core::convert::From<
+                    String,
+                >>::from(format!("decode_string: {}", e))
+            })?;
+        s.into()
+    })
+}
+#[allow(
+    non_snake_case,
+    unused_mut,
+    unused_variables,
+    unused_braces,
+    unused_parens,
+    dead_code,
+    clippy::useless_conversion,
+    clippy::needless_question_mark,
+    clippy::let_and_return,
+    clippy::nonminimal_bool,
+    clippy::eq_op
+)]
 pub(crate) unsafe fn Label_to_String_63dec766<'a>(
     env: &mut jni::JNIEnv<'a>,
     v: perftest_flat::Label,
@@ -11469,6 +11497,32 @@ pub(crate) unsafe fn bool_to_jboolean_31306d98<'a>(
     clippy::nonminimal_bool,
     clippy::eq_op
 )]
+pub(crate) unsafe fn borrowed_text_to_JString_b6a9f7b3<'a>(
+    env: &mut jni::JNIEnv<'a>,
+    v: &str,
+) -> ::core::result::Result<jni::objects::JString<'a>, __JniErr> {
+    Ok({
+        env.new_string(v)
+            .map_err(|e| {
+                <__JniErr as ::core::convert::From<
+                    String,
+                >>::from(format!("encode_str: {}", e))
+            })?
+    })
+}
+#[allow(
+    non_snake_case,
+    unused_mut,
+    unused_variables,
+    unused_braces,
+    unused_parens,
+    dead_code,
+    clippy::useless_conversion,
+    clippy::needless_question_mark,
+    clippy::let_and_return,
+    clippy::nonminimal_bool,
+    clippy::eq_op
+)]
 pub(crate) unsafe fn f64_2_to_JDoubleArray_dc30d1f9<'a>(
     env: &mut jni::JNIEnv<'a>,
     v: [f64; 2],
@@ -12529,32 +12583,6 @@ pub(crate) unsafe fn jlong_to_u64_4384a5d6<'env, 'v>(
     v: &jni::sys::jlong,
 ) -> ::core::result::Result<u64, __JniErr> {
     Ok(*v as ::core::primitive::u64)
-}
-#[allow(
-    non_snake_case,
-    unused_mut,
-    unused_variables,
-    unused_braces,
-    unused_parens,
-    dead_code,
-    clippy::useless_conversion,
-    clippy::needless_question_mark,
-    clippy::let_and_return,
-    clippy::nonminimal_bool,
-    clippy::eq_op
-)]
-pub(crate) unsafe fn str_to_JString_7b77dc67<'a>(
-    env: &mut jni::JNIEnv<'a>,
-    v: &str,
-) -> ::core::result::Result<jni::objects::JString<'a>, __JniErr> {
-    Ok({
-        env.new_string(v)
-            .map_err(|e| {
-                <__JniErr as ::core::convert::From<
-                    String,
-                >>::from(format!("encode_str: {}", e))
-            })?
-    })
 }
 #[allow(
     non_snake_case,
@@ -22222,7 +22250,7 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_storageTryWithLa
     static __DSINK_MID: ::prebindgen_jni_runtime::CachedIfaceMethod = ::prebindgen_jni_runtime::CachedIfaceMethod::new();
     const __DSINK_FQN: &str = "io/prebindgen/covertest/errors/StorageErrorHandlerRaw";
     const __DSINK_DESCR: &str = "(Ljava/lang/String;J)Ljava/lang/Object;";
-    let label = match JString_to_String_c7f3ca43(&mut env, &label) {
+    let label = match JString_to_owned_text_220e25c6(&mut env, &label) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__e) => {
             signal_binding_error(
@@ -22355,7 +22383,7 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_stringNew<'a>(
     static __SINK_MID: ::prebindgen_jni_runtime::CachedIfaceMethod = ::prebindgen_jni_runtime::CachedIfaceMethod::new();
     const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
     const __SINK_DESCR: &str = "(Ljava/lang/String;)Ljava/lang/Object;";
-    let s = match JString_to_String_c7f3ca43(&mut env, &s) {
+    let s = match JString_to_owned_text_220e25c6(&mut env, &s) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__e) => {
             signal_binding_error(
@@ -24965,7 +24993,7 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_constGetCoverTag
     const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
     const __SINK_DESCR: &str = "(Ljava/lang/String;)Ljava/lang/Object;";
     let __out = perftest_flat::COVER_TAG;
-    match str_to_JString_7b77dc67(&mut env, __out) {
+    match borrowed_text_to_JString_b6a9f7b3(&mut env, __out) {
         ::core::result::Result::Ok(__w) => __w,
         ::core::result::Result::Err(__e) => {
             signal_binding_error(

--- a/examples/covertest-kotlin/src/generated_bindings.rs
+++ b/examples/covertest-kotlin/src/generated_bindings.rs
@@ -440,7 +440,7 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_constGetCoverVer
         use cov_helpers::*;
         crate::cover_version()
     };
-    match String_to_JString_c7f3ca43(&mut env, __out) {
+    match owned_text_to_JString_220e25c6(&mut env, __out) {
         ::core::result::Result::Ok(__w) => __w,
         ::core::result::Result::Err(__e) => {
             signal_binding_error(
@@ -473,7 +473,7 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_constGetCoverBan
         use cov_helpers::*;
         format!("{COVER_TAG}:{COVER_MAGIC:#x}")
     };
-    match String_to_JString_c7f3ca43(&mut env, __out) {
+    match owned_text_to_JString_220e25c6(&mut env, __out) {
         ::core::result::Result::Ok(__w) => __w,
         ::core::result::Result::Err(__e) => {
             signal_binding_error(
@@ -847,7 +847,7 @@ pub(crate) unsafe fn Box_Box_Option_String_to_JString_299999e0<'a>(
     ::core::result::Result::Ok({
         match **v {
             ::core::option::Option::Some(__value) => {
-                String_to_JString_c7f3ca43(env, __value)?
+                owned_text_to_JString_220e25c6(env, __value)?
             }
             ::core::option::Option::None => jni::objects::JObject::null().into(),
         }
@@ -2704,7 +2704,7 @@ pub(crate) unsafe fn JObject_to_Lookup_94ada15e<'env, 'v>(
                         String,
                     >>::from(format!("Lookup.Failed.v0: {}", e)))?;
                 let __p_v0_raw: jni::objects::JString = __p_v0_obj.into();
-                let __p_v0 = JString_to_String_c7f3ca43(env, &__p_v0_raw)?;
+                let __p_v0 = JString_to_owned_text_220e25c6(env, &__p_v0_raw)?;
                 return ::core::result::Result::Ok(perftest_flat::Lookup::Failed(__p_v0));
             }
             ::core::result::Result::Err(
@@ -3256,7 +3256,7 @@ pub(crate) unsafe fn JObject_to_Observation_435b0724<'env, 'v>(
                 String,
             >>::from(format!("Observation.note: {}", e)))?;
         let __note_raw: jni::objects::JString = __note_jobj.into();
-        let note = JString_to_String_c7f3ca43(env, &__note_raw)?;
+        let note = JString_to_owned_text_220e25c6(env, &__note_raw)?;
         perftest_flat::Observation {
             id,
             reading,
@@ -3624,7 +3624,7 @@ pub(crate) unsafe fn JObject_to_Reading_2261050f<'env, 'v>(
                         String,
                     >>::from(format!("Reading.Tagged.v0: {}", e)))?;
                 let __p_v0_raw: jni::objects::JString = __p_v0_obj.into();
-                let __p_v0 = JString_to_String_c7f3ca43(env, &__p_v0_raw)?;
+                let __p_v0 = JString_to_owned_text_220e25c6(env, &__p_v0_raw)?;
                 let __p_v1_obj: jni::objects::JObject = env
                     .get_field(__obj, "v1", "Lio/prebindgen/covertest/model/Priority;")
                     .and_then(|val| val.l())
@@ -3909,7 +3909,7 @@ pub(crate) unsafe fn JObject_to_Vec_Label_3fdf860d<'env, 'a>(
             __sequence_values
                 .push(
                     {
-                        let __chain_s0 = JString_to_String_c7f3ca43(
+                        let __chain_s0 = JString_to_owned_text_220e25c6(
                             env,
                             &__sequence_part,
                         )?;
@@ -4328,7 +4328,7 @@ pub(crate) unsafe fn JObject_to_impl_Fn_Ledger_Send_Sync_static_c76008cc<'env, '
                                     __cb0_obj7 = jni::objects::JObject::null();
                                 }
                                 perftest_flat::Lookup::Failed(__sv0) => {
-                                    let __enc___cb0_obj7 = match String_to_JString_c7f3ca43(
+                                    let __enc___cb0_obj7 = match owned_text_to_JString_220e25c6(
                                         &mut env,
                                         __sv0.clone(),
                                     ) {
@@ -4477,7 +4477,7 @@ pub(crate) unsafe fn JObject_to_impl_Fn_Ledger_Send_Sync_static_c76008cc<'env, '
                                 }
                             };
                             let __cb0_obj8: jni::objects::JObject = {
-                                let __enc8 = match String_to_JString_c7f3ca43(
+                                let __enc8 = match owned_text_to_JString_220e25c6(
                                     &mut env,
                                     __u0.label,
                                 ) {
@@ -4598,7 +4598,7 @@ pub(crate) unsafe fn JObject_to_impl_Fn_Ledger_Send_Sync_static_c76008cc<'env, '
                                     __cb0_obj16 = jni::objects::JObject::null();
                                 }
                                 perftest_flat::Lookup::Failed(__sv0) => {
-                                    let __enc___cb0_obj16 = match String_to_JString_c7f3ca43(
+                                    let __enc___cb0_obj16 = match owned_text_to_JString_220e25c6(
                                         &mut env,
                                         __sv0.clone(),
                                     ) {
@@ -4747,7 +4747,7 @@ pub(crate) unsafe fn JObject_to_impl_Fn_Ledger_Send_Sync_static_c76008cc<'env, '
                                 }
                             };
                             let __cb0_obj17: jni::objects::JObject = {
-                                let __enc17 = match String_to_JString_c7f3ca43(
+                                let __enc17 = match owned_text_to_JString_220e25c6(
                                     &mut env,
                                     __u1.label,
                                 ) {
@@ -5749,7 +5749,7 @@ pub(crate) unsafe fn JObject_to_impl_Fn_Probe_Send_Sync_static_b0418db6<'env, 'v
                                         __cb0_obj3 = jni::objects::JObject::null();
                                     }
                                     perftest_flat::Lookup::Failed(__sv0) => {
-                                        let __enc___cb0_obj3 = match String_to_JString_c7f3ca43(
+                                        let __enc___cb0_obj3 = match owned_text_to_JString_220e25c6(
                                             &mut env,
                                             __sv0.clone(),
                                         ) {
@@ -6068,7 +6068,7 @@ pub(crate) unsafe fn JObject_to_impl_Fn_Report_Send_Sync_static_eb5ca515<'env, '
                             __cb0_obj7 = jni::objects::JObject::null();
                         }
                         perftest_flat::Lookup::Failed(__sv0) => {
-                            let __enc___cb0_obj7 = match String_to_JString_c7f3ca43(
+                            let __enc___cb0_obj7 = match owned_text_to_JString_220e25c6(
                                 &mut env,
                                 __sv0.clone(),
                             ) {
@@ -6167,7 +6167,7 @@ pub(crate) unsafe fn JObject_to_impl_Fn_Report_Send_Sync_static_eb5ca515<'env, '
                         jni::sys::jvalue { j: __enc4 }
                     };
                     let __cb0_obj8: jni::objects::JObject = {
-                        let __enc8 = match String_to_JString_c7f3ca43(
+                        let __enc8 = match owned_text_to_JString_220e25c6(
                             &mut env,
                             __vf0.label,
                         ) {
@@ -6585,7 +6585,9 @@ pub(crate) unsafe fn JString_to_Box_Option_String_caeff346<'env, 'v>(
                 ::core::option::Option::None
             } else {
                 let __present = v;
-                ::core::option::Option::Some(JString_to_String_c7f3ca43(env, __present)?)
+                ::core::option::Option::Some(
+                    JString_to_owned_text_220e25c6(env, __present)?,
+                )
             }
         }),
     )
@@ -6666,36 +6668,8 @@ pub(crate) unsafe fn JString_to_Option_String_56d5e304<'env, 'v>(
             ::core::option::Option::None
         } else {
             let __present = v;
-            ::core::option::Option::Some(JString_to_String_c7f3ca43(env, __present)?)
+            ::core::option::Option::Some(JString_to_owned_text_220e25c6(env, __present)?)
         }
-    })
-}
-#[allow(
-    non_snake_case,
-    unused_mut,
-    unused_variables,
-    unused_braces,
-    unused_parens,
-    dead_code,
-    clippy::useless_conversion,
-    clippy::needless_question_mark,
-    clippy::let_and_return,
-    clippy::nonminimal_bool,
-    clippy::eq_op
-)]
-pub(crate) unsafe fn JString_to_String_c7f3ca43<'env, 'v>(
-    env: &mut jni::JNIEnv<'env>,
-    v: &jni::objects::JString<'v>,
-) -> ::core::result::Result<String, __JniErr> {
-    Ok({
-        let s = env
-            .get_string(v)
-            .map_err(|e| {
-                <__JniErr as ::core::convert::From<
-                    String,
-                >>::from(format!("decode_string: {}", e))
-            })?;
-        s.into()
     })
 }
 #[allow(
@@ -6908,7 +6882,7 @@ pub(crate) unsafe fn Lookup_to_tuple4_68d54df3<'a>(
                     2i32,
                     (),
                     (0 as jni::sys::jlong,),
-                    (String_to_JString_c7f3ca43(env, __part0)?,),
+                    (owned_text_to_JString_220e25c6(env, __part0)?,),
                 )
             }
         }
@@ -9318,7 +9292,7 @@ pub(crate) unsafe fn Observation_to_JObject_435b0724<'a>(
                 ___reading_g5 = 0i64;
             }
             perftest_flat::Reading::Labeled(__s0_0, __s0_1) => {
-                let ___reading_tagged_v0: jni::objects::JObject = String_to_JString_c7f3ca43(
+                let ___reading_tagged_v0: jni::objects::JObject = owned_text_to_JString_220e25c6(
                         env,
                         __s0_0.clone(),
                     )?
@@ -9402,7 +9376,7 @@ pub(crate) unsafe fn Observation_to_JObject_435b0724<'a>(
                         ___fallback_g5 = 0i64;
                     }
                     perftest_flat::Reading::Labeled(__s0_0, __s0_1) => {
-                        let ___fallback_tagged_v0: jni::objects::JObject = String_to_JString_c7f3ca43(
+                        let ___fallback_tagged_v0: jni::objects::JObject = owned_text_to_JString_220e25c6(
                                 env,
                                 __s0_0.clone(),
                             )?
@@ -9445,7 +9419,7 @@ pub(crate) unsafe fn Observation_to_JObject_435b0724<'a>(
                 ___fallback_g5 = 0i64;
             }
         }
-        let ___note: jni::objects::JObject = String_to_JString_c7f3ca43(
+        let ___note: jni::objects::JObject = owned_text_to_JString_220e25c6(
                 env,
                 v.note.clone(),
             )?
@@ -9908,7 +9882,7 @@ pub(crate) unsafe fn Option_String_to_JString_56d5e304<'a>(
     ::core::result::Result::Ok({
         match v {
             ::core::option::Option::Some(__value) => {
-                String_to_JString_c7f3ca43(env, __value)?
+                owned_text_to_JString_220e25c6(env, __value)?
             }
             ::core::option::Option::None => jni::objects::JObject::null().into(),
         }
@@ -10403,7 +10377,7 @@ pub(crate) unsafe fn Reading_to_tuple6_4cad5c2d<'a>(
                     (0 as jni::sys::jlong,),
                     (0 as jni::sys::jlong, 0 as jni::sys::jlong),
                     (
-                        String_to_JString_c7f3ca43(env, (*&*__part0).clone())?,
+                        owned_text_to_JString_220e25c6(env, (*&*__part0).clone())?,
                         Priority_to_jint_447102d2(env, (*&*__part1).clone())?,
                     ),
                     (0 as jni::sys::jlong,),
@@ -10492,7 +10466,7 @@ pub(crate) unsafe fn Reading_to_tuple6_69702d1f<'a>(
                     (0 as jni::sys::jlong,),
                     (0 as jni::sys::jlong, 0 as jni::sys::jlong),
                     (
-                        String_to_JString_c7f3ca43(env, __part0)?,
+                        owned_text_to_JString_220e25c6(env, __part0)?,
                         Priority_to_jint_447102d2(env, __part1)?,
                     ),
                     (0 as jni::sys::jlong,),
@@ -10798,32 +10772,6 @@ pub(crate) unsafe fn Storage_to_jlong_1b233abd<'a>(
     clippy::nonminimal_bool,
     clippy::eq_op
 )]
-pub(crate) unsafe fn String_to_JString_c7f3ca43<'a>(
-    env: &mut jni::JNIEnv<'a>,
-    v: String,
-) -> ::core::result::Result<jni::objects::JString<'a>, __JniErr> {
-    Ok({
-        env.new_string(&*v)
-            .map_err(|e| {
-                <__JniErr as ::core::convert::From<
-                    String,
-                >>::from(format!("encode_str: {}", e))
-            })?
-    })
-}
-#[allow(
-    non_snake_case,
-    unused_mut,
-    unused_variables,
-    unused_braces,
-    unused_parens,
-    dead_code,
-    clippy::useless_conversion,
-    clippy::needless_question_mark,
-    clippy::let_and_return,
-    clippy::nonminimal_bool,
-    clippy::eq_op
-)]
 pub(crate) unsafe fn String_to_Label_c1a79668<'a>(
     env: &mut jni::JNIEnv<'a>,
     v: String,
@@ -11093,7 +11041,7 @@ pub(crate) unsafe fn Vec_Label_to_JObject_3fdf860d<'a>(
                     .map_err(|__e| <__JniErr as ::core::convert::From<
                         String,
                     >>::from(__e.to_string()))?;
-                String_to_JString_c7f3ca43(env, __chain_s0)
+                owned_text_to_JString_220e25c6(env, __chain_s0)
             }?;
             let __sequence_object: jni::objects::JObject = __sequence_part.into();
             __sequence_list
@@ -11341,7 +11289,7 @@ pub(crate) unsafe fn Verdict_to_JObject_a94c1ffd<'a>(
                 ___outcome_g1 = jni::objects::JObject::null();
             }
             perftest_flat::Lookup::Failed(__s0_0) => {
-                let ___outcome_failed_v0: jni::objects::JObject = String_to_JString_c7f3ca43(
+                let ___outcome_failed_v0: jni::objects::JObject = owned_text_to_JString_220e25c6(
                         env,
                         __s0_0.clone(),
                     )?
@@ -12597,6 +12545,32 @@ pub(crate) unsafe fn jlong_to_u64_4384a5d6<'env, 'v>(
     clippy::nonminimal_bool,
     clippy::eq_op
 )]
+pub(crate) unsafe fn owned_text_to_JString_220e25c6<'a>(
+    env: &mut jni::JNIEnv<'a>,
+    v: String,
+) -> ::core::result::Result<jni::objects::JString<'a>, __JniErr> {
+    Ok({
+        env.new_string(&*v)
+            .map_err(|e| {
+                <__JniErr as ::core::convert::From<
+                    String,
+                >>::from(format!("encode_str: {}", e))
+            })?
+    })
+}
+#[allow(
+    non_snake_case,
+    unused_mut,
+    unused_variables,
+    unused_braces,
+    unused_parens,
+    dead_code,
+    clippy::useless_conversion,
+    clippy::needless_question_mark,
+    clippy::let_and_return,
+    clippy::nonminimal_bool,
+    clippy::eq_op
+)]
 #[inline(always)]
 pub(crate) unsafe fn tuple1_to_ConstArray_7d60a1f4<'env, 'a>(
     env: &mut jni::JNIEnv<'env>,
@@ -13223,7 +13197,7 @@ pub(crate) unsafe fn tuple4_to_Observation_438d4015<'env, 'a>(
         id: jlong_to_i64_fbf9a9bc(env, &((v).0))?,
         reading: tuple6_to_Reading_69702d1f(env, (v).1)?,
         fallback: tuple2_to_Option_Reading_550e9a70(env, (v).2)?,
-        note: JString_to_String_c7f3ca43(env, &((v).3))?,
+        note: JString_to_owned_text_220e25c6(env, &((v).3))?,
     })
 }
 #[allow(
@@ -13434,7 +13408,7 @@ pub(crate) unsafe fn tuple6_to_Reading_69702d1f<'env, 'a>(
                 let __choice = v;
                 let __arm = (__choice).4;
                 perftest_flat::Reading::Labeled(
-                    JString_to_String_c7f3ca43(env, &((__arm).0))?,
+                    JString_to_owned_text_220e25c6(env, &((__arm).0))?,
                     jint_to_Priority_447102d2(env, &((__arm).1))?,
                 )
             }
@@ -15618,7 +15592,7 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_coverTagRuntime<
     const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
     const __SINK_DESCR: &str = "(Ljava/lang/String;)Ljava/lang/Object;";
     let __out = perftest_flat::cover_tag_runtime();
-    match String_to_JString_c7f3ca43(&mut env, __out) {
+    match owned_text_to_JString_220e25c6(&mut env, __out) {
         ::core::result::Result::Ok(__w) => __w,
         ::core::result::Result::Err(__e) => {
             signal_binding_error(
@@ -16369,7 +16343,7 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_labelBorrowedCon
                 .map_err(|__e| <__JniErr as ::core::convert::From<
                     String,
                 >>::from(__e.to_string()))?;
-            String_to_JString_c7f3ca43(&mut env, __chain_s0)
+            owned_text_to_JString_220e25c6(&mut env, __chain_s0)
         }
     })() {
         ::core::result::Result::Ok(__w) => __w,
@@ -16400,7 +16374,7 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_labelReverse<'a>
     const __SINK_DESCR: &str = "(Ljava/lang/String;)Ljava/lang/Object;";
     let l = match (|| -> ::core::result::Result<_, __JniErr> {
         {
-            let __chain_s0 = JString_to_String_c7f3ca43(&mut env, &l)?;
+            let __chain_s0 = JString_to_owned_text_220e25c6(&mut env, &l)?;
             let __chain_s1 = String_to_Label_c1a79668(&mut env, __chain_s0)
                 .map_err(|__e| <__JniErr as ::core::convert::From<
                     String,
@@ -16428,7 +16402,7 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_labelReverse<'a>
                 .map_err(|__e| <__JniErr as ::core::convert::From<
                     String,
                 >>::from(__e.to_string()))?;
-            String_to_JString_c7f3ca43(&mut env, __chain_s0)
+            owned_text_to_JString_220e25c6(&mut env, __chain_s0)
         }
     })() {
         ::core::result::Result::Ok(__w) => __w,
@@ -16795,7 +16769,7 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_ledgerNew<'a>(
                     __obj7 = jni::objects::JObject::null();
                 }
                 perftest_flat::Lookup::Failed(__sv0) => {
-                    let __enc___obj7 = match String_to_JString_c7f3ca43(
+                    let __enc___obj7 = match owned_text_to_JString_220e25c6(
                         &mut env,
                         __sv0.clone(),
                     ) {
@@ -16977,7 +16951,7 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_ledgerNew<'a>(
                 }
             };
             let __obj8: jni::objects::JObject = {
-                let __enc8 = match String_to_JString_c7f3ca43(&mut env, __u0.label) {
+                let __enc8 = match owned_text_to_JString_220e25c6(&mut env, __u0.label) {
                     ::core::result::Result::Ok(__w) => __w,
                     ::core::result::Result::Err(__e) => {
                         signal_binding_error(
@@ -17105,7 +17079,7 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_ledgerNew<'a>(
                     __obj16 = jni::objects::JObject::null();
                 }
                 perftest_flat::Lookup::Failed(__sv0) => {
-                    let __enc___obj16 = match String_to_JString_c7f3ca43(
+                    let __enc___obj16 = match owned_text_to_JString_220e25c6(
                         &mut env,
                         __sv0.clone(),
                     ) {
@@ -17287,7 +17261,10 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_ledgerNew<'a>(
                 }
             };
             let __obj17: jni::objects::JObject = {
-                let __enc17 = match String_to_JString_c7f3ca43(&mut env, __u1.label) {
+                let __enc17 = match owned_text_to_JString_220e25c6(
+                    &mut env,
+                    __u1.label,
+                ) {
                     ::core::result::Result::Ok(__w) => __w,
                     ::core::result::Result::Err(__e) => {
                         signal_binding_error(
@@ -18909,7 +18886,7 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_probeNew<'a>(
                         __obj3 = jni::objects::JObject::null();
                     }
                     perftest_flat::Lookup::Failed(__sv0) => {
-                        let __enc___obj3 = match String_to_JString_c7f3ca43(
+                        let __enc___obj3 = match owned_text_to_JString_220e25c6(
                             &mut env,
                             __sv0.clone(),
                         ) {
@@ -20465,7 +20442,7 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_storageErrorMess
         }
     };
     let __out = perftest_flat::storage_error_message(&e);
-    match String_to_JString_c7f3ca43(&mut env, __out) {
+    match owned_text_to_JString_220e25c6(&mut env, __out) {
         ::core::result::Result::Ok(__w) => __w,
         ::core::result::Result::Err(__e) => {
             signal_binding_error(
@@ -20940,7 +20917,7 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_storageLabels<'a
     let __vec = perftest_flat::storage_labels(&s);
     let mut __acc = __acc;
     for __elem in __vec.into_iter() {
-        let __enc = match String_to_JString_c7f3ca43(&mut env, __elem) {
+        let __enc = match owned_text_to_JString_220e25c6(&mut env, __elem) {
             ::core::result::Result::Ok(__w) => __w,
             ::core::result::Result::Err(__e) => {
                 signal_binding_error(
@@ -22179,7 +22156,7 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_storageTryFromSt
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__de) => {
             let __eze0: jni::objects::JObject = {
-                let __enc0 = match String_to_JString_c7f3ca43(
+                let __enc0 = match owned_text_to_JString_220e25c6(
                     &mut env,
                     perftest_flat::storage_error_message(&__de),
                 ) {
@@ -22268,7 +22245,7 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_storageTryWithLa
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__de) => {
             let __eze0: jni::objects::JObject = {
-                let __enc0 = match String_to_JString_c7f3ca43(
+                let __enc0 = match owned_text_to_JString_220e25c6(
                     &mut env,
                     perftest_flat::storage_error_message(&__de),
                 ) {
@@ -22398,7 +22375,7 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_stringNew<'a>(
         }
     };
     let __out = perftest_flat::string_new(&s);
-    match String_to_JString_c7f3ca43(&mut env, __out) {
+    match owned_text_to_JString_220e25c6(&mut env, __out) {
         ::core::result::Result::Ok(__w) => __w,
         ::core::result::Result::Err(__e) => {
             signal_binding_error(
@@ -22606,7 +22583,7 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_summaryDescribe<
         }
     };
     let __out = crate::summary_describe(&__folded_s, verbose);
-    match String_to_JString_c7f3ca43(&mut env, __out) {
+    match owned_text_to_JString_220e25c6(&mut env, __out) {
         ::core::result::Result::Ok(__w) => __w,
         ::core::result::Result::Err(__e) => {
             signal_binding_error(

--- a/examples/emitcheck/src/generated_bindings.rs
+++ b/examples/emitcheck/src/generated_bindings.rs
@@ -256,7 +256,7 @@ pub(crate) unsafe fn JObject_to_impl_Fn_ZSample_Send_Sync_static_24e97b15<'env, 
                         let __o0: &::core::option::Option<_> = &(&__vf0).opt_plain;
                         match __o0 {
                             ::core::option::Option::Some(__n0) => {
-                                let __enc0 = match str_to_JString_7b77dc67(
+                                let __enc0 = match borrowed_text_to_JString_b6a9f7b3(
                                     &mut env,
                                     myflat::z_keyexpr_as_str(__n0),
                                 ) {
@@ -278,7 +278,7 @@ pub(crate) unsafe fn JObject_to_impl_Fn_ZSample_Send_Sync_static_24e97b15<'env, 
                         let __o0: &::core::option::Option<_> = &(&__vf0).opt_boxed;
                         match __o0 {
                             ::core::option::Option::Some(__n0) => {
-                                let __enc1 = match str_to_JString_7b77dc67(
+                                let __enc1 = match borrowed_text_to_JString_b6a9f7b3(
                                     &mut env,
                                     myflat::z_keyexpr_as_str(__n0),
                                 ) {
@@ -529,7 +529,7 @@ pub(crate) unsafe fn ZSample_to_jlong_757bca9c<'a>(
     clippy::nonminimal_bool,
     clippy::eq_op
 )]
-pub(crate) unsafe fn str_to_JString_7b77dc67<'a>(
+pub(crate) unsafe fn borrowed_text_to_JString_b6a9f7b3<'a>(
     env: &mut jni::JNIEnv<'a>,
     v: &str,
 ) -> ::core::result::Result<jni::objects::JString<'a>, __JniErr> {

--- a/examples/emitcheck/src/generated_bindings.rs
+++ b/examples/emitcheck/src/generated_bindings.rs
@@ -329,7 +329,7 @@ pub(crate) unsafe fn JObject_to_impl_Fn_ZSample_Send_Sync_static_24e97b15<'env, 
                         __enc3.into()
                     };
                     let __cb0_obj4: jni::objects::JObject = {
-                        let __enc4 = match String_to_JString_c7f3ca43(
+                        let __enc4 = match owned_text_to_JString_220e25c6(
                             &mut env,
                             __vf0.text_plain.clone(),
                         ) {
@@ -439,32 +439,6 @@ pub(crate) unsafe fn JObject_to_impl_Fn_ZSample_Send_Sync_static_24e97b15<'env, 
     clippy::nonminimal_bool,
     clippy::eq_op
 )]
-pub(crate) unsafe fn String_to_JString_c7f3ca43<'a>(
-    env: &mut jni::JNIEnv<'a>,
-    v: String,
-) -> ::core::result::Result<jni::objects::JString<'a>, __JniErr> {
-    Ok({
-        env.new_string(&*v)
-            .map_err(|e| {
-                <__JniErr as ::core::convert::From<
-                    String,
-                >>::from(format!("encode_str: {}", e))
-            })?
-    })
-}
-#[allow(
-    non_snake_case,
-    unused_mut,
-    unused_variables,
-    unused_braces,
-    unused_parens,
-    dead_code,
-    clippy::useless_conversion,
-    clippy::needless_question_mark,
-    clippy::let_and_return,
-    clippy::nonminimal_bool,
-    clippy::eq_op
-)]
 pub(crate) unsafe fn Vec_u8_to_JByteArray_7936d5de<'a>(
     env: &mut jni::JNIEnv<'a>,
     v: Vec<u8>,
@@ -535,6 +509,32 @@ pub(crate) unsafe fn borrowed_text_to_JString_b6a9f7b3<'a>(
 ) -> ::core::result::Result<jni::objects::JString<'a>, __JniErr> {
     Ok({
         env.new_string(v)
+            .map_err(|e| {
+                <__JniErr as ::core::convert::From<
+                    String,
+                >>::from(format!("encode_str: {}", e))
+            })?
+    })
+}
+#[allow(
+    non_snake_case,
+    unused_mut,
+    unused_variables,
+    unused_braces,
+    unused_parens,
+    dead_code,
+    clippy::useless_conversion,
+    clippy::needless_question_mark,
+    clippy::let_and_return,
+    clippy::nonminimal_bool,
+    clippy::eq_op
+)]
+pub(crate) unsafe fn owned_text_to_JString_220e25c6<'a>(
+    env: &mut jni::JNIEnv<'a>,
+    v: String,
+) -> ::core::result::Result<jni::objects::JString<'a>, __JniErr> {
+    Ok({
+        env.new_string(&*v)
             .map_err(|e| {
                 <__JniErr as ::core::convert::From<
                     String,

--- a/examples/emitcheck/src/generated_bindings.rs
+++ b/examples/emitcheck/src/generated_bindings.rs
@@ -179,6 +179,32 @@ pub(crate) unsafe fn Cow_static_str_to_JString_47272020<'a>(
     clippy::nonminimal_bool,
     clippy::eq_op
 )]
+pub(crate) unsafe fn Cow_static_u8_to_JByteArray_5ff7543f<'a>(
+    env: &mut jni::JNIEnv<'a>,
+    v: ::std::borrow::Cow<'static, [u8]>,
+) -> ::core::result::Result<jni::objects::JByteArray<'a>, __JniErr> {
+    Ok({
+        env.byte_array_from_slice(&v)
+            .map_err(|e| {
+                <__JniErr as ::core::convert::From<
+                    String,
+                >>::from(format!("encode_byte_array: {}", e))
+            })?
+    })
+}
+#[allow(
+    non_snake_case,
+    unused_mut,
+    unused_variables,
+    unused_braces,
+    unused_parens,
+    dead_code,
+    clippy::useless_conversion,
+    clippy::needless_question_mark,
+    clippy::let_and_return,
+    clippy::nonminimal_bool,
+    clippy::eq_op
+)]
 pub(crate) unsafe fn JObject_to_impl_Fn_ZSample_Send_Sync_static_24e97b15<'env, 'v>(
     env: &mut jni::JNIEnv<'env>,
     v: &jni::objects::JObject<'v>,
@@ -287,7 +313,7 @@ pub(crate) unsafe fn JObject_to_impl_Fn_ZSample_Send_Sync_static_24e97b15<'env, 
                         __enc2.into()
                     };
                     let __cb0_obj3: jni::objects::JObject = {
-                        let __enc3 = match std_borrow_Cow_u8_to_JByteArray_c6a6bddf(
+                        let __enc3 = match Cow_static_u8_to_JByteArray_5ff7543f(
                             &mut env,
                             __vf0.seq_cow.clone(),
                         ) {
@@ -489,32 +515,6 @@ pub(crate) unsafe fn ZSample_to_jlong_757bca9c<'a>(
     v: myflat::ZSample,
 ) -> ::core::result::Result<jni::sys::jlong, __JniErr> {
     Ok(std::boxed::Box::into_raw(std::boxed::Box::new(v)) as i64)
-}
-#[allow(
-    non_snake_case,
-    unused_mut,
-    unused_variables,
-    unused_braces,
-    unused_parens,
-    dead_code,
-    clippy::useless_conversion,
-    clippy::needless_question_mark,
-    clippy::let_and_return,
-    clippy::nonminimal_bool,
-    clippy::eq_op
-)]
-pub(crate) unsafe fn std_borrow_Cow_u8_to_JByteArray_c6a6bddf<'a>(
-    env: &mut jni::JNIEnv<'a>,
-    v: ::std::borrow::Cow<'_, [u8]>,
-) -> ::core::result::Result<jni::objects::JByteArray<'a>, __JniErr> {
-    Ok({
-        env.byte_array_from_slice(&v)
-            .map_err(|e| {
-                <__JniErr as ::core::convert::From<
-                    String,
-                >>::from(format!("encode_byte_array: {}", e))
-            })?
-    })
 }
 #[allow(
     non_snake_case,

--- a/prebindgen-flat/src/flat/key.rs
+++ b/prebindgen-flat/src/flat/key.rs
@@ -27,9 +27,13 @@ use quote::ToTokens;
 /// them from somewhere that knows what they mean: the registry's reading, or
 /// the declaration that wrote them (#291).
 ///
-/// What a key can still answer about itself is what it is **called** —
-/// [`Self::as_str`], [`Self::ident`], [`Self::short_name`] — because a name is
-/// not syntax.
+/// What a key can still answer about itself is its canonical identity label
+/// ([`Self::as_str`]) and, where that identity is a path, its nominal name
+/// ([`Self::ident`], [`Self::short_name`]). The identity label resembles
+/// normalized Rust syntax for structural types, but that resemblance grants no
+/// semantic authority: consumers must never parse it or branch on particular
+/// spellings. Classification belongs to [`TypeRef::kind`](super::TypeRef::kind)
+/// and the structured readings derived from it.
 #[derive(Clone)]
 pub struct TypeKey {
     /// Canonical token string — the identity `Eq`/`Hash` compare, and the whole
@@ -115,7 +119,13 @@ impl TypeKey {
         Self::from_type(&syn::parse_quote!(#ident))
     }
 
-    /// The canonical string form.
+    /// The canonical identity label.
+    ///
+    /// This is for diagnostics, stable artifact labels, and interoperation
+    /// with declaration APIs that identify types textually. It is not a type
+    /// model: do not parse it or compare it with Rust spellings to classify a
+    /// type. Ask [`TypeRef::kind`](super::TypeRef::kind) or another structured
+    /// model reading instead.
     pub fn as_str(&self) -> &str {
         &self.canon
     }

--- a/prebindgen-jni/src/jni/chain.rs
+++ b/prebindgen-jni/src/jni/chain.rs
@@ -200,6 +200,18 @@ enum JValueBody {
     PrimitiveArray(Box<crate::jni::prim_array::PrimArray>),
 }
 
+/// How a terminal codec obtains the Rust type in its generated signature.
+///
+/// A crossing is spelled by [`Emit`] at the final write. Bare `str` is the
+/// one semantic exception: it is unsized, so its JNI codec uses an owned text
+/// carrier on input and a borrowed text carrier on output. The concrete Rust
+/// spellings for those carriers are deliberately confined to `render` too.
+#[derive(Clone, Copy)]
+enum JValueSource {
+    Crossing,
+    TextCarrier,
+}
+
 /// One terminal value crossing, retained without source Rust syntax.
 ///
 /// The JNI representation and source-independent conversion policy are safe
@@ -207,14 +219,14 @@ enum JValueBody {
 /// keeps the Flat reading opaque until the writer supplies [`Emit`]. Most
 /// codecs retain a ready expression; fixed-size arrays retain their JNI policy
 /// and build the source-typed expression only while rendering. Bare `str`
-/// records its adapter-authored `String`/`&str` signature explicitly without
-/// deriving either spelling from the crossing.
+/// retains only the semantic fact that it needs a text carrier; the concrete
+/// owned/borrowed Rust carrier is chosen inside final rendering.
 #[derive(Clone)]
 pub(crate) struct JValueCodecPlan {
     ident: syn::Ident,
     direction: Direction,
     source: TypeRef,
-    adapter_source: Option<syn::Type>,
+    source_kind: JValueSource,
     wire: syn::Type,
     body: JValueBody,
 }
@@ -231,37 +243,30 @@ impl JValueCodecPlan {
             ident,
             direction,
             source,
-            adapter_source: None,
+            source_kind: JValueSource::Crossing,
             wire,
             body: JValueBody::Ready(body),
         }
     }
 
-    /// A codec whose Rust signature deliberately differs from its crossing.
-    ///
-    /// The supplied type is adapter-authored syntax, not syntax extracted from
-    /// `source`: bare `str` is unsized, so JNI decodes it into `String` and
-    /// encodes it through `&str`. Keeping that exception explicit lets the
-    /// crossing remain opaque while preserving the actual converter contract.
-    pub(crate) fn with_adapter_source(
+    /// A bare-`str` codec whose concrete owned/borrowed carrier is selected
+    /// only during final rendering.
+    pub(crate) fn text(
         direction: Direction,
         source: TypeRef,
-        adapter_source: syn::Type,
         wire: syn::Type,
         body: syn::Expr,
     ) -> Self {
-        use quote::ToTokens as _;
-
-        let source_tokens = adapter_source.to_token_stream();
-        let ident = match direction {
-            Direction::Construct => crate::jni::emit::input_name(&source_tokens, &wire),
-            Direction::Deconstruct => crate::jni::emit::output_name(&source_tokens, &wire),
+        let semantic_source = match direction {
+            Direction::Construct => "owned_text",
+            Direction::Deconstruct => "borrowed_text",
         };
+        let ident = planned_name_for_key(direction, semantic_source, &wire);
         Self {
             ident,
             direction,
             source,
-            adapter_source: Some(adapter_source),
+            source_kind: JValueSource::TextCarrier,
             wire,
             body: JValueBody::Ready(body),
         }
@@ -277,7 +282,7 @@ impl JValueCodecPlan {
             ident,
             direction,
             source,
-            adapter_source: None,
+            source_kind: JValueSource::Crossing,
             wire: spec.wire.clone(),
             body: JValueBody::PrimitiveArray(Box::new(spec)),
         }
@@ -289,11 +294,11 @@ impl JValueCodecPlan {
 
     fn render(&self, emit: &Emit) -> syn::ItemFn {
         let name = &self.ident;
-        let source = self
-            .adapter_source
-            .as_ref()
-            .map(|source| quote::quote!(#source))
-            .unwrap_or_else(|| emit.spell(&self.source));
+        let source = match (self.source_kind, self.direction) {
+            (JValueSource::Crossing, _) => emit.spell(&self.source),
+            (JValueSource::TextCarrier, Direction::Construct) => quote::quote!(String),
+            (JValueSource::TextCarrier, Direction::Deconstruct) => quote::quote!(&str),
+        };
         let wire = &self.wire;
         let body = match &self.body {
             JValueBody::Ready(body) => body.clone(),
@@ -1224,7 +1229,16 @@ pub(crate) fn planned_name(
     intermediate: &syn::Type,
 ) -> syn::Ident {
     let key = source.key();
-    let source_key = key.as_str();
+    planned_name_for_key(direction, key.as_str(), intermediate)
+}
+
+/// Stable private name for a plan identified by an adapter semantic rather
+/// than by a source crossing. This accepts a semantic label, not Rust syntax.
+fn planned_name_for_key(
+    direction: Direction,
+    source_key: &str,
+    intermediate: &syn::Type,
+) -> syn::Ident {
     let source_id = crate::jni::emit::sanitize_for_ident(source_key);
     let wire_id = match intermediate {
         syn::Type::Tuple(tuple) if !tuple.elems.is_empty() => {

--- a/prebindgen-jni/src/jni/chain.rs
+++ b/prebindgen-jni/src/jni/chain.rs
@@ -202,14 +202,29 @@ enum JValueBody {
 
 /// How a terminal codec obtains the Rust type in its generated signature.
 ///
-/// A crossing is spelled by [`Emit`] at the final write. Bare `str` is the
-/// one semantic exception: it is unsized, so its JNI codec uses an owned text
-/// carrier on input and a borrowed text carrier on output. The concrete Rust
+/// A crossing is spelled by [`Emit`] at the final write. Text terminals can
+/// instead select a semantic owned or borrowed carrier. The concrete Rust
 /// spellings for those carriers are deliberately confined to `render` too.
 #[derive(Clone, Copy)]
 enum JValueSource {
     Crossing,
-    TextCarrier,
+    Text(JTextCarrier),
+}
+
+/// Adapter-semantic text ownership, before its Rust carrier is spelled.
+#[derive(Clone, Copy)]
+pub(crate) enum JTextCarrier {
+    Owned,
+    Borrowed,
+}
+
+impl JTextCarrier {
+    fn identity(self) -> &'static str {
+        match self {
+            Self::Owned => "owned_text",
+            Self::Borrowed => "borrowed_text",
+        }
+    }
 }
 
 /// One terminal value crossing, retained without source Rust syntax.
@@ -218,9 +233,9 @@ enum JValueSource {
 /// to freeze during recipe compilation. Source Rust spelling is not: the plan
 /// keeps the Flat reading opaque until the writer supplies [`Emit`]. Most
 /// codecs retain a ready expression; fixed-size arrays retain their JNI policy
-/// and build the source-typed expression only while rendering. Bare `str`
-/// retains only the semantic fact that it needs a text carrier; the concrete
-/// owned/borrowed Rust carrier is chosen inside final rendering.
+/// and build the source-typed expression only while rendering. Text codecs
+/// retain only their ownership semantics; the concrete owned/borrowed Rust
+/// carrier is chosen inside final rendering.
 #[derive(Clone)]
 pub(crate) struct JValueCodecPlan {
     ident: syn::Ident,
@@ -249,24 +264,21 @@ impl JValueCodecPlan {
         }
     }
 
-    /// A bare-`str` codec whose concrete owned/borrowed carrier is selected
-    /// only during final rendering.
+    /// A text codec whose concrete owned/borrowed carrier is selected only
+    /// during final rendering.
     pub(crate) fn text(
         direction: Direction,
         source: TypeRef,
+        carrier: JTextCarrier,
         wire: syn::Type,
         body: syn::Expr,
     ) -> Self {
-        let semantic_source = match direction {
-            Direction::Construct => "owned_text",
-            Direction::Deconstruct => "borrowed_text",
-        };
-        let ident = planned_name_for_key(direction, semantic_source, &wire);
+        let ident = planned_name_for_key(direction, carrier.identity(), &wire);
         Self {
             ident,
             direction,
             source,
-            source_kind: JValueSource::TextCarrier,
+            source_kind: JValueSource::Text(carrier),
             wire,
             body: JValueBody::Ready(body),
         }
@@ -294,10 +306,10 @@ impl JValueCodecPlan {
 
     fn render(&self, emit: &Emit) -> syn::ItemFn {
         let name = &self.ident;
-        let source = match (self.source_kind, self.direction) {
-            (JValueSource::Crossing, _) => emit.spell(&self.source),
-            (JValueSource::TextCarrier, Direction::Construct) => quote::quote!(String),
-            (JValueSource::TextCarrier, Direction::Deconstruct) => quote::quote!(&str),
+        let source = match self.source_kind {
+            JValueSource::Crossing => emit.spell(&self.source),
+            JValueSource::Text(JTextCarrier::Owned) => quote::quote!(String),
+            JValueSource::Text(JTextCarrier::Borrowed) => quote::quote!(&str),
         };
         let wire = &self.wire;
         let body = match &self.body {

--- a/prebindgen-jni/src/jni/compile.rs
+++ b/prebindgen-jni/src/jni/compile.rs
@@ -956,6 +956,28 @@ impl<R: Conversions> JCompile<'_, R> {
                 );
                 let metadata = self.decls.framework_meta(kotlin_name);
                 (wire, body, niches, metadata, Some(adapter_source))
+            } else if direction == Direction::Deconstruct
+                && matches!(
+                    source.kind(),
+                    TypeKind::Cow { inner, .. } if inner.key().as_str() == "[u8]"
+                )
+            {
+                let adapter_source: syn::Type = syn::parse_quote!(::std::borrow::Cow<'_, [u8]>);
+                let wire: syn::Type = syn::parse_quote!(jni::objects::JByteArray);
+                let body: syn::Expr = syn::parse_quote!({
+                    env.byte_array_from_slice(&v).map_err(|e| {
+                        <__JniErr as ::core::convert::From<String>>::from(format!(
+                            "encode_byte_array: {}",
+                            e
+                        ))
+                    })?
+                });
+                let niches = default_niches_for_wire(&wire);
+                let kotlin_name = self
+                    .decls
+                    .override_kotlin_name(&source.key(), Some(KtType::byte_array()));
+                let metadata = self.decls.framework_meta(kotlin_name);
+                (wire, body, niches, metadata, Some(adapter_source))
             } else if !matches!(source.kind(), TypeKind::Str)
                 && matches!(source.unwrapped().kind(), TypeKind::Str | TypeKind::String)
             {
@@ -2324,6 +2346,12 @@ impl<R: Conversions> Compile for JCompile<'_, R> {
         inner: &JFrag,
     ) -> Frag<Self> {
         let ty = at.crossing.spelled();
+        // `Cow<'_, [u8]>` is classified as a Sequence by the flat model, but
+        // its declared JNI representation is one terminal byte array. Freeze
+        // that terminal before attempting structural List composition.
+        if let Some(planned) = self.planned_value_codec(at) {
+            return Ok(planned);
+        }
         let emit = cx.emit();
         if let Some(planned) = self.planned_sequence(at, elements, inner) {
             return Ok(planned);

--- a/prebindgen-jni/src/jni/compile.rs
+++ b/prebindgen-jni/src/jni/compile.rs
@@ -890,7 +890,7 @@ impl<R: Conversions> JCompile<'_, R> {
                 } else {
                     self.decls.framework_meta(kotlin_name)
                 };
-                (wire, body, niches, metadata, false)
+                (wire, body, niches, metadata, None)
             } else if matches!(source.kind(), TypeKind::Str) {
                 let wire: syn::Type = syn::parse_quote!(jni::objects::JString);
                 let body = match direction {
@@ -917,7 +917,11 @@ impl<R: Conversions> JCompile<'_, R> {
                     .decls
                     .override_kotlin_name(&source.key(), Some(KtType::string()));
                 let metadata = self.decls.framework_meta(kotlin_name);
-                (wire, body, niches, metadata, true)
+                let carrier = match direction {
+                    Direction::Construct => crate::jni::chain::JTextCarrier::Owned,
+                    Direction::Deconstruct => crate::jni::chain::JTextCarrier::Borrowed,
+                };
+                (wire, body, niches, metadata, Some(carrier))
             } else if direction == Direction::Deconstruct
                 && matches!(
                     source.kind(),
@@ -942,7 +946,13 @@ impl<R: Conversions> JCompile<'_, R> {
                     .decls
                     .override_kotlin_name(&source.key(), Some(KtType::string()));
                 let metadata = self.decls.framework_meta(kotlin_name);
-                (wire, body, niches, metadata, true)
+                (
+                    wire,
+                    body,
+                    niches,
+                    metadata,
+                    Some(crate::jni::chain::JTextCarrier::Borrowed),
+                )
             } else if direction == Direction::Deconstruct
                 && matches!(source.kind(), TypeKind::Cow { .. })
                 && matches!(
@@ -964,7 +974,7 @@ impl<R: Conversions> JCompile<'_, R> {
                     .decls
                     .override_kotlin_name(&source.key(), Some(KtType::byte_array()));
                 let metadata = self.decls.framework_meta(kotlin_name);
-                (wire, body, niches, metadata, false)
+                (wire, body, niches, metadata, None)
             } else if !matches!(source.kind(), TypeKind::Str)
                 && matches!(source.unwrapped().kind(), TypeKind::Str | TypeKind::String)
             {
@@ -1004,7 +1014,9 @@ impl<R: Conversions> JCompile<'_, R> {
                     .decls
                     .override_kotlin_name(&source.key(), Some(KtType::string()));
                 let metadata = self.decls.framework_meta(kotlin_name);
-                (wire, body, niches, metadata, false)
+                let carrier = matches!(source.kind(), TypeKind::String)
+                    .then_some(crate::jni::chain::JTextCarrier::Owned);
+                (wire, body, niches, metadata, carrier)
             } else if direction == Direction::Deconstruct && matches!(source.kind(), TypeKind::Unit)
             {
                 (
@@ -1012,13 +1024,19 @@ impl<R: Conversions> JCompile<'_, R> {
                     syn::parse_quote!(v),
                     Niches::empty(),
                     KotlinMeta::default(),
-                    false,
+                    None,
                 )
             } else {
                 return None;
             };
-        let plan = if text_carrier {
-            crate::jni::chain::JValueCodecPlan::text(direction, source.clone(), wire.clone(), body)
+        let plan = if let Some(carrier) = text_carrier {
+            crate::jni::chain::JValueCodecPlan::text(
+                direction,
+                source.clone(),
+                carrier,
+                wire.clone(),
+                body,
+            )
         } else {
             crate::jni::chain::JValueCodecPlan::new(direction, source.clone(), wire.clone(), body)
         };

--- a/prebindgen-jni/src/jni/compile.rs
+++ b/prebindgen-jni/src/jni/compile.rs
@@ -8,7 +8,7 @@
 
 use kotlin_codegen::KtType;
 use prebindgen_registry::{
-    flat::{Alternative, Function, TypeKind, TypeRef},
+    flat::{Alternative, Function, ScalarKind, TypeKind, TypeRef},
     recipe::{
         At, Bound, Carrier, Compile, Cx, Direction, Frag, Mode, Part, Parts, Validity, Yield,
     },
@@ -957,9 +957,10 @@ impl<R: Conversions> JCompile<'_, R> {
                 let metadata = self.decls.framework_meta(kotlin_name);
                 (wire, body, niches, metadata, Some(adapter_source))
             } else if direction == Direction::Deconstruct
+                && matches!(source.kind(), TypeKind::Cow { .. })
                 && matches!(
-                    source.kind(),
-                    TypeKind::Cow { inner, .. } if inner.key().as_str() == "[u8]"
+                    source.sequence_elem().map(TypeRef::kind),
+                    Some(TypeKind::Scalar(ScalarKind::U8))
                 )
             {
                 let wire: syn::Type = syn::parse_quote!(jni::objects::JByteArray);

--- a/prebindgen-jni/src/jni/compile.rs
+++ b/prebindgen-jni/src/jni/compile.rs
@@ -877,7 +877,7 @@ impl<R: Conversions> JCompile<'_, R> {
     fn planned_value_codec(&self, at: At<'_>) -> Option<JFrag> {
         let source = at.crossing.spelled();
         let direction = at.crossing.direction();
-        let (wire, body, niches, metadata, adapter_source) =
+        let (wire, body, niches, metadata, text_carrier) =
             if matches!(source.kind(), TypeKind::Scalar(_)) {
                 let (wire, body) = match direction {
                     Direction::Construct => crate::jni::emit::primitive_input(&source.key()),
@@ -885,50 +885,39 @@ impl<R: Conversions> JCompile<'_, R> {
                 }?;
                 let niches = default_niches_for_wire(&wire);
                 let kotlin_name = kotlin_for_wire(&wire);
-                let metadata = if source.key().as_str() == "u64" {
+                let metadata = if crate::jni::trait_impl::is_unsigned64(source) {
                     self.decls.unsigned64_leaf_meta()
                 } else {
                     self.decls.framework_meta(kotlin_name)
                 };
-                (wire, body, niches, metadata, None)
+                (wire, body, niches, metadata, false)
             } else if matches!(source.kind(), TypeKind::Str) {
                 let wire: syn::Type = syn::parse_quote!(jni::objects::JString);
-                let (adapter_source, body, kotlin_key) = match direction {
-                    Direction::Construct => (
-                        syn::parse_quote!(String),
-                        syn::parse_quote!({
-                            let s = env.get_string(v).map_err(|e| {
-                                <__JniErr as ::core::convert::From<String>>::from(format!(
-                                    "decode_string: {}",
-                                    e
-                                ))
-                            })?;
-                            s.into()
-                        }),
-                        source.key(),
-                    ),
-                    Direction::Deconstruct => {
-                        let rust: syn::Type = syn::parse_quote!(&str);
-                        (
-                            rust.clone(),
-                            syn::parse_quote!({
-                                env.new_string(v).map_err(|e| {
-                                    <__JniErr as ::core::convert::From<String>>::from(format!(
-                                        "encode_str: {}",
-                                        e
-                                    ))
-                                })?
-                            }),
-                            TypeKey::from_type(&rust),
-                        )
-                    }
+                let body = match direction {
+                    Direction::Construct => syn::parse_quote!({
+                        let s = env.get_string(v).map_err(|e| {
+                            <__JniErr as ::core::convert::From<String>>::from(format!(
+                                "decode_string: {}",
+                                e
+                            ))
+                        })?;
+                        s.into()
+                    }),
+                    Direction::Deconstruct => syn::parse_quote!({
+                        env.new_string(v).map_err(|e| {
+                            <__JniErr as ::core::convert::From<String>>::from(format!(
+                                "encode_str: {}",
+                                e
+                            ))
+                        })?
+                    }),
                 };
                 let niches = default_niches_for_wire(&wire);
                 let kotlin_name = self
                     .decls
-                    .override_kotlin_name(&kotlin_key, Some(KtType::string()));
+                    .override_kotlin_name(&source.key(), Some(KtType::string()));
                 let metadata = self.decls.framework_meta(kotlin_name);
-                (wire, body, niches, metadata, Some(adapter_source))
+                (wire, body, niches, metadata, true)
             } else if direction == Direction::Deconstruct
                 && matches!(
                     source.kind(),
@@ -939,7 +928,6 @@ impl<R: Conversions> JCompile<'_, R> {
                     } if matches!(inner.kind(), TypeKind::Str)
                 )
             {
-                let adapter_source: syn::Type = syn::parse_quote!(&str);
                 let wire: syn::Type = syn::parse_quote!(jni::objects::JString);
                 let body = syn::parse_quote!({
                     env.new_string(v).map_err(|e| {
@@ -950,12 +938,11 @@ impl<R: Conversions> JCompile<'_, R> {
                     })?
                 });
                 let niches = default_niches_for_wire(&wire);
-                let kotlin_name = self.decls.override_kotlin_name(
-                    &TypeKey::from_type(&adapter_source),
-                    Some(KtType::string()),
-                );
+                let kotlin_name = self
+                    .decls
+                    .override_kotlin_name(&source.key(), Some(KtType::string()));
                 let metadata = self.decls.framework_meta(kotlin_name);
-                (wire, body, niches, metadata, Some(adapter_source))
+                (wire, body, niches, metadata, true)
             } else if direction == Direction::Deconstruct
                 && matches!(source.kind(), TypeKind::Cow { .. })
                 && matches!(
@@ -977,7 +964,7 @@ impl<R: Conversions> JCompile<'_, R> {
                     .decls
                     .override_kotlin_name(&source.key(), Some(KtType::byte_array()));
                 let metadata = self.decls.framework_meta(kotlin_name);
-                (wire, body, niches, metadata, None)
+                (wire, body, niches, metadata, false)
             } else if !matches!(source.kind(), TypeKind::Str)
                 && matches!(source.unwrapped().kind(), TypeKind::Str | TypeKind::String)
             {
@@ -1017,7 +1004,7 @@ impl<R: Conversions> JCompile<'_, R> {
                     .decls
                     .override_kotlin_name(&source.key(), Some(KtType::string()));
                 let metadata = self.decls.framework_meta(kotlin_name);
-                (wire, body, niches, metadata, None)
+                (wire, body, niches, metadata, false)
             } else if direction == Direction::Deconstruct && matches!(source.kind(), TypeKind::Unit)
             {
                 (
@@ -1025,25 +1012,15 @@ impl<R: Conversions> JCompile<'_, R> {
                     syn::parse_quote!(v),
                     Niches::empty(),
                     KotlinMeta::default(),
-                    None,
+                    false,
                 )
             } else {
                 return None;
             };
-        let plan = match adapter_source {
-            Some(adapter_source) => crate::jni::chain::JValueCodecPlan::with_adapter_source(
-                direction,
-                source.clone(),
-                adapter_source,
-                wire.clone(),
-                body,
-            ),
-            None => crate::jni::chain::JValueCodecPlan::new(
-                direction,
-                source.clone(),
-                wire.clone(),
-                body,
-            ),
+        let plan = if text_carrier {
+            crate::jni::chain::JValueCodecPlan::text(direction, source.clone(), wire.clone(), body)
+        } else {
+            crate::jni::chain::JValueCodecPlan::new(direction, source.clone(), wire.clone(), body)
         };
         let ident = plan.name().clone();
         let conv = ConverterImpl {

--- a/prebindgen-jni/src/jni/compile.rs
+++ b/prebindgen-jni/src/jni/compile.rs
@@ -962,7 +962,6 @@ impl<R: Conversions> JCompile<'_, R> {
                     TypeKind::Cow { inner, .. } if inner.key().as_str() == "[u8]"
                 )
             {
-                let adapter_source: syn::Type = syn::parse_quote!(::std::borrow::Cow<'_, [u8]>);
                 let wire: syn::Type = syn::parse_quote!(jni::objects::JByteArray);
                 let body: syn::Expr = syn::parse_quote!({
                     env.byte_array_from_slice(&v).map_err(|e| {
@@ -977,7 +976,7 @@ impl<R: Conversions> JCompile<'_, R> {
                     .decls
                     .override_kotlin_name(&source.key(), Some(KtType::byte_array()));
                 let metadata = self.decls.framework_meta(kotlin_name);
-                (wire, body, niches, metadata, Some(adapter_source))
+                (wire, body, niches, metadata, None)
             } else if !matches!(source.kind(), TypeKind::Str)
                 && matches!(source.unwrapped().kind(), TypeKind::Str | TypeKind::String)
             {

--- a/prebindgen-jni/src/jni/tests/flatten.rs
+++ b/prebindgen-jni/src/jni/tests/flatten.rs
@@ -444,7 +444,7 @@ fn rust_side_only_input_type() {
     // The wrapper folds the ctor Rust-side.
     assert!(rc.contains("myflat::z_opts_new("), "{rust}");
     assert!(
-        rc.contains("let__chain_s0=JString_to_String_")
+        rc.contains("let__chain_s0=JString_to_owned_text_")
             && rc.contains("let__chain_s1=String_to_Label_"),
         "the expansion leaf must invoke its frozen terminal-then-stage pipeline:\n{rust}"
     );

--- a/prebindgen-jni/src/jni/tests/sealed.rs
+++ b/prebindgen-jni/src/jni/tests/sealed.rs
@@ -2900,7 +2900,7 @@ fn borrowed_sequences_keep_their_registry_plan_or_specialized_shape() {
             && borrowed_ident.starts_with("JObject_to_Vec_String_")
             && compact.contains("Result<Vec<String>,__JniErr>")
             && compact.contains("letmut__sequence_values")
-            && compact.contains("JString_to_String"),
+            && compact.contains("JString_to_owned_text"),
         "the borrowed input must retain the executable registry Sequence plan: {borrowed_ident}\n{borrowed_rendered}"
     );
 

--- a/prebindgen-jni/src/jni/tests/values.rs
+++ b/prebindgen-jni/src/jni/tests/values.rs
@@ -159,6 +159,14 @@ fn unsized_str_retains_semantic_text_codec_plans() {
         ),
         (
             syn::parse_quote!(
+                pub fn owned_text_len(value: String) -> i64 {
+                    value.len() as i64
+                }
+            ),
+            loc.clone(),
+        ),
+        (
+            syn::parse_quote!(
                 pub fn text_emit(cb: impl Fn(Text) + Send + Sync + 'static) {
                     unimplemented!()
                 }
@@ -173,6 +181,7 @@ fn unsized_str_retains_semantic_text_codec_plans() {
             crate::package!()
                 .class(crate::ptr_class!(Text))
                 .fun(prebindgen_registry::fun!(text_len))
+                .fun(prebindgen_registry::fun!(owned_text_len))
                 .fun(prebindgen_registry::fun!(text_emit)),
         )
         .expand(
@@ -188,6 +197,10 @@ fn unsized_str_retains_semantic_text_codec_plans() {
         .registry
         .reading(&TypeKey::from_type(&syn::parse_quote!(&str)))
         .expect("&str reading");
+    let string_reading = generation
+        .registry
+        .reading(&TypeKey::from_type(&syn::parse_quote!(String)))
+        .expect("String reading");
 
     let input = generation.decls.in_frag(&str_reading).expect("str input");
     let bare_output = generation.decls.out_frag(&str_reading).expect("str output");
@@ -195,6 +208,10 @@ fn unsized_str_retains_semantic_text_codec_plans() {
         .decls
         .out_frag(&ref_reading)
         .expect("&str output");
+    let string_input = generation
+        .decls
+        .in_frag(&string_reading)
+        .expect("String input");
     assert!(
         input.is_value_codec_plan(),
         "the unsized input must retain a semantic owned-text plan"
@@ -202,6 +219,11 @@ fn unsized_str_retains_semantic_text_codec_plans() {
     assert!(
         bare_output.is_value_codec_plan() && ref_output.is_value_codec_plan(),
         "both output crossings must retain the semantic borrowed-text plan"
+    );
+    assert_eq!(
+        input.converter_ident(),
+        string_input.converter_ident(),
+        "bare str input and String must share the owned-text decoder"
     );
     assert_eq!(
         bare_output.converter_ident(),
@@ -2225,14 +2247,14 @@ fn convert_via_local_fns() {
     assert!(rc.contains("crate::conv::label_in("), "{rust}");
     assert!(rc.contains("crate::conv::label_out("), "{rust}");
     assert!(
-        rc.contains("let__chain_s0=JString_to_String_")
+        rc.contains("let__chain_s0=JString_to_owned_text_")
             && rc.contains("let__chain_s1=String_to_Label_")
             && rc.contains("Result::<_,__JniErr>::Ok(__chain_s1)"),
         "the ordinary input must invoke its frozen terminal-then-stage pipeline:\n{rust}"
     );
     assert!(
         rc.contains("let__chain_s0=Label_to_String_")
-            && rc.contains("String_to_JString_")
+            && rc.contains("owned_text_to_JString_")
             && rc.contains("env,__chain_s0)"),
         "the ordinary output must invoke its frozen stage-then-terminal pipeline:\n{rust}"
     );
@@ -2284,7 +2306,7 @@ fn multi_stage_pipeline_preserves_registry_order() {
     let rc: String = rust.split_whitespace().collect();
 
     assert!(
-        rc.contains("let__chain_s0=JString_to_String_")
+        rc.contains("let__chain_s0=JString_to_owned_text_")
             && rc.contains("let__chain_s1=String_to_Label_")
             && rc.contains("let__chain_s2=Label_to_Tag_")
             && rc.contains("Result::<_,__JniErr>::Ok(__chain_s2)"),
@@ -2293,7 +2315,7 @@ fn multi_stage_pipeline_preserves_registry_order() {
     assert!(
         rc.contains("let__chain_s0=Tag_to_Label_")
             && rc.contains("let__chain_s1=Label_to_String_")
-            && rc.contains("String_to_JString_")
+            && rc.contains("owned_text_to_JString_")
             && rc.contains("env,__chain_s1)"),
         "deconstruct must run outer stage, inner stage, then terminal:\n{rust}"
     );

--- a/prebindgen-jni/src/jni/tests/values.rs
+++ b/prebindgen-jni/src/jni/tests/values.rs
@@ -250,6 +250,37 @@ fn fixed_primitive_arrays_retain_late_registry_plans() {
 }
 
 #[test]
+fn cow_byte_slices_retain_a_late_adapter_typed_value_codec() {
+    let registry = crate::test_util::reg_from_items(declare_referenced(vec![(
+        syn::parse_quote!(
+            pub fn cow_bytes() -> Cow<'static, [u8]> {
+                unimplemented!()
+            }
+        ),
+        myflat_loc(),
+    )]))
+    .expect("index Cow-byte fixture");
+    let generation = JniGenBuilder::new()
+        .set_package_prefix("io.test.jni")
+        .package(crate::package!().fun(prebindgen_registry::fun!(cow_bytes)))
+        .build_with(registry)
+        .expect("resolve Cow-byte fixture");
+    let reading = generation
+        .registry
+        .reading(&TypeKey::from_type(&syn::parse_quote!(Cow<'static, [u8]>)))
+        .expect("Cow-byte reading");
+
+    assert!(
+        generation
+            .decls
+            .out_frag(&reading)
+            .expect("Cow-byte output")
+            .is_value_codec_plan(),
+        "Cow<[u8]> output must retain an unrendered adapter-typed value codec"
+    );
+}
+
+#[test]
 fn bounded_duration_option_uses_u64_niche_without_boxing() {
     let loc = myflat_loc();
     let items: Vec<(syn::Item, SourceLocation)> = [

--- a/prebindgen-jni/src/jni/tests/values.rs
+++ b/prebindgen-jni/src/jni/tests/values.rs
@@ -250,7 +250,7 @@ fn fixed_primitive_arrays_retain_late_registry_plans() {
 }
 
 #[test]
-fn cow_byte_slices_retain_a_late_adapter_typed_value_codec() {
+fn cow_byte_slices_retain_a_late_value_codec() {
     let registry = crate::test_util::reg_from_items(declare_referenced(vec![(
         syn::parse_quote!(
             pub fn cow_bytes() -> Cow<'static, [u8]> {
@@ -270,13 +270,20 @@ fn cow_byte_slices_retain_a_late_adapter_typed_value_codec() {
         .reading(&TypeKey::from_type(&syn::parse_quote!(Cow<'static, [u8]>)))
         .expect("Cow-byte reading");
 
+    let output = generation
+        .decls
+        .out_frag(&reading)
+        .expect("Cow-byte output");
     assert!(
-        generation
-            .decls
-            .out_frag(&reading)
-            .expect("Cow-byte output")
-            .is_value_codec_plan(),
-        "Cow<[u8]> output must retain an unrendered adapter-typed value codec"
+        output.is_value_codec_plan(),
+        "Cow<[u8]> output must retain an unrendered value codec"
+    );
+    assert!(
+        output
+            .converter_ident()
+            .to_string()
+            .contains("Cow_static_u8"),
+        "the late codec identity must preserve the crossing's lifetime"
     );
 }
 

--- a/prebindgen-jni/src/jni/tests/values.rs
+++ b/prebindgen-jni/src/jni/tests/values.rs
@@ -130,7 +130,7 @@ fn owned_strings_and_unit_retain_late_value_codec_plans() {
 }
 
 #[test]
-fn unsized_str_retains_adapter_typed_value_codec_plans() {
+fn unsized_str_retains_semantic_text_codec_plans() {
     let loc = myflat_loc();
     let registry = crate::test_util::reg_from_items(declare_referenced(vec![
         (
@@ -197,11 +197,11 @@ fn unsized_str_retains_adapter_typed_value_codec_plans() {
         .expect("&str output");
     assert!(
         input.is_value_codec_plan(),
-        "the unsized input must retain a plan whose adapter type is String"
+        "the unsized input must retain a semantic owned-text plan"
     );
     assert!(
         bare_output.is_value_codec_plan() && ref_output.is_value_codec_plan(),
-        "both output crossings must retain the adapter-typed &str plan"
+        "both output crossings must retain the semantic borrowed-text plan"
     );
     assert_eq!(
         bare_output.converter_ident(),

--- a/prebindgen-jni/src/jni/trait_impl.rs
+++ b/prebindgen-jni/src/jni/trait_impl.rs
@@ -159,46 +159,6 @@ impl Declarations {
         )
     }
 
-    /// `Cow<[u8]>` output converter (any lifetime form) — see the call site
-    /// in [`Self::output_terminal`]. `None` when `ty` isn't a
-    /// `Cow<…, [u8]>` path.
-    fn cow_bytes_output(
-        &self,
-        ty: &prebindgen_registry::flat::TypeRef,
-    ) -> Option<ConverterImpl<KotlinMeta>> {
-        // `TypeKind::Cow` is the form, and its `inner` is the argument — where
-        // this walked a path's last segment, compared the ident to the NAME
-        // `"Cow"`, and scanned the angle-bracketed arguments for a `[u8]`.
-        let prebindgen_registry::flat::TypeKind::Cow { inner, .. } = ty.kind() else {
-            return None;
-        };
-        if inner.key().as_str() != "[u8]" {
-            return None;
-        }
-        // The generated fn's param type must be resolvable without imports —
-        // normalize whatever path form the accessor wrote to the full one.
-        let norm_ty: syn::Type = syn::parse_quote!(::std::borrow::Cow<'_, [u8]>);
-        let wire: syn::Type = syn::parse_quote!(jni::objects::JByteArray);
-        let body: syn::Expr = syn::parse_quote!({
-            env.byte_array_from_slice(&v).map_err(|e| {
-                <__JniErr as ::core::convert::From<String>>::from(format!(
-                    "encode_byte_array: {}",
-                    e
-                ))
-            })?
-        });
-        let kotlin_name = self.override_kotlin_name(&ty.key(), Some(KtType::byte_array()));
-        let niches = default_niches_for_wire(&wire);
-        Some(ConverterImpl {
-            subs: vec![],
-            pre_stages: vec![],
-            function: self.build_output_fn(&norm_ty, &wire, &body, None),
-            destination: wire,
-            niches,
-            metadata: self.framework_meta(kotlin_name),
-        })
-    }
-
     /// Universal "opaque Box-handle as `jlong`" pair — input side.
     ///
     /// Use for any Rust type whose lifecycle is owned by the Java side:
@@ -2146,14 +2106,6 @@ impl Declarations {
             }
         }
         if let Some(conv) = self.lookup_output(reading, registry, emit) {
-            return Some(conv);
-        }
-        // `Cow<'_, [u8]>` (any lifetime): a borrow-or-owned byte container —
-        // one copy into the JVM array straight off the `Deref<[u8]>`, no
-        // intermediate owned `Vec` (the zero-copy dual of the `Vec<u8>`
-        // output, for accessors like `zenoh::ZBytes::to_bytes()` that borrow
-        // when the payload is contiguous). Surfaces as Kotlin `ByteArray`.
-        if let Some(conv) = self.cow_bytes_output(reading) {
             return Some(conv);
         }
         if let Some((wire, body)) = (!matches!(

--- a/prebindgen-jni/src/jni/trait_impl.rs
+++ b/prebindgen-jni/src/jni/trait_impl.rs
@@ -9,6 +9,16 @@ use prebindgen_registry::{Building, Conversions, Crossing, RegistryBuilder};
 
 use super::*;
 
+/// Whether Flat classifies this exact crossing as the unsigned 64-bit scalar.
+/// Destination policy asks the model once through this helper; no caller reads
+/// or compares Rust spelling.
+pub(crate) fn is_unsigned64(ty: &prebindgen_registry::flat::TypeRef) -> bool {
+    matches!(
+        ty.kind(),
+        prebindgen_registry::flat::TypeKind::Scalar(prebindgen_registry::flat::ScalarKind::U64)
+    )
+}
+
 /// The `#[allow(...)]` carried by every generated converter `fn`.
 ///
 /// Generated converters are uniform templates, not hand-written idiomatic Rust,
@@ -822,7 +832,7 @@ impl Declarations {
             // unsupported status (`Vec<u8>` is the rank-0 ByteArray special).
             None => {
                 matches!(elem.kind(), prebindgen_registry::flat::TypeKind::String)
-                    || elem.key().as_str() == "u64"
+                    || is_unsigned64(elem)
             }
         }
     }
@@ -1822,7 +1832,7 @@ impl Declarations {
         {
             let niches = default_niches_for_wire(&wire);
             let kotlin_name = kotlin_for_wire(&wire);
-            let metadata = if reading.key().as_str() == "u64" {
+            let metadata = if is_unsigned64(reading) {
                 self.unsigned64_leaf_meta()
             } else {
                 self.framework_meta(kotlin_name)
@@ -2120,7 +2130,7 @@ impl Declarations {
         {
             let niches = default_niches_for_wire(&wire);
             let kotlin_name = kotlin_for_wire(&wire);
-            let metadata = if reading.key().as_str() == "u64" {
+            let metadata = if is_unsigned64(reading) {
                 self.unsigned64_leaf_meta()
             } else {
                 self.framework_meta(kotlin_name)


### PR DESCRIPTION
## Why

`Cow<'_, [u8]>` output still escaped the registry-owned Rust generation path through an eager `Declarations::cow_bytes_output` builder. That fallback parsed and rendered a Rust signature before final emission, even though the registry had already classified the crossing and selected its recipe.

The review exposed the broader version of the same boundary mistake: JNI terminal planning also classified `Cow<[u8]>` and `u64` by comparing canonical Rust spellings, while bare `str` plans retained concrete `String`/`&str` source types. These facts already exist in the Flat model or are adapter semantics; none require source Rust syntax during planning.

## What changed

- freeze the `Cow<[u8]> -> JByteArray` output conversion as a `JValueCodecPlan`
- classify `Cow<[u8]>` through `TypeKind::Cow`, `TypeRef::sequence_elem()`, and `ScalarKind::U8`
- classify every JNI unsigned-64 special case through `ScalarKind::U64`
- retain bare-`str` codecs as semantic owned-text/borrowed-text carriers; choose `String` or `&str` only inside final rendering
- let final emission spell the actual `Cow` crossing, preserving its source lifetime instead of normalizing it to `'_`
- delete the eager `cow_bytes_output` builder and its legacy output-terminal dispatch
- correct `TypeKey::as_str` documentation: it is an identity label, not a classification API
- add seam coverage for the frozen Cow codec and semantic text-carrier plans

The JNI ABI and Kotlin surface are unchanged. Generated Rust is semantically unchanged apart from private converter names/order and the Cow converter now faithfully using the crossing's actual lifetime.

## Validation

- `cargo test --workspace`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS=-Dwarnings cargo doc --workspace --no-deps`
- `./examples/regen-check.sh` — clean after committing regenerated artifacts
- `examples/covertest-kotlin/gradlew run --console=plain` — 61/61 sections
