### PR TITLE
Render JNI enum codecs from frozen plans

### DIFF
--- a/prebindgen-jni/src/jni/chain.rs
+++ b/prebindgen-jni/src/jni/chain.rs
@@ -194,6 +194,15 @@ impl RustFunction for JFunction {
 #[derive(Clone)]
 enum JValueBody {
     Ready(syn::Expr),
+    /// A fieldless enum decoder. Variant identity and discriminants are Flat
+    /// facts; the enum's Rust spelling is deliberately supplied only while
+    /// rendering the final file.
+    EnumInput {
+        diagnostic_name: String,
+        source_module: syn::Path,
+        enum_name: syn::Ident,
+        variants: Vec<(syn::Ident, i64)>,
+    },
     /// Array classification and JNI method selection are adapter policy. The
     /// decoder's element and full-array type ascriptions are source spelling,
     /// so its body is built only during final rendering.
@@ -300,20 +309,71 @@ impl JValueCodecPlan {
         }
     }
 
+    pub(crate) fn enum_input(
+        source: TypeRef,
+        source_module: syn::Path,
+        enum_name: syn::Ident,
+        variants: Vec<(syn::Ident, i64)>,
+    ) -> Self {
+        let wire = syn::parse_quote!(jni::sys::jint);
+        let ident = planned_name(Direction::Construct, &source, &wire);
+        let diagnostic_name = enum_name.to_string();
+        Self {
+            ident,
+            direction: Direction::Construct,
+            source,
+            source_kind: JValueSource::Crossing,
+            wire,
+            body: JValueBody::EnumInput {
+                diagnostic_name,
+                source_module,
+                enum_name,
+                variants,
+            },
+        }
+    }
+
     pub(crate) fn name(&self) -> &syn::Ident {
         &self.ident
     }
 
     fn render(&self, emit: &Emit) -> syn::ItemFn {
         let name = &self.ident;
-        let source = match self.source_kind {
-            JValueSource::Crossing => emit.spell(&self.source),
-            JValueSource::Text(JTextCarrier::Owned) => quote::quote!(String),
-            JValueSource::Text(JTextCarrier::Borrowed) => quote::quote!(&str),
+        let source: syn::Type = match self.source_kind {
+            JValueSource::Crossing => emit.spell_ty(&self.source),
+            JValueSource::Text(JTextCarrier::Owned) => syn::parse_quote!(String),
+            JValueSource::Text(JTextCarrier::Borrowed) => syn::parse_quote!(&str),
         };
         let wire = &self.wire;
         let body = match &self.body {
             JValueBody::Ready(body) => body.clone(),
+            JValueBody::EnumInput {
+                diagnostic_name,
+                source_module,
+                enum_name,
+                variants,
+            } => {
+                let arms = variants.iter().map(|(variant, value)| {
+                    let value = proc_macro2::Literal::i64_unsuffixed(*value);
+                    quote::quote!(#value => #source_module::#enum_name::#variant,)
+                });
+                syn::parse_quote!({
+                    match *v as i64 {
+                        #(#arms)*
+                        other => {
+                            return ::core::result::Result::Err(
+                                <__JniErr as ::core::convert::From<String>>::from(
+                                    format!(
+                                        "invalid {} discriminant: {}",
+                                        #diagnostic_name,
+                                        other
+                                    )
+                                )
+                            );
+                        }
+                    }
+                })
+            }
             JValueBody::PrimitiveArray(spec) => match self.direction {
                 Direction::Construct => {
                     crate::jni::prim_array::input_body(&self.source, spec, emit)

--- a/prebindgen-jni/src/jni/compile.rs
+++ b/prebindgen-jni/src/jni/compile.rs
@@ -875,6 +875,9 @@ impl<R: Conversions> JCompile<'_, R> {
 
     /// Freeze a terminal value codec without asking `Emit` to spell its source.
     fn planned_value_codec(&self, at: At<'_>) -> Option<JFrag> {
+        if let Some(fragment) = self.planned_enum_codec(at) {
+            return Some(fragment);
+        }
         let source = at.crossing.spelled();
         let direction = at.crossing.direction();
         let (wire, body, niches, metadata, text_carrier) =
@@ -1040,6 +1043,71 @@ impl<R: Conversions> JCompile<'_, R> {
         } else {
             crate::jni::chain::JValueCodecPlan::new(direction, source.clone(), wire.clone(), body)
         };
+        let ident = plan.name().clone();
+        let conv = ConverterImpl {
+            subs: vec![],
+            pre_stages: vec![],
+            function: crate::jni::chain::planned_marker(&ident),
+            destination: wire,
+            niches,
+            metadata,
+        };
+        Some(JFrag::planned(
+            at,
+            conv,
+            crate::jni::chain::JFunction::value_codec(plan),
+        ))
+    }
+
+    /// Freeze a declared fieldless enum as Flat variant/discriminant facts.
+    /// The plan deliberately does not retain an enum path or a rendered Rust
+    /// body: final emission supplies the source type and constructs the variant
+    /// paths from it.
+    fn planned_enum_codec(&self, at: At<'_>) -> Option<JFrag> {
+        let source = at.crossing.spelled();
+        let key = source.key();
+        let cfg = self.decls.types.get(&key)?;
+        if !cfg.is_enum_class() {
+            return None;
+        }
+        let name = key.ident()?;
+        let item = crate::jni::trait_impl::flat_unit_enum(self.registry, &name, "enum_class");
+        let item = item?;
+        let variants = item
+            .discriminant_values()
+            .unwrap_or_else(|variant| {
+                panic!(
+                    "enum `{}` variant `{variant}` has a non-literal discriminant; use a literal \
+                     integer value (e.g. `= 1`) or an implicit discriminant",
+                    item.name
+                )
+            })
+            .into_iter()
+            .map(|(variant, value)| (variant.clone(), value))
+            .collect();
+        let wire: syn::Type = syn::parse_quote!(jni::sys::jint);
+        let direction = at.crossing.direction();
+        let plan = match direction {
+            Direction::Construct => crate::jni::chain::JValueCodecPlan::enum_input(
+                source.clone(),
+                self.decls.fn_module(self.registry, &item.name),
+                item.name.clone(),
+                variants,
+            ),
+            Direction::Deconstruct => crate::jni::chain::JValueCodecPlan::new(
+                direction,
+                source.clone(),
+                wire.clone(),
+                syn::parse_quote!({ v as jni::sys::jint }),
+            ),
+        };
+        let (niches, niche_sentinels) = self.decls.enum_niches(item, self.registry, direction);
+        let kotlin_name = cfg
+            .name_spec
+            .as_ref()
+            .map(|spec| KtType::cls(self.decls.fqn_of(spec)));
+        let mut metadata = self.decls.framework_meta(kotlin_name);
+        metadata.niche_sentinels = niche_sentinels;
         let ident = plan.name().clone();
         let conv = ConverterImpl {
             subs: vec![],

--- a/prebindgen-jni/src/jni/emit/convert.rs
+++ b/prebindgen-jni/src/jni/emit/convert.rs
@@ -1,6 +1,4 @@
-//! Scalar / `Option` / enum converter bodies and their wire probes.
-
-use prebindgen_registry::Conversions;
+//! Scalar and `Option` converter bodies and their wire probes.
 
 use super::*;
 
@@ -262,80 +260,6 @@ pub(crate) fn default_niches_for_wire(wire: &syn::Type) -> Niches {
     } else {
         Niches::empty()
     }
-}
-
-// ──────────────────────────────────────────────────────────────────────
-// Struct rank-0 bodies
-// ──────────────────────────────────────────────────────────────────────
-
-/// `jint → Rust enum` decoder body for a `enum_class`-declared enum.
-/// Wire is `jni::sys::jint`. The framework builds the decode `match`
-/// directly from the enum's own discriminants — no `TryFrom<i32>` impl
-/// is required on the flat enum (the enum declaration is the single
-/// source of truth for the int↔variant mapping, shared with the Kotlin
-/// `value(N)` constants via [`enum_discriminant_values`]). An unknown
-/// discriminant surfaces as the framework `__JniErr`.
-///
-/// The arms use the bare ident — same shape as the wrapper function's
-/// `v: <ident>` signature — so binding crates can pick whichever
-/// upstream type a bare `<ident>` resolves to in their include-site
-/// `use` statements. Pairs with output body below.
-pub(crate) fn enum_input_body(
-    ext: &Declarations,
-    registry: &impl Conversions,
-    e: &prebindgen_registry::flat::Enum,
-) -> (syn::Type, syn::Expr) {
-    let ident = &e.name;
-    let ident_name = ident.to_string();
-    // Qualify the variant constructors with the enum's origin module,
-    // exactly as the type-position pass qualifies the enum's return type —
-    // otherwise a bare `Enum::Variant` fails to resolve when the enum lives
-    // in a source crate (the usual flat-library case).
-    let source_module = ext.fn_module(registry, ident);
-    // The model's numbering, not a second copy of it: `Enum::discriminant_values`
-    // is what the frontend computed at parse time, overflow rule and all.
-    let arms = e
-        .discriminant_values()
-        .unwrap_or_else(|name| {
-            panic!(
-                "enum `{}` variant `{name}` has a non-literal discriminant; use a literal \
-                 integer value (e.g. `= 1`) or an implicit discriminant",
-                e.name
-            )
-        })
-        .into_iter()
-        .map(|(variant, value)| {
-            let lit = proc_macro2::Literal::i64_unsuffixed(value);
-            quote! { #lit => #source_module::#ident::#variant, }
-        });
-    let body: syn::Expr = syn::parse_quote!({
-        match *v as i64 {
-            #(#arms)*
-            other => {
-                return ::core::result::Result::Err(
-                    <__JniErr as ::core::convert::From<String>>::from(
-                        format!("invalid {} discriminant: {}", #ident_name, other)
-                    )
-                );
-            }
-        }
-    });
-    (syn::parse_quote!(jni::sys::jint), body)
-}
-
-/// `Rust enum → jint` encoder body for a `enum_class`-declared enum.
-/// Wire is `jni::sys::jint`. Relies on the declared enum's repr
-/// supporting an `as` cast (i.e. C-like enum, no fields); the
-/// [`assert_only_unit_variants`] check below catches violations
-/// upstream of the cast. The body works without naming the enum type
-/// at all — `v` is already typed via the wrapper signature, so the
-/// `as` cast picks up the right type by inference.
-pub(crate) fn enum_output_body(
-    _ext: &Declarations,
-    _e: &prebindgen_registry::flat::Enum,
-) -> (syn::Type, syn::Expr) {
-    let body: syn::Expr = syn::parse_quote!({ v as jni::sys::jint });
-    (syn::parse_quote!(jni::sys::jint), body)
 }
 
 // ──────────────────────────────────────────────────────────────────────

--- a/prebindgen-jni/src/jni/tests/values.rs
+++ b/prebindgen-jni/src/jni/tests/values.rs
@@ -410,6 +410,10 @@ fn enum_terminal_allocates_one_niche_per_optional_layer() {
     let reading = gen.registry.reading(&key).expect("Priority reading");
     let input = gen.decls.in_frag(&reading).expect("Priority input");
     let output = gen.decls.out_frag(&reading).expect("Priority output");
+    assert!(
+        input.is_value_codec_plan() && output.is_value_codec_plan(),
+        "both Priority directions must retain unrendered enum codec plans"
+    );
     assert_eq!(input.niches.len(), 2);
     assert_eq!(output.niches.len(), 2);
     assert_eq!(

--- a/prebindgen-jni/src/jni/trait_impl.rs
+++ b/prebindgen-jni/src/jni/trait_impl.rs
@@ -1344,7 +1344,7 @@ fn peel_one_borrow(t: &prebindgen_registry::flat::TypeRef) -> &prebindgen_regist
 /// `syn::ItemEnum` to work out which of the two shapes it had — the
 /// classification the model makes once, at parse time, and expresses as two
 /// different elements.
-fn flat_unit_enum<'r>(
+pub(crate) fn flat_unit_enum<'r>(
     registry: &'r impl Conversions,
     name: &syn::Ident,
     declarator: &str,
@@ -1785,38 +1785,6 @@ impl Declarations {
                 return Some(self.opaque_handle_input(reading, emit));
             }
         }
-        // `enum_class`-declared enums: jint wire, `TryFrom<i32>` decode.
-        // Registered before the user-wrapper lookup so a stray
-        // `input_wrapper` registration on the same key would have to be
-        // intentional. The rank-0 enum arm produces a terminal converter
-        // (jint → Rust enum) with the configured Kotlin FQN in metadata.
-        if let Some(cfg) = self.types.get(&key) {
-            if cfg.is_enum_class() {
-                if let Some(name) = reading.key().ident() {
-                    // The ELEMENT, and the match is the check: a declared
-                    // `enum_class!` over a data-carrying enum is a `Variant`,
-                    // not an `Enum`, so the shape assertion the two bodies used
-                    // to run is the kind the model already decided.
-                    if let Some(e) = flat_unit_enum(registry, &name, "enum_class") {
-                        let (wire, body) = enum_input_body(self, registry, e);
-                        let (niches, niche_sentinels) =
-                            self.enum_niches(e, registry, Direction::Construct);
-                        let kotlin_name =
-                            cfg.name_spec.as_ref().map(|s| KtType::cls(self.fqn_of(s)));
-                        let mut metadata = self.framework_meta(kotlin_name);
-                        metadata.niche_sentinels = niche_sentinels;
-                        return Some(ConverterImpl {
-                            subs: vec![],
-                            pre_stages: vec![],
-                            function: self.build_input_fn_of(reading, &wire, &body, None, emit),
-                            destination: wire,
-                            niches,
-                            metadata,
-                        });
-                    }
-                }
-            }
-        }
         if let Some(conv) = self.lookup_input(reading, registry, emit) {
             return Some(conv);
         }
@@ -2086,33 +2054,6 @@ impl Declarations {
         if let Some(cfg) = self.types.get(&key) {
             if cfg.is_opaque() {
                 return Some(self.opaque_handle_output(reading, emit));
-            }
-        }
-        // `enum_class`-declared enums: jint wire, `as jni::sys::jint`
-        // encode. Symmetric to the input arm above; relies on
-        // `#[repr(i32)]` (or any repr that supports the cast) on the
-        // declared enum so the discriminant value round-trips identically.
-        if let Some(cfg) = self.types.get(&key) {
-            if cfg.is_enum_class() {
-                if let Some(name) = reading.key().ident() {
-                    if let Some(e) = flat_unit_enum(registry, &name, "enum_class") {
-                        let (wire, body) = enum_output_body(self, e);
-                        let (niches, niche_sentinels) =
-                            self.enum_niches(e, registry, Direction::Deconstruct);
-                        let kotlin_name =
-                            cfg.name_spec.as_ref().map(|s| KtType::cls(self.fqn_of(s)));
-                        let mut metadata = self.framework_meta(kotlin_name);
-                        metadata.niche_sentinels = niche_sentinels;
-                        return Some(ConverterImpl {
-                            subs: vec![],
-                            pre_stages: vec![],
-                            function: self.build_output_fn_of(reading, &wire, &body, None, emit),
-                            destination: wire,
-                            niches,
-                            metadata,
-                        });
-                    }
-                }
             }
         }
         if let Some(conv) = self.lookup_output(reading, registry, emit) {


### PR DESCRIPTION
## Summary

- Move fieldless Rust enums declared through JniGen's `enum_class!` adapter from eager complete converter functions to frozen `JValueCodecPlan`s.
- Freeze Flat-model variant identities, discriminants, source origin, JNI `jint` representation, and Optional niche allocation during registry composition; spell the source `TypeRef` and assemble qualified variant constructors only during final Rust rendering.
- Delete the superseded eager enum input/output body builders and terminal fallback branches. Generated Rust, Kotlin, native names, and JNI descriptors remain byte-for-byte unchanged.

## Design

The decoder plan retains semantic enum facts, not captured source-type syntax. The final writer supplies `Emit` for the converter signature and combines the retained source module, enum name, and variant name for each match arm. The output direction retains only the adapter-authored discriminant cast. Both directions continue to expose the same ordered unused `jint` values to registry-composed `Option<Priority>` and `Option<Option<Priority>>` chains.

A seam assertion now requires both `Priority` directions to retain unrendered value-codec plans while the existing test continues to pin both nested Optional niches.

## Verification

- `cargo test --workspace` — passed
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` — passed
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps` — passed
- `cargo fmt --all --check` — passed
- `git diff --check origin/feature/chained-rust-generation...HEAD` — passed
- `bash examples/regen-check.sh` — passed; committed generated output is byte-identical
- `cd examples/covertest-kotlin && ./gradlew run --console=plain` — passed all 61 runtime sections

Related to #513 and #558.
