### PR TITLE
Drive C converter emission from registry fragments

### DIFF
--- a/examples/example-cbindgen/generated/example_flat_aarch64.rs
+++ b/examples/example-cbindgen/generated/example_flat_aarch64.rs
@@ -392,35 +392,6 @@ pub(crate) unsafe fn __cbg_in_Foo(v: foo_t) -> example_flat::Foo {
     }
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) unsafe fn __cbg_in_Grade(
-    v: ::core::mem::MaybeUninit<grade_t>,
-) -> ::core::result::Result<example_flat::Grade, ::std::string::String> {
-    const _: () = {
-        assert!(
-            ::core::mem::size_of:: < grade_t > () == ::core::mem::size_of:: <
-            ::core::ffi::c_int > (),
-            "`grade_t`: a #[repr(C)] enum must have the size of a C `int`"
-        );
-        assert!(
-            ::core::mem::align_of:: < grade_t > () == ::core::mem::align_of:: <
-            ::core::ffi::c_int > (),
-            "`grade_t`: a #[repr(C)] enum must have the alignment of a C `int`"
-        );
-    };
-    let __raw: ::core::ffi::c_int = ::core::ptr::read(
-        v.as_ptr() as *const ::core::ffi::c_int,
-    );
-    if __raw == grade_t::Low as ::core::ffi::c_int {
-        return ::core::result::Result::Ok(example_flat::Grade::Low);
-    }
-    if __raw == grade_t::High as ::core::ffi::c_int {
-        return ::core::result::Result::Ok(example_flat::Grade::High);
-    }
-    ::core::result::Result::Err(
-        ::std::format!("invalid discriminant {} for `grade_t`", __raw),
-    )
-}
-#[allow(non_snake_case, unused_variables, dead_code)]
 pub(crate) unsafe fn __cbg_in_InsideFoo(
     v: ::core::mem::MaybeUninit<inside_foo_t>,
 ) -> ::core::result::Result<example_flat::InsideFoo, ::std::string::String> {
@@ -639,24 +610,6 @@ pub(crate) unsafe fn __cbg_in_Shape(
     })
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) unsafe fn __cbg_in_String(
-    v: *const ::core::ffi::c_char,
-) -> ::core::result::Result<::std::string::String, ::std::string::String> {
-    if v.is_null() {
-        return ::core::result::Result::Err(
-            ::std::string::String::from("null pointer passed for String argument"),
-        );
-    }
-    match ::std::ffi::CStr::from_ptr(v).to_str() {
-        ::core::result::Result::Ok(s) => ::core::result::Result::Ok(s.to_owned()),
-        ::core::result::Result::Err(_) => {
-            ::core::result::Result::Err(
-                ::std::string::String::from("invalid UTF-8 in String argument"),
-            )
-        }
-    }
-}
-#[allow(non_snake_case, unused_variables, dead_code)]
 pub(crate) unsafe fn __cbg_in_String_field(
     v: *const ::core::ffi::c_char,
 ) -> ::std::string::String {
@@ -714,8 +667,6 @@ pub(crate) unsafe fn __cbg_in_bool(v: ::core::mem::MaybeUninit<bool>) -> bool {
 pub(crate) fn __cbg_in_f64(v: f64) -> f64 {
     v
 }
-#[allow(non_snake_case, dead_code, unused_variables)]
-pub(crate) fn __cbg_in_str() {}
 #[allow(non_snake_case, unused_variables, dead_code)]
 pub(crate) fn __cbg_in_u64(v: u64) -> u64 {
     v
@@ -869,16 +820,10 @@ pub(crate) fn __cbg_out_i32(v: i32) -> i32 {
 pub(crate) fn __cbg_out_u64(v: u64) -> u64 {
     v
 }
-#[allow(non_snake_case, dead_code, unused_variables)]
-pub(crate) fn __cbg_out_unit(v: ()) {}
 #[allow(non_snake_case, dead_code, unused)]
 pub(crate) fn __cbg_outmark_option_Grade() {}
 #[allow(non_snake_case, dead_code, unused)]
 pub(crate) fn __cbg_outmark_option_f64() {}
-#[allow(non_snake_case, dead_code, unused)]
-pub(crate) fn __cbg_result_Result___Calculator___Error__() {}
-#[allow(non_snake_case, dead_code, unused)]
-pub(crate) fn __cbg_result_Result___f64___Error__() {}
 #[no_mangle]
 #[allow(non_snake_case, unused_mut, unused_variables, unused_unsafe, dead_code)]
 pub unsafe extern "C" fn calculator_absorb(

--- a/examples/example-cbindgen/generated/example_flat_aarch64_internal_unstable.rs
+++ b/examples/example-cbindgen/generated/example_flat_aarch64_internal_unstable.rs
@@ -392,35 +392,6 @@ pub(crate) unsafe fn __cbg_in_Foo(v: foo_t) -> example_flat::Foo {
     }
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) unsafe fn __cbg_in_Grade(
-    v: ::core::mem::MaybeUninit<grade_t>,
-) -> ::core::result::Result<example_flat::Grade, ::std::string::String> {
-    const _: () = {
-        assert!(
-            ::core::mem::size_of:: < grade_t > () == ::core::mem::size_of:: <
-            ::core::ffi::c_int > (),
-            "`grade_t`: a #[repr(C)] enum must have the size of a C `int`"
-        );
-        assert!(
-            ::core::mem::align_of:: < grade_t > () == ::core::mem::align_of:: <
-            ::core::ffi::c_int > (),
-            "`grade_t`: a #[repr(C)] enum must have the alignment of a C `int`"
-        );
-    };
-    let __raw: ::core::ffi::c_int = ::core::ptr::read(
-        v.as_ptr() as *const ::core::ffi::c_int,
-    );
-    if __raw == grade_t::Low as ::core::ffi::c_int {
-        return ::core::result::Result::Ok(example_flat::Grade::Low);
-    }
-    if __raw == grade_t::High as ::core::ffi::c_int {
-        return ::core::result::Result::Ok(example_flat::Grade::High);
-    }
-    ::core::result::Result::Err(
-        ::std::format!("invalid discriminant {} for `grade_t`", __raw),
-    )
-}
-#[allow(non_snake_case, unused_variables, dead_code)]
 pub(crate) unsafe fn __cbg_in_InsideFoo(
     v: ::core::mem::MaybeUninit<inside_foo_t>,
 ) -> ::core::result::Result<example_flat::InsideFoo, ::std::string::String> {
@@ -639,24 +610,6 @@ pub(crate) unsafe fn __cbg_in_Shape(
     })
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) unsafe fn __cbg_in_String(
-    v: *const ::core::ffi::c_char,
-) -> ::core::result::Result<::std::string::String, ::std::string::String> {
-    if v.is_null() {
-        return ::core::result::Result::Err(
-            ::std::string::String::from("null pointer passed for String argument"),
-        );
-    }
-    match ::std::ffi::CStr::from_ptr(v).to_str() {
-        ::core::result::Result::Ok(s) => ::core::result::Result::Ok(s.to_owned()),
-        ::core::result::Result::Err(_) => {
-            ::core::result::Result::Err(
-                ::std::string::String::from("invalid UTF-8 in String argument"),
-            )
-        }
-    }
-}
-#[allow(non_snake_case, unused_variables, dead_code)]
 pub(crate) unsafe fn __cbg_in_String_field(
     v: *const ::core::ffi::c_char,
 ) -> ::std::string::String {
@@ -714,8 +667,6 @@ pub(crate) unsafe fn __cbg_in_bool(v: ::core::mem::MaybeUninit<bool>) -> bool {
 pub(crate) fn __cbg_in_f64(v: f64) -> f64 {
     v
 }
-#[allow(non_snake_case, dead_code, unused_variables)]
-pub(crate) fn __cbg_in_str() {}
 #[allow(non_snake_case, unused_variables, dead_code)]
 pub(crate) fn __cbg_in_u64(v: u64) -> u64 {
     v
@@ -869,16 +820,10 @@ pub(crate) fn __cbg_out_i32(v: i32) -> i32 {
 pub(crate) fn __cbg_out_u64(v: u64) -> u64 {
     v
 }
-#[allow(non_snake_case, dead_code, unused_variables)]
-pub(crate) fn __cbg_out_unit(v: ()) {}
 #[allow(non_snake_case, dead_code, unused)]
 pub(crate) fn __cbg_outmark_option_Grade() {}
 #[allow(non_snake_case, dead_code, unused)]
 pub(crate) fn __cbg_outmark_option_f64() {}
-#[allow(non_snake_case, dead_code, unused)]
-pub(crate) fn __cbg_result_Result___Calculator___Error__() {}
-#[allow(non_snake_case, dead_code, unused)]
-pub(crate) fn __cbg_result_Result___f64___Error__() {}
 #[no_mangle]
 #[allow(non_snake_case, unused_mut, unused_variables, unused_unsafe, dead_code)]
 pub unsafe extern "C" fn calculator_absorb(

--- a/examples/example-cbindgen/generated/example_flat_aarch64_unstable.rs
+++ b/examples/example-cbindgen/generated/example_flat_aarch64_unstable.rs
@@ -392,35 +392,6 @@ pub(crate) unsafe fn __cbg_in_Foo(v: foo_t) -> example_flat::Foo {
     }
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) unsafe fn __cbg_in_Grade(
-    v: ::core::mem::MaybeUninit<grade_t>,
-) -> ::core::result::Result<example_flat::Grade, ::std::string::String> {
-    const _: () = {
-        assert!(
-            ::core::mem::size_of:: < grade_t > () == ::core::mem::size_of:: <
-            ::core::ffi::c_int > (),
-            "`grade_t`: a #[repr(C)] enum must have the size of a C `int`"
-        );
-        assert!(
-            ::core::mem::align_of:: < grade_t > () == ::core::mem::align_of:: <
-            ::core::ffi::c_int > (),
-            "`grade_t`: a #[repr(C)] enum must have the alignment of a C `int`"
-        );
-    };
-    let __raw: ::core::ffi::c_int = ::core::ptr::read(
-        v.as_ptr() as *const ::core::ffi::c_int,
-    );
-    if __raw == grade_t::Low as ::core::ffi::c_int {
-        return ::core::result::Result::Ok(example_flat::Grade::Low);
-    }
-    if __raw == grade_t::High as ::core::ffi::c_int {
-        return ::core::result::Result::Ok(example_flat::Grade::High);
-    }
-    ::core::result::Result::Err(
-        ::std::format!("invalid discriminant {} for `grade_t`", __raw),
-    )
-}
-#[allow(non_snake_case, unused_variables, dead_code)]
 pub(crate) unsafe fn __cbg_in_InsideFoo(
     v: ::core::mem::MaybeUninit<inside_foo_t>,
 ) -> ::core::result::Result<example_flat::InsideFoo, ::std::string::String> {
@@ -639,24 +610,6 @@ pub(crate) unsafe fn __cbg_in_Shape(
     })
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) unsafe fn __cbg_in_String(
-    v: *const ::core::ffi::c_char,
-) -> ::core::result::Result<::std::string::String, ::std::string::String> {
-    if v.is_null() {
-        return ::core::result::Result::Err(
-            ::std::string::String::from("null pointer passed for String argument"),
-        );
-    }
-    match ::std::ffi::CStr::from_ptr(v).to_str() {
-        ::core::result::Result::Ok(s) => ::core::result::Result::Ok(s.to_owned()),
-        ::core::result::Result::Err(_) => {
-            ::core::result::Result::Err(
-                ::std::string::String::from("invalid UTF-8 in String argument"),
-            )
-        }
-    }
-}
-#[allow(non_snake_case, unused_variables, dead_code)]
 pub(crate) unsafe fn __cbg_in_String_field(
     v: *const ::core::ffi::c_char,
 ) -> ::std::string::String {
@@ -714,8 +667,6 @@ pub(crate) unsafe fn __cbg_in_bool(v: ::core::mem::MaybeUninit<bool>) -> bool {
 pub(crate) fn __cbg_in_f64(v: f64) -> f64 {
     v
 }
-#[allow(non_snake_case, dead_code, unused_variables)]
-pub(crate) fn __cbg_in_str() {}
 #[allow(non_snake_case, unused_variables, dead_code)]
 pub(crate) fn __cbg_in_u64(v: u64) -> u64 {
     v
@@ -869,16 +820,10 @@ pub(crate) fn __cbg_out_i32(v: i32) -> i32 {
 pub(crate) fn __cbg_out_u64(v: u64) -> u64 {
     v
 }
-#[allow(non_snake_case, dead_code, unused_variables)]
-pub(crate) fn __cbg_out_unit(v: ()) {}
 #[allow(non_snake_case, dead_code, unused)]
 pub(crate) fn __cbg_outmark_option_Grade() {}
 #[allow(non_snake_case, dead_code, unused)]
 pub(crate) fn __cbg_outmark_option_f64() {}
-#[allow(non_snake_case, dead_code, unused)]
-pub(crate) fn __cbg_result_Result___Calculator___Error__() {}
-#[allow(non_snake_case, dead_code, unused)]
-pub(crate) fn __cbg_result_Result___f64___Error__() {}
 #[no_mangle]
 #[allow(non_snake_case, unused_mut, unused_variables, unused_unsafe, dead_code)]
 pub unsafe extern "C" fn calculator_absorb(

--- a/examples/example-cbindgen/generated/example_flat_x86_64.rs
+++ b/examples/example-cbindgen/generated/example_flat_x86_64.rs
@@ -392,35 +392,6 @@ pub(crate) unsafe fn __cbg_in_Foo(v: foo_t) -> example_flat::Foo {
     }
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) unsafe fn __cbg_in_Grade(
-    v: ::core::mem::MaybeUninit<grade_t>,
-) -> ::core::result::Result<example_flat::Grade, ::std::string::String> {
-    const _: () = {
-        assert!(
-            ::core::mem::size_of:: < grade_t > () == ::core::mem::size_of:: <
-            ::core::ffi::c_int > (),
-            "`grade_t`: a #[repr(C)] enum must have the size of a C `int`"
-        );
-        assert!(
-            ::core::mem::align_of:: < grade_t > () == ::core::mem::align_of:: <
-            ::core::ffi::c_int > (),
-            "`grade_t`: a #[repr(C)] enum must have the alignment of a C `int`"
-        );
-    };
-    let __raw: ::core::ffi::c_int = ::core::ptr::read(
-        v.as_ptr() as *const ::core::ffi::c_int,
-    );
-    if __raw == grade_t::Low as ::core::ffi::c_int {
-        return ::core::result::Result::Ok(example_flat::Grade::Low);
-    }
-    if __raw == grade_t::High as ::core::ffi::c_int {
-        return ::core::result::Result::Ok(example_flat::Grade::High);
-    }
-    ::core::result::Result::Err(
-        ::std::format!("invalid discriminant {} for `grade_t`", __raw),
-    )
-}
-#[allow(non_snake_case, unused_variables, dead_code)]
 pub(crate) unsafe fn __cbg_in_InsideFoo(
     v: ::core::mem::MaybeUninit<inside_foo_t>,
 ) -> ::core::result::Result<example_flat::InsideFoo, ::std::string::String> {
@@ -639,24 +610,6 @@ pub(crate) unsafe fn __cbg_in_Shape(
     })
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) unsafe fn __cbg_in_String(
-    v: *const ::core::ffi::c_char,
-) -> ::core::result::Result<::std::string::String, ::std::string::String> {
-    if v.is_null() {
-        return ::core::result::Result::Err(
-            ::std::string::String::from("null pointer passed for String argument"),
-        );
-    }
-    match ::std::ffi::CStr::from_ptr(v).to_str() {
-        ::core::result::Result::Ok(s) => ::core::result::Result::Ok(s.to_owned()),
-        ::core::result::Result::Err(_) => {
-            ::core::result::Result::Err(
-                ::std::string::String::from("invalid UTF-8 in String argument"),
-            )
-        }
-    }
-}
-#[allow(non_snake_case, unused_variables, dead_code)]
 pub(crate) unsafe fn __cbg_in_String_field(
     v: *const ::core::ffi::c_char,
 ) -> ::std::string::String {
@@ -714,8 +667,6 @@ pub(crate) unsafe fn __cbg_in_bool(v: ::core::mem::MaybeUninit<bool>) -> bool {
 pub(crate) fn __cbg_in_f64(v: f64) -> f64 {
     v
 }
-#[allow(non_snake_case, dead_code, unused_variables)]
-pub(crate) fn __cbg_in_str() {}
 #[allow(non_snake_case, unused_variables, dead_code)]
 pub(crate) fn __cbg_in_u64(v: u64) -> u64 {
     v
@@ -869,16 +820,10 @@ pub(crate) fn __cbg_out_i32(v: i32) -> i32 {
 pub(crate) fn __cbg_out_u64(v: u64) -> u64 {
     v
 }
-#[allow(non_snake_case, dead_code, unused_variables)]
-pub(crate) fn __cbg_out_unit(v: ()) {}
 #[allow(non_snake_case, dead_code, unused)]
 pub(crate) fn __cbg_outmark_option_Grade() {}
 #[allow(non_snake_case, dead_code, unused)]
 pub(crate) fn __cbg_outmark_option_f64() {}
-#[allow(non_snake_case, dead_code, unused)]
-pub(crate) fn __cbg_result_Result___Calculator___Error__() {}
-#[allow(non_snake_case, dead_code, unused)]
-pub(crate) fn __cbg_result_Result___f64___Error__() {}
 #[no_mangle]
 #[allow(non_snake_case, unused_mut, unused_variables, unused_unsafe, dead_code)]
 pub unsafe extern "C" fn calculator_absorb(

--- a/examples/example-cbindgen/generated/example_flat_x86_64_internal_unstable.rs
+++ b/examples/example-cbindgen/generated/example_flat_x86_64_internal_unstable.rs
@@ -392,35 +392,6 @@ pub(crate) unsafe fn __cbg_in_Foo(v: foo_t) -> example_flat::Foo {
     }
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) unsafe fn __cbg_in_Grade(
-    v: ::core::mem::MaybeUninit<grade_t>,
-) -> ::core::result::Result<example_flat::Grade, ::std::string::String> {
-    const _: () = {
-        assert!(
-            ::core::mem::size_of:: < grade_t > () == ::core::mem::size_of:: <
-            ::core::ffi::c_int > (),
-            "`grade_t`: a #[repr(C)] enum must have the size of a C `int`"
-        );
-        assert!(
-            ::core::mem::align_of:: < grade_t > () == ::core::mem::align_of:: <
-            ::core::ffi::c_int > (),
-            "`grade_t`: a #[repr(C)] enum must have the alignment of a C `int`"
-        );
-    };
-    let __raw: ::core::ffi::c_int = ::core::ptr::read(
-        v.as_ptr() as *const ::core::ffi::c_int,
-    );
-    if __raw == grade_t::Low as ::core::ffi::c_int {
-        return ::core::result::Result::Ok(example_flat::Grade::Low);
-    }
-    if __raw == grade_t::High as ::core::ffi::c_int {
-        return ::core::result::Result::Ok(example_flat::Grade::High);
-    }
-    ::core::result::Result::Err(
-        ::std::format!("invalid discriminant {} for `grade_t`", __raw),
-    )
-}
-#[allow(non_snake_case, unused_variables, dead_code)]
 pub(crate) unsafe fn __cbg_in_InsideFoo(
     v: ::core::mem::MaybeUninit<inside_foo_t>,
 ) -> ::core::result::Result<example_flat::InsideFoo, ::std::string::String> {
@@ -639,24 +610,6 @@ pub(crate) unsafe fn __cbg_in_Shape(
     })
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) unsafe fn __cbg_in_String(
-    v: *const ::core::ffi::c_char,
-) -> ::core::result::Result<::std::string::String, ::std::string::String> {
-    if v.is_null() {
-        return ::core::result::Result::Err(
-            ::std::string::String::from("null pointer passed for String argument"),
-        );
-    }
-    match ::std::ffi::CStr::from_ptr(v).to_str() {
-        ::core::result::Result::Ok(s) => ::core::result::Result::Ok(s.to_owned()),
-        ::core::result::Result::Err(_) => {
-            ::core::result::Result::Err(
-                ::std::string::String::from("invalid UTF-8 in String argument"),
-            )
-        }
-    }
-}
-#[allow(non_snake_case, unused_variables, dead_code)]
 pub(crate) unsafe fn __cbg_in_String_field(
     v: *const ::core::ffi::c_char,
 ) -> ::std::string::String {
@@ -714,8 +667,6 @@ pub(crate) unsafe fn __cbg_in_bool(v: ::core::mem::MaybeUninit<bool>) -> bool {
 pub(crate) fn __cbg_in_f64(v: f64) -> f64 {
     v
 }
-#[allow(non_snake_case, dead_code, unused_variables)]
-pub(crate) fn __cbg_in_str() {}
 #[allow(non_snake_case, unused_variables, dead_code)]
 pub(crate) fn __cbg_in_u64(v: u64) -> u64 {
     v
@@ -869,16 +820,10 @@ pub(crate) fn __cbg_out_i32(v: i32) -> i32 {
 pub(crate) fn __cbg_out_u64(v: u64) -> u64 {
     v
 }
-#[allow(non_snake_case, dead_code, unused_variables)]
-pub(crate) fn __cbg_out_unit(v: ()) {}
 #[allow(non_snake_case, dead_code, unused)]
 pub(crate) fn __cbg_outmark_option_Grade() {}
 #[allow(non_snake_case, dead_code, unused)]
 pub(crate) fn __cbg_outmark_option_f64() {}
-#[allow(non_snake_case, dead_code, unused)]
-pub(crate) fn __cbg_result_Result___Calculator___Error__() {}
-#[allow(non_snake_case, dead_code, unused)]
-pub(crate) fn __cbg_result_Result___f64___Error__() {}
 #[no_mangle]
 #[allow(non_snake_case, unused_mut, unused_variables, unused_unsafe, dead_code)]
 pub unsafe extern "C" fn calculator_absorb(

--- a/examples/perftest-c/generated/perftest.rs
+++ b/examples/perftest-c/generated/perftest.rs
@@ -391,24 +391,6 @@ pub(crate) unsafe fn __cbg_in___str<'a>(
         }
     }
 }
-#[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) unsafe fn __cbg_in_bool(v: ::core::mem::MaybeUninit<bool>) -> bool {
-    ::core::ptr::read(v.as_ptr() as *const u8) != 0
-}
-#[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) fn __cbg_in_f64(v: f64) -> f64 {
-    v
-}
-#[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) fn __cbg_in_i32(v: i32) -> i32 {
-    v
-}
-#[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) fn __cbg_in_i64(v: i64) -> i64 {
-    v
-}
-#[allow(non_snake_case, dead_code, unused_variables)]
-pub(crate) fn __cbg_in_str() {}
 #[allow(non_snake_case, dead_code, unused)]
 pub(crate) fn __cbg_inmark_slice_Payload() {}
 #[allow(non_snake_case, unused_variables, dead_code)]
@@ -456,26 +438,12 @@ pub(crate) fn __cbg_out_chain_vec_Payload(
         __sequence_output
     }
 }
-#[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) fn __cbg_out_f64(v: f64) -> f64 {
-    v
-}
-#[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) fn __cbg_out_i32(v: i32) -> i32 {
-    v
-}
-#[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) fn __cbg_out_i64(v: i64) -> i64 {
-    v
-}
 #[allow(non_snake_case, dead_code, unused)]
 pub(crate) unsafe fn __cbg_out_ref_Payload(
     v: &perftest_flat::Payload,
 ) -> *const payload_t {
     v as *const perftest_flat::Payload as *const payload_t
 }
-#[allow(non_snake_case, dead_code, unused_variables)]
-pub(crate) fn __cbg_out_unit(v: ()) {}
 #[allow(non_snake_case, unused_variables, dead_code)]
 pub(crate) fn __cbg_out_usize(v: usize) -> usize {
     v

--- a/prebindgen-c/src/compile.rs
+++ b/prebindgen-c/src/compile.rs
@@ -299,6 +299,7 @@ pub(crate) enum CRepresentation {}
 impl Representation for CRepresentation {
     type Intermediate = TypeKey;
     type Step = CCall;
+    type ConverterArtifact = CFunction;
     type TerminalCodec = CCall;
     type ProductBridge = CCall;
     type OptionalBridge = CCall;
@@ -420,13 +421,18 @@ impl CFrag {
             self.value.failure(),
             Cleanup::None,
         );
-        FragmentPlan::new(
+        let plan = FragmentPlan::new(
             self.id.clone(),
             self.source.clone(),
             TypeKey::from_type(&self.destination),
             converter,
             self.yields.clone(),
-        )
+        );
+        if self.function.is_deferred_invoke() {
+            plan
+        } else {
+            plan.with_artifact(self.function.clone())
+        }
     }
 
     /// A multi-wire crossing whose exact ABI is carried by its frozen value.

--- a/prebindgen-c/src/lib.rs
+++ b/prebindgen-c/src/lib.rs
@@ -347,10 +347,11 @@ impl Cbindgen {
         &self,
         out_path: impl AsRef<std::path::Path>,
     ) -> Result<std::path::PathBuf, prebindgen_registry::WriteRustError> {
+        let converters: Vec<_> = self.gen.converter_functions().cloned().collect();
         Ok(prebindgen_registry::write::write_rust(
             &self.registry,
             &self.gen,
-            &self.gen.compiled_fns,
+            &converters,
             out_path,
         )?)
     }
@@ -445,15 +446,17 @@ pub struct CbindgenBuilder {
     /// argument sites, and callback artifacts.
     pub(crate) generation:
         Option<prebindgen_registry::generation::GenerationPlan<crate::compile::CRepresentation>>,
-    /// Every reached converter function plan this binding retained.
-    ///
-    /// Filled once by [`Self::build_with`] and handed to `write_rust` directly.
-    /// Every entry is a typed terminal or composed shape plan that the shared
-    /// writer renders only after resolution and validation.
-    /// The writer sorts and de-duplicates by function name, so the order here
-    /// decides which of two same-named functions wins and not where any of them
-    /// lands.
-    pub(crate) compiled_fns: Vec<chain::CFunction>,
+}
+
+impl CbindgenBuilder {
+    /// Frozen converter artifacts in registry-owned dependency order.
+    pub(crate) fn converter_functions(&self) -> impl Iterator<Item = &chain::CFunction> {
+        self.generation
+            .as_ref()
+            .expect("C generation plan is frozen after resolution")
+            .fragments()
+            .filter_map(|fragment| fragment.artifact())
+    }
 }
 
 /// A mangler over a single name component (Rust short name, base, or fn ident).

--- a/prebindgen-c/src/tests/boundary_invariants.rs
+++ b/prebindgen-c/src/tests/boundary_invariants.rs
@@ -669,6 +669,7 @@ fn legacy_c_shape_and_callback_planners_are_deleted() {
         "fn src_ty_of",
         "Complete(syn::ItemFn)",
         "CFunction::complete",
+        "compiled_fns",
     ] {
         assert!(
             !sources.contains(deleted),

--- a/prebindgen-c/src/tests/lowering.rs
+++ b/prebindgen-c/src/tests/lowering.rs
@@ -174,8 +174,7 @@ fn custom_conversion_stays_unrendered_until_final_write() {
     assert_eq!(
         generated
             .gen
-            .compiled_fns
-            .iter()
+            .converter_functions()
             .filter(|function| function.is_custom())
             .count(),
         2,
@@ -252,12 +251,11 @@ fn output_terminals_stay_unrendered_until_final_write() {
     assert_eq!(
         generated
             .gen
-            .compiled_fns
-            .iter()
+            .converter_functions()
             .filter(|function| function.is_output_terminal())
             .count(),
-        7,
-        "every whole-value output operation must retain a semantic plan before final writing"
+        6,
+        "every reached whole-value output operation must retain a semantic plan before final writing; unit has no C value site"
     );
 }
 
@@ -302,12 +300,11 @@ fn input_terminals_stay_unrendered_until_final_write() {
     assert_eq!(
         generated
             .gen
-            .compiled_fns
-            .iter()
+            .converter_functions()
             .filter(|function| function.is_input_terminal())
             .count(),
-        7,
-        "every whole-value input operation must retain a semantic plan before final writing"
+        6,
+        "every reached whole-value input operation must retain a semantic plan before final writing; &str uses the slice plan without reaching an element terminal"
     );
 }
 
@@ -341,8 +338,7 @@ fn tagged_union_payloads_stay_unrendered_until_final_write() {
             .expect("resolve");
         generated
             .gen
-            .compiled_fns
-            .iter()
+            .converter_functions()
             .filter(|function| function.is_payload())
             .count()
     })
@@ -372,7 +368,7 @@ fn specialized_field_terminals_stay_unrendered_until_final_write() {
         .build_with(registry)
         .expect("resolve");
 
-    let functions = &generated.gen.compiled_fns;
+    let functions: Vec<_> = generated.gen.converter_functions().collect();
     assert_eq!(
         functions
             .iter()
@@ -432,8 +428,7 @@ fn borrow_terminals_stay_unrendered_until_final_write() {
         assert_eq!(
             generated
                 .gen
-                .compiled_fns
-                .iter()
+                .converter_functions()
                 .filter(|function| function.borrow_operation() == Some(&operation))
                 .count(),
             1,
@@ -465,8 +460,7 @@ fn slice_input_terminals_stay_unrendered_until_final_write() {
 
     let mut operations: Vec<(TypeKey, bool)> = generated
         .gen
-        .compiled_fns
-        .iter()
+        .converter_functions()
         .filter_map(|function| function.slice_input_operation())
         .map(|(element, reinterpret)| (element.key(), reinterpret))
         .collect();
@@ -507,20 +501,22 @@ fn multi_wire_markers_stay_typed_until_final_write() {
         .build_with(registry)
         .expect("resolve");
 
-    for operation in [
-        MarkerOperation::Optional,
-        MarkerOperation::Sequence,
-        MarkerOperation::Result,
-    ] {
+    for operation in [MarkerOperation::Optional, MarkerOperation::Sequence] {
         assert!(
             generated
                 .gen
-                .compiled_fns
-                .iter()
+                .converter_functions()
                 .any(|function| function.marker_operation() == Some(&operation)),
             "{operation:?} must retain its own semantic marker before final writing"
         );
     }
+    assert!(
+        !generated
+            .gen
+            .converter_functions()
+            .any(|function| function.marker_operation() == Some(&MarkerOperation::Result)),
+        "Result is split into return/error sites and its planning-only whole-value marker must be pruned"
+    );
 }
 
 /// An adapter with no declarations writes an empty (whitespace-only) file.

--- a/prebindgen-c/src/tests/tagged_unions.rs
+++ b/prebindgen-c/src/tests/tagged_unions.rs
@@ -222,11 +222,17 @@ fn tagged_union_as_data_struct_field() {
             unimplemented!()
         }
     );
+    let inspect: syn::ItemFn = syn::parse_quote!(
+        pub fn drawing_id(drawing: Drawing) -> u64 {
+            unimplemented!()
+        }
+    );
     let registry = crate::test_util::reg_from_items(declare_referenced([
         (syn::Item::Enum(shape_enum()), loc.clone()),
         (syn::Item::Enum(operation_enum()), loc.clone()),
         (syn::Item::Struct(st), loc.clone()),
         (syn::Item::Fn(f), loc.clone()),
+        (syn::Item::Fn(inspect), loc.clone()),
     ]))
     .expect("index items");
 
@@ -239,6 +245,8 @@ fn tagged_union_as_data_struct_field() {
         .tagged_union(syn::parse_quote!(Shape))
         .data_struct(syn::parse_quote!(Drawing))
         .function(syn::parse_quote!(drawing_new))
+        .panic()
+        .function(syn::parse_quote!(drawing_id))
         .panic();
 
     let src = write(cbindgen, registry, "tagged_union_field");

--- a/prebindgen-c/src/trait_impl.rs
+++ b/prebindgen-c/src/trait_impl.rs
@@ -1105,15 +1105,6 @@ impl CbindgenBuilder {
                 message: errors.to_string(),
             }
         })?);
-        // What the compilation produced, kept for emission and for lookup.
-        self.compiled_fns = self
-            .compiled
-            .borrow()
-            .fragments()
-            .into_iter()
-            .map(|f| f.function.clone())
-            .filter(|function| !function.is_deferred_invoke())
-            .collect();
         self.validate_resolved(&registry)
             .map_err(|message| prebindgen_registry::ScanError::AdapterInvariant { message })?;
         Ok(Cbindgen {

--- a/prebindgen-registry/src/generation.rs
+++ b/prebindgen-registry/src/generation.rs
@@ -168,6 +168,12 @@ pub trait Representation {
     type Intermediate: Clone + Eq;
     /// One adapter-declared conversion between two graph values.
     type Step;
+    /// Frozen adapter artifact that renders this fragment's private converter.
+    ///
+    /// The registry owns its dependency-ordered placement but treats the
+    /// payload as opaque. [`FragmentPlan`] represents fragments without a
+    /// standalone converter explicitly.
+    type ConverterArtifact;
     /// Terminal conversion at an [`Atomic`](ShapePlan::Atomic) shape.
     type TerminalCodec;
     /// Packing or unpacking a fixed product.
@@ -555,6 +561,7 @@ pub struct FragmentPlan<R: Representation> {
     source: TypeRef,
     intermediate: R::Intermediate,
     converter: ConverterPlan<R>,
+    artifact: Option<R::ConverterArtifact>,
     yields: Yield,
 }
 
@@ -572,8 +579,15 @@ impl<R: Representation> FragmentPlan<R> {
             source,
             intermediate,
             converter,
+            artifact: None,
             yields,
         }
+    }
+
+    /// Attach the adapter's frozen private-converter artifact.
+    pub fn with_artifact(mut self, artifact: R::ConverterArtifact) -> Self {
+        self.artifact = Some(artifact);
+        self
     }
 
     /// Semantic fragment identity.
@@ -594,6 +608,11 @@ impl<R: Representation> FragmentPlan<R> {
     /// Registry-composed converter operation graph.
     pub fn converter(&self) -> &ConverterPlan<R> {
         &self.converter
+    }
+
+    /// Adapter-owned converter artifact in registry dependency order.
+    pub fn artifact(&self) -> Option<&R::ConverterArtifact> {
+        self.artifact.as_ref()
     }
 
     /// Source-value contract produced by this fragment.

--- a/prebindgen-registry/src/generation/tests.rs
+++ b/prebindgen-registry/src/generation/tests.rs
@@ -12,6 +12,7 @@ struct Fake;
 impl Representation for Fake {
     type Intermediate = &'static str;
     type Step = &'static str;
+    type ConverterArtifact = &'static str;
     type TerminalCodec = &'static str;
     type ProductBridge = &'static str;
     type OptionalBridge = &'static str;
@@ -168,7 +169,8 @@ fn freeze_prunes_unreached_fragments_and_orders_dependencies_first() {
             Cleanup::None,
         ),
         yield_of(&pair, Mode::Owned, Validity::SelfSufficient),
-    );
+    )
+    .with_artifact("pair converter");
     let site_plan = site(&model, &pair, None, 2);
     let site_id = site_plan.id().clone();
     let helper_id = ArtifactId::new("converter", "pair").unwrap();
@@ -177,18 +179,14 @@ fn freeze_prunes_unreached_fragments_and_orders_dependencies_first() {
     let mut builder = GenerationPlanBuilder::<Fake>::new();
     builder
         .fragment(pair_plan)
-        .fragment(atomic(
-            &model,
-            unused.clone(),
-            Failure::Infallible,
-            Mode::Owned,
-        ))
-        .fragment(atomic(
-            &model,
-            leaf.clone(),
-            Failure::Infallible,
-            Mode::Owned,
-        ))
+        .fragment(
+            atomic(&model, unused.clone(), Failure::Infallible, Mode::Owned)
+                .with_artifact("unused converter"),
+        )
+        .fragment(
+            atomic(&model, leaf.clone(), Failure::Infallible, Mode::Owned)
+                .with_artifact("leaf converter"),
+        )
         .site(site_plan)
         .artifact(artifact(
             "wrapper",
@@ -209,6 +207,11 @@ fn freeze_prunes_unreached_fragments_and_orders_dependencies_first() {
 
     let fragments: Vec<_> = plan.fragments().map(FragmentPlan::id).collect();
     assert_eq!(fragments, vec![&leaf, &pair]);
+    let converter_artifacts: Vec<_> = plan
+        .fragments()
+        .map(|fragment| *fragment.artifact().expect("reached converter artifact"))
+        .collect();
+    assert_eq!(converter_artifacts, ["leaf converter", "pair converter"]);
     assert!(plan.fragment(&unused).is_none());
     let artifacts: Vec<_> = plan.artifacts().map(ArtifactPlan::id).collect();
     assert_eq!(artifacts, vec![&helper_id, &wrapper_id]);


### PR DESCRIPTION
## Summary

- Store each adapter-owned converter artifact on its immutable registry `FragmentPlan`, where the registry already validates reachability and fixes dependency-first order.
- Freeze every non-Invoke `CFunction` into that plan and derive C writer input from `GenerationPlan::fragments()`, deleting the duplicate C `compiled_fns` cache and fencing against its return. Invoke remains artifact-owned because the callback artifact renders that helper.
- Let registry reachability omit private helpers that no emitted boundary consumes: unit-return converters, unused element terminals, unused declared-type directions, and planning-only whole-`Result` markers. The committed C fixtures lose 307 dead generated lines while exported C ABI and wrapper behavior remain semantically unchanged.

The shared writer still receives a short-lived `Vec<CFunction>` adapter at its old API seam; removing that seam and the mutable resolution cache is intentionally left to the following writer-cutover slices.

Related to #513.

## Verification

- `cargo fmt --all -- --check` — passed
- `cargo test -p prebindgen-registry -p prebindgen-c --lib` — passed (209 registry, 109 C)
- `cargo test --workspace --all-features` — passed
- `cargo clippy --workspace --all-targets --all-features -- --deny warnings` — passed
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps` — passed
- `./examples/regen-check.sh` — passed; committed output reproduced byte-for-byte
- `cd examples/covertest-kotlin && ./gradlew run --console=plain` — passed (61 sections)