### PR TITLE
Render JNI opaque handle codecs from frozen plans

### DIFF
--- a/prebindgen-jni/src/jni/chain.rs
+++ b/prebindgen-jni/src/jni/chain.rs
@@ -19,7 +19,7 @@ enum JBody {
     Complete(Box<syn::ItemFn>),
     Marker(syn::Ident),
     ValueCodec(Box<JValueCodecPlan>),
-    OwnedHandle(Box<JOwnedHandlePlan>),
+    HandleCodec(Box<JHandleCodecPlan>),
     BorrowedOptionalHandle(Box<JBorrowedOptionalHandlePlan>),
     Product(Box<JProductPlan>),
     Choice(Box<JChoicePlan>),
@@ -41,8 +41,8 @@ impl JFunction {
         }
     }
 
-    pub(crate) fn owned_handle(plan: JOwnedHandlePlan) -> Self {
-        Self(JBody::OwnedHandle(Box::new(plan)))
+    pub(crate) fn handle_codec(plan: JHandleCodecPlan) -> Self {
+        Self(JBody::HandleCodec(Box::new(plan)))
     }
 
     pub(crate) fn value_codec(plan: JValueCodecPlan) -> Self {
@@ -84,6 +84,11 @@ impl JFunction {
     }
 
     #[cfg(test)]
+    pub(crate) fn is_handle_codec(&self) -> bool {
+        matches!(self.0, JBody::HandleCodec(_))
+    }
+
+    #[cfg(test)]
     pub(crate) fn is_borrowed_optional_handle(&self) -> bool {
         matches!(self.0, JBody::BorrowedOptionalHandle(_))
     }
@@ -104,7 +109,7 @@ impl JFunction {
         match &self.0 {
             JBody::Complete(_) => {}
             JBody::Marker(_) | JBody::ValueCodec(_) => {}
-            JBody::OwnedHandle(plan) => plan.reachable.set(true),
+            JBody::HandleCodec(plan) => plan.reachable.set(true),
             JBody::BorrowedOptionalHandle(plan) => plan.reachable.set(true),
             JBody::Product(plan) => {
                 plan.reachable.set(true);
@@ -145,7 +150,7 @@ impl RustFunction for JFunction {
             JBody::Complete(function) => &function.sig.ident,
             JBody::Marker(ident) => ident,
             JBody::ValueCodec(plan) => &plan.ident,
-            JBody::OwnedHandle(plan) => &plan.ident,
+            JBody::HandleCodec(plan) => &plan.ident,
             JBody::BorrowedOptionalHandle(plan) => &plan.ident,
             JBody::Product(plan) => &plan.ident,
             JBody::Choice(plan) => &plan.ident,
@@ -163,7 +168,7 @@ impl RustFunction for JFunction {
             // reachability to the children they call. Until those parents are
             // planned too, every compiled value codec remains an emitted leaf.
             JBody::ValueCodec(_) => true,
-            JBody::OwnedHandle(plan) => plan.reachable.get(),
+            JBody::HandleCodec(plan) => plan.reachable.get(),
             JBody::BorrowedOptionalHandle(plan) => plan.reachable.get(),
             JBody::Product(plan) => plan.reachable.get(),
             JBody::Optional(plan) => plan.reachable.get(),
@@ -180,7 +185,7 @@ impl RustFunction for JFunction {
             JBody::Complete(function) => (**function).clone(),
             JBody::Marker(ident) => planned_marker(ident),
             JBody::ValueCodec(plan) => plan.render(emit),
-            JBody::OwnedHandle(plan) => plan.render(emit),
+            JBody::HandleCodec(plan) => plan.render(emit),
             JBody::BorrowedOptionalHandle(plan) => plan.render(emit),
             JBody::Product(plan) => plan.render(emit),
             JBody::Optional(plan) => plan.render(emit),
@@ -775,45 +780,104 @@ impl shared::Child for JChild {
     }
 }
 
-/// Owned opaque-handle input, kept syntax-free until final emission.
+/// Which ownership operation an opaque-handle terminal performs.
+#[derive(Clone, Copy)]
+pub(crate) enum JHandleOperation {
+    ConsumeInput,
+    BorrowInput,
+    OwnOutput,
+    CloneOutput,
+}
+
+/// One opaque `Box`-handle terminal, kept source-syntax-free until final
+/// emission.
+///
+/// All operations use `jni::sys::jlong`, not `*mut T`, because JNI's wire is
+/// 64 bits even on a 32-bit target. Owned output leaks `Box<T>` to the JVM;
+/// owned input reclaims it with `Box::from_raw`. Borrowed input instead keeps
+/// the allocation JVM-owned through `OwnedObject<T>`, and borrowed output
+/// clones the referent into a fresh owned handle.
+///
+/// Both input operations reject zero and odd values. Zero is the optional
+/// niche (`Box::into_raw` cannot produce it). Bit zero is reserved by Kotlin's
+/// `NativeHandle` as the closed tag: an odd pointer means close won a race
+/// after the wrapper's pre-lock check and must never be dereferenced. This
+/// convention depends on the separately emitted `align_of::<T>() >= 2` guard
+/// for every opaque handle type.
 #[derive(Clone)]
-pub(crate) struct JOwnedHandlePlan {
+pub(crate) struct JHandleCodecPlan {
     pub(crate) ident: syn::Ident,
     pub(crate) reachable: std::rc::Rc<std::cell::Cell<bool>>,
     pub(crate) source: TypeRef,
     pub(crate) module: syn::Path,
+    pub(crate) target: syn::Ident,
+    pub(crate) operation: JHandleOperation,
 }
 
-impl JOwnedHandlePlan {
+impl JHandleCodecPlan {
     fn render(&self, emit: &Emit) -> syn::ItemFn {
         let name = &self.ident;
-        let source = shared::Source::spell(
-            &JSource {
-                wrappers: Vec::new(),
-                module: Some(self.module.clone()),
-            },
-            &self.source,
-            emit,
-        );
+        let mut source = emit.spell_ty(&self.source);
+        let mut qualifier = QualifySource {
+            module: &self.module,
+            target: self.target.clone(),
+        };
+        syn::visit_mut::VisitMut::visit_type_mut(&mut qualifier, &mut source);
         let allow = crate::jni::trait_impl::generated_converter_attr();
-        syn::parse_quote!(
-            #allow
-            pub(crate) unsafe fn #name<'env, 'v>(
-                env: &mut jni::JNIEnv<'env>,
-                v: &jni::sys::jlong,
-            ) -> ::core::result::Result<#source, __JniErr> {
-                if *v == 0 || (*v & 1) == 1 {
-                    return ::core::result::Result::Err(
-                        <__JniErr as ::core::convert::From<String>>::from(
-                            "Operation on a closed native handle.".to_string(),
-                        ),
-                    );
+        match self.operation {
+            JHandleOperation::ConsumeInput => syn::parse_quote!(
+                #allow
+                pub(crate) unsafe fn #name<'env, 'v>(
+                    env: &mut jni::JNIEnv<'env>,
+                    v: &jni::sys::jlong,
+                ) -> ::core::result::Result<#source, __JniErr> {
+                    if *v == 0 || (*v & 1) == 1 {
+                        return ::core::result::Result::Err(
+                            <__JniErr as ::core::convert::From<String>>::from(
+                                "Operation on a closed native handle.".to_string(),
+                            ),
+                        );
+                    }
+                    ::core::result::Result::Ok(unsafe {
+                        *::std::boxed::Box::from_raw(*v as *mut #source)
+                    })
                 }
-                ::core::result::Result::Ok(unsafe {
-                    *::std::boxed::Box::from_raw(*v as *mut #source)
-                })
-            }
-        )
+            ),
+            JHandleOperation::BorrowInput => syn::parse_quote!(
+                #allow
+                pub(crate) unsafe fn #name<'env, 'v>(
+                    env: &mut jni::JNIEnv<'env>,
+                    v: &jni::sys::jlong,
+                ) -> ::core::result::Result<OwnedObject<#source>, __JniErr> {
+                    if *v == 0 || (*v & 1) == 1 {
+                        return ::core::result::Result::Err(
+                            <__JniErr as ::core::convert::From<String>>::from(
+                                "Operation on a closed native handle.".to_string(),
+                            ),
+                        );
+                    }
+                    Ok(unsafe { OwnedObject::from_raw(*v as *const #source) })
+                }
+            ),
+            JHandleOperation::OwnOutput => syn::parse_quote!(
+                #allow
+                pub(crate) unsafe fn #name<'a>(
+                    env: &mut jni::JNIEnv<'a>,
+                    v: #source,
+                ) -> ::core::result::Result<jni::sys::jlong, __JniErr> {
+                    Ok(std::boxed::Box::into_raw(std::boxed::Box::new(v)) as i64)
+                }
+            ),
+            JHandleOperation::CloneOutput => syn::parse_quote!(
+                #allow
+                pub(crate) unsafe fn #name<'a>(
+                    env: &mut jni::JNIEnv<'a>,
+                    v: #source,
+                ) -> ::core::result::Result<jni::sys::jlong, __JniErr> {
+                    Ok(std::boxed::Box::into_raw(std::boxed::Box::new(v.clone())) as i64)
+                }
+            ),
+        }
     }
 }
 

--- a/prebindgen-jni/src/jni/compile.rs
+++ b/prebindgen-jni/src/jni/compile.rs
@@ -1155,12 +1155,7 @@ impl<R: Conversions> JCompile<'_, R> {
     }
 
     /// The borrow arms, which are neither a terminal nor an arity layer.
-    fn borrow(
-        &self,
-        ty: &TypeRef,
-        emit: &prebindgen_registry::Emit,
-        into_rust: bool,
-    ) -> Option<ConverterImpl<KotlinMeta>> {
+    fn borrow(&self, ty: &TypeRef, into_rust: bool) -> Option<ConverterImpl<KotlinMeta>> {
         let TypeKind::Ref {
             mutable,
             inner: borrowed,
@@ -1187,58 +1182,136 @@ impl<R: Conversions> JCompile<'_, R> {
             if !writes_reach_the_caller {
                 return None;
             }
-            if ty.erased_wrappers().is_empty()
-                && self
-                    .decls
-                    .types
-                    .get(&inner.key())
-                    .is_some_and(|cfg| cfg.is_opaque())
-            {
-                let mut c = self.decls.opaque_handle_input(inner, emit);
-                c.metadata.projection = c.metadata.projection.map(|projection| Projection {
-                    owned: false,
-                    ..projection
-                });
-                c.subs = vec![inner.key()];
-                return Some(c);
-            }
             let mut c = self.decls.input_borrow(ty, inner)?;
             c.subs = vec![inner.key()];
             Some(c)
         } else {
-            let mut c = self.decls.output_borrow(ty, inner, emit)?;
-            c.subs = vec![inner.key()];
-            Some(c)
+            None
         }
     }
 
-    /// Plan an owned opaque input without spelling its Rust type. Product
-    /// fields use this ordinary atomic fragment; final emission performs the
-    /// only `TypeRef` -> Rust syntax conversion.
-    fn planned_owned_handle(&self, at: At<'_>) -> Option<JFrag> {
-        if at.crossing.direction() != Direction::Construct || at.crossing.mode() != Mode::Owned {
-            return None;
-        }
+    /// Plan every opaque-handle terminal without spelling its Rust type.
+    /// Ownership policy is adapter data; final emission performs the only
+    /// `TypeRef` -> Rust syntax conversion.
+    fn planned_handle_codec(&self, at: At<'_>) -> Option<JFrag> {
         let source = at.crossing.spelled();
-        let cfg = self.decls.types.get(&source.key())?;
-        if !cfg.is_opaque() || !source.erased_wrappers().is_empty() {
+        if !source.erased_wrappers().is_empty() {
             return None;
         }
-        let TypeKind::Named { id, .. } = source.unwrapped().kind() else {
-            return None;
-        };
-        let source_ident = id.ident()?;
-        let module = self.decls.fn_module(self.registry, &source_ident);
+        let direction = at.crossing.direction();
         let wire: syn::Type = syn::parse_quote!(jni::sys::jlong);
-        let base = crate::jni::chain::planned_name(Direction::Construct, source, &wire);
-        let ident = format_ident!("{base}_owned");
+        let (render_source, target, operation, ident, metadata, subs) = match source.kind() {
+            TypeKind::Named { id, .. }
+                if self
+                    .decls
+                    .types
+                    .get(&source.key())
+                    .is_some_and(|cfg| cfg.is_opaque()) =>
+            {
+                let target = id.ident()?;
+                let operation = match direction {
+                    Direction::Construct if at.crossing.mode() == Mode::Owned => {
+                        crate::jni::chain::JHandleOperation::ConsumeInput
+                    }
+                    Direction::Deconstruct if at.crossing.mode() == Mode::Owned => {
+                        crate::jni::chain::JHandleOperation::OwnOutput
+                    }
+                    _ => return None,
+                };
+                let base = crate::jni::chain::planned_name(direction, source, &wire);
+                let ident = match operation {
+                    crate::jni::chain::JHandleOperation::ConsumeInput => {
+                        format_ident!("{base}_owned")
+                    }
+                    _ => base,
+                };
+                (
+                    source.clone(),
+                    target,
+                    operation,
+                    ident,
+                    self.decls.opaque_leaf_meta(source.key()),
+                    Vec::new(),
+                )
+            }
+            TypeKind::Ref {
+                mutable,
+                inner: borrowed,
+                ..
+            } => {
+                let target_ref = source.borrow_target()?;
+                if !self
+                    .decls
+                    .types
+                    .get(&target_ref.key())
+                    .is_some_and(|cfg| cfg.is_opaque())
+                {
+                    return None;
+                }
+                let TypeKind::Named { id, .. } = target_ref.unwrapped().kind() else {
+                    return None;
+                };
+                let target = id.ident()?;
+                let operation = match direction {
+                    Direction::Construct
+                        if !*mutable
+                            || self
+                                .decls
+                                .types
+                                .get(&borrowed.key())
+                                .is_some_and(|cfg| cfg.is_opaque()) =>
+                    {
+                        crate::jni::chain::JHandleOperation::BorrowInput
+                    }
+                    Direction::Deconstruct if !*mutable => {
+                        crate::jni::chain::JHandleOperation::CloneOutput
+                    }
+                    _ => return None,
+                };
+                let (render_source, name_source) = match operation {
+                    crate::jni::chain::JHandleOperation::BorrowInput => {
+                        (target_ref.clone(), target_ref)
+                    }
+                    _ => (source.clone(), source),
+                };
+                let ident = crate::jni::chain::planned_name(direction, name_source, &wire);
+                let mut metadata = self.decls.opaque_leaf_meta(target_ref.key());
+                if matches!(operation, crate::jni::chain::JHandleOperation::BorrowInput) {
+                    metadata.projection = metadata.projection.map(|projection| Projection {
+                        owned: false,
+                        ..projection
+                    });
+                }
+                (
+                    render_source,
+                    target,
+                    operation,
+                    ident,
+                    metadata,
+                    vec![target_ref.key()],
+                )
+            }
+            _ => return None,
+        };
+        let module = self.decls.fn_module(self.registry, &target);
         let marker = crate::jni::chain::planned_marker(&ident);
         let rust =
-            crate::jni::chain::JFunction::owned_handle(crate::jni::chain::JOwnedHandlePlan {
+            crate::jni::chain::JFunction::handle_codec(crate::jni::chain::JHandleCodecPlan {
                 ident,
-                reachable: std::rc::Rc::new(std::cell::Cell::new(false)),
-                source: source.clone(),
+                // Legacy parents can retain only the child's converter name,
+                // so they cannot activate its `JFunction` dependency yet.
+                // Output and borrowed-input terminals were unconditional
+                // functions before this late plan; keep that exact emission
+                // rule until those parents become plans too. Owned input was
+                // already a reachable plan and remains demand-driven.
+                reachable: std::rc::Rc::new(std::cell::Cell::new(
+                    direction == Direction::Deconstruct
+                        || matches!(operation, crate::jni::chain::JHandleOperation::BorrowInput),
+                )),
+                source: render_source,
                 module,
+                target,
+                operation,
             });
         Some(JFrag {
             conv: ConverterImpl {
@@ -1246,8 +1319,8 @@ impl<R: Conversions> JCompile<'_, R> {
                 function: marker,
                 pre_stages: Vec::new(),
                 niches: Niches::one(syn::parse_quote!(0i64), syn::parse_quote!(*v == 0)),
-                metadata: self.decls.opaque_leaf_meta(source.key()),
-                subs: Vec::new(),
+                metadata,
+                subs,
             },
             choice_arm: None,
             rust,
@@ -2251,7 +2324,7 @@ impl<R: Conversions> Compile for JCompile<'_, R> {
         if let Some(frag) = self.planned_primitive_array(at) {
             return Ok(frag);
         }
-        if let Some(frag) = self.planned_owned_handle(at) {
+        if let Some(frag) = self.planned_handle_codec(at) {
             return Ok(frag);
         }
         let emit = cx.emit();
@@ -2259,13 +2332,13 @@ impl<R: Conversions> Compile for JCompile<'_, R> {
             Direction::Construct => self
                 .decls
                 .input_terminal(ty, self.registry, emit)
-                .or_else(|| self.borrow(ty, emit, true))
+                .or_else(|| self.borrow(ty, true))
                 .or_else(|| self.decls.input_transparent_bridge(ty, self.registry, emit)),
             Direction::Deconstruct => self
                 .decls
                 .output_terminal(ty, self.registry, emit)
                 .or_else(|| self.decls.result_shape(ty, self.registry, emit))
-                .or_else(|| self.borrow(ty, emit, false))
+                .or_else(|| self.borrow(ty, false))
                 .or_else(|| {
                     self.decls
                         .output_transparent_bridge(ty, self.registry, emit)
@@ -2423,12 +2496,12 @@ impl<R: Conversions> Compile for JCompile<'_, R> {
             Direction::Construct => self
                 .decls
                 .input_terminal(ty, self.registry, emit)
-                .or_else(|| self.borrow(ty, emit, true))
+                .or_else(|| self.borrow(ty, true))
                 .or_else(|| self.decls.input_transparent_bridge(ty, self.registry, emit)),
             Direction::Deconstruct => self
                 .decls
                 .output_terminal(ty, self.registry, emit)
-                .or_else(|| self.borrow(ty, emit, false))
+                .or_else(|| self.borrow(ty, false))
                 .or_else(|| {
                     self.decls
                         .output_transparent_bridge(ty, self.registry, emit)
@@ -2984,6 +3057,11 @@ impl Conv {
     #[cfg(test)]
     pub(crate) fn is_value_codec_plan(&self) -> bool {
         self.0.rust.is_value_codec()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn is_handle_codec_plan(&self) -> bool {
+        self.0.rust.is_handle_codec()
     }
 }
 

--- a/prebindgen-jni/src/jni/metadata.rs
+++ b/prebindgen-jni/src/jni/metadata.rs
@@ -124,15 +124,6 @@ pub struct KotlinMeta {
 }
 
 impl KotlinMeta {
-    pub fn from_name(name: impl Into<String>) -> Self {
-        Self {
-            kotlin_name: Some(KtType::cls(name)),
-            value_rust_type: None,
-            projection: None,
-            niche_sentinels: Vec::new(),
-        }
-    }
-
     /// True iff this (input-direction) converter decodes a directly-consumable
     /// owned opaque handle — i.e. its projection is a bare `Handle` leaf with no
     /// `Option`/`Vec` fold. Replaces the former `converter_returns_owned_object`

--- a/prebindgen-jni/src/jni/tests/values.rs
+++ b/prebindgen-jni/src/jni/tests/values.rs
@@ -3,6 +3,68 @@ use prebindgen_registry::Conversions;
 use super::*;
 
 #[test]
+fn opaque_handles_retain_late_plans_for_all_ownership_operations() {
+    let loc = myflat_loc();
+    let registry = crate::test_util::reg_from_items(declare_referenced(vec![
+        (
+            syn::parse_quote!(
+                pub struct Token {
+                    _private: u8,
+                }
+            ),
+            loc.clone(),
+        ),
+        (
+            syn::parse_quote!(
+                pub fn owned_handle(value: Token) -> Token {
+                    value
+                }
+            ),
+            loc.clone(),
+        ),
+        (
+            syn::parse_quote!(
+                pub fn borrowed_handle(value: &Token) -> &Token {
+                    value
+                }
+            ),
+            loc,
+        ),
+    ]))
+    .expect("index handle fixture");
+    let generation = JniGenBuilder::new()
+        .set_package_prefix("io.test.jni")
+        .package(
+            crate::package!()
+                .class(crate::ptr_class!(Token))
+                .fun(prebindgen_registry::fun!(owned_handle))
+                .fun(prebindgen_registry::fun!(borrowed_handle)),
+        )
+        .build_with(registry)
+        .expect("resolve handle fixture");
+
+    for ty in [syn::parse_quote!(Token), syn::parse_quote!(&Token)] {
+        let reading = generation.registry.reading_of(&ty).expect("handle reading");
+        assert!(
+            generation
+                .decls
+                .in_frag(&reading)
+                .expect("handle input")
+                .is_handle_codec_plan(),
+            "the handle input must retain an unrendered handle codec: {ty:?}"
+        );
+        assert!(
+            generation
+                .decls
+                .out_frag(&reading)
+                .expect("handle output")
+                .is_handle_codec_plan(),
+            "the handle output must retain an unrendered handle codec: {ty:?}"
+        );
+    }
+}
+
+#[test]
 fn bare_scalars_retain_late_registry_plans_in_both_directions() {
     let registry = crate::test_util::reg_from_items(declare_referenced(vec![(
         syn::parse_quote!(

--- a/prebindgen-jni/src/jni/trait_impl.rs
+++ b/prebindgen-jni/src/jni/trait_impl.rs
@@ -169,95 +169,10 @@ impl Declarations {
         )
     }
 
-    /// Universal "opaque Box-handle as `jlong`" pair — input side.
-    ///
-    /// Use for any Rust type whose lifecycle is owned by the Java side:
-    /// Java holds the raw `Box<T>` pointer as a `Long` and calls Rust
-    /// passing the pointer. The converter handles both parameter
-    /// shapes, the decision is taken in `on_function` from the
-    /// parameter's syntax:
-    ///
-    /// **`&T` sites (borrow)**: `OwnedObject::from_raw` stores the
-    /// pointer without taking ownership of the `Box`; `Deref<Target
-    /// = T>` exposes `&*ptr` so the generated call site can borrow it
-    /// as `&T`. The wrapper has no `Drop` — nothing is freed, the
-    /// heap allocation stays with Java. The Java side must take the
-    /// pointer out of its `NativeHandle.withPtr` (read lock) so the
-    /// borrow is sequenced against any concurrent consume / close.
-    ///
-    /// **`T` sites (consume, by-value)**: the call-site emitter
-    /// bypasses `OwnedObject` and inlines `*Box::from_raw(ptr)` —
-    /// infallible. The Java side must take the pointer out of its
-    /// `NativeHandle.consume` (write lock + atomic null) before
-    /// invoking this entry point; that write lock drains concurrent
-    /// borrows and the atomic-null ensures the same Long cannot be
-    /// passed twice. No `T: Clone` bound (Box requires nothing of T),
-    /// so non-Clone handles (`Publisher<'a>`, `Subscriber<()>`) can
-    /// consume.
-    ///
-    /// **Convention** (single rule for both input and output):
-    /// * Wire: `jni::sys::jlong` — the same width JNI hands across
-    ///   the boundary on every platform (`*mut T` would mismatch
-    ///   on 32-bit, where ptr size is 4 but jlong is 8).
-    /// * Output: `Box::into_raw(Box::new(v)) as i64` — leak the heap
-    ///   allocation to Java; sole owner is whoever later calls
-    ///   `Box::from_raw` on the same pointer.
-    /// * Input: `OwnedObject::from_raw(*v as *const T)` (borrow only),
-    ///   after rejecting null and tag-bit-set values — bit 0 is the
-    ///   Kotlin-side closed tag (see `NativeHandle`), so an odd `jlong`
-    ///   is a handle that was closed after the wrapper's pre-lock guard;
-    ///   it must never be dereferenced.
-    /// * Niche: `0i64` / `*v == 0` — `Box::into_raw` never returns 0,
-    ///   so `Option<T>` automatically synthesises `0` = `None`,
-    ///   matching the legacy "null pointer" ABI for nullable handles.
-    ///   A *tagged* (closed-but-present) value is an error, not `None`.
-    pub fn opaque_handle_input(
-        &self,
-        reading: &prebindgen_registry::flat::TypeRef,
-        emit: &prebindgen_registry::Emit,
-    ) -> ConverterImpl<KotlinMeta> {
-        let wire: syn::Type = syn::parse_quote!(jni::sys::jlong);
-        let ty = emit.spell(reading);
-        let name = input_name(&ty, &wire);
-        let gen_allow = generated_converter_attr();
-        let function: syn::ItemFn = syn::parse_quote!(
-            #gen_allow
-            pub(crate) unsafe fn #name<'env, 'v>(
-                env: &mut jni::JNIEnv<'env>,
-                v: &jni::sys::jlong,
-            ) -> ::core::result::Result<OwnedObject<#ty>, __JniErr> {
-                // Null or tag-bit-set (closed handle raced past the Kotlin
-                // pre-lock guard) — reject before any dereference.
-                if *v == 0 || (*v & 1) == 1 {
-                    return ::core::result::Result::Err(
-                        <__JniErr as ::core::convert::From<String>>::from(
-                            "Operation on a closed native handle.".to_string(),
-                        ),
-                    );
-                }
-                Ok(unsafe { OwnedObject::from_raw(*v as *const #ty) })
-            }
-        );
-        ConverterImpl {
-            subs: vec![],
-            function,
-            destination: wire,
-            pre_stages: vec![],
-            niches: Niches::one(syn::parse_quote!(0i64), syn::parse_quote!(*v == 0)),
-            // Opaque handles' value-context Kotlin name stays `"Long"`
-            // (the jlong wire mention); the *typed* Kotlin rendering is
-            // derived from `handle` below. The wrapper's `?` path surfaces
-            // an `OwnedObject::from_raw` failure as the framework
-            // `JniBindingError`, so the throws fields point at the
-            // framework exception.
-            metadata: self.opaque_leaf_meta(reading.key()),
-        }
-    }
-
-    /// Leaf metadata for an opaque handle: value-context name `"Long"`
-    /// plus the [`Projection`] that folds outward through wrappers (owned,
-    /// [`FoldStrategy::Base`]). The single seam where a Rust type is
-    /// first marked a closeable native handle.
+    /// Leaf metadata for an opaque handle: value-context name `Long` plus the
+    /// projection that folds outward through wrappers. The corresponding
+    /// ownership, null-niche, and odd-pointer-tag operations live in the late
+    /// `JHandleCodecPlan`; this method describes the Kotlin-facing leaf only.
     pub(crate) fn opaque_leaf_meta(&self, key: TypeKey) -> KotlinMeta {
         KotlinMeta {
             projection: Some(Projection {
@@ -408,31 +323,6 @@ impl Declarations {
             length_names: &length_names,
         };
         syn::visit_mut::VisitMut::visit_item_mut(&mut visitor, item);
-    }
-
-    /// Output side of [`Self::opaque_handle_input`] — see that method's
-    /// docs for the full convention.
-    pub fn opaque_handle_output(
-        &self,
-        reading: &prebindgen_registry::flat::TypeRef,
-        emit: &prebindgen_registry::Emit,
-    ) -> ConverterImpl<KotlinMeta> {
-        let wire: syn::Type = syn::parse_quote!(jni::sys::jlong);
-        let body: syn::Expr =
-            syn::parse_quote!(std::boxed::Box::into_raw(std::boxed::Box::new(v)) as i64);
-        ConverterImpl {
-            subs: vec![],
-            function: self.build_output_fn_of(reading, &wire, &body, None, emit),
-            destination: wire,
-            pre_stages: vec![],
-            niches: Niches::one(syn::parse_quote!(0i64), syn::parse_quote!(*v == 0)),
-            // Opaque handles' value-context name `"Long"` + folded
-            // `Projection` — see [`Self::opaque_handle_input`] /
-            // [`Self::opaque_leaf_meta`]. Framework throws because the
-            // wrapper's emitted match-arm still has a `JniBindingError`
-            // branch reachable via the chain.
-            metadata: self.opaque_leaf_meta(reading.key()),
-        }
     }
 }
 
@@ -1599,18 +1489,11 @@ impl Prebindgen for Declarations {
         validate_bindings(self, registry)
     }
 
-    /// The other-side type of every `convert!` conversion, in the
-    /// conversion's direction: an input fn's parameter type (peeled of `&`)
-    /// must have its own **input** converter for the composed rank-0 body to
-    /// chain through; an output fn's return type needs the **output** twin.
-    /// Signatures are read from the registry (missing fns are reported by
-    /// the scan's helper-function warning; the body derivation later
-    /// hard-errors with the precise decl).
-    /// Emit the `OwnedObject<T>` borrow wrapper used by
-    /// [`Self::opaque_handle_input`] into the destination file.
-    /// The struct is referenced by an unqualified `OwnedObject` from
-    /// the same generated file, so no `use` paths leak into the host
-    /// crate's source tree.
+    /// Emit shared Rust items needed by JNI wrappers and late converters.
+    ///
+    /// This includes the `OwnedObject<T>` carrier used by borrowed opaque
+    /// handle plans. It is referenced unqualified from the same generated
+    /// file, so no `use` path leaks into the host crate's source tree.
     fn prerequisites(
         &self,
         registry: &Registry,
@@ -1777,14 +1660,9 @@ impl Declarations {
         // generated Rust uses this.
         // Everything below reads the reading: the identity for a lookup, the
         // spelling for what generated Rust says. Neither needs a node.
-        // Structured-config overrides first (opaque handles, then user-
-        // registered rank-0 wrappers, then built-ins).
+        // Structured-config overrides first (user-registered rank-0 wrappers,
+        // then built-ins). Opaque handles are retained before this fallback.
         let key = reading.key();
-        if let Some(cfg) = self.types.get(&key) {
-            if cfg.is_opaque() {
-                return Some(self.opaque_handle_input(reading, emit));
-            }
-        }
         if let Some(conv) = self.lookup_input(reading, registry, emit) {
             return Some(conv);
         }
@@ -2049,13 +1927,9 @@ impl Declarations {
         // Classify off `kind`, spell with `spell()` — see `input_terminal`.
         // Everything below reads the reading: the identity for a lookup, the
         // spelling for what generated Rust says. Neither needs a node.
-        // Structured-config overrides first (opaque handles, then built-ins).
+        // Structured-config overrides first (built-ins). Opaque handles are
+        // retained before this fallback.
         let key = reading.key();
-        if let Some(cfg) = self.types.get(&key) {
-            if cfg.is_opaque() {
-                return Some(self.opaque_handle_output(reading, emit));
-            }
-        }
         if let Some(conv) = self.lookup_output(reading, registry, emit) {
             return Some(conv);
         }
@@ -2103,43 +1977,6 @@ impl Declarations {
                     metadata: self.framework_meta(kotlin_name),
                 });
             }
-        }
-        None
-    }
-
-    /// Borrowed-handle output terminals.
-    pub(crate) fn output_borrow(
-        &self,
-        produced: &prebindgen_registry::flat::TypeRef,
-        t1: &prebindgen_registry::flat::TypeRef,
-        emit: &prebindgen_registry::Emit,
-    ) -> Option<ConverterImpl<KotlinMeta>> {
-        // Borrowed opaque-handle output (`&T` / `&'static T` where `T` is a
-        // declared opaque handle). Canonical zenoh-flat's `z_*` accessors
-        // return *borrowed* handles for the C tier's zero-copy borrows, but
-        // the JVM keeps its handle past the call — so the only sound lowering
-        // is to clone the referent into a fresh owned `Box`-handle (every such
-        // zenoh handle type is `Clone`). This mirrors `opaque_handle_output`
-        // with a `.clone()`; `Option<&T>` then composes through the `Option`
-        // arm below (it looks up this `&T` entry as its inner). Matched
-        // structurally so the lifetime variant `&'static _` is covered too.
-        if matches!(
-            produced.kind(),
-            prebindgen_registry::flat::TypeKind::Ref { mutable: false, .. }
-        ) && self.types.get(&t1.key()).is_some_and(|c| c.is_opaque())
-        {
-            let wire: syn::Type = syn::parse_quote!(jni::sys::jlong);
-            let body: syn::Expr = syn::parse_quote!(
-                std::boxed::Box::into_raw(std::boxed::Box::new(v.clone())) as i64
-            );
-            return Some(ConverterImpl {
-                subs: vec![],
-                function: self.build_output_fn_of(produced, &wire, &body, None, emit),
-                destination: wire,
-                pre_stages: vec![],
-                niches: Niches::one(syn::parse_quote!(0i64), syn::parse_quote!(*v == 0)),
-                metadata: self.opaque_leaf_meta(t1.key()),
-            });
         }
         None
     }


### PR DESCRIPTION
Part of #513.

## Summary

Replace JniGen's eager opaque-handle Rust builders with one retained handle-codec plan.

The plan covers all four ownership operations:

- consume an owned JNI handle into a Rust value;
- borrow a JVM-owned handle through OwnedObject;
- box an owned Rust output as a new JNI handle;
- clone a borrowed Rust output into a new owned JNI handle.

Rust source types remain Flat TypeRef values during recipe compilation. They are spelled and source-qualified only when the final Rust file is rendered.

## Why

Opaque handles still had three eager builders spread between terminal selection and borrow handling. Those builders accepted Emit and constructed source-typed Rust functions before final generation, unlike the chain-based Product, Optional, Choice, Sequence, Invoke, value, array, and enum paths.

Keeping one frozen operation also makes the ownership convention explicit in one place: jlong wire width, zero as the optional niche, bit zero as Kotlin's closed-handle tag, Box ownership transfer, non-owning borrowed input, and clone-on-borrow output.

## Design

JHandleCodecPlan retains only model and adapter facts: the TypeRef, source module and nominal type identity, operation, converter name, and reachability state. Its final renderer is the only code that asks Emit to spell the Rust type.

The existing owned-input plan becomes the general handle plan. The eager opaque_handle_input, opaque_handle_output, and output_borrow builders are removed, along with the now-unused KotlinMeta constructor.

A temporary emission compatibility rule remains explicit: legacy parents can copy a child converter name without retaining its JFunction dependency. Borrowed-input and output handle terminals therefore keep their historical unconditional emission, while owned input remains demand-driven. Converting those remaining parents to plans will remove this exception.

A seam test asserts that Token and &Token both retain handle plans in both directions. This proves all four operations stay unrendered until final output, rather than merely comparing generated text.

## Compatibility

Regenerating the maintained covertest Rust and Kotlin artifacts produces no diff.

This PR does not use TypeKey text or inspect normalized Rust syntax. The broader TypeKey opacity cleanup is tracked separately in #558.

## Validation

- cargo test --workspace
- cargo clippy --workspace --all-targets --all-features -- -D warnings
- RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps
- cargo fmt --all -- --check
- cargo build -p covertest-kotlin --release plus clean generated-artifact diff
- examples/covertest-kotlin/gradlew run --console=plain: 61/61 sections pass

— Codex (GPT-5)
