### PR TITLE
Freeze JNI primitive terminals from Flat kinds

### DIFF
--- a/prebindgen-jni/src/jni/compile.rs
+++ b/prebindgen-jni/src/jni/compile.rs
@@ -893,9 +893,12 @@ impl<R: Conversions> JCompile<'_, R> {
         let direction = at.crossing.direction();
         let (wire, body, niches, metadata, text_carrier) =
             if matches!(source.kind(), TypeKind::Scalar(_)) {
+                let TypeKind::Scalar(kind) = source.kind() else {
+                    unreachable!("the scalar branch is guarded by the Flat kind")
+                };
                 let (wire, body) = match direction {
-                    Direction::Construct => crate::jni::emit::primitive_input(&source.key()),
-                    Direction::Deconstruct => crate::jni::emit::primitive_output(&source.key()),
+                    Direction::Construct => crate::jni::emit::scalar_input(*kind),
+                    Direction::Deconstruct => crate::jni::emit::scalar_output(*kind),
                 }?;
                 let niches = default_niches_for_wire(&wire);
                 let kotlin_name = kotlin_for_wire(&wire);
@@ -904,6 +907,21 @@ impl<R: Conversions> JCompile<'_, R> {
                 } else {
                     self.decls.framework_meta(kotlin_name)
                 };
+                (wire, body, niches, metadata, None)
+            } else if matches!(
+                source.kind(),
+                TypeKind::Vec(element)
+                    if matches!(element.kind(), TypeKind::Scalar(ScalarKind::U8))
+            ) {
+                let (wire, body) = match direction {
+                    Direction::Construct => crate::jni::emit::byte_vector_input(),
+                    Direction::Deconstruct => crate::jni::emit::byte_vector_output(),
+                };
+                let niches = default_niches_for_wire(&wire);
+                let kotlin_name = self
+                    .decls
+                    .override_kotlin_name(&source.key(), Some(KtType::byte_array()));
+                let metadata = self.decls.framework_meta(kotlin_name);
                 (wire, body, niches, metadata, None)
             } else if matches!(source.kind(), TypeKind::Str) {
                 let wire: syn::Type = syn::parse_quote!(jni::objects::JString);
@@ -2746,7 +2764,7 @@ impl<R: Conversions> Compile for JCompile<'_, R> {
     type Plan = JPlan;
     type Error = JErr;
 
-    fn atomic(&mut self, cx: &mut Cx<'_>, at: At<'_>) -> Frag<Self> {
+    fn atomic(&mut self, _cx: &mut Cx<'_>, at: At<'_>) -> Frag<Self> {
         let ty = at.crossing.spelled();
         if let Some(frag) = self.planned_value_codec(at) {
             return Ok(frag);
@@ -2772,16 +2790,9 @@ impl<R: Conversions> Compile for JCompile<'_, R> {
         if let Some(frag) = self.planned_sum_codec(at) {
             return Ok(frag);
         }
-        let emit = cx.emit();
         let conv = match at.crossing.direction() {
-            Direction::Construct => self
-                .decls
-                .input_terminal(ty, emit)
-                .or_else(|| self.borrow(ty, true)),
-            Direction::Deconstruct => self
-                .decls
-                .output_terminal(ty, emit)
-                .or_else(|| self.borrow(ty, false)),
+            Direction::Construct => self.borrow(ty, true),
+            Direction::Deconstruct => self.borrow(ty, false),
         };
         if conv.is_none()
             && at.crossing.direction() == Direction::Deconstruct
@@ -2915,7 +2926,7 @@ impl<R: Conversions> Compile for JCompile<'_, R> {
 
     fn sequence(
         &mut self,
-        cx: &mut Cx<'_>,
+        _cx: &mut Cx<'_>,
         at: At<'_>,
         elements: Mode,
         inner: &JFrag,
@@ -2936,16 +2947,9 @@ impl<R: Conversions> Compile for JCompile<'_, R> {
         if let Some(planned) = self.planned_transparent_bridge(at) {
             return Ok(planned);
         }
-        let emit = cx.emit();
         let conv = match at.crossing.direction() {
-            Direction::Construct => self
-                .decls
-                .input_terminal(ty, emit)
-                .or_else(|| self.borrow(ty, true)),
-            Direction::Deconstruct => self
-                .decls
-                .output_terminal(ty, emit)
-                .or_else(|| self.borrow(ty, false)),
+            Direction::Construct => self.borrow(ty, true),
+            Direction::Deconstruct => self.borrow(ty, false),
         };
         let mut frag = self.wrap(at, "no JNI representation for this run", conv)?;
         frag.nested_chain = inner.composed_chain();

--- a/prebindgen-jni/src/jni/emit/convert.rs
+++ b/prebindgen-jni/src/jni/emit/convert.rs
@@ -1,4 +1,4 @@
-//! Scalar and `Option` converter bodies and their wire probes.
+//! JNI scalar/byte-vector terminal bodies and shared wire probes.
 
 use super::*;
 
@@ -34,17 +34,19 @@ pub(crate) fn sentinel_for_wire(wire: &syn::Type) -> TokenStream {
 // Primitive bodies
 // ──────────────────────────────────────────────────────────────────────
 
-pub(crate) fn primitive_input(key: &TypeKey) -> Option<(syn::Type, syn::Expr)> {
-    let key = key.as_str().to_string();
+pub(crate) fn scalar_input(
+    kind: prebindgen_registry::flat::ScalarKind,
+) -> Option<(syn::Type, syn::Expr)> {
+    use prebindgen_registry::flat::ScalarKind;
     // Bodies receive `v: &<wire>`; primitives are Copy so `*v` works.
-    Some(match key.as_str() {
-        "bool" => (
+    Some(match kind {
+        ScalarKind::Bool => (
             syn::parse_quote!(jni::sys::jboolean),
             syn::parse_quote!(*v != 0),
         ),
-        "i32" => (syn::parse_quote!(jni::sys::jint), syn::parse_quote!(*v)),
-        "i64" => (syn::parse_quote!(jni::sys::jlong), syn::parse_quote!(*v)),
-        "u8" => (
+        ScalarKind::I32 => (syn::parse_quote!(jni::sys::jint), syn::parse_quote!(*v)),
+        ScalarKind::I64 => (syn::parse_quote!(jni::sys::jlong), syn::parse_quote!(*v)),
+        ScalarKind::U8 => (
             syn::parse_quote!(jni::sys::jint),
             syn::parse_quote!(::core::primitive::u8::try_from(*v).map_err(|_| {
                 <__JniErr as ::core::convert::From<String>>::from(format!(
@@ -53,7 +55,7 @@ pub(crate) fn primitive_input(key: &TypeKey) -> Option<(syn::Type, syn::Expr)> {
                 ))
             })?),
         ),
-        "u16" => (
+        ScalarKind::U16 => (
             syn::parse_quote!(jni::sys::jint),
             syn::parse_quote!(::core::primitive::u16::try_from(*v).map_err(|_| {
                 <__JniErr as ::core::convert::From<String>>::from(format!(
@@ -62,7 +64,7 @@ pub(crate) fn primitive_input(key: &TypeKey) -> Option<(syn::Type, syn::Expr)> {
                 ))
             })?),
         ),
-        "u32" => (
+        ScalarKind::U32 => (
             syn::parse_quote!(jni::sys::jlong),
             syn::parse_quote!(::core::primitive::u32::try_from(*v).map_err(|_| {
                 <__JniErr as ::core::convert::From<String>>::from(format!(
@@ -74,96 +76,77 @@ pub(crate) fn primitive_input(key: &TypeKey) -> Option<(syn::Type, syn::Expr)> {
         // Kotlin's public surface is `ULong`, but the JNI tier receives its
         // underlying `Long` bit pattern. Rust's `as u64` is the inverse of
         // Kotlin's `ULong.toLong()` for all 64 bits.
-        "u64" => (
+        ScalarKind::U64 => (
             syn::parse_quote!(jni::sys::jlong),
             syn::parse_quote!(*v as ::core::primitive::u64),
         ),
-        "f64" => (syn::parse_quote!(jni::sys::jdouble), syn::parse_quote!(*v)),
-        "String" => (
-            syn::parse_quote!(jni::objects::JString),
-            syn::parse_quote!({
-                let s = env.get_string(v).map_err(|e| {
-                    <__JniErr as ::core::convert::From<String>>::from(format!(
-                        "decode_string: {}",
-                        e
-                    ))
-                })?;
-                s.into()
-            }),
-        ),
-        "Vec < u8 >" => (
-            syn::parse_quote!(jni::objects::JByteArray),
-            syn::parse_quote!({
-                env.convert_byte_array(v).map_err(|e| {
-                    <__JniErr as ::core::convert::From<String>>::from(format!(
-                        "decode_byte_array: {}",
-                        e
-                    ))
-                })?
-            }),
-        ),
+        ScalarKind::F64 => (syn::parse_quote!(jni::sys::jdouble), syn::parse_quote!(*v)),
         _ => return None,
     })
 }
 
-pub(crate) fn primitive_output(key: &TypeKey) -> Option<(syn::Type, syn::Expr)> {
-    let key = key.as_str().to_string();
+pub(crate) fn scalar_output(
+    kind: prebindgen_registry::flat::ScalarKind,
+) -> Option<(syn::Type, syn::Expr)> {
+    use prebindgen_registry::flat::ScalarKind;
     // Output wrappers take v by value (move). Primitives are Copy, so
-    // `v as wire` works. String/Vec consume v.
-    Some(match key.as_str() {
-        "bool" => (
+    // `v as wire` works.
+    Some(match kind {
+        ScalarKind::Bool => (
             syn::parse_quote!(jni::sys::jboolean),
             syn::parse_quote!(v as jni::sys::jboolean),
         ),
-        "i32" => (
+        ScalarKind::I32 => (
             syn::parse_quote!(jni::sys::jint),
             syn::parse_quote!(v as jni::sys::jint),
         ),
-        "i64" => (
+        ScalarKind::I64 => (
             syn::parse_quote!(jni::sys::jlong),
             syn::parse_quote!(v as jni::sys::jlong),
         ),
-        "u8" | "u16" => (
+        ScalarKind::U8 | ScalarKind::U16 => (
             syn::parse_quote!(jni::sys::jint),
             syn::parse_quote!(v as jni::sys::jint),
         ),
-        "u32" | "u64" => (
+        ScalarKind::U32 | ScalarKind::U64 => (
             syn::parse_quote!(jni::sys::jlong),
             syn::parse_quote!(v as jni::sys::jlong),
         ),
-        "f64" => (
+        ScalarKind::F64 => (
             syn::parse_quote!(jni::sys::jdouble),
             syn::parse_quote!(v as jni::sys::jdouble),
-        ),
-        "String" => (
-            syn::parse_quote!(jni::objects::JString),
-            syn::parse_quote!({
-                env.new_string(v.as_str()).map_err(|e| {
-                    <__JniErr as ::core::convert::From<String>>::from(format!(
-                        "encode_string: {}",
-                        e
-                    ))
-                })?
-            }),
-        ),
-        "Vec < u8 >" => (
-            syn::parse_quote!(jni::objects::JByteArray),
-            syn::parse_quote!({
-                env.byte_array_from_slice(v.as_slice()).map_err(|e| {
-                    <__JniErr as ::core::convert::From<String>>::from(format!(
-                        "encode_byte_array: {}",
-                        e
-                    ))
-                })?
-            }),
         ),
         _ => return None,
     })
 }
 
-// ──────────────────────────────────────────────────────────────────────
-// Option<_> wrappers
-// ──────────────────────────────────────────────────────────────────────
+pub(crate) fn byte_vector_input() -> (syn::Type, syn::Expr) {
+    (
+        syn::parse_quote!(jni::objects::JByteArray),
+        syn::parse_quote!({
+            env.convert_byte_array(v).map_err(|e| {
+                <__JniErr as ::core::convert::From<String>>::from(format!(
+                    "decode_byte_array: {}",
+                    e
+                ))
+            })?
+        }),
+    )
+}
+
+pub(crate) fn byte_vector_output() -> (syn::Type, syn::Expr) {
+    (
+        syn::parse_quote!(jni::objects::JByteArray),
+        syn::parse_quote!({
+            env.byte_array_from_slice(v.as_slice()).map_err(|e| {
+                <__JniErr as ::core::convert::From<String>>::from(format!(
+                    "encode_byte_array: {}",
+                    e
+                ))
+            })?
+        }),
+    )
+}
 
 // ──────────────────────────────────────────────────────────────────────
 // Callback wrappers — impl Fn(args) -> JObject (erased Kotlin lambda)

--- a/prebindgen-jni/src/jni/tests/values.rs
+++ b/prebindgen-jni/src/jni/tests/values.rs
@@ -104,6 +104,68 @@ fn bare_scalars_retain_late_registry_plans_in_both_directions() {
 }
 
 #[test]
+fn byte_vectors_retain_late_registry_plans_in_both_directions() {
+    let registry = crate::test_util::reg_from_items(declare_referenced(vec![(
+        syn::parse_quote!(
+            pub fn bytes_echo(value: Vec<u8>) -> Vec<u8> {
+                value
+            }
+        ),
+        myflat_loc(),
+    )]))
+    .expect("index byte-vector fixture");
+    let generation = JniGenBuilder::new()
+        .set_package_prefix("io.test.jni")
+        .package(crate::package!().fun(prebindgen_registry::fun!(bytes_echo)))
+        .build_with(registry)
+        .expect("resolve byte-vector fixture");
+    let reading = generation
+        .registry
+        .reading(&TypeKey::from_type(&syn::parse_quote!(Vec<u8>)))
+        .expect("Vec<u8> reading");
+
+    assert!(
+        generation
+            .decls
+            .in_frag(&reading)
+            .expect("Vec<u8> input")
+            .is_value_codec_plan(),
+        "the byte-vector input must retain an unrendered value codec plan"
+    );
+    assert!(
+        generation
+            .decls
+            .out_frag(&reading)
+            .expect("Vec<u8> output")
+            .is_value_codec_plan(),
+        "the byte-vector output must retain an unrendered value codec plan"
+    );
+}
+
+/// Recipe compilation selects terminal representations from Flat kinds and
+/// retains source readings; it cannot spell source Rust or recover a kind by
+/// parsing a key string. `Emit` belongs only to the final renderer.
+#[test]
+fn jni_recipe_planning_has_no_emit_or_key_text_escape() {
+    let compile = include_str!("../compile.rs");
+    assert!(!compile.contains(".emit()"), "{compile}");
+
+    let terminals = include_str!("../emit/convert.rs");
+    assert!(!terminals.contains("TypeKey"), "{terminals}");
+    let terminal_selection = terminals
+        .split_once("pub(crate) fn scalar_input(")
+        .expect("scalar terminal policy")
+        .1
+        .split_once("// Callback wrappers")
+        .expect("end of terminal policy")
+        .0;
+    assert!(
+        !terminal_selection.contains(".as_str()"),
+        "{terminal_selection}"
+    );
+}
+
+#[test]
 fn owned_strings_and_unit_retain_late_value_codec_plans() {
     let registry = crate::test_util::reg_from_items(declare_referenced(vec![
         (

--- a/prebindgen-jni/src/jni/trait_impl.rs
+++ b/prebindgen-jni/src/jni/trait_impl.rs
@@ -56,103 +56,6 @@ pub(crate) fn generated_converter_attr() -> syn::Attribute {
 // ──────────────────────────────────────────────────────────────────────
 
 impl Declarations {
-    /// [`Self::build_input_fn`] for a caller holding the **reading** of the Rust
-    /// type this converter yields — the terminals and the transparent bridges.
-    ///
-    /// The borrow annotation is the only thing it does differently:
-    /// [`annotate_borrow_with_lifetime`] matched a `syn::Type::Reference` with
-    /// no lifetime, and the model states both facts on
-    /// [`TypeKind::Ref`](prebindgen_registry::flat::TypeKind::Ref), so this spells
-    /// `&'env [mut] <inner>` off the classification. Everything else the
-    /// signature needs is the spelling, which is the reading's own tokens.
-    pub(crate) fn build_input_fn_of(
-        &self,
-        rust: &prebindgen_registry::flat::TypeRef,
-        wire: &syn::Type,
-        body: &syn::Expr,
-        exc: Option<&syn::Type>,
-        emit: &prebindgen_registry::Emit,
-    ) -> syn::ItemFn {
-        let spelled = emit.spell(rust);
-        let rust_with_lifetime = match rust.kind() {
-            prebindgen_registry::flat::TypeKind::Ref {
-                lifetime: None,
-                mutable,
-                inner,
-            } => {
-                let inner = emit.spell(inner);
-                let m = if *mutable { quote!(mut) } else { quote!() };
-                quote!(&'env #m #inner)
-            }
-            _ => spelled.clone(),
-        };
-        self.build_input_fn_parts(&spelled, &rust_with_lifetime, wire, body, exc)
-    }
-
-    pub(crate) fn build_input_fn_parts(
-        &self,
-        rust: &TokenStream,
-        rust_with_lifetime: &TokenStream,
-        wire: &syn::Type,
-        body: &syn::Expr,
-        exc: Option<&syn::Type>,
-    ) -> syn::ItemFn {
-        let name = input_name(rust, wire);
-        let wire_with_lifetime = annotate_jobject_with_lifetime(wire, "v");
-        let err_type = exc.cloned().unwrap_or_else(default_err_type);
-        let ret_body = body_for_exc(body, exc);
-        let gen_allow = generated_converter_attr();
-        if matches!(wire, syn::Type::Ptr(_)) {
-            syn::parse_quote!(
-                #gen_allow
-                pub(crate) unsafe fn #name<'env>(env: &mut jni::JNIEnv<'env>, v: #wire) -> ::core::result::Result<#rust_with_lifetime, #err_type> {
-                    #ret_body
-                }
-            )
-        } else {
-            syn::parse_quote!(
-                #gen_allow
-                pub(crate) unsafe fn #name<'env, 'v>(env: &mut jni::JNIEnv<'env>, v: &#wire_with_lifetime) -> ::core::result::Result<#rust_with_lifetime, #err_type> {
-                    #ret_body
-                }
-            )
-        }
-    }
-
-    /// [`Self::build_output_fn_parts`] off the **reading**. The output signature takes
-    /// the value by move and needs no lifetime splice, so this is the spelling
-    /// and nothing else.
-    pub(crate) fn build_output_fn_of(
-        &self,
-        rust: &prebindgen_registry::flat::TypeRef,
-        wire: &syn::Type,
-        body: &syn::Expr,
-        exc: Option<&syn::Type>,
-        emit: &prebindgen_registry::Emit,
-    ) -> syn::ItemFn {
-        self.build_output_fn_parts(&emit.spell(rust), wire, body, exc)
-    }
-
-    pub(crate) fn build_output_fn_parts(
-        &self,
-        rust: &TokenStream,
-        wire: &syn::Type,
-        body: &syn::Expr,
-        exc: Option<&syn::Type>,
-    ) -> syn::ItemFn {
-        let name = output_name(rust, wire);
-        let wire_with_lifetime = annotate_jobject_with_lifetime(wire, "a");
-        let err_type = exc.cloned().unwrap_or_else(default_err_type);
-        let ret_body = body_for_exc(body, exc);
-        let gen_allow = generated_converter_attr();
-        syn::parse_quote!(
-            #gen_allow
-            pub(crate) unsafe fn #name<'a>(env: &mut jni::JNIEnv<'a>, v: #rust) -> ::core::result::Result<#wire_with_lifetime, #err_type> {
-                #ret_body
-            }
-        )
-    }
-
     /// Leaf metadata for an opaque handle: value-context name `Long` plus the
     /// projection that folds outward through wrappers. The corresponding
     /// ownership, null-niche, and odd-pointer-tag operations live in the late
@@ -1570,9 +1473,8 @@ impl Prebindgen for Declarations {
         _registry: &Registry,
         _emit: &prebindgen_registry::Emit,
     ) -> TokenStream {
-        // Struct converter bodies are emitted by the resolver via
-        // input_terminal / output_terminal below; no separate
-        // per-struct item is needed.
+        // Struct converter bodies are emitted from retained registry plans;
+        // no separate per-struct item is needed.
         TokenStream::new()
     }
 
@@ -1619,103 +1521,6 @@ impl Prebindgen for Declarations {
             #alias
             #wrapper
         }
-    }
-}
-
-/// Remaining rank-0 compatibility terminal builders, now inherent helpers
-/// called by registry recipe compilation.
-impl Declarations {
-    // ── Input converters ─────────────────────────────────────────────
-
-    /// Remaining whole-type **input** compatibility categories: destination
-    /// primitive overrides and the explicit whole-object sum decoder.
-    ///
-    /// Bare scalars and all string terminals are compiled as
-    /// `JValueCodecPlan`s before this fallback is entered.
-    pub(crate) fn input_terminal(
-        &self,
-        reading: &prebindgen_registry::flat::TypeRef,
-        emit: &prebindgen_registry::Emit,
-    ) -> Option<ConverterImpl<KotlinMeta>> {
-        // Classify off `kind`, spell with `spell()`: the arms below that ask what
-        // a type IS use `reading`, and everything that has to name it in
-        // generated Rust uses this.
-        // Everything below reads the reading: the identity for a lookup, the
-        // spelling for what generated Rust says. Neither needs a node.
-        // Opaque handles and canonical custom conversions are retained before
-        // this fallback.
-        if let Some((wire, body)) = (!matches!(
-            reading.unwrapped().kind(),
-            prebindgen_registry::flat::TypeKind::Scalar(_)
-                | prebindgen_registry::flat::TypeKind::Str
-                | prebindgen_registry::flat::TypeKind::String
-                | prebindgen_registry::flat::TypeKind::Unit
-        ))
-        .then(|| primitive_input(&reading.key()))
-        .flatten()
-        {
-            let niches = default_niches_for_wire(&wire);
-            let kotlin_name = kotlin_for_wire(&wire);
-            let metadata = if is_unsigned64(reading) {
-                self.unsigned64_leaf_meta()
-            } else {
-                self.framework_meta(kotlin_name)
-            };
-            return Some(ConverterImpl {
-                subs: vec![],
-                pre_stages: vec![],
-                function: self.build_input_fn_of(reading, &wire, &body, None, emit),
-                destination: wire,
-                niches,
-                metadata,
-            });
-        }
-        None
-    }
-
-    // ── Output converters ────────────────────────────────────────────
-
-    /// Remaining whole-type **output** compatibility category: destination
-    /// primitive overrides.
-    /// Bare scalars, all string terminals, and unit are compiled as
-    /// `JValueCodecPlan`s before this fallback is entered.
-    pub(crate) fn output_terminal(
-        &self,
-        reading: &prebindgen_registry::flat::TypeRef,
-        emit: &prebindgen_registry::Emit,
-    ) -> Option<ConverterImpl<KotlinMeta>> {
-        // Classify off `kind`, spell with `spell()` — see `input_terminal`.
-        // Everything below reads the reading: the identity for a lookup, the
-        // spelling for what generated Rust says. Neither needs a node.
-        // Opaque handles and canonical custom conversions are retained before
-        // this fallback.
-        if let Some((wire, body)) = (!matches!(
-            reading.unwrapped().kind(),
-            prebindgen_registry::flat::TypeKind::Scalar(_)
-                | prebindgen_registry::flat::TypeKind::Str
-                | prebindgen_registry::flat::TypeKind::String
-                | prebindgen_registry::flat::TypeKind::Unit
-        ))
-        .then(|| primitive_output(&reading.key()))
-        .flatten()
-        {
-            let niches = default_niches_for_wire(&wire);
-            let kotlin_name = kotlin_for_wire(&wire);
-            let metadata = if is_unsigned64(reading) {
-                self.unsigned64_leaf_meta()
-            } else {
-                self.framework_meta(kotlin_name)
-            };
-            return Some(ConverterImpl {
-                subs: vec![],
-                pre_stages: vec![],
-                function: self.build_output_fn_of(reading, &wire, &body, None, emit),
-                destination: wire,
-                niches,
-                metadata,
-            });
-        }
-        None
     }
 }
 


### PR DESCRIPTION
## Summary

- select JNI scalar terminals from Flat `ScalarKind` and the byte-vector terminal from the structured `Vec<Scalar(U8)>` reading, retaining both directions as late `JValueCodecPlan`s
- remove the final `input_terminal` / `output_terminal` fallback and its eager Rust function builders, so JNI recipe compilation no longer obtains `Emit`
- add an architectural seam test that rejects planning-time `.emit()` and type-key text inspection in terminal selection; broader `TypeKey` opacity remains tracked by #558

Generated Rust, JNI ABI, and Kotlin artifacts remain byte-identical.

Part of #513.

## Verification

- `cargo test -p prebindgen-jni --lib -q` — passed, 293 tests
- `cargo test --workspace` — passed
- `cargo clippy --workspace --all-targets -- -D warnings` — passed
- `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps` — passed
- `cargo fmt --all --check` — passed
- `git diff --check` — passed
- `bash examples/regen-check.sh` — passed; generated output byte-identical
- `cd examples/covertest-kotlin && ./gradlew run --console=plain` — passed, all 61 sections
