### PR TITLE
Deduplicate converters by registry operation

### DIFF
--- a/docs/model.md
+++ b/docs/model.md
@@ -252,8 +252,11 @@ JniGen's constant hook returns two, a getter and an alias.
 1. the adapter's **prerequisites** — helper functions, type aliases, the
 `#[repr(C)]` structs a C header reads — emitted first so everything below can
 refer to them;
-2. the converters it was handed, sorted by name and deduplicated, so one
-function per name reaches the file however many crossings produced it;
+2. the converter plans it was handed. Registry-owned operations are grouped by
+their semantic `OperationId` before rendering, with a reachable representative
+preferred when fragments retain separate reachability state. Compatibility
+plans that do not yet expose an operation identity are still rendered and
+deduplicated by their preselected name;
 3. the per-item output, in the order above;
 4. the source crate's own feature guards, verbatim.
 
@@ -366,7 +369,9 @@ adapter-declared intermediate representation. Adapter terminals likewise name
 their semantic operation, such as borrowing or consuming an opaque handle.
 The final writer turns that identity into a readable private symbol: a bounded
 semantic stem followed by a stable hash. The hash disambiguates the name; it
-does not replace the model and adapter vocabulary useful to a reader.
+does not replace the model and adapter vocabulary useful to a reader. The
+writer also groups plans by this identity before invoking their renderer, so
+sharing is decided before either the symbol or function body exists.
 
 The generated code has to name Rust types. Where a source function's parameter
 is written `&Sample`, the converter for it has to produce a `&Sample`, because

