### PR TITLE
Render JNI whole-struct codecs from frozen plans

### DIFF
--- a/prebindgen-jni/src/jni/chain.rs
+++ b/prebindgen-jni/src/jni/chain.rs
@@ -28,6 +28,7 @@ enum JBody {
     Choice(Box<JChoicePlan>),
     Sequence(Box<JSequencePlan>),
     Optional(Box<JOptionalPlan>),
+    StructCodec(Box<JStructCodecPlan>),
     Invoke(Box<crate::jni::emit::JInvokePlan>),
 }
 
@@ -84,6 +85,10 @@ impl JFunction {
         Self(JBody::Choice(Box::new(plan)))
     }
 
+    pub(crate) fn struct_codec(plan: JStructCodecPlan) -> Self {
+        Self(JBody::StructCodec(Box::new(plan)))
+    }
+
     pub(crate) fn invoke(plan: crate::jni::emit::JInvokePlan) -> Self {
         Self(JBody::Invoke(Box::new(plan)))
     }
@@ -101,6 +106,11 @@ impl JFunction {
     #[cfg(test)]
     pub(crate) fn is_handle_codec(&self) -> bool {
         matches!(self.0, JBody::HandleCodec(_))
+    }
+
+    #[cfg(test)]
+    pub(crate) fn is_struct_codec(&self) -> bool {
+        matches!(self.0, JBody::StructCodec(_))
     }
 
     #[cfg(test)]
@@ -174,6 +184,10 @@ impl JFunction {
                     dependency.mark_reachable();
                 }
             }
+            // The legacy whole-object parents still make every terminal
+            // reachable. Struct codecs retain no source syntax, but keep that
+            // compatibility reachability until those parents are planned too.
+            JBody::StructCodec(_) => {}
             // An Invoke plan exists only for a declared callback crossing and
             // is called directly by that crossing's wrapper. Unlike reusable
             // child converters, it is reachable by construction and needs no
@@ -198,6 +212,7 @@ impl RustFunction for JFunction {
             JBody::Choice(plan) => &plan.ident,
             JBody::Sequence(plan) => &plan.ident,
             JBody::Optional(plan) => &plan.ident,
+            JBody::StructCodec(plan) => &plan.ident,
             JBody::Invoke(plan) => plan.name(),
         }
     }
@@ -222,6 +237,7 @@ impl RustFunction for JFunction {
             JBody::Optional(plan) => plan.reachable.get(),
             JBody::Sequence(plan) => plan.reachable.get(),
             JBody::Choice(plan) => plan.reachable.get(),
+            JBody::StructCodec(_) => true,
             // See `mark_reachable`: callback converters are roots, never
             // dormant dependencies waiting for a parent to activate them.
             JBody::Invoke(_) => true,
@@ -242,7 +258,73 @@ impl RustFunction for JFunction {
             JBody::Optional(plan) => plan.render(emit),
             JBody::Choice(plan) => plan.render(emit),
             JBody::Sequence(plan) => plan.render(emit),
+            JBody::StructCodec(plan) => plan.render(emit),
             JBody::Invoke(plan) => plan.render(emit),
+        }
+    }
+}
+
+/// One whole-object struct terminal retained as Flat shape plus JNI policy.
+///
+/// The plan deliberately holds no `syn::Type` or token body for the source
+/// crossing. The writer supplies [`Emit`] once resolution, glue planning, and
+/// Kotlin planning are complete; only then is the source signature spelled and
+/// the captured struct delimiter shape assembled.
+#[derive(Clone)]
+pub(crate) struct JStructCodecPlan {
+    pub(crate) ident: syn::Ident,
+    pub(crate) source: TypeRef,
+    pub(crate) direction: Direction,
+    pub(crate) body: JStructCodecBody,
+}
+
+#[derive(Clone)]
+pub(crate) enum JStructCodecBody {
+    Input(Box<crate::jni::emit::JObjectStructInputPlan>),
+    Output {
+        plan: std::rc::Rc<crate::jni::struct_plan::StructPlan>,
+        java_class_name: String,
+    },
+}
+
+impl JStructCodecPlan {
+    fn render(&self, emit: &Emit) -> syn::ItemFn {
+        let name = &self.ident;
+        let source = emit.spell_ty(&self.source);
+        let wire: syn::Type = syn::parse_quote!(jni::objects::JObject);
+        let body = match &self.body {
+            JStructCodecBody::Input(plan) => plan.render(emit),
+            JStructCodecBody::Output {
+                plan,
+                java_class_name,
+            } => crate::jni::emit::render_struct_output_body(plan, java_class_name),
+        };
+        let allow = crate::jni::trait_impl::generated_converter_attr();
+        match self.direction {
+            Direction::Construct => {
+                let wire = annotate_jobject_with_lifetime(&wire, "v");
+                syn::parse_quote!(
+                    #allow
+                    pub(crate) unsafe fn #name<'env, 'v>(
+                        env: &mut jni::JNIEnv<'env>,
+                        v: &#wire,
+                    ) -> ::core::result::Result<#source, __JniErr> {
+                        Ok(#body)
+                    }
+                )
+            }
+            Direction::Deconstruct => {
+                let wire = annotate_jobject_with_lifetime(&wire, "a");
+                syn::parse_quote!(
+                    #allow
+                    pub(crate) unsafe fn #name<'a>(
+                        env: &mut jni::JNIEnv<'a>,
+                        v: #source,
+                    ) -> ::core::result::Result<#wire, __JniErr> {
+                        Ok(#body)
+                    }
+                )
+            }
         }
     }
 }
@@ -996,6 +1078,22 @@ impl JPipeline {
         }
     }
 
