### PR TITLE
Make the shared converter table identity-only

### DIFF
--- a/prebindgen-c/src/compile.rs
+++ b/prebindgen-c/src/compile.rs
@@ -459,7 +459,7 @@ impl CFrag {
     }
 
     /// A canonical scalar conversion retained as an operation until final
-    /// Rust emission rather than routed through `ConverterImpl::function`.
+    /// Rust emission rather than routed through a complete-function carrier.
     fn from_custom(at: At<'_>, plan: crate::chain::CustomPlan, niches: Niches) -> Self {
         let destination = plan.wire.clone();
         let subs = vec![TypeKey::from_type(&destination)];

--- a/prebindgen-c/src/trait_impl.rs
+++ b/prebindgen-c/src/trait_impl.rs
@@ -1049,7 +1049,7 @@ impl CbindgenBuilder {
         // conversion resolution ran. It is cloned here as a map of `Rc`s`; the
         // immutable generation plan below becomes the only rendering input.
         let registry = declared
-            .convert_with(|crossing, built, _emit| {
+            .convert_with(|crossing, built| {
                 let mut compiler = prebindgen_registry::recipe::Compiler::resume(
                     &model,
                     &recipes,

--- a/prebindgen-jni/src/jni/compile.rs
+++ b/prebindgen-jni/src/jni/compile.rs
@@ -710,7 +710,7 @@ impl JFrag {
         conv: ConverterImpl<KotlinMeta>,
         rust: crate::jni::chain::JFunction,
     ) -> Self {
-        let validity = validity_of(&conv, at.crossing.direction());
+        let validity = validity_of(at.crossing.direction(), at.crossing.mode());
         Self {
             conv,
             rust,
@@ -763,29 +763,17 @@ impl JFrag {
 /// declared opaque handle clones its referent into a fresh `Box`-handle, and a
 /// `&str` output copies into a JVM string, so both are self-sufficient although
 /// the crossing is a borrow.
-fn validity_of(conv: &ConverterImpl<KotlinMeta>, direction: Direction) -> Validity {
-    match direction {
+fn validity_of(direction: Direction, mode: Mode) -> Validity {
+    match (direction, mode) {
         // Rust to the JVM. Every JNI wire value is a `jlong` the Rust side
         // handed over or a JVM object the JVM now owns; nothing on this wire
         // points into the Rust value it came from.
-        Direction::Deconstruct => Validity::SelfSufficient,
-        // The JVM to Rust: what the converter's own function hands back. A
-        // decode that yields a borrow is valid only for the call, which is
-        // exactly right at a parameter and refused at a return.
-        Direction::Construct => match &conv.function.sig.output {
-            syn::ReturnType::Type(_, ty) if produces_borrow(ty) => Validity::Borrowed,
-            _ => Validity::SelfSufficient,
-        },
-    }
-}
-
-/// Whether a converter's return type hands back a borrow — `&T`, or a
-/// `Result<&T, E>` whose success arm is one.
-fn produces_borrow(ty: &syn::Type) -> bool {
-    match ty {
-        syn::Type::Reference(_) => true,
-        _ => prebindgen_registry::types_util::result_parts(ty)
-            .is_some_and(|(ok, _)| matches!(ok, syn::Type::Reference(_))),
+        (Direction::Deconstruct, _) => Validity::SelfSufficient,
+        // The JVM to Rust: Flat says whether the crossing lends the value. A
+        // borrowed crossing is valid only for the call, which is exactly right
+        // at a parameter and refused at a return.
+        (Direction::Construct, Mode::Shared | Mode::Exclusive) => Validity::Borrowed,
+        (Direction::Construct, Mode::Owned) => Validity::SelfSufficient,
     }
 }
 
@@ -1076,7 +1064,7 @@ impl<R: Conversions> JCompile<'_, R> {
         let conv = ConverterImpl {
             subs: vec![],
             pre_stages: vec![],
-            function: crate::jni::chain::planned_marker(&ident),
+            converter: ident.clone(),
             destination: wire,
             niches,
             metadata,
@@ -1131,7 +1119,6 @@ impl<R: Conversions> JCompile<'_, R> {
             }
         };
         let ident = crate::jni::chain::planned_name(direction, source, &wire);
-        let marker = crate::jni::chain::planned_marker(&ident);
         let niches = default_niches_for_wire(&wire);
         let kotlin_name = self
             .decls
@@ -1144,7 +1131,7 @@ impl<R: Conversions> JCompile<'_, R> {
             ConverterImpl {
                 subs: Vec::new(),
                 pre_stages: Vec::new(),
-                function: marker,
+                converter: ident.clone(),
                 destination: wire,
                 niches,
                 metadata: self.decls.framework_meta(kotlin_name),
@@ -1179,7 +1166,6 @@ impl<R: Conversions> JCompile<'_, R> {
         };
         let wire: syn::Type = syn::parse_quote!(jni::objects::JObject);
         let ident = crate::jni::chain::planned_name(Direction::Construct, source, &wire);
-        let marker = crate::jni::chain::planned_marker(&ident);
         let kotlin_name = cfg
             .name_spec
             .as_ref()
@@ -1189,7 +1175,7 @@ impl<R: Conversions> JCompile<'_, R> {
             ConverterImpl {
                 subs: Vec::new(),
                 pre_stages: Vec::new(),
-                function: marker,
+                converter: ident.clone(),
                 destination: wire.clone(),
                 niches: default_niches_for_wire(&wire),
                 metadata: self.decls.framework_meta(kotlin_name),
@@ -1259,7 +1245,7 @@ impl<R: Conversions> JCompile<'_, R> {
         let conv = ConverterImpl {
             subs: vec![],
             pre_stages: vec![],
-            function: crate::jni::chain::planned_marker(&ident),
+            converter: ident.clone(),
             destination: wire,
             niches,
             metadata,
@@ -1289,7 +1275,7 @@ impl<R: Conversions> JCompile<'_, R> {
         let conv = ConverterImpl {
             subs: vec![],
             pre_stages: vec![],
-            function: crate::jni::chain::planned_marker(&ident),
+            converter: ident.clone(),
             destination: wire,
             niches,
             metadata,
@@ -1441,10 +1427,9 @@ impl<R: Conversions> JCompile<'_, R> {
             _ => return None,
         };
         let module = self.decls.fn_module(self.registry, &target);
-        let marker = crate::jni::chain::planned_marker(&ident);
         let rust =
             crate::jni::chain::JFunction::handle_codec(crate::jni::chain::JHandleCodecPlan {
-                ident,
+                ident: ident.clone(),
                 // Borrowed-input terminals were unconditional functions before
                 // this late plan and remain so until every compatibility parent
                 // retains dependencies. Owned input and both output operations
@@ -1462,7 +1447,7 @@ impl<R: Conversions> JCompile<'_, R> {
         Some(JFrag {
             conv: ConverterImpl {
                 destination: wire,
-                function: marker,
+                converter: ident.clone(),
                 pre_stages: Vec::new(),
                 niches: Niches::one(syn::parse_quote!(0i64), syn::parse_quote!(*v == 0)),
                 metadata,
@@ -1495,9 +1480,8 @@ impl<R: Conversions> JCompile<'_, R> {
         let (ok, err) = source.fallible_parts()?;
         let success = self.decls.out_frag(ok)?;
         let ident = crate::jni::chain::model_operation_name("result_peel", &source.key());
-        let marker = crate::jni::chain::planned_marker(&ident);
         let mut pre_stages = vec![Stage {
-            function: marker,
+            converter: ident.clone(),
             metadata: KotlinMeta::default(),
         }];
         pre_stages.extend(success.pre_stages.iter().cloned());
@@ -1513,7 +1497,7 @@ impl<R: Conversions> JCompile<'_, R> {
             at,
             ConverterImpl {
                 destination: success.destination.clone(),
-                function: success.function.clone(),
+                converter: success.converter.clone(),
                 pre_stages,
                 niches: default_niches_for_wire(&success.destination),
                 metadata: KotlinMeta {
@@ -1559,11 +1543,11 @@ impl<R: Conversions> JCompile<'_, R> {
         let stages = match direction {
             Direction::Construct => entry
                 .input_stage_order()
-                .map(|(_, stage)| stage.function.sig.ident.clone())
+                .map(|(_, stage)| stage.converter.clone())
                 .collect(),
             Direction::Deconstruct => entry
                 .output_stage_order()
-                .map(|(_, stage)| stage.function.sig.ident.clone())
+                .map(|(_, stage)| stage.converter.clone())
                 .collect(),
         };
         // The outer bridge already receives the exact parameter form expected
@@ -1591,9 +1575,8 @@ impl<R: Conversions> JCompile<'_, R> {
             }
             _ => crate::jni::chain::model_operation_name(operation, &source.key()),
         };
-        let marker = crate::jni::chain::planned_marker(&ident);
         let rust = crate::jni::chain::JFunction::transparent(crate::jni::chain::JTransparentPlan {
-            ident,
+            ident: ident.clone(),
             reachable: std::rc::Rc::new(std::cell::Cell::new(false)),
             inner: entry.0.rust.clone(),
             source: source.clone(),
@@ -1605,7 +1588,7 @@ impl<R: Conversions> JCompile<'_, R> {
             at,
             ConverterImpl {
                 destination: entry.destination.clone(),
-                function: marker,
+                converter: ident.clone(),
                 pre_stages: Vec::new(),
                 niches: entry.niches.clone(),
                 metadata: entry.metadata.clone(),
@@ -1749,7 +1732,7 @@ impl<R: Conversions> JCompile<'_, R> {
             },
         );
         let mut pre_stages = vec![Stage {
-            function: crate::jni::chain::planned_marker(&ident),
+            converter: ident.clone(),
             metadata: KotlinMeta::default(),
         }];
         pre_stages.extend(inner.pre_stages.iter().cloned());
@@ -1768,7 +1751,7 @@ impl<R: Conversions> JCompile<'_, R> {
         Declarations::attach_domain_sentinels(&mut metadata, sentinels);
         let conv = ConverterImpl {
             destination: inner.destination.clone(),
-            function: inner.function.clone(),
+            converter: inner.converter.clone(),
             pre_stages,
             niches,
             metadata,
@@ -1796,12 +1779,12 @@ impl<R: Conversions> JCompile<'_, R> {
             Direction::Construct => frag
                 .conv
                 .input_stage_order()
-                .map(|(_, stage)| stage.function.sig.ident.clone())
+                .map(|(_, stage)| stage.converter.clone())
                 .collect(),
             Direction::Deconstruct => frag
                 .conv
                 .output_stage_order()
-                .map(|(_, stage)| stage.function.sig.ident.clone())
+                .map(|(_, stage)| stage.converter.clone())
                 .collect(),
         };
         match direction {
@@ -1889,11 +1872,10 @@ impl<R: Conversions> JCompile<'_, R> {
                 }
             })
             .collect();
-        let marker = crate::jni::chain::planned_marker(&ident);
         let rust = crate::jni::chain::JFunction::product(crate::jni::chain::JProductPlan {
             reachable: std::rc::Rc::new(std::cell::Cell::new(false)),
             dependencies,
-            ident,
+            ident: ident.clone(),
             mode: at.crossing.mode(),
             chain: prebindgen_registry::chain::Product {
                 source: source.clone(),
@@ -1911,7 +1893,7 @@ impl<R: Conversions> JCompile<'_, R> {
         Some(JFrag {
             conv: ConverterImpl {
                 destination: intermediate,
-                function: marker,
+                converter: ident.clone(),
                 pre_stages: Vec::new(),
                 niches: Niches::empty(),
                 metadata: KotlinMeta::default(),
@@ -2048,9 +2030,8 @@ impl<R: Conversions> JCompile<'_, R> {
             .collect();
         let layouts = planned.iter().map(|(_, arm)| arm.layout.clone()).collect();
         let ident = crate::jni::chain::planned_name(direction, at.crossing.spelled(), &destination);
-        let marker = crate::jni::chain::planned_marker(&ident);
         let rust = crate::jni::chain::JFunction::choice(crate::jni::chain::JChoicePlan {
-            ident,
+            ident: ident.clone(),
             reachable: std::rc::Rc::new(std::cell::Cell::new(false)),
             dependencies,
             mode: at.crossing.mode(),
@@ -2074,7 +2055,7 @@ impl<R: Conversions> JCompile<'_, R> {
         Some(JFrag {
             conv: ConverterImpl {
                 destination,
-                function: marker,
+                converter: ident.clone(),
                 pre_stages: Vec::new(),
                 niches: Niches::empty(),
                 metadata: KotlinMeta::default(),
@@ -2198,7 +2179,6 @@ impl<R: Conversions> JCompile<'_, R> {
             source.clone()
         };
         let ident = crate::jni::chain::planned_name(direction, &produced, &destination);
-        let marker = crate::jni::chain::planned_marker(&ident);
         let bridge = match direction {
             Direction::Construct => crate::jni::chain::JSequenceBridge::Input {
                 child: Box::new(child_wire),
@@ -2206,7 +2186,7 @@ impl<R: Conversions> JCompile<'_, R> {
             Direction::Deconstruct => crate::jni::chain::JSequenceBridge::Output,
         };
         let rust = crate::jni::chain::JFunction::sequence(crate::jni::chain::JSequencePlan {
-            ident,
+            ident: ident.clone(),
             reachable: std::rc::Rc::new(std::cell::Cell::new(false)),
             dependencies: vec![inner.rust.clone()],
             mode: at.crossing.mode(),
@@ -2230,7 +2210,7 @@ impl<R: Conversions> JCompile<'_, R> {
         Some(JFrag {
             conv: ConverterImpl {
                 destination,
-                function: marker,
+                converter: ident.clone(),
                 pre_stages: Vec::new(),
                 niches,
                 metadata: KotlinMeta {
@@ -2287,10 +2267,9 @@ impl<R: Conversions> JCompile<'_, R> {
         let module = self.decls.fn_module(self.registry, &source_ident);
         let wire: syn::Type = syn::parse_quote!(jni::sys::jlong);
         let ident = crate::jni::chain::planned_name(Direction::Construct, source, &wire);
-        let marker = crate::jni::chain::planned_marker(&ident);
         let rust = crate::jni::chain::JFunction::borrowed_optional_handle(
             crate::jni::chain::JBorrowedOptionalHandlePlan {
-                ident,
+                ident: ident.clone(),
                 reachable: std::rc::Rc::new(std::cell::Cell::new(false)),
                 target: target.clone(),
                 module,
@@ -2315,7 +2294,7 @@ impl<R: Conversions> JCompile<'_, R> {
         Some(JFrag {
             conv: ConverterImpl {
                 destination: wire,
-                function: marker,
+                converter: ident.clone(),
                 pre_stages: Vec::new(),
                 niches: Niches::empty(),
                 metadata: KotlinMeta {
@@ -2400,12 +2379,12 @@ impl<R: Conversions> JCompile<'_, R> {
             Direction::Construct => inner
                 .conv
                 .input_stage_order()
-                .map(|(_, stage)| stage.function.sig.ident.clone())
+                .map(|(_, stage)| stage.converter.clone())
                 .collect(),
             Direction::Deconstruct => inner
                 .conv
                 .output_stage_order()
-                .map(|(_, stage)| stage.function.sig.ident.clone())
+                .map(|(_, stage)| stage.converter.clone())
                 .collect(),
         };
 
@@ -2586,9 +2565,8 @@ impl<R: Conversions> JCompile<'_, R> {
             && matches!(&layout, JLayout::Optional(_)))
         .then(|| inner.out_wires.clone())
         .flatten();
-        let marker = crate::jni::chain::planned_marker(&ident);
         let rust = crate::jni::chain::JFunction::optional(crate::jni::chain::JOptionalPlan {
-            ident,
+            ident: ident.clone(),
             reachable: std::rc::Rc::new(std::cell::Cell::new(false)),
             dependencies: vec![inner.rust.clone()],
             chain: prebindgen_registry::chain::Optional {
@@ -2609,7 +2587,7 @@ impl<R: Conversions> JCompile<'_, R> {
         Some(JFrag {
             conv: ConverterImpl {
                 destination,
-                function: marker,
+                converter: ident.clone(),
                 pre_stages: Vec::new(),
                 niches,
                 metadata: KotlinMeta {
@@ -3557,7 +3535,7 @@ impl std::ops::Deref for Conv {
 impl Wire {
     /// The wire-facing function this value crosses through.
     pub(crate) fn conv(&self) -> Option<&syn::Ident> {
-        self.entry.as_ref().map(|e| &e.function.sig.ident)
+        self.entry.as_ref().map(ConverterImpl::converter_ident)
     }
 
     /// Whether the conversion carries Rust-side stages beyond its wire-facing
@@ -3601,10 +3579,7 @@ impl<R: Conversions> JCompile<'_, R> {
     fn parts_marker(&self, subs: Vec<TypeKey>) -> ConverterImpl<KotlinMeta> {
         ConverterImpl {
             destination: syn::parse_quote!(()),
-            function: syn::parse_quote!(
-                #[allow(dead_code)]
-                fn __jni_parts() {}
-            ),
+            converter: format_ident!("__jni_parts"),
             pre_stages: Vec::new(),
             niches: Niches::empty(),
             metadata: KotlinMeta::default(),

--- a/prebindgen-jni/src/jni/emit/flat_input.rs
+++ b/prebindgen-jni/src/jni/emit/flat_input.rs
@@ -741,7 +741,7 @@ pub(crate) struct FlatInputPlan {
 // parameter spelled `impl Into<S>` never becomes a `TypeRef` and never reached
 // the call. `cargo check` confirmed it dead rather than the reasoning alone.
 // jnigen's actual `impl Into<…>` support is elsewhere: plugin wrapper exts build
-// a `ConverterImpl::function` by hand via `Declarations::input_converter_name`,
+// a converter artifact identity via `Declarations::input_converter_name`,
 // which never consults this.
 // `flat_probe_inner` lived here: it peeled `&` then `Option` off a SPELLING to
 // reach the type an enum probe should ask about. Its last caller now asks

--- a/prebindgen-jni/src/jni/struct_plan.rs
+++ b/prebindgen-jni/src/jni/struct_plan.rs
@@ -68,7 +68,7 @@ impl ConvChain {
         ConvChain {
             stages: entry
                 .output_stage_order()
-                .map(|(_, stage)| stage.function.sig.ident.clone())
+                .map(|(_, stage)| stage.converter.clone())
                 .collect(),
             function: entry.converter_ident().clone(),
         }

--- a/prebindgen-jni/src/jni/trait_impl.rs
+++ b/prebindgen-jni/src/jni/trait_impl.rs
@@ -116,8 +116,8 @@ impl Declarations {
     }
 
     /// Canonical input-converter name for `(rust, wire)` — exposed
-    /// for plugin wrapper exts that build `ConverterImpl::function`
-    /// manually with a non-standard return type (e.g.
+    /// for plugin wrapper exts that name a converter artifact with a
+    /// non-standard return type (e.g.
     /// `impl Into<…>` parameters that can't be expressed via
     /// `input_wrapper_shape`'s fixed signature shape).
     pub fn input_converter_name(&self, rust: &syn::Type, wire: &syn::Type) -> syn::Ident {
@@ -573,7 +573,7 @@ impl Declarations {
         Some(ConverterImpl {
             subs: vec![],
             destination: inner.destination.clone(),
-            function: inner.function.clone(),
+            converter: inner.converter.clone(),
             pre_stages: vec![],
             niches: inner.niches.clone(),
             metadata: KotlinMeta {
@@ -704,7 +704,7 @@ impl JniGenBuilder {
         // invariants, reported together once the walk is done.
         let mut refusals: Vec<String> = Vec::new();
         let registry = declared
-            .convert_with(|crossing, built, _emit| {
+            .convert_with(|crossing, built| {
                 let mut compiler = prebindgen_registry::recipe::Compiler::resume(
                     &model,
                     decls.recipe_table(),
@@ -827,9 +827,12 @@ impl JniGenBuilder {
             .flat_map(|f| {
                 std::iter::once(f.rust.clone())
                     .chain(f.rust_stages.iter().cloned())
-                    .chain(f.conv.pre_stages.iter().map(|s| {
-                        crate::jni::chain::JFunction::marker(s.function.sig.ident.clone())
-                    }))
+                    .chain(
+                        f.conv
+                            .pre_stages
+                            .iter()
+                            .map(|s| crate::jni::chain::JFunction::marker(s.converter.clone())),
+                    )
             })
             .collect();
         let generation = crate::jni::generation::JniGenerationPlan::freeze(&mut decls, &registry);
@@ -1162,7 +1165,7 @@ impl Declarations {
         let conv = ConverterImpl {
             subs: vec![],
             pre_stages: vec![],
-            function: crate::jni::chain::planned_marker(plan.name()),
+            converter: plan.name().clone(),
             destination: wire,
             niches,
             metadata: self.framework_meta(Some(KtType::any())),

--- a/prebindgen-registry/src/chain.rs
+++ b/prebindgen-registry/src/chain.rs
@@ -31,19 +31,6 @@ impl Call {
         }
     }
 
-    /// Recover a legacy function's callable contract during migration.
-    pub fn complete(function: &syn::ItemFn) -> Self {
-        Self::new(
-            function.sig.ident.clone(),
-            matches!(
-                &function.sig.output,
-                syn::ReturnType::Type(_, ty)
-                    if crate::types_util::result_parts(ty).is_some()
-            ),
-            function.sig.unsafety.is_some(),
-        )
-    }
-
     /// Generated function identifier.
     pub fn ident(&self) -> &syn::Ident {
         &self.ident

--- a/prebindgen-registry/src/lib.rs
+++ b/prebindgen-registry/src/lib.rs
@@ -18,8 +18,8 @@
 //! Write one generator per destination language. It does two things:
 //!
 //! * **Says how the language represents Rust types on the wire** — it builds a
-//!   [`ConverterImpl`] (a generated converter fn plus its wire type) for each
-//!   crossing the registry hands it, and gives them all back through
+//!   [`ConverterImpl`] (a converter artifact identity plus its wire type) for
+//!   each crossing the registry hands it, and gives them all back through
 //!   `RegistryBuilder::convert_with`.
 //! * **Owns the Rust-emission key** and emits wrapper code per item —
 //!   `on_function` / `on_struct` / `on_enum` / `on_const` on the
@@ -63,12 +63,14 @@
 //! The same machinery serves very different languages:
 //!
 //! * **C / cbindgen back-end** (the separate `prebindgen-c` crate): wire types
-//!   are raw pointers and primitive C types; converters are thin transmutes;
-//!   `pre_stages` are usually empty (errors surface as return codes).
+//!   are raw pointers and primitive C types; converter artifacts are thin
+//!   transmutes; `pre_stages` are usually empty (errors surface as return
+//!   codes).
 //! * **JNI / Kotlin back-end** (the separate `prebindgen-jni` crate): wire
-//!   types are JNI handles (`jlong`, `JObject`); converters marshal across the
-//!   JVM boundary; `pre_stages` carry fallible steps whose `Err` arms throw
-//!   JVM exceptions (the exception info lives in that back-end's `Metadata`).
+//!   types are JNI handles (`jlong`, `JObject`); converter artifacts marshal
+//!   across the JVM boundary; `pre_stages` carry fallible steps whose `Err`
+//!   arms throw JVM exceptions (the exception info lives in that back-end's
+//!   `Metadata`).
 //!
 //! # Macros
 //!

--- a/prebindgen-registry/src/prebindgen.rs
+++ b/prebindgen-registry/src/prebindgen.rs
@@ -10,10 +10,10 @@
 //! `on_input_type`, no deferral, and no fixed-point loop retrying until it
 //! converges.
 //!
-//! [`ConverterImpl::function`] is the **complete** Rust function for a
-//! converter — signature, body, attributes, lifetimes. The generator owns 100%
-//! of the shape. Callers read the name from `function.sig.ident` and the wire
-//! form from `destination`.
+//! [`ConverterImpl::converter`] is the stable identity of the wire-facing
+//! converter. Its executable artifact is retained separately by the adapter's
+//! frozen generation plan; this shared registry carrier never stores rendered
+//! Rust syntax.
 
 use proc_macro2::TokenStream;
 
@@ -27,19 +27,18 @@ pub type NamePredicate = std::sync::Arc<dyn Fn(&str) -> bool + Send + Sync>;
 /// One link in a converter's [stage chain](`ConverterImpl::pre_stages`) —
 /// a value-inspecting step that sits between the rust value the
 /// `#[prebindgen]` fn yields/receives and the wire-facing
-/// [`ConverterImpl::function`].
+/// [`ConverterImpl::converter`].
 ///
 /// Each stage is a fallible `In → Result<Out, Err>` function. The core
-/// pipeline only ever emits and de-duplicates [`Self::function`]; how a
+/// pipeline only ever orders [`Self::converter`]; how a
 /// stage's `Err` arm is surfaced to the foreign side — throw an exception,
 /// return an error code, set `errno`, … — is entirely up to the
 /// destination-language adapter and is described by [`Self::metadata`].
 #[derive(Clone)]
 pub struct Stage<M = ()> {
-    /// Complete function definition for this stage. Same shape as
-    /// [`ConverterImpl::function`] but typed for this stage's own `In →
-    /// Out` and own error type.
-    pub function: syn::ItemFn,
+    /// Stable identity of this stage's separately retained executable
+    /// artifact.
+    pub converter: syn::Ident,
     /// Adapter-specific extras for this stage — the same type as the owning
     /// converter's ([`ConverterImpl::metadata`]). The core never
     /// inspects this; the adapter's emitter reads it to decide how the
@@ -50,9 +49,10 @@ pub struct Stage<M = ()> {
 }
 
 /// Result of resolving one converter — the wire (destination) type the rest
-/// of the registry sees, plus the complete generated function.
+/// of the registry sees, plus the identity of its separately retained
+/// executable artifact.
 ///
-/// Invariant: `function.sig.ident` MUST be a deterministic function of the
+/// Invariant: `converter` MUST be a deterministic function of the
 /// `(rust_type, destination)` pair so that callers of this converter — both
 /// other generated converters from the same adapter and any hand-written code
 /// that knows the convention — can compute or look up the name.
@@ -64,14 +64,14 @@ pub struct ConverterImpl<M = ()> {
     /// is the adapter's internal calling convention; `destination` is the
     /// value the wire carries on success.
     pub destination: syn::Type,
-    /// Complete function definition for the **wire-facing** stage. The
-    /// adapter owns the parameter list, return type, `unsafe`/`pub`
-    /// modifiers, lifetime parameters, and any attribute annotations.
+    /// Stable identity of the **wire-facing** stage. The adapter's frozen
+    /// generation plan owns its parameter list, return type, body, and other
+    /// Rust emission policy.
     /// For input direction this is the FIRST stage in execution order
     /// (it takes the wire); for output direction this is the LAST stage
     /// (it produces the wire).
-    pub function: syn::ItemFn,
-    /// **Rust-side** stages that compose with [`Self::function`] to form
+    pub converter: syn::Ident,
+    /// **Rust-side** stages that compose with [`Self::converter`] to form
     /// the full conversion chain. Default empty — a 1-stage converter
     /// is just `function`.
     ///
@@ -118,7 +118,7 @@ pub struct ConverterImpl<M = ()> {
 impl<M> ConverterImpl<M> {
     /// Identifier of the wire-facing converter function.
     pub fn converter_ident(&self) -> &syn::Ident {
-        &self.function.sig.ident
+        &self.converter
     }
 
     /// Wire type this conversion carries on success.

--- a/prebindgen-registry/src/registry/declare.rs
+++ b/prebindgen-registry/src/registry/declare.rs
@@ -18,7 +18,7 @@ use super::*;
 /// let registry = Registry::builder(flat)?
 ///     .export(&name)
 ///     .decompose(decompositions)
-///     .convert_with(|crossing, built, emit| my_gen.convert(crossing, built, emit))?
+///     .convert_with(|crossing, built| my_gen.convert(crossing, built))?
 ///     .build()?;
 /// ```
 ///
@@ -361,9 +361,9 @@ impl RegistryBuilder {
     /// Build a conversion for each crossing, in dependency order.
     ///
     /// `f` is called once per crossing, and answers with an [`Answer`] rather
-    /// than the conversion itself: the conversion belongs to the adapter, which
-    /// emits from it and looks it up, and what the registry needs back is which
-    /// other crossings this one is built out of. Returning `None` records a gap
+    /// than the conversion itself: the executable conversion belongs to the
+    /// adapter's frozen plan, and what the registry needs back is which other
+    /// crossings this one is built out of. Returning `None` records a gap
     /// — whether that gap matters is decided by [`Self::build`], not here.
     ///
     /// The walk is inner types first, so by the time `f` sees `Option<Handle>`
@@ -374,16 +374,11 @@ impl RegistryBuilder {
     /// before this returns.
     pub fn convert_with<F>(mut self, mut f: F) -> Result<Self, WriteRustError>
     where
-        F: FnMut(&Crossing, &Building<'_>, &crate::Emit) -> Option<Answer>,
+        F: FnMut(&Crossing, &Building<'_>) -> Option<Answer>,
     {
-        // A converter IS generated Rust — `ConverterImpl::function` is a
-        // complete `syn::ItemFn` the adapter writes — so this closure is an
-        // emission callback and is handed the capability, exactly as the
-        // `on_*` ones are. See `prebindgen_flat::flat::emit`.
-        let emit = crate::Emit::new();
         let order = self.derive()?.to_vec();
         for crossing in &order {
-            if let Some(answer) = f(crossing, &self.view(), &emit) {
+            if let Some(answer) = f(crossing, &self.view()) {
                 self.built.insert(crossing.clone(), answer);
             }
         }

--- a/prebindgen-registry/src/registry/mod.rs
+++ b/prebindgen-registry/src/registry/mod.rs
@@ -109,7 +109,7 @@
 //!     .decompose(self.decompositions())
 //!     // `built` already holds everything this crossing composes from: that is
 //!     // what sorted means.
-//!     .convert_with(|crossing, built, emit| self.convert(crossing, built, emit))?
+//!     .convert_with(|crossing, built| self.convert(crossing, built))?
 //!     .build()?;
 //!
 //! self.emit(&registry, out)   // read-only from here

--- a/prebindgen-registry/src/registry/tests.rs
+++ b/prebindgen-registry/src/registry/tests.rs
@@ -23,7 +23,7 @@ trait DeclareAndResolve<M> {
 trait AsStub {
     fn stub(&self) -> &StubExt;
     /// Default: converts nothing, so every required crossing is a gap.
-    fn converter(&self, _ty: &syn::Type) -> Option<ConverterImpl> {
+    fn converter(&self, _ty: &prebindgen_flat::flat::TypeRef) -> Option<ConverterImpl> {
         None
     }
 }
@@ -44,8 +44,8 @@ impl DeclareAndResolve<()> for RegistryBuilder {
             .validate_with(&ext)?
             // The reading, not a spelling re-derived from the key: this is the
             // route a real generator takes, so the stub takes it too (#291).
-            .convert_with(|crossing, built, emit| {
-                let conv = ext.converter(&emit.spell_ty(&built.reading(&crossing.1)?))?;
+            .convert_with(|crossing, built| {
+                let conv = ext.converter(&built.reading(&crossing.1)?)?;
                 Some(Answer::over(conv.subs))
             })?
             .build()?;
@@ -231,26 +231,14 @@ fn scan_declared_collects_all_missing_kinds_in_one_error() {
 fn conversion_helpers_expose_converter_chain_contract() {
     let entry = crate::ConverterImpl {
         destination: syn::parse_quote!(jni::sys::jlong),
-        function: syn::parse_quote!(
-            fn __wire(v: Owned) -> jni::sys::jlong {
-                0
-            }
-        ),
+        converter: syn::parse_quote!(__wire),
         pre_stages: vec![
             crate::Stage {
-                function: syn::parse_quote!(
-                    fn __stage_rust(v: Rust) -> Result<Mid, Err> {
-                        todo!()
-                    }
-                ),
+                converter: syn::parse_quote!(__stage_rust),
                 metadata: (),
             },
             crate::Stage {
-                function: syn::parse_quote!(
-                    fn __stage_wire(v: Mid) -> Result<Owned, Err> {
-                        todo!()
-                    }
-                ),
+                converter: syn::parse_quote!(__stage_wire),
                 metadata: (),
             },
         ],
@@ -270,14 +258,14 @@ fn conversion_helpers_expose_converter_chain_contract() {
     assert_eq!(
         entry
             .output_stage_order()
-            .map(|(_, s)| s.function.sig.ident.to_string())
+            .map(|(_, s)| s.converter.to_string())
             .collect::<Vec<_>>(),
         vec!["__stage_rust", "__stage_wire"]
     );
     assert_eq!(
         entry
             .input_stage_order()
-            .map(|(_, s)| s.function.sig.ident.to_string())
+            .map(|(_, s)| s.converter.to_string())
             .collect::<Vec<_>>(),
         vec!["__stage_wire", "__stage_rust"]
     );
@@ -285,6 +273,47 @@ fn conversion_helpers_expose_converter_chain_contract() {
         entry.subs.iter().map(TypeKey::as_str).collect::<Vec<_>>(),
         vec!["Rust", "Mid"]
     );
+}
+
+/// Converter-table rows are semantic registry data. Executable Rust belongs to
+/// the adapter's frozen artifact plan and may only be assembled by its final
+/// renderer.
+#[test]
+fn conversion_carriers_cannot_store_complete_rust_syntax() {
+    let source = include_str!("../prebindgen.rs");
+    let carriers = source
+        .split_once("pub struct Stage")
+        .expect("Stage declaration")
+        .1
+        .split_once("/// The single extension point")
+        .expect("end of conversion carriers")
+        .0;
+    assert!(!carriers.contains("syn::ItemFn"), "{carriers}");
+    assert!(!carriers.contains("TokenStream"), "{carriers}");
+    assert_eq!(carriers.matches("pub converter: syn::Ident").count(), 2);
+
+    let chain = include_str!("../chain.rs");
+    assert!(!chain.contains("Call::complete"), "{chain}");
+    assert!(
+        !chain.contains("fn complete(function: &syn::ItemFn)"),
+        "{chain}"
+    );
+}
+
+/// Recipe planning sees Flat readings and already-built answers. Restoring an
+/// `Emit` argument here would reopen source spelling before final rendering.
+#[test]
+fn conversion_planning_cannot_obtain_emit() {
+    let source = include_str!("declare.rs");
+    let convert_with = source
+        .split_once("pub fn convert_with")
+        .expect("convert_with declaration")
+        .1
+        .split_once("/// The scanned registry")
+        .expect("end of convert_with")
+        .0;
+    assert!(!convert_with.contains("Emit"), "{convert_with}");
+    assert!(!convert_with.contains("spell_ty"), "{convert_with}");
 }
 
 /// A name collision across two chained source streams fails registry
@@ -1446,17 +1475,15 @@ fn a_type_only_a_local_fn_writes_still_has_a_reading() {
         fn stub(&self) -> &StubExt {
             &self.0
         }
-        fn converter(&self, ty: &syn::Type) -> Option<ConverterImpl> {
+        fn converter(&self, ty: &prebindgen_flat::flat::TypeRef) -> Option<ConverterImpl> {
             Self::converter(ty)
         }
     }
     impl AnyConverterExt {
-        fn converter(ty: &syn::Type) -> Option<ConverterImpl> {
+        fn converter(_ty: &prebindgen_flat::flat::TypeRef) -> Option<ConverterImpl> {
             Some(ConverterImpl {
-                destination: ty.clone(),
-                function: syn::parse_quote!(
-                    fn __id() {}
-                ),
+                destination: syn::parse_quote!(()),
+                converter: syn::parse_quote!(__id),
                 pre_stages: vec![],
                 subs: vec![],
                 niches: Niches::empty(),


### PR DESCRIPTION
## Outcome

The shared converter table can no longer carry complete Rust functions, and registry conversion planning can no longer obtain `Emit`.

`ConverterImpl` and `Stage` now retain only the wire-facing or stage artifact identity plus their existing semantic data. Executable converters remain in adapter-owned frozen plans and are assembled only by final rendering.

## What changed

- Replaced `ConverterImpl::function: syn::ItemFn` and `Stage::function: syn::ItemFn` with identity-only `syn::Ident` fields.
- Removed the obsolete shared `Call::complete(&syn::ItemFn)` syntax bridge.
- Removed `Emit` from `RegistryBuilder::convert_with`; conversion callbacks now receive only a Flat `Crossing` and already-built registry view.
- Updated C and JNI resolution to the capability-free callback.
- Updated JNI converter/stage composition to use artifact identities, eliminating all planned dummy `ItemFn` construction in recipe compilation.
- Replaced JNI borrow-validity inference from a generated function return signature with Flat `Direction` and `Mode`.
- Added architectural fences against syntax-bearing converter carriers and planning-time `Emit`.

The temporary `ConverterImpl` and `Stage` table vocabulary still exists and remains a later deletion target. This PR removes its source-syntax and planning-capability leaks; it does not claim the shared writer cutover is complete.

Generated Rust, C headers, Kotlin, and ABI are byte-identical.

Part of #513.

## Verification

- `cargo test -p prebindgen-registry --lib` — 209 tests passed
- `cargo test -p prebindgen-jni --lib` — 295 tests passed
- `cargo test --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`
- `cargo fmt --all --check`
- `git diff --check`
- `bash examples/regen-check.sh` — all committed generated output byte-identical
- `cd examples/covertest-kotlin && ./gradlew run --console=plain` — all 61 sections passed