### PR TITLE
Freeze JNI converter emission in generation plan

### DIFF
--- a/prebindgen-jni/src/jni/builder.rs
+++ b/prebindgen-jni/src/jni/builder.rs
@@ -127,7 +127,6 @@ impl Declarations {
 impl Default for Declarations {
     fn default() -> Self {
         Self {
-            compiled_fns: Vec::new(),
             tables: None,
             compiled: Default::default(),
             package: String::new(),

--- a/prebindgen-jni/src/jni/compile.rs
+++ b/prebindgen-jni/src/jni/compile.rs
@@ -729,6 +729,24 @@ impl JFrag {
         }
     }
 
+    /// Every private Rust artifact carried by this registry fragment.
+    ///
+    /// A custom conversion may add semantic Rust-side stages beside its
+    /// wire-facing converter. Marker-only compatibility stages stay in the
+    /// ordered list so the shared writer can de-duplicate them by identity;
+    /// their `should_emit` policy keeps them out of the final file.
+    pub(crate) fn converter_artifacts(&self) -> Vec<crate::jni::chain::JFunction> {
+        std::iter::once(self.rust.clone())
+            .chain(self.rust_stages.iter().cloned())
+            .chain(
+                self.conv
+                    .pre_stages
+                    .iter()
+                    .map(|stage| crate::jni::chain::JFunction::marker(stage.converter.clone())),
+            )
+            .collect()
+    }
+
     pub(crate) fn composed_chain(&self) -> Option<ComposedChain> {
         if !self.composed_only {
             if let Some(layout) = self.layout.clone().filter(JLayout::is_composed) {
@@ -3378,7 +3396,12 @@ impl crate::jni::Declarations {
     /// The conversion for `ty` in the given direction, from the fragments
     /// compiled so far.
     pub(crate) fn frag(&self, ty: &TypeRef, direction: Direction) -> Option<Conv> {
-        Some(Conv(self.compiled.borrow().fragment(&ty.key(), direction)?))
+        let key = ty.key();
+        let fragment = match &self.generation {
+            Some(generation) => generation.fragment(&key, direction),
+            None => self.compiled.borrow().fragment(&key, direction),
+        }?;
+        Some(Conv(fragment))
     }
 
     pub(crate) fn in_frag(&self, ty: &TypeRef) -> Option<Conv> {
@@ -3402,12 +3425,18 @@ impl crate::jni::Declarations {
             .recipe_table()
             .key_of(&crossing.key(), &crate::jni::recipes::parts())
             .cloned();
-        let compiled = self.compiled.borrow();
-        parts
-            .and_then(|parts| compiled.recipe_fragment(&key, &parts))
-            .or_else(|| compiled.fragment(&key, Direction::Construct))?
-            .wires
-            .clone()
+        let fragment = match &self.generation {
+            Some(generation) => parts
+                .and_then(|parts| generation.recipe_fragment(&key, &parts))
+                .or_else(|| generation.fragment(&key, Direction::Construct)),
+            None => {
+                let compiled = self.compiled.borrow();
+                parts
+                    .and_then(|parts| compiled.recipe_fragment(&key, &parts))
+                    .or_else(|| compiled.fragment(&key, Direction::Construct))
+            }
+        }?;
+        fragment.wires.clone()
     }
 
     /// The exact registry-composed converter for a crossing.
@@ -3426,10 +3455,12 @@ impl crate::jni::Declarations {
             .recipe_table()
             .key_of(&crossing.key(), &crate::jni::recipes::parts())
             .cloned();
-        let compiled = self.compiled.borrow();
-        let frag = match row {
-            Some(row) => compiled.recipe_fragment(&ty.key(), &row)?,
-            None => compiled.fragment(&ty.key(), direction)?,
+        let key = ty.key();
+        let frag = match (&self.generation, row) {
+            (Some(generation), Some(row)) => generation.recipe_fragment(&key, &row)?,
+            (Some(generation), None) => generation.fragment(&key, direction)?,
+            (None, Some(row)) => self.compiled.borrow().recipe_fragment(&key, &row)?,
+            (None, None) => self.compiled.borrow().fragment(&key, direction)?,
         };
         frag.composed_chain()
     }

--- a/prebindgen-jni/src/jni/fn_plan.rs
+++ b/prebindgen-jni/src/jni/fn_plan.rs
@@ -907,26 +907,6 @@ fn return_site(
     planned.ok().flatten()
 }
 
-/// The values one function's decomposed return hands out, compiled through
-/// `Compiler::site`.
-///
-/// Test support until the encode side takes it: this is the whole of what a
-/// decomposed return site produces, and holding it to the expansion plan is
-/// what says the two agree before anything depends on it.
-#[cfg(test)]
-pub(crate) fn decomposed_return_for_test(
-    ext: &Declarations,
-    registry: &Registry,
-    func: &syn::Ident,
-) -> Option<Vec<crate::jni::compile::OutWire>> {
-    let f = registry.flat().function(func)?;
-    let ret = f.ret.borrow_target().unwrap_or(&f.ret);
-    let ret = ret.optional_inner().unwrap_or(ret);
-    let ret = ret.sequence_elem().unwrap_or(ret);
-    let ret = ret.borrow_target().unwrap_or(ret);
-    return_site(ext, registry, func, ret, None).and_then(|p| p.decomposed())
-}
-
 /// Freeze the exact Rust-to-JNI delivery selected for one domain-error plan.
 ///
 /// Error decompositions may be function-unique value-form walks, so their

--- a/prebindgen-jni/src/jni/generation.rs
+++ b/prebindgen-jni/src/jni/generation.rs
@@ -13,6 +13,11 @@ use super::*;
 
 /// All cross-artifact JNI decisions frozen at the end of resolution.
 pub(crate) struct JniGenerationPlan {
+    /// Registry-compiled recipe fragments, frozen after the last site has been
+    /// planned. This is the sole post-resolution source of private converter
+    /// artifacts and fragment lookups; the mutable planning store is drained
+    /// when this plan is built.
+    conversions: prebindgen_registry::recipe::Compiled<crate::jni::compile::JFrag>,
     functions: HashMap<syn::Ident, Rc<JniFunctionPlan>>,
     interfaces: BTreeMap<SpecKey, Arc<IfaceSpec>>,
     /// Every declared data class is recorded, including an explicit `None` for
@@ -78,12 +83,49 @@ impl JniGenerationPlan {
         }
 
         Self {
+            conversions: std::mem::take(&mut *decls.compiled.borrow_mut()),
             functions: std::mem::take(decls.fn_plans.get_mut()),
             interfaces: std::mem::take(decls.iface_specs.get_mut()),
             structs: std::mem::take(decls.struct_plans.get_mut()),
             sums: std::mem::take(decls.sum_plans.get_mut()),
             vec_builds: std::mem::take(decls.vec_build_plans.get_mut()),
         }
+    }
+
+    pub(crate) fn fragment(
+        &self,
+        ty: &TypeKey,
+        direction: prebindgen_registry::recipe::Direction,
+    ) -> Option<Rc<crate::jni::compile::JFrag>> {
+        self.conversions.fragment(ty, direction)
+    }
+
+    pub(crate) fn recipe_fragment(
+        &self,
+        ty: &TypeKey,
+        recipe: &prebindgen_registry::recipe::RecipeKey,
+    ) -> Option<Rc<crate::jni::compile::JFrag>> {
+        self.conversions.recipe_fragment(ty, recipe)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn conversions(
+        &self,
+    ) -> &prebindgen_registry::recipe::Compiled<crate::jni::compile::JFrag> {
+        &self.conversions
+    }
+
+    /// Frozen private converter artifacts derived from registry fragments.
+    ///
+    /// This is deliberately an ephemeral collection at the writer boundary,
+    /// not a second cache beside the fragment graph.
+    pub(crate) fn converter_functions(&self) -> Vec<crate::jni::chain::JFunction> {
+        self.conversions
+            .fragments()
+            .into_iter()
+            .filter(|fragment| !fragment.composed_only)
+            .flat_map(crate::jni::compile::JFrag::converter_artifacts)
+            .collect()
     }
 
     pub(crate) fn function(&self, ident: &syn::Ident) -> Option<Rc<JniFunctionPlan>> {
@@ -124,8 +166,9 @@ impl JniGenerationPlan {
     }
 
     #[cfg(test)]
-    pub(crate) fn counts(&self) -> (usize, usize, usize, usize, usize) {
+    pub(crate) fn counts(&self) -> (usize, usize, usize, usize, usize, usize) {
         (
+            self.conversions.len(),
             self.functions.len(),
             self.interfaces.len(),
             self.structs.len(),

--- a/prebindgen-jni/src/jni/mod.rs
+++ b/prebindgen-jni/src/jni/mod.rs
@@ -553,7 +553,7 @@ impl JniGen {
             self.registry.flat(),
             self.decls.recipe_table(),
             self.decls.site_bindings(),
-            self.decls.compiled.borrow().clone(),
+            self.generation_plan().conversions().clone(),
         );
         let mut adapter = crate::jni::compile::JCompile {
             decls: &self.decls,
@@ -629,8 +629,9 @@ impl JniGen {
         let row =
             prebindgen_registry::recipe::Crossing::new(reading.clone(), Direction::Deconstruct)
                 .row(crate::jni::recipes::parts());
-        let compiled = self.decls.compiled.borrow();
-        let wires = compiled
+        let wires = self
+            .generation_plan()
+            .conversions()
             .recipe_fragment(&reading.key(), &row)?
             .out_wires
             .clone()?;
@@ -695,8 +696,11 @@ impl JniGen {
     /// states.
     pub(crate) fn return_site_lines_for_test(&self, func: &str) -> Option<Vec<String>> {
         let ident = syn::Ident::new(func, proc_macro2::Span::call_site());
-        let wires =
-            crate::jni::fn_plan::decomposed_return_for_test(&self.decls, &self.registry, &ident)?;
+        let plan = self.generation_plan().function(&ident)?;
+        let crate::jni::fn_plan::FnOutputPlan::Unfold(output) = &plan.output else {
+            return None;
+        };
+        let wires = &output.wires;
         Some(
             wires
                 .iter()
@@ -792,9 +796,8 @@ impl JniGen {
             direction,
         }
         .row(crate::jni::recipes::parts());
-        self.decls
-            .compiled
-            .borrow()
+        self.generation_plan()
+            .conversions()
             .recipe_fragment(&TypeKey::from_ident(&ident), &row)
             .is_some()
     }
@@ -810,7 +813,7 @@ impl JniGen {
         let key = reading.key();
         let row = prebindgen_registry::recipe::Crossing::new(reading.clone(), Direction::Construct)
             .row(crate::jni::recipes::parts());
-        let compiled = self.decls.compiled.borrow();
+        let compiled = self.generation_plan().conversions();
         // A declared class states its composition under `parts`; an optional
         // over one has no recipe of its own and composes on the recipe the registry
         // derived, which is the crossing's default.
@@ -832,8 +835,9 @@ impl JniGen {
 
         let ty: syn::Type = syn::parse_str(spelling).ok()?;
         let reading = prebindgen_registry::Conversions::reading_of(&self.registry, &ty)?;
-        let compiled = self.decls.compiled.borrow();
-        let fragment = compiled.fragment(&reading.key(), Direction::Construct)?;
+        let fragment = self
+            .generation_plan()
+            .fragment(&reading.key(), Direction::Construct)?;
         Some(fragment.rust.is_borrowed_optional_handle())
     }
 
@@ -844,8 +848,9 @@ impl JniGen {
 
         let ty: syn::Type = syn::parse_str(spelling).ok()?;
         let reading = prebindgen_registry::Conversions::reading_of(&self.registry, &ty)?;
-        let compiled = self.decls.compiled.borrow();
-        let fragment = compiled.fragment(&reading.key(), Direction::Construct)?;
+        let fragment = self
+            .generation_plan()
+            .fragment(&reading.key(), Direction::Construct)?;
         Some(fragment.rust.is_optional())
     }
 
@@ -857,8 +862,9 @@ impl JniGen {
         let ty: syn::Type = syn::parse_str(spelling).ok()?;
         let reading = prebindgen_registry::Conversions::reading_of(&self.registry, &ty)?;
         let key = reading.key();
-        let compiled = self.decls.compiled.borrow();
-        let fragment = compiled.fragment(&key, Direction::Construct)?;
+        let fragment = self
+            .generation_plan()
+            .fragment(&key, Direction::Construct)?;
         Some((
             fragment.conv.converter_ident().to_string(),
             fragment.rust.is_invoke(),
@@ -890,10 +896,16 @@ impl JniGen {
         &self,
         out_path: impl AsRef<std::path::Path>,
     ) -> Result<std::path::PathBuf, prebindgen_registry::WriteRustError> {
+        let conversions = self
+            .decls
+            .generation
+            .as_ref()
+            .expect("resolved JniGen has no frozen generation plan")
+            .converter_functions();
         Ok(prebindgen_registry::write::write_rust(
             &self.registry,
             &self.decls,
-            &self.decls.compiled_fns,
+            &conversions,
             out_path,
         )?)
     }
@@ -993,15 +1005,6 @@ pub struct Declarations {
     /// function/trait call policy and Flat representation/error readings;
     /// final rendering spells those readings and qualifies their origins.
     pub(crate) convert_decls: Vec<ConvertDecl>,
-    /// Every conversion this binding compiled.
-    ///
-    /// Filled once by `JniGenBuilder::build_with` and handed to `write_rust`
-    /// directly. It is what reaches the generated file, so a fragment no longer
-    /// has to be expressible as one `ConverterImpl` to be emitted — only to be
-    /// looked up. The writer sorts and de-duplicates by function name, so the
-    /// order here decides which of two same-named functions wins and not where
-    /// any of them lands.
-    pub(crate) compiled_fns: Vec<chain::JFunction>,
     /// Every conversion this binding has compiled so far, keyed by crossing.
     ///
     /// What the emitters ask instead of the converter table. A table entry
@@ -1015,7 +1018,9 @@ pub struct Declarations {
     /// `convert_with`. A conversion for one type is built out of the
     /// conversions for its inners, which the resolver compiles first — the same
     /// order that filled the converter table, so a fragment is there exactly
-    /// when a table entry would have been.
+    /// when a table entry would have been. Resolution drains it into
+    /// [`generation::JniGenerationPlan`]; writers and writer-facing lookups
+    /// cannot resume or mutate this store.
     pub(crate) compiled: std::rc::Rc<
         std::cell::RefCell<prebindgen_registry::recipe::Compiled<crate::jni::compile::JFrag>>,
     >,

--- a/prebindgen-jni/src/jni/tests/callbacks.rs
+++ b/prebindgen-jni/src/jni/tests/callbacks.rs
@@ -832,13 +832,30 @@ fn generation_plan_freezes_and_drains_derivations() {
 
 #[test]
 fn generation_has_no_parallel_converter_function_cache() {
-    let sources = [
-        include_str!("../builder.rs"),
-        include_str!("../generation.rs"),
-        include_str!("../mod.rs"),
-        include_str!("../trait_impl.rs"),
-    ]
-    .join("\n");
+    fn production_sources(dir: &std::path::Path, sources: &mut String) {
+        let mut entries: Vec<_> = std::fs::read_dir(dir)
+            .expect("read JNI source directory")
+            .map(|entry| entry.expect("read JNI source entry").path())
+            .collect();
+        entries.sort();
+        for path in entries {
+            if path.is_dir() {
+                if path.file_name().is_some_and(|name| name == "tests") {
+                    continue;
+                }
+                production_sources(&path, sources);
+            } else if path.extension().is_some_and(|extension| extension == "rs") {
+                sources.push_str(&std::fs::read_to_string(path).expect("read JNI source file"));
+                sources.push('\n');
+            }
+        }
+    }
+
+    let mut sources = String::new();
+    production_sources(
+        &std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src/jni"),
+        &mut sources,
+    );
     assert!(
         !sources.contains("compiled_fns"),
         "JNI converter emission must derive from frozen registry fragments"

--- a/prebindgen-jni/src/jni/tests/callbacks.rs
+++ b/prebindgen-jni/src/jni/tests/callbacks.rs
@@ -772,7 +772,16 @@ fn generation_plan_freezes_and_drains_derivations() {
     assert!(ext.struct_plans.borrow().is_empty());
     assert!(ext.sum_plans.borrow().is_empty());
     assert!(ext.vec_build_plans.borrow().is_empty());
-    let (functions, interfaces, structs, sums, vec_builds) = gen.generation_plan().counts();
+    assert!(
+        ext.compiled.borrow().is_empty(),
+        "the mutable recipe compiler store is drained at freeze"
+    );
+    let (conversions, functions, interfaces, structs, sums, vec_builds) =
+        gen.generation_plan().counts();
+    assert!(
+        conversions >= 1,
+        "registry fragments are frozen for emission"
+    );
     assert_eq!(functions, 1);
     assert!(interfaces >= 1, "the binding error interface is frozen");
     assert_eq!(structs, 1);
@@ -819,6 +828,21 @@ fn generation_plan_freezes_and_drains_derivations() {
     assert!(ext.struct_plans.borrow().is_empty());
     assert!(ext.sum_plans.borrow().is_empty());
     assert!(ext.vec_build_plans.borrow().is_empty());
+}
+
+#[test]
+fn generation_has_no_parallel_converter_function_cache() {
+    let sources = [
+        include_str!("../builder.rs"),
+        include_str!("../generation.rs"),
+        include_str!("../mod.rs"),
+        include_str!("../trait_impl.rs"),
+    ]
+    .join("\n");
+    assert!(
+        !sources.contains("compiled_fns"),
+        "JNI converter emission must derive from frozen registry fragments"
+    );
 }
 
 /// A callback identity is the same whether its args come from the **reading**

--- a/prebindgen-jni/src/jni/trait_impl.rs
+++ b/prebindgen-jni/src/jni/trait_impl.rs
@@ -805,36 +805,6 @@ impl JniGenBuilder {
             }
             .into());
         }
-        // What the compilation produced, kept for emission. The converter table
-        // stays the lookup index; this is what reaches the file.
-        decls.compiled_fns = decls
-            .compiled
-            .borrow()
-            .fragments()
-            .into_iter()
-            // A composed-only fragment has no conversion to emit: the `parts`
-            // recipe states what a `data_class` is made of, and the function that
-            // reads those several values and rebuilds the struct is what the
-            // emitter switch brings. Its marker would otherwise reach the file.
-            // Deliberately not "has wires" — an `Option<data_class>` has both a
-            // wire list and a conversion of its own.
-            .filter(|f| !f.composed_only)
-            // A JNI conversion already emits more than one function: a
-            // `convert!` with a fallible or binding-local step carries it as a
-            // pre-stage, and every one of them has to reach the file. This is
-            // the case the converter table could hold only because it kept a
-            // list beside the conversion; a fragment says it directly.
-            .flat_map(|f| {
-                std::iter::once(f.rust.clone())
-                    .chain(f.rust_stages.iter().cloned())
-                    .chain(
-                        f.conv
-                            .pre_stages
-                            .iter()
-                            .map(|s| crate::jni::chain::JFunction::marker(s.converter.clone())),
-                    )
-            })
-            .collect();
         let generation = crate::jni::generation::JniGenerationPlan::freeze(&mut decls, &registry);
         decls.generation = Some(std::rc::Rc::new(generation));
         Ok(JniGen { decls, registry })


### PR DESCRIPTION
## Summary

- freeze the registry compiler's JNI recipe fragments into `JniGenerationPlan` and drain the mutable build-phase store at the resolution boundary
- derive private converter artifacts from those frozen fragments when `write_rust` begins, deleting the parallel `compiled_fns` emission cache
- route post-resolution fragment lookups and test seams through the immutable plan; add fences proving the mutable store is empty and the duplicate cache cannot return

This is the JNI counterpart to #571. It makes registry-compiled fragments the sole post-resolution source of converter artifacts without claiming the later shared-writer cutover: `ConverterImpl` / `Stage` still carry early helper identifiers, and moving those identities into the registry remains a separate umbrella stage.

Generated Rust, C artifacts, JNI ABI, and generated Kotlin are byte-for-byte unchanged.

## Verification

- `cargo test -p prebindgen-jni --all-features --lib` — passed, 296 tests
- `cargo test --workspace --all-features` — passed
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` — passed
- `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --all-features --no-deps` — passed
- `cargo fmt --all --check` — passed
- `git diff --check` — passed
- `bash examples/regen-check.sh` — passed; committed generated output is byte-identical
- `cd examples/covertest-kotlin && ./gradlew run --console=plain` — passed, all 61 sections

Part of #513.