--- a/prebindgen-jni/src/jni/chain.rs
+++ b/prebindgen-jni/src/jni/chain.rs
@@ -201,6 +201,25 @@ impl JFunction {
 }
 
 impl RustFunction for JFunction {
+    fn operation_id(&self) -> Option<&OperationId> {
+        Some(match &self.0 {
+            JBody::Marker(operation) => operation,
+            JBody::ValueCodec(plan) => &plan.operation,
+            JBody::HandleCodec(plan) => &plan.operation_id,
+            JBody::CustomConversion(plan) => &plan.operation,
+            JBody::Result(plan) => &plan.operation,
+            JBody::Transparent(plan) => &plan.operation,
+            JBody::BorrowedOptionalHandle(plan) => &plan.operation,
+            JBody::Product(plan) => &plan.operation,
+            JBody::Choice(plan) => &plan.operation,
+            JBody::Sequence(plan) => &plan.operation,
+            JBody::Optional(plan) => &plan.operation,
+            JBody::StructCodec(plan) => &plan.operation,
+            JBody::SumCodec(plan) => &plan.operation,
+            JBody::Invoke(plan) => plan.operation_id(),
+        })
+    }
+
     fn should_emit(&self) -> bool {
         match &self.0 {
             JBody::Marker(_) => false,

--- a/prebindgen-jni/src/jni/emit/callback.rs
+++ b/prebindgen-jni/src/jni/emit/callback.rs
@@ -226,6 +226,10 @@ pub(crate) struct JInvokePlan {
 }
 
 impl JInvokePlan {
+    pub(crate) fn operation_id(&self) -> &prebindgen_registry::OperationId {
+        &self.operation
+    }
+
     pub(crate) fn render(&self, emit: &prebindgen_registry::Emit) -> syn::ItemFn {
         let rendered = self.chain.render(emit);
         let name = emit.operation_ident("jni", &self.operation);

--- a/prebindgen-registry/src/write.rs
+++ b/prebindgen-registry/src/write.rs
@@ -15,7 +15,7 @@
 //! adapters migrating incrementally.
 
 use std::{
-    collections::{BTreeMap, BTreeSet},
+    collections::{BTreeMap, BTreeSet, HashMap},
     path::{Path, PathBuf},
 };
 
@@ -87,6 +87,16 @@ impl std::error::Error for WriteError {}
 /// validation are complete, with the same [`crate::Emit`] capability used for
 /// the rest of final Rust emission.
 pub trait RustFunction {
+    /// Registry-owned semantic identity of this operation.
+    ///
+    /// Plans that return an identity are de-duplicated before rendering, so
+    /// sharing never depends on the Rust symbol selected by final emission.
+    /// `None` is the compatibility path for adapters that still retain a
+    /// preselected function name.
+    fn operation_id(&self) -> Option<&crate::generation::OperationId> {
+        None
+    }
+
     /// Whether this plan is reachable from the generated adapter surface.
     /// Validation-only plans may return false and remain available for diagnostics.
     fn should_emit(&self) -> bool {
@@ -106,12 +116,14 @@ impl RustFunction for syn::ItemFn {
 /// Emit a resolved registry whose private converters are rendered at this
 /// final writing boundary.
 ///
-/// `conversions` is what the adapter's compilation produced. It is sorted and
-/// de-duplicated by function name here, so the order decides which of two
-/// same-named functions wins and not where any of them lands. Handing them
-/// over directly is what frees an adapter to emit a conversion the converter
-/// table could not hold — several functions for one crossing, or one occupying
-/// more than a single wire value.
+/// `conversions` is what the adapter's compilation produced. Registry-owned
+/// operations are de-duplicated by [`crate::generation::OperationId`] before
+/// rendering; if separate fragments retain separate reachability state, a
+/// reachable representative wins. Compatibility plans without semantic
+/// identity are still sorted and de-duplicated by their preselected function
+/// name after rendering. Handing the plans over directly is what frees an
+/// adapter to emit a conversion the converter table could not hold — several
+/// functions for one crossing, or one occupying more than a single wire value.
 ///
 /// Already-rendered [`syn::ItemFn`] values implement [`RustFunction`], so
 /// adapters can migrate to semantic plans incrementally without a second API.
@@ -203,10 +215,29 @@ pub fn write_rust<P: AsRef<Path>, E: Prebindgen, C: RustFunction>(
             .map(|(_, item)| ext.on_const(item, registry, &emit)),
     )?);
 
-    // Render converters only after per-item planning has marked the late plans
-    // reachable, while still placing them before adapter output in the file.
-    let conversions: Vec<_> = conversions
-        .iter()
+    // Select one semantic operation only after per-item planning has marked
+    // late plans reachable. This lets a reached twin replace an earlier
+    // dormant twin without materializing either Rust function first.
+    let mut operation_positions: HashMap<crate::generation::OperationId, usize> = HashMap::new();
+    let mut unique_conversions: Vec<&C> = Vec::new();
+    for plan in conversions {
+        let Some(operation) = plan.operation_id() else {
+            unique_conversions.push(plan);
+            continue;
+        };
+        match operation_positions.get(operation).copied() {
+            Some(position) if !unique_conversions[position].should_emit() && plan.should_emit() => {
+                unique_conversions[position] = plan;
+            }
+            Some(_) => {}
+            None => {
+                operation_positions.insert(operation.clone(), unique_conversions.len());
+                unique_conversions.push(plan);
+            }
+        }
+    }
+    let conversions: Vec<_> = unique_conversions
+        .into_iter()
         .map(|plan| (plan.should_emit(), plan.render(&emit)))
         .collect();
     let converter_names: BTreeSet<String> = conversions

--- a/prebindgen-registry/src/write/tests.rs
+++ b/prebindgen-registry/src/write/tests.rs
@@ -70,6 +70,31 @@ struct LatePlan {
     reachable: Rc<Cell<bool>>,
 }
 
+#[derive(Clone)]
+struct OperationPlan {
+    operation: crate::generation::OperationId,
+    reachable: bool,
+    renders: Rc<Cell<usize>>,
+    rendered_reachable: Rc<Cell<bool>>,
+}
+
+impl RustFunction for OperationPlan {
+    fn operation_id(&self) -> Option<&crate::generation::OperationId> {
+        Some(&self.operation)
+    }
+
+    fn should_emit(&self) -> bool {
+        self.reachable
+    }
+
+    fn render(&self, emit: &crate::Emit) -> syn::ItemFn {
+        self.renders.set(self.renders.get() + 1);
+        self.rendered_reachable.set(self.reachable);
+        let ident = emit.operation_ident("test", &self.operation);
+        syn::parse_quote!(fn #ident() {})
+    }
+}
+
 impl RustFunction for LatePlan {
     fn should_emit(&self) -> bool {
         self.reachable.get()
@@ -235,6 +260,58 @@ fn dedup_and_sort() {
     // (uppercase P < lowercase h).
     assert_eq!(items[0].0.to_string(), "Ptr_to_Sample_bbbb");
     assert_eq!(items[1].0.to_string(), "handle_to_u64_aaaa");
+}
+
+#[test]
+fn registry_operations_are_deduplicated_before_rendering() {
+    let item: syn::ItemFn = syn::parse_quote!(
+        fn a_fn() {}
+    );
+    let ident: syn::Ident = syn::parse_quote!(a_fn);
+    let registry =
+        crate::test_util::reg_from_items(vec![(syn::Item::Fn(item), SourceLocation::default())])
+            .expect("index")
+            .export(&ident)
+            .scanned()
+            .expect("scan");
+    let operation = crate::generation::OperationId::shared(
+        crate::generation::ArtifactId::new("test", "shared-converter").expect("identity"),
+        crate::recipe::Direction::Construct,
+    );
+    let renders = Rc::new(Cell::new(0));
+    let rendered_reachable = Rc::new(Cell::new(false));
+    let dormant = OperationPlan {
+        operation: operation.clone(),
+        reachable: false,
+        renders: renders.clone(),
+        rendered_reachable: rendered_reachable.clone(),
+    };
+    let reachable = OperationPlan {
+        operation,
+        reachable: true,
+        renders: renders.clone(),
+        rendered_reachable: rendered_reachable.clone(),
+    };
+    let dir = crate::test_util::unique_test_dir("write_operation_dedup");
+    std::fs::create_dir_all(&dir).unwrap();
+
+    write_rust(
+        &registry,
+        &IdentityExt,
+        &[dormant, reachable],
+        dir.join("gen.rs"),
+    )
+    .expect("write Rust");
+
+    assert_eq!(
+        renders.get(),
+        1,
+        "a shared registry operation must be rendered exactly once"
+    );
+    assert!(
+        rendered_reachable.get(),
+        "a reachable representative must replace an earlier dormant twin"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- expose registry-owned `OperationId` from every frozen JNI converter-plan variant
- group equal semantic operations before invoking the final Rust renderer
- prefer a reachable representative when equivalent fragments retain separate reachability cells
- keep name-based post-render deduplication only as the explicit compatibility path for adapters, currently C, that still preselect Rust converter names
- update the Flat-model description and add a writer regression test for dormant-first/reachable-second sharing

## Why

#573 moved converter identity into the registry and made final helper names readable, but the shared writer still rendered every retained JNI plan and then deduplicated the resulting functions by Rust identifier. The operation identity therefore determined the name but did not yet determine sharing.

This slice makes semantic identity operational. The writer first groups plans by `OperationId`, then renders one representative. A rendered name or function body cannot influence that decision because neither exists yet.

The first implementation exposed a compatibility detail that the old name collision had hidden: separate fragments can retain the same operation with separate reachability cells. Keeping the first plan could therefore select a dormant copy over a later reachable copy. The final selection rule prefers any reachable representative while preserving first-seen order otherwise.

## Boundary

This PR intentionally converts JNI only. C converter plans still retain adapter-selected `syn::Ident` values and continue through the documented compatibility name-deduplication path. Moving C onto `OperationId` is the next prerequisite for deleting that path entirely.

Generated Rust, Kotlin, JNI symbols/descriptors, C output, and public behavior are unchanged.

## Verification

- `cargo test --workspace --all-features`
- `cargo clippy --all-targets --all-features -- --deny warnings`
- `./examples/regen-check.sh` — committed generated output byte-identical
- `cd examples/covertest-kotlin && ./gradlew run --console=plain` — 61 sections passed
