### PR TITLE
Render JNI whole-sum codecs from frozen plans

### DIFF
--- a/prebindgen-jni/src/jni/chain.rs
+++ b/prebindgen-jni/src/jni/chain.rs
@@ -29,6 +29,7 @@ enum JBody {
     Sequence(Box<JSequencePlan>),
     Optional(Box<JOptionalPlan>),
     StructCodec(Box<JStructCodecPlan>),
+    SumCodec(Box<JSumCodecPlan>),
     Invoke(Box<crate::jni::emit::JInvokePlan>),
 }
 
@@ -89,6 +90,10 @@ impl JFunction {
         Self(JBody::StructCodec(Box::new(plan)))
     }
 
+    pub(crate) fn sum_codec(plan: JSumCodecPlan) -> Self {
+        Self(JBody::SumCodec(Box::new(plan)))
+    }
+
     pub(crate) fn invoke(plan: crate::jni::emit::JInvokePlan) -> Self {
         Self(JBody::Invoke(Box::new(plan)))
     }
@@ -111,6 +116,11 @@ impl JFunction {
     #[cfg(test)]
     pub(crate) fn is_struct_codec(&self) -> bool {
         matches!(self.0, JBody::StructCodec(_))
+    }
+
+    #[cfg(test)]
+    pub(crate) fn is_sum_codec(&self) -> bool {
+        matches!(self.0, JBody::SumCodec(_))
     }
 
     #[cfg(test)]
@@ -185,9 +195,11 @@ impl JFunction {
                 }
             }
             // The legacy whole-object parents still make every terminal
-            // reachable. Struct codecs retain no source syntax, but keep that
-            // compatibility reachability until those parents are planned too.
+            // reachable. Whole-object codecs retain no source syntax, but keep
+            // that compatibility reachability until those parents are planned
+            // too.
             JBody::StructCodec(_) => {}
+            JBody::SumCodec(_) => {}
             // An Invoke plan exists only for a declared callback crossing and
             // is called directly by that crossing's wrapper. Unlike reusable
             // child converters, it is reachable by construction and needs no
@@ -213,6 +225,7 @@ impl RustFunction for JFunction {
             JBody::Sequence(plan) => &plan.ident,
             JBody::Optional(plan) => &plan.ident,
             JBody::StructCodec(plan) => &plan.ident,
+            JBody::SumCodec(plan) => &plan.ident,
             JBody::Invoke(plan) => plan.name(),
         }
     }
@@ -238,6 +251,7 @@ impl RustFunction for JFunction {
             JBody::Sequence(plan) => plan.reachable.get(),
             JBody::Choice(plan) => plan.reachable.get(),
             JBody::StructCodec(_) => true,
+            JBody::SumCodec(_) => true,
             // See `mark_reachable`: callback converters are roots, never
             // dormant dependencies waiting for a parent to activate them.
             JBody::Invoke(_) => true,
@@ -259,6 +273,7 @@ impl RustFunction for JFunction {
             JBody::Choice(plan) => plan.render(emit),
             JBody::Sequence(plan) => plan.render(emit),
             JBody::StructCodec(plan) => plan.render(emit),
+            JBody::SumCodec(plan) => plan.render(emit),
             JBody::Invoke(plan) => plan.render(emit),
         }
     }
@@ -326,6 +341,36 @@ impl JStructCodecPlan {
                 )
             }
         }
+    }
+}
+
+/// One whole-object sealed-sum input retained as Flat alternatives plus JNI
+/// property policy. Source spelling and alternative construction are deferred
+/// to the final writer-owned [`Emit`] pass.
+#[derive(Clone)]
+pub(crate) struct JSumCodecPlan {
+    pub(crate) ident: syn::Ident,
+    pub(crate) source: TypeRef,
+    pub(crate) body: crate::jni::emit::JObjectSumInputPlan,
+}
+
+impl JSumCodecPlan {
+    fn render(&self, emit: &Emit) -> syn::ItemFn {
+        let name = &self.ident;
+        let source = emit.spell_ty(&self.source);
+        let wire: syn::Type = syn::parse_quote!(jni::objects::JObject);
+        let wire = annotate_jobject_with_lifetime(&wire, "v");
+        let body = self.body.render(emit);
+        let allow = crate::jni::trait_impl::generated_converter_attr();
+        syn::parse_quote!(
+            #allow
+            pub(crate) unsafe fn #name<'env, 'v>(
+                env: &mut jni::JNIEnv<'env>,
+                v: &#wire,
+            ) -> ::core::result::Result<#source, __JniErr> {
+                Ok(#body)
+            }
+        )
     }
 }
 

--- a/prebindgen-jni/src/jni/compile.rs
+++ b/prebindgen-jni/src/jni/compile.rs
@@ -1140,6 +1140,54 @@ impl<R: Conversions> JCompile<'_, R> {
         ))
     }
 
+    /// Freeze the explicit whole-object decoder for a declared sealed sum.
+    /// Choice construction remains registry-composed for flattened sites; this
+    /// plan is only the one-`JObject` representation used by nested objects.
+    fn planned_sum_codec(&self, at: At<'_>) -> Option<JFrag> {
+        if at.crossing.direction() != Direction::Construct {
+            return None;
+        }
+        let source = at.crossing.spelled();
+        let TypeKind::Named { id, .. } = source.kind() else {
+            return None;
+        };
+        let name = id.ident()?;
+        let cfg = self.decls.types.get(&source.key())?;
+        cfg.sum()?;
+        let prebindgen_registry::flat::Type::Variant(sum) =
+            self.registry.flat().declared_type(&name)?
+        else {
+            return None;
+        };
+        let wire: syn::Type = syn::parse_quote!(jni::objects::JObject);
+        let ident = crate::jni::chain::planned_name(Direction::Construct, source, &wire);
+        let marker = crate::jni::chain::planned_marker(&ident);
+        let kotlin_name = cfg
+            .name_spec
+            .as_ref()
+            .map(|spec| KtType::cls(self.decls.fqn_of(spec)));
+        Some(JFrag::planned(
+            at,
+            ConverterImpl {
+                subs: Vec::new(),
+                pre_stages: Vec::new(),
+                function: marker,
+                destination: wire.clone(),
+                niches: default_niches_for_wire(&wire),
+                metadata: self.decls.framework_meta(kotlin_name),
+            },
+            crate::jni::chain::JFunction::sum_codec(crate::jni::chain::JSumCodecPlan {
+                ident,
+                source: source.clone(),
+                body: crate::jni::emit::build_jobject_sum_input_plan(
+                    self.decls,
+                    sum,
+                    self.registry,
+                )?,
+            }),
+        ))
+    }
+
     /// Freeze a declared fieldless enum as Flat variant/discriminant facts.
     /// The plan deliberately does not retain an enum path or a rendered Rust
     /// body: final emission supplies the source type and constructs the variant