+    /// Render a converter pipeline inside another generated converter, where
+    /// `env` is already the borrowed `JNIEnv` rather than an owned wrapper
+    /// parameter. Whole-object property plans use this to retain child chains
+    /// without retaining their generated Rust expressions.
+    pub(crate) fn invoke_converter(
+        &self,
+        env: TokenStream,
+        value: TokenStream,
+        stage_base: &syn::Ident,
+    ) -> TokenStream {
+        let JPipelineBody::Converter(child) = &self.body else {
+            unreachable!("a whole-object field cannot use the transient Vec-handle site ABI")
+        };
+        child.invoke_input_value_with_env(env, value, stage_base)
+    }
+
     /// Render the already-planned call graph around `value`.
     pub(crate) fn invoke(&self, value: TokenStream, emit: &Emit) -> TokenStream {
         match &self.body {
@@ -1039,6 +1137,44 @@ impl JVecHandleInput {
 }
 
 impl JChild {
+    /// Render a constructing child as the value it yields inside an enclosing
+    /// converter. Unlike the ordinary chain API this consumes `Result` here,
+    /// because the enclosing function already owns the error channel. Stage
+    /// bindings are named by the property that owns them, preventing sibling
+    /// fields from colliding.
+    fn invoke_input_value_with_env(
+        &self,
+        env: TokenStream,
+        value: TokenStream,
+        stage_base: &syn::Ident,
+    ) -> TokenStream {
+        assert_eq!(self.direction, Direction::Construct);
+        let converter = self.call.ident();
+        let value = match self.value_use {
+            JValueUse::Direct => value,
+            JValueUse::SharedRef => shared_ref(value),
+            JValueUse::Cloned => quote!((*#value).clone()),
+        };
+        let first = quote!(#converter(#env, #value));
+        if self.stages.is_empty() {
+            return quote!(#first?);
+        }
+        let first_name = format_ident!("{}_s0", stage_base);
+        let mut body = quote!(let #first_name = #first?;);
+        let mut previous = first_name;
+        for (index, stage) in self.stages.iter().enumerate() {
+            let next = format_ident!("{}_s{}", stage_base, index + 1);
+            body.extend(quote!(
+                let #next = #stage(#env, #previous)
+                    .map_err(|__e| <__JniErr as ::core::convert::From<String>>::from(
+                        __e.to_string()
+                    ))?;
+            ));
+            previous = next;
+        }
+        quote!({ #body #previous })
+    }
+
     /// Render this child in a context that supplies its own `JNIEnv` expression.
     /// Registry-composed converter bodies receive an `&mut JNIEnv` named
     /// `env`; exported wrappers own a mutable `JNIEnv` and pass `&mut env`.

--- a/prebindgen-jni/src/jni/compile.rs
+++ b/prebindgen-jni/src/jni/compile.rs
@@ -1070,6 +1070,76 @@ impl<R: Conversions> JCompile<'_, R> {
         ))
     }
 
+    /// Freeze a whole-object struct terminal from the Flat declaration and
+    /// already-selected child chains. No source type is spelled and no Rust
+    /// body is assembled here; [`JStructCodecPlan`](crate::jni::chain::JStructCodecPlan)
+    /// performs both only when the shared writer supplies `Emit`.
+    fn planned_struct_codec(&self, at: At<'_>) -> Option<JFrag> {
+        let source = at.crossing.spelled();
+        let TypeKind::Named { id, .. } = source.kind() else {
+            return None;
+        };
+        let name = id.ident()?;
+        let st = self.registry.flat().struct_type(&name)?;
+        let direction = at.crossing.direction();
+        let wire: syn::Type = syn::parse_quote!(jni::objects::JObject);
+        let body = match direction {
+            Direction::Construct => crate::jni::chain::JStructCodecBody::Input(Box::new(
+                crate::jni::emit::build_jobject_struct_input_plan(self.decls, st, self.registry)?,
+            )),
+            Direction::Deconstruct => {
+                let plan = self.decls.struct_plan(self.registry, st, 0)?;
+                let registered = self
+                    .decls
+                    .types
+                    .get(&source.key())
+                    .and_then(|config| config.name_spec.as_ref())
+                    .map(|spec| self.decls.fqn_of(spec));
+                let prefix = self.decls.java_class_prefix();
+                let java_class_name = registered.map_or_else(
+                    || {
+                        if prefix.is_empty() {
+                            st.name.to_string()
+                        } else {
+                            format!("{prefix}/{}", st.name)
+                        }
+                    },
+                    |fqn| fqn.replace('.', "/"),
+                );
+                crate::jni::chain::JStructCodecBody::Output {
+                    plan,
+                    java_class_name,
+                }
+            }
+        };
+        let ident = crate::jni::chain::planned_name(direction, source, &wire);
+        let marker = crate::jni::chain::planned_marker(&ident);
+        let niches = default_niches_for_wire(&wire);
+        let kotlin_name = self
+            .decls
+            .types
+            .get(&source.key())
+            .and_then(|config| config.name_spec.as_ref())
+            .map(|spec| KtType::cls(self.decls.fqn_of(spec)));
+        Some(JFrag::planned(
+            at,
+            ConverterImpl {
+                subs: Vec::new(),
+                pre_stages: Vec::new(),
+                function: marker,
+                destination: wire,
+                niches,
+                metadata: self.decls.framework_meta(kotlin_name),
+            },
+            crate::jni::chain::JFunction::struct_codec(crate::jni::chain::JStructCodecPlan {
+                ident,
+                source: source.clone(),
+                direction,
+                body,
+            }),
+        ))
+    }
+
     /// Freeze a declared fieldless enum as Flat variant/discriminant facts.
     /// The plan deliberately does not retain an enum path or a rendered Rust
     /// body: final emission supplies the source type and constructs the variant
@@ -2648,6 +2718,9 @@ impl<R: Conversions> Compile for JCompile<'_, R> {
         if let Some(frag) = self.planned_transparent_bridge(at) {
             return Ok(frag);
         }
+        if let Some(frag) = self.planned_struct_codec(at) {
+            return Ok(frag);
+        }
         let emit = cx.emit();
         let conv = match at.crossing.direction() {
             Direction::Construct => self
@@ -2656,7 +2729,7 @@ impl<R: Conversions> Compile for JCompile<'_, R> {
                 .or_else(|| self.borrow(ty, true)),
             Direction::Deconstruct => self
                 .decls
-                .output_terminal(ty, self.registry, emit)
+                .output_terminal(ty, emit)
                 .or_else(|| self.borrow(ty, false)),
         };
         if conv.is_none()
@@ -2820,7 +2893,7 @@ impl<R: Conversions> Compile for JCompile<'_, R> {
                 .or_else(|| self.borrow(ty, true)),
             Direction::Deconstruct => self
                 .decls
-                .output_terminal(ty, self.registry, emit)
+                .output_terminal(ty, emit)
                 .or_else(|| self.borrow(ty, false)),
         };
         let mut frag = self.wrap(at, "no JNI representation for this run", conv)?;
@@ -3365,6 +3438,14 @@ impl Conv {
         JCompile::<Registry>::planned_pipeline(direction, mode, &self.0)
     }
 
+    pub(crate) fn destination(&self) -> &syn::Type {
+        &self.0.conv.destination
+    }
+
+    pub(crate) fn projection(&self) -> Option<Projection> {
+        self.0.conv.metadata.projection.clone()
+    }
+
     /// Freeze this exact compiled fragment as one outgoing ABI operation.
     pub(crate) fn output_abi(&self) -> OutAbi {
         self.0.output_abi()
@@ -3378,6 +3459,11 @@ impl Conv {
     #[cfg(test)]
     pub(crate) fn is_handle_codec_plan(&self) -> bool {
         self.0.rust.is_handle_codec()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn is_struct_codec_plan(&self) -> bool {
+        self.0.rust.is_struct_codec()
     }
 
     #[cfg(test)]

--- a/prebindgen-jni/src/jni/emit/flat_input.rs
+++ b/prebindgen-jni/src/jni/emit/flat_input.rs
@@ -16,262 +16,341 @@ use crate::jni::trait_impl::build_through_erased_wrappers;
 /// answer rather than a last-path-segment test on tokens that had a reading one
 /// level up. Same move `build_flat_struct_node` made for the flatten path; this
 /// is the whole-object `.jobject_input()` decoder.
-pub(crate) fn struct_input_body(
+#[derive(Clone)]
+pub(crate) struct JObjectStructInputPlan {
+    shape: flat::Struct,
+    source_module: syn::Path,
+    fields: Vec<JObjectStructFieldPlan>,
+}
+
+#[derive(Clone)]
+struct JObjectStructFieldPlan {
+    name: syn::Ident,
+    property: String,
+    error: String,
+    kind: JObjectStructFieldKind,
+}
+
+#[derive(Clone)]
+enum JObjectStructFieldKind {
+    Handle {
+        descriptor: String,
+        pipeline: crate::jni::chain::JPipeline,
+    },
+    Unsigned64 {
+        optional: bool,
+        wrap_some: bool,
+        pipeline: crate::jni::chain::JPipeline,
+    },
+    Enum {
+        descriptor: String,
+        optional: bool,
+        pipeline: crate::jni::chain::JPipeline,
+    },
+    Primitive {
+        wire: syn::Type,
+        descriptor: String,
+        accessor: syn::Ident,
+        pipeline: crate::jni::chain::JPipeline,
+    },
+    IntoObject {
+        wire: syn::Type,
+        descriptor: String,
+        pipeline: crate::jni::chain::JPipeline,
+    },
+    Object {
+        descriptor: String,
+        pipeline: crate::jni::chain::JPipeline,
+    },
+}
+
+/// Freeze the explicit whole-`JObject` struct decoder without assembling Rust
+/// source. Every branch below selects JVM property policy from Flat readings
+/// and already-compiled registry fragments. The final writer alone constructs
+/// bindings, child calls, and the source struct literal.
+pub(crate) fn build_jobject_struct_input_plan(
     ext: &Declarations,
     s: &flat::Struct,
     registry: &impl Conversions,
-    emit: &prebindgen_registry::Emit,
-) -> Option<(syn::Type, syn::Expr)> {
+) -> Option<JObjectStructInputPlan> {
     let struct_name = s.name.to_string();
-    let struct_module = struct_module_path(ext, registry, &s.name);
-    let struct_ident = &s.name;
-
-    let mut field_preludes: Vec<TokenStream> = Vec::new();
-    let mut field_init: Vec<TokenStream> = Vec::new();
-
+    let mut fields = Vec::new();
     for field in &s.fields {
-        // A positional field has no name to read a JVM slot by, which is what
-        // the `syn::Fields::Named` guard used to say one level up. Said per
-        // field now, because the element models a field list rather than a
-        // `syn::Fields` shape.
-        let fname_ident = field.name.clone()?;
-        // The name the property was DECLARED with — `GetFieldID` takes the
-        // slot's exact name, so this cannot be derived a second way.
-        let camel = kotlin_property_name(&fname_ident);
-        let err_prefix = format!("{struct_name}.{camel}: {{}}");
-        let raw_ident = format_ident!("__{}_raw", fname_ident);
-
-        // Defer if any field's input converter isn't resolved yet — the
-        // fixed-point loop will retry on the next iteration. The field's own
-        // reading straight to its entry — the `reading_of` hop only ever
-        // recovered what the field already carried.
-        let field_entry = ext.in_frag(&field.ty)?;
-        field_entry.activate();
-        // The optional layer off the MODEL, asked once and reused: every site
-        // below that wants "is this field optional" reads this, so they cannot
-        // disagree with each other the way four independent path-segment tests
-        // could (#273). `option_inner_type` compared the last path segment, so
-        // a field spelled `Box<Option<T>>` answered "not optional" here.
-        let field_optional = field.ty.optional_inner().is_some();
+        let name = field.name.clone()?;
+        let property = kotlin_property_name(&name);
+        let error = format!("{struct_name}.{property}: {{}}");
+        let optional = field.ty.optional_inner().is_some();
         let inner = field.ty.optional_inner().unwrap_or(&field.ty);
-        let field_wire = field_entry.destination.clone();
-        // The field's COMPLETE decode, stages included — a `convert!` type
-        // reaches its Rust value through them (`jlong -> u64 -> Duration`).
-        let field_conv = composed_entry_decode(&field_entry, &raw_ident, &fname_ident);
+        let entry = ext.in_frag(&field.ty)?;
+        let wire = entry.destination().clone();
+        let projection = entry.projection();
+        let whole = entry.pipeline(
+            prebindgen_registry::recipe::Direction::Construct,
+            prebindgen_registry::recipe::Mode::Owned,
+        );
 
-        // Projection fields — mirror of `struct_output_body`'s kind branch:
-        //  * Handle: read the JNINativeHandle object from the JVM slot,
-        //    `peek()` the raw jlong, then run the per-field input converter
-        //    (jlong-keyed; null handle ⇒ jlong 0 ⇒ `None` via the niche path).
-        if let Some(proj) = &field_entry.metadata.projection {
-            match proj.kind {
-                ProjectionKind::Handle => {
-                    let java_path = handle_field_fqn(ext, proj).replace('.', "/");
-                    let sig = format!("L{};", java_path);
-                    let tmp_ident = format_ident!("__{}_jobj", fname_ident);
-                    field_preludes.push(quote! {
-                        let #tmp_ident: jni::objects::JObject = env.get_field(v, #camel, #sig)
-                            .and_then(|val| val.l())
-                            .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(format!(#err_prefix, e)))?;
-                        let #raw_ident: jni::sys::jlong = if #tmp_ident.is_null() {
-                            0
-                        } else {
-                            env.call_method(&#tmp_ident, "peek", "()J", &[])
-                                .and_then(|val| val.j())
-                                .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(format!(#err_prefix, e)))?
-                        };
-                        let #fname_ident = #field_conv;
-                    });
-                }
+        let kind = if let Some(projection) = projection {
+            match projection.kind {
+                ProjectionKind::Handle => JObjectStructFieldKind::Handle {
+                    descriptor: format!(
+                        "L{};",
+                        handle_field_fqn(ext, &projection).replace('.', "/")
+                    ),
+                    pipeline: whole,
+                },
                 ProjectionKind::Unsigned64 => {
-                    if field_optional {
-                        let niche = matches!(
-                            proj.strategy,
+                    let niche = optional
+                        && matches!(
+                            projection.strategy,
                             FoldStrategy::Optional(NullableKind::Niche, _)
                         );
-                        let inner_entry = ext.in_frag(inner)?;
-                        inner_entry.activate();
-                        let inner_conv =
-                            composed_entry_decode(&inner_entry, &raw_ident, &fname_ident);
-                        let tmp_ident = format_ident!("__{}_jobj", fname_ident);
-                        let decode = if niche {
-                            // The Kotlin data-class property is still `ULong?`
-                            // (and therefore boxed in object storage), but its
-                            // JNI converter is niche-keyed on primitive jlong.
-                            // Run the complete field converter so every custom
-                            // semantic stage (e.g. u64 -> Duration) is applied.
-                            quote! { #field_conv }
-                        } else {
-                            quote! {
-                                ::core::option::Option::Some(#inner_conv)
-                            }
-                        };
-                        field_preludes.push(quote! {
-                            let #tmp_ident: jni::objects::JObject = env
-                                .get_field(v, #camel, "Lkotlin/ULong;")
-                                .and_then(|val| val.l())
-                                .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(format!(#err_prefix, e)))?;
-                            let #fname_ident = if #tmp_ident.is_null() {
-                                ::core::option::Option::None
-                            } else {
-                                let #raw_ident: jni::sys::jlong = env
-                                    .call_method(&#tmp_ident, "unbox-impl", "()J", &[])
-                                    .and_then(|val| val.j())
-                                    .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(format!(#err_prefix, e)))?;
-                                #decode
-                            };
-                        });
+                    let pipeline = if optional && !niche {
+                        ext.in_frag(inner)?.pipeline(
+                            prebindgen_registry::recipe::Direction::Construct,
+                            prebindgen_registry::recipe::Mode::Owned,
+                        )
                     } else {
-                        field_preludes.push(quote! {
-                            let #raw_ident: jni::sys::jlong = env
-                                .get_field(v, #camel, "J")
-                                .and_then(|val| val.j())
-                                .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(format!(#err_prefix, e)))?;
-                            let #fname_ident = #field_conv;
-                        });
+                        whole
+                    };
+                    JObjectStructFieldKind::Unsigned64 {
+                        optional,
+                        wrap_some: optional && !niche,
+                        pipeline,
                     }
                 }
             }
-            field_init.push(quote!(#fname_ident));
-            continue;
-        }
-
-        // Enum-typed field (bare or `Option`-wrapped): the Kotlin data class
-        // stores the TYPED enum object (`Priority` / `Priority?`), so read the
-        // slot with the enum-class descriptor and decode the discriminant via
-        // its `value` getter (`getValue()I`); a null object is the `None` arm.
-        // (The generic converters can't be used here: both are jint-keyed,
-        // while this Kotlin property is an enum object or null.)
-        if ext.is_kotlin_enum_reading(inner) {
-            // The NAME off the classification, not off the last path segment:
-            // `Box<T>` IS `T` here, and taking the spelling apart would answer
-            // about the wrapper.
-            if let Some(fqn) = match inner.unwrapped().kind() {
+        } else if ext.is_kotlin_enum_reading(inner) {
+            let fqn = match inner.unwrapped().kind() {
                 flat::TypeKind::Named { id, .. } => id.ident(),
                 _ => None,
             }
-            .and_then(|n| ext.kotlin_fqn(&TypeKey::from_ident(&n)))
-            .map(|v| v.to_string())
-            {
-                let sig = format!("L{};", fqn.replace('.', "/"));
-                let inner_entry = ext.in_frag(inner)?;
-                inner_entry.activate();
-                let inner_conv = composed_entry_decode(&inner_entry, &raw_ident, &fname_ident);
-                let tmp_ident = format_ident!("__{}_jobj", fname_ident);
-                let decode = if field_optional {
-                    quote! {
-                        let #fname_ident = if #tmp_ident.is_null() {
-                            ::core::option::Option::None
-                        } else {
-                            let #raw_ident: jni::sys::jint = env.call_method(&#tmp_ident, "getValue", "()I", &[])
-                                .and_then(|val| val.i())
-                                .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(format!(#err_prefix, e)))?;
-                            ::core::option::Option::Some(#inner_conv)
-                        };
-                    }
-                } else {
-                    quote! {
-                        let #raw_ident: jni::sys::jint = env.call_method(&#tmp_ident, "getValue", "()I", &[])
-                            .and_then(|val| val.i())
-                            .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(format!(#err_prefix, e)))?;
-                        let #fname_ident = #inner_conv;
-                    }
-                };
-                field_preludes.push(quote! {
-                    let #tmp_ident: jni::objects::JObject = env.get_field(v, #camel, #sig)
-                        .and_then(|val| val.l())
-                        .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(format!(#err_prefix, e)))?;
-                    #decode
-                });
-                field_init.push(quote!(#fname_ident));
-                continue;
+            .and_then(|ident| ext.kotlin_fqn(&TypeKey::from_ident(&ident)))?;
+            let pipeline = if optional {
+                ext.in_frag(inner)?.pipeline(
+                    prebindgen_registry::recipe::Direction::Construct,
+                    prebindgen_registry::recipe::Mode::Owned,
+                )
+            } else {
+                whole
+            };
+            JObjectStructFieldKind::Enum {
+                descriptor: format!("L{};", fqn.replace('.', "/")),
+                optional,
+                pipeline,
             }
-        }
-
-        match jni_field_access(&field_wire) {
-            Some((sig, accessor, false)) => {
-                field_preludes.push(quote! {
-                    let #raw_ident: #field_wire = env.get_field(v, #camel, #sig)
-                        .and_then(|val| val.#accessor())
-                        .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(format!(#err_prefix, e)))? as _;
-                    let #fname_ident = #field_conv;
-                });
-            }
-            Some((sig, _, true)) => {
-                let tmp_ident = format_ident!("__{}_jobj", fname_ident);
-                field_preludes.push(quote! {
-                    let #tmp_ident: jni::objects::JObject = env.get_field(v, #camel, #sig)
-                        .and_then(|val| val.l())
-                        .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(format!(#err_prefix, e)))?;
-                    let #raw_ident: #field_wire = #tmp_ident.into();
-                    let #fname_ident = #field_conv;
-                });
-            }
-            None => {
-                // Wire is JObject — fetch via .l() and pass by reference. JNI
-                // `GetFieldID` needs the slot's EXACT static descriptor: the
-                // box class for an `Option`-boxed primitive, the registered
-                // Kotlin class for a nested data-class field (Option-stripped
-                // — a nullable field keeps the same descriptor), `List` for a
-                // `Vec` field.
-                let sig = ext
-                    .in_frag(inner)
-                    .and_then(|e| jni_field_access(&e.destination))
-                    .and_then(|(sig, _, is_obj)| {
-                        if is_obj {
-                            Some(sig.to_string())
-                        } else {
-                            box_descriptor_for_primitive(sig).map(str::to_string)
-                        }
-                    })
-                    .or_else(|| {
-                        // The NAME off the classification, not off the last
-                        // path segment.
-                        match inner.unwrapped().kind() {
-                            flat::TypeKind::Named { id, .. } => id.ident(),
-                            _ => None,
-                        }
-                        .and_then(|name| {
-                            ext.kotlin_fqn(&TypeKey::from_ident(&name))
-                                .map(|v| format!("L{};", v.replace('.', "/")))
+        } else {
+            match jni_field_access(&wire) {
+                Some((descriptor, accessor, false)) => JObjectStructFieldKind::Primitive {
+                    wire,
+                    descriptor: descriptor.to_string(),
+                    accessor,
+                    pipeline: whole,
+                },
+                Some((descriptor, _, true)) => JObjectStructFieldKind::IntoObject {
+                    wire,
+                    descriptor: descriptor.to_string(),
+                    pipeline: whole,
+                },
+                None => {
+                    let descriptor = ext
+                        .in_frag(inner)
+                        .and_then(|entry| jni_field_access(entry.destination()))
+                        .and_then(|(descriptor, _, is_object)| {
+                            if is_object {
+                                Some(descriptor.to_string())
+                            } else {
+                                box_descriptor_for_primitive(descriptor).map(str::to_string)
+                            }
                         })
-                    })
-                    .or_else(|| {
-                        // A run of values is what `kind` says it is.
-                        // `pat_match_top(.., "Vec")` compared the last path
-                        // segment, so a `Box<Vec<T>>` answered false.
-                        if inner.sequence_elem().is_some() {
-                            Some("Ljava/util/List;".to_string())
-                        } else {
-                            None
-                        }
-                    })
-                    .unwrap_or_else(|| "Ljava/lang/Object;".to_string());
-                field_preludes.push(quote! {
-                    let #raw_ident: jni::objects::JObject = env.get_field(v, #camel, #sig)
-                        .and_then(|val| val.l())
-                        .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(format!(#err_prefix, e)))?;
-                    let #fname_ident = #field_conv;
-                });
+                        .or_else(|| {
+                            match inner.unwrapped().kind() {
+                                flat::TypeKind::Named { id, .. } => id.ident(),
+                                _ => None,
+                            }
+                            .and_then(|ident| {
+                                ext.kotlin_fqn(&TypeKey::from_ident(&ident))
+                                    .map(|fqn| format!("L{};", fqn.replace('.', "/")))
+                            })
+                        })
+                        .or_else(|| {
+                            inner
+                                .sequence_elem()
+                                .is_some()
+                                .then(|| "Ljava/util/List;".to_string())
+                        })
+                        .unwrap_or_else(|| "Ljava/lang/Object;".to_string());
+                    JObjectStructFieldKind::Object {
+                        descriptor,
+                        pipeline: whole,
+                    }
+                }
             }
-        }
-        field_init.push(quote!(#fname_ident));
+        };
+        fields.push(JObjectStructFieldPlan {
+            name,
+            property,
+            error,
+            kind,
+        });
     }
+    Some(JObjectStructInputPlan {
+        shape: s.clone(),
+        source_module: struct_module_path(ext, registry, &s.name),
+        fields,
+    })
+}
 
-    // The struct's OWN delimiters, from the one place that chooses them.
-    // `flat::Struct` does not record whether its fields were named — that is
-    // spelling — so hard-coding braces here emitted `Unit {}` for
-    // `struct Unit;` and `Empty {}` for `struct Empty()`, neither of which is
-    // Rust. The `syn::Fields::Named` guard this walk replaced happened to
-    // refuse both; the per-field name check cannot, because an empty struct
-    // has no field to refuse. `Struct::spell` is the dual of the
-    // `Alternative::spell` the sum decoder uses for exactly this.
-    let ctor = emit.shape_struct(s, quote!(#struct_module::#struct_ident), &field_init);
-    let body: syn::Expr = syn::parse_quote!({
-        #(#field_preludes)*
-        #ctor
-    });
-    Some((syn::parse_quote!(jni::objects::JObject), body))
+impl JObjectStructInputPlan {
+    pub(crate) fn render(&self, emit: &prebindgen_registry::Emit) -> syn::Expr {
+        let mut preludes = Vec::new();
+        let mut inits = Vec::new();
+        for field in &self.fields {
+            let name = &field.name;
+            let property = &field.property;
+            let error = &field.error;
+            let raw = format_ident!("__{}_raw", name);
+            let object = format_ident!("__{}_jobj", name);
+            let code = match &field.kind {
+                JObjectStructFieldKind::Handle {
+                    descriptor,
+                    pipeline,
+                } => {
+                    let decode = pipeline.invoke_converter(quote!(env), quote!(#raw), name);
+                    quote! {
+                        let #object: jni::objects::JObject = env.get_field(v, #property, #descriptor)
+                            .and_then(|val| val.l())
+                            .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(format!(#error, e)))?;
+                        let #raw: jni::sys::jlong = if #object.is_null() {
+                            0
+                        } else {
+                            env.call_method(&#object, "peek", "()J", &[])
+                                .and_then(|val| val.j())
+                                .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(format!(#error, e)))?
+                        };
+                        let #name = #decode;
+                    }
+                }
+                JObjectStructFieldKind::Unsigned64 {
+                    optional,
+                    wrap_some,
+                    pipeline,
+                } => {
+                    let decode = pipeline.invoke_converter(quote!(env), quote!(#raw), name);
+                    if *optional {
+                        let decoded = if *wrap_some {
+                            quote!(::core::option::Option::Some(#decode))
+                        } else {
+                            quote!(#decode)
+                        };
+                        quote! {
+                            let #object: jni::objects::JObject = env
+                                .get_field(v, #property, "Lkotlin/ULong;")
+                                .and_then(|val| val.l())
+                                .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(format!(#error, e)))?;
+                            let #name = if #object.is_null() {
+                                ::core::option::Option::None
+                            } else {
+                                let #raw: jni::sys::jlong = env
+                                    .call_method(&#object, "unbox-impl", "()J", &[])
+                                    .and_then(|val| val.j())
+                                    .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(format!(#error, e)))?;
+                                #decoded
+                            };
+                        }
+                    } else {
+                        quote! {
+                            let #raw: jni::sys::jlong = env
+                                .get_field(v, #property, "J")
+                                .and_then(|val| val.j())
+                                .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(format!(#error, e)))?;
+                            let #name = #decode;
+                        }
+                    }
+                }
+                JObjectStructFieldKind::Enum {
+                    descriptor,
+                    optional,
+                    pipeline,
+                } => {
+                    let decode = pipeline.invoke_converter(quote!(env), quote!(#raw), name);
+                    if *optional {
+                        quote! {
+                            let #object: jni::objects::JObject = env.get_field(v, #property, #descriptor)
+                                .and_then(|val| val.l())
+                                .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(format!(#error, e)))?;
+                            let #name = if #object.is_null() {
+                                ::core::option::Option::None
+                            } else {
+                                let #raw: jni::sys::jint = env.call_method(&#object, "getValue", "()I", &[])
+                                    .and_then(|val| val.i())
+                                    .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(format!(#error, e)))?;
+                                ::core::option::Option::Some(#decode)
+                            };
+                        }
+                    } else {
+                        quote! {
+                            let #object: jni::objects::JObject = env.get_field(v, #property, #descriptor)
+                                .and_then(|val| val.l())
+                                .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(format!(#error, e)))?;
+                            let #raw: jni::sys::jint = env.call_method(&#object, "getValue", "()I", &[])
+                                .and_then(|val| val.i())
+                                .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(format!(#error, e)))?;
+                            let #name = #decode;
+                        }
+                    }
+                }
+                JObjectStructFieldKind::Primitive {
+                    wire,
+                    descriptor,
+                    accessor,
+                    pipeline,
+                } => {
+                    let decode = pipeline.invoke_converter(quote!(env), quote!(#raw), name);
+                    quote! {
+                        let #raw: #wire = env.get_field(v, #property, #descriptor)
+                            .and_then(|val| val.#accessor())
+                            .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(format!(#error, e)))? as _;
+                        let #name = #decode;
+                    }
+                }
+                JObjectStructFieldKind::IntoObject {
+                    wire,
+                    descriptor,
+                    pipeline,
+                } => {
+                    let decode = pipeline.invoke_converter(quote!(env), quote!(#raw), name);
+                    quote! {
+                        let #object: jni::objects::JObject = env.get_field(v, #property, #descriptor)
+                            .and_then(|val| val.l())
+                            .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(format!(#error, e)))?;
+                        let #raw: #wire = #object.into();
+                        let #name = #decode;
+                    }
+                }
+                JObjectStructFieldKind::Object {
+                    descriptor,
+                    pipeline,
+                } => {
+                    let decode = pipeline.invoke_converter(quote!(env), quote!(#raw), name);
+                    quote! {
+                        let #raw: jni::objects::JObject = env.get_field(v, #property, #descriptor)
+                            .and_then(|val| val.l())
+                            .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(format!(#error, e)))?;
+                        let #name = #decode;
+                    }
+                }
+            };
+            preludes.push(code);
+            inits.push(quote!(#name));
+        }
+        let module = &self.source_module;
+        let ident = &self.shape.name;
+        let ctor = emit.shape_struct(&self.shape, quote!(#module::#ident), &inits);
+        syn::parse_quote!({
+            #(#preludes)*
+            #ctor
+        })
+    }
 }
 
 /// Whole-object **input** decode for a `sealed_class` sum: a `JObject` of the
@@ -376,7 +455,7 @@ pub(crate) fn sum_input_body(
 
 /// Read one Kotlin property off `receiver` and decode it to its Rust value,
 /// binding the result to `bind`. Mirrors the per-field decode
-/// [`struct_input_body`] performs, for the positions that are properties of a
+/// [`JObjectStructInputPlan`] performs, for positions that are properties of a
 /// generated class rather than fields of a data class.
 #[allow(clippy::too_many_arguments)]
 fn read_kotlin_property(
@@ -406,7 +485,7 @@ fn read_kotlin_property(
 
     // A handle property is a `NativeHandle` object whose raw pointer comes
     // from `peek()`; an enum property is the Kotlin enum class, decoded
-    // through its `getValue`. Both mirror `struct_input_body`.
+    // through its `getValue`. Both mirror `JObjectStructInputPlan`.
     if let Some(proj) = &entry.metadata.projection {
         if matches!(proj.kind, ProjectionKind::Handle) {
             let fqn = handle_field_fqn(ext, proj).replace('.', "/");
@@ -433,7 +512,7 @@ fn read_kotlin_property(
     // An enum property — bare or under `Option` — is stored as the Kotlin
     // **enum object**, so it is read through `getValue`, NOT through the
     // generic converters: both are `jint`-keyed, and neither matches what the
-    // JVM slot actually holds. `struct_input_body` makes the same
+    // JVM slot actually holds. `JObjectStructInputPlan` makes the same
     // distinction for data-class fields; this is that logic for a property.
     if ext.is_kotlin_enum_reading(inner) {
         // The NAME off the classification, not off the last path segment.

--- a/prebindgen-jni/src/jni/emit/struct_out.rs
+++ b/prebindgen-jni/src/jni/emit/struct_out.rs
@@ -19,7 +19,7 @@ pub(crate) fn handle_field_fqn(ext: &Declarations, h: &Projection) -> String {
             FoldStrategy::Iterable(_) => panic!(
                 "struct handle field: collection (Vec<Handle>) layers are not yet \
                  supported by the struct encode/decode bridge — add array codegen \
-                 to struct_output_body/struct_input_body to lift this guard"
+                 to the late struct output/input plans to lift this guard"
             ),
         }
     }
@@ -98,31 +98,6 @@ pub(crate) fn synth_value_struct_leaves(
             })
             .collect(),
     )
-}
-
-/// Recursively flatten a struct's output encode into a list of leaf wire
-/// slots plus the preludes that compute them, so the whole object graph can
-/// be built by a **single** Kotlin `fromParts` call (no per-nested-struct
-/// `call_static_method`). Nested non-optional data-class fields are inlined;
-/// nested `Option<data-class>` fields emit a `present` `jboolean` slot followed
-/// by the child's leaves (encoded in the `Some` arm, defaulted in the `None`
-/// arm). Leaves (primitives, handles→`jlong`, enums→`jint`, strings, arrays,
-/// `Vec`) terminate the recursion.
-///
-/// The field classification is the shared [`build_struct_plan`] — the same
-/// plan `flatten_struct_factory` walks for the Kotlin side, so the slot
-/// order and JVM descriptors agree by construction.
-pub(crate) fn flatten_struct_encode(
-    ext: &Declarations,
-    registry: &impl Conversions,
-    s: &prebindgen_registry::flat::Struct,
-    access: &TokenStream,
-    prefix: &str,
-    depth: usize,
-    env_expr: &TokenStream,
-) -> Option<(TokenStream, Vec<EncSlot>)> {
-    let plan = ext.struct_plan(registry, s, depth)?;
-    Some(encode_plan(&plan, access, prefix, depth, env_expr))
 }
 
 /// Walk a [`StructPlan`] emitting the Rust-side wire encode: per leaf a
@@ -539,38 +514,19 @@ fn encode_field(
     (preludes, slots)
 }
 
-pub(crate) fn struct_output_body(
-    ext: &Declarations,
-    s: &prebindgen_registry::flat::Struct,
-    registry: &impl Conversions,
-) -> Option<(syn::Type, syn::Expr)> {
-    let struct_name = s.name.to_string();
-    // Prefer the registered Kotlin FQN (`io.zenoh.jni.JniSample`) so the
-    // mangle closure flows through; fall back to the bare struct ident
-    // qualified with the package when no `data_class` /
-    // `ptr_class` declaration exists for this Rust type.
-    let struct_ident = &s.name;
-    let struct_ty: syn::Type = syn::parse_quote!(#struct_ident);
-    let registered_fqn = ext
-        .types
-        .get(&TypeKey::from_type(&struct_ty))
-        .and_then(|cfg| cfg.name_spec.as_ref())
-        .map(|s| ext.fqn_of(s));
-    let java_class_prefix = ext.java_class_prefix();
-    let java_class_name = if let Some(fqn) = registered_fqn {
-        fqn.replace('.', "/")
-    } else if java_class_prefix.is_empty() {
-        struct_name.clone()
-    } else {
-        format!("{}/{}", java_class_prefix, struct_name)
-    };
-
+/// Assemble the Rust→JVM half of a frozen whole-struct codec.
+///
+/// Classification, child selection, JVM descriptors, and the target Kotlin
+/// class are all frozen before this point. This function only turns that plan
+/// into the final converter body; it performs no registry or declaration
+/// lookup and cannot rediscover source-type facts.
+pub(crate) fn render_struct_output_body(plan: &StructPlan, java_class_name: &str) -> syn::Expr {
     // Recursively flatten the whole object graph into leaf wires, then build it
     // with ONE `call_static_method("fromParts", …)` — no per-nested-struct JNI
     // crossing. The Kotlin `fromParts` factory (recursively flattened the same
     // way in `render_data_class_source`) reassembles the graph in bytecode.
     let access = quote!(v);
-    let (preludes, slots) = flatten_struct_encode(ext, registry, s, &access, "", 0, &quote!(env))?;
+    let (preludes, slots) = encode_plan(plan, &access, "", 0, &quote!(env));
 
     let mut sig = String::from("(");
     let mut args: Vec<TokenStream> = Vec::new();
@@ -598,7 +554,7 @@ pub(crate) fn struct_output_body(
         .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(format!("encode struct via fromParts: {}", e)))?;
         __obj
     });
-    Some((syn::parse_quote!(jni::objects::JObject), body))
+    body
 }
 
 pub(crate) fn struct_module_path(

--- a/prebindgen-jni/src/jni/fold.rs
+++ b/prebindgen-jni/src/jni/fold.rs
@@ -81,7 +81,7 @@ pub(crate) fn projection_wrap_expr(kind: &ProjectionKind, short: &str, raw: &str
 /// For a projection (handle / unsigned) **struct field**,
 /// compute the `(wire_param_type, wrap_expr)` the data class's `fromParts`
 /// factory uses: the wire param type matches the leaf wire
-/// `struct_output_body` passes (handle → `Long` jlong sentinel), and the wrap
+/// the late struct-output codec passes (handle → `Long` jlong sentinel), and the wrap
 /// reconstructs the typed value in JVM
 /// bytecode (`Short(arg)`, with null mapped from the `0L` sentinel for handles
 /// or the declared invalid `Long` for a bounded unsigned representation; JVM

--- a/prebindgen-jni/src/jni/render.rs
+++ b/prebindgen-jni/src/jni/render.rs
@@ -226,7 +226,7 @@ pub(crate) fn build_data_class(
         }
         class = class.member(KtFun::new("close").modifier("override").body(body));
     }
-    // `fromParts` factory: native (`struct_output_body`) makes ONE
+    // `fromParts` factory: the late native struct codec makes ONE
     // `call_static_method` passing the whole graph's flattened leaf wires;
     // this factory reassembles it (incl. nested `Child.fromParts(...)`) in
     // JVM bytecode. `public`, not `internal`: an `internal` fun is mangled

--- a/prebindgen-jni/src/jni/tests/values.rs
+++ b/prebindgen-jni/src/jni/tests/values.rs
@@ -333,6 +333,33 @@ fn fixed_primitive_arrays_retain_late_registry_plans() {
     );
 }
 
+/// Whole-struct planning may inspect Flat fields and freeze JNI property
+/// policy, but it must not receive the capability that spells captured source
+/// types. Pin both entry points: the recipe compiler never asks its context for
+/// `Emit`, and the JObject plan builder cannot accept one later.
+#[test]
+fn whole_struct_planning_has_no_source_spelling_access() {
+    let compile = include_str!("../compile.rs");
+    let planner = compile
+        .split_once("    fn planned_struct_codec(&self, at: At<'_>)")
+        .expect("whole-struct planner")
+        .1
+        .split_once("    /// Freeze a declared fieldless enum")
+        .expect("end of whole-struct planner")
+        .0;
+    assert!(!planner.contains(".emit()"), "{planner}");
+
+    let input = include_str!("../emit/flat_input.rs");
+    let signature = input
+        .split_once("pub(crate) fn build_jobject_struct_input_plan(")
+        .expect("JObject struct plan builder")
+        .1
+        .split_once(") -> Option<JObjectStructInputPlan>")
+        .expect("JObject struct plan signature")
+        .0;
+    assert!(!signature.contains("Emit"), "{signature}");
+}
+
 #[test]
 fn cow_byte_slices_retain_a_late_value_codec() {
     let registry = crate::test_util::reg_from_items(declare_referenced(vec![(
@@ -1524,6 +1551,26 @@ fn jobject_input_is_an_explicit_hybrid_leaf_escape_hatch() {
     let _ = std::fs::remove_dir_all(&dir);
     std::fs::create_dir_all(&dir).unwrap();
     let generation = jni.build_with(registry).expect("resolve");
+    let object_child = generation
+        .registry
+        .reading(&TypeKey::from_type(&syn::parse_quote!(ObjectChild)))
+        .expect("ObjectChild reading");
+    assert!(
+        generation
+            .decls
+            .in_frag(&object_child)
+            .expect("ObjectChild whole input")
+            .is_struct_codec_plan(),
+        "the explicit JObject decoder must remain an unrendered struct plan"
+    );
+    assert!(
+        generation
+            .decls
+            .out_frag(&object_child)
+            .expect("ObjectChild whole output")
+            .is_struct_codec_plan(),
+        "the fromParts encoder must remain an unrendered struct plan"
+    );
     // The two boundaries this fixture draws, stated as the recipe states them:
     // `object` is declared `.jobject_input()` and stays ONE value, and `maybe`
     // is an `Option<data_class>`, which is a presence flag plus the inner's

--- a/prebindgen-jni/src/jni/trait_impl.rs
+++ b/prebindgen-jni/src/jni/trait_impl.rs
@@ -1628,7 +1628,7 @@ impl Declarations {
     // ── Input converters ─────────────────────────────────────────────
 
     /// Remaining whole-type **input** compatibility categories: destination
-    /// primitive overrides and explicit whole-object sum/struct decoders.
+    /// primitive overrides and the explicit whole-object sum decoder.
     ///
     /// Bare scalars and all string terminals are compiled as
     /// `JValueCodecPlan`s before this fallback is entered.
@@ -1703,27 +1703,6 @@ impl Declarations {
                     });
                 }
             }
-            if let Some(s) = registry.flat().struct_type(&name) {
-                let (wire, body) = struct_input_body(self, s, registry, emit)?;
-                let niches = default_niches_for_wire(&wire);
-                // Auto-generated struct: the value-context Kotlin name is
-                // whatever the user pinned via `data_class`. If
-                // they didn't, leave `kotlin_name = None` — emitter
-                // surfaces this as a build-time hard error.
-                let kotlin_name = self
-                    .types
-                    .get(&key)
-                    .and_then(|c| c.name_spec.as_ref())
-                    .map(|s| KtType::cls(self.fqn_of(s)));
-                return Some(ConverterImpl {
-                    subs: vec![],
-                    pre_stages: vec![],
-                    function: self.build_input_fn_of(reading, &wire, &body, None, emit),
-                    destination: wire,
-                    niches,
-                    metadata: self.framework_meta(kotlin_name),
-                });
-            }
             // Bare-ident enum: leave to the consuming crate to override
             // (today's CongestionControl etc. fall here — caller's wrapper
             // ext returns Some in its own input_terminal).
@@ -1733,14 +1712,13 @@ impl Declarations {
 
     // ── Output converters ────────────────────────────────────────────
 
-    /// Remaining whole-type **output** compatibility categories: destination
-    /// primitive overrides and explicit whole-object struct encoders.
+    /// Remaining whole-type **output** compatibility category: destination
+    /// primitive overrides.
     /// Bare scalars, all string terminals, and unit are compiled as
     /// `JValueCodecPlan`s before this fallback is entered.
     pub(crate) fn output_terminal(
         &self,
         reading: &prebindgen_registry::flat::TypeRef,
-        registry: &impl Conversions,
         emit: &prebindgen_registry::Emit,
     ) -> Option<ConverterImpl<KotlinMeta>> {
         // Classify off `kind`, spell with `spell()` — see `input_terminal`.
@@ -1748,7 +1726,6 @@ impl Declarations {
         // spelling for what generated Rust says. Neither needs a node.
         // Opaque handles and canonical custom conversions are retained before
         // this fallback.
-        let key = reading.key();
         if let Some((wire, body)) = (!matches!(
             reading.unwrapped().kind(),
             prebindgen_registry::flat::TypeKind::Scalar(_)
@@ -1774,25 +1751,6 @@ impl Declarations {
                 niches,
                 metadata,
             });
-        }
-        if let Some(name) = reading.key().ident() {
-            if let Some(s) = registry.flat().struct_type(&name) {
-                let (wire, body) = struct_output_body(self, s, registry)?;
-                let niches = default_niches_for_wire(&wire);
-                let kotlin_name = self
-                    .types
-                    .get(&key)
-                    .and_then(|c| c.name_spec.as_ref())
-                    .map(|s| KtType::cls(self.fqn_of(s)));
-                return Some(ConverterImpl {
-                    subs: vec![],
-                    pre_stages: vec![],
-                    function: self.build_output_fn_of(reading, &wire, &body, None, emit),
-                    destination: wire,
-                    niches,
-                    metadata: self.framework_meta(kotlin_name),
-                });
-            }
         }
         None
     }


### PR DESCRIPTION
## Summary

- retain JNI whole-object struct input and output terminals as frozen plans carrying the Flat source reading, struct shape, selected JNI field policy, and already-compiled child converter pipelines;
- spell the source `TypeRef` and assemble the Rust converter body only in the final `RustFunction::render` pass after the shared writer supplies `Emit`;
- delete the eager `struct_input_body` / `struct_output_body` builders and their terminal fallbacks while preserving `.jobject_input()` as the explicit one-`JObject` boundary.

## Design and compatibility

The input plan classifies each field from Flat readings and freezes only adapter-owned JNI policy such as property descriptors, primitive handling, handle access, and child pipelines. Final rendering asks `Emit` to construct the source struct shape. Output reuses the frozen Kotlin `StructPlan` and renders its constructor call only at the same final boundary.

A seam test proves the whole-struct compiler cannot obtain `Emit` and that the input-plan builder cannot accept it. The explicit `JObject` fixture also proves both directions retain `JStructCodecPlan` rather than a complete Rust function.

Whole-struct codecs remain unconditionally emitted while their legacy whole-object parents still own compatibility reachability. A later slice will move those parents onto planned dependencies and remove this temporary reachability rule.

Generated Rust, JNI ABI, and Kotlin artifacts remain byte-identical.

Related to #513 and #506.

## Verification

- `cargo test --workspace` — passed
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` — passed
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps` — passed
- `cargo fmt --all --check` — passed
- `git diff --check` — passed
- `bash examples/regen-check.sh` — passed; generated output byte-identical
- `cd examples/covertest-kotlin && ./gradlew run --console=plain` — passed all 61 sections