### PR TITLE
Give C converters registry operation identity

### DIFF
--- a/docs/model.md
+++ b/docs/model.md
@@ -254,9 +254,13 @@ JniGen's constant hook returns two, a getter and an alias.
 refer to them;
 2. the converter plans it was handed. Registry-owned operations are grouped by
 their semantic `OperationId` before rendering, with a reachable representative
-preferred when fragments retain separate reachability state. Compatibility
-plans that do not yet expose an operation identity are still rendered and
-deduplicated by their preselected name;
+preferred when fragments retain separate reachability state. Both JniGen and
+Cbindgen converter plans now expose that identity. Their remaining preselected
+C helper names are compatibility formatting only: a test fence verifies that
+they describe exactly the same sharing partition as `OperationId`, while later
+slices move those private names to final `Emit` allocation. Generic
+compatibility functions that do not expose an operation identity are still
+rendered and deduplicated by their preselected name;
 3. the per-item output, in the order above;
 4. the source crate's own feature guards, verbatim.
 

--- a/prebindgen-c/src/chain.rs
+++ b/prebindgen-c/src/chain.rs
@@ -51,6 +51,7 @@ impl chain::Child for CCall {
 /// A typed converter plan waiting for final rendering.
 #[derive(Clone)]
 pub(crate) struct CFunction {
+    operation: prebindgen_registry::OperationId,
     call: CCall,
     body: CBody,
 }
@@ -74,111 +75,136 @@ enum CBody {
 }
 
 impl CFunction {
-    pub(crate) fn product(plan: ProductPlan) -> Self {
+    pub(crate) fn product(operation: prebindgen_registry::OperationId, plan: ProductPlan) -> Self {
         let call = CCall(chain::Call::new(
             plan.ident.clone(),
             plan.fields.iter().any(|field| field.converter.fallible()),
             plan.direction == Direction::Construct,
         ));
         Self {
+            operation,
             call,
             body: CBody::Product(plan),
         }
     }
 
-    pub(crate) fn custom(plan: CustomPlan) -> Self {
+    pub(crate) fn custom(operation: prebindgen_registry::OperationId, plan: CustomPlan) -> Self {
         let call = CCall(chain::Call::new(plan.ident.clone(), plan.fallible(), false));
         Self {
+            operation,
             call,
             body: CBody::Custom(plan),
         }
     }
 
-    pub(crate) fn output_terminal(plan: OutputTerminalPlan) -> Self {
+    pub(crate) fn output_terminal(
+        operation: prebindgen_registry::OperationId,
+        plan: OutputTerminalPlan,
+    ) -> Self {
         let call = CCall(chain::Call::new(plan.ident.clone(), false, false));
         Self {
+            operation,
             call,
             body: CBody::OutputTerminal(plan),
         }
     }
 
-    pub(crate) fn input_terminal(plan: InputTerminalPlan) -> Self {
+    pub(crate) fn input_terminal(
+        operation: prebindgen_registry::OperationId,
+        plan: InputTerminalPlan,
+    ) -> Self {
         let call = CCall(chain::Call::new(
             plan.ident.clone(),
             plan.operation.fallible(),
             plan.operation.unsafe_(),
         ));
         Self {
+            operation,
             call,
             body: CBody::InputTerminal(plan),
         }
     }
 
-    pub(crate) fn payload(plan: PayloadPlan) -> Self {
+    pub(crate) fn payload(operation: prebindgen_registry::OperationId, plan: PayloadPlan) -> Self {
         let call = CCall(chain::Call::new(
             plan.ident.clone(),
             plan.direction == Direction::Construct && !plan.optional,
             plan.direction == Direction::Construct,
         ));
         Self {
+            operation,
             call,
             body: CBody::Payload(plan),
         }
     }
 
-    pub(crate) fn borrow(plan: BorrowPlan) -> Self {
+    pub(crate) fn borrow(operation: prebindgen_registry::OperationId, plan: BorrowPlan) -> Self {
         let call = CCall(chain::Call::new(
             plan.ident.clone(),
             plan.operation.fallible(),
             true,
         ));
         Self {
+            operation,
             call,
             body: CBody::Borrow(plan),
         }
     }
 
-    pub(crate) fn slice_input(plan: SliceInputPlan) -> Self {
+    pub(crate) fn slice_input(
+        operation: prebindgen_registry::OperationId,
+        plan: SliceInputPlan,
+    ) -> Self {
         let call = CCall(chain::Call::new(plan.ident.clone(), false, false));
         Self {
+            operation,
             call,
             body: CBody::SliceInput(plan),
         }
     }
 
-    pub(crate) fn marker(plan: MarkerPlan) -> Self {
+    pub(crate) fn marker(operation: prebindgen_registry::OperationId, plan: MarkerPlan) -> Self {
         let call = CCall(chain::Call::new(plan.ident.clone(), false, false));
         Self {
+            operation,
             call,
             body: CBody::Marker(plan),
         }
     }
 
-    pub(crate) fn optional(plan: OptionalPlan) -> Self {
+    pub(crate) fn optional(
+        operation: prebindgen_registry::OperationId,
+        plan: OptionalPlan,
+    ) -> Self {
         let call = CCall(chain::Call::new(
             plan.ident.clone(),
             plan.converter.fallible(),
             true,
         ));
         Self {
+            operation,
             call,
             body: CBody::Optional(plan),
         }
     }
 
-    pub(crate) fn sequence(plan: SequencePlan) -> Self {
+    pub(crate) fn sequence(
+        operation: prebindgen_registry::OperationId,
+        plan: SequencePlan,
+    ) -> Self {
         let call = CCall(chain::Call::new(
             plan.ident.clone(),
             plan.child.fallible(),
             plan.child.unsafe_(),
         ));
         Self {
+            operation,
             call,
             body: CBody::Sequence(plan),
         }
     }
 
-    pub(crate) fn choice(plan: ChoicePlan) -> Self {
+    pub(crate) fn choice(operation: prebindgen_registry::OperationId, plan: ChoicePlan) -> Self {
         let fallible = plan.direction == Direction::Construct
             || plan
                 .arms
@@ -191,13 +217,18 @@ impl CFunction {
             plan.direction == Direction::Construct,
         ));
         Self {
+            operation,
             call,
             body: CBody::Choice(plan),
         }
     }
 
-    pub(crate) fn deferred_invoke(ident: syn::Ident) -> Self {
+    pub(crate) fn deferred_invoke(
+        operation: prebindgen_registry::OperationId,
+        ident: syn::Ident,
+    ) -> Self {
         Self {
+            operation,
             call: CCall(chain::Call::new(ident, false, true)),
             body: CBody::DeferredInvoke,
         }
@@ -205,6 +236,13 @@ impl CFunction {
 
     pub(crate) fn is_deferred_invoke(&self) -> bool {
         matches!(self.body, CBody::DeferredInvoke)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn operation_and_compatibility_name(
+        &self,
+    ) -> (&prebindgen_registry::OperationId, &syn::Ident) {
+        (&self.operation, self.call.ident())
     }
 
     #[cfg(test)]
@@ -279,6 +317,10 @@ impl CFunction {
 }
 
 impl RustFunction for CFunction {
+    fn operation_id(&self) -> Option<&prebindgen_registry::OperationId> {
+        Some(&self.operation)
+    }
+
     fn render(&self, emit: &Emit) -> syn::ItemFn {
         match &self.body {
             CBody::Custom(plan) => plan.render(emit),

--- a/prebindgen-c/src/compile.rs
+++ b/prebindgen-c/src/compile.rs
@@ -13,8 +13,9 @@
 use prebindgen_registry::{
     flat::{Alternative, Function},
     generation::{
-        AbiLayout, ChoiceArity, Cleanup, ConverterPlan, Failure, FixedArity, FragmentPlan,
-        FragmentUse, NichePlan, Representation, ShapePlan, SiteId, SitePlan,
+        AbiLayout, ArtifactId, ChoiceArity, Cleanup, ConverterPlan, Failure, FixedArity,
+        FragmentPlan, FragmentUse, NichePlan, OperationId, Representation, ShapePlan, SiteId,
+        SitePlan,
     },
     recipe::{At, Carrier, Compile, Cx, Frag, Mode, Parts, Role, Validity, Yield},
     FragmentId,
@@ -362,6 +363,58 @@ fn fragment_use(fragment: &CFrag) -> FragmentUse {
     FragmentUse::new(fragment.id.clone(), fragment.yields.clone())
 }
 
+fn c_artifact(kind: &'static str, name: impl Into<String>) -> ArtifactId {
+    ArtifactId::new(kind, name).expect("C operation identity is non-empty")
+}
+
+fn model_operation(at: At<'_>, kind: &'static str, name: impl Into<String>) -> OperationId {
+    model_operation_for(at.crossing.value(), at, kind, name)
+}
+
+fn model_operation_for(
+    source: &TypeRef,
+    at: At<'_>,
+    kind: &'static str,
+    name: impl Into<String>,
+) -> OperationId {
+    OperationId::model_artifact(source, c_artifact(kind, name), at.crossing.direction())
+}
+
+fn marker_name(operation: &MarkerOperation) -> &'static str {
+    match operation {
+        MarkerOperation::ChoiceArm => "choice-arm",
+        MarkerOperation::Optional => "optional",
+        MarkerOperation::Sequence => "sequence",
+        MarkerOperation::Result => "result",
+    }
+}
+
+fn input_terminal_name(operation: &crate::chain::InputTerminalOperation) -> &'static str {
+    match operation {
+        crate::chain::InputTerminalOperation::OwnedHandle { .. } => "owned-handle",
+        crate::chain::InputTerminalOperation::ValueOpaque { .. } => "value-opaque",
+        crate::chain::InputTerminalOperation::Enum { .. } => "enum",
+        crate::chain::InputTerminalOperation::String => "string",
+        crate::chain::InputTerminalOperation::StringField => "string-field",
+        crate::chain::InputTerminalOperation::StrMarker => "str-marker",
+        crate::chain::InputTerminalOperation::Bool => "bool",
+        crate::chain::InputTerminalOperation::Scalar => "scalar",
+    }
+}
+
+fn output_terminal_name(operation: &crate::chain::OutputTerminalOperation) -> &'static str {
+    match operation {
+        crate::chain::OutputTerminalOperation::Unit => "unit",
+        crate::chain::OutputTerminalOperation::String => "string",
+        crate::chain::OutputTerminalOperation::BoolField => "bool-field",
+        crate::chain::OutputTerminalOperation::Scalar => "scalar",
+        crate::chain::OutputTerminalOperation::OwnedHandle { .. } => "owned-handle",
+        crate::chain::OutputTerminalOperation::OpaqueError { .. } => "opaque-error",
+        crate::chain::OutputTerminalOperation::ValueOpaque => "value-opaque",
+        crate::chain::OutputTerminalOperation::Enum { .. } => "enum",
+    }
+}
+
 impl Carrier for CFrag {
     fn yields(&self) -> Yield {
         self.yields.clone()
@@ -439,7 +492,8 @@ impl CFrag {
     fn from_marker(at: At<'_>, plan: MarkerPlan) -> Self {
         let destination: syn::Type = syn::parse_quote!(());
         let subs = plan.subs.iter().map(TypeRef::key).collect();
-        let function = CFunction::marker(plan);
+        let operation = model_operation(at, "c-marker", marker_name(&plan.operation));
+        let function = CFunction::marker(operation, plan);
         let niches = Niches::empty();
         let value = CValue::Direct {
             wire: destination.clone(),
@@ -469,7 +523,8 @@ impl CFrag {
     fn from_custom(at: At<'_>, plan: crate::chain::CustomPlan, niches: Niches) -> Self {
         let destination = plan.wire.clone();
         let subs = vec![TypeKey::from_type(&destination)];
-        let function = CFunction::custom(plan);
+        let operation = model_operation_for(&plan.source, at, "c-terminal", "custom");
+        let function = CFunction::custom(operation, plan);
         let value = CValue::Direct {
             wire: destination.clone(),
             converter: function.call().clone(),
@@ -496,7 +551,13 @@ impl CFrag {
     /// A whole-value output retained as an operation until final Rust emission.
     fn from_output_terminal(at: At<'_>, plan: crate::chain::OutputTerminalPlan) -> Self {
         let destination = plan.wire.clone();
-        let function = CFunction::output_terminal(plan);
+        let operation = model_operation_for(
+            &plan.source,
+            at,
+            "c-terminal-output",
+            output_terminal_name(&plan.operation),
+        );
+        let function = CFunction::output_terminal(operation, plan);
         let niches = Niches::empty();
         let value = CValue::Direct {
             wire: destination.clone(),
@@ -524,7 +585,13 @@ impl CFrag {
     /// A whole-value input retained as an operation until final Rust emission.
     fn from_input_terminal(at: At<'_>, plan: crate::chain::InputTerminalPlan) -> Self {
         let destination = plan.wire.clone();
-        let function = CFunction::input_terminal(plan);
+        let operation = model_operation_for(
+            &plan.source,
+            at,
+            "c-terminal-input",
+            input_terminal_name(&plan.operation),
+        );
+        let function = CFunction::input_terminal(operation, plan);
         let niches = Niches::empty();
         let value = CValue::Direct {
             wire: destination.clone(),
@@ -552,7 +619,9 @@ impl CFrag {
     /// A tagged-union pointer payload retained until final Rust emission.
     fn from_payload(at: At<'_>, plan: crate::chain::PayloadPlan) -> Self {
         let destination = plan.wire.clone();
-        let function = CFunction::payload(plan);
+        let payload_kind = format!("payload-optional-{}-boxed-{}", plan.optional, plan.boxed);
+        let operation = model_operation_for(&plan.source, at, "c-terminal", payload_kind);
+        let function = CFunction::payload(operation, plan);
         let niches = Niches::empty();
         let value = CValue::Direct {
             wire: destination.clone(),
@@ -581,7 +650,15 @@ impl CFrag {
     fn from_borrow(at: At<'_>, plan: crate::chain::BorrowPlan) -> Self {
         let destination = plan.wire.clone();
         let subs = vec![plan.source_inner.key()];
-        let function = CFunction::borrow(plan);
+        let borrow_kind = match plan.operation {
+            crate::chain::BorrowOperation::StrInput => "str-input",
+            crate::chain::BorrowOperation::SharedInput => "shared-input",
+            crate::chain::BorrowOperation::MutableInput => "mutable-input",
+            crate::chain::BorrowOperation::MutableUninitInput => "mutable-uninit-input",
+            crate::chain::BorrowOperation::SharedOutput => "shared-output",
+        };
+        let operation = model_operation_for(&plan.source_inner, at, "c-borrow", borrow_kind);
+        let function = CFunction::borrow(operation, plan);
         let niches = Niches::empty();
         let value = CValue::Direct {
             wire: destination.clone(),
@@ -612,7 +689,16 @@ impl CFrag {
         let element = plan.element.clone();
         let reinterpret = plan.reinterpret;
         let subs = vec![element.key()];
-        let function = CFunction::slice_input(plan);
+        let operation = model_operation(
+            at,
+            "c-slice-input",
+            if plan.reinterpret {
+                "reinterpret"
+            } else {
+                "direct"
+            },
+        );
+        let function = CFunction::slice_input(operation, plan);
         let niches = Niches::empty();
         let value = CValue::BorrowedInput {
             element,
@@ -822,15 +908,29 @@ impl<R: Conversions> Compile for CCompile<'_, R> {
                 Niches::empty(),
             )
         };
-        let function = CFunction::optional(OptionalPlan {
-            ident: format_ident!("__cbg_in_option_{}", sanitize(&elem.key())),
-            source: at.crossing.spelled().clone(),
-            source_module: self.gen.source_module.clone(),
-            wire: wire.clone(),
-            converter: inner.function.call().clone(),
-            repr,
-            borrowed: elem.borrow_target().is_some(),
-        });
+        let representation = match &repr {
+            OptionalRepr::Niche { .. } => "niche",
+            OptionalRepr::Nullable { read_direct: true } => "nullable-direct",
+            OptionalRepr::Nullable { read_direct: false } => "nullable-indirect",
+        };
+        let operation = OperationId::optional_converter(
+            at.crossing.value(),
+            at.crossing.mode(),
+            c_artifact("c-optional-intermediate", representation),
+            at.crossing.direction(),
+        );
+        let function = CFunction::optional(
+            operation,
+            OptionalPlan {
+                ident: format_ident!("__cbg_in_option_{}", sanitize(&elem.key())),
+                source: at.crossing.spelled().clone(),
+                source_module: self.gen.source_module.clone(),
+                wire: wire.clone(),
+                converter: inner.function.call().clone(),
+                repr,
+                borrowed: elem.borrow_target().is_some(),
+            },
+        );
         let value = CValue::Direct {
             wire: wire.clone(),
             converter: function.call().clone(),
@@ -865,14 +965,21 @@ impl<R: Conversions> Compile for CCompile<'_, R> {
         if at.crossing.direction() == Direction::Deconstruct {
             if let TypeKind::Vec(element) = at.crossing.value().kind() {
                 if !marker_destination(&inner.destination) {
-                    let function = CFunction::sequence(SequencePlan {
-                        ident: format_ident!("__cbg_out_chain_vec_{}", sanitize(&element.key())),
-                        source: ty.clone(),
-                        element: (**element).clone(),
-                        source_module: self.gen.source_module.clone(),
-                        child_wire: inner.destination.clone(),
-                        child: inner.function.call().clone(),
-                    });
+                    let operation = at.sequence_converter_for(at.crossing.value());
+                    let function = CFunction::sequence(
+                        operation,
+                        SequencePlan {
+                            ident: format_ident!(
+                                "__cbg_out_chain_vec_{}",
+                                sanitize(&element.key())
+                            ),
+                            source: ty.clone(),
+                            element: (**element).clone(),
+                            source_module: self.gen.source_module.clone(),
+                            child_wire: inner.destination.clone(),
+                            child: inner.function.call().clone(),
+                        },
+                    );
                     let value = CValue::OwnedSequence {
                         element_wire: inner.destination.clone(),
                         converter: function.call().clone(),
@@ -1026,13 +1133,20 @@ impl<R: Conversions> Compile for CCompile<'_, R> {
                 })
                 .map(|(p, _)| p.ty.key())
                 .collect();
-            let function = CFunction::marker(MarkerPlan {
-                ident: format_ident!("__cbg_arm"),
-                operation: MarkerOperation::ChoiceArm,
-                // Choice retains the exact part FragmentUse edges; this
-                // transient bridge has no independent dependency.
-                subs: Vec::new(),
-            });
+            let operation = OperationId::shared(
+                c_artifact("c-marker", "choice-arm"),
+                at.crossing.direction(),
+            );
+            let function = CFunction::marker(
+                operation,
+                MarkerPlan {
+                    ident: format_ident!("__cbg_arm"),
+                    operation: MarkerOperation::ChoiceArm,
+                    // Choice retains the exact part FragmentUse edges; this
+                    // transient bridge has no independent dependency.
+                    subs: Vec::new(),
+                },
+            );
             let destination: syn::Type = syn::parse_quote!(());
             let value = CValue::Direct {
                 wire: destination.clone(),
@@ -1109,14 +1223,23 @@ impl<R: Conversions> Compile for CCompile<'_, R> {
             Direction::Deconstruct => CbindgenBuilder::out_name_of(&key),
         };
         let wire: syn::Type = syn::parse_quote!(#c_struct);
-        let function = CFunction::product(ProductPlan {
-            ident,
-            source: at.crossing.spelled().clone(),
-            source_module: self.gen.source_module.clone(),
-            wire: wire.clone(),
-            direction,
-            fields,
-        });
+        let operation = OperationId::product_converter(
+            at.crossing.value(),
+            at.crossing.mode(),
+            c_artifact("c-product-intermediate", "repr-c-struct"),
+            at.crossing.direction(),
+        );
+        let function = CFunction::product(
+            operation,
+            ProductPlan {
+                ident,
+                source: at.crossing.spelled().clone(),
+                source_module: self.gen.source_module.clone(),
+                wire: wire.clone(),
+                direction,
+                fields,
+            },
+        );
         let value = CValue::Direct {
             wire: wire.clone(),
             converter: function.call().clone(),
@@ -1204,14 +1327,23 @@ impl<R: Conversions> Compile for CCompile<'_, R> {
                     .collect()
             })
             .collect();
-        let function = CFunction::choice(ChoicePlan {
-            ident,
-            source: at.crossing.spelled().clone(),
-            source_module: self.gen.source_module.clone(),
-            wire: cname,
-            direction,
-            arms: planned_arms,
-        });
+        let operation = OperationId::choice_converter(
+            at.crossing.value(),
+            at.crossing.mode(),
+            c_artifact("c-choice-intermediate", "repr-c-tagged-union"),
+            at.crossing.direction(),
+        );
+        let function = CFunction::choice(
+            operation,
+            ChoicePlan {
+                ident,
+                source: at.crossing.spelled().clone(),
+                source_module: self.gen.source_module.clone(),
+                wire: cname,
+                direction,
+                arms: planned_arms,
+            },
+        );
         let value = CValue::Direct {
             wire: destination.clone(),
             converter: function.call().clone(),
@@ -1251,10 +1383,11 @@ impl<R: Conversions> Compile for CCompile<'_, R> {
         }
         let c_struct = self.gen.callback_c_ident(&key);
         let destination: syn::Type = syn::parse_quote!(#c_struct);
-        let function = CFunction::deferred_invoke(format_ident!(
-            "__cbg_in_{}",
-            self.gen.callback_c_name(&key)
-        ));
+        let operation = model_operation(at, "c-invoke", "callback-capture");
+        let function = CFunction::deferred_invoke(
+            operation,
+            format_ident!("__cbg_in_{}", self.gen.callback_c_name(&key)),
+        );
         let value = CValue::Direct {
             wire: destination.clone(),
             converter: function.call().clone(),

--- a/prebindgen-c/src/tests/mod.rs
+++ b/prebindgen-c/src/tests/mod.rs
@@ -22,8 +22,30 @@ fn write(cbindgen: CbindgenBuilder, registry: RegistryBuilder, tag: &str) -> Str
     std::fs::create_dir_all(&dir).unwrap();
     let out = dir.join(format!("{tag}.rs"));
     let gen = cbindgen.build_with(registry).expect("resolve");
+    assert_converter_identity_matches_compatibility_names(&gen);
     let path = gen.write_rust(&out).expect("write_rust");
     std::fs::read_to_string(&path).unwrap()
+}
+
+fn assert_converter_identity_matches_compatibility_names(gen: &Cbindgen) {
+    let mut names_by_operation = std::collections::HashMap::new();
+    let mut operations_by_name = std::collections::HashMap::new();
+    for function in gen.gen.converter_functions() {
+        let (operation, name) = function.operation_and_compatibility_name();
+        let name = name.to_string();
+        if let Some(previous) = names_by_operation.insert(operation.clone(), name.clone()) {
+            assert_eq!(
+                previous, name,
+                "one semantic C operation must not select two compatibility names"
+            );
+        }
+        if let Some(previous) = operations_by_name.insert(name.clone(), operation.clone()) {
+            assert_eq!(
+                previous, *operation,
+                "one compatibility name must not hide two semantic C operations: {name}"
+            );
+        }
+    }
 }
 
 fn error_struct() -> syn::ItemStruct {


### PR DESCRIPTION
## Summary

- give every retained C converter plan an explicit registry-owned `OperationId`
- identify terminals, borrows, callbacks, and composed Product, Optional, Sequence, and Choice converters by their semantic conversion contract
- let the shared writer deduplicate C helpers by operation identity before rendering
- verify across the C test fixtures that semantic identity and the existing private helper names describe exactly the same sharing partition

## Why

Cbindgen still selected private Rust helper names while compiling recipes. After registry operation deduplication landed, those plans lacked `OperationId`, so C remained on the writer’s rendered-name compatibility path. This slice makes sharing a model-level decision for both in-tree language adapters without yet combining that architectural change with the larger call-site and generated-name migration.

Each identity records the model carrier, direction, and adapter semantic that changes the conversion contract. Composed shapes use the registry constructors and adapter-declared intermediate representation. Terminal identities distinguish operations such as scalar, owned-handle, enum, string-field, and opaque-error conversion; the retained source carrier prevents unrelated terminal plans from aliasing.

The existing C helper identifiers remain temporarily in the plans because wrappers and parent converters still call them before final rendering. A test-only bijection checks both directions: one operation cannot select two compatibility names, and one compatibility name cannot hide two operations. A following slice can therefore replace those names with final `Emit` allocation without changing which helpers are shared.

Generated Rust, C headers, JNI output, and Kotlin output remain byte-identical in this slice.

## Verification

- `cargo fmt --all --check` — passed
- `cargo test -p prebindgen-c --lib` — 109 passed
- `cargo test --workspace --all-features` — passed
- `cargo clippy --workspace --all-targets --all-features -- --deny warnings` — passed
- `./examples/regen-check.sh` — committed generated output byte-identical
- `cd examples/covertest-kotlin && ./gradlew run --console=plain` — 61 sections passed
