### PR TITLE
Render JNI callback delivery from frozen plans

### DIFF
--- a/prebindgen-jni/src/jni/chain.rs
+++ b/prebindgen-jni/src/jni/chain.rs
@@ -977,17 +977,29 @@ impl JPipeline {
         }
     }
 
+    /// Render an already-planned Rust-to-JNI call graph.
+    ///
+    /// Output pipelines can only contain converter children. The transient
+    /// Vec-handle operation is an input-site ABI and is the sole pipeline body
+    /// that needs [`Emit`] to spell its element type. Keeping that case out of
+    /// this API lets return, error, and callback delivery assemble their JNI
+    /// protocol without gaining access to source Rust spelling.
+    pub(crate) fn invoke_output(&self, value: TokenStream) -> TokenStream {
+        let JPipelineBody::Converter(child) = &self.body else {
+            unreachable!("a Rust-to-JNI pipeline cannot contain an input Vec handle")
+        };
+        let call = child.invoke_with_env(quote!(&mut env), value);
+        if child.stages.is_empty() {
+            call
+        } else {
+            quote!((|| -> ::core::result::Result<_, __JniErr> { #call })())
+        }
+    }
+
     /// Render the already-planned call graph around `value`.
     pub(crate) fn invoke(&self, value: TokenStream, emit: &Emit) -> TokenStream {
         match &self.body {
-            JPipelineBody::Converter(child) => {
-                let call = child.invoke_with_env(quote!(&mut env), value);
-                if child.stages.is_empty() {
-                    call
-                } else {
-                    quote!((|| -> ::core::result::Result<_, __JniErr> { #call })())
-                }
-            }
+            JPipelineBody::Converter(_) => self.invoke_output(value),
             JPipelineBody::VecHandle(plan) => {
                 let value = plan.invoke(value, emit);
                 quote!(::core::result::Result::<_, __JniErr>::Ok(#value))

--- a/prebindgen-jni/src/jni/compile.rs
+++ b/prebindgen-jni/src/jni/compile.rs
@@ -2986,7 +2986,7 @@ impl<R: Conversions> Compile for JCompile<'_, R> {
 
     fn callback(
         &mut self,
-        cx: &mut Cx<'_>,
+        _cx: &mut Cx<'_>,
         at: At<'_>,
         arg_fragments: &[&JFrag],
         _result: Option<&JFrag>,
@@ -2995,9 +2995,9 @@ impl<R: Conversions> Compile for JCompile<'_, R> {
         let TypeKind::Callback { args } = ty.unwrapped().kind() else {
             return Err(refuse(at, "a callback recipe over a type that is not one"));
         };
-        let planned =
-            self.decls
-                .dispatch_fn_input(ty, args, self.registry, arg_fragments, cx.emit());
+        let planned = self
+            .decls
+            .dispatch_fn_input(ty, args, self.registry, arg_fragments);
         let (conv, rust) = planned.ok_or_else(|| refuse(at, "undeclared callback signature"))?;
         let mut fragment = JFrag::new(at, conv);
         fragment.rust = rust;

--- a/prebindgen-jni/src/jni/emit/callback.rs
+++ b/prebindgen-jni/src/jni/emit/callback.rs
@@ -6,10 +6,23 @@ use prebindgen_registry::{chain::Chain as _, Conversions};
 use super::*;
 
 #[derive(Clone)]
-struct JInvokePart {
-    source: syn::Ident,
-    prepare: TokenStream,
-    arguments: Vec<TokenStream>,
+enum JInvokePart {
+    Fold {
+        delivery: FrozenDelivery,
+        fold_obj: syn::Ident,
+        fold_id: syn::Ident,
+        element_frame: syn::LitInt,
+    },
+    Decomposed {
+        delivery: FrozenDelivery,
+        optional: bool,
+    },
+    Whole {
+        pipeline: Box<crate::jni::chain::JPipeline>,
+        projection: Option<Projection>,
+        wire: syn::Type,
+        primitive: bool,
+    },
 }
 
 impl prebindgen_registry::chain::InvokePart for JInvokePart {
@@ -17,13 +30,123 @@ impl prebindgen_registry::chain::InvokePart for JInvokePart {
         &self,
         value: &syn::Ident,
         index: usize,
-        _emit: &prebindgen_registry::Emit,
+        emit: &prebindgen_registry::Emit,
     ) -> prebindgen_registry::chain::RenderedInvokePart {
         assert_eq!(value, &callback_argument_name(index));
-        assert_eq!(value, &self.source);
+        let fail = |msg: TokenStream| -> TokenStream {
+            quote! {
+                return ::core::result::Result::Err(
+                    <__JniErr as ::core::convert::From<String>>::from(#msg));
+            }
+        };
+        let (prepare, arguments) = match self {
+            Self::Fold {
+                delivery,
+                fold_obj,
+                fold_id,
+                element_frame,
+            } => {
+                let obj_idents: Vec<syn::Ident> = (0..delivery.wire_count())
+                    .map(|part| format_ident!("__cbfold{}_obj{}", index, part))
+                    .collect();
+                let (leaf_stmts, leaf_args, _) = encode_plan_leaves(
+                    delivery,
+                    delivery.delivered(),
+                    &obj_idents,
+                    &quote!(__cb_elem),
+                    &fail,
+                    emit,
+                );
+                let acc = format_ident!("__fold{}_acc", index);
+                (
+                    quote! {
+                        let #acc: jni::objects::JObject = env
+                            .new_object("java/util/ArrayList", "()V", &[])
+                            .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(format!("fold: new ArrayList: {}", e)))?;
+                        for __cb_elem in #value.iter() {
+                            env.push_local_frame(#element_frame)
+                                .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(format!("fold: push frame: {}", e)))?;
+                            let __fold_res = (|| -> ::core::result::Result<(), __JniErr> {
+                                #leaf_stmts
+                                let _ = unsafe {
+                                    env.call_method_unchecked(
+                                        &#fold_obj,
+                                        #fold_id,
+                                        jni::signature::ReturnType::Object,
+                                        &[jni::sys::jvalue { l: #acc.as_raw() }, #(#leaf_args),*],
+                                    )
+                                }
+                                .map_err(|e| {
+                                    let _ = env.exception_describe();
+                                    <__JniErr as ::core::convert::From<String>>::from(format!("fold run: {}", e))
+                                })?;
+                                ::core::result::Result::Ok(())
+                            })();
+                            let _ = unsafe { env.pop_local_frame(&jni::objects::JObject::null()) };
+                            __fold_res?;
+                        }
+                    },
+                    vec![quote!(jni::sys::jvalue { l: #acc.as_raw() })],
+                )
+            }
+            Self::Decomposed { delivery, optional } => {
+                let obj_idents: Vec<syn::Ident> = (0..delivery.wire_count())
+                    .map(|part| format_ident!("__cb{}_obj{}", index, part))
+                    .collect();
+                let (stmts, mut arguments, present) = encode_plan_leaves(
+                    delivery,
+                    delivery.delivered(),
+                    &obj_idents,
+                    &quote!(#value),
+                    &fail,
+                    emit,
+                );
+                if *optional {
+                    let present = present.expect("a frozen optional callback delivery has a gate");
+                    arguments.insert(0, quote!(jni::sys::jvalue { z: #present }));
+                }
+                (stmts, arguments)
+            }
+            Self::Whole {
+                pipeline,
+                projection,
+                wire,
+                primitive,
+            } => {
+                let enc = format_ident!("__cb{}_enc", index);
+                let call = pipeline.invoke_output(quote!(#value));
+                if projection
+                    .as_ref()
+                    .is_some_and(|projection| projection.kind == ProjectionKind::Handle)
+                {
+                    (
+                        quote!(let #enc = #call?;),
+                        vec![quote!(jni::sys::jvalue { j: #enc })],
+                    )
+                } else if *primitive {
+                    let letter = jni_field_access(wire)
+                        .expect("a primitive callback wire has a jvalue member")
+                        .1;
+                    (
+                        quote!(let #enc = #call?;),
+                        vec![quote!(jni::sys::jvalue { #letter: #enc })],
+                    )
+                } else {
+                    let object = format_ident!("__cb{}_obj", index);
+                    let cast = cast_wire_to_jobject(&enc, wire, &fail);
+                    (
+                        quote! {
+                            let #enc = #call?;
+                            let #object: jni::objects::JObject = #cast;
+                        },
+                        vec![quote!(jni::sys::jvalue { l: #object.as_raw() })],
+                    )
+                }
+            }
+        };
         prebindgen_registry::chain::RenderedInvokePart {
-            prepare: self.prepare.clone(),
-            arguments: self.arguments.clone(),
+            prepare,
+            arguments,
             cleanup: TokenStream::new(),
         }
     }
@@ -247,7 +370,6 @@ pub(crate) fn callback_input(
     args: &[prebindgen_registry::flat::TypeRef],
     registry: &impl Conversions,
     arg_fragments: &[&crate::jni::compile::JFrag],
-    emit: &prebindgen_registry::Emit,
 ) -> Option<(syn::Type, JInvokePlan)> {
     // Human-readable tag for attach/log messages.
     let name = format!(
@@ -259,35 +381,13 @@ pub(crate) fn callback_input(
     );
     let name_lit = syn::LitStr::new(&name, Span::call_site());
 
-    // Trampoline error path for the shared leaf encoder: convert the message
-    // to `__JniErr` inside the per-invocation `Result` closure.
-    let fail = |msg: TokenStream| -> TokenStream {
-        quote! {
-            return ::core::result::Result::Err(
-                <__JniErr as ::core::convert::From<String>>::from(#msg));
-        }
-    };
-
-    let arg_names: Vec<syn::Ident> = (0..args.len()).map(callback_argument_name).collect();
-    // Per-arg encode preludes binding the typed `run`'s args in declared
-    // order (a decomposed arg contributes one arg per leaf). Each entry of
-    // `jvalue_exprs` is a typed `jvalue`: raw primitives for primitive-wire
-    // leaves, `{ l: obj.as_raw() }` for object leaves — matching the
-    // descriptor of the generated callback interface's `run`.
-    let mut preludes: Vec<TokenStream> = Vec::new();
-    let mut jvalue_exprs: Vec<TokenStream> = Vec::new();
+    let mut parts = Vec::with_capacity(args.len());
     let mut total: usize = 0;
     // One-time setup statements (folder singleton + method id for an
     // `&[data_class]` fold arg), spliced before the `Box::new` so the move
     // closure captures them.
     let mut fold_setups: Vec<TokenStream> = Vec::new();
-    let mut part_ranges = Vec::with_capacity(args.len());
-
     for (i, arg_ty) in args.iter().enumerate() {
-        let prelude_start = preludes.len();
-        let argument_start = jvalue_exprs.len();
-        let cb_arg = &arg_names[i];
-
         // `&[data_class]` fold arg: instead of building the whole `List` on the
         // Rust side, allocate an empty `ArrayList` and fold each element's raw
         // leaves through the hoisted `__<Folder>Holder.instance` (Kotlin does
@@ -330,64 +430,14 @@ pub(crate) fn callback_input(
                         .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(format!("resolve folder run {}: {}", #run_cls, e)))?
                 };
             });
-            // Per fire: one `ArrayList`, fold each element's leaves through the
-            // appender (which mutates the list in place and returns it — the
-            // return is ignored). Each element's leaf locals live in a nested
-            // local frame so they are freed per element (the daemon-thread
-            // local-ref discipline — only the `acc` ref crosses iterations).
-            let acc = format_ident!("__fold{}_acc", i);
-            let obj_idents: Vec<syn::Ident> = (0..plan.leaves.len())
-                .map(|k| format_ident!("__cbfold{}_obj{}", i, k))
-                .collect();
-            let (leaf_stmts, leaf_args, _) = encode_plan_leaves(
-                ext,
-                registry,
-                crate::jni::emit::Delivered::planned(plan, wires, chain),
-                &obj_idents,
-                &quote!(__cb_elem),
-                &fail,
-                emit,
-            );
             let elem_frame = std::cmp::max(16, 2 * plan.leaves.len() + 6);
-            let elem_frame_lit = syn::LitInt::new(&elem_frame.to_string(), Span::call_site());
-            preludes.push(quote! {
-                let #acc: jni::objects::JObject = env
-                    .new_object("java/util/ArrayList", "()V", &[])
-                    .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(format!("fold: new ArrayList: {}", e)))?;
-                for __cb_elem in #cb_arg.iter() {
-                    env.push_local_frame(#elem_frame_lit)
-                        .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(format!("fold: push frame: {}", e)))?;
-                    let __fold_res = (|| -> ::core::result::Result<(), __JniErr> {
-                        #leaf_stmts
-                        // The appender returns the same list it mutates, so the
-                        // result is discarded; `#acc` (an outer-frame ref) stays
-                        // valid across the nested frame.
-                        let _ = unsafe {
-                            env.call_method_unchecked(
-                                &#fold_obj,
-                                #fold_id,
-                                jni::signature::ReturnType::Object,
-                                &[jni::sys::jvalue { l: #acc.as_raw() }, #(#leaf_args),*],
-                            )
-                        }
-                        .map_err(|e| {
-                            let _ = env.exception_describe();
-                            <__JniErr as ::core::convert::From<String>>::from(format!("fold run: {}", e))
-                        })?;
-                        ::core::result::Result::Ok(())
-                    })();
-                    let _ = unsafe { env.pop_local_frame(&jni::objects::JObject::null()) };
-                    __fold_res?;
-                }
+            parts.push(JInvokePart::Fold {
+                delivery: FrozenDelivery::new(ext, registry, plan, wires, chain),
+                fold_obj,
+                fold_id,
+                element_frame: syn::LitInt::new(&elem_frame.to_string(), Span::call_site()),
             });
-            jvalue_exprs.push(quote!(jni::sys::jvalue { l: #acc.as_raw() }));
             total += 1;
-            part_ranges.push((
-                prelude_start,
-                preludes.len(),
-                argument_start,
-                jvalue_exprs.len(),
-            ));
             continue;
         }
 
@@ -396,34 +446,21 @@ pub(crate) fn callback_input(
         if let Some(plan) = effective_callback_plan(ext, registry, arg_ty) {
             let fragment = *arg_fragments.get(i)?;
             let (wires, chain) = freeze_callback_delivery(ext, plan, fragment)?;
-            let obj_idents: Vec<syn::Ident> = (0..plan.leaves.len())
-                .map(|k| format_ident!("__cb{}_obj{}", i, k))
-                .collect();
-            let (stmts, mut arg_exprs, present) = encode_plan_leaves(
-                ext,
-                registry,
-                crate::jni::emit::Delivered::planned(plan, wires, chain),
-                &obj_idents,
-                &quote!(#cb_arg),
-                &fail,
-                emit,
-            );
             let optional = plan.is_optional_base();
-            if optional && present.is_none() {
+            if optional
+                && !matches!(
+                    chain.as_ref().map(|chain| &chain.layout),
+                    Some(crate::jni::compile::JLayout::Optional(inner))
+                        if inner.leaf_count() == plan.leaves.len()
+                )
+            {
                 return None;
             }
-            if let Some(present) = present {
-                arg_exprs.insert(0, quote!(jni::sys::jvalue { z: #present }));
-            }
-            preludes.push(stmts);
-            total += arg_exprs.len();
-            jvalue_exprs.extend(arg_exprs);
-            part_ranges.push((
-                prelude_start,
-                preludes.len(),
-                argument_start,
-                jvalue_exprs.len(),
-            ));
+            total += plan.leaves.len() + usize::from(optional);
+            parts.push(JInvokePart::Decomposed {
+                delivery: FrozenDelivery::new(ext, registry, plan, wires, chain),
+                optional,
+            });
             continue;
         }
 
@@ -433,83 +470,25 @@ pub(crate) fn callback_input(
         // projection, and the final JNI wire; rendering does not look the type
         // up again or reconstruct any of those decisions.
         let fragment = *arg_fragments.get(i)?;
-        let cb_val = quote!(#cb_arg);
         let arg_abi = fragment.output_abi();
         arg_abi.activate();
         let crate::jni::compile::OutAbi::Value(arg_value) = arg_abi else {
             unreachable!("a whole callback argument is not a synthesized selector")
         };
         let arg_wire = arg_value.pipeline.wire().clone();
-        let enc_ident = format_ident!("__cb{}_enc", i);
-        let obj_ident = format_ident!("__cb{}_obj", i);
-
-        let conversion = arg_value.pipeline.invoke(cb_val, emit);
-        let conv = quote!(#conversion?);
-
-        // Plan-less opaque-handle arg: encode to a raw `jlong` (`Box::into_raw`)
-        // and deliver it as-is. The typed handle class is constructed Kotlin-side
-        // by the generated `asRaw` proxy (`WrapKind::HandleOwned`), which also
-        // `close()`s it after `run` (close-unless-taken) — so no Rust
-        // `new_object` and no post-invoke close. The Kotlin wrap lets a queryable
-        // consumer reply through the handle inside the callback (a consuming
-        // reply zeroes the slot, making the proxy's `close` a no-op). See
-        // `owned_handle_iface_param`.
-        if let Some(h) = &arg_value.projection {
-            if matches!(h.kind, ProjectionKind::Handle) {
-                preludes.push(quote! {
-                    let #enc_ident = #conv;
-                });
-                jvalue_exprs.push(quote!(jni::sys::jvalue { j: #enc_ident }));
-                total += 1;
-                part_ranges.push((
-                    prelude_start,
-                    preludes.len(),
-                    argument_start,
-                    jvalue_exprs.len(),
-                ));
-                continue;
-            }
-        }
-
-        // Whole-value arg (scalar / String / data-class …):
-        // encode with its output converter. A non-`Option` primitive-wire arg
-        // passes its raw primitive; everything else casts to JObject. Output
-        // converters take the value by move; `cb_arg` is the closure
-        // parameter, so pass it directly.
         let arg_is_prim = arg_value
             .projection
             .as_ref()
             .is_none_or(|p| p.kind == ProjectionKind::Unsigned64)
             && arg_ty.optional_inner().is_none()
             && matches!(jni_field_access(&arg_wire), Some((_, _, false)));
-        if arg_is_prim {
-            let letter = jni_field_access(&arg_wire).unwrap().1;
-            preludes.push(quote! {
-                let #enc_ident = #conv;
-            });
-            jvalue_exprs.push(quote!(jni::sys::jvalue { #letter: #enc_ident }));
-            total += 1;
-            part_ranges.push((
-                prelude_start,
-                preludes.len(),
-                argument_start,
-                jvalue_exprs.len(),
-            ));
-            continue;
-        }
-        let cast = cast_wire_to_jobject(&enc_ident, &arg_wire, &fail);
-        preludes.push(quote! {
-            let #enc_ident = #conv;
-            let #obj_ident: jni::objects::JObject = #cast;
+        parts.push(JInvokePart::Whole {
+            pipeline: Box::new(arg_value.pipeline.clone()),
+            projection: arg_value.projection.clone(),
+            wire: arg_wire,
+            primitive: arg_is_prim,
         });
-        jvalue_exprs.push(quote!(jni::sys::jvalue { l: #obj_ident.as_raw() }));
         total += 1;
-        part_ranges.push((
-            prelude_start,
-            preludes.len(),
-            argument_start,
-            jvalue_exprs.len(),
-        ));
     }
 
     // Typed `run` descriptor of the generated callback interface — the SAME
@@ -526,18 +505,6 @@ pub(crate) fn callback_input(
     let frame_cap = std::cmp::max(16, 2 * total + 6);
     let frame_cap_lit = syn::LitInt::new(&frame_cap.to_string(), Span::call_site());
 
-    let parts = part_ranges
-        .into_iter()
-        .enumerate()
-        .map(|(index, (ps, pe, as_, ae))| JInvokePart {
-            source: arg_names[index].clone(),
-            prepare: {
-                let values = &preludes[ps..pe];
-                quote!(#(#values)*)
-            },
-            arguments: jvalue_exprs[as_..ae].to_vec(),
-        })
-        .collect::<Vec<_>>();
     let chain = prebindgen_registry::chain::Invoke {
         source: source.clone(),
         arguments: args.to_vec(),

--- a/prebindgen-jni/src/jni/emit/delivery.rs
+++ b/prebindgen-jni/src/jni/emit/delivery.rs
@@ -41,6 +41,7 @@ pub(crate) fn emit_unfold_delivery(
     emit: &prebindgen_registry::Emit,
 ) -> TokenStream {
     use prebindgen_registry::unfold::UnfoldShape;
+    let context = LiveDeliveryContext::new(ext, registry);
 
     let n = plan.leaves.len();
 
@@ -65,7 +66,7 @@ pub(crate) fn emit_unfold_delivery(
     let encode_leaves = |value: &TokenStream, optional: bool| {
         let mut delivered = Delivered::planned(plan, output.wires.clone(), output.chain.clone());
         delivered.optional = optional;
-        encode_plan_leaves(ext, registry, delivered, &obj_idents, value, &fail, emit)
+        encode_plan_leaves(&context, delivered, &obj_idents, value, &fail, emit)
     };
 
     // Cached-interface call statics for the builder / folder `run`.
@@ -547,6 +548,193 @@ pub(crate) struct Delivered<'a> {
     pub(crate) chain: Option<crate::jni::compile::ComposedChain>,
 }
 
+/// Facts the leaf renderer may consult after a delivery operation has been
+/// selected. The live implementation serves ordinary wrapper rendering; an
+/// Invoke plan freezes the same answers so callback planning does not retain a
+/// registry or obtain [`prebindgen_registry::Emit`].
+pub(crate) trait DeliveryContext {
+    fn qualify(&self, ident: &syn::Ident) -> syn::Path;
+    fn leaf_is_prim(&self, leaf: &crate::jni::compile::OutWire) -> bool;
+    fn leaf_wire(&self, leaf: &crate::jni::compile::OutWire) -> syn::Type;
+    fn sum(
+        &self,
+        leaf: &crate::jni::compile::OutWire,
+    ) -> (syn::Path, &prebindgen_registry::flat::Variant);
+}
+
+pub(crate) struct LiveDeliveryContext<'a, R> {
+    ext: &'a Declarations,
+    registry: &'a R,
+}
+
+impl<'a, R> LiveDeliveryContext<'a, R> {
+    pub(crate) fn new(ext: &'a Declarations, registry: &'a R) -> Self {
+        Self { ext, registry }
+    }
+}
+
+impl<R: Conversions> DeliveryContext for LiveDeliveryContext<'_, R> {
+    fn qualify(&self, ident: &syn::Ident) -> syn::Path {
+        self.ext.fn_module(self.registry, ident)
+    }
+
+    fn leaf_is_prim(&self, leaf: &crate::jni::compile::OutWire) -> bool {
+        leaf_is_prim(self.ext, leaf)
+    }
+
+    fn leaf_wire(&self, leaf: &crate::jni::compile::OutWire) -> syn::Type {
+        leaf_wire(self.ext, leaf)
+    }
+
+    fn sum(
+        &self,
+        leaf: &crate::jni::compile::OutWire,
+    ) -> (syn::Path, &prebindgen_registry::flat::Variant) {
+        let prebindgen_registry::flat::TypeKind::Named { id, .. } = leaf.out_ty.unwrapped().kind()
+        else {
+            panic!("jnigen sum unfold: selector type is not named")
+        };
+        let ident = id
+            .ident()
+            .unwrap_or_else(|| panic!("jnigen sum unfold: selector type is not an identifier"));
+        let module = self.ext.fn_module(self.registry, &ident);
+        let source = syn::parse_quote!(#module::#ident);
+        let Some(prebindgen_registry::flat::Type::Variant(sum)) =
+            self.registry.flat().declared_type(&ident)
+        else {
+            panic!("jnigen sum unfold: no indexed sum `{ident}`")
+        };
+        (source, sum)
+    }
+}
+
+#[derive(Clone)]
+struct FrozenSum {
+    source: syn::Path,
+    model: prebindgen_registry::flat::Variant,
+}
+
+/// Callback delivery facts frozen while the registry is available. Rust
+/// source types remain as opaque readings inside the wires/pipelines; the only
+/// syntax retained here is origin qualification and Flat alternative shape,
+/// both consumed with `Emit` by the final Invoke renderer.
+#[derive(Clone)]
+pub(crate) struct FrozenDelivery {
+    wires: Vec<crate::jni::compile::OutWire>,
+    hoists: Vec<prebindgen_registry::unfold::Hoist>,
+    by_ref: bool,
+    fixed_product: bool,
+    optional: bool,
+    chain: Option<crate::jni::compile::ComposedChain>,
+    modules: std::collections::BTreeMap<String, syn::Path>,
+    sums: std::collections::BTreeMap<String, FrozenSum>,
+}
+
+impl FrozenDelivery {
+    pub(crate) fn new(
+        ext: &Declarations,
+        registry: &impl Conversions,
+        plan: &prebindgen_registry::unfold::UnfoldPlan,
+        wires: Vec<crate::jni::compile::OutWire>,
+        chain: Option<crate::jni::compile::ComposedChain>,
+    ) -> Self {
+        let mut modules = std::collections::BTreeMap::new();
+        for step in plan
+            .hoists
+            .iter()
+            .flat_map(|hoist| &hoist.prefix)
+            .chain(wires.iter().flat_map(|wire| wire.reach()))
+        {
+            if let prebindgen_registry::unfold::PathStep::Call { ident, .. } = step {
+                modules
+                    .entry(ident.to_string())
+                    .or_insert_with(|| ext.fn_module(registry, ident));
+            }
+        }
+        let mut sums = std::collections::BTreeMap::new();
+        for wire in wires.iter().filter(|wire| wire.is_tag()) {
+            let prebindgen_registry::flat::TypeKind::Named { id, .. } =
+                wire.out_ty.unwrapped().kind()
+            else {
+                panic!("jnigen sum unfold: selector type is not named")
+            };
+            let ident = id.ident().unwrap_or_else(|| {
+                panic!(
+                    "jnigen sum unfold: selector type `{}` is not an identifier",
+                    id.name
+                )
+            });
+            let Some(prebindgen_registry::flat::Type::Variant(sum)) =
+                registry.flat().declared_type(&ident)
+            else {
+                panic!("jnigen sum unfold: no indexed sum `{ident}`")
+            };
+            let module = ext.fn_module(registry, &ident);
+            sums.entry(id.name.clone()).or_insert_with(|| FrozenSum {
+                source: syn::parse_quote!(#module::#ident),
+                model: sum.clone(),
+            });
+        }
+        Self {
+            wires,
+            hoists: plan.hoists.clone(),
+            by_ref: plan.by_ref,
+            fixed_product: plan.fixed_builder,
+            optional: plan.is_optional_base(),
+            chain,
+            modules,
+            sums,
+        }
+    }
+
+    pub(crate) fn delivered(&self) -> Delivered<'_> {
+        Delivered {
+            wires: self.wires.clone(),
+            hoists: &self.hoists,
+            by_ref: self.by_ref,
+            fixed_product: self.fixed_product,
+            optional: self.optional,
+            chain: self.chain.clone(),
+        }
+    }
+
+    pub(crate) fn wire_count(&self) -> usize {
+        self.wires.len()
+    }
+}
+
+impl DeliveryContext for FrozenDelivery {
+    fn qualify(&self, ident: &syn::Ident) -> syn::Path {
+        self.modules
+            .get(&ident.to_string())
+            .unwrap_or_else(|| panic!("frozen JNI delivery has no origin for `{ident}`"))
+            .clone()
+    }
+
+    fn leaf_is_prim(&self, leaf: &crate::jni::compile::OutWire) -> bool {
+        frozen_leaf_is_prim(leaf)
+    }
+
+    fn leaf_wire(&self, leaf: &crate::jni::compile::OutWire) -> syn::Type {
+        frozen_leaf_wire(leaf)
+    }
+
+    fn sum(
+        &self,
+        leaf: &crate::jni::compile::OutWire,
+    ) -> (syn::Path, &prebindgen_registry::flat::Variant) {
+        let prebindgen_registry::flat::TypeKind::Named { id, .. } = leaf.out_ty.unwrapped().kind()
+        else {
+            panic!("jnigen sum unfold: selector type is not named")
+        };
+        let sum = self
+            .sums
+            .get(&id.name)
+            .unwrap_or_else(|| panic!("frozen JNI delivery has no sum `{}`", id.name));
+        (sum.source.clone(), &sum.model)
+    }
+}
+
 impl<'a> Delivered<'a> {
     /// Delivery from a registry-compiled return, callback, or error site.
     pub(crate) fn planned(
@@ -908,8 +1096,7 @@ fn reach_leaf(
 /// arm of fallible externs (whose `fail` routes an encoding failure to the
 /// binding-error channel).
 pub(crate) fn encode_plan_leaves(
-    ext: &Declarations,
-    registry: &impl Conversions,
+    context: &impl DeliveryContext,
     site: Delivered<'_>,
     obj_idents: &[syn::Ident],
     value: &TokenStream,
@@ -926,7 +1113,7 @@ pub(crate) fn encode_plan_leaves(
     } = site;
     // Per-fn origin qualification: each accessor call is prefixed with the
     // module of the crate that defines it (multi-source bindings).
-    let qualify = |id: &syn::Ident| -> syn::Path { ext.fn_module(registry, id) };
+    let qualify = |id: &syn::Ident| -> syn::Path { context.qualify(id) };
     let n = wires.len();
 
     // Typed `jvalue` argument expression per leaf, in leaf order: a non-null
@@ -937,7 +1124,7 @@ pub(crate) fn encode_plan_leaves(
     let mut arg_exprs: Vec<TokenStream> = Vec::with_capacity(n);
     for (idx, leaf) in wires.iter().enumerate() {
         let obj_ident = &obj_idents[idx];
-        if leaf_is_prim(ext, leaf) {
+        if context.leaf_is_prim(leaf) {
             arg_exprs.push(quote!(#obj_ident));
         } else {
             arg_exprs.push(quote!(jni::sys::jvalue { l: #obj_ident.as_raw() }));
@@ -984,8 +1171,8 @@ pub(crate) fn encode_plan_leaves(
                     });
                     continue;
                 }
-                let wire = leaf_wire(ext, leaf);
-                if leaf_is_prim(ext, leaf) {
+                let wire = context.leaf_wire(leaf);
+                if context.leaf_is_prim(leaf) {
                     let (_, member, _) = jni_field_access(&wire)
                         .expect("a primitive Product leaf has a JNI jvalue member");
                     stmts.extend(quote! {
@@ -1130,8 +1317,7 @@ pub(crate) fn encode_plan_leaves(
             }
         };
         let (group_stmts, group_args) = encode_sum_group(
-            ext,
-            registry,
+            context,
             &wires[seg.clone()],
             &obj_idents[seg.clone()],
             matched,
@@ -1144,7 +1330,7 @@ pub(crate) fn encode_plan_leaves(
                 let ids: Vec<&syn::Ident> = obj_idents[seg.clone()].iter().collect();
                 let slots: Vec<Slot> = wires[seg.clone()]
                     .iter()
-                    .map(|l| leaf_slot(ext, l))
+                    .map(|l| leaf_slot(context, l))
                     .collect();
                 let tys = slots.iter().map(|s| &s.ty);
                 let defaults = slots.iter().map(|s| &s.default);
@@ -1492,7 +1678,7 @@ pub(crate) fn encode_plan_leaves(
         // leaves whose `None` arm must yield a JVM null) encodes the reached
         // value with the leaf's output converter and casts to JObject.
         let enc_ident = format_ident!("__enc{}", idx);
-        if leaf_is_prim(ext, leaf) {
+        if context.leaf_is_prim(leaf) {
             let letter = jni_field_access(&wire)
                 .expect("leaf_is_prim guarantees a primitive wire")
                 .1;
@@ -1535,8 +1721,8 @@ pub(crate) fn encode_plan_leaves(
             })
             .collect();
         let ids: Vec<&syn::Ident> = idxs.iter().map(|&k| &obj_idents[k]).collect();
-        let tys = idxs.iter().map(|&k| leaf_slot(ext, &wires[k]).ty);
-        let defaults = idxs.iter().map(|&k| leaf_slot(ext, &wires[k]).default);
+        let tys = idxs.iter().map(|&k| leaf_slot(context, &wires[k]).ty);
+        let defaults = idxs.iter().map(|&k| leaf_slot(context, &wires[k]).default);
         // Matched BY VALUE: the local is this arm's alone (every leaf under the
         // hoist is in it), so a consuming value form's fields move out here
         // exactly as they do at an unconditional one.
@@ -1599,6 +1785,34 @@ pub(crate) fn leaf_wire(ext: &Declarations, leaf: &crate::jni::compile::OutWire)
             .destination
             .clone(),
     }
+}
+
+fn frozen_leaf_wire(leaf: &crate::jni::compile::OutWire) -> syn::Type {
+    match &leaf.abi {
+        Some(crate::jni::compile::OutAbi::Tag) => syn::parse_quote!(jni::sys::jint),
+        Some(crate::jni::compile::OutAbi::Value(value)) => value.pipeline.wire().clone(),
+        None => panic!("frozen JNI delivery leaf `{}` has no output ABI", leaf.name),
+    }
+}
+
+fn frozen_leaf_is_prim(leaf: &crate::jni::compile::OutWire) -> bool {
+    if leaf.is_tag() {
+        return !leaf.nullable;
+    }
+    if leaf.nullable {
+        return false;
+    }
+    let Some(crate::jni::compile::OutAbi::Value(value)) = &leaf.abi else {
+        panic!("frozen JNI delivery leaf `{}` has no output ABI", leaf.name)
+    };
+    let proj_ok = match &value.projection {
+        None => true,
+        Some(projection) => matches!(
+            projection.kind,
+            ProjectionKind::Handle | ProjectionKind::Unsigned64
+        ),
+    };
+    proj_ok && matches!(jni_field_access(value.pipeline.wire()), Some((_, _, false)))
 }
 
 /// The wire half of [`leaf_is_prim`]: does a leaf of this type occupy a **raw

--- a/prebindgen-jni/src/jni/emit/sum_out.rs
+++ b/prebindgen-jni/src/jni/emit/sum_out.rs
@@ -86,8 +86,11 @@ pub(crate) struct Slot {
     pub(crate) default: TokenStream,
 }
 
-pub(crate) fn leaf_slot(ext: &Declarations, leaf: &crate::jni::compile::OutWire) -> Slot {
-    if !leaf_is_prim(ext, leaf) {
+pub(crate) fn leaf_slot(
+    context: &impl DeliveryContext,
+    leaf: &crate::jni::compile::OutWire,
+) -> Slot {
+    if !context.leaf_is_prim(leaf) {
         return Slot {
             prim: false,
             ty: quote!(jni::objects::JObject),
@@ -99,7 +102,7 @@ pub(crate) fn leaf_slot(ext: &Declarations, leaf: &crate::jni::compile::OutWire)
     let (sig, letter) = if leaf.is_tag() {
         ("I", format_ident!("i"))
     } else {
-        let wire = leaf_wire(ext, leaf);
+        let wire = context.leaf_wire(leaf);
         let (sig, letter, _) =
             jni_field_access(&wire).expect("leaf_is_prim guarantees a primitive wire");
         (sig, letter)
@@ -136,8 +139,7 @@ pub(crate) fn is_sum_row(leaves: &[crate::jni::compile::OutWire]) -> bool {
 /// is that a leaf here is not an independent expression — its slot exists in
 /// every arm and only one arm computes it.
 pub(crate) fn encode_sum_group(
-    ext: &Declarations,
-    registry: &impl Conversions,
+    context: &impl DeliveryContext,
     leaves: &[crate::jni::compile::OutWire],
     obj_idents: &[syn::Ident],
     matched: TokenStream,
@@ -151,27 +153,9 @@ pub(crate) fn encode_sum_group(
         .iter()
         .find(|l| l.is_tag())
         .expect("a sum segment carries its selector leaf");
-    // The name off the reading — `TypeId` IS the name, so nothing takes a path
-    // apart to re-derive one.
-    let prebindgen_registry::flat::TypeKind::Named { id, .. } = tag_leaf.out_ty.unwrapped().kind()
-    else {
-        panic!(
-            "jnigen sum unfold: selector type `{}` is not a named type",
-            tag_leaf.out_ty.key()
-        )
-    };
-    // Raw-aware: a sum may legitimately be named `r#type`, and `Ident::new`
-    // rejects that spelling.
-    let ident = id.ident().unwrap_or_else(|| {
-        panic!(
-            "jnigen sum unfold: selector type `{}` is not a single identifier",
-            id.name
-        )
-    });
-    let module = ext.fn_module(registry, &ident);
-    let source: syn::Path = syn::parse_quote!(#module::#ident);
+    let (source, sum) = context.sum(tag_leaf);
 
-    let slots: Vec<Slot> = leaves.iter().map(|l| leaf_slot(ext, l)).collect();
+    let slots: Vec<Slot> = leaves.iter().map(|l| leaf_slot(context, l)).collect();
 
     let arg_exprs: Vec<TokenStream> = leaves
         .iter()
@@ -205,15 +189,6 @@ pub(crate) fn encode_sum_group(
         .position(|l| l.is_tag())
         .expect("a sum plan carries its selector leaf");
     let tag_id = &obj_idents[tag_idx];
-    // A unit variant contributes no leaf, so the arm list is driven by the
-    // enum's own alternatives, not by the grouped leaves. `enum_item` hands
-    // back only the `syn::ItemEnum`, deliberately — a consumer that acts on the
-    // Variant/Enum distinction asks `declared_type` (#289).
-    let Some(prebindgen_registry::flat::Type::Variant(sum)) = registry.flat().declared_type(&ident)
-    else {
-        panic!("jnigen sum unfold: no indexed sum `{ident}` for the decomposed sum")
-    };
-
     let arms: Vec<TokenStream> = sum
         .alternatives
         .iter()
@@ -252,7 +227,7 @@ pub(crate) fn encode_sum_group(
                 .zip(&binds)
                 .map(|(&idx, bind)| {
                     encode_group_leaf(
-                        ext,
+                        context,
                         &leaves[idx],
                         &obj_idents[idx],
                         slots[idx].prim,
@@ -310,7 +285,7 @@ pub(crate) fn encode_sum_group(
 /// payload and a struct field of the same type reach their converter the same
 /// way.
 fn encode_group_leaf(
-    ext: &Declarations,
+    context: &impl DeliveryContext,
     leaf: &crate::jni::compile::OutWire,
     obj_ident: &syn::Ident,
     prim: bool,
@@ -328,7 +303,7 @@ fn encode_group_leaf(
             leaf.name
         ),
     };
-    let wire = leaf_wire(ext, leaf);
+    let wire = context.leaf_wire(leaf);
     let conv_fail = fail(quote!(__e.to_string()));
     let enc = format_ident!("__enc_{}", obj_ident);
     let mut encode = TokenStream::new();

--- a/prebindgen-jni/src/jni/emit/wrapper.rs
+++ b/prebindgen-jni/src/jni/emit/wrapper.rs
@@ -326,9 +326,9 @@ pub(crate) fn emit_jni_function_wrapper_with_callee(
                 return #on_err;
             }
         };
+        let context = LiveDeliveryContext::new(ext, registry);
         let (ze_stmts, ze_args, _) = encode_plan_leaves(
-            ext,
-            registry,
+            &context,
             crate::jni::emit::Delivered::planned(&ep.unfold, ep.wires.clone(), ep.chain.clone()),
             &eze_idents,
             &quote!(__de),

--- a/prebindgen-jni/src/jni/tests/callbacks.rs
+++ b/prebindgen-jni/src/jni/tests/callbacks.rs
@@ -305,6 +305,9 @@ fn undeclared_expanded_callback_retains_its_registry_invoke_plan() {
 /// and the adapter planner cannot accept an `Emit` parameter later.
 #[test]
 fn callback_planning_has_no_source_spelling_access() {
+    // These delimiters deliberately follow rustfmt's stable spelling of both
+    // private signatures. If either signature changes, update this fence's
+    // boundary before deciding whether the new capability is still forbidden.
     let compile = include_str!("../compile.rs");
     let callback_hook = compile
         .split_once("    fn callback(\n")

--- a/prebindgen-jni/src/jni/tests/callbacks.rs
+++ b/prebindgen-jni/src/jni/tests/callbacks.rs
@@ -299,6 +299,33 @@ fn undeclared_expanded_callback_retains_its_registry_invoke_plan() {
     assert!(rust.contains("ledger_archived(&__cb_arg0)"), "{rust}");
 }
 
+/// Planning an Invoke may freeze Flat/model and JNI ABI facts, but only the
+/// final `RustFunction::render` boundary may receive `Emit`. Pin both sides of
+/// that seam: the recipe hook does not ask its compiler context for spelling,
+/// and the adapter planner cannot accept an `Emit` parameter later.
+#[test]
+fn callback_planning_has_no_source_spelling_access() {
+    let compile = include_str!("../compile.rs");
+    let callback_hook = compile
+        .split_once("    fn callback(\n")
+        .expect("callback recipe hook")
+        .1
+        .split_once("    /// One site:")
+        .expect("end of callback recipe hook")
+        .0;
+    assert!(!callback_hook.contains(".emit()"), "{callback_hook}");
+
+    let callback = include_str!("../emit/callback.rs");
+    let planner_signature = callback
+        .split_once("pub(crate) fn callback_input(\n")
+        .expect("callback planner")
+        .1
+        .split_once(") -> Option<(syn::Type, JInvokePlan)>")
+        .expect("callback planner signature")
+        .0;
+    assert!(!planner_signature.contains("Emit"), "{planner_signature}");
+}
+
 /// Regression: a callback-delivered type that has BOTH a nested handle identity
 /// (a child `ptr_class` reached by an accessor) AND its own root identity
 /// (`expand_return!` `.field_self()`) must emit the root MOVE after every borrow of

--- a/prebindgen-jni/src/jni/trait_impl.rs
+++ b/prebindgen-jni/src/jni/trait_impl.rs
@@ -1252,9 +1252,8 @@ impl Declarations {
         args: &[prebindgen_registry::flat::TypeRef],
         registry: &impl Conversions,
         arg_fragments: &[&crate::jni::compile::JFrag],
-        emit: &prebindgen_registry::Emit,
     ) -> Option<(ConverterImpl<KotlinMeta>, crate::jni::chain::JFunction)> {
-        let (wire, plan) = callback_input(self, source, args, registry, arg_fragments, emit)?;
+        let (wire, plan) = callback_input(self, source, args, registry, arg_fragments)?;
         let niches = default_niches_for_wire(&wire);
         // `impl Fn(...)` crosses the extern tier as the erased lambda object
         // (`Any`) — same as the unfold builder / error-sink params. The typed


### PR DESCRIPTION
## Why

JNI callback crossings already retained the registry's shared `Invoke` chain, but each `JInvokePart` still contained Rust tokens assembled during recipe planning. That assembly called `cx.emit()`, so callback planning could spell captured source types before the final writer boundary.

## What changed

- Retain callback arguments as semantic `Fold`, `Decomposed`, or `Whole` delivery operations. The registry's final `InvokePart::render` pass now supplies the source argument binding and `Emit`.
- Freeze the exact JNI output ABI, converter pipelines, accessor origin qualification, and Flat sum alternatives needed by decomposed callback delivery. Final rendering consumes that snapshot without a registry lookup.
- Share the leaf encoder through explicit live/frozen delivery contexts, so ordinary return/error rendering and late callback rendering keep one implementation.
- Split Rust-to-JNI pipeline invocation from the input-only transient-`Vec` handle operation. Output delivery can invoke its frozen converter graph without accepting `Emit`.
- Remove `Emit` from `callback_input`, `dispatch_fn_input`, and the callback recipe hook. A source-boundary test prevents that access from returning.

This removes the callback compiler's final planning-time source-spelling path. The two remaining `cx.emit()` calls are confined to the explicit atomic/sequence whole-object terminal compatibility fallback handled by later umbrella slices.

## Compatibility

Generated Rust, generated Kotlin, JNI names/descriptors, and runtime behavior are unchanged. The regeneration check is byte-identical.

## Verification

- `cargo test --workspace` — passed
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` — passed
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps` — passed
- `cargo fmt --all --check` — passed
- `git diff --check` — passed
- `bash examples/regen-check.sh` — passed; generated output byte-identical
- `cd examples/covertest-kotlin && ./gradlew run --console=plain` — passed all 61 sections

Part of #513.