@@ -2721,11 +2769,14 @@ impl<R: Conversions> Compile for JCompile<'_, R> {
         if let Some(frag) = self.planned_struct_codec(at) {
             return Ok(frag);
         }
+        if let Some(frag) = self.planned_sum_codec(at) {
+            return Ok(frag);
+        }
         let emit = cx.emit();
         let conv = match at.crossing.direction() {
             Direction::Construct => self
                 .decls
-                .input_terminal(ty, self.registry, emit)
+                .input_terminal(ty, emit)
                 .or_else(|| self.borrow(ty, true)),
             Direction::Deconstruct => self
                 .decls
@@ -2889,7 +2940,7 @@ impl<R: Conversions> Compile for JCompile<'_, R> {
         let conv = match at.crossing.direction() {
             Direction::Construct => self
                 .decls
-                .input_terminal(ty, self.registry, emit)
+                .input_terminal(ty, emit)
                 .or_else(|| self.borrow(ty, true)),
             Direction::Deconstruct => self
                 .decls
@@ -3464,6 +3515,11 @@ impl Conv {
     #[cfg(test)]
     pub(crate) fn is_struct_codec_plan(&self) -> bool {
         self.0.rust.is_struct_codec()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn is_sum_codec_plan(&self) -> bool {
+        self.0.rust.is_sum_codec()
     }
 
     #[cfg(test)]

--- a/prebindgen-jni/src/jni/emit/flat_input.rs
+++ b/prebindgen-jni/src/jni/emit/flat_input.rs
@@ -28,6 +28,7 @@ struct JObjectStructFieldPlan {
     name: syn::Ident,
     property: String,
     error: String,
+    sum_payload: bool,
     kind: JObjectStructFieldKind,
 }
 
@@ -79,119 +80,9 @@ pub(crate) fn build_jobject_struct_input_plan(
         let name = field.name.clone()?;
         let property = kotlin_property_name(&name);
         let error = format!("{struct_name}.{property}: {{}}");
-        let optional = field.ty.optional_inner().is_some();
-        let inner = field.ty.optional_inner().unwrap_or(&field.ty);
-        let entry = ext.in_frag(&field.ty)?;
-        let wire = entry.destination().clone();
-        let projection = entry.projection();
-        let whole = entry.pipeline(
-            prebindgen_registry::recipe::Direction::Construct,
-            prebindgen_registry::recipe::Mode::Owned,
-        );
-
-        let kind = if let Some(projection) = projection {
-            match projection.kind {
-                ProjectionKind::Handle => JObjectStructFieldKind::Handle {
-                    descriptor: format!(
-                        "L{};",
-                        handle_field_fqn(ext, &projection).replace('.', "/")
-                    ),
-                    pipeline: whole,
-                },
-                ProjectionKind::Unsigned64 => {
-                    let niche = optional
-                        && matches!(
-                            projection.strategy,
-                            FoldStrategy::Optional(NullableKind::Niche, _)
-                        );
-                    let pipeline = if optional && !niche {
-                        ext.in_frag(inner)?.pipeline(
-                            prebindgen_registry::recipe::Direction::Construct,
-                            prebindgen_registry::recipe::Mode::Owned,
-                        )
-                    } else {
-                        whole
-                    };
-                    JObjectStructFieldKind::Unsigned64 {
-                        optional,
-                        wrap_some: optional && !niche,
-                        pipeline,
-                    }
-                }
-            }
-        } else if ext.is_kotlin_enum_reading(inner) {
-            let fqn = match inner.unwrapped().kind() {
-                flat::TypeKind::Named { id, .. } => id.ident(),
-                _ => None,
-            }
-            .and_then(|ident| ext.kotlin_fqn(&TypeKey::from_ident(&ident)))?;
-            let pipeline = if optional {
-                ext.in_frag(inner)?.pipeline(
-                    prebindgen_registry::recipe::Direction::Construct,
-                    prebindgen_registry::recipe::Mode::Owned,
-                )
-            } else {
-                whole
-            };
-            JObjectStructFieldKind::Enum {
-                descriptor: format!("L{};", fqn.replace('.', "/")),
-                optional,
-                pipeline,
-            }
-        } else {
-            match jni_field_access(&wire) {
-                Some((descriptor, accessor, false)) => JObjectStructFieldKind::Primitive {
-                    wire,
-                    descriptor: descriptor.to_string(),
-                    accessor,
-                    pipeline: whole,
-                },
-                Some((descriptor, _, true)) => JObjectStructFieldKind::IntoObject {
-                    wire,
-                    descriptor: descriptor.to_string(),
-                    pipeline: whole,
-                },
-                None => {
-                    let descriptor = ext
-                        .in_frag(inner)
-                        .and_then(|entry| jni_field_access(entry.destination()))
-                        .and_then(|(descriptor, _, is_object)| {
-                            if is_object {
-                                Some(descriptor.to_string())
-                            } else {
-                                box_descriptor_for_primitive(descriptor).map(str::to_string)
-                            }
-                        })
-                        .or_else(|| {
-                            match inner.unwrapped().kind() {
-                                flat::TypeKind::Named { id, .. } => id.ident(),
-                                _ => None,
-                            }
-                            .and_then(|ident| {
-                                ext.kotlin_fqn(&TypeKey::from_ident(&ident))
-                                    .map(|fqn| format!("L{};", fqn.replace('.', "/")))
-                            })
-                        })
-                        .or_else(|| {
-                            inner
-                                .sequence_elem()
-                                .is_some()
-                                .then(|| "Ljava/util/List;".to_string())
-                        })
-                        .unwrap_or_else(|| "Ljava/lang/Object;".to_string());
-                    JObjectStructFieldKind::Object {
-                        descriptor,
-                        pipeline: whole,
-                    }
-                }
-            }
-        };
-        fields.push(JObjectStructFieldPlan {
-            name,
-            property,
-            error,
-            kind,
-        });
+        fields.push(build_jobject_property_plan(
+            ext, &field.ty, name, property, error, false,
+        )?);
     }
     Some(JObjectStructInputPlan {
         shape: s.clone(),
@@ -200,147 +91,136 @@ pub(crate) fn build_jobject_struct_input_plan(
     })
 }
 
+fn build_jobject_property_plan(
+    ext: &Declarations,
+    reading: &TypeRef,
+    name: syn::Ident,
+    property: String,
+    error: String,
+    sum_payload: bool,
+) -> Option<JObjectStructFieldPlan> {
+    let optional = reading.optional_inner().is_some();
+    let inner = reading.optional_inner().unwrap_or(reading);
+    let entry = ext.in_frag(reading)?;
+    let wire = entry.destination().clone();
+    let projection = entry.projection();
+    let whole = entry.pipeline(
+        prebindgen_registry::recipe::Direction::Construct,
+        prebindgen_registry::recipe::Mode::Owned,
+    );
+    let kind = if let Some(projection) = projection
+        .as_ref()
+        .filter(|projection| matches!(&projection.kind, ProjectionKind::Handle))
+    {
+        JObjectStructFieldKind::Handle {
+            descriptor: format!("L{};", handle_field_fqn(ext, projection).replace('.', "/")),
+            pipeline: whole,
+        }
+    } else if let Some(projection) = projection
+        .as_ref()
+        .filter(|projection| !sum_payload && matches!(&projection.kind, ProjectionKind::Unsigned64))
+    {
+        let niche = optional
+            && matches!(
+                projection.strategy,
+                FoldStrategy::Optional(NullableKind::Niche, _)
+            );
+        let pipeline = if optional && !niche {
+            ext.in_frag(inner)?.pipeline(
+                prebindgen_registry::recipe::Direction::Construct,
+                prebindgen_registry::recipe::Mode::Owned,
+            )
+        } else {
+            whole
+        };
+        JObjectStructFieldKind::Unsigned64 {
+            optional,
+            wrap_some: optional && !niche,
+            pipeline,
+        }
+    } else if ext.is_kotlin_enum_reading(inner) {
+        let fqn = match inner.unwrapped().kind() {
+            flat::TypeKind::Named { id, .. } => id.ident(),
+            _ => None,
+        }
+        .and_then(|ident| ext.kotlin_fqn(&TypeKey::from_ident(&ident)))?;
+        let pipeline = if optional {
+            ext.in_frag(inner)?.pipeline(
+                prebindgen_registry::recipe::Direction::Construct,
+                prebindgen_registry::recipe::Mode::Owned,
+            )
+        } else {
+            whole
+        };
+        JObjectStructFieldKind::Enum {
+            descriptor: format!("L{};", fqn.replace('.', "/")),
+            optional,
+            pipeline,
+        }
+    } else {
+        match jni_field_access(&wire) {
+            Some((descriptor, accessor, false)) => JObjectStructFieldKind::Primitive {
+                wire,
+                descriptor: descriptor.to_string(),
+                accessor,
+                pipeline: whole,
+            },
+            Some((descriptor, _, true)) => JObjectStructFieldKind::IntoObject {
+                wire,
+                descriptor: descriptor.to_string(),
+                pipeline: whole,
+            },
+            None => {
+                let descriptor = ext
+                    .in_frag(inner)
+                    .and_then(|entry| jni_field_access(entry.destination()))
+                    .and_then(|(descriptor, _, is_object)| {
+                        if is_object {
+                            Some(descriptor.to_string())
+                        } else {
+                            box_descriptor_for_primitive(descriptor).map(str::to_string)
+                        }
+                    })
+                    .or_else(|| {
+                        match inner.unwrapped().kind() {
+                            flat::TypeKind::Named { id, .. } => id.ident(),
+                            _ => None,
+                        }
+                        .and_then(|ident| {
+                            ext.kotlin_fqn(&TypeKey::from_ident(&ident))
+                                .map(|fqn| format!("L{};", fqn.replace('.', "/")))
+                        })
+                    })
+                    .or_else(|| {
+                        inner
+                            .sequence_elem()
+                            .is_some()
+                            .then(|| "Ljava/util/List;".to_string())
+                    })
+                    .unwrap_or_else(|| "Ljava/lang/Object;".to_string());
+                JObjectStructFieldKind::Object {
+                    descriptor,
+                    pipeline: whole,
+                }
+            }
+        }
+    };
+    Some(JObjectStructFieldPlan {
+        name,
+        property,
+        error,
+        sum_payload,
+        kind,
+    })
+}
+
 impl JObjectStructInputPlan {
     pub(crate) fn render(&self, emit: &prebindgen_registry::Emit) -> syn::Expr {
         let mut preludes = Vec::new();
         let mut inits = Vec::new();
         for field in &self.fields {
+            preludes.push(field.render(quote!(v)));
             let name = &field.name;
-            let property = &field.property;
-            let error = &field.error;
-            let raw = format_ident!("__{}_raw", name);
-            let object = format_ident!("__{}_jobj", name);
-            let code = match &field.kind {
-                JObjectStructFieldKind::Handle {
-                    descriptor,
-                    pipeline,
-                } => {
-                    let decode = pipeline.invoke_converter(quote!(env), quote!(#raw), name);
-                    quote! {
-                        let #object: jni::objects::JObject = env.get_field(v, #property, #descriptor)
-                            .and_then(|val| val.l())
-                            .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(format!(#error, e)))?;
-                        let #raw: jni::sys::jlong = if #object.is_null() {
-                            0
-                        } else {
-                            env.call_method(&#object, "peek", "()J", &[])
-                                .and_then(|val| val.j())
-                                .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(format!(#error, e)))?
-                        };
-                        let #name = #decode;
-                    }
-                }
-                JObjectStructFieldKind::Unsigned64 {
-                    optional,
-                    wrap_some,
-                    pipeline,
-                } => {
-                    let decode = pipeline.invoke_converter(quote!(env), quote!(#raw), name);
-                    if *optional {
-                        let decoded = if *wrap_some {
-                            quote!(::core::option::Option::Some(#decode))
-                        } else {
-                            quote!(#decode)
-                        };
-                        quote! {
-                            let #object: jni::objects::JObject = env
-                                .get_field(v, #property, "Lkotlin/ULong;")
-                                .and_then(|val| val.l())
-                                .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(format!(#error, e)))?;
-                            let #name = if #object.is_null() {
-                                ::core::option::Option::None
-                            } else {
-                                let #raw: jni::sys::jlong = env
-                                    .call_method(&#object, "unbox-impl", "()J", &[])
-                                    .and_then(|val| val.j())
-                                    .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(format!(#error, e)))?;
-                                #decoded
-                            };
-                        }
-                    } else {
-                        quote! {
-                            let #raw: jni::sys::jlong = env
-                                .get_field(v, #property, "J")
-                                .and_then(|val| val.j())
-                                .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(format!(#error, e)))?;
-                            let #name = #decode;
-                        }
-                    }
-                }
-                JObjectStructFieldKind::Enum {
-                    descriptor,
-                    optional,
-                    pipeline,
-                } => {
-                    let decode = pipeline.invoke_converter(quote!(env), quote!(#raw), name);
-                    if *optional {
-                        quote! {
-                            let #object: jni::objects::JObject = env.get_field(v, #property, #descriptor)
-                                .and_then(|val| val.l())
-                                .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(format!(#error, e)))?;
-                            let #name = if #object.is_null() {
-                                ::core::option::Option::None
-                            } else {
-                                let #raw: jni::sys::jint = env.call_method(&#object, "getValue", "()I", &[])
-                                    .and_then(|val| val.i())
-                                    .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(format!(#error, e)))?;
-                                ::core::option::Option::Some(#decode)
-                            };
-                        }
-                    } else {
-                        quote! {
-                            let #object: jni::objects::JObject = env.get_field(v, #property, #descriptor)
-                                .and_then(|val| val.l())
-                                .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(format!(#error, e)))?;
-                            let #raw: jni::sys::jint = env.call_method(&#object, "getValue", "()I", &[])
-                                .and_then(|val| val.i())
-                                .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(format!(#error, e)))?;
-                            let #name = #decode;
-                        }
-                    }
-                }
-                JObjectStructFieldKind::Primitive {
-                    wire,
-                    descriptor,
-                    accessor,
-                    pipeline,
-                } => {
-                    let decode = pipeline.invoke_converter(quote!(env), quote!(#raw), name);
-                    quote! {
-                        let #raw: #wire = env.get_field(v, #property, #descriptor)
-                            .and_then(|val| val.#accessor())
-                            .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(format!(#error, e)))? as _;
-                        let #name = #decode;
-                    }
-                }
-                JObjectStructFieldKind::IntoObject {
-                    wire,
-                    descriptor,
-                    pipeline,
-                } => {
-                    let decode = pipeline.invoke_converter(quote!(env), quote!(#raw), name);
-                    quote! {
-                        let #object: jni::objects::JObject = env.get_field(v, #property, #descriptor)
-                            .and_then(|val| val.l())
-                            .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(format!(#error, e)))?;
-                        let #raw: #wire = #object.into();
-                        let #name = #decode;
-                    }
-                }
-                JObjectStructFieldKind::Object {
-                    descriptor,
-                    pipeline,
-                } => {
-                    let decode = pipeline.invoke_converter(quote!(env), quote!(#raw), name);
-                    quote! {
-                        let #raw: jni::objects::JObject = env.get_field(v, #property, #descriptor)
-                            .and_then(|val| val.l())
-                            .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(format!(#error, e)))?;
-                        let #name = #decode;
-                    }
-                }
-            };
-            preludes.push(code);
             inits.push(quote!(#name));
         }
         let module = &self.source_module;
@@ -350,6 +230,154 @@ impl JObjectStructInputPlan {
             #(#preludes)*
             #ctor
         })
+    }
+}
+
+impl JObjectStructFieldPlan {
+    fn render(&self, receiver: TokenStream) -> TokenStream {
+        let name = &self.name;
+        let property = &self.property;
+        let error = &self.error;
+        let raw = if self.sum_payload {
+            format_ident!("{}_raw", name)
+        } else {
+            format_ident!("__{}_raw", name)
+        };
+        let object = if self.sum_payload {
+            format_ident!("{}_obj", name)
+        } else {
+            format_ident!("__{}_jobj", name)
+        };
+        match &self.kind {
+            JObjectStructFieldKind::Handle {
+                descriptor,
+                pipeline,
+            } => {
+                let decode = pipeline.invoke_converter(quote!(env), quote!(#raw), name);
+                quote! {
+                    let #object: jni::objects::JObject = env.get_field(#receiver, #property, #descriptor)
+                        .and_then(|val| val.l())
+                        .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(format!(#error, e)))?;
+                    let #raw: jni::sys::jlong = if #object.is_null() {
+                        0
+                    } else {
+                        env.call_method(&#object, "peek", "()J", &[])
+                            .and_then(|val| val.j())
+                            .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(format!(#error, e)))?
+                    };
+                    let #name = #decode;
+                }
+            }
+            JObjectStructFieldKind::Unsigned64 {
+                optional,
+                wrap_some,
+                pipeline,
+            } => {
+                let decode = pipeline.invoke_converter(quote!(env), quote!(#raw), name);
+                if *optional {
+                    let decoded = if *wrap_some {
+                        quote!(::core::option::Option::Some(#decode))
+                    } else {
+                        quote!(#decode)
+                    };
+                    quote! {
+                        let #object: jni::objects::JObject = env
+                            .get_field(#receiver, #property, "Lkotlin/ULong;")
+                            .and_then(|val| val.l())
+                            .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(format!(#error, e)))?;
+                        let #name = if #object.is_null() {
+                            ::core::option::Option::None
+                        } else {
+                            let #raw: jni::sys::jlong = env
+                                .call_method(&#object, "unbox-impl", "()J", &[])
+                                .and_then(|val| val.j())
+                                .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(format!(#error, e)))?;
+                            #decoded
+                        };
+                    }
+                } else {
+                    quote! {
+                        let #raw: jni::sys::jlong = env
+                            .get_field(#receiver, #property, "J")
+                            .and_then(|val| val.j())
+                            .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(format!(#error, e)))?;
+                        let #name = #decode;
+                    }
+                }
+            }
+            JObjectStructFieldKind::Enum {
+                descriptor,
+                optional,
+                pipeline,
+            } => {
+                let decode = pipeline.invoke_converter(quote!(env), quote!(#raw), name);
+                if *optional {
+                    quote! {
+                        let #object: jni::objects::JObject = env.get_field(#receiver, #property, #descriptor)
+                            .and_then(|val| val.l())
+                            .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(format!(#error, e)))?;
+                        let #name = if #object.is_null() {
+                            ::core::option::Option::None
+                        } else {
+                            let #raw: jni::sys::jint = env.call_method(&#object, "getValue", "()I", &[])
+                                .and_then(|val| val.i())
+                                .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(format!(#error, e)))?;
+                            ::core::option::Option::Some(#decode)
+                        };
+                    }
+                } else {
+                    quote! {
+                        let #object: jni::objects::JObject = env.get_field(#receiver, #property, #descriptor)
+                            .and_then(|val| val.l())
+                            .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(format!(#error, e)))?;
+                        let #raw: jni::sys::jint = env.call_method(&#object, "getValue", "()I", &[])
+                            .and_then(|val| val.i())
+                            .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(format!(#error, e)))?;
+                        let #name = #decode;
+                    }
+                }
+            }
+            JObjectStructFieldKind::Primitive {
+                wire,
+                descriptor,
+                accessor,
+                pipeline,
+            } => {
+                let decode = pipeline.invoke_converter(quote!(env), quote!(#raw), name);
+                quote! {
+                    let #raw: #wire = env.get_field(#receiver, #property, #descriptor)
+                        .and_then(|val| val.#accessor())
+                        .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(format!(#error, e)))? as _;
+                    let #name = #decode;
+                }
+            }
+            JObjectStructFieldKind::IntoObject {
+                wire,
+                descriptor,
+                pipeline,
+            } => {
+                let decode = pipeline.invoke_converter(quote!(env), quote!(#raw), name);
+                quote! {
+                    let #object: jni::objects::JObject = env.get_field(#receiver, #property, #descriptor)
+                        .and_then(|val| val.l())
+                        .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(format!(#error, e)))?;
+                    let #raw: #wire = #object.into();
+                    let #name = #decode;
+                }
+            }
+            JObjectStructFieldKind::Object {
+                descriptor,
+                pipeline,
+            } => {
+                let decode = pipeline.invoke_converter(quote!(env), quote!(#raw), name);
+                quote! {
+                    let #raw: jni::objects::JObject = env.get_field(#receiver, #property, #descriptor)
+                        .and_then(|val| val.l())
+                        .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(format!(#error, e)))?;
+                    let #name = #decode;
+                }
+            }
+        }
     }
 }
 
@@ -374,297 +402,114 @@ impl JObjectStructInputPlan {
 /// below asks the model instead of peeling tokens. It also retires the two zips
 /// this used to run — a `SumSpec` derived from the item, paired back against the
 /// item it came from — because `Alternative` already is that pairing.
-pub(crate) fn sum_input_body(
+#[derive(Clone)]
+pub(crate) struct JObjectSumInputPlan {
+    shape: flat::Variant,
+    source_module: syn::Path,
+    enum_name: String,
+    alternatives: Vec<JObjectSumAlternativePlan>,
+}
+
+#[derive(Clone)]
+struct JObjectSumAlternativePlan {
+    shape: flat::Alternative,
+    jvm_class: String,
+    fields: Vec<JObjectSumFieldPlan>,
+}
+
+#[derive(Clone)]
+struct JObjectSumFieldPlan {
+    shape: flat::Field,
+    property: JObjectStructFieldPlan,
+}
+
+pub(crate) fn build_jobject_sum_input_plan(
     ext: &Declarations,
     v: &flat::Variant,
     registry: &impl Conversions,
-    emit: &prebindgen_registry::Emit,
-) -> Option<(syn::Type, syn::Expr)> {
+) -> Option<JObjectSumInputPlan> {
     let key = TypeKey::from_ident(&v.name);
     let cfg = ext.types.get(&key)?;
     let sum_cfg = cfg.sum()?;
     let iface_fqn = cfg.name_spec.as_ref().map(|s| ext.fqn_of(s))?;
     let iface_path = iface_fqn.replace('.', "/");
-    let source_module = ext.fn_module(registry, &v.name);
-    let enum_ident = &v.name;
     let enum_name = v.name.to_string();
-
-    let mut arms: Vec<TokenStream> = Vec::new();
+    let mut alternatives = Vec::new();
     for alt in &v.alternatives {
-        let vident = &alt.name;
-        let kotlin_name = ext.sum_variant_class_name(sum_cfg, vident);
-        // A variant class is NESTED in the interface, so its JVM binary name
-        // is `Outer$Variant`.
+        let kotlin_name = ext.sum_variant_class_name(sum_cfg, &alt.name);
         let jvm_class = format!("{iface_path}${kotlin_name}");
-
-        let mut preludes: Vec<TokenStream> = Vec::new();
-        let mut inits: Vec<TokenStream> = Vec::new();
+        let mut fields = Vec::new();
         for field in &alt.fields {
-            let prop = crate::jni::struct_plan::sum_field_prop_name(&field.member());
-            let bind = format_ident!("__p_{}", prop);
-            let err_prefix = format!("{enum_name}.{kotlin_name}.{prop}: {{}}");
-            let (pre, value) =
-                read_kotlin_property(ext, &quote!(__obj), &prop, &field.ty, &bind, &err_prefix)?;
-            preludes.push(pre);
-            inits.push(field.bind(&value));
+            let property = crate::jni::struct_plan::sum_field_prop_name(&field.member());
+            let bind = format_ident!("__p_{}", property);
+            let error = format!("{enum_name}.{kotlin_name}.{property}: {{}}");
+            fields.push(JObjectSumFieldPlan {
+                shape: field.clone(),
+                property: build_jobject_property_plan(ext, &field.ty, bind, property, error, true)?,
+            });
         }
-        // The alternative's OWN delimiters, from the one place that chooses
-        // them. `B()` carries no payload and still must be written `E::B()` —
-        // a three-arm `syn::Fields` match here would have had to re-derive
-        // that, and `Alternative::is_empty()` cannot: `B`, `B()` and `B {}`
-        // are all empty by it.
-        let ctor =
-            emit.shape_alternative(alt, quote!(#source_module::#enum_ident::#vident), &inits);
-        arms.push(quote! {
-            if env.is_instance_of(__obj, #jvm_class)
-                .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(
-                    format!(concat!(#enum_name, ": instanceof ", #jvm_class, ": {}"), e)))?
-            {
-                #(#preludes)*
-                return ::core::result::Result::Ok(#ctor);
-            }
+        alternatives.push(JObjectSumAlternativePlan {
+            shape: alt.clone(),
+            jvm_class,
+            fields,
         });
     }
-
-    // No arm matched: the JVM object is not one of the declared variants —
-    // a binding error through the ordinary channel, never a panic.
-    let no_match = format!("{enum_name}: value is not one of its declared variants");
-    // NULL must be rejected BEFORE the dispatch: JNI specifies that
-    // `IsInstanceOf(NULL, any)` is true ("a NULL object can be cast to any
-    // class"), so a null would match the first arm and silently decode as
-    // that variant — for a unit first variant, without even a failed field
-    // read to give it away. An `Option<sum>` never reaches here with null:
-    // its wrapper carves the null niche first and yields `None`.
-    let null_msg = format!("{enum_name}: null value where a variant was required");
-    let body: syn::Expr = syn::parse_quote!({
-        let __obj = v;
-        (|| -> ::core::result::Result<#source_module::#enum_ident, __JniErr> {
-            if __obj.is_null() {
-                return ::core::result::Result::Err(
-                    <__JniErr as ::core::convert::From<String>>::from(#null_msg.to_string()),
-                );
-            }
-            #(#arms)*
-            ::core::result::Result::Err(
-                <__JniErr as ::core::convert::From<String>>::from(#no_match.to_string()),
-            )
-        })()?
-    });
-    Some((syn::parse_quote!(jni::objects::JObject), body))
+    Some(JObjectSumInputPlan {
+        shape: v.clone(),
+        source_module: ext.fn_module(registry, &v.name),
+        enum_name,
+        alternatives,
+    })
 }
 
-/// Read one Kotlin property off `receiver` and decode it to its Rust value,
-/// binding the result to `bind`. Mirrors the per-field decode
-/// [`JObjectStructInputPlan`] performs, for positions that are properties of a
-/// generated class rather than fields of a data class.
-#[allow(clippy::too_many_arguments)]
-fn read_kotlin_property(
-    ext: &Declarations,
-    receiver: &TokenStream,
-    prop: &str,
-    reading: &TypeRef,
-    bind: &syn::Ident,
-    err_prefix: &str,
-) -> Option<(TokenStream, TokenStream)> {
-    // The payload's own reading straight to its entry, and the layer questions
-    // below asked of it once — `option_inner_type` compared the last path
-    // segment, so a payload spelled `Box<Option<T>>` answered "not optional"
-    // four separate times here (#289).
-    let entry = ext.in_frag(reading)?;
-    entry.activate();
-    let optional = reading.optional_inner().is_some();
-    let inner = reading.optional_inner().unwrap_or(reading);
-    let wire = entry.destination.clone();
-    let raw = format_ident!("{}_raw", bind);
-    // The COMPLETE wire → Rust chain, not just the wire-facing converter: a
-    // `convert!`-declared type reaches its Rust value through the rust-side
-    // stages that follow (`jlong → u64 → Duration`). Stage bindings are named
-    // off `bind`, so two payloads of the same type in one variant do not
-    // collide.
-    let conv = composed_property_decode(&entry, bind);
-
-    // A handle property is a `NativeHandle` object whose raw pointer comes
-    // from `peek()`; an enum property is the Kotlin enum class, decoded
-    // through its `getValue`. Both mirror `JObjectStructInputPlan`.
-    if let Some(proj) = &entry.metadata.projection {
-        if matches!(proj.kind, ProjectionKind::Handle) {
-            let fqn = handle_field_fqn(ext, proj).replace('.', "/");
-            let sig = format!("L{fqn};");
-            let obj = format_ident!("{}_obj", bind);
-            return Some((
-                quote! {
-                    let #obj: jni::objects::JObject = env.get_field(#receiver, #prop, #sig)
-                        .and_then(|val| val.l())
-                        .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(format!(#err_prefix, e)))?;
-                    let #raw: jni::sys::jlong = if #obj.is_null() {
-                        0
-                    } else {
-                        env.call_method(&#obj, "peek", "()J", &[])
-                            .and_then(|val| val.j())
-                            .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(format!(#err_prefix, e)))?
-                    };
-                    let #bind = #conv;
-                },
-                quote!(#bind),
-            ));
-        }
-    }
-    // An enum property — bare or under `Option` — is stored as the Kotlin
-    // **enum object**, so it is read through `getValue`, NOT through the
-    // generic converters: both are `jint`-keyed, and neither matches what the
-    // JVM slot actually holds. `JObjectStructInputPlan` makes the same
-    // distinction for data-class fields; this is that logic for a property.
-    if ext.is_kotlin_enum_reading(inner) {
-        // The NAME off the classification, not off the last path segment.
-        let fqn = match inner.unwrapped().kind() {
-            flat::TypeKind::Named { id, .. } => id.ident(),
-            _ => None,
-        }
-        .and_then(|n| ext.kotlin_fqn(&TypeKey::from_ident(&n)))
-        .map(|v| v.to_string())?;
-        let sig = format!("L{};", fqn.replace('.', "/"));
-        let obj = format_ident!("{}_obj", bind);
-        // Under `Option`, JVM null is `None` and the INNER converter decodes
-        // the discriminant; the outer converter would expect a boxed Integer.
-        let decode = if optional {
-            let inner_entry = ext.in_frag(inner)?;
-            inner_entry.activate();
-            let inner_conv = composed_entry_decode(&inner_entry, &raw, bind);
-            quote! {
-                let #bind = if #obj.is_null() {
-                    ::core::option::Option::None
-                } else {
-                    let #raw: jni::sys::jint = env.call_method(&#obj, "getValue", "()I", &[])
-                        .and_then(|val| val.i())
-                        .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(format!(#err_prefix, e)))?;
-                    ::core::option::Option::Some(#inner_conv)
-                };
+impl JObjectSumInputPlan {
+    pub(crate) fn render(&self, emit: &prebindgen_registry::Emit) -> syn::Expr {
+        let source_module = &self.source_module;
+        let enum_ident = &self.shape.name;
+        let enum_name = &self.enum_name;
+        let mut arms = Vec::new();
+        for alternative in &self.alternatives {
+            let vident = &alternative.shape.name;
+            let jvm_class = &alternative.jvm_class;
+            let mut preludes = Vec::new();
+            let mut inits = Vec::new();
+            for field in &alternative.fields {
+                preludes.push(field.property.render(quote!(__obj)));
+                let bind = &field.property.name;
+                inits.push(field.shape.bind(&quote!(#bind)));
             }
-        } else {
-            quote! {
-                let #raw: jni::sys::jint = env.call_method(&#obj, "getValue", "()I", &[])
-                    .and_then(|val| val.i())
-                    .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(format!(#err_prefix, e)))?;
-                let #bind = #conv;
-            }
-        };
-        return Some((
-            quote! {
-                let #obj: jni::objects::JObject = env.get_field(#receiver, #prop, #sig)
-                    .and_then(|val| val.l())
-                    .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(format!(#err_prefix, e)))?;
-                #decode
-            },
-            quote!(#bind),
-        ));
-    }
-    match jni_field_access(&wire) {
-        Some((sig, accessor, false)) => Some((
-            quote! {
-                let #raw: #wire = env.get_field(#receiver, #prop, #sig)
-                    .and_then(|val| val.#accessor())
-                    .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(format!(#err_prefix, e)))? as _;
-                let #bind = #conv;
-            },
-            quote!(#bind),
-        )),
-        Some((sig, _, true)) => {
-            let obj = format_ident!("{}_obj", bind);
-            Some((
-                quote! {
-                    let #obj: jni::objects::JObject = env.get_field(#receiver, #prop, #sig)
-                        .and_then(|val| val.l())
-                        .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(format!(#err_prefix, e)))?;
-                    let #raw: #wire = #obj.into();
-                    let #bind = #conv;
-                },
-                quote!(#bind),
-            ))
+            let ctor = emit.shape_alternative(
+                &alternative.shape,
+                quote!(#source_module::#enum_ident::#vident),
+                &inits,
+            );
+            arms.push(quote! {
+                if env.is_instance_of(__obj, #jvm_class)
+                    .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(
+                        format!(concat!(#enum_name, ": instanceof ", #jvm_class, ": {}"), e)))?
+                {
+                    #(#preludes)*
+                    return ::core::result::Result::Ok(#ctor);
+                }
+            });
         }
-        None => {
-            // Object-shaped wire with no fixed descriptor (a nested data
-            // class, another sum, a `List`): the slot's descriptor is the
-            // registered Kotlin class and the value decodes through its own
-            // converter — the same delegation the data-class path uses.
-            let sig = match inner.unwrapped().kind() {
-                // The NAME off the classification, not off the last path
-                // segment: `Box<T>` IS `T` here.
-                flat::TypeKind::Named { id, .. } => id.ident(),
-                _ => None,
-            }
-            .and_then(|name| ext.kotlin_fqn(&TypeKey::from_ident(&name)))
-            .map(|v| format!("L{};", v.replace('.', "/")))
-            .or_else(|| {
-                // A run of values is what `kind` says it is.
-                // `pat_match_top(.., "Vec")` compared the last path segment, so
-                // a `Box<Vec<T>>` answered false.
-                inner
-                    .sequence_elem()
-                    .is_some()
-                    .then(|| "Ljava/util/List;".to_string())
-            })
-            .unwrap_or_else(|| "Ljava/lang/Object;".to_string());
-            Some((
-                quote! {
-                    let #raw: jni::objects::JObject = env.get_field(#receiver, #prop, #sig)
-                        .and_then(|val| val.l())
-                        .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(format!(#err_prefix, e)))?;
-                    let #bind = #conv;
-                },
-                quote!(#bind),
-            ))
-        }
+        let no_match = format!("{enum_name}: value is not one of its declared variants");
+        let null_msg = format!("{enum_name}: null value where a variant was required");
+        syn::parse_quote!({
+            let __obj = v;
+            (|| -> ::core::result::Result<#source_module::#enum_ident, __JniErr> {
+                if __obj.is_null() {
+                    return ::core::result::Result::Err(
+                        <__JniErr as ::core::convert::From<String>>::from(#null_msg.to_string()),
+                    );
+                }
+                #(#arms)*
+                ::core::result::Result::Err(
+                    <__JniErr as ::core::convert::From<String>>::from(#no_match.to_string()),
+                )
+            })()?
+        })
     }
-}
-
-/// The complete `wire -> Rust` decode of one value read out of a JVM object:
-/// the wire-facing converter applied to `raw`, followed by the rust-side
-/// stages a custom [`convert!`](prebindgen_registry::convert) declaration inserts.
-///
-/// The mirror of [`ConvChain::call`](super::super::struct_plan::ConvChain) on
-/// the output side, and of the structural wrappers' own chain composition:
-/// stopping at [`ConverterImpl::converter_ident`] would bind the *representation*
-/// (`u64`) where the Rust value (`Duration`) is required, which does not
-/// compile.
-///
-/// Every converter invocation in this module's whole-object decoders goes
-/// through here — a data-class field, a sealed-class property, and the inner
-/// converter an `Option`/enum slot delegates to — so a chain cannot be dropped
-/// by one branch happening not to have been the one under test. Stage bindings
-/// derive from `stage_base`, so two values of the same type in one scope get
-/// distinct names.
-fn composed_entry_decode(
-    entry: &prebindgen_registry::ConverterImpl<KotlinMeta>,
-    raw: &syn::Ident,
-    stage_base: &syn::Ident,
-) -> TokenStream {
-    let converter = entry.converter_ident();
-    if entry.pre_stages.is_empty() {
-        return quote!(#converter(env, &#raw)?);
-    }
-    let s0 = format_ident!("{}_s0", stage_base);
-    let mut body = quote! { let #s0 = #converter(env, &#raw)?; };
-    let mut previous = s0;
-    for (order, (_, stage)) in entry.input_stage_order().enumerate() {
-        let stage_fn = &stage.function.sig.ident;
-        let next = format_ident!("{}_s{}", stage_base, order + 1);
-        body.extend(quote! {
-            let #next = #stage_fn(env, #previous)
-                .map_err(|__e| <__JniErr as ::core::convert::From<String>>::from(
-                    __e.to_string()))?;
-        });
-        previous = next;
-    }
-    quote!({ #body #previous })
-}
-
-/// [`composed_entry_decode`] for a sealed-class property, whose raw binding is
-/// `<bind>_raw` by construction.
-fn composed_property_decode(
-    entry: &prebindgen_registry::ConverterImpl<KotlinMeta>,
-    bind: &syn::Ident,
-) -> TokenStream {
-    composed_entry_decode(entry, &format_ident!("{}_raw", bind), bind)
 }
 
 // ──────────────────────────────────────────────────────────────────────

--- a/prebindgen-jni/src/jni/tests/sealed.rs
+++ b/prebindgen-jni/src/jni/tests/sealed.rs
@@ -1,4 +1,4 @@
-use prebindgen_registry::RegistryBuilder;
+use prebindgen_registry::{Conversions, RegistryBuilder};
 
 use super::*;
 
@@ -667,7 +667,7 @@ fn sum_is_its_own_type_kind() {
 /// * a **cell** says the type entered the pipeline;
 /// * a **root** says the binding demands its converter — cleared here, because
 ///   a sum crosses decomposed and has no whole-value output converter;
-/// * an **entry** says one resolved — present INPUT-side (`sum_input_body`
+/// * an **entry** says one resolved — present INPUT-side (a retained sum plan
 ///   decodes a whole `JObject`), absent OUTPUT-side, and that asymmetry is the
 ///   design, not an accident.
 ///
@@ -739,6 +739,14 @@ fn a_sums_registry_cells_are_registered_but_not_required() {
     assert!(
         reg.has_entry_for_test(Direction::Construct, &key) == Some(true),
         "the input direction has a whole-object decoder"
+    );
+    let reading = gen.registry.reading(&key).expect("Reading model type");
+    assert!(
+        gen.decls
+            .in_frag(&reading)
+            .expect("Reading whole-object input")
+            .is_sum_codec_plan(),
+        "the whole-object decoder must retain an unrendered sum plan"
     );
     assert!(
         reg.has_entry_for_test(Direction::Deconstruct, &key) == Some(false),

--- a/prebindgen-jni/src/jni/tests/values.rs
+++ b/prebindgen-jni/src/jni/tests/values.rs
@@ -333,31 +333,48 @@ fn fixed_primitive_arrays_retain_late_registry_plans() {
     );
 }
 
-/// Whole-struct planning may inspect Flat fields and freeze JNI property
-/// policy, but it must not receive the capability that spells captured source
-/// types. Pin both entry points: the recipe compiler never asks its context for
-/// `Emit`, and the JObject plan builder cannot accept one later.
+/// Whole-object planning may inspect Flat fields/alternatives and freeze JNI
+/// property policy, but it must not receive the capability that spells
+/// captured source types. Pin both struct and sum entry points: the recipe
+/// compiler never asks its context for `Emit`, and neither JObject plan builder
+/// can accept one later.
 #[test]
-fn whole_struct_planning_has_no_source_spelling_access() {
+fn whole_object_planning_has_no_source_spelling_access() {
     let compile = include_str!("../compile.rs");
-    let planner = compile
+    let struct_planner = compile
         .split_once("    fn planned_struct_codec(&self, at: At<'_>)")
         .expect("whole-struct planner")
         .1
-        .split_once("    /// Freeze a declared fieldless enum")
+        .split_once("    /// Freeze the explicit whole-object decoder")
         .expect("end of whole-struct planner")
         .0;
-    assert!(!planner.contains(".emit()"), "{planner}");
+    assert!(!struct_planner.contains(".emit()"), "{struct_planner}");
+    let sum_planner = compile
+        .split_once("    fn planned_sum_codec(&self, at: At<'_>)")
+        .expect("whole-sum planner")
+        .1
+        .split_once("    /// Freeze a declared fieldless enum")
+        .expect("end of whole-sum planner")
+        .0;
+    assert!(!sum_planner.contains(".emit()"), "{sum_planner}");
 
     let input = include_str!("../emit/flat_input.rs");
-    let signature = input
+    let struct_signature = input
         .split_once("pub(crate) fn build_jobject_struct_input_plan(")
         .expect("JObject struct plan builder")
         .1
         .split_once(") -> Option<JObjectStructInputPlan>")
         .expect("JObject struct plan signature")
         .0;
-    assert!(!signature.contains("Emit"), "{signature}");
+    assert!(!struct_signature.contains("Emit"), "{struct_signature}");
+    let sum_signature = input
+        .split_once("pub(crate) fn build_jobject_sum_input_plan(")
+        .expect("JObject sum plan builder")
+        .1
+        .split_once(") -> Option<JObjectSumInputPlan>")
+        .expect("JObject sum plan signature")
+        .0;
+    assert!(!sum_signature.contains("Emit"), "{sum_signature}");
 }
 
 #[test]

--- a/prebindgen-jni/src/jni/trait_impl.rs
+++ b/prebindgen-jni/src/jni/trait_impl.rs
@@ -1635,7 +1635,6 @@ impl Declarations {
     pub(crate) fn input_terminal(
         &self,
         reading: &prebindgen_registry::flat::TypeRef,
-        registry: &impl Conversions,
         emit: &prebindgen_registry::Emit,
     ) -> Option<ConverterImpl<KotlinMeta>> {
         // Classify off `kind`, spell with `spell()`: the arms below that ask what
@@ -1645,7 +1644,6 @@ impl Declarations {
         // spelling for what generated Rust says. Neither needs a node.
         // Opaque handles and canonical custom conversions are retained before
         // this fallback.
-        let key = reading.key();
         if let Some((wire, body)) = (!matches!(
             reading.unwrapped().kind(),
             prebindgen_registry::flat::TypeKind::Scalar(_)
@@ -1671,41 +1669,6 @@ impl Declarations {
                 niches,
                 metadata,
             });
-        }
-        if let Some(name) = reading.key().ident() {
-            // A `sealed_class` sum reached as a whole `JObject` — a field of a
-            // data class, or any position where the parent is already an
-            // object. Its own converter, so the parent's generic field branch
-            // delegates exactly as it does for a nested data class. (The
-            // OUTPUT direction has no counterpart: a sum crosses Rust →
-            // Kotlin flattened, always.)
-            if self.types.get(&key).is_some_and(|c| c.sum().is_some()) {
-                if let Some(prebindgen_registry::flat::Type::Variant(v)) =
-                    registry.flat().declared_type(&name)
-                {
-                    let (wire, body) = sum_input_body(self, v, registry, emit)?;
-                    // The wire's own null niche, exactly as a data class gets
-                    // — that is what lets `Option<sum>` fold with JVM null as
-                    // `None` instead of needing a boxed wrapper.
-                    let niches = default_niches_for_wire(&wire);
-                    let kotlin_name = self
-                        .types
-                        .get(&key)
-                        .and_then(|c| c.name_spec.as_ref())
-                        .map(|s| KtType::cls(self.fqn_of(s)));
-                    return Some(ConverterImpl {
-                        subs: vec![],
-                        pre_stages: vec![],
-                        function: self.build_input_fn_of(reading, &wire, &body, None, emit),
-                        destination: wire,
-                        niches,
-                        metadata: self.framework_meta(kotlin_name),
-                    });
-                }
-            }
-            // Bare-ident enum: leave to the consuming crate to override
-            // (today's CongestionControl etc. fall here — caller's wrapper
-            // ext returns Some in its own input_terminal).
         }
         None
     }


### PR DESCRIPTION
## Summary

- Retain a sealed-sum whole-object input as `JSumCodecPlan`: Flat alternatives, JNI class/property policy, and child registry pipelines are frozen during compilation, while the final writer-owned `Emit` pass alone spells the Rust type and constructs enum alternatives.
- Share one frozen JVM property plan between data-class fields and sealed-sum payloads. The existing surface differences remain explicit: sum payloads keep raw Kotlin `Long` slots for unsigned projections and their established temporary names; data-class fields keep the `ULong` object policy.
- Delete the eager `sum_input_body` fallback and its duplicate composed-decoder helpers. A seam test proves both whole-struct and whole-sum planning cannot obtain `Emit`, and a live registry assertion proves the sum input retains an unrendered plan.

This is intentionally input-only. Rust-to-Kotlin sums continue to cross as registry-composed, flattened `Choice` parts; there is no whole-object sum output converter.

Generated Rust, Kotlin, and C artifacts remain byte-identical.

Part of #513.

## Verification

- `cargo test --workspace` — passed
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` — passed
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps` — passed
- `cargo fmt --all --check` — passed
- `git diff --check` — passed
- `bash examples/regen-check.sh` — passed; committed generated output is byte-identical
- `cd examples/covertest-kotlin && ./gradlew run --console=plain` — passed all 61 sections