### PR TITLE
Allocate C converter names at final emission

### DIFF
--- a/docs/model.md
+++ b/docs/model.md
@@ -255,12 +255,13 @@ refer to them;
 2. the converter plans it was handed. Registry-owned operations are grouped by
 their semantic `OperationId` before rendering, with a reachable representative
 preferred when fragments retain separate reachability state. Both JniGen and
-Cbindgen converter plans now expose that identity. Their remaining preselected
-C helper names are compatibility formatting only: a test fence verifies that
-they describe exactly the same sharing partition as `OperationId`, while later
-slices move those private names to final `Emit` allocation. Generic
-compatibility functions that do not expose an operation identity are still
-rendered and deduplicated by their preselected name;
+Cbindgen converter plans expose that identity, and composed calls retain the
+same identity rather than a private Rust name. Only final rendering asks
+`Emit` to allocate the identifier used by both definition and calls. The name
+keeps model and adapter vocabulary as a readable semantic stem, with a stable
+hash only as its collision suffix. Generic compatibility functions that do not
+expose an operation identity are still rendered and deduplicated by their
+preselected name;
 3. the per-item output, in the order above;
 4. the source crate's own feature guards, verbatim.
 

--- a/examples/example-cbindgen/generated/example_flat_aarch64.rs
+++ b/examples/example-cbindgen/generated/example_flat_aarch64.rs
@@ -178,7 +178,7 @@ pub struct closure_history_batch_t {
     pub drop: ::core::option::Option<unsafe extern "C" fn(*mut ::core::ffi::c_void)>,
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) unsafe fn __cbg_in_closure_history_batch_t(
+pub(crate) unsafe fn __c_in_convert_wire_to_impl_Fn_Vec_f64_Send_Sync_static_c_invoke_callback_capture_3dd7f8fbc61877ce(
     c: closure_history_batch_t,
 ) -> impl Fn(::std::vec::Vec<f64>) + Send + Sync + 'static {
     struct __Ctx {
@@ -203,7 +203,9 @@ pub(crate) unsafe fn __cbg_in_closure_history_batch_t(
         if let ::core::option::Option::Some(__f) = __call {
             let mut __w0_0 = ::core::mem::MaybeUninit::<*mut f64>::zeroed();
             let mut __w0_1 = ::core::mem::MaybeUninit::<usize>::zeroed();
-            let __arr: ::std::vec::Vec<f64> = __cbg_out_chain_vec_f64(__a0);
+            let __arr: ::std::vec::Vec<f64> = __c_out_convert_sequence_Vec_f64_to_wire_ad99887ef4e62c28(
+                __a0,
+            );
             let (__p, __n) = __cbg_alloc_array(__arr);
             *__w0_0.as_mut_ptr() = __p;
             *__w0_1.as_mut_ptr() = __n;
@@ -225,7 +227,7 @@ pub struct closure_maybe_grade_t {
     pub drop: ::core::option::Option<unsafe extern "C" fn(*mut ::core::ffi::c_void)>,
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) unsafe fn __cbg_in_closure_maybe_grade_t(
+pub(crate) unsafe fn __c_in_convert_wire_to_impl_Fn_Option_Grade_Send_Sync_static_c_invoke_callback_capture_5512a1f2265e79a0(
     c: closure_maybe_grade_t,
 ) -> impl Fn(::core::option::Option<example_flat::Grade>) + Send + Sync + 'static {
     struct __Ctx {
@@ -253,7 +255,9 @@ pub(crate) unsafe fn __cbg_in_closure_maybe_grade_t(
             match __a0 {
                 ::core::option::Option::Some(__x) => {
                     *__w0_0.as_mut_ptr() = true;
-                    *__w0_1.as_mut_ptr() = __cbg_out_Grade(__x);
+                    *__w0_1.as_mut_ptr() = __c_out_convert_Grade_c_terminal_output_enum_to_wire_a59c7b101e0a9e37(
+                        __x,
+                    );
                 }
                 ::core::option::Option::None => {
                     *__w0_0.as_mut_ptr() = false;
@@ -277,7 +281,7 @@ pub struct closure_maybe_value_t {
     pub drop: ::core::option::Option<unsafe extern "C" fn(*mut ::core::ffi::c_void)>,
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) unsafe fn __cbg_in_closure_maybe_value_t(
+pub(crate) unsafe fn __c_in_convert_wire_to_impl_Fn_Option_f64_Send_Sync_static_c_invoke_callback_capture_053af7d76b4f1245(
     c: closure_maybe_value_t,
 ) -> impl Fn(::core::option::Option<f64>) + Send + Sync + 'static {
     struct __Ctx {
@@ -305,7 +309,9 @@ pub(crate) unsafe fn __cbg_in_closure_maybe_value_t(
             match __a0 {
                 ::core::option::Option::Some(__x) => {
                     *__w0_0.as_mut_ptr() = true;
-                    *__w0_1.as_mut_ptr() = __cbg_out_f64(__x);
+                    *__w0_1.as_mut_ptr() = __c_out_convert_f64_c_terminal_output_scalar_to_wire_6aa94606ef14f673(
+                        __x,
+                    );
                 }
                 ::core::option::Option::None => {
                     *__w0_0.as_mut_ptr() = false;
@@ -325,7 +331,7 @@ pub struct closure_value_t {
     pub drop: ::core::option::Option<unsafe extern "C" fn(*mut ::core::ffi::c_void)>,
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) unsafe fn __cbg_in_closure_value_t(
+pub(crate) unsafe fn __c_in_convert_wire_to_impl_Fn_f64_Send_Sync_static_c_invoke_callback_capture_88739bf29d2a9906(
     c: closure_value_t,
 ) -> impl Fn(f64) + Send + Sync + 'static {
     struct __Ctx {
@@ -348,13 +354,41 @@ pub(crate) unsafe fn __cbg_in_closure_value_t(
     });
     move |__a0: f64| {
         if let ::core::option::Option::Some(__f) = __call {
-            let __w0 = __cbg_out_f64(__a0);
+            let __w0 = __c_out_convert_f64_c_terminal_output_scalar_to_wire_6aa94606ef14f673(
+                __a0,
+            );
             unsafe { __f(__w0, __ctx.context) }
         }
     }
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) unsafe fn __cbg_in_Calculator(
+pub(crate) unsafe fn __c_in_convert_wire_to_Calculator_c_borrow_mutable_input_f30bfe45043bc69c<
+    'a,
+>(
+    v: *mut calculator_t,
+) -> ::core::result::Result<&'a mut example_flat::Calculator, ::std::string::String> {
+    if v.is_null() {
+        return ::core::result::Result::Err(
+            ::std::string::String::from("null Calculator pointer"),
+        );
+    }
+    ::core::result::Result::Ok(&mut *(v as *mut example_flat::Calculator))
+}
+#[allow(non_snake_case, unused_variables, dead_code)]
+pub(crate) unsafe fn __c_in_convert_wire_to_Calculator_c_borrow_shared_input_48be88e9df13aa53<
+    'a,
+>(
+    v: *const calculator_t,
+) -> ::core::result::Result<&'a example_flat::Calculator, ::std::string::String> {
+    if v.is_null() {
+        return ::core::result::Result::Err(
+            ::std::string::String::from("null Calculator pointer"),
+        );
+    }
+    ::core::result::Result::Ok(&*(v as *const example_flat::Calculator))
+}
+#[allow(non_snake_case, unused_variables, dead_code)]
+pub(crate) unsafe fn __c_in_convert_wire_to_Calculator_c_terminal_input_owned_handle_b7bb400a642eb999(
     v: *mut calculator_t,
 ) -> ::core::result::Result<example_flat::Calculator, ::std::string::String> {
     if v.is_null() {
@@ -367,32 +401,46 @@ pub(crate) unsafe fn __cbg_in_Calculator(
     )
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) unsafe fn __cbg_in_Caption(v: caption_t) -> example_flat::Caption {
+pub(crate) unsafe fn __c_in_convert_wire_to_Caption_c_product_intermediate_repr_c_struct_a9076d1a0d6740b3(
+    v: caption_t,
+) -> example_flat::Caption {
     example_flat::Caption {
-        id: __cbg_in_u64(v.id),
-        text: __cbg_in_String_field(v.text),
-        emphatic: __cbg_in_bool(v.emphatic),
+        id: __c_in_convert_wire_to_u64_c_terminal_input_scalar_4e87470ad83635c8(v.id),
+        text: __c_in_convert_wire_to_String_c_terminal_input_string_field_b6091e2e8553ccde(
+            v.text,
+        ),
+        emphatic: __c_in_convert_wire_to_bool_c_terminal_input_bool_e48e0629cd6287b3(
+            v.emphatic,
+        ),
     }
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) unsafe fn __cbg_in_Drawing(
+pub(crate) unsafe fn __c_in_convert_wire_to_Drawing_c_product_intermediate_repr_c_struct_3b927b21caf2df63(
     v: drawing_t,
 ) -> ::core::result::Result<example_flat::Drawing, ::std::string::String> {
     ::core::result::Result::Ok(example_flat::Drawing {
-        id: __cbg_in_u64(v.id),
-        shape: __cbg_in_Shape(v.shape)?,
+        id: __c_in_convert_wire_to_u64_c_terminal_input_scalar_4e87470ad83635c8(v.id),
+        shape: __c_in_convert_wire_to_Shape_c_choice_intermediate_repr_c_tagged_union_8ddb52c185c8b923(
+            v.shape,
+        )?,
     })
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) unsafe fn __cbg_in_Foo(v: foo_t) -> example_flat::Foo {
+pub(crate) unsafe fn __c_in_convert_wire_to_Foo_c_product_intermediate_repr_c_struct_157d1b61f2a5b9d5(
+    v: foo_t,
+) -> example_flat::Foo {
     example_flat::Foo {
-        id: __cbg_in_u64(v.id),
-        aarch64_field: __cbg_in_u64(v.aarch64_field),
-        stable_field: __cbg_in_u64(v.stable_field),
+        id: __c_in_convert_wire_to_u64_c_terminal_input_scalar_4e87470ad83635c8(v.id),
+        aarch64_field: __c_in_convert_wire_to_u64_c_terminal_input_scalar_4e87470ad83635c8(
+            v.aarch64_field,
+        ),
+        stable_field: __c_in_convert_wire_to_u64_c_terminal_input_scalar_4e87470ad83635c8(
+            v.stable_field,
+        ),
     }
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) unsafe fn __cbg_in_InsideFoo(
+pub(crate) unsafe fn __c_in_convert_wire_to_InsideFoo_c_terminal_input_enum_70ed7847e05e3330(
     v: ::core::mem::MaybeUninit<inside_foo_t>,
 ) -> ::core::result::Result<example_flat::InsideFoo, ::std::string::String> {
     const _: () = {
@@ -421,11 +469,13 @@ pub(crate) unsafe fn __cbg_in_InsideFoo(
     )
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) fn __cbg_in_Millis(v: u64) -> example_flat::Millis {
+pub(crate) fn __c_in_convert_wire_to_Millis_c_terminal_custom_771f8034eae1c639(
+    v: u64,
+) -> example_flat::Millis {
     example_flat::millis_from_raw(v)
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) unsafe fn __cbg_in_Note(
+pub(crate) unsafe fn __c_in_convert_wire_to_Note_c_choice_intermediate_repr_c_tagged_union_4de1f2981255d608(
     v: ::core::mem::MaybeUninit<note_t>,
 ) -> ::core::result::Result<example_flat::Note, ::std::string::String> {
     ::core::result::Result::Ok({
@@ -451,7 +501,11 @@ pub(crate) unsafe fn __cbg_in_Note(
                         }
                     }
                 };
-                example_flat::Note::Titled(__cbg_in_Caption((__arm).0))
+                example_flat::Note::Titled(
+                    __c_in_convert_wire_to_Caption_c_product_intermediate_repr_c_struct_a9076d1a0d6740b3(
+                        (__arm).0,
+                    ),
+                )
             }
             2 => {
                 let __choice = unsafe { (v).assume_init() };
@@ -463,7 +517,11 @@ pub(crate) unsafe fn __cbg_in_Note(
                         }
                     }
                 };
-                example_flat::Note::After(__cbg_in_Millis((__arm).0))
+                example_flat::Note::After(
+                    __c_in_convert_wire_to_Millis_c_terminal_custom_771f8034eae1c639(
+                        (__arm).0,
+                    ),
+                )
             }
             3 => {
                 let __choice = unsafe { (v).assume_init() };
@@ -475,7 +533,11 @@ pub(crate) unsafe fn __cbg_in_Note(
                         }
                     }
                 };
-                example_flat::Note::Flagged(__cbg_in_bool((__arm).0))
+                example_flat::Note::Flagged(
+                    __c_in_convert_wire_to_bool_c_terminal_input_bool_e48e0629cd6287b3(
+                        (__arm).0,
+                    ),
+                )
             }
             4 => {
                 let __choice = unsafe { (v).assume_init() };
@@ -487,7 +549,11 @@ pub(crate) unsafe fn __cbg_in_Note(
                         }
                     }
                 };
-                example_flat::Note::Sketched(__cbg_in_Drawing((__arm).0)?)
+                example_flat::Note::Sketched(
+                    __c_in_convert_wire_to_Drawing_c_product_intermediate_repr_c_struct_3b927b21caf2df63(
+                        (__arm).0,
+                    )?,
+                )
             }
             _ => {
                 return ::core::result::Result::Err(
@@ -501,7 +567,7 @@ pub(crate) unsafe fn __cbg_in_Note(
     })
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) unsafe fn __cbg_in_Operation(
+pub(crate) unsafe fn __c_in_convert_wire_to_Operation_c_terminal_input_enum_a23b6023635a8da5(
     v: ::core::mem::MaybeUninit<operation_t>,
 ) -> ::core::result::Result<example_flat::Operation, ::std::string::String> {
     const _: () = {
@@ -536,7 +602,7 @@ pub(crate) unsafe fn __cbg_in_Operation(
     )
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) unsafe fn __cbg_in_Shape(
+pub(crate) unsafe fn __c_in_convert_wire_to_Shape_c_choice_intermediate_repr_c_tagged_union_8ddb52c185c8b923(
     v: ::core::mem::MaybeUninit<shape_t>,
 ) -> ::core::result::Result<example_flat::Shape, ::std::string::String> {
     ::core::result::Result::Ok({
@@ -562,7 +628,11 @@ pub(crate) unsafe fn __cbg_in_Shape(
                         }
                     }
                 };
-                example_flat::Shape::Circle(__cbg_in_f64((__arm).0))
+                example_flat::Shape::Circle(
+                    __c_in_convert_wire_to_f64_c_terminal_input_scalar_7d8a0a733495e599(
+                        (__arm).0,
+                    ),
+                )
             }
             2 => {
                 let __choice = unsafe { (v).assume_init() };
@@ -577,8 +647,12 @@ pub(crate) unsafe fn __cbg_in_Shape(
                     }
                 };
                 example_flat::Shape::Rect {
-                    width: __cbg_in_f64((__arm).0),
-                    height: __cbg_in_f64((__arm).1),
+                    width: __c_in_convert_wire_to_f64_c_terminal_input_scalar_7d8a0a733495e599(
+                        (__arm).0,
+                    ),
+                    height: __c_in_convert_wire_to_f64_c_terminal_input_scalar_7d8a0a733495e599(
+                        (__arm).1,
+                    ),
                 }
             }
             3 => {
@@ -594,8 +668,12 @@ pub(crate) unsafe fn __cbg_in_Shape(
                     }
                 };
                 example_flat::Shape::Labeled(
-                    __cbg_in_String_field((__arm).0),
-                    __cbg_in_Operation((__arm).1)?,
+                    __c_in_convert_wire_to_String_c_terminal_input_string_field_b6091e2e8553ccde(
+                        (__arm).0,
+                    ),
+                    __c_in_convert_wire_to_Operation_c_terminal_input_enum_a23b6023635a8da5(
+                        (__arm).1,
+                    )?,
                 )
             }
             _ => {
@@ -610,7 +688,7 @@ pub(crate) unsafe fn __cbg_in_Shape(
     })
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) unsafe fn __cbg_in_String_field(
+pub(crate) unsafe fn __c_in_convert_wire_to_String_c_terminal_input_string_field_b6091e2e8553ccde(
     v: *const ::core::ffi::c_char,
 ) -> ::std::string::String {
     if v.is_null() {
@@ -620,29 +698,19 @@ pub(crate) unsafe fn __cbg_in_String_field(
     }
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) unsafe fn __cbg_in___Calculator<'a>(
-    v: *const calculator_t,
-) -> ::core::result::Result<&'a example_flat::Calculator, ::std::string::String> {
-    if v.is_null() {
-        return ::core::result::Result::Err(
-            ::std::string::String::from("null Calculator pointer"),
-        );
-    }
-    ::core::result::Result::Ok(&*(v as *const example_flat::Calculator))
+pub(crate) unsafe fn __c_in_convert_wire_to_bool_c_terminal_input_bool_e48e0629cd6287b3(
+    v: ::core::mem::MaybeUninit<bool>,
+) -> bool {
+    ::core::ptr::read(v.as_ptr() as *const u8) != 0
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) unsafe fn __cbg_in___mut_Calculator<'a>(
-    v: *mut calculator_t,
-) -> ::core::result::Result<&'a mut example_flat::Calculator, ::std::string::String> {
-    if v.is_null() {
-        return ::core::result::Result::Err(
-            ::std::string::String::from("null Calculator pointer"),
-        );
-    }
-    ::core::result::Result::Ok(&mut *(v as *mut example_flat::Calculator))
+pub(crate) fn __c_in_convert_wire_to_f64_c_terminal_input_scalar_7d8a0a733495e599(
+    v: f64,
+) -> f64 {
+    v
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) unsafe fn __cbg_in___str<'a>(
+pub(crate) unsafe fn __c_in_convert_wire_to_str_c_borrow_str_input_246c2b9955bb6ef2<'a>(
     v: *const ::core::ffi::c_char,
 ) -> ::core::result::Result<&'a str, ::std::string::String> {
     if v.is_null() {
@@ -660,92 +728,132 @@ pub(crate) unsafe fn __cbg_in___str<'a>(
     }
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) unsafe fn __cbg_in_bool(v: ::core::mem::MaybeUninit<bool>) -> bool {
-    ::core::ptr::read(v.as_ptr() as *const u8) != 0
-}
-#[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) fn __cbg_in_f64(v: f64) -> f64 {
+pub(crate) fn __c_in_convert_wire_to_u64_c_terminal_input_scalar_4e87470ad83635c8(
+    v: u64,
+) -> u64 {
     v
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) fn __cbg_in_u64(v: u64) -> u64 {
-    v
-}
-#[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) fn __cbg_out_Calculator(v: example_flat::Calculator) -> *mut calculator_t {
+pub(crate) fn __c_out_convert_Calculator_c_terminal_output_owned_handle_to_wire_4d20353780559007(
+    v: example_flat::Calculator,
+) -> *mut calculator_t {
     ::std::boxed::Box::into_raw(::std::boxed::Box::new(v)) as *mut calculator_t
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) fn __cbg_out_Caption(v: example_flat::Caption) -> caption_t {
+pub(crate) fn __c_out_convert_Caption_c_product_intermediate_repr_c_struct_to_wire_3bc5d236333a6e28(
+    v: example_flat::Caption,
+) -> caption_t {
     caption_t {
-        id: __cbg_out_u64(v.id),
-        text: __cbg_out_String(v.text),
-        emphatic: __cbg_out_bool_field(v.emphatic),
+        id: __c_out_convert_u64_c_terminal_output_scalar_to_wire_518245fe60cf3590(v.id),
+        text: __c_out_convert_String_c_terminal_output_string_to_wire_182528409f6ab8d3(
+            v.text,
+        ),
+        emphatic: __c_out_convert_bool_c_terminal_output_bool_field_to_wire_6a810eb4cb986700(
+            v.emphatic,
+        ),
     }
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) fn __cbg_out_Drawing(v: example_flat::Drawing) -> drawing_t {
+pub(crate) fn __c_out_convert_Drawing_c_product_intermediate_repr_c_struct_to_wire_50eac9aa069a6838(
+    v: example_flat::Drawing,
+) -> drawing_t {
     drawing_t {
-        id: __cbg_out_u64(v.id),
-        shape: __cbg_out_Shape(v.shape),
+        id: __c_out_convert_u64_c_terminal_output_scalar_to_wire_518245fe60cf3590(v.id),
+        shape: __c_out_convert_Shape_c_choice_intermediate_repr_c_tagged_union_to_wire_1c9175b2e9cd70a6(
+            v.shape,
+        ),
     }
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) fn __cbg_out_Error(v: example_flat::Error) -> *mut ::core::ffi::c_char {
+pub(crate) fn __c_out_convert_Error_c_terminal_output_opaque_error_to_wire_9d010015abcb2259(
+    v: example_flat::Error,
+) -> *mut ::core::ffi::c_char {
     __cbg_alloc_cstr(example_flat::error_get_message(&v))
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) fn __cbg_out_Foo(v: example_flat::Foo) -> foo_t {
+pub(crate) fn __c_out_convert_Foo_c_product_intermediate_repr_c_struct_to_wire_02ab0b068798553e(
+    v: example_flat::Foo,
+) -> foo_t {
     foo_t {
-        id: __cbg_out_u64(v.id),
-        aarch64_field: __cbg_out_u64(v.aarch64_field),
-        stable_field: __cbg_out_u64(v.stable_field),
+        id: __c_out_convert_u64_c_terminal_output_scalar_to_wire_518245fe60cf3590(v.id),
+        aarch64_field: __c_out_convert_u64_c_terminal_output_scalar_to_wire_518245fe60cf3590(
+            v.aarch64_field,
+        ),
+        stable_field: __c_out_convert_u64_c_terminal_output_scalar_to_wire_518245fe60cf3590(
+            v.stable_field,
+        ),
     }
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) fn __cbg_out_Grade(v: example_flat::Grade) -> grade_t {
+pub(crate) fn __c_out_convert_Grade_c_terminal_output_enum_to_wire_a59c7b101e0a9e37(
+    v: example_flat::Grade,
+) -> grade_t {
     match v {
         example_flat::Grade::Low => grade_t::Low,
         example_flat::Grade::High => grade_t::High,
     }
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) fn __cbg_out_InsideFoo(v: example_flat::InsideFoo) -> inside_foo_t {
+pub(crate) fn __c_out_convert_InsideFoo_c_terminal_output_enum_to_wire_b103ad5e4be33376(
+    v: example_flat::InsideFoo,
+) -> inside_foo_t {
     match v {
         example_flat::InsideFoo::DouddleDee => inside_foo_t::DouddleDee,
         example_flat::InsideFoo::DouddleDum => inside_foo_t::DouddleDum,
     }
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) fn __cbg_out_Millis(v: example_flat::Millis) -> u64 {
+pub(crate) fn __c_out_convert_Millis_c_terminal_custom_to_wire_0c2f6b5f81dfcd94(
+    v: example_flat::Millis,
+) -> u64 {
     example_flat::millis_to_raw(&v)
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) fn __cbg_out_Note(v: example_flat::Note) -> ::core::mem::MaybeUninit<note_t> {
+pub(crate) fn __c_out_convert_Note_c_choice_intermediate_repr_c_tagged_union_to_wire_c9cea85d5266d21b(
+    v: example_flat::Note,
+) -> ::core::mem::MaybeUninit<note_t> {
     ::core::mem::MaybeUninit::new({
         match v {
             example_flat::Note::Silent => note_t::Silent,
             example_flat::Note::Titled(__part0) => {
-                let __built_arm = (__cbg_out_Caption(__part0),);
+                let __built_arm = (
+                    __c_out_convert_Caption_c_product_intermediate_repr_c_struct_to_wire_3bc5d236333a6e28(
+                        __part0,
+                    ),
+                );
                 note_t::Titled(__built_arm.0)
             }
             example_flat::Note::After(__part0) => {
-                let __built_arm = (__cbg_out_Millis(__part0),);
+                let __built_arm = (
+                    __c_out_convert_Millis_c_terminal_custom_to_wire_0c2f6b5f81dfcd94(
+                        __part0,
+                    ),
+                );
                 note_t::After(__built_arm.0)
             }
             example_flat::Note::Flagged(__part0) => {
-                let __built_arm = (__cbg_out_bool_field(__part0),);
+                let __built_arm = (
+                    __c_out_convert_bool_c_terminal_output_bool_field_to_wire_6a810eb4cb986700(
+                        __part0,
+                    ),
+                );
                 note_t::Flagged(__built_arm.0)
             }
             example_flat::Note::Sketched(__part0) => {
-                let __built_arm = (__cbg_out_Drawing(__part0),);
+                let __built_arm = (
+                    __c_out_convert_Drawing_c_product_intermediate_repr_c_struct_to_wire_50eac9aa069a6838(
+                        __part0,
+                    ),
+                );
                 note_t::Sketched(__built_arm.0)
             }
         }
     })
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) fn __cbg_out_Operation(v: example_flat::Operation) -> operation_t {
+pub(crate) fn __c_out_convert_Operation_c_terminal_output_enum_to_wire_457f6036394dc821(
+    v: example_flat::Operation,
+) -> operation_t {
     match v {
         example_flat::Operation::Add => operation_t::Add,
         example_flat::Operation::Sub => operation_t::Sub,
@@ -753,19 +861,34 @@ pub(crate) fn __cbg_out_Operation(v: example_flat::Operation) -> operation_t {
         example_flat::Operation::Div => operation_t::Div,
     }
 }
+#[allow(non_snake_case, dead_code, unused)]
+pub(crate) fn __c_out_convert_Option_Grade_c_marker_optional_to_wire_e2c04af90b0abd17() {}
+#[allow(non_snake_case, dead_code, unused)]
+pub(crate) fn __c_out_convert_Option_f64_c_marker_optional_to_wire_c1ba5adc99623ff4() {}
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) fn __cbg_out_Shape(
+pub(crate) fn __c_out_convert_Shape_c_choice_intermediate_repr_c_tagged_union_to_wire_1c9175b2e9cd70a6(
     v: example_flat::Shape,
 ) -> ::core::mem::MaybeUninit<shape_t> {
     ::core::mem::MaybeUninit::new({
         match v {
             example_flat::Shape::Empty => shape_t::Empty,
             example_flat::Shape::Circle(__part0) => {
-                let __built_arm = (__cbg_out_f64(__part0),);
+                let __built_arm = (
+                    __c_out_convert_f64_c_terminal_output_scalar_to_wire_6aa94606ef14f673(
+                        __part0,
+                    ),
+                );
                 shape_t::Circle(__built_arm.0)
             }
             example_flat::Shape::Rect { width: __part0, height: __part1 } => {
-                let __built_arm = (__cbg_out_f64(__part0), __cbg_out_f64(__part1));
+                let __built_arm = (
+                    __c_out_convert_f64_c_terminal_output_scalar_to_wire_6aa94606ef14f673(
+                        __part0,
+                    ),
+                    __c_out_convert_f64_c_terminal_output_scalar_to_wire_6aa94606ef14f673(
+                        __part1,
+                    ),
+                );
                 shape_t::Rect {
                     width: __built_arm.0,
                     height: __built_arm.1,
@@ -773,8 +896,14 @@ pub(crate) fn __cbg_out_Shape(
             }
             example_flat::Shape::Labeled(__part0, __part1) => {
                 let __built_arm = (
-                    __cbg_out_String(__part0),
-                    ::core::mem::MaybeUninit::new(__cbg_out_Operation(__part1)),
+                    __c_out_convert_String_c_terminal_output_string_to_wire_182528409f6ab8d3(
+                        __part0,
+                    ),
+                    ::core::mem::MaybeUninit::new(
+                        __c_out_convert_Operation_c_terminal_output_enum_to_wire_457f6036394dc821(
+                            __part1,
+                        ),
+                    ),
                 );
                 shape_t::Labeled(__built_arm.0, __built_arm.1)
             }
@@ -782,48 +911,60 @@ pub(crate) fn __cbg_out_Shape(
     })
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) fn __cbg_out_String(v: ::std::string::String) -> *mut ::core::ffi::c_char {
+pub(crate) fn __c_out_convert_String_c_terminal_output_string_to_wire_182528409f6ab8d3(
+    v: ::std::string::String,
+) -> *mut ::core::ffi::c_char {
     __cbg_alloc_cstr(v)
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) fn __cbg_out_bool(v: bool) -> bool {
-    v
-}
-#[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) fn __cbg_out_bool_field(v: bool) -> ::core::mem::MaybeUninit<bool> {
+pub(crate) fn __c_out_convert_bool_c_terminal_output_bool_field_to_wire_6a810eb4cb986700(
+    v: bool,
+) -> ::core::mem::MaybeUninit<bool> {
     ::core::mem::MaybeUninit::new(v)
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
+pub(crate) fn __c_out_convert_bool_c_terminal_output_scalar_to_wire_cc0ad9760da17efd(
+    v: bool,
+) -> bool {
+    v
+}
+#[allow(non_snake_case, unused_variables, dead_code)]
+pub(crate) fn __c_out_convert_f64_c_terminal_output_scalar_to_wire_6aa94606ef14f673(
+    v: f64,
+) -> f64 {
+    v
+}
+#[allow(non_snake_case, unused_variables, dead_code)]
+pub(crate) fn __c_out_convert_i32_c_terminal_output_scalar_to_wire_ae82162f636ebcd5(
+    v: i32,
+) -> i32 {
+    v
+}
+#[allow(non_snake_case, unused_variables, dead_code)]
 #[inline(always)]
-pub(crate) fn __cbg_out_chain_vec_f64(v: ::std::vec::Vec<f64>) -> ::std::vec::Vec<f64> {
+pub(crate) fn __c_out_convert_sequence_Vec_f64_to_wire_ad99887ef4e62c28(
+    v: ::std::vec::Vec<f64>,
+) -> ::std::vec::Vec<f64> {
     {
         let __sequence_source = v;
         let mut __sequence_output: ::std::vec::Vec<f64> = ::std::vec::Vec::with_capacity(
             (__sequence_source).len(),
         );
         for __sequence_element in __sequence_source.into_iter() {
-            let __sequence_part = __cbg_out_f64(__sequence_element);
+            let __sequence_part = __c_out_convert_f64_c_terminal_output_scalar_to_wire_6aa94606ef14f673(
+                __sequence_element,
+            );
             __sequence_output.push(__sequence_part);
         }
         __sequence_output
     }
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) fn __cbg_out_f64(v: f64) -> f64 {
+pub(crate) fn __c_out_convert_u64_c_terminal_output_scalar_to_wire_518245fe60cf3590(
+    v: u64,
+) -> u64 {
     v
 }
-#[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) fn __cbg_out_i32(v: i32) -> i32 {
-    v
-}
-#[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) fn __cbg_out_u64(v: u64) -> u64 {
-    v
-}
-#[allow(non_snake_case, dead_code, unused)]
-pub(crate) fn __cbg_outmark_option_Grade() {}
-#[allow(non_snake_case, dead_code, unused)]
-pub(crate) fn __cbg_outmark_option_f64() {}
 #[no_mangle]
 #[allow(non_snake_case, unused_mut, unused_variables, unused_unsafe, dead_code)]
 pub unsafe extern "C" fn calculator_absorb(
@@ -837,7 +978,7 @@ pub unsafe extern "C" fn calculator_absorb(
             "aliasing arguments: `a` (consumed) and `b` (borrowed) are the same `Calculator` — a consumed or exclusively-borrowed resource may not be named twice in one call",
         );
         if !e.is_null() {
-            *e = __cbg_out_Error(
+            *e = __c_out_convert_Error_c_terminal_output_opaque_error_to_wire_9d010015abcb2259(
                 <example_flat::Error as ::core::convert::From<
                     ::std::string::String,
                 >>::from(__msg),
@@ -845,11 +986,13 @@ pub unsafe extern "C" fn calculator_absorb(
         }
         return false;
     }
-    let a = match __cbg_in_Calculator(a) {
+    let a = match __c_in_convert_wire_to_Calculator_c_terminal_input_owned_handle_b7bb400a642eb999(
+        a,
+    ) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__msg) => {
             if !e.is_null() {
-                *e = __cbg_out_Error(
+                *e = __c_out_convert_Error_c_terminal_output_opaque_error_to_wire_9d010015abcb2259(
                     <example_flat::Error as ::core::convert::From<
                         ::std::string::String,
                     >>::from(__msg),
@@ -858,11 +1001,13 @@ pub unsafe extern "C" fn calculator_absorb(
             return false;
         }
     };
-    let b = match __cbg_in___Calculator(b) {
+    let b = match __c_in_convert_wire_to_Calculator_c_borrow_shared_input_48be88e9df13aa53(
+        b,
+    ) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__msg) => {
             if !e.is_null() {
-                *e = __cbg_out_Error(
+                *e = __c_out_convert_Error_c_terminal_output_opaque_error_to_wire_9d010015abcb2259(
                     <example_flat::Error as ::core::convert::From<
                         ::std::string::String,
                     >>::from(__msg),
@@ -873,12 +1018,16 @@ pub unsafe extern "C" fn calculator_absorb(
     };
     match example_flat::calculator_absorb(a, b) {
         ::core::result::Result::Ok(__v) => {
-            *out = __cbg_out_f64(__v);
+            *out = __c_out_convert_f64_c_terminal_output_scalar_to_wire_6aa94606ef14f673(
+                __v,
+            );
             true
         }
         ::core::result::Result::Err(__err) => {
             if !e.is_null() {
-                *e = __cbg_out_Error(__err);
+                *e = __c_out_convert_Error_c_terminal_output_opaque_error_to_wire_9d010015abcb2259(
+                    __err,
+                );
             }
             false
         }
@@ -893,11 +1042,13 @@ pub unsafe extern "C" fn calculator_apply(
     out: *mut f64,
     e: *mut *mut ::core::ffi::c_char,
 ) -> bool {
-    let c = match __cbg_in___mut_Calculator(c) {
+    let c = match __c_in_convert_wire_to_Calculator_c_borrow_mutable_input_f30bfe45043bc69c(
+        c,
+    ) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__msg) => {
             if !e.is_null() {
-                *e = __cbg_out_Error(
+                *e = __c_out_convert_Error_c_terminal_output_opaque_error_to_wire_9d010015abcb2259(
                     <example_flat::Error as ::core::convert::From<
                         ::std::string::String,
                     >>::from(__msg),
@@ -906,11 +1057,13 @@ pub unsafe extern "C" fn calculator_apply(
             return false;
         }
     };
-    let op = match __cbg_in_Operation(op) {
+    let op = match __c_in_convert_wire_to_Operation_c_terminal_input_enum_a23b6023635a8da5(
+        op,
+    ) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__msg) => {
             if !e.is_null() {
-                *e = __cbg_out_Error(
+                *e = __c_out_convert_Error_c_terminal_output_opaque_error_to_wire_9d010015abcb2259(
                     <example_flat::Error as ::core::convert::From<
                         ::std::string::String,
                     >>::from(__msg),
@@ -919,15 +1072,21 @@ pub unsafe extern "C" fn calculator_apply(
             return false;
         }
     };
-    let operand = __cbg_in_f64(operand);
+    let operand = __c_in_convert_wire_to_f64_c_terminal_input_scalar_7d8a0a733495e599(
+        operand,
+    );
     match example_flat::calculator_apply(c, op, operand) {
         ::core::result::Result::Ok(__v) => {
-            *out = __cbg_out_f64(__v);
+            *out = __c_out_convert_f64_c_terminal_output_scalar_to_wire_6aa94606ef14f673(
+                __v,
+            );
             true
         }
         ::core::result::Result::Err(__err) => {
             if !e.is_null() {
-                *e = __cbg_out_Error(__err);
+                *e = __c_out_convert_Error_c_terminal_output_opaque_error_to_wire_9d010015abcb2259(
+                    __err,
+                );
             }
             false
         }
@@ -939,19 +1098,25 @@ pub unsafe extern "C" fn calculator_for_each(
     c: *const calculator_t,
     f: closure_value_t,
 ) {
-    let c = match __cbg_in___Calculator(c) {
+    let c = match __c_in_convert_wire_to_Calculator_c_borrow_shared_input_48be88e9df13aa53(
+        c,
+    ) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__msg) => {
             panic!("{}", __msg);
         }
     };
-    let f = __cbg_in_closure_value_t(f);
+    let f = __c_in_convert_wire_to_impl_Fn_f64_Send_Sync_static_c_invoke_callback_capture_88739bf29d2a9906(
+        f,
+    );
     example_flat::calculator_for_each(c, f);
 }
 #[no_mangle]
 #[allow(non_snake_case, unused_mut, unused_variables, unused_unsafe, dead_code)]
 pub unsafe extern "C" fn calculator_get_count(c: *const calculator_t) -> u64 {
-    let c = match __cbg_in___Calculator(c) {
+    let c = match __c_in_convert_wire_to_Calculator_c_borrow_shared_input_48be88e9df13aa53(
+        c,
+    ) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__msg) => {
             panic!("{}", __msg);
@@ -959,7 +1124,7 @@ pub unsafe extern "C" fn calculator_get_count(c: *const calculator_t) -> u64 {
     };
     let __v = example_flat::calculator_get_count(c);
     let __ret: u64;
-    __ret = __cbg_out_u64(__v);
+    __ret = __c_out_convert_u64_c_terminal_output_scalar_to_wire_518245fe60cf3590(__v);
     __ret
 }
 #[no_mangle]
@@ -968,7 +1133,9 @@ pub unsafe extern "C" fn calculator_get_history(
     c: *const calculator_t,
     len: *mut usize,
 ) -> *mut f64 {
-    let c = match __cbg_in___Calculator(c) {
+    let c = match __c_in_convert_wire_to_Calculator_c_borrow_shared_input_48be88e9df13aa53(
+        c,
+    ) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__msg) => {
             panic!("{}", __msg);
@@ -976,7 +1143,9 @@ pub unsafe extern "C" fn calculator_get_history(
     };
     let __v = example_flat::calculator_get_history(c);
     let __ret: *mut f64;
-    let __arr: ::std::vec::Vec<f64> = __cbg_out_chain_vec_f64(__v);
+    let __arr: ::std::vec::Vec<f64> = __c_out_convert_sequence_Vec_f64_to_wire_ad99887ef4e62c28(
+        __v,
+    );
     let (__p, __n) = __cbg_alloc_array(__arr);
     __ret = __p;
     *len = __n;
@@ -985,7 +1154,9 @@ pub unsafe extern "C" fn calculator_get_history(
 #[no_mangle]
 #[allow(non_snake_case, unused_mut, unused_variables, unused_unsafe, dead_code)]
 pub unsafe extern "C" fn calculator_get_value(c: *const calculator_t) -> f64 {
-    let c = match __cbg_in___Calculator(c) {
+    let c = match __c_in_convert_wire_to_Calculator_c_borrow_shared_input_48be88e9df13aa53(
+        c,
+    ) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__msg) => {
             panic!("{}", __msg);
@@ -993,7 +1164,7 @@ pub unsafe extern "C" fn calculator_get_value(c: *const calculator_t) -> f64 {
     };
     let __v = example_flat::calculator_get_value(c);
     let __ret: f64;
-    __ret = __cbg_out_f64(__v);
+    __ret = __c_out_convert_f64_c_terminal_output_scalar_to_wire_6aa94606ef14f673(__v);
     __ret
 }
 #[no_mangle]
@@ -1002,13 +1173,17 @@ pub unsafe extern "C" fn calculator_grade_or_none(
     c: *const calculator_t,
     f: closure_maybe_grade_t,
 ) {
-    let c = match __cbg_in___Calculator(c) {
+    let c = match __c_in_convert_wire_to_Calculator_c_borrow_shared_input_48be88e9df13aa53(
+        c,
+    ) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__msg) => {
             panic!("{}", __msg);
         }
     };
-    let f = __cbg_in_closure_maybe_grade_t(f);
+    let f = __c_in_convert_wire_to_impl_Fn_Option_Grade_Send_Sync_static_c_invoke_callback_capture_5512a1f2265e79a0(
+        f,
+    );
     example_flat::calculator_grade_or_none(c, f);
 }
 #[no_mangle]
@@ -1017,28 +1192,36 @@ pub unsafe extern "C" fn calculator_history_batch(
     c: *const calculator_t,
     f: closure_history_batch_t,
 ) {
-    let c = match __cbg_in___Calculator(c) {
+    let c = match __c_in_convert_wire_to_Calculator_c_borrow_shared_input_48be88e9df13aa53(
+        c,
+    ) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__msg) => {
             panic!("{}", __msg);
         }
     };
-    let f = __cbg_in_closure_history_batch_t(f);
+    let f = __c_in_convert_wire_to_impl_Fn_Vec_f64_Send_Sync_static_c_invoke_callback_capture_3dd7f8fbc61877ce(
+        f,
+    );
     example_flat::calculator_history_batch(c, f);
 }
 #[no_mangle]
 #[allow(non_snake_case, unused_mut, unused_variables, unused_unsafe, dead_code)]
 pub unsafe extern "C" fn calculator_is(c: *const calculator_t, value: f64) -> bool {
-    let c = match __cbg_in___Calculator(c) {
+    let c = match __c_in_convert_wire_to_Calculator_c_borrow_shared_input_48be88e9df13aa53(
+        c,
+    ) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__msg) => {
             panic!("{}", __msg);
         }
     };
-    let value = __cbg_in_f64(value);
+    let value = __c_in_convert_wire_to_f64_c_terminal_input_scalar_7d8a0a733495e599(
+        value,
+    );
     let __v = example_flat::calculator_is(c, value);
     let __ret: bool;
-    __ret = __cbg_out_bool(__v);
+    __ret = __c_out_convert_bool_c_terminal_output_scalar_to_wire_cc0ad9760da17efd(__v);
     __ret
 }
 #[no_mangle]
@@ -1047,13 +1230,17 @@ pub unsafe extern "C" fn calculator_last_or_none(
     c: *const calculator_t,
     f: closure_maybe_value_t,
 ) {
-    let c = match __cbg_in___Calculator(c) {
+    let c = match __c_in_convert_wire_to_Calculator_c_borrow_shared_input_48be88e9df13aa53(
+        c,
+    ) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__msg) => {
             panic!("{}", __msg);
         }
     };
-    let f = __cbg_in_closure_maybe_value_t(f);
+    let f = __c_in_convert_wire_to_impl_Fn_Option_f64_Send_Sync_static_c_invoke_callback_capture_053af7d76b4f1245(
+        f,
+    );
     example_flat::calculator_last_or_none(c, f);
 }
 #[no_mangle]
@@ -1068,7 +1255,7 @@ pub unsafe extern "C" fn calculator_merge(
             "aliasing arguments: `a` (consumed) and `b` (consumed) are the same `Calculator` — a consumed or exclusively-borrowed resource may not be named twice in one call",
         );
         if !e.is_null() {
-            *e = __cbg_out_Error(
+            *e = __c_out_convert_Error_c_terminal_output_opaque_error_to_wire_9d010015abcb2259(
                 <example_flat::Error as ::core::convert::From<
                     ::std::string::String,
                 >>::from(__msg),
@@ -1076,11 +1263,13 @@ pub unsafe extern "C" fn calculator_merge(
         }
         return ::core::ptr::null_mut();
     }
-    let a = match __cbg_in_Calculator(a) {
+    let a = match __c_in_convert_wire_to_Calculator_c_terminal_input_owned_handle_b7bb400a642eb999(
+        a,
+    ) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__msg) => {
             if !e.is_null() {
-                *e = __cbg_out_Error(
+                *e = __c_out_convert_Error_c_terminal_output_opaque_error_to_wire_9d010015abcb2259(
                     <example_flat::Error as ::core::convert::From<
                         ::std::string::String,
                     >>::from(__msg),
@@ -1089,11 +1278,13 @@ pub unsafe extern "C" fn calculator_merge(
             return ::core::ptr::null_mut();
         }
     };
-    let b = match __cbg_in_Calculator(b) {
+    let b = match __c_in_convert_wire_to_Calculator_c_terminal_input_owned_handle_b7bb400a642eb999(
+        b,
+    ) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__msg) => {
             if !e.is_null() {
-                *e = __cbg_out_Error(
+                *e = __c_out_convert_Error_c_terminal_output_opaque_error_to_wire_9d010015abcb2259(
                     <example_flat::Error as ::core::convert::From<
                         ::std::string::String,
                     >>::from(__msg),
@@ -1105,12 +1296,16 @@ pub unsafe extern "C" fn calculator_merge(
     match example_flat::calculator_merge(a, b) {
         ::core::result::Result::Ok(__v) => {
             let __ret: *mut calculator_t;
-            __ret = __cbg_out_Calculator(__v);
+            __ret = __c_out_convert_Calculator_c_terminal_output_owned_handle_to_wire_4d20353780559007(
+                __v,
+            );
             __ret
         }
         ::core::result::Result::Err(__err) => {
             if !e.is_null() {
-                *e = __cbg_out_Error(__err);
+                *e = __c_out_convert_Error_c_terminal_output_opaque_error_to_wire_9d010015abcb2259(
+                    __err,
+                );
             }
             ::core::ptr::null_mut()
         }
@@ -1121,7 +1316,9 @@ pub unsafe extern "C" fn calculator_merge(
 pub unsafe extern "C" fn calculator_new() -> *mut calculator_t {
     let __v = example_flat::calculator_new();
     let __ret: *mut calculator_t;
-    __ret = __cbg_out_Calculator(__v);
+    __ret = __c_out_convert_Calculator_c_terminal_output_owned_handle_to_wire_4d20353780559007(
+        __v,
+    );
     __ret
 }
 #[no_mangle]
@@ -1129,7 +1326,9 @@ pub unsafe extern "C" fn calculator_new() -> *mut calculator_t {
 pub unsafe extern "C" fn calculator_new_clone(
     c: *const calculator_t,
 ) -> *mut calculator_t {
-    let c = match __cbg_in___Calculator(c) {
+    let c = match __c_in_convert_wire_to_Calculator_c_borrow_shared_input_48be88e9df13aa53(
+        c,
+    ) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__msg) => {
             panic!("{}", __msg);
@@ -1137,7 +1336,9 @@ pub unsafe extern "C" fn calculator_new_clone(
     };
     let __v = example_flat::calculator_new_clone(c);
     let __ret: *mut calculator_t;
-    __ret = __cbg_out_Calculator(__v);
+    __ret = __c_out_convert_Calculator_c_terminal_output_owned_handle_to_wire_4d20353780559007(
+        __v,
+    );
     __ret
 }
 #[no_mangle]
@@ -1146,11 +1347,11 @@ pub unsafe extern "C" fn calculator_new_from_str(
     s: *const ::core::ffi::c_char,
     e: *mut *mut ::core::ffi::c_char,
 ) -> *mut calculator_t {
-    let s = match __cbg_in___str(s) {
+    let s = match __c_in_convert_wire_to_str_c_borrow_str_input_246c2b9955bb6ef2(s) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__msg) => {
             if !e.is_null() {
-                *e = __cbg_out_Error(
+                *e = __c_out_convert_Error_c_terminal_output_opaque_error_to_wire_9d010015abcb2259(
                     <example_flat::Error as ::core::convert::From<
                         ::std::string::String,
                     >>::from(__msg),
@@ -1162,12 +1363,16 @@ pub unsafe extern "C" fn calculator_new_from_str(
     match example_flat::calculator_new_from_str(s) {
         ::core::result::Result::Ok(__v) => {
             let __ret: *mut calculator_t;
-            __ret = __cbg_out_Calculator(__v);
+            __ret = __c_out_convert_Calculator_c_terminal_output_owned_handle_to_wire_4d20353780559007(
+                __v,
+            );
             __ret
         }
         ::core::result::Result::Err(__err) => {
             if !e.is_null() {
-                *e = __cbg_out_Error(__err);
+                *e = __c_out_convert_Error_c_terminal_output_opaque_error_to_wire_9d010015abcb2259(
+                    __err,
+                );
             }
             ::core::ptr::null_mut()
         }
@@ -1178,7 +1383,9 @@ pub unsafe extern "C" fn calculator_new_from_str(
 pub unsafe extern "C" fn calculator_to_string(
     c: *const calculator_t,
 ) -> *mut ::core::ffi::c_char {
-    let c = match __cbg_in___Calculator(c) {
+    let c = match __c_in_convert_wire_to_Calculator_c_borrow_shared_input_48be88e9df13aa53(
+        c,
+    ) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__msg) => {
             panic!("{}", __msg);
@@ -1186,7 +1393,9 @@ pub unsafe extern "C" fn calculator_to_string(
     };
     let __v = example_flat::calculator_to_string(c);
     let __ret: *mut ::core::ffi::c_char;
-    __ret = __cbg_out_String(__v);
+    __ret = __c_out_convert_String_c_terminal_output_string_to_wire_182528409f6ab8d3(
+        __v,
+    );
     __ret
 }
 #[no_mangle]
@@ -1196,17 +1405,23 @@ pub unsafe extern "C" fn caption_new(
     text: *const ::core::ffi::c_char,
     emphatic: ::core::mem::MaybeUninit<bool>,
 ) -> caption_t {
-    let id = __cbg_in_u64(id);
-    let text = match __cbg_in___str(text) {
+    let id = __c_in_convert_wire_to_u64_c_terminal_input_scalar_4e87470ad83635c8(id);
+    let text = match __c_in_convert_wire_to_str_c_borrow_str_input_246c2b9955bb6ef2(
+        text,
+    ) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__msg) => {
             panic!("{}", __msg);
         }
     };
-    let emphatic = __cbg_in_bool(emphatic);
+    let emphatic = __c_in_convert_wire_to_bool_c_terminal_input_bool_e48e0629cd6287b3(
+        emphatic,
+    );
     let __v = example_flat::caption_new(id, text, emphatic);
     let __ret: caption_t;
-    __ret = __cbg_out_Caption(__v);
+    __ret = __c_out_convert_Caption_c_product_intermediate_repr_c_struct_to_wire_3bc5d236333a6e28(
+        __v,
+    );
     __ret
 }
 #[no_mangle]
@@ -1214,7 +1429,9 @@ pub unsafe extern "C" fn caption_new(
 pub unsafe extern "C" fn drawing_get_shape(
     d: drawing_t,
 ) -> ::core::mem::MaybeUninit<shape_t> {
-    let d = match __cbg_in_Drawing(d) {
+    let d = match __c_in_convert_wire_to_Drawing_c_product_intermediate_repr_c_struct_3b927b21caf2df63(
+        d,
+    ) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__msg) => {
             panic!("{}", __msg);
@@ -1222,7 +1439,9 @@ pub unsafe extern "C" fn drawing_get_shape(
     };
     let __v = example_flat::drawing_get_shape(d);
     let __ret: ::core::mem::MaybeUninit<shape_t>;
-    __ret = __cbg_out_Shape(__v);
+    __ret = __c_out_convert_Shape_c_choice_intermediate_repr_c_tagged_union_to_wire_1c9175b2e9cd70a6(
+        __v,
+    );
     __ret
 }
 #[no_mangle]
@@ -1231,8 +1450,10 @@ pub unsafe extern "C" fn drawing_new(
     id: u64,
     shape: ::core::mem::MaybeUninit<shape_t>,
 ) -> drawing_t {
-    let id = __cbg_in_u64(id);
-    let shape = match __cbg_in_Shape(shape) {
+    let id = __c_in_convert_wire_to_u64_c_terminal_input_scalar_4e87470ad83635c8(id);
+    let shape = match __c_in_convert_wire_to_Shape_c_choice_intermediate_repr_c_tagged_union_8ddb52c185c8b923(
+        shape,
+    ) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__msg) => {
             panic!("{}", __msg);
@@ -1240,25 +1461,31 @@ pub unsafe extern "C" fn drawing_new(
     };
     let __v = example_flat::drawing_new(id, shape);
     let __ret: drawing_t;
-    __ret = __cbg_out_Drawing(__v);
+    __ret = __c_out_convert_Drawing_c_product_intermediate_repr_c_struct_to_wire_50eac9aa069a6838(
+        __v,
+    );
     __ret
 }
 #[no_mangle]
 #[allow(non_snake_case, unused_mut, unused_variables, unused_unsafe, dead_code)]
 pub unsafe extern "C" fn foo_get_id(f: foo_t) -> u64 {
-    let f = __cbg_in_Foo(f);
+    let f = __c_in_convert_wire_to_Foo_c_product_intermediate_repr_c_struct_157d1b61f2a5b9d5(
+        f,
+    );
     let __v = example_flat::foo_get_id(f);
     let __ret: u64;
-    __ret = __cbg_out_u64(__v);
+    __ret = __c_out_convert_u64_c_terminal_output_scalar_to_wire_518245fe60cf3590(__v);
     __ret
 }
 #[no_mangle]
 #[allow(non_snake_case, unused_mut, unused_variables, unused_unsafe, dead_code)]
 pub unsafe extern "C" fn foo_new(id: u64) -> foo_t {
-    let id = __cbg_in_u64(id);
+    let id = __c_in_convert_wire_to_u64_c_terminal_input_scalar_4e87470ad83635c8(id);
     let __v = example_flat::foo_new(id);
     let __ret: foo_t;
-    __ret = __cbg_out_Foo(__v);
+    __ret = __c_out_convert_Foo_c_product_intermediate_repr_c_struct_to_wire_02ab0b068798553e(
+        __v,
+    );
     __ret
 }
 #[no_mangle]
@@ -1266,7 +1493,9 @@ pub unsafe extern "C" fn foo_new(id: u64) -> foo_t {
 pub unsafe extern "C" fn inside_foo_default() -> inside_foo_t {
     let __v = example_flat::inside_foo_default();
     let __ret: inside_foo_t;
-    __ret = __cbg_out_InsideFoo(__v);
+    __ret = __c_out_convert_InsideFoo_c_terminal_output_enum_to_wire_b103ad5e4be33376(
+        __v,
+    );
     __ret
 }
 #[no_mangle]
@@ -1274,7 +1503,9 @@ pub unsafe extern "C" fn inside_foo_default() -> inside_foo_t {
 pub unsafe extern "C" fn inside_foo_value(
     x: ::core::mem::MaybeUninit<inside_foo_t>,
 ) -> i32 {
-    let x = match __cbg_in_InsideFoo(x) {
+    let x = match __c_in_convert_wire_to_InsideFoo_c_terminal_input_enum_70ed7847e05e3330(
+        x,
+    ) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__msg) => {
             panic!("{}", __msg);
@@ -1282,13 +1513,15 @@ pub unsafe extern "C" fn inside_foo_value(
     };
     let __v = example_flat::inside_foo_value(x);
     let __ret: i32;
-    __ret = __cbg_out_i32(__v);
+    __ret = __c_out_convert_i32_c_terminal_output_scalar_to_wire_ae82162f636ebcd5(__v);
     __ret
 }
 #[no_mangle]
 #[allow(non_snake_case, unused_mut, unused_variables, unused_unsafe, dead_code)]
 pub unsafe extern "C" fn note_emphatic(n: ::core::mem::MaybeUninit<note_t>) -> bool {
-    let n = match __cbg_in_Note(n) {
+    let n = match __c_in_convert_wire_to_Note_c_choice_intermediate_repr_c_tagged_union_4de1f2981255d608(
+        n,
+    ) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__msg) => {
             panic!("{}", __msg);
@@ -1296,7 +1529,7 @@ pub unsafe extern "C" fn note_emphatic(n: ::core::mem::MaybeUninit<note_t>) -> b
     };
     let __v = example_flat::note_emphatic(n);
     let __ret: bool;
-    __ret = __cbg_out_bool(__v);
+    __ret = __c_out_convert_bool_c_terminal_output_scalar_to_wire_cc0ad9760da17efd(__v);
     __ret
 }
 #[no_mangle]
@@ -1304,10 +1537,14 @@ pub unsafe extern "C" fn note_emphatic(n: ::core::mem::MaybeUninit<note_t>) -> b
 pub unsafe extern "C" fn note_new_after(
     millis: u64,
 ) -> ::core::mem::MaybeUninit<note_t> {
-    let millis = __cbg_in_u64(millis);
+    let millis = __c_in_convert_wire_to_u64_c_terminal_input_scalar_4e87470ad83635c8(
+        millis,
+    );
     let __v = example_flat::note_new_after(millis);
     let __ret: ::core::mem::MaybeUninit<note_t>;
-    __ret = __cbg_out_Note(__v);
+    __ret = __c_out_convert_Note_c_choice_intermediate_repr_c_tagged_union_to_wire_c9cea85d5266d21b(
+        __v,
+    );
     __ret
 }
 #[no_mangle]
@@ -1315,10 +1552,12 @@ pub unsafe extern "C" fn note_new_after(
 pub unsafe extern "C" fn note_new_flagged(
     flag: ::core::mem::MaybeUninit<bool>,
 ) -> ::core::mem::MaybeUninit<note_t> {
-    let flag = __cbg_in_bool(flag);
+    let flag = __c_in_convert_wire_to_bool_c_terminal_input_bool_e48e0629cd6287b3(flag);
     let __v = example_flat::note_new_flagged(flag);
     let __ret: ::core::mem::MaybeUninit<note_t>;
-    __ret = __cbg_out_Note(__v);
+    __ret = __c_out_convert_Note_c_choice_intermediate_repr_c_tagged_union_to_wire_c9cea85d5266d21b(
+        __v,
+    );
     __ret
 }
 #[no_mangle]
@@ -1326,7 +1565,9 @@ pub unsafe extern "C" fn note_new_flagged(
 pub unsafe extern "C" fn note_new_silent() -> ::core::mem::MaybeUninit<note_t> {
     let __v = example_flat::note_new_silent();
     let __ret: ::core::mem::MaybeUninit<note_t>;
-    __ret = __cbg_out_Note(__v);
+    __ret = __c_out_convert_Note_c_choice_intermediate_repr_c_tagged_union_to_wire_c9cea85d5266d21b(
+        __v,
+    );
     __ret
 }
 #[no_mangle]
@@ -1335,8 +1576,10 @@ pub unsafe extern "C" fn note_new_sketched(
     id: u64,
     label: *const ::core::ffi::c_char,
 ) -> ::core::mem::MaybeUninit<note_t> {
-    let id = __cbg_in_u64(id);
-    let label = match __cbg_in___str(label) {
+    let id = __c_in_convert_wire_to_u64_c_terminal_input_scalar_4e87470ad83635c8(id);
+    let label = match __c_in_convert_wire_to_str_c_borrow_str_input_246c2b9955bb6ef2(
+        label,
+    ) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__msg) => {
             panic!("{}", __msg);
@@ -1344,7 +1587,9 @@ pub unsafe extern "C" fn note_new_sketched(
     };
     let __v = example_flat::note_new_sketched(id, label);
     let __ret: ::core::mem::MaybeUninit<note_t>;
-    __ret = __cbg_out_Note(__v);
+    __ret = __c_out_convert_Note_c_choice_intermediate_repr_c_tagged_union_to_wire_c9cea85d5266d21b(
+        __v,
+    );
     __ret
 }
 #[no_mangle]
@@ -1354,23 +1599,31 @@ pub unsafe extern "C" fn note_new_titled(
     text: *const ::core::ffi::c_char,
     emphatic: ::core::mem::MaybeUninit<bool>,
 ) -> ::core::mem::MaybeUninit<note_t> {
-    let id = __cbg_in_u64(id);
-    let text = match __cbg_in___str(text) {
+    let id = __c_in_convert_wire_to_u64_c_terminal_input_scalar_4e87470ad83635c8(id);
+    let text = match __c_in_convert_wire_to_str_c_borrow_str_input_246c2b9955bb6ef2(
+        text,
+    ) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__msg) => {
             panic!("{}", __msg);
         }
     };
-    let emphatic = __cbg_in_bool(emphatic);
+    let emphatic = __c_in_convert_wire_to_bool_c_terminal_input_bool_e48e0629cd6287b3(
+        emphatic,
+    );
     let __v = example_flat::note_new_titled(id, text, emphatic);
     let __ret: ::core::mem::MaybeUninit<note_t>;
-    __ret = __cbg_out_Note(__v);
+    __ret = __c_out_convert_Note_c_choice_intermediate_repr_c_tagged_union_to_wire_c9cea85d5266d21b(
+        __v,
+    );
     __ret
 }
 #[no_mangle]
 #[allow(non_snake_case, unused_mut, unused_variables, unused_unsafe, dead_code)]
 pub unsafe extern "C" fn note_value(n: ::core::mem::MaybeUninit<note_t>) -> u64 {
-    let n = match __cbg_in_Note(n) {
+    let n = match __c_in_convert_wire_to_Note_c_choice_intermediate_repr_c_tagged_union_4de1f2981255d608(
+        n,
+    ) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__msg) => {
             panic!("{}", __msg);
@@ -1378,13 +1631,15 @@ pub unsafe extern "C" fn note_value(n: ::core::mem::MaybeUninit<note_t>) -> u64 
     };
     let __v = example_flat::note_value(n);
     let __ret: u64;
-    __ret = __cbg_out_u64(__v);
+    __ret = __c_out_convert_u64_c_terminal_output_scalar_to_wire_518245fe60cf3590(__v);
     __ret
 }
 #[no_mangle]
 #[allow(non_snake_case, unused_mut, unused_variables, unused_unsafe, dead_code)]
 pub unsafe extern "C" fn shape_area(s: ::core::mem::MaybeUninit<shape_t>) -> f64 {
-    let s = match __cbg_in_Shape(s) {
+    let s = match __c_in_convert_wire_to_Shape_c_choice_intermediate_repr_c_tagged_union_8ddb52c185c8b923(
+        s,
+    ) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__msg) => {
             panic!("{}", __msg);
@@ -1392,7 +1647,7 @@ pub unsafe extern "C" fn shape_area(s: ::core::mem::MaybeUninit<shape_t>) -> f64
     };
     let __v = example_flat::shape_area(s);
     let __ret: f64;
-    __ret = __cbg_out_f64(__v);
+    __ret = __c_out_convert_f64_c_terminal_output_scalar_to_wire_6aa94606ef14f673(__v);
     __ret
 }
 #[no_mangle]
@@ -1400,7 +1655,9 @@ pub unsafe extern "C" fn shape_area(s: ::core::mem::MaybeUninit<shape_t>) -> f64
 pub unsafe extern "C" fn shape_get_label(
     s: ::core::mem::MaybeUninit<shape_t>,
 ) -> *mut ::core::ffi::c_char {
-    let s = match __cbg_in_Shape(s) {
+    let s = match __c_in_convert_wire_to_Shape_c_choice_intermediate_repr_c_tagged_union_8ddb52c185c8b923(
+        s,
+    ) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__msg) => {
             panic!("{}", __msg);
@@ -1408,7 +1665,9 @@ pub unsafe extern "C" fn shape_get_label(
     };
     let __v = example_flat::shape_get_label(s);
     let __ret: *mut ::core::ffi::c_char;
-    __ret = __cbg_out_String(__v);
+    __ret = __c_out_convert_String_c_terminal_output_string_to_wire_182528409f6ab8d3(
+        __v,
+    );
     __ret
 }
 #[no_mangle]
@@ -1416,10 +1675,14 @@ pub unsafe extern "C" fn shape_get_label(
 pub unsafe extern "C" fn shape_new_circle(
     radius: f64,
 ) -> ::core::mem::MaybeUninit<shape_t> {
-    let radius = __cbg_in_f64(radius);
+    let radius = __c_in_convert_wire_to_f64_c_terminal_input_scalar_7d8a0a733495e599(
+        radius,
+    );
     let __v = example_flat::shape_new_circle(radius);
     let __ret: ::core::mem::MaybeUninit<shape_t>;
-    __ret = __cbg_out_Shape(__v);
+    __ret = __c_out_convert_Shape_c_choice_intermediate_repr_c_tagged_union_to_wire_1c9175b2e9cd70a6(
+        __v,
+    );
     __ret
 }
 #[no_mangle]
@@ -1427,7 +1690,9 @@ pub unsafe extern "C" fn shape_new_circle(
 pub unsafe extern "C" fn shape_new_empty() -> ::core::mem::MaybeUninit<shape_t> {
     let __v = example_flat::shape_new_empty();
     let __ret: ::core::mem::MaybeUninit<shape_t>;
-    __ret = __cbg_out_Shape(__v);
+    __ret = __c_out_convert_Shape_c_choice_intermediate_repr_c_tagged_union_to_wire_1c9175b2e9cd70a6(
+        __v,
+    );
     __ret
 }
 #[no_mangle]
@@ -1436,13 +1701,17 @@ pub unsafe extern "C" fn shape_new_labeled(
     label: *const ::core::ffi::c_char,
     op: ::core::mem::MaybeUninit<operation_t>,
 ) -> ::core::mem::MaybeUninit<shape_t> {
-    let label = match __cbg_in___str(label) {
+    let label = match __c_in_convert_wire_to_str_c_borrow_str_input_246c2b9955bb6ef2(
+        label,
+    ) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__msg) => {
             panic!("{}", __msg);
         }
     };
-    let op = match __cbg_in_Operation(op) {
+    let op = match __c_in_convert_wire_to_Operation_c_terminal_input_enum_a23b6023635a8da5(
+        op,
+    ) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__msg) => {
             panic!("{}", __msg);
@@ -1450,7 +1719,9 @@ pub unsafe extern "C" fn shape_new_labeled(
     };
     let __v = example_flat::shape_new_labeled(label, op);
     let __ret: ::core::mem::MaybeUninit<shape_t>;
-    __ret = __cbg_out_Shape(__v);
+    __ret = __c_out_convert_Shape_c_choice_intermediate_repr_c_tagged_union_to_wire_1c9175b2e9cd70a6(
+        __v,
+    );
     __ret
 }
 #[no_mangle]
@@ -1459,11 +1730,17 @@ pub unsafe extern "C" fn shape_new_rect(
     width: f64,
     height: f64,
 ) -> ::core::mem::MaybeUninit<shape_t> {
-    let width = __cbg_in_f64(width);
-    let height = __cbg_in_f64(height);
+    let width = __c_in_convert_wire_to_f64_c_terminal_input_scalar_7d8a0a733495e599(
+        width,
+    );
+    let height = __c_in_convert_wire_to_f64_c_terminal_input_scalar_7d8a0a733495e599(
+        height,
+    );
     let __v = example_flat::shape_new_rect(width, height);
     let __ret: ::core::mem::MaybeUninit<shape_t>;
-    __ret = __cbg_out_Shape(__v);
+    __ret = __c_out_convert_Shape_c_choice_intermediate_repr_c_tagged_union_to_wire_1c9175b2e9cd70a6(
+        __v,
+    );
     __ret
 }
 #[no_mangle]
@@ -1473,11 +1750,13 @@ pub unsafe extern "C" fn shape_try_area(
     out: *mut f64,
     e: *mut *mut ::core::ffi::c_char,
 ) -> bool {
-    let s = match __cbg_in_Shape(s) {
+    let s = match __c_in_convert_wire_to_Shape_c_choice_intermediate_repr_c_tagged_union_8ddb52c185c8b923(
+        s,
+    ) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__msg) => {
             if !e.is_null() {
-                *e = __cbg_out_Error(
+                *e = __c_out_convert_Error_c_terminal_output_opaque_error_to_wire_9d010015abcb2259(
                     <example_flat::Error as ::core::convert::From<
                         ::std::string::String,
                     >>::from(__msg),
@@ -1488,12 +1767,16 @@ pub unsafe extern "C" fn shape_try_area(
     };
     match example_flat::shape_try_area(s) {
         ::core::result::Result::Ok(__v) => {
-            *out = __cbg_out_f64(__v);
+            *out = __c_out_convert_f64_c_terminal_output_scalar_to_wire_6aa94606ef14f673(
+                __v,
+            );
             true
         }
         ::core::result::Result::Err(__err) => {
             if !e.is_null() {
-                *e = __cbg_out_Error(__err);
+                *e = __c_out_convert_Error_c_terminal_output_opaque_error_to_wire_9d010015abcb2259(
+                    __err,
+                );
             }
             false
         }

--- a/examples/example-cbindgen/generated/example_flat_aarch64_internal_unstable.rs
+++ b/examples/example-cbindgen/generated/example_flat_aarch64_internal_unstable.rs
@@ -178,7 +178,7 @@ pub struct closure_history_batch_t {
     pub drop: ::core::option::Option<unsafe extern "C" fn(*mut ::core::ffi::c_void)>,
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) unsafe fn __cbg_in_closure_history_batch_t(
+pub(crate) unsafe fn __c_in_convert_wire_to_impl_Fn_Vec_f64_Send_Sync_static_c_invoke_callback_capture_3dd7f8fbc61877ce(
     c: closure_history_batch_t,
 ) -> impl Fn(::std::vec::Vec<f64>) + Send + Sync + 'static {
     struct __Ctx {
@@ -203,7 +203,9 @@ pub(crate) unsafe fn __cbg_in_closure_history_batch_t(
         if let ::core::option::Option::Some(__f) = __call {
             let mut __w0_0 = ::core::mem::MaybeUninit::<*mut f64>::zeroed();
             let mut __w0_1 = ::core::mem::MaybeUninit::<usize>::zeroed();
-            let __arr: ::std::vec::Vec<f64> = __cbg_out_chain_vec_f64(__a0);
+            let __arr: ::std::vec::Vec<f64> = __c_out_convert_sequence_Vec_f64_to_wire_ad99887ef4e62c28(
+                __a0,
+            );
             let (__p, __n) = __cbg_alloc_array(__arr);
             *__w0_0.as_mut_ptr() = __p;
             *__w0_1.as_mut_ptr() = __n;
@@ -225,7 +227,7 @@ pub struct closure_maybe_grade_t {
     pub drop: ::core::option::Option<unsafe extern "C" fn(*mut ::core::ffi::c_void)>,
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) unsafe fn __cbg_in_closure_maybe_grade_t(
+pub(crate) unsafe fn __c_in_convert_wire_to_impl_Fn_Option_Grade_Send_Sync_static_c_invoke_callback_capture_5512a1f2265e79a0(
     c: closure_maybe_grade_t,
 ) -> impl Fn(::core::option::Option<example_flat::Grade>) + Send + Sync + 'static {
     struct __Ctx {
@@ -253,7 +255,9 @@ pub(crate) unsafe fn __cbg_in_closure_maybe_grade_t(
             match __a0 {
                 ::core::option::Option::Some(__x) => {
                     *__w0_0.as_mut_ptr() = true;
-                    *__w0_1.as_mut_ptr() = __cbg_out_Grade(__x);
+                    *__w0_1.as_mut_ptr() = __c_out_convert_Grade_c_terminal_output_enum_to_wire_a59c7b101e0a9e37(
+                        __x,
+                    );
                 }
                 ::core::option::Option::None => {
                     *__w0_0.as_mut_ptr() = false;
@@ -277,7 +281,7 @@ pub struct closure_maybe_value_t {
     pub drop: ::core::option::Option<unsafe extern "C" fn(*mut ::core::ffi::c_void)>,
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) unsafe fn __cbg_in_closure_maybe_value_t(
+pub(crate) unsafe fn __c_in_convert_wire_to_impl_Fn_Option_f64_Send_Sync_static_c_invoke_callback_capture_053af7d76b4f1245(
     c: closure_maybe_value_t,
 ) -> impl Fn(::core::option::Option<f64>) + Send + Sync + 'static {
     struct __Ctx {
@@ -305,7 +309,9 @@ pub(crate) unsafe fn __cbg_in_closure_maybe_value_t(
             match __a0 {
                 ::core::option::Option::Some(__x) => {
                     *__w0_0.as_mut_ptr() = true;
-                    *__w0_1.as_mut_ptr() = __cbg_out_f64(__x);
+                    *__w0_1.as_mut_ptr() = __c_out_convert_f64_c_terminal_output_scalar_to_wire_6aa94606ef14f673(
+                        __x,
+                    );
                 }
                 ::core::option::Option::None => {
                     *__w0_0.as_mut_ptr() = false;
@@ -325,7 +331,7 @@ pub struct closure_value_t {
     pub drop: ::core::option::Option<unsafe extern "C" fn(*mut ::core::ffi::c_void)>,
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) unsafe fn __cbg_in_closure_value_t(
+pub(crate) unsafe fn __c_in_convert_wire_to_impl_Fn_f64_Send_Sync_static_c_invoke_callback_capture_88739bf29d2a9906(
     c: closure_value_t,
 ) -> impl Fn(f64) + Send + Sync + 'static {
     struct __Ctx {
@@ -348,13 +354,41 @@ pub(crate) unsafe fn __cbg_in_closure_value_t(
     });
     move |__a0: f64| {
         if let ::core::option::Option::Some(__f) = __call {
-            let __w0 = __cbg_out_f64(__a0);
+            let __w0 = __c_out_convert_f64_c_terminal_output_scalar_to_wire_6aa94606ef14f673(
+                __a0,
+            );
             unsafe { __f(__w0, __ctx.context) }
         }
     }
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) unsafe fn __cbg_in_Calculator(
+pub(crate) unsafe fn __c_in_convert_wire_to_Calculator_c_borrow_mutable_input_f30bfe45043bc69c<
+    'a,
+>(
+    v: *mut calculator_t,
+) -> ::core::result::Result<&'a mut example_flat::Calculator, ::std::string::String> {
+    if v.is_null() {
+        return ::core::result::Result::Err(
+            ::std::string::String::from("null Calculator pointer"),
+        );
+    }
+    ::core::result::Result::Ok(&mut *(v as *mut example_flat::Calculator))
+}
+#[allow(non_snake_case, unused_variables, dead_code)]
+pub(crate) unsafe fn __c_in_convert_wire_to_Calculator_c_borrow_shared_input_48be88e9df13aa53<
+    'a,
+>(
+    v: *const calculator_t,
+) -> ::core::result::Result<&'a example_flat::Calculator, ::std::string::String> {
+    if v.is_null() {
+        return ::core::result::Result::Err(
+            ::std::string::String::from("null Calculator pointer"),
+        );
+    }
+    ::core::result::Result::Ok(&*(v as *const example_flat::Calculator))
+}
+#[allow(non_snake_case, unused_variables, dead_code)]
+pub(crate) unsafe fn __c_in_convert_wire_to_Calculator_c_terminal_input_owned_handle_b7bb400a642eb999(
     v: *mut calculator_t,
 ) -> ::core::result::Result<example_flat::Calculator, ::std::string::String> {
     if v.is_null() {
@@ -367,32 +401,46 @@ pub(crate) unsafe fn __cbg_in_Calculator(
     )
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) unsafe fn __cbg_in_Caption(v: caption_t) -> example_flat::Caption {
+pub(crate) unsafe fn __c_in_convert_wire_to_Caption_c_product_intermediate_repr_c_struct_a9076d1a0d6740b3(
+    v: caption_t,
+) -> example_flat::Caption {
     example_flat::Caption {
-        id: __cbg_in_u64(v.id),
-        text: __cbg_in_String_field(v.text),
-        emphatic: __cbg_in_bool(v.emphatic),
+        id: __c_in_convert_wire_to_u64_c_terminal_input_scalar_4e87470ad83635c8(v.id),
+        text: __c_in_convert_wire_to_String_c_terminal_input_string_field_b6091e2e8553ccde(
+            v.text,
+        ),
+        emphatic: __c_in_convert_wire_to_bool_c_terminal_input_bool_e48e0629cd6287b3(
+            v.emphatic,
+        ),
     }
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) unsafe fn __cbg_in_Drawing(
+pub(crate) unsafe fn __c_in_convert_wire_to_Drawing_c_product_intermediate_repr_c_struct_3b927b21caf2df63(
     v: drawing_t,
 ) -> ::core::result::Result<example_flat::Drawing, ::std::string::String> {
     ::core::result::Result::Ok(example_flat::Drawing {
-        id: __cbg_in_u64(v.id),
-        shape: __cbg_in_Shape(v.shape)?,
+        id: __c_in_convert_wire_to_u64_c_terminal_input_scalar_4e87470ad83635c8(v.id),
+        shape: __c_in_convert_wire_to_Shape_c_choice_intermediate_repr_c_tagged_union_8ddb52c185c8b923(
+            v.shape,
+        )?,
     })
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) unsafe fn __cbg_in_Foo(v: foo_t) -> example_flat::Foo {
+pub(crate) unsafe fn __c_in_convert_wire_to_Foo_c_product_intermediate_repr_c_struct_157d1b61f2a5b9d5(
+    v: foo_t,
+) -> example_flat::Foo {
     example_flat::Foo {
-        id: __cbg_in_u64(v.id),
-        aarch64_field: __cbg_in_u64(v.aarch64_field),
-        unstable_field: __cbg_in_u64(v.unstable_field),
+        id: __c_in_convert_wire_to_u64_c_terminal_input_scalar_4e87470ad83635c8(v.id),
+        aarch64_field: __c_in_convert_wire_to_u64_c_terminal_input_scalar_4e87470ad83635c8(
+            v.aarch64_field,
+        ),
+        unstable_field: __c_in_convert_wire_to_u64_c_terminal_input_scalar_4e87470ad83635c8(
+            v.unstable_field,
+        ),
     }
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) unsafe fn __cbg_in_InsideFoo(
+pub(crate) unsafe fn __c_in_convert_wire_to_InsideFoo_c_terminal_input_enum_70ed7847e05e3330(
     v: ::core::mem::MaybeUninit<inside_foo_t>,
 ) -> ::core::result::Result<example_flat::InsideFoo, ::std::string::String> {
     const _: () = {
@@ -421,11 +469,13 @@ pub(crate) unsafe fn __cbg_in_InsideFoo(
     )
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) fn __cbg_in_Millis(v: u64) -> example_flat::Millis {
+pub(crate) fn __c_in_convert_wire_to_Millis_c_terminal_custom_771f8034eae1c639(
+    v: u64,
+) -> example_flat::Millis {
     example_flat::millis_from_raw(v)
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) unsafe fn __cbg_in_Note(
+pub(crate) unsafe fn __c_in_convert_wire_to_Note_c_choice_intermediate_repr_c_tagged_union_4de1f2981255d608(
     v: ::core::mem::MaybeUninit<note_t>,
 ) -> ::core::result::Result<example_flat::Note, ::std::string::String> {
     ::core::result::Result::Ok({
@@ -451,7 +501,11 @@ pub(crate) unsafe fn __cbg_in_Note(
                         }
                     }
                 };
-                example_flat::Note::Titled(__cbg_in_Caption((__arm).0))
+                example_flat::Note::Titled(
+                    __c_in_convert_wire_to_Caption_c_product_intermediate_repr_c_struct_a9076d1a0d6740b3(
+                        (__arm).0,
+                    ),
+                )
             }
             2 => {
                 let __choice = unsafe { (v).assume_init() };
@@ -463,7 +517,11 @@ pub(crate) unsafe fn __cbg_in_Note(
                         }
                     }
                 };
-                example_flat::Note::After(__cbg_in_Millis((__arm).0))
+                example_flat::Note::After(
+                    __c_in_convert_wire_to_Millis_c_terminal_custom_771f8034eae1c639(
+                        (__arm).0,
+                    ),
+                )
             }
             3 => {
                 let __choice = unsafe { (v).assume_init() };
@@ -475,7 +533,11 @@ pub(crate) unsafe fn __cbg_in_Note(
                         }
                     }
                 };
-                example_flat::Note::Flagged(__cbg_in_bool((__arm).0))
+                example_flat::Note::Flagged(
+                    __c_in_convert_wire_to_bool_c_terminal_input_bool_e48e0629cd6287b3(
+                        (__arm).0,
+                    ),
+                )
             }
             4 => {
                 let __choice = unsafe { (v).assume_init() };
@@ -487,7 +549,11 @@ pub(crate) unsafe fn __cbg_in_Note(
                         }
                     }
                 };
-                example_flat::Note::Sketched(__cbg_in_Drawing((__arm).0)?)
+                example_flat::Note::Sketched(
+                    __c_in_convert_wire_to_Drawing_c_product_intermediate_repr_c_struct_3b927b21caf2df63(
+                        (__arm).0,
+                    )?,
+                )
             }
             _ => {
                 return ::core::result::Result::Err(
@@ -501,7 +567,7 @@ pub(crate) unsafe fn __cbg_in_Note(
     })
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) unsafe fn __cbg_in_Operation(
+pub(crate) unsafe fn __c_in_convert_wire_to_Operation_c_terminal_input_enum_a23b6023635a8da5(
     v: ::core::mem::MaybeUninit<operation_t>,
 ) -> ::core::result::Result<example_flat::Operation, ::std::string::String> {
     const _: () = {
@@ -536,7 +602,7 @@ pub(crate) unsafe fn __cbg_in_Operation(
     )
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) unsafe fn __cbg_in_Shape(
+pub(crate) unsafe fn __c_in_convert_wire_to_Shape_c_choice_intermediate_repr_c_tagged_union_8ddb52c185c8b923(
     v: ::core::mem::MaybeUninit<shape_t>,
 ) -> ::core::result::Result<example_flat::Shape, ::std::string::String> {
     ::core::result::Result::Ok({
@@ -562,7 +628,11 @@ pub(crate) unsafe fn __cbg_in_Shape(
                         }
                     }
                 };
-                example_flat::Shape::Circle(__cbg_in_f64((__arm).0))
+                example_flat::Shape::Circle(
+                    __c_in_convert_wire_to_f64_c_terminal_input_scalar_7d8a0a733495e599(
+                        (__arm).0,
+                    ),
+                )
             }
             2 => {
                 let __choice = unsafe { (v).assume_init() };
@@ -577,8 +647,12 @@ pub(crate) unsafe fn __cbg_in_Shape(
                     }
                 };
                 example_flat::Shape::Rect {
-                    width: __cbg_in_f64((__arm).0),
-                    height: __cbg_in_f64((__arm).1),
+                    width: __c_in_convert_wire_to_f64_c_terminal_input_scalar_7d8a0a733495e599(
+                        (__arm).0,
+                    ),
+                    height: __c_in_convert_wire_to_f64_c_terminal_input_scalar_7d8a0a733495e599(
+                        (__arm).1,
+                    ),
                 }
             }
             3 => {
@@ -594,8 +668,12 @@ pub(crate) unsafe fn __cbg_in_Shape(
                     }
                 };
                 example_flat::Shape::Labeled(
-                    __cbg_in_String_field((__arm).0),
-                    __cbg_in_Operation((__arm).1)?,
+                    __c_in_convert_wire_to_String_c_terminal_input_string_field_b6091e2e8553ccde(
+                        (__arm).0,
+                    ),
+                    __c_in_convert_wire_to_Operation_c_terminal_input_enum_a23b6023635a8da5(
+                        (__arm).1,
+                    )?,
                 )
             }
             _ => {
@@ -610,7 +688,7 @@ pub(crate) unsafe fn __cbg_in_Shape(
     })
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) unsafe fn __cbg_in_String_field(
+pub(crate) unsafe fn __c_in_convert_wire_to_String_c_terminal_input_string_field_b6091e2e8553ccde(
     v: *const ::core::ffi::c_char,
 ) -> ::std::string::String {
     if v.is_null() {
@@ -620,29 +698,19 @@ pub(crate) unsafe fn __cbg_in_String_field(
     }
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) unsafe fn __cbg_in___Calculator<'a>(
-    v: *const calculator_t,
-) -> ::core::result::Result<&'a example_flat::Calculator, ::std::string::String> {
-    if v.is_null() {
-        return ::core::result::Result::Err(
-            ::std::string::String::from("null Calculator pointer"),
-        );
-    }
-    ::core::result::Result::Ok(&*(v as *const example_flat::Calculator))
+pub(crate) unsafe fn __c_in_convert_wire_to_bool_c_terminal_input_bool_e48e0629cd6287b3(
+    v: ::core::mem::MaybeUninit<bool>,
+) -> bool {
+    ::core::ptr::read(v.as_ptr() as *const u8) != 0
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) unsafe fn __cbg_in___mut_Calculator<'a>(
-    v: *mut calculator_t,
-) -> ::core::result::Result<&'a mut example_flat::Calculator, ::std::string::String> {
-    if v.is_null() {
-        return ::core::result::Result::Err(
-            ::std::string::String::from("null Calculator pointer"),
-        );
-    }
-    ::core::result::Result::Ok(&mut *(v as *mut example_flat::Calculator))
+pub(crate) fn __c_in_convert_wire_to_f64_c_terminal_input_scalar_7d8a0a733495e599(
+    v: f64,
+) -> f64 {
+    v
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) unsafe fn __cbg_in___str<'a>(
+pub(crate) unsafe fn __c_in_convert_wire_to_str_c_borrow_str_input_246c2b9955bb6ef2<'a>(
     v: *const ::core::ffi::c_char,
 ) -> ::core::result::Result<&'a str, ::std::string::String> {
     if v.is_null() {
@@ -660,92 +728,132 @@ pub(crate) unsafe fn __cbg_in___str<'a>(
     }
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) unsafe fn __cbg_in_bool(v: ::core::mem::MaybeUninit<bool>) -> bool {
-    ::core::ptr::read(v.as_ptr() as *const u8) != 0
-}
-#[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) fn __cbg_in_f64(v: f64) -> f64 {
+pub(crate) fn __c_in_convert_wire_to_u64_c_terminal_input_scalar_4e87470ad83635c8(
+    v: u64,
+) -> u64 {
     v
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) fn __cbg_in_u64(v: u64) -> u64 {
-    v
-}
-#[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) fn __cbg_out_Calculator(v: example_flat::Calculator) -> *mut calculator_t {
+pub(crate) fn __c_out_convert_Calculator_c_terminal_output_owned_handle_to_wire_4d20353780559007(
+    v: example_flat::Calculator,
+) -> *mut calculator_t {
     ::std::boxed::Box::into_raw(::std::boxed::Box::new(v)) as *mut calculator_t
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) fn __cbg_out_Caption(v: example_flat::Caption) -> caption_t {
+pub(crate) fn __c_out_convert_Caption_c_product_intermediate_repr_c_struct_to_wire_3bc5d236333a6e28(
+    v: example_flat::Caption,
+) -> caption_t {
     caption_t {
-        id: __cbg_out_u64(v.id),
-        text: __cbg_out_String(v.text),
-        emphatic: __cbg_out_bool_field(v.emphatic),
+        id: __c_out_convert_u64_c_terminal_output_scalar_to_wire_518245fe60cf3590(v.id),
+        text: __c_out_convert_String_c_terminal_output_string_to_wire_182528409f6ab8d3(
+            v.text,
+        ),
+        emphatic: __c_out_convert_bool_c_terminal_output_bool_field_to_wire_6a810eb4cb986700(
+            v.emphatic,
+        ),
     }
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) fn __cbg_out_Drawing(v: example_flat::Drawing) -> drawing_t {
+pub(crate) fn __c_out_convert_Drawing_c_product_intermediate_repr_c_struct_to_wire_50eac9aa069a6838(
+    v: example_flat::Drawing,
+) -> drawing_t {
     drawing_t {
-        id: __cbg_out_u64(v.id),
-        shape: __cbg_out_Shape(v.shape),
+        id: __c_out_convert_u64_c_terminal_output_scalar_to_wire_518245fe60cf3590(v.id),
+        shape: __c_out_convert_Shape_c_choice_intermediate_repr_c_tagged_union_to_wire_1c9175b2e9cd70a6(
+            v.shape,
+        ),
     }
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) fn __cbg_out_Error(v: example_flat::Error) -> *mut ::core::ffi::c_char {
+pub(crate) fn __c_out_convert_Error_c_terminal_output_opaque_error_to_wire_9d010015abcb2259(
+    v: example_flat::Error,
+) -> *mut ::core::ffi::c_char {
     __cbg_alloc_cstr(example_flat::error_get_message(&v))
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) fn __cbg_out_Foo(v: example_flat::Foo) -> foo_t {
+pub(crate) fn __c_out_convert_Foo_c_product_intermediate_repr_c_struct_to_wire_02ab0b068798553e(
+    v: example_flat::Foo,
+) -> foo_t {
     foo_t {
-        id: __cbg_out_u64(v.id),
-        aarch64_field: __cbg_out_u64(v.aarch64_field),
-        unstable_field: __cbg_out_u64(v.unstable_field),
+        id: __c_out_convert_u64_c_terminal_output_scalar_to_wire_518245fe60cf3590(v.id),
+        aarch64_field: __c_out_convert_u64_c_terminal_output_scalar_to_wire_518245fe60cf3590(
+            v.aarch64_field,
+        ),
+        unstable_field: __c_out_convert_u64_c_terminal_output_scalar_to_wire_518245fe60cf3590(
+            v.unstable_field,
+        ),
     }
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) fn __cbg_out_Grade(v: example_flat::Grade) -> grade_t {
+pub(crate) fn __c_out_convert_Grade_c_terminal_output_enum_to_wire_a59c7b101e0a9e37(
+    v: example_flat::Grade,
+) -> grade_t {
     match v {
         example_flat::Grade::Low => grade_t::Low,
         example_flat::Grade::High => grade_t::High,
     }
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) fn __cbg_out_InsideFoo(v: example_flat::InsideFoo) -> inside_foo_t {
+pub(crate) fn __c_out_convert_InsideFoo_c_terminal_output_enum_to_wire_b103ad5e4be33376(
+    v: example_flat::InsideFoo,
+) -> inside_foo_t {
     match v {
         example_flat::InsideFoo::DouddleDee => inside_foo_t::DouddleDee,
         example_flat::InsideFoo::DouddleDum => inside_foo_t::DouddleDum,
     }
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) fn __cbg_out_Millis(v: example_flat::Millis) -> u64 {
+pub(crate) fn __c_out_convert_Millis_c_terminal_custom_to_wire_0c2f6b5f81dfcd94(
+    v: example_flat::Millis,
+) -> u64 {
     example_flat::millis_to_raw(&v)
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) fn __cbg_out_Note(v: example_flat::Note) -> ::core::mem::MaybeUninit<note_t> {
+pub(crate) fn __c_out_convert_Note_c_choice_intermediate_repr_c_tagged_union_to_wire_c9cea85d5266d21b(
+    v: example_flat::Note,
+) -> ::core::mem::MaybeUninit<note_t> {
     ::core::mem::MaybeUninit::new({
         match v {
             example_flat::Note::Silent => note_t::Silent,
             example_flat::Note::Titled(__part0) => {
-                let __built_arm = (__cbg_out_Caption(__part0),);
+                let __built_arm = (
+                    __c_out_convert_Caption_c_product_intermediate_repr_c_struct_to_wire_3bc5d236333a6e28(
+                        __part0,
+                    ),
+                );
                 note_t::Titled(__built_arm.0)
             }
             example_flat::Note::After(__part0) => {
-                let __built_arm = (__cbg_out_Millis(__part0),);
+                let __built_arm = (
+                    __c_out_convert_Millis_c_terminal_custom_to_wire_0c2f6b5f81dfcd94(
+                        __part0,
+                    ),
+                );
                 note_t::After(__built_arm.0)
             }
             example_flat::Note::Flagged(__part0) => {
-                let __built_arm = (__cbg_out_bool_field(__part0),);
+                let __built_arm = (
+                    __c_out_convert_bool_c_terminal_output_bool_field_to_wire_6a810eb4cb986700(
+                        __part0,
+                    ),
+                );
                 note_t::Flagged(__built_arm.0)
             }
             example_flat::Note::Sketched(__part0) => {
-                let __built_arm = (__cbg_out_Drawing(__part0),);
+                let __built_arm = (
+                    __c_out_convert_Drawing_c_product_intermediate_repr_c_struct_to_wire_50eac9aa069a6838(
+                        __part0,
+                    ),
+                );
                 note_t::Sketched(__built_arm.0)
             }
         }
     })
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) fn __cbg_out_Operation(v: example_flat::Operation) -> operation_t {
+pub(crate) fn __c_out_convert_Operation_c_terminal_output_enum_to_wire_457f6036394dc821(
+    v: example_flat::Operation,
+) -> operation_t {
     match v {
         example_flat::Operation::Add => operation_t::Add,
         example_flat::Operation::Sub => operation_t::Sub,
@@ -753,19 +861,34 @@ pub(crate) fn __cbg_out_Operation(v: example_flat::Operation) -> operation_t {
         example_flat::Operation::Div => operation_t::Div,
     }
 }
+#[allow(non_snake_case, dead_code, unused)]
+pub(crate) fn __c_out_convert_Option_Grade_c_marker_optional_to_wire_e2c04af90b0abd17() {}
+#[allow(non_snake_case, dead_code, unused)]
+pub(crate) fn __c_out_convert_Option_f64_c_marker_optional_to_wire_c1ba5adc99623ff4() {}
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) fn __cbg_out_Shape(
+pub(crate) fn __c_out_convert_Shape_c_choice_intermediate_repr_c_tagged_union_to_wire_1c9175b2e9cd70a6(
     v: example_flat::Shape,
 ) -> ::core::mem::MaybeUninit<shape_t> {
     ::core::mem::MaybeUninit::new({
         match v {
             example_flat::Shape::Empty => shape_t::Empty,
             example_flat::Shape::Circle(__part0) => {
-                let __built_arm = (__cbg_out_f64(__part0),);
+                let __built_arm = (
+                    __c_out_convert_f64_c_terminal_output_scalar_to_wire_6aa94606ef14f673(
+                        __part0,
+                    ),
+                );
                 shape_t::Circle(__built_arm.0)
             }
             example_flat::Shape::Rect { width: __part0, height: __part1 } => {
-                let __built_arm = (__cbg_out_f64(__part0), __cbg_out_f64(__part1));
+                let __built_arm = (
+                    __c_out_convert_f64_c_terminal_output_scalar_to_wire_6aa94606ef14f673(
+                        __part0,
+                    ),
+                    __c_out_convert_f64_c_terminal_output_scalar_to_wire_6aa94606ef14f673(
+                        __part1,
+                    ),
+                );
                 shape_t::Rect {
                     width: __built_arm.0,
                     height: __built_arm.1,
@@ -773,8 +896,14 @@ pub(crate) fn __cbg_out_Shape(
             }
             example_flat::Shape::Labeled(__part0, __part1) => {
                 let __built_arm = (
-                    __cbg_out_String(__part0),
-                    ::core::mem::MaybeUninit::new(__cbg_out_Operation(__part1)),
+                    __c_out_convert_String_c_terminal_output_string_to_wire_182528409f6ab8d3(
+                        __part0,
+                    ),
+                    ::core::mem::MaybeUninit::new(
+                        __c_out_convert_Operation_c_terminal_output_enum_to_wire_457f6036394dc821(
+                            __part1,
+                        ),
+                    ),
                 );
                 shape_t::Labeled(__built_arm.0, __built_arm.1)
             }
@@ -782,48 +911,60 @@ pub(crate) fn __cbg_out_Shape(
     })
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) fn __cbg_out_String(v: ::std::string::String) -> *mut ::core::ffi::c_char {
+pub(crate) fn __c_out_convert_String_c_terminal_output_string_to_wire_182528409f6ab8d3(
+    v: ::std::string::String,
+) -> *mut ::core::ffi::c_char {
     __cbg_alloc_cstr(v)
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) fn __cbg_out_bool(v: bool) -> bool {
-    v
-}
-#[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) fn __cbg_out_bool_field(v: bool) -> ::core::mem::MaybeUninit<bool> {
+pub(crate) fn __c_out_convert_bool_c_terminal_output_bool_field_to_wire_6a810eb4cb986700(
+    v: bool,
+) -> ::core::mem::MaybeUninit<bool> {
     ::core::mem::MaybeUninit::new(v)
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
+pub(crate) fn __c_out_convert_bool_c_terminal_output_scalar_to_wire_cc0ad9760da17efd(
+    v: bool,
+) -> bool {
+    v
+}
+#[allow(non_snake_case, unused_variables, dead_code)]
+pub(crate) fn __c_out_convert_f64_c_terminal_output_scalar_to_wire_6aa94606ef14f673(
+    v: f64,
+) -> f64 {
+    v
+}
+#[allow(non_snake_case, unused_variables, dead_code)]
+pub(crate) fn __c_out_convert_i32_c_terminal_output_scalar_to_wire_ae82162f636ebcd5(
+    v: i32,
+) -> i32 {
+    v
+}
+#[allow(non_snake_case, unused_variables, dead_code)]
 #[inline(always)]
-pub(crate) fn __cbg_out_chain_vec_f64(v: ::std::vec::Vec<f64>) -> ::std::vec::Vec<f64> {
+pub(crate) fn __c_out_convert_sequence_Vec_f64_to_wire_ad99887ef4e62c28(
+    v: ::std::vec::Vec<f64>,
+) -> ::std::vec::Vec<f64> {
     {
         let __sequence_source = v;
         let mut __sequence_output: ::std::vec::Vec<f64> = ::std::vec::Vec::with_capacity(
             (__sequence_source).len(),
         );
         for __sequence_element in __sequence_source.into_iter() {
-            let __sequence_part = __cbg_out_f64(__sequence_element);
+            let __sequence_part = __c_out_convert_f64_c_terminal_output_scalar_to_wire_6aa94606ef14f673(
+                __sequence_element,
+            );
             __sequence_output.push(__sequence_part);
         }
         __sequence_output
     }
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) fn __cbg_out_f64(v: f64) -> f64 {
+pub(crate) fn __c_out_convert_u64_c_terminal_output_scalar_to_wire_518245fe60cf3590(
+    v: u64,
+) -> u64 {
     v
 }
-#[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) fn __cbg_out_i32(v: i32) -> i32 {
-    v
-}
-#[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) fn __cbg_out_u64(v: u64) -> u64 {
-    v
-}
-#[allow(non_snake_case, dead_code, unused)]
-pub(crate) fn __cbg_outmark_option_Grade() {}
-#[allow(non_snake_case, dead_code, unused)]
-pub(crate) fn __cbg_outmark_option_f64() {}
 #[no_mangle]
 #[allow(non_snake_case, unused_mut, unused_variables, unused_unsafe, dead_code)]
 pub unsafe extern "C" fn calculator_absorb(
@@ -837,7 +978,7 @@ pub unsafe extern "C" fn calculator_absorb(
             "aliasing arguments: `a` (consumed) and `b` (borrowed) are the same `Calculator` — a consumed or exclusively-borrowed resource may not be named twice in one call",
         );
         if !e.is_null() {
-            *e = __cbg_out_Error(
+            *e = __c_out_convert_Error_c_terminal_output_opaque_error_to_wire_9d010015abcb2259(
                 <example_flat::Error as ::core::convert::From<
                     ::std::string::String,
                 >>::from(__msg),
@@ -845,11 +986,13 @@ pub unsafe extern "C" fn calculator_absorb(
         }
         return false;
     }
-    let a = match __cbg_in_Calculator(a) {
+    let a = match __c_in_convert_wire_to_Calculator_c_terminal_input_owned_handle_b7bb400a642eb999(
+        a,
+    ) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__msg) => {
             if !e.is_null() {
-                *e = __cbg_out_Error(
+                *e = __c_out_convert_Error_c_terminal_output_opaque_error_to_wire_9d010015abcb2259(
                     <example_flat::Error as ::core::convert::From<
                         ::std::string::String,
                     >>::from(__msg),
@@ -858,11 +1001,13 @@ pub unsafe extern "C" fn calculator_absorb(
             return false;
         }
     };
-    let b = match __cbg_in___Calculator(b) {
+    let b = match __c_in_convert_wire_to_Calculator_c_borrow_shared_input_48be88e9df13aa53(
+        b,
+    ) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__msg) => {
             if !e.is_null() {
-                *e = __cbg_out_Error(
+                *e = __c_out_convert_Error_c_terminal_output_opaque_error_to_wire_9d010015abcb2259(
                     <example_flat::Error as ::core::convert::From<
                         ::std::string::String,
                     >>::from(__msg),
@@ -873,12 +1018,16 @@ pub unsafe extern "C" fn calculator_absorb(
     };
     match example_flat::calculator_absorb(a, b) {
         ::core::result::Result::Ok(__v) => {
-            *out = __cbg_out_f64(__v);
+            *out = __c_out_convert_f64_c_terminal_output_scalar_to_wire_6aa94606ef14f673(
+                __v,
+            );
             true
         }
         ::core::result::Result::Err(__err) => {
             if !e.is_null() {
-                *e = __cbg_out_Error(__err);
+                *e = __c_out_convert_Error_c_terminal_output_opaque_error_to_wire_9d010015abcb2259(
+                    __err,
+                );
             }
             false
         }
@@ -893,11 +1042,13 @@ pub unsafe extern "C" fn calculator_apply(
     out: *mut f64,
     e: *mut *mut ::core::ffi::c_char,
 ) -> bool {
-    let c = match __cbg_in___mut_Calculator(c) {
+    let c = match __c_in_convert_wire_to_Calculator_c_borrow_mutable_input_f30bfe45043bc69c(
+        c,
+    ) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__msg) => {
             if !e.is_null() {
-                *e = __cbg_out_Error(
+                *e = __c_out_convert_Error_c_terminal_output_opaque_error_to_wire_9d010015abcb2259(
                     <example_flat::Error as ::core::convert::From<
                         ::std::string::String,
                     >>::from(__msg),
@@ -906,11 +1057,13 @@ pub unsafe extern "C" fn calculator_apply(
             return false;
         }
     };
-    let op = match __cbg_in_Operation(op) {
+    let op = match __c_in_convert_wire_to_Operation_c_terminal_input_enum_a23b6023635a8da5(
+        op,
+    ) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__msg) => {
             if !e.is_null() {
-                *e = __cbg_out_Error(
+                *e = __c_out_convert_Error_c_terminal_output_opaque_error_to_wire_9d010015abcb2259(
                     <example_flat::Error as ::core::convert::From<
                         ::std::string::String,
                     >>::from(__msg),
@@ -919,15 +1072,21 @@ pub unsafe extern "C" fn calculator_apply(
             return false;
         }
     };
-    let operand = __cbg_in_f64(operand);
+    let operand = __c_in_convert_wire_to_f64_c_terminal_input_scalar_7d8a0a733495e599(
+        operand,
+    );
     match example_flat::calculator_apply(c, op, operand) {
         ::core::result::Result::Ok(__v) => {
-            *out = __cbg_out_f64(__v);
+            *out = __c_out_convert_f64_c_terminal_output_scalar_to_wire_6aa94606ef14f673(
+                __v,
+            );
             true
         }
         ::core::result::Result::Err(__err) => {
             if !e.is_null() {
-                *e = __cbg_out_Error(__err);
+                *e = __c_out_convert_Error_c_terminal_output_opaque_error_to_wire_9d010015abcb2259(
+                    __err,
+                );
             }
             false
         }
@@ -939,19 +1098,25 @@ pub unsafe extern "C" fn calculator_for_each(
     c: *const calculator_t,
     f: closure_value_t,
 ) {
-    let c = match __cbg_in___Calculator(c) {
+    let c = match __c_in_convert_wire_to_Calculator_c_borrow_shared_input_48be88e9df13aa53(
+        c,
+    ) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__msg) => {
             panic!("{}", __msg);
         }
     };
-    let f = __cbg_in_closure_value_t(f);
+    let f = __c_in_convert_wire_to_impl_Fn_f64_Send_Sync_static_c_invoke_callback_capture_88739bf29d2a9906(
+        f,
+    );
     example_flat::calculator_for_each(c, f);
 }
 #[no_mangle]
 #[allow(non_snake_case, unused_mut, unused_variables, unused_unsafe, dead_code)]
 pub unsafe extern "C" fn calculator_get_count(c: *const calculator_t) -> u64 {
-    let c = match __cbg_in___Calculator(c) {
+    let c = match __c_in_convert_wire_to_Calculator_c_borrow_shared_input_48be88e9df13aa53(
+        c,
+    ) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__msg) => {
             panic!("{}", __msg);
@@ -959,7 +1124,7 @@ pub unsafe extern "C" fn calculator_get_count(c: *const calculator_t) -> u64 {
     };
     let __v = example_flat::calculator_get_count(c);
     let __ret: u64;
-    __ret = __cbg_out_u64(__v);
+    __ret = __c_out_convert_u64_c_terminal_output_scalar_to_wire_518245fe60cf3590(__v);
     __ret
 }
 #[no_mangle]
@@ -968,7 +1133,9 @@ pub unsafe extern "C" fn calculator_get_history(
     c: *const calculator_t,
     len: *mut usize,
 ) -> *mut f64 {
-    let c = match __cbg_in___Calculator(c) {
+    let c = match __c_in_convert_wire_to_Calculator_c_borrow_shared_input_48be88e9df13aa53(
+        c,
+    ) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__msg) => {
             panic!("{}", __msg);
@@ -976,7 +1143,9 @@ pub unsafe extern "C" fn calculator_get_history(
     };
     let __v = example_flat::calculator_get_history(c);
     let __ret: *mut f64;
-    let __arr: ::std::vec::Vec<f64> = __cbg_out_chain_vec_f64(__v);
+    let __arr: ::std::vec::Vec<f64> = __c_out_convert_sequence_Vec_f64_to_wire_ad99887ef4e62c28(
+        __v,
+    );
     let (__p, __n) = __cbg_alloc_array(__arr);
     __ret = __p;
     *len = __n;
@@ -985,7 +1154,9 @@ pub unsafe extern "C" fn calculator_get_history(
 #[no_mangle]
 #[allow(non_snake_case, unused_mut, unused_variables, unused_unsafe, dead_code)]
 pub unsafe extern "C" fn calculator_get_value(c: *const calculator_t) -> f64 {
-    let c = match __cbg_in___Calculator(c) {
+    let c = match __c_in_convert_wire_to_Calculator_c_borrow_shared_input_48be88e9df13aa53(
+        c,
+    ) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__msg) => {
             panic!("{}", __msg);
@@ -993,7 +1164,7 @@ pub unsafe extern "C" fn calculator_get_value(c: *const calculator_t) -> f64 {
     };
     let __v = example_flat::calculator_get_value(c);
     let __ret: f64;
-    __ret = __cbg_out_f64(__v);
+    __ret = __c_out_convert_f64_c_terminal_output_scalar_to_wire_6aa94606ef14f673(__v);
     __ret
 }
 #[no_mangle]
@@ -1002,13 +1173,17 @@ pub unsafe extern "C" fn calculator_grade_or_none(
     c: *const calculator_t,
     f: closure_maybe_grade_t,
 ) {
-    let c = match __cbg_in___Calculator(c) {
+    let c = match __c_in_convert_wire_to_Calculator_c_borrow_shared_input_48be88e9df13aa53(
+        c,
+    ) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__msg) => {
             panic!("{}", __msg);
         }
     };
-    let f = __cbg_in_closure_maybe_grade_t(f);
+    let f = __c_in_convert_wire_to_impl_Fn_Option_Grade_Send_Sync_static_c_invoke_callback_capture_5512a1f2265e79a0(
+        f,
+    );
     example_flat::calculator_grade_or_none(c, f);
 }
 #[no_mangle]
@@ -1017,28 +1192,36 @@ pub unsafe extern "C" fn calculator_history_batch(
     c: *const calculator_t,
     f: closure_history_batch_t,
 ) {
-    let c = match __cbg_in___Calculator(c) {
+    let c = match __c_in_convert_wire_to_Calculator_c_borrow_shared_input_48be88e9df13aa53(
+        c,
+    ) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__msg) => {
             panic!("{}", __msg);
         }
     };
-    let f = __cbg_in_closure_history_batch_t(f);
+    let f = __c_in_convert_wire_to_impl_Fn_Vec_f64_Send_Sync_static_c_invoke_callback_capture_3dd7f8fbc61877ce(
+        f,
+    );
     example_flat::calculator_history_batch(c, f);
 }
 #[no_mangle]
 #[allow(non_snake_case, unused_mut, unused_variables, unused_unsafe, dead_code)]
 pub unsafe extern "C" fn calculator_is(c: *const calculator_t, value: f64) -> bool {
-    let c = match __cbg_in___Calculator(c) {
+    let c = match __c_in_convert_wire_to_Calculator_c_borrow_shared_input_48be88e9df13aa53(
+        c,
+    ) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__msg) => {
             panic!("{}", __msg);
         }
     };
-    let value = __cbg_in_f64(value);
+    let value = __c_in_convert_wire_to_f64_c_terminal_input_scalar_7d8a0a733495e599(
+        value,
+    );
     let __v = example_flat::calculator_is(c, value);
     let __ret: bool;
-    __ret = __cbg_out_bool(__v);
+    __ret = __c_out_convert_bool_c_terminal_output_scalar_to_wire_cc0ad9760da17efd(__v);
     __ret
 }
 #[no_mangle]
@@ -1047,13 +1230,17 @@ pub unsafe extern "C" fn calculator_last_or_none(
     c: *const calculator_t,
     f: closure_maybe_value_t,
 ) {
-    let c = match __cbg_in___Calculator(c) {
+    let c = match __c_in_convert_wire_to_Calculator_c_borrow_shared_input_48be88e9df13aa53(
+        c,
+    ) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__msg) => {
             panic!("{}", __msg);
         }
     };
-    let f = __cbg_in_closure_maybe_value_t(f);
+    let f = __c_in_convert_wire_to_impl_Fn_Option_f64_Send_Sync_static_c_invoke_callback_capture_053af7d76b4f1245(
+        f,
+    );
     example_flat::calculator_last_or_none(c, f);
 }
 #[no_mangle]
@@ -1068,7 +1255,7 @@ pub unsafe extern "C" fn calculator_merge(
             "aliasing arguments: `a` (consumed) and `b` (consumed) are the same `Calculator` — a consumed or exclusively-borrowed resource may not be named twice in one call",
         );
         if !e.is_null() {
-            *e = __cbg_out_Error(
+            *e = __c_out_convert_Error_c_terminal_output_opaque_error_to_wire_9d010015abcb2259(
                 <example_flat::Error as ::core::convert::From<
                     ::std::string::String,
                 >>::from(__msg),
@@ -1076,11 +1263,13 @@ pub unsafe extern "C" fn calculator_merge(
         }
         return ::core::ptr::null_mut();
     }
-    let a = match __cbg_in_Calculator(a) {
+    let a = match __c_in_convert_wire_to_Calculator_c_terminal_input_owned_handle_b7bb400a642eb999(
+        a,
+    ) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__msg) => {
             if !e.is_null() {
-                *e = __cbg_out_Error(
+                *e = __c_out_convert_Error_c_terminal_output_opaque_error_to_wire_9d010015abcb2259(
                     <example_flat::Error as ::core::convert::From<
                         ::std::string::String,
                     >>::from(__msg),
@@ -1089,11 +1278,13 @@ pub unsafe extern "C" fn calculator_merge(
             return ::core::ptr::null_mut();
         }
     };
-    let b = match __cbg_in_Calculator(b) {
+    let b = match __c_in_convert_wire_to_Calculator_c_terminal_input_owned_handle_b7bb400a642eb999(
+        b,
+    ) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__msg) => {
             if !e.is_null() {
-                *e = __cbg_out_Error(
+                *e = __c_out_convert_Error_c_terminal_output_opaque_error_to_wire_9d010015abcb2259(
                     <example_flat::Error as ::core::convert::From<
                         ::std::string::String,
                     >>::from(__msg),
@@ -1105,12 +1296,16 @@ pub unsafe extern "C" fn calculator_merge(
     match example_flat::calculator_merge(a, b) {
         ::core::result::Result::Ok(__v) => {
             let __ret: *mut calculator_t;
-            __ret = __cbg_out_Calculator(__v);
+            __ret = __c_out_convert_Calculator_c_terminal_output_owned_handle_to_wire_4d20353780559007(
+                __v,
+            );
             __ret
         }
         ::core::result::Result::Err(__err) => {
             if !e.is_null() {
-                *e = __cbg_out_Error(__err);
+                *e = __c_out_convert_Error_c_terminal_output_opaque_error_to_wire_9d010015abcb2259(
+                    __err,
+                );
             }
             ::core::ptr::null_mut()
         }
@@ -1121,7 +1316,9 @@ pub unsafe extern "C" fn calculator_merge(
 pub unsafe extern "C" fn calculator_new() -> *mut calculator_t {
     let __v = example_flat::calculator_new();
     let __ret: *mut calculator_t;
-    __ret = __cbg_out_Calculator(__v);
+    __ret = __c_out_convert_Calculator_c_terminal_output_owned_handle_to_wire_4d20353780559007(
+        __v,
+    );
     __ret
 }
 #[no_mangle]
@@ -1129,7 +1326,9 @@ pub unsafe extern "C" fn calculator_new() -> *mut calculator_t {
 pub unsafe extern "C" fn calculator_new_clone(
     c: *const calculator_t,
 ) -> *mut calculator_t {
-    let c = match __cbg_in___Calculator(c) {
+    let c = match __c_in_convert_wire_to_Calculator_c_borrow_shared_input_48be88e9df13aa53(
+        c,
+    ) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__msg) => {
             panic!("{}", __msg);
@@ -1137,7 +1336,9 @@ pub unsafe extern "C" fn calculator_new_clone(
     };
     let __v = example_flat::calculator_new_clone(c);
     let __ret: *mut calculator_t;
-    __ret = __cbg_out_Calculator(__v);
+    __ret = __c_out_convert_Calculator_c_terminal_output_owned_handle_to_wire_4d20353780559007(
+        __v,
+    );
     __ret
 }
 #[no_mangle]
@@ -1146,11 +1347,11 @@ pub unsafe extern "C" fn calculator_new_from_str(
     s: *const ::core::ffi::c_char,
     e: *mut *mut ::core::ffi::c_char,
 ) -> *mut calculator_t {
-    let s = match __cbg_in___str(s) {
+    let s = match __c_in_convert_wire_to_str_c_borrow_str_input_246c2b9955bb6ef2(s) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__msg) => {
             if !e.is_null() {
-                *e = __cbg_out_Error(
+                *e = __c_out_convert_Error_c_terminal_output_opaque_error_to_wire_9d010015abcb2259(
                     <example_flat::Error as ::core::convert::From<
                         ::std::string::String,
                     >>::from(__msg),
@@ -1162,12 +1363,16 @@ pub unsafe extern "C" fn calculator_new_from_str(
     match example_flat::calculator_new_from_str(s) {
         ::core::result::Result::Ok(__v) => {
             let __ret: *mut calculator_t;
-            __ret = __cbg_out_Calculator(__v);
+            __ret = __c_out_convert_Calculator_c_terminal_output_owned_handle_to_wire_4d20353780559007(
+                __v,
+            );
             __ret
         }
         ::core::result::Result::Err(__err) => {
             if !e.is_null() {
-                *e = __cbg_out_Error(__err);
+                *e = __c_out_convert_Error_c_terminal_output_opaque_error_to_wire_9d010015abcb2259(
+                    __err,
+                );
             }
             ::core::ptr::null_mut()
         }
@@ -1176,7 +1381,9 @@ pub unsafe extern "C" fn calculator_new_from_str(
 #[no_mangle]
 #[allow(non_snake_case, unused_mut, unused_variables, unused_unsafe, dead_code)]
 pub unsafe extern "C" fn calculator_reset(c: *mut calculator_t) {
-    let c = match __cbg_in___mut_Calculator(c) {
+    let c = match __c_in_convert_wire_to_Calculator_c_borrow_mutable_input_f30bfe45043bc69c(
+        c,
+    ) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__msg) => {
             panic!("{}", __msg);
@@ -1189,7 +1396,9 @@ pub unsafe extern "C" fn calculator_reset(c: *mut calculator_t) {
 pub unsafe extern "C" fn calculator_to_string(
     c: *const calculator_t,
 ) -> *mut ::core::ffi::c_char {
-    let c = match __cbg_in___Calculator(c) {
+    let c = match __c_in_convert_wire_to_Calculator_c_borrow_shared_input_48be88e9df13aa53(
+        c,
+    ) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__msg) => {
             panic!("{}", __msg);
@@ -1197,7 +1406,9 @@ pub unsafe extern "C" fn calculator_to_string(
     };
     let __v = example_flat::calculator_to_string(c);
     let __ret: *mut ::core::ffi::c_char;
-    __ret = __cbg_out_String(__v);
+    __ret = __c_out_convert_String_c_terminal_output_string_to_wire_182528409f6ab8d3(
+        __v,
+    );
     __ret
 }
 #[no_mangle]
@@ -1207,17 +1418,23 @@ pub unsafe extern "C" fn caption_new(
     text: *const ::core::ffi::c_char,
     emphatic: ::core::mem::MaybeUninit<bool>,
 ) -> caption_t {
-    let id = __cbg_in_u64(id);
-    let text = match __cbg_in___str(text) {
+    let id = __c_in_convert_wire_to_u64_c_terminal_input_scalar_4e87470ad83635c8(id);
+    let text = match __c_in_convert_wire_to_str_c_borrow_str_input_246c2b9955bb6ef2(
+        text,
+    ) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__msg) => {
             panic!("{}", __msg);
         }
     };
-    let emphatic = __cbg_in_bool(emphatic);
+    let emphatic = __c_in_convert_wire_to_bool_c_terminal_input_bool_e48e0629cd6287b3(
+        emphatic,
+    );
     let __v = example_flat::caption_new(id, text, emphatic);
     let __ret: caption_t;
-    __ret = __cbg_out_Caption(__v);
+    __ret = __c_out_convert_Caption_c_product_intermediate_repr_c_struct_to_wire_3bc5d236333a6e28(
+        __v,
+    );
     __ret
 }
 #[no_mangle]
@@ -1225,7 +1442,9 @@ pub unsafe extern "C" fn caption_new(
 pub unsafe extern "C" fn drawing_get_shape(
     d: drawing_t,
 ) -> ::core::mem::MaybeUninit<shape_t> {
-    let d = match __cbg_in_Drawing(d) {
+    let d = match __c_in_convert_wire_to_Drawing_c_product_intermediate_repr_c_struct_3b927b21caf2df63(
+        d,
+    ) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__msg) => {
             panic!("{}", __msg);
@@ -1233,7 +1452,9 @@ pub unsafe extern "C" fn drawing_get_shape(
     };
     let __v = example_flat::drawing_get_shape(d);
     let __ret: ::core::mem::MaybeUninit<shape_t>;
-    __ret = __cbg_out_Shape(__v);
+    __ret = __c_out_convert_Shape_c_choice_intermediate_repr_c_tagged_union_to_wire_1c9175b2e9cd70a6(
+        __v,
+    );
     __ret
 }
 #[no_mangle]
@@ -1242,8 +1463,10 @@ pub unsafe extern "C" fn drawing_new(
     id: u64,
     shape: ::core::mem::MaybeUninit<shape_t>,
 ) -> drawing_t {
-    let id = __cbg_in_u64(id);
-    let shape = match __cbg_in_Shape(shape) {
+    let id = __c_in_convert_wire_to_u64_c_terminal_input_scalar_4e87470ad83635c8(id);
+    let shape = match __c_in_convert_wire_to_Shape_c_choice_intermediate_repr_c_tagged_union_8ddb52c185c8b923(
+        shape,
+    ) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__msg) => {
             panic!("{}", __msg);
@@ -1251,25 +1474,31 @@ pub unsafe extern "C" fn drawing_new(
     };
     let __v = example_flat::drawing_new(id, shape);
     let __ret: drawing_t;
-    __ret = __cbg_out_Drawing(__v);
+    __ret = __c_out_convert_Drawing_c_product_intermediate_repr_c_struct_to_wire_50eac9aa069a6838(
+        __v,
+    );
     __ret
 }
 #[no_mangle]
 #[allow(non_snake_case, unused_mut, unused_variables, unused_unsafe, dead_code)]
 pub unsafe extern "C" fn foo_get_id(f: foo_t) -> u64 {
-    let f = __cbg_in_Foo(f);
+    let f = __c_in_convert_wire_to_Foo_c_product_intermediate_repr_c_struct_157d1b61f2a5b9d5(
+        f,
+    );
     let __v = example_flat::foo_get_id(f);
     let __ret: u64;
-    __ret = __cbg_out_u64(__v);
+    __ret = __c_out_convert_u64_c_terminal_output_scalar_to_wire_518245fe60cf3590(__v);
     __ret
 }
 #[no_mangle]
 #[allow(non_snake_case, unused_mut, unused_variables, unused_unsafe, dead_code)]
 pub unsafe extern "C" fn foo_new(id: u64) -> foo_t {
-    let id = __cbg_in_u64(id);
+    let id = __c_in_convert_wire_to_u64_c_terminal_input_scalar_4e87470ad83635c8(id);
     let __v = example_flat::foo_new(id);
     let __ret: foo_t;
-    __ret = __cbg_out_Foo(__v);
+    __ret = __c_out_convert_Foo_c_product_intermediate_repr_c_struct_to_wire_02ab0b068798553e(
+        __v,
+    );
     __ret
 }
 #[no_mangle]
@@ -1277,7 +1506,9 @@ pub unsafe extern "C" fn foo_new(id: u64) -> foo_t {
 pub unsafe extern "C" fn inside_foo_default() -> inside_foo_t {
     let __v = example_flat::inside_foo_default();
     let __ret: inside_foo_t;
-    __ret = __cbg_out_InsideFoo(__v);
+    __ret = __c_out_convert_InsideFoo_c_terminal_output_enum_to_wire_b103ad5e4be33376(
+        __v,
+    );
     __ret
 }
 #[no_mangle]
@@ -1285,7 +1516,9 @@ pub unsafe extern "C" fn inside_foo_default() -> inside_foo_t {
 pub unsafe extern "C" fn inside_foo_value(
     x: ::core::mem::MaybeUninit<inside_foo_t>,
 ) -> i32 {
-    let x = match __cbg_in_InsideFoo(x) {
+    let x = match __c_in_convert_wire_to_InsideFoo_c_terminal_input_enum_70ed7847e05e3330(
+        x,
+    ) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__msg) => {
             panic!("{}", __msg);
@@ -1293,13 +1526,15 @@ pub unsafe extern "C" fn inside_foo_value(
     };
     let __v = example_flat::inside_foo_value(x);
     let __ret: i32;
-    __ret = __cbg_out_i32(__v);
+    __ret = __c_out_convert_i32_c_terminal_output_scalar_to_wire_ae82162f636ebcd5(__v);
     __ret
 }
 #[no_mangle]
 #[allow(non_snake_case, unused_mut, unused_variables, unused_unsafe, dead_code)]
 pub unsafe extern "C" fn note_emphatic(n: ::core::mem::MaybeUninit<note_t>) -> bool {
-    let n = match __cbg_in_Note(n) {
+    let n = match __c_in_convert_wire_to_Note_c_choice_intermediate_repr_c_tagged_union_4de1f2981255d608(
+        n,
+    ) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__msg) => {
             panic!("{}", __msg);
@@ -1307,7 +1542,7 @@ pub unsafe extern "C" fn note_emphatic(n: ::core::mem::MaybeUninit<note_t>) -> b
     };
     let __v = example_flat::note_emphatic(n);
     let __ret: bool;
-    __ret = __cbg_out_bool(__v);
+    __ret = __c_out_convert_bool_c_terminal_output_scalar_to_wire_cc0ad9760da17efd(__v);
     __ret
 }
 #[no_mangle]
@@ -1315,10 +1550,14 @@ pub unsafe extern "C" fn note_emphatic(n: ::core::mem::MaybeUninit<note_t>) -> b
 pub unsafe extern "C" fn note_new_after(
     millis: u64,
 ) -> ::core::mem::MaybeUninit<note_t> {
-    let millis = __cbg_in_u64(millis);
+    let millis = __c_in_convert_wire_to_u64_c_terminal_input_scalar_4e87470ad83635c8(
+        millis,
+    );
     let __v = example_flat::note_new_after(millis);
     let __ret: ::core::mem::MaybeUninit<note_t>;
-    __ret = __cbg_out_Note(__v);
+    __ret = __c_out_convert_Note_c_choice_intermediate_repr_c_tagged_union_to_wire_c9cea85d5266d21b(
+        __v,
+    );
     __ret
 }
 #[no_mangle]
@@ -1326,10 +1565,12 @@ pub unsafe extern "C" fn note_new_after(
 pub unsafe extern "C" fn note_new_flagged(
     flag: ::core::mem::MaybeUninit<bool>,
 ) -> ::core::mem::MaybeUninit<note_t> {
-    let flag = __cbg_in_bool(flag);
+    let flag = __c_in_convert_wire_to_bool_c_terminal_input_bool_e48e0629cd6287b3(flag);
     let __v = example_flat::note_new_flagged(flag);
     let __ret: ::core::mem::MaybeUninit<note_t>;
-    __ret = __cbg_out_Note(__v);
+    __ret = __c_out_convert_Note_c_choice_intermediate_repr_c_tagged_union_to_wire_c9cea85d5266d21b(
+        __v,
+    );
     __ret
 }
 #[no_mangle]
@@ -1337,7 +1578,9 @@ pub unsafe extern "C" fn note_new_flagged(
 pub unsafe extern "C" fn note_new_silent() -> ::core::mem::MaybeUninit<note_t> {
     let __v = example_flat::note_new_silent();
     let __ret: ::core::mem::MaybeUninit<note_t>;
-    __ret = __cbg_out_Note(__v);
+    __ret = __c_out_convert_Note_c_choice_intermediate_repr_c_tagged_union_to_wire_c9cea85d5266d21b(
+        __v,
+    );
     __ret
 }
 #[no_mangle]
@@ -1346,8 +1589,10 @@ pub unsafe extern "C" fn note_new_sketched(
     id: u64,
     label: *const ::core::ffi::c_char,
 ) -> ::core::mem::MaybeUninit<note_t> {
-    let id = __cbg_in_u64(id);
-    let label = match __cbg_in___str(label) {
+    let id = __c_in_convert_wire_to_u64_c_terminal_input_scalar_4e87470ad83635c8(id);
+    let label = match __c_in_convert_wire_to_str_c_borrow_str_input_246c2b9955bb6ef2(
+        label,
+    ) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__msg) => {
             panic!("{}", __msg);
@@ -1355,7 +1600,9 @@ pub unsafe extern "C" fn note_new_sketched(
     };
     let __v = example_flat::note_new_sketched(id, label);
     let __ret: ::core::mem::MaybeUninit<note_t>;
-    __ret = __cbg_out_Note(__v);
+    __ret = __c_out_convert_Note_c_choice_intermediate_repr_c_tagged_union_to_wire_c9cea85d5266d21b(
+        __v,
+    );
     __ret
 }
 #[no_mangle]
@@ -1365,23 +1612,31 @@ pub unsafe extern "C" fn note_new_titled(
     text: *const ::core::ffi::c_char,
     emphatic: ::core::mem::MaybeUninit<bool>,
 ) -> ::core::mem::MaybeUninit<note_t> {
-    let id = __cbg_in_u64(id);
-    let text = match __cbg_in___str(text) {
+    let id = __c_in_convert_wire_to_u64_c_terminal_input_scalar_4e87470ad83635c8(id);
+    let text = match __c_in_convert_wire_to_str_c_borrow_str_input_246c2b9955bb6ef2(
+        text,
+    ) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__msg) => {
             panic!("{}", __msg);
         }
     };
-    let emphatic = __cbg_in_bool(emphatic);
+    let emphatic = __c_in_convert_wire_to_bool_c_terminal_input_bool_e48e0629cd6287b3(
+        emphatic,
+    );
     let __v = example_flat::note_new_titled(id, text, emphatic);
     let __ret: ::core::mem::MaybeUninit<note_t>;
-    __ret = __cbg_out_Note(__v);
+    __ret = __c_out_convert_Note_c_choice_intermediate_repr_c_tagged_union_to_wire_c9cea85d5266d21b(
+        __v,
+    );
     __ret
 }
 #[no_mangle]
 #[allow(non_snake_case, unused_mut, unused_variables, unused_unsafe, dead_code)]
 pub unsafe extern "C" fn note_value(n: ::core::mem::MaybeUninit<note_t>) -> u64 {
-    let n = match __cbg_in_Note(n) {
+    let n = match __c_in_convert_wire_to_Note_c_choice_intermediate_repr_c_tagged_union_4de1f2981255d608(
+        n,
+    ) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__msg) => {
             panic!("{}", __msg);
@@ -1389,13 +1644,15 @@ pub unsafe extern "C" fn note_value(n: ::core::mem::MaybeUninit<note_t>) -> u64 
     };
     let __v = example_flat::note_value(n);
     let __ret: u64;
-    __ret = __cbg_out_u64(__v);
+    __ret = __c_out_convert_u64_c_terminal_output_scalar_to_wire_518245fe60cf3590(__v);
     __ret
 }
 #[no_mangle]
 #[allow(non_snake_case, unused_mut, unused_variables, unused_unsafe, dead_code)]
 pub unsafe extern "C" fn shape_area(s: ::core::mem::MaybeUninit<shape_t>) -> f64 {
-    let s = match __cbg_in_Shape(s) {
+    let s = match __c_in_convert_wire_to_Shape_c_choice_intermediate_repr_c_tagged_union_8ddb52c185c8b923(
+        s,
+    ) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__msg) => {
             panic!("{}", __msg);
@@ -1403,7 +1660,7 @@ pub unsafe extern "C" fn shape_area(s: ::core::mem::MaybeUninit<shape_t>) -> f64
     };
     let __v = example_flat::shape_area(s);
     let __ret: f64;
-    __ret = __cbg_out_f64(__v);
+    __ret = __c_out_convert_f64_c_terminal_output_scalar_to_wire_6aa94606ef14f673(__v);
     __ret
 }
 #[no_mangle]
@@ -1411,7 +1668,9 @@ pub unsafe extern "C" fn shape_area(s: ::core::mem::MaybeUninit<shape_t>) -> f64
 pub unsafe extern "C" fn shape_get_label(
     s: ::core::mem::MaybeUninit<shape_t>,
 ) -> *mut ::core::ffi::c_char {
-    let s = match __cbg_in_Shape(s) {
+    let s = match __c_in_convert_wire_to_Shape_c_choice_intermediate_repr_c_tagged_union_8ddb52c185c8b923(
+        s,
+    ) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__msg) => {
             panic!("{}", __msg);
@@ -1419,7 +1678,9 @@ pub unsafe extern "C" fn shape_get_label(
     };
     let __v = example_flat::shape_get_label(s);
     let __ret: *mut ::core::ffi::c_char;
-    __ret = __cbg_out_String(__v);
+    __ret = __c_out_convert_String_c_terminal_output_string_to_wire_182528409f6ab8d3(
+        __v,
+    );
     __ret
 }
 #[no_mangle]
@@ -1427,10 +1688,14 @@ pub unsafe extern "C" fn shape_get_label(
 pub unsafe extern "C" fn shape_new_circle(
     radius: f64,
 ) -> ::core::mem::MaybeUninit<shape_t> {
-    let radius = __cbg_in_f64(radius);
+    let radius = __c_in_convert_wire_to_f64_c_terminal_input_scalar_7d8a0a733495e599(
+        radius,
+    );
     let __v = example_flat::shape_new_circle(radius);
     let __ret: ::core::mem::MaybeUninit<shape_t>;
-    __ret = __cbg_out_Shape(__v);
+    __ret = __c_out_convert_Shape_c_choice_intermediate_repr_c_tagged_union_to_wire_1c9175b2e9cd70a6(
+        __v,
+    );
     __ret
 }
 #[no_mangle]
@@ -1438,7 +1703,9 @@ pub unsafe extern "C" fn shape_new_circle(
 pub unsafe extern "C" fn shape_new_empty() -> ::core::mem::MaybeUninit<shape_t> {
     let __v = example_flat::shape_new_empty();
     let __ret: ::core::mem::MaybeUninit<shape_t>;
-    __ret = __cbg_out_Shape(__v);
+    __ret = __c_out_convert_Shape_c_choice_intermediate_repr_c_tagged_union_to_wire_1c9175b2e9cd70a6(
+        __v,
+    );
     __ret
 }
 #[no_mangle]
@@ -1447,13 +1714,17 @@ pub unsafe extern "C" fn shape_new_labeled(
     label: *const ::core::ffi::c_char,
     op: ::core::mem::MaybeUninit<operation_t>,
 ) -> ::core::mem::MaybeUninit<shape_t> {
-    let label = match __cbg_in___str(label) {
+    let label = match __c_in_convert_wire_to_str_c_borrow_str_input_246c2b9955bb6ef2(
+        label,
+    ) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__msg) => {
             panic!("{}", __msg);
         }
     };
-    let op = match __cbg_in_Operation(op) {
+    let op = match __c_in_convert_wire_to_Operation_c_terminal_input_enum_a23b6023635a8da5(
+        op,
+    ) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__msg) => {
             panic!("{}", __msg);
@@ -1461,7 +1732,9 @@ pub unsafe extern "C" fn shape_new_labeled(
     };
     let __v = example_flat::shape_new_labeled(label, op);
     let __ret: ::core::mem::MaybeUninit<shape_t>;
-    __ret = __cbg_out_Shape(__v);
+    __ret = __c_out_convert_Shape_c_choice_intermediate_repr_c_tagged_union_to_wire_1c9175b2e9cd70a6(
+        __v,
+    );
     __ret
 }
 #[no_mangle]
@@ -1470,11 +1743,17 @@ pub unsafe extern "C" fn shape_new_rect(
     width: f64,
     height: f64,
 ) -> ::core::mem::MaybeUninit<shape_t> {
-    let width = __cbg_in_f64(width);
-    let height = __cbg_in_f64(height);
+    let width = __c_in_convert_wire_to_f64_c_terminal_input_scalar_7d8a0a733495e599(
+        width,
+    );
+    let height = __c_in_convert_wire_to_f64_c_terminal_input_scalar_7d8a0a733495e599(
+        height,
+    );
     let __v = example_flat::shape_new_rect(width, height);
     let __ret: ::core::mem::MaybeUninit<shape_t>;
-    __ret = __cbg_out_Shape(__v);
+    __ret = __c_out_convert_Shape_c_choice_intermediate_repr_c_tagged_union_to_wire_1c9175b2e9cd70a6(
+        __v,
+    );
     __ret
 }
 #[no_mangle]
@@ -1484,11 +1763,13 @@ pub unsafe extern "C" fn shape_try_area(
     out: *mut f64,
     e: *mut *mut ::core::ffi::c_char,
 ) -> bool {
-    let s = match __cbg_in_Shape(s) {
+    let s = match __c_in_convert_wire_to_Shape_c_choice_intermediate_repr_c_tagged_union_8ddb52c185c8b923(
+        s,
+    ) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__msg) => {
             if !e.is_null() {
-                *e = __cbg_out_Error(
+                *e = __c_out_convert_Error_c_terminal_output_opaque_error_to_wire_9d010015abcb2259(
                     <example_flat::Error as ::core::convert::From<
                         ::std::string::String,
                     >>::from(__msg),
@@ -1499,12 +1780,16 @@ pub unsafe extern "C" fn shape_try_area(
     };
     match example_flat::shape_try_area(s) {
         ::core::result::Result::Ok(__v) => {
-            *out = __cbg_out_f64(__v);
+            *out = __c_out_convert_f64_c_terminal_output_scalar_to_wire_6aa94606ef14f673(
+                __v,
+            );
             true
         }
         ::core::result::Result::Err(__err) => {
             if !e.is_null() {
-                *e = __cbg_out_Error(__err);
+                *e = __c_out_convert_Error_c_terminal_output_opaque_error_to_wire_9d010015abcb2259(
+                    __err,
+                );
             }
             false
         }

--- a/examples/example-cbindgen/generated/example_flat_aarch64_unstable.rs
+++ b/examples/example-cbindgen/generated/example_flat_aarch64_unstable.rs
@@ -178,7 +178,7 @@ pub struct closure_history_batch_t {
     pub drop: ::core::option::Option<unsafe extern "C" fn(*mut ::core::ffi::c_void)>,
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) unsafe fn __cbg_in_closure_history_batch_t(
+pub(crate) unsafe fn __c_in_convert_wire_to_impl_Fn_Vec_f64_Send_Sync_static_c_invoke_callback_capture_3dd7f8fbc61877ce(
     c: closure_history_batch_t,
 ) -> impl Fn(::std::vec::Vec<f64>) + Send + Sync + 'static {
     struct __Ctx {
@@ -203,7 +203,9 @@ pub(crate) unsafe fn __cbg_in_closure_history_batch_t(
         if let ::core::option::Option::Some(__f) = __call {
             let mut __w0_0 = ::core::mem::MaybeUninit::<*mut f64>::zeroed();
             let mut __w0_1 = ::core::mem::MaybeUninit::<usize>::zeroed();
-            let __arr: ::std::vec::Vec<f64> = __cbg_out_chain_vec_f64(__a0);
+            let __arr: ::std::vec::Vec<f64> = __c_out_convert_sequence_Vec_f64_to_wire_ad99887ef4e62c28(
+                __a0,
+            );
             let (__p, __n) = __cbg_alloc_array(__arr);
             *__w0_0.as_mut_ptr() = __p;
             *__w0_1.as_mut_ptr() = __n;
@@ -225,7 +227,7 @@ pub struct closure_maybe_grade_t {
     pub drop: ::core::option::Option<unsafe extern "C" fn(*mut ::core::ffi::c_void)>,
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) unsafe fn __cbg_in_closure_maybe_grade_t(
+pub(crate) unsafe fn __c_in_convert_wire_to_impl_Fn_Option_Grade_Send_Sync_static_c_invoke_callback_capture_5512a1f2265e79a0(
     c: closure_maybe_grade_t,
 ) -> impl Fn(::core::option::Option<example_flat::Grade>) + Send + Sync + 'static {
     struct __Ctx {
@@ -253,7 +255,9 @@ pub(crate) unsafe fn __cbg_in_closure_maybe_grade_t(
             match __a0 {
                 ::core::option::Option::Some(__x) => {
                     *__w0_0.as_mut_ptr() = true;
-                    *__w0_1.as_mut_ptr() = __cbg_out_Grade(__x);
+                    *__w0_1.as_mut_ptr() = __c_out_convert_Grade_c_terminal_output_enum_to_wire_a59c7b101e0a9e37(
+                        __x,
+                    );
                 }
                 ::core::option::Option::None => {
                     *__w0_0.as_mut_ptr() = false;
@@ -277,7 +281,7 @@ pub struct closure_maybe_value_t {
     pub drop: ::core::option::Option<unsafe extern "C" fn(*mut ::core::ffi::c_void)>,
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) unsafe fn __cbg_in_closure_maybe_value_t(
+pub(crate) unsafe fn __c_in_convert_wire_to_impl_Fn_Option_f64_Send_Sync_static_c_invoke_callback_capture_053af7d76b4f1245(
     c: closure_maybe_value_t,
 ) -> impl Fn(::core::option::Option<f64>) + Send + Sync + 'static {
     struct __Ctx {
@@ -305,7 +309,9 @@ pub(crate) unsafe fn __cbg_in_closure_maybe_value_t(
             match __a0 {
                 ::core::option::Option::Some(__x) => {
                     *__w0_0.as_mut_ptr() = true;
-                    *__w0_1.as_mut_ptr() = __cbg_out_f64(__x);
+                    *__w0_1.as_mut_ptr() = __c_out_convert_f64_c_terminal_output_scalar_to_wire_6aa94606ef14f673(
+                        __x,
+                    );
                 }
                 ::core::option::Option::None => {
                     *__w0_0.as_mut_ptr() = false;
@@ -325,7 +331,7 @@ pub struct closure_value_t {
     pub drop: ::core::option::Option<unsafe extern "C" fn(*mut ::core::ffi::c_void)>,
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) unsafe fn __cbg_in_closure_value_t(
+pub(crate) unsafe fn __c_in_convert_wire_to_impl_Fn_f64_Send_Sync_static_c_invoke_callback_capture_88739bf29d2a9906(
     c: closure_value_t,
 ) -> impl Fn(f64) + Send + Sync + 'static {
     struct __Ctx {
@@ -348,13 +354,41 @@ pub(crate) unsafe fn __cbg_in_closure_value_t(
     });
     move |__a0: f64| {
         if let ::core::option::Option::Some(__f) = __call {
-            let __w0 = __cbg_out_f64(__a0);
+            let __w0 = __c_out_convert_f64_c_terminal_output_scalar_to_wire_6aa94606ef14f673(
+                __a0,
+            );
             unsafe { __f(__w0, __ctx.context) }
         }
     }
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) unsafe fn __cbg_in_Calculator(
+pub(crate) unsafe fn __c_in_convert_wire_to_Calculator_c_borrow_mutable_input_f30bfe45043bc69c<
+    'a,
+>(
+    v: *mut calculator_t,
+) -> ::core::result::Result<&'a mut example_flat::Calculator, ::std::string::String> {
+    if v.is_null() {
+        return ::core::result::Result::Err(
+            ::std::string::String::from("null Calculator pointer"),
+        );
+    }
+    ::core::result::Result::Ok(&mut *(v as *mut example_flat::Calculator))
+}
+#[allow(non_snake_case, unused_variables, dead_code)]
+pub(crate) unsafe fn __c_in_convert_wire_to_Calculator_c_borrow_shared_input_48be88e9df13aa53<
+    'a,
+>(
+    v: *const calculator_t,
+) -> ::core::result::Result<&'a example_flat::Calculator, ::std::string::String> {
+    if v.is_null() {
+        return ::core::result::Result::Err(
+            ::std::string::String::from("null Calculator pointer"),
+        );
+    }
+    ::core::result::Result::Ok(&*(v as *const example_flat::Calculator))
+}
+#[allow(non_snake_case, unused_variables, dead_code)]
+pub(crate) unsafe fn __c_in_convert_wire_to_Calculator_c_terminal_input_owned_handle_b7bb400a642eb999(
     v: *mut calculator_t,
 ) -> ::core::result::Result<example_flat::Calculator, ::std::string::String> {
     if v.is_null() {
@@ -367,32 +401,46 @@ pub(crate) unsafe fn __cbg_in_Calculator(
     )
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) unsafe fn __cbg_in_Caption(v: caption_t) -> example_flat::Caption {
+pub(crate) unsafe fn __c_in_convert_wire_to_Caption_c_product_intermediate_repr_c_struct_a9076d1a0d6740b3(
+    v: caption_t,
+) -> example_flat::Caption {
     example_flat::Caption {
-        id: __cbg_in_u64(v.id),
-        text: __cbg_in_String_field(v.text),
-        emphatic: __cbg_in_bool(v.emphatic),
+        id: __c_in_convert_wire_to_u64_c_terminal_input_scalar_4e87470ad83635c8(v.id),
+        text: __c_in_convert_wire_to_String_c_terminal_input_string_field_b6091e2e8553ccde(
+            v.text,
+        ),
+        emphatic: __c_in_convert_wire_to_bool_c_terminal_input_bool_e48e0629cd6287b3(
+            v.emphatic,
+        ),
     }
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) unsafe fn __cbg_in_Drawing(
+pub(crate) unsafe fn __c_in_convert_wire_to_Drawing_c_product_intermediate_repr_c_struct_3b927b21caf2df63(
     v: drawing_t,
 ) -> ::core::result::Result<example_flat::Drawing, ::std::string::String> {
     ::core::result::Result::Ok(example_flat::Drawing {
-        id: __cbg_in_u64(v.id),
-        shape: __cbg_in_Shape(v.shape)?,
+        id: __c_in_convert_wire_to_u64_c_terminal_input_scalar_4e87470ad83635c8(v.id),
+        shape: __c_in_convert_wire_to_Shape_c_choice_intermediate_repr_c_tagged_union_8ddb52c185c8b923(
+            v.shape,
+        )?,
     })
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) unsafe fn __cbg_in_Foo(v: foo_t) -> example_flat::Foo {
+pub(crate) unsafe fn __c_in_convert_wire_to_Foo_c_product_intermediate_repr_c_struct_157d1b61f2a5b9d5(
+    v: foo_t,
+) -> example_flat::Foo {
     example_flat::Foo {
-        id: __cbg_in_u64(v.id),
-        aarch64_field: __cbg_in_u64(v.aarch64_field),
-        unstable_field: __cbg_in_u64(v.unstable_field),
+        id: __c_in_convert_wire_to_u64_c_terminal_input_scalar_4e87470ad83635c8(v.id),
+        aarch64_field: __c_in_convert_wire_to_u64_c_terminal_input_scalar_4e87470ad83635c8(
+            v.aarch64_field,
+        ),
+        unstable_field: __c_in_convert_wire_to_u64_c_terminal_input_scalar_4e87470ad83635c8(
+            v.unstable_field,
+        ),
     }
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) unsafe fn __cbg_in_InsideFoo(
+pub(crate) unsafe fn __c_in_convert_wire_to_InsideFoo_c_terminal_input_enum_70ed7847e05e3330(
     v: ::core::mem::MaybeUninit<inside_foo_t>,
 ) -> ::core::result::Result<example_flat::InsideFoo, ::std::string::String> {
     const _: () = {
@@ -421,11 +469,13 @@ pub(crate) unsafe fn __cbg_in_InsideFoo(
     )
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) fn __cbg_in_Millis(v: u64) -> example_flat::Millis {
+pub(crate) fn __c_in_convert_wire_to_Millis_c_terminal_custom_771f8034eae1c639(
+    v: u64,
+) -> example_flat::Millis {
     example_flat::millis_from_raw(v)
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) unsafe fn __cbg_in_Note(
+pub(crate) unsafe fn __c_in_convert_wire_to_Note_c_choice_intermediate_repr_c_tagged_union_4de1f2981255d608(
     v: ::core::mem::MaybeUninit<note_t>,
 ) -> ::core::result::Result<example_flat::Note, ::std::string::String> {
     ::core::result::Result::Ok({
@@ -451,7 +501,11 @@ pub(crate) unsafe fn __cbg_in_Note(
                         }
                     }
                 };
-                example_flat::Note::Titled(__cbg_in_Caption((__arm).0))
+                example_flat::Note::Titled(
+                    __c_in_convert_wire_to_Caption_c_product_intermediate_repr_c_struct_a9076d1a0d6740b3(
+                        (__arm).0,
+                    ),
+                )
             }
             2 => {
                 let __choice = unsafe { (v).assume_init() };
@@ -463,7 +517,11 @@ pub(crate) unsafe fn __cbg_in_Note(
                         }
                     }
                 };
-                example_flat::Note::After(__cbg_in_Millis((__arm).0))
+                example_flat::Note::After(
+                    __c_in_convert_wire_to_Millis_c_terminal_custom_771f8034eae1c639(
+                        (__arm).0,
+                    ),
+                )
             }
             3 => {
                 let __choice = unsafe { (v).assume_init() };
@@ -475,7 +533,11 @@ pub(crate) unsafe fn __cbg_in_Note(
                         }
                     }
                 };
-                example_flat::Note::Flagged(__cbg_in_bool((__arm).0))
+                example_flat::Note::Flagged(
+                    __c_in_convert_wire_to_bool_c_terminal_input_bool_e48e0629cd6287b3(
+                        (__arm).0,
+                    ),
+                )
             }
             4 => {
                 let __choice = unsafe { (v).assume_init() };
@@ -487,7 +549,11 @@ pub(crate) unsafe fn __cbg_in_Note(
                         }
                     }
                 };
-                example_flat::Note::Sketched(__cbg_in_Drawing((__arm).0)?)
+                example_flat::Note::Sketched(
+                    __c_in_convert_wire_to_Drawing_c_product_intermediate_repr_c_struct_3b927b21caf2df63(
+                        (__arm).0,
+                    )?,
+                )
             }
             _ => {
                 return ::core::result::Result::Err(
@@ -501,7 +567,7 @@ pub(crate) unsafe fn __cbg_in_Note(
     })
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) unsafe fn __cbg_in_Operation(
+pub(crate) unsafe fn __c_in_convert_wire_to_Operation_c_terminal_input_enum_a23b6023635a8da5(
     v: ::core::mem::MaybeUninit<operation_t>,
 ) -> ::core::result::Result<example_flat::Operation, ::std::string::String> {
     const _: () = {
@@ -536,7 +602,7 @@ pub(crate) unsafe fn __cbg_in_Operation(
     )
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) unsafe fn __cbg_in_Shape(
+pub(crate) unsafe fn __c_in_convert_wire_to_Shape_c_choice_intermediate_repr_c_tagged_union_8ddb52c185c8b923(
     v: ::core::mem::MaybeUninit<shape_t>,
 ) -> ::core::result::Result<example_flat::Shape, ::std::string::String> {
     ::core::result::Result::Ok({
@@ -562,7 +628,11 @@ pub(crate) unsafe fn __cbg_in_Shape(
                         }
                     }
                 };
-                example_flat::Shape::Circle(__cbg_in_f64((__arm).0))
+                example_flat::Shape::Circle(
+                    __c_in_convert_wire_to_f64_c_terminal_input_scalar_7d8a0a733495e599(
+                        (__arm).0,
+                    ),
+                )
             }
             2 => {
                 let __choice = unsafe { (v).assume_init() };
@@ -577,8 +647,12 @@ pub(crate) unsafe fn __cbg_in_Shape(
                     }
                 };
                 example_flat::Shape::Rect {
-                    width: __cbg_in_f64((__arm).0),
-                    height: __cbg_in_f64((__arm).1),
+                    width: __c_in_convert_wire_to_f64_c_terminal_input_scalar_7d8a0a733495e599(
+                        (__arm).0,
+                    ),
+                    height: __c_in_convert_wire_to_f64_c_terminal_input_scalar_7d8a0a733495e599(
+                        (__arm).1,
+                    ),
                 }
             }
             3 => {
@@ -594,8 +668,12 @@ pub(crate) unsafe fn __cbg_in_Shape(
                     }
                 };
                 example_flat::Shape::Labeled(
-                    __cbg_in_String_field((__arm).0),
-                    __cbg_in_Operation((__arm).1)?,
+                    __c_in_convert_wire_to_String_c_terminal_input_string_field_b6091e2e8553ccde(
+                        (__arm).0,
+                    ),
+                    __c_in_convert_wire_to_Operation_c_terminal_input_enum_a23b6023635a8da5(
+                        (__arm).1,
+                    )?,
                 )
             }
             _ => {
@@ -610,7 +688,7 @@ pub(crate) unsafe fn __cbg_in_Shape(
     })
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) unsafe fn __cbg_in_String_field(
+pub(crate) unsafe fn __c_in_convert_wire_to_String_c_terminal_input_string_field_b6091e2e8553ccde(
     v: *const ::core::ffi::c_char,
 ) -> ::std::string::String {
     if v.is_null() {
@@ -620,29 +698,19 @@ pub(crate) unsafe fn __cbg_in_String_field(
     }
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) unsafe fn __cbg_in___Calculator<'a>(
-    v: *const calculator_t,
-) -> ::core::result::Result<&'a example_flat::Calculator, ::std::string::String> {
-    if v.is_null() {
-        return ::core::result::Result::Err(
-            ::std::string::String::from("null Calculator pointer"),
-        );
-    }
-    ::core::result::Result::Ok(&*(v as *const example_flat::Calculator))
+pub(crate) unsafe fn __c_in_convert_wire_to_bool_c_terminal_input_bool_e48e0629cd6287b3(
+    v: ::core::mem::MaybeUninit<bool>,
+) -> bool {
+    ::core::ptr::read(v.as_ptr() as *const u8) != 0
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) unsafe fn __cbg_in___mut_Calculator<'a>(
-    v: *mut calculator_t,
-) -> ::core::result::Result<&'a mut example_flat::Calculator, ::std::string::String> {
-    if v.is_null() {
-        return ::core::result::Result::Err(
-            ::std::string::String::from("null Calculator pointer"),
-        );
-    }
-    ::core::result::Result::Ok(&mut *(v as *mut example_flat::Calculator))
+pub(crate) fn __c_in_convert_wire_to_f64_c_terminal_input_scalar_7d8a0a733495e599(
+    v: f64,
+) -> f64 {
+    v
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) unsafe fn __cbg_in___str<'a>(
+pub(crate) unsafe fn __c_in_convert_wire_to_str_c_borrow_str_input_246c2b9955bb6ef2<'a>(
     v: *const ::core::ffi::c_char,
 ) -> ::core::result::Result<&'a str, ::std::string::String> {
     if v.is_null() {
@@ -660,92 +728,132 @@ pub(crate) unsafe fn __cbg_in___str<'a>(
     }
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) unsafe fn __cbg_in_bool(v: ::core::mem::MaybeUninit<bool>) -> bool {
-    ::core::ptr::read(v.as_ptr() as *const u8) != 0
-}
-#[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) fn __cbg_in_f64(v: f64) -> f64 {
+pub(crate) fn __c_in_convert_wire_to_u64_c_terminal_input_scalar_4e87470ad83635c8(
+    v: u64,
+) -> u64 {
     v
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) fn __cbg_in_u64(v: u64) -> u64 {
-    v
-}
-#[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) fn __cbg_out_Calculator(v: example_flat::Calculator) -> *mut calculator_t {
+pub(crate) fn __c_out_convert_Calculator_c_terminal_output_owned_handle_to_wire_4d20353780559007(
+    v: example_flat::Calculator,
+) -> *mut calculator_t {
     ::std::boxed::Box::into_raw(::std::boxed::Box::new(v)) as *mut calculator_t
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) fn __cbg_out_Caption(v: example_flat::Caption) -> caption_t {
+pub(crate) fn __c_out_convert_Caption_c_product_intermediate_repr_c_struct_to_wire_3bc5d236333a6e28(
+    v: example_flat::Caption,
+) -> caption_t {
     caption_t {
-        id: __cbg_out_u64(v.id),
-        text: __cbg_out_String(v.text),
-        emphatic: __cbg_out_bool_field(v.emphatic),
+        id: __c_out_convert_u64_c_terminal_output_scalar_to_wire_518245fe60cf3590(v.id),
+        text: __c_out_convert_String_c_terminal_output_string_to_wire_182528409f6ab8d3(
+            v.text,
+        ),
+        emphatic: __c_out_convert_bool_c_terminal_output_bool_field_to_wire_6a810eb4cb986700(
+            v.emphatic,
+        ),
     }
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) fn __cbg_out_Drawing(v: example_flat::Drawing) -> drawing_t {
+pub(crate) fn __c_out_convert_Drawing_c_product_intermediate_repr_c_struct_to_wire_50eac9aa069a6838(
+    v: example_flat::Drawing,
+) -> drawing_t {
     drawing_t {
-        id: __cbg_out_u64(v.id),
-        shape: __cbg_out_Shape(v.shape),
+        id: __c_out_convert_u64_c_terminal_output_scalar_to_wire_518245fe60cf3590(v.id),
+        shape: __c_out_convert_Shape_c_choice_intermediate_repr_c_tagged_union_to_wire_1c9175b2e9cd70a6(
+            v.shape,
+        ),
     }
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) fn __cbg_out_Error(v: example_flat::Error) -> *mut ::core::ffi::c_char {
+pub(crate) fn __c_out_convert_Error_c_terminal_output_opaque_error_to_wire_9d010015abcb2259(
+    v: example_flat::Error,
+) -> *mut ::core::ffi::c_char {
     __cbg_alloc_cstr(example_flat::error_get_message(&v))
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) fn __cbg_out_Foo(v: example_flat::Foo) -> foo_t {
+pub(crate) fn __c_out_convert_Foo_c_product_intermediate_repr_c_struct_to_wire_02ab0b068798553e(
+    v: example_flat::Foo,
+) -> foo_t {
     foo_t {
-        id: __cbg_out_u64(v.id),
-        aarch64_field: __cbg_out_u64(v.aarch64_field),
-        unstable_field: __cbg_out_u64(v.unstable_field),
+        id: __c_out_convert_u64_c_terminal_output_scalar_to_wire_518245fe60cf3590(v.id),
+        aarch64_field: __c_out_convert_u64_c_terminal_output_scalar_to_wire_518245fe60cf3590(
+            v.aarch64_field,
+        ),
+        unstable_field: __c_out_convert_u64_c_terminal_output_scalar_to_wire_518245fe60cf3590(
+            v.unstable_field,
+        ),
     }
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) fn __cbg_out_Grade(v: example_flat::Grade) -> grade_t {
+pub(crate) fn __c_out_convert_Grade_c_terminal_output_enum_to_wire_a59c7b101e0a9e37(
+    v: example_flat::Grade,
+) -> grade_t {
     match v {
         example_flat::Grade::Low => grade_t::Low,
         example_flat::Grade::High => grade_t::High,
     }
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) fn __cbg_out_InsideFoo(v: example_flat::InsideFoo) -> inside_foo_t {
+pub(crate) fn __c_out_convert_InsideFoo_c_terminal_output_enum_to_wire_b103ad5e4be33376(
+    v: example_flat::InsideFoo,
+) -> inside_foo_t {
     match v {
         example_flat::InsideFoo::DouddleDee => inside_foo_t::DouddleDee,
         example_flat::InsideFoo::DouddleDum => inside_foo_t::DouddleDum,
     }
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) fn __cbg_out_Millis(v: example_flat::Millis) -> u64 {
+pub(crate) fn __c_out_convert_Millis_c_terminal_custom_to_wire_0c2f6b5f81dfcd94(
+    v: example_flat::Millis,
+) -> u64 {
     example_flat::millis_to_raw(&v)
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) fn __cbg_out_Note(v: example_flat::Note) -> ::core::mem::MaybeUninit<note_t> {
+pub(crate) fn __c_out_convert_Note_c_choice_intermediate_repr_c_tagged_union_to_wire_c9cea85d5266d21b(
+    v: example_flat::Note,
+) -> ::core::mem::MaybeUninit<note_t> {
     ::core::mem::MaybeUninit::new({
         match v {
             example_flat::Note::Silent => note_t::Silent,
             example_flat::Note::Titled(__part0) => {
-                let __built_arm = (__cbg_out_Caption(__part0),);
+                let __built_arm = (
+                    __c_out_convert_Caption_c_product_intermediate_repr_c_struct_to_wire_3bc5d236333a6e28(
+                        __part0,
+                    ),
+                );
                 note_t::Titled(__built_arm.0)
             }
             example_flat::Note::After(__part0) => {
-                let __built_arm = (__cbg_out_Millis(__part0),);
+                let __built_arm = (
+                    __c_out_convert_Millis_c_terminal_custom_to_wire_0c2f6b5f81dfcd94(
+                        __part0,
+                    ),
+                );
                 note_t::After(__built_arm.0)
             }
             example_flat::Note::Flagged(__part0) => {
-                let __built_arm = (__cbg_out_bool_field(__part0),);
+                let __built_arm = (
+                    __c_out_convert_bool_c_terminal_output_bool_field_to_wire_6a810eb4cb986700(
+                        __part0,
+                    ),
+                );
                 note_t::Flagged(__built_arm.0)
             }
             example_flat::Note::Sketched(__part0) => {
-                let __built_arm = (__cbg_out_Drawing(__part0),);
+                let __built_arm = (
+                    __c_out_convert_Drawing_c_product_intermediate_repr_c_struct_to_wire_50eac9aa069a6838(
+                        __part0,
+                    ),
+                );
                 note_t::Sketched(__built_arm.0)
             }
         }
     })
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) fn __cbg_out_Operation(v: example_flat::Operation) -> operation_t {
+pub(crate) fn __c_out_convert_Operation_c_terminal_output_enum_to_wire_457f6036394dc821(
+    v: example_flat::Operation,
+) -> operation_t {
     match v {
         example_flat::Operation::Add => operation_t::Add,
         example_flat::Operation::Sub => operation_t::Sub,
@@ -753,19 +861,34 @@ pub(crate) fn __cbg_out_Operation(v: example_flat::Operation) -> operation_t {
         example_flat::Operation::Div => operation_t::Div,
     }
 }
+#[allow(non_snake_case, dead_code, unused)]
+pub(crate) fn __c_out_convert_Option_Grade_c_marker_optional_to_wire_e2c04af90b0abd17() {}
+#[allow(non_snake_case, dead_code, unused)]
+pub(crate) fn __c_out_convert_Option_f64_c_marker_optional_to_wire_c1ba5adc99623ff4() {}
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) fn __cbg_out_Shape(
+pub(crate) fn __c_out_convert_Shape_c_choice_intermediate_repr_c_tagged_union_to_wire_1c9175b2e9cd70a6(
     v: example_flat::Shape,
 ) -> ::core::mem::MaybeUninit<shape_t> {
     ::core::mem::MaybeUninit::new({
         match v {
             example_flat::Shape::Empty => shape_t::Empty,
             example_flat::Shape::Circle(__part0) => {
-                let __built_arm = (__cbg_out_f64(__part0),);
+                let __built_arm = (
+                    __c_out_convert_f64_c_terminal_output_scalar_to_wire_6aa94606ef14f673(
+                        __part0,
+                    ),
+                );
                 shape_t::Circle(__built_arm.0)
             }
             example_flat::Shape::Rect { width: __part0, height: __part1 } => {
-                let __built_arm = (__cbg_out_f64(__part0), __cbg_out_f64(__part1));
+                let __built_arm = (
+                    __c_out_convert_f64_c_terminal_output_scalar_to_wire_6aa94606ef14f673(
+                        __part0,
+                    ),
+                    __c_out_convert_f64_c_terminal_output_scalar_to_wire_6aa94606ef14f673(
+                        __part1,
+                    ),
+                );
                 shape_t::Rect {
                     width: __built_arm.0,
                     height: __built_arm.1,
@@ -773,8 +896,14 @@ pub(crate) fn __cbg_out_Shape(
             }
             example_flat::Shape::Labeled(__part0, __part1) => {
                 let __built_arm = (
-                    __cbg_out_String(__part0),
-                    ::core::mem::MaybeUninit::new(__cbg_out_Operation(__part1)),
+                    __c_out_convert_String_c_terminal_output_string_to_wire_182528409f6ab8d3(
+                        __part0,
+                    ),
+                    ::core::mem::MaybeUninit::new(
+                        __c_out_convert_Operation_c_terminal_output_enum_to_wire_457f6036394dc821(
+                            __part1,
+                        ),
+                    ),
                 );
                 shape_t::Labeled(__built_arm.0, __built_arm.1)
             }
@@ -782,48 +911,60 @@ pub(crate) fn __cbg_out_Shape(
     })
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) fn __cbg_out_String(v: ::std::string::String) -> *mut ::core::ffi::c_char {
+pub(crate) fn __c_out_convert_String_c_terminal_output_string_to_wire_182528409f6ab8d3(
+    v: ::std::string::String,
+) -> *mut ::core::ffi::c_char {
     __cbg_alloc_cstr(v)
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) fn __cbg_out_bool(v: bool) -> bool {
-    v
-}
-#[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) fn __cbg_out_bool_field(v: bool) -> ::core::mem::MaybeUninit<bool> {
+pub(crate) fn __c_out_convert_bool_c_terminal_output_bool_field_to_wire_6a810eb4cb986700(
+    v: bool,
+) -> ::core::mem::MaybeUninit<bool> {
     ::core::mem::MaybeUninit::new(v)
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
+pub(crate) fn __c_out_convert_bool_c_terminal_output_scalar_to_wire_cc0ad9760da17efd(
+    v: bool,
+) -> bool {
+    v
+}
+#[allow(non_snake_case, unused_variables, dead_code)]
+pub(crate) fn __c_out_convert_f64_c_terminal_output_scalar_to_wire_6aa94606ef14f673(
+    v: f64,
+) -> f64 {
+    v
+}
+#[allow(non_snake_case, unused_variables, dead_code)]
+pub(crate) fn __c_out_convert_i32_c_terminal_output_scalar_to_wire_ae82162f636ebcd5(
+    v: i32,
+) -> i32 {
+    v
+}
+#[allow(non_snake_case, unused_variables, dead_code)]
 #[inline(always)]
-pub(crate) fn __cbg_out_chain_vec_f64(v: ::std::vec::Vec<f64>) -> ::std::vec::Vec<f64> {
+pub(crate) fn __c_out_convert_sequence_Vec_f64_to_wire_ad99887ef4e62c28(
+    v: ::std::vec::Vec<f64>,
+) -> ::std::vec::Vec<f64> {
     {
         let __sequence_source = v;
         let mut __sequence_output: ::std::vec::Vec<f64> = ::std::vec::Vec::with_capacity(
             (__sequence_source).len(),
         );
         for __sequence_element in __sequence_source.into_iter() {
-            let __sequence_part = __cbg_out_f64(__sequence_element);
+            let __sequence_part = __c_out_convert_f64_c_terminal_output_scalar_to_wire_6aa94606ef14f673(
+                __sequence_element,
+            );
             __sequence_output.push(__sequence_part);
         }
         __sequence_output
     }
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) fn __cbg_out_f64(v: f64) -> f64 {
+pub(crate) fn __c_out_convert_u64_c_terminal_output_scalar_to_wire_518245fe60cf3590(
+    v: u64,
+) -> u64 {
     v
 }
-#[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) fn __cbg_out_i32(v: i32) -> i32 {
-    v
-}
-#[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) fn __cbg_out_u64(v: u64) -> u64 {
-    v
-}
-#[allow(non_snake_case, dead_code, unused)]
-pub(crate) fn __cbg_outmark_option_Grade() {}
-#[allow(non_snake_case, dead_code, unused)]
-pub(crate) fn __cbg_outmark_option_f64() {}
 #[no_mangle]
 #[allow(non_snake_case, unused_mut, unused_variables, unused_unsafe, dead_code)]
 pub unsafe extern "C" fn calculator_absorb(
@@ -837,7 +978,7 @@ pub unsafe extern "C" fn calculator_absorb(
             "aliasing arguments: `a` (consumed) and `b` (borrowed) are the same `Calculator` — a consumed or exclusively-borrowed resource may not be named twice in one call",
         );
         if !e.is_null() {
-            *e = __cbg_out_Error(
+            *e = __c_out_convert_Error_c_terminal_output_opaque_error_to_wire_9d010015abcb2259(
                 <example_flat::Error as ::core::convert::From<
                     ::std::string::String,
                 >>::from(__msg),
@@ -845,11 +986,13 @@ pub unsafe extern "C" fn calculator_absorb(
         }
         return false;
     }
-    let a = match __cbg_in_Calculator(a) {
+    let a = match __c_in_convert_wire_to_Calculator_c_terminal_input_owned_handle_b7bb400a642eb999(
+        a,
+    ) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__msg) => {
             if !e.is_null() {
-                *e = __cbg_out_Error(
+                *e = __c_out_convert_Error_c_terminal_output_opaque_error_to_wire_9d010015abcb2259(
                     <example_flat::Error as ::core::convert::From<
                         ::std::string::String,
                     >>::from(__msg),
@@ -858,11 +1001,13 @@ pub unsafe extern "C" fn calculator_absorb(
             return false;
         }
     };
-    let b = match __cbg_in___Calculator(b) {
+    let b = match __c_in_convert_wire_to_Calculator_c_borrow_shared_input_48be88e9df13aa53(
+        b,
+    ) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__msg) => {
             if !e.is_null() {
-                *e = __cbg_out_Error(
+                *e = __c_out_convert_Error_c_terminal_output_opaque_error_to_wire_9d010015abcb2259(
                     <example_flat::Error as ::core::convert::From<
                         ::std::string::String,
                     >>::from(__msg),
@@ -873,12 +1018,16 @@ pub unsafe extern "C" fn calculator_absorb(
     };
     match example_flat::calculator_absorb(a, b) {
         ::core::result::Result::Ok(__v) => {
-            *out = __cbg_out_f64(__v);
+            *out = __c_out_convert_f64_c_terminal_output_scalar_to_wire_6aa94606ef14f673(
+                __v,
+            );
             true
         }
         ::core::result::Result::Err(__err) => {
             if !e.is_null() {
-                *e = __cbg_out_Error(__err);
+                *e = __c_out_convert_Error_c_terminal_output_opaque_error_to_wire_9d010015abcb2259(
+                    __err,
+                );
             }
             false
         }
@@ -893,11 +1042,13 @@ pub unsafe extern "C" fn calculator_apply(
     out: *mut f64,
     e: *mut *mut ::core::ffi::c_char,
 ) -> bool {
-    let c = match __cbg_in___mut_Calculator(c) {
+    let c = match __c_in_convert_wire_to_Calculator_c_borrow_mutable_input_f30bfe45043bc69c(
+        c,
+    ) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__msg) => {
             if !e.is_null() {
-                *e = __cbg_out_Error(
+                *e = __c_out_convert_Error_c_terminal_output_opaque_error_to_wire_9d010015abcb2259(
                     <example_flat::Error as ::core::convert::From<
                         ::std::string::String,
                     >>::from(__msg),
@@ -906,11 +1057,13 @@ pub unsafe extern "C" fn calculator_apply(
             return false;
         }
     };
-    let op = match __cbg_in_Operation(op) {
+    let op = match __c_in_convert_wire_to_Operation_c_terminal_input_enum_a23b6023635a8da5(
+        op,
+    ) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__msg) => {
             if !e.is_null() {
-                *e = __cbg_out_Error(
+                *e = __c_out_convert_Error_c_terminal_output_opaque_error_to_wire_9d010015abcb2259(
                     <example_flat::Error as ::core::convert::From<
                         ::std::string::String,
                     >>::from(__msg),
@@ -919,15 +1072,21 @@ pub unsafe extern "C" fn calculator_apply(
             return false;
         }
     };
-    let operand = __cbg_in_f64(operand);
+    let operand = __c_in_convert_wire_to_f64_c_terminal_input_scalar_7d8a0a733495e599(
+        operand,
+    );
     match example_flat::calculator_apply(c, op, operand) {
         ::core::result::Result::Ok(__v) => {
-            *out = __cbg_out_f64(__v);
+            *out = __c_out_convert_f64_c_terminal_output_scalar_to_wire_6aa94606ef14f673(
+                __v,
+            );
             true
         }
         ::core::result::Result::Err(__err) => {
             if !e.is_null() {
-                *e = __cbg_out_Error(__err);
+                *e = __c_out_convert_Error_c_terminal_output_opaque_error_to_wire_9d010015abcb2259(
+                    __err,
+                );
             }
             false
         }
@@ -939,19 +1098,25 @@ pub unsafe extern "C" fn calculator_for_each(
     c: *const calculator_t,
     f: closure_value_t,
 ) {
-    let c = match __cbg_in___Calculator(c) {
+    let c = match __c_in_convert_wire_to_Calculator_c_borrow_shared_input_48be88e9df13aa53(
+        c,
+    ) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__msg) => {
             panic!("{}", __msg);
         }
     };
-    let f = __cbg_in_closure_value_t(f);
+    let f = __c_in_convert_wire_to_impl_Fn_f64_Send_Sync_static_c_invoke_callback_capture_88739bf29d2a9906(
+        f,
+    );
     example_flat::calculator_for_each(c, f);
 }
 #[no_mangle]
 #[allow(non_snake_case, unused_mut, unused_variables, unused_unsafe, dead_code)]
 pub unsafe extern "C" fn calculator_get_count(c: *const calculator_t) -> u64 {
-    let c = match __cbg_in___Calculator(c) {
+    let c = match __c_in_convert_wire_to_Calculator_c_borrow_shared_input_48be88e9df13aa53(
+        c,
+    ) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__msg) => {
             panic!("{}", __msg);
@@ -959,7 +1124,7 @@ pub unsafe extern "C" fn calculator_get_count(c: *const calculator_t) -> u64 {
     };
     let __v = example_flat::calculator_get_count(c);
     let __ret: u64;
-    __ret = __cbg_out_u64(__v);
+    __ret = __c_out_convert_u64_c_terminal_output_scalar_to_wire_518245fe60cf3590(__v);
     __ret
 }
 #[no_mangle]
@@ -968,7 +1133,9 @@ pub unsafe extern "C" fn calculator_get_history(
     c: *const calculator_t,
     len: *mut usize,
 ) -> *mut f64 {
-    let c = match __cbg_in___Calculator(c) {
+    let c = match __c_in_convert_wire_to_Calculator_c_borrow_shared_input_48be88e9df13aa53(
+        c,
+    ) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__msg) => {
             panic!("{}", __msg);
@@ -976,7 +1143,9 @@ pub unsafe extern "C" fn calculator_get_history(
     };
     let __v = example_flat::calculator_get_history(c);
     let __ret: *mut f64;
-    let __arr: ::std::vec::Vec<f64> = __cbg_out_chain_vec_f64(__v);
+    let __arr: ::std::vec::Vec<f64> = __c_out_convert_sequence_Vec_f64_to_wire_ad99887ef4e62c28(
+        __v,
+    );
     let (__p, __n) = __cbg_alloc_array(__arr);
     __ret = __p;
     *len = __n;
@@ -985,7 +1154,9 @@ pub unsafe extern "C" fn calculator_get_history(
 #[no_mangle]
 #[allow(non_snake_case, unused_mut, unused_variables, unused_unsafe, dead_code)]
 pub unsafe extern "C" fn calculator_get_value(c: *const calculator_t) -> f64 {
-    let c = match __cbg_in___Calculator(c) {
+    let c = match __c_in_convert_wire_to_Calculator_c_borrow_shared_input_48be88e9df13aa53(
+        c,
+    ) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__msg) => {
             panic!("{}", __msg);
@@ -993,7 +1164,7 @@ pub unsafe extern "C" fn calculator_get_value(c: *const calculator_t) -> f64 {
     };
     let __v = example_flat::calculator_get_value(c);
     let __ret: f64;
-    __ret = __cbg_out_f64(__v);
+    __ret = __c_out_convert_f64_c_terminal_output_scalar_to_wire_6aa94606ef14f673(__v);
     __ret
 }
 #[no_mangle]
@@ -1002,13 +1173,17 @@ pub unsafe extern "C" fn calculator_grade_or_none(
     c: *const calculator_t,
     f: closure_maybe_grade_t,
 ) {
-    let c = match __cbg_in___Calculator(c) {
+    let c = match __c_in_convert_wire_to_Calculator_c_borrow_shared_input_48be88e9df13aa53(
+        c,
+    ) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__msg) => {
             panic!("{}", __msg);
         }
     };
-    let f = __cbg_in_closure_maybe_grade_t(f);
+    let f = __c_in_convert_wire_to_impl_Fn_Option_Grade_Send_Sync_static_c_invoke_callback_capture_5512a1f2265e79a0(
+        f,
+    );
     example_flat::calculator_grade_or_none(c, f);
 }
 #[no_mangle]
@@ -1017,28 +1192,36 @@ pub unsafe extern "C" fn calculator_history_batch(
     c: *const calculator_t,
     f: closure_history_batch_t,
 ) {
-    let c = match __cbg_in___Calculator(c) {
+    let c = match __c_in_convert_wire_to_Calculator_c_borrow_shared_input_48be88e9df13aa53(
+        c,
+    ) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__msg) => {
             panic!("{}", __msg);
         }
     };
-    let f = __cbg_in_closure_history_batch_t(f);
+    let f = __c_in_convert_wire_to_impl_Fn_Vec_f64_Send_Sync_static_c_invoke_callback_capture_3dd7f8fbc61877ce(
+        f,
+    );
     example_flat::calculator_history_batch(c, f);
 }
 #[no_mangle]
 #[allow(non_snake_case, unused_mut, unused_variables, unused_unsafe, dead_code)]
 pub unsafe extern "C" fn calculator_is(c: *const calculator_t, value: f64) -> bool {
-    let c = match __cbg_in___Calculator(c) {
+    let c = match __c_in_convert_wire_to_Calculator_c_borrow_shared_input_48be88e9df13aa53(
+        c,
+    ) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__msg) => {
             panic!("{}", __msg);
         }
     };
-    let value = __cbg_in_f64(value);
+    let value = __c_in_convert_wire_to_f64_c_terminal_input_scalar_7d8a0a733495e599(
+        value,
+    );
     let __v = example_flat::calculator_is(c, value);
     let __ret: bool;
-    __ret = __cbg_out_bool(__v);
+    __ret = __c_out_convert_bool_c_terminal_output_scalar_to_wire_cc0ad9760da17efd(__v);
     __ret
 }
 #[no_mangle]
@@ -1047,13 +1230,17 @@ pub unsafe extern "C" fn calculator_last_or_none(
     c: *const calculator_t,
     f: closure_maybe_value_t,
 ) {
-    let c = match __cbg_in___Calculator(c) {
+    let c = match __c_in_convert_wire_to_Calculator_c_borrow_shared_input_48be88e9df13aa53(
+        c,
+    ) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__msg) => {
             panic!("{}", __msg);
         }
     };
-    let f = __cbg_in_closure_maybe_value_t(f);
+    let f = __c_in_convert_wire_to_impl_Fn_Option_f64_Send_Sync_static_c_invoke_callback_capture_053af7d76b4f1245(
+        f,
+    );
     example_flat::calculator_last_or_none(c, f);
 }
 #[no_mangle]
@@ -1068,7 +1255,7 @@ pub unsafe extern "C" fn calculator_merge(
             "aliasing arguments: `a` (consumed) and `b` (consumed) are the same `Calculator` — a consumed or exclusively-borrowed resource may not be named twice in one call",
         );
         if !e.is_null() {
-            *e = __cbg_out_Error(
+            *e = __c_out_convert_Error_c_terminal_output_opaque_error_to_wire_9d010015abcb2259(
                 <example_flat::Error as ::core::convert::From<
                     ::std::string::String,
                 >>::from(__msg),
@@ -1076,11 +1263,13 @@ pub unsafe extern "C" fn calculator_merge(
         }
         return ::core::ptr::null_mut();
     }
-    let a = match __cbg_in_Calculator(a) {
+    let a = match __c_in_convert_wire_to_Calculator_c_terminal_input_owned_handle_b7bb400a642eb999(
+        a,
+    ) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__msg) => {
             if !e.is_null() {
-                *e = __cbg_out_Error(
+                *e = __c_out_convert_Error_c_terminal_output_opaque_error_to_wire_9d010015abcb2259(
                     <example_flat::Error as ::core::convert::From<
                         ::std::string::String,
                     >>::from(__msg),
@@ -1089,11 +1278,13 @@ pub unsafe extern "C" fn calculator_merge(
             return ::core::ptr::null_mut();
         }
     };
-    let b = match __cbg_in_Calculator(b) {
+    let b = match __c_in_convert_wire_to_Calculator_c_terminal_input_owned_handle_b7bb400a642eb999(
+        b,
+    ) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__msg) => {
             if !e.is_null() {
-                *e = __cbg_out_Error(
+                *e = __c_out_convert_Error_c_terminal_output_opaque_error_to_wire_9d010015abcb2259(
                     <example_flat::Error as ::core::convert::From<
                         ::std::string::String,
                     >>::from(__msg),
@@ -1105,12 +1296,16 @@ pub unsafe extern "C" fn calculator_merge(
     match example_flat::calculator_merge(a, b) {
         ::core::result::Result::Ok(__v) => {
             let __ret: *mut calculator_t;
-            __ret = __cbg_out_Calculator(__v);
+            __ret = __c_out_convert_Calculator_c_terminal_output_owned_handle_to_wire_4d20353780559007(
+                __v,
+            );
             __ret
         }
         ::core::result::Result::Err(__err) => {
             if !e.is_null() {
-                *e = __cbg_out_Error(__err);
+                *e = __c_out_convert_Error_c_terminal_output_opaque_error_to_wire_9d010015abcb2259(
+                    __err,
+                );
             }
             ::core::ptr::null_mut()
         }
@@ -1121,7 +1316,9 @@ pub unsafe extern "C" fn calculator_merge(
 pub unsafe extern "C" fn calculator_new() -> *mut calculator_t {
     let __v = example_flat::calculator_new();
     let __ret: *mut calculator_t;
-    __ret = __cbg_out_Calculator(__v);
+    __ret = __c_out_convert_Calculator_c_terminal_output_owned_handle_to_wire_4d20353780559007(
+        __v,
+    );
     __ret
 }
 #[no_mangle]
@@ -1129,7 +1326,9 @@ pub unsafe extern "C" fn calculator_new() -> *mut calculator_t {
 pub unsafe extern "C" fn calculator_new_clone(
     c: *const calculator_t,
 ) -> *mut calculator_t {
-    let c = match __cbg_in___Calculator(c) {
+    let c = match __c_in_convert_wire_to_Calculator_c_borrow_shared_input_48be88e9df13aa53(
+        c,
+    ) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__msg) => {
             panic!("{}", __msg);
@@ -1137,7 +1336,9 @@ pub unsafe extern "C" fn calculator_new_clone(
     };
     let __v = example_flat::calculator_new_clone(c);
     let __ret: *mut calculator_t;
-    __ret = __cbg_out_Calculator(__v);
+    __ret = __c_out_convert_Calculator_c_terminal_output_owned_handle_to_wire_4d20353780559007(
+        __v,
+    );
     __ret
 }
 #[no_mangle]
@@ -1146,11 +1347,11 @@ pub unsafe extern "C" fn calculator_new_from_str(
     s: *const ::core::ffi::c_char,
     e: *mut *mut ::core::ffi::c_char,
 ) -> *mut calculator_t {
-    let s = match __cbg_in___str(s) {
+    let s = match __c_in_convert_wire_to_str_c_borrow_str_input_246c2b9955bb6ef2(s) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__msg) => {
             if !e.is_null() {
-                *e = __cbg_out_Error(
+                *e = __c_out_convert_Error_c_terminal_output_opaque_error_to_wire_9d010015abcb2259(
                     <example_flat::Error as ::core::convert::From<
                         ::std::string::String,
                     >>::from(__msg),
@@ -1162,12 +1363,16 @@ pub unsafe extern "C" fn calculator_new_from_str(
     match example_flat::calculator_new_from_str(s) {
         ::core::result::Result::Ok(__v) => {
             let __ret: *mut calculator_t;
-            __ret = __cbg_out_Calculator(__v);
+            __ret = __c_out_convert_Calculator_c_terminal_output_owned_handle_to_wire_4d20353780559007(
+                __v,
+            );
             __ret
         }
         ::core::result::Result::Err(__err) => {
             if !e.is_null() {
-                *e = __cbg_out_Error(__err);
+                *e = __c_out_convert_Error_c_terminal_output_opaque_error_to_wire_9d010015abcb2259(
+                    __err,
+                );
             }
             ::core::ptr::null_mut()
         }
@@ -1176,7 +1381,9 @@ pub unsafe extern "C" fn calculator_new_from_str(
 #[no_mangle]
 #[allow(non_snake_case, unused_mut, unused_variables, unused_unsafe, dead_code)]
 pub unsafe extern "C" fn calculator_reset(c: *mut calculator_t) {
-    let c = match __cbg_in___mut_Calculator(c) {
+    let c = match __c_in_convert_wire_to_Calculator_c_borrow_mutable_input_f30bfe45043bc69c(
+        c,
+    ) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__msg) => {
             panic!("{}", __msg);
@@ -1189,7 +1396,9 @@ pub unsafe extern "C" fn calculator_reset(c: *mut calculator_t) {
 pub unsafe extern "C" fn calculator_to_string(
     c: *const calculator_t,
 ) -> *mut ::core::ffi::c_char {
-    let c = match __cbg_in___Calculator(c) {
+    let c = match __c_in_convert_wire_to_Calculator_c_borrow_shared_input_48be88e9df13aa53(
+        c,
+    ) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__msg) => {
             panic!("{}", __msg);
@@ -1197,7 +1406,9 @@ pub unsafe extern "C" fn calculator_to_string(
     };
     let __v = example_flat::calculator_to_string(c);
     let __ret: *mut ::core::ffi::c_char;
-    __ret = __cbg_out_String(__v);
+    __ret = __c_out_convert_String_c_terminal_output_string_to_wire_182528409f6ab8d3(
+        __v,
+    );
     __ret
 }
 #[no_mangle]
@@ -1207,17 +1418,23 @@ pub unsafe extern "C" fn caption_new(
     text: *const ::core::ffi::c_char,
     emphatic: ::core::mem::MaybeUninit<bool>,
 ) -> caption_t {
-    let id = __cbg_in_u64(id);
-    let text = match __cbg_in___str(text) {
+    let id = __c_in_convert_wire_to_u64_c_terminal_input_scalar_4e87470ad83635c8(id);
+    let text = match __c_in_convert_wire_to_str_c_borrow_str_input_246c2b9955bb6ef2(
+        text,
+    ) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__msg) => {
             panic!("{}", __msg);
         }
     };
-    let emphatic = __cbg_in_bool(emphatic);
+    let emphatic = __c_in_convert_wire_to_bool_c_terminal_input_bool_e48e0629cd6287b3(
+        emphatic,
+    );
     let __v = example_flat::caption_new(id, text, emphatic);
     let __ret: caption_t;
-    __ret = __cbg_out_Caption(__v);
+    __ret = __c_out_convert_Caption_c_product_intermediate_repr_c_struct_to_wire_3bc5d236333a6e28(
+        __v,
+    );
     __ret
 }
 #[no_mangle]
@@ -1225,7 +1442,9 @@ pub unsafe extern "C" fn caption_new(
 pub unsafe extern "C" fn drawing_get_shape(
     d: drawing_t,
 ) -> ::core::mem::MaybeUninit<shape_t> {
-    let d = match __cbg_in_Drawing(d) {
+    let d = match __c_in_convert_wire_to_Drawing_c_product_intermediate_repr_c_struct_3b927b21caf2df63(
+        d,
+    ) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__msg) => {
             panic!("{}", __msg);
@@ -1233,7 +1452,9 @@ pub unsafe extern "C" fn drawing_get_shape(
     };
     let __v = example_flat::drawing_get_shape(d);
     let __ret: ::core::mem::MaybeUninit<shape_t>;
-    __ret = __cbg_out_Shape(__v);
+    __ret = __c_out_convert_Shape_c_choice_intermediate_repr_c_tagged_union_to_wire_1c9175b2e9cd70a6(
+        __v,
+    );
     __ret
 }
 #[no_mangle]
@@ -1242,8 +1463,10 @@ pub unsafe extern "C" fn drawing_new(
     id: u64,
     shape: ::core::mem::MaybeUninit<shape_t>,
 ) -> drawing_t {
-    let id = __cbg_in_u64(id);
-    let shape = match __cbg_in_Shape(shape) {
+    let id = __c_in_convert_wire_to_u64_c_terminal_input_scalar_4e87470ad83635c8(id);
+    let shape = match __c_in_convert_wire_to_Shape_c_choice_intermediate_repr_c_tagged_union_8ddb52c185c8b923(
+        shape,
+    ) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__msg) => {
             panic!("{}", __msg);
@@ -1251,25 +1474,31 @@ pub unsafe extern "C" fn drawing_new(
     };
     let __v = example_flat::drawing_new(id, shape);
     let __ret: drawing_t;
-    __ret = __cbg_out_Drawing(__v);
+    __ret = __c_out_convert_Drawing_c_product_intermediate_repr_c_struct_to_wire_50eac9aa069a6838(
+        __v,
+    );
     __ret
 }
 #[no_mangle]
 #[allow(non_snake_case, unused_mut, unused_variables, unused_unsafe, dead_code)]
 pub unsafe extern "C" fn foo_get_id(f: foo_t) -> u64 {
-    let f = __cbg_in_Foo(f);
+    let f = __c_in_convert_wire_to_Foo_c_product_intermediate_repr_c_struct_157d1b61f2a5b9d5(
+        f,
+    );
     let __v = example_flat::foo_get_id(f);
     let __ret: u64;
-    __ret = __cbg_out_u64(__v);
+    __ret = __c_out_convert_u64_c_terminal_output_scalar_to_wire_518245fe60cf3590(__v);
     __ret
 }
 #[no_mangle]
 #[allow(non_snake_case, unused_mut, unused_variables, unused_unsafe, dead_code)]
 pub unsafe extern "C" fn foo_new(id: u64) -> foo_t {
-    let id = __cbg_in_u64(id);
+    let id = __c_in_convert_wire_to_u64_c_terminal_input_scalar_4e87470ad83635c8(id);
     let __v = example_flat::foo_new(id);
     let __ret: foo_t;
-    __ret = __cbg_out_Foo(__v);
+    __ret = __c_out_convert_Foo_c_product_intermediate_repr_c_struct_to_wire_02ab0b068798553e(
+        __v,
+    );
     __ret
 }
 #[no_mangle]
@@ -1277,7 +1506,9 @@ pub unsafe extern "C" fn foo_new(id: u64) -> foo_t {
 pub unsafe extern "C" fn inside_foo_default() -> inside_foo_t {
     let __v = example_flat::inside_foo_default();
     let __ret: inside_foo_t;
-    __ret = __cbg_out_InsideFoo(__v);
+    __ret = __c_out_convert_InsideFoo_c_terminal_output_enum_to_wire_b103ad5e4be33376(
+        __v,
+    );
     __ret
 }
 #[no_mangle]
@@ -1285,7 +1516,9 @@ pub unsafe extern "C" fn inside_foo_default() -> inside_foo_t {
 pub unsafe extern "C" fn inside_foo_value(
     x: ::core::mem::MaybeUninit<inside_foo_t>,
 ) -> i32 {
-    let x = match __cbg_in_InsideFoo(x) {
+    let x = match __c_in_convert_wire_to_InsideFoo_c_terminal_input_enum_70ed7847e05e3330(
+        x,
+    ) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__msg) => {
             panic!("{}", __msg);
@@ -1293,13 +1526,15 @@ pub unsafe extern "C" fn inside_foo_value(
     };
     let __v = example_flat::inside_foo_value(x);
     let __ret: i32;
-    __ret = __cbg_out_i32(__v);
+    __ret = __c_out_convert_i32_c_terminal_output_scalar_to_wire_ae82162f636ebcd5(__v);
     __ret
 }
 #[no_mangle]
 #[allow(non_snake_case, unused_mut, unused_variables, unused_unsafe, dead_code)]
 pub unsafe extern "C" fn note_emphatic(n: ::core::mem::MaybeUninit<note_t>) -> bool {
-    let n = match __cbg_in_Note(n) {
+    let n = match __c_in_convert_wire_to_Note_c_choice_intermediate_repr_c_tagged_union_4de1f2981255d608(
+        n,
+    ) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__msg) => {
             panic!("{}", __msg);
@@ -1307,7 +1542,7 @@ pub unsafe extern "C" fn note_emphatic(n: ::core::mem::MaybeUninit<note_t>) -> b
     };
     let __v = example_flat::note_emphatic(n);
     let __ret: bool;
-    __ret = __cbg_out_bool(__v);
+    __ret = __c_out_convert_bool_c_terminal_output_scalar_to_wire_cc0ad9760da17efd(__v);
     __ret
 }
 #[no_mangle]
@@ -1315,10 +1550,14 @@ pub unsafe extern "C" fn note_emphatic(n: ::core::mem::MaybeUninit<note_t>) -> b
 pub unsafe extern "C" fn note_new_after(
     millis: u64,
 ) -> ::core::mem::MaybeUninit<note_t> {
-    let millis = __cbg_in_u64(millis);
+    let millis = __c_in_convert_wire_to_u64_c_terminal_input_scalar_4e87470ad83635c8(
+        millis,
+    );
     let __v = example_flat::note_new_after(millis);
     let __ret: ::core::mem::MaybeUninit<note_t>;
-    __ret = __cbg_out_Note(__v);
+    __ret = __c_out_convert_Note_c_choice_intermediate_repr_c_tagged_union_to_wire_c9cea85d5266d21b(
+        __v,
+    );
     __ret
 }
 #[no_mangle]
@@ -1326,10 +1565,12 @@ pub unsafe extern "C" fn note_new_after(
 pub unsafe extern "C" fn note_new_flagged(
     flag: ::core::mem::MaybeUninit<bool>,
 ) -> ::core::mem::MaybeUninit<note_t> {
-    let flag = __cbg_in_bool(flag);
+    let flag = __c_in_convert_wire_to_bool_c_terminal_input_bool_e48e0629cd6287b3(flag);
     let __v = example_flat::note_new_flagged(flag);
     let __ret: ::core::mem::MaybeUninit<note_t>;
-    __ret = __cbg_out_Note(__v);
+    __ret = __c_out_convert_Note_c_choice_intermediate_repr_c_tagged_union_to_wire_c9cea85d5266d21b(
+        __v,
+    );
     __ret
 }
 #[no_mangle]
@@ -1337,7 +1578,9 @@ pub unsafe extern "C" fn note_new_flagged(
 pub unsafe extern "C" fn note_new_silent() -> ::core::mem::MaybeUninit<note_t> {
     let __v = example_flat::note_new_silent();
     let __ret: ::core::mem::MaybeUninit<note_t>;
-    __ret = __cbg_out_Note(__v);
+    __ret = __c_out_convert_Note_c_choice_intermediate_repr_c_tagged_union_to_wire_c9cea85d5266d21b(
+        __v,
+    );
     __ret
 }
 #[no_mangle]
@@ -1346,8 +1589,10 @@ pub unsafe extern "C" fn note_new_sketched(
     id: u64,
     label: *const ::core::ffi::c_char,
 ) -> ::core::mem::MaybeUninit<note_t> {
-    let id = __cbg_in_u64(id);
-    let label = match __cbg_in___str(label) {
+    let id = __c_in_convert_wire_to_u64_c_terminal_input_scalar_4e87470ad83635c8(id);
+    let label = match __c_in_convert_wire_to_str_c_borrow_str_input_246c2b9955bb6ef2(
+        label,
+    ) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__msg) => {
             panic!("{}", __msg);
@@ -1355,7 +1600,9 @@ pub unsafe extern "C" fn note_new_sketched(
     };
     let __v = example_flat::note_new_sketched(id, label);
     let __ret: ::core::mem::MaybeUninit<note_t>;
-    __ret = __cbg_out_Note(__v);
+    __ret = __c_out_convert_Note_c_choice_intermediate_repr_c_tagged_union_to_wire_c9cea85d5266d21b(
+        __v,
+    );
     __ret
 }
 #[no_mangle]
@@ -1365,23 +1612,31 @@ pub unsafe extern "C" fn note_new_titled(
     text: *const ::core::ffi::c_char,
     emphatic: ::core::mem::MaybeUninit<bool>,
 ) -> ::core::mem::MaybeUninit<note_t> {
-    let id = __cbg_in_u64(id);
-    let text = match __cbg_in___str(text) {
+    let id = __c_in_convert_wire_to_u64_c_terminal_input_scalar_4e87470ad83635c8(id);
+    let text = match __c_in_convert_wire_to_str_c_borrow_str_input_246c2b9955bb6ef2(
+        text,
+    ) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__msg) => {
             panic!("{}", __msg);
         }
     };
-    let emphatic = __cbg_in_bool(emphatic);
+    let emphatic = __c_in_convert_wire_to_bool_c_terminal_input_bool_e48e0629cd6287b3(
+        emphatic,
+    );
     let __v = example_flat::note_new_titled(id, text, emphatic);
     let __ret: ::core::mem::MaybeUninit<note_t>;
-    __ret = __cbg_out_Note(__v);
+    __ret = __c_out_convert_Note_c_choice_intermediate_repr_c_tagged_union_to_wire_c9cea85d5266d21b(
+        __v,
+    );
     __ret
 }
 #[no_mangle]
 #[allow(non_snake_case, unused_mut, unused_variables, unused_unsafe, dead_code)]
 pub unsafe extern "C" fn note_value(n: ::core::mem::MaybeUninit<note_t>) -> u64 {
-    let n = match __cbg_in_Note(n) {
+    let n = match __c_in_convert_wire_to_Note_c_choice_intermediate_repr_c_tagged_union_4de1f2981255d608(
+        n,
+    ) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__msg) => {
             panic!("{}", __msg);
@@ -1389,13 +1644,15 @@ pub unsafe extern "C" fn note_value(n: ::core::mem::MaybeUninit<note_t>) -> u64 
     };
     let __v = example_flat::note_value(n);
     let __ret: u64;
-    __ret = __cbg_out_u64(__v);
+    __ret = __c_out_convert_u64_c_terminal_output_scalar_to_wire_518245fe60cf3590(__v);
     __ret
 }
 #[no_mangle]
 #[allow(non_snake_case, unused_mut, unused_variables, unused_unsafe, dead_code)]
 pub unsafe extern "C" fn shape_area(s: ::core::mem::MaybeUninit<shape_t>) -> f64 {
-    let s = match __cbg_in_Shape(s) {
+    let s = match __c_in_convert_wire_to_Shape_c_choice_intermediate_repr_c_tagged_union_8ddb52c185c8b923(
+        s,
+    ) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__msg) => {
             panic!("{}", __msg);
@@ -1403,7 +1660,7 @@ pub unsafe extern "C" fn shape_area(s: ::core::mem::MaybeUninit<shape_t>) -> f64
     };
     let __v = example_flat::shape_area(s);
     let __ret: f64;
-    __ret = __cbg_out_f64(__v);
+    __ret = __c_out_convert_f64_c_terminal_output_scalar_to_wire_6aa94606ef14f673(__v);
     __ret
 }
 #[no_mangle]
@@ -1411,7 +1668,9 @@ pub unsafe extern "C" fn shape_area(s: ::core::mem::MaybeUninit<shape_t>) -> f64
 pub unsafe extern "C" fn shape_get_label(
     s: ::core::mem::MaybeUninit<shape_t>,
 ) -> *mut ::core::ffi::c_char {
-    let s = match __cbg_in_Shape(s) {
+    let s = match __c_in_convert_wire_to_Shape_c_choice_intermediate_repr_c_tagged_union_8ddb52c185c8b923(
+        s,
+    ) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__msg) => {
             panic!("{}", __msg);
@@ -1419,7 +1678,9 @@ pub unsafe extern "C" fn shape_get_label(
     };
     let __v = example_flat::shape_get_label(s);
     let __ret: *mut ::core::ffi::c_char;
-    __ret = __cbg_out_String(__v);
+    __ret = __c_out_convert_String_c_terminal_output_string_to_wire_182528409f6ab8d3(
+        __v,
+    );
     __ret
 }
 #[no_mangle]
@@ -1427,10 +1688,14 @@ pub unsafe extern "C" fn shape_get_label(
 pub unsafe extern "C" fn shape_new_circle(
     radius: f64,
 ) -> ::core::mem::MaybeUninit<shape_t> {
-    let radius = __cbg_in_f64(radius);
+    let radius = __c_in_convert_wire_to_f64_c_terminal_input_scalar_7d8a0a733495e599(
+        radius,
+    );
     let __v = example_flat::shape_new_circle(radius);
     let __ret: ::core::mem::MaybeUninit<shape_t>;
-    __ret = __cbg_out_Shape(__v);
+    __ret = __c_out_convert_Shape_c_choice_intermediate_repr_c_tagged_union_to_wire_1c9175b2e9cd70a6(
+        __v,
+    );
     __ret
 }
 #[no_mangle]
@@ -1438,7 +1703,9 @@ pub unsafe extern "C" fn shape_new_circle(
 pub unsafe extern "C" fn shape_new_empty() -> ::core::mem::MaybeUninit<shape_t> {
     let __v = example_flat::shape_new_empty();
     let __ret: ::core::mem::MaybeUninit<shape_t>;
-    __ret = __cbg_out_Shape(__v);
+    __ret = __c_out_convert_Shape_c_choice_intermediate_repr_c_tagged_union_to_wire_1c9175b2e9cd70a6(
+        __v,
+    );
     __ret
 }
 #[no_mangle]
@@ -1447,13 +1714,17 @@ pub unsafe extern "C" fn shape_new_labeled(
     label: *const ::core::ffi::c_char,
     op: ::core::mem::MaybeUninit<operation_t>,
 ) -> ::core::mem::MaybeUninit<shape_t> {
-    let label = match __cbg_in___str(label) {
+    let label = match __c_in_convert_wire_to_str_c_borrow_str_input_246c2b9955bb6ef2(
+        label,
+    ) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__msg) => {
             panic!("{}", __msg);
         }
     };
-    let op = match __cbg_in_Operation(op) {
+    let op = match __c_in_convert_wire_to_Operation_c_terminal_input_enum_a23b6023635a8da5(
+        op,
+    ) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__msg) => {
             panic!("{}", __msg);
@@ -1461,7 +1732,9 @@ pub unsafe extern "C" fn shape_new_labeled(
     };
     let __v = example_flat::shape_new_labeled(label, op);
     let __ret: ::core::mem::MaybeUninit<shape_t>;
-    __ret = __cbg_out_Shape(__v);
+    __ret = __c_out_convert_Shape_c_choice_intermediate_repr_c_tagged_union_to_wire_1c9175b2e9cd70a6(
+        __v,
+    );
     __ret
 }
 #[no_mangle]
@@ -1470,11 +1743,17 @@ pub unsafe extern "C" fn shape_new_rect(
     width: f64,
     height: f64,
 ) -> ::core::mem::MaybeUninit<shape_t> {
-    let width = __cbg_in_f64(width);
-    let height = __cbg_in_f64(height);
+    let width = __c_in_convert_wire_to_f64_c_terminal_input_scalar_7d8a0a733495e599(
+        width,
+    );
+    let height = __c_in_convert_wire_to_f64_c_terminal_input_scalar_7d8a0a733495e599(
+        height,
+    );
     let __v = example_flat::shape_new_rect(width, height);
     let __ret: ::core::mem::MaybeUninit<shape_t>;
-    __ret = __cbg_out_Shape(__v);
+    __ret = __c_out_convert_Shape_c_choice_intermediate_repr_c_tagged_union_to_wire_1c9175b2e9cd70a6(
+        __v,
+    );
     __ret
 }
 #[no_mangle]
@@ -1484,11 +1763,13 @@ pub unsafe extern "C" fn shape_try_area(
     out: *mut f64,
     e: *mut *mut ::core::ffi::c_char,
 ) -> bool {
-    let s = match __cbg_in_Shape(s) {
+    let s = match __c_in_convert_wire_to_Shape_c_choice_intermediate_repr_c_tagged_union_8ddb52c185c8b923(
+        s,
+    ) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__msg) => {
             if !e.is_null() {
-                *e = __cbg_out_Error(
+                *e = __c_out_convert_Error_c_terminal_output_opaque_error_to_wire_9d010015abcb2259(
                     <example_flat::Error as ::core::convert::From<
                         ::std::string::String,
                     >>::from(__msg),
@@ -1499,12 +1780,16 @@ pub unsafe extern "C" fn shape_try_area(
     };
     match example_flat::shape_try_area(s) {
         ::core::result::Result::Ok(__v) => {
-            *out = __cbg_out_f64(__v);
+            *out = __c_out_convert_f64_c_terminal_output_scalar_to_wire_6aa94606ef14f673(
+                __v,
+            );
             true
         }
         ::core::result::Result::Err(__err) => {
             if !e.is_null() {
-                *e = __cbg_out_Error(__err);
+                *e = __c_out_convert_Error_c_terminal_output_opaque_error_to_wire_9d010015abcb2259(
+                    __err,
+                );
             }
             false
         }

--- a/examples/example-cbindgen/generated/example_flat_x86_64.rs
+++ b/examples/example-cbindgen/generated/example_flat_x86_64.rs
@@ -178,7 +178,7 @@ pub struct closure_history_batch_t {
     pub drop: ::core::option::Option<unsafe extern "C" fn(*mut ::core::ffi::c_void)>,
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) unsafe fn __cbg_in_closure_history_batch_t(
+pub(crate) unsafe fn __c_in_convert_wire_to_impl_Fn_Vec_f64_Send_Sync_static_c_invoke_callback_capture_3dd7f8fbc61877ce(
     c: closure_history_batch_t,
 ) -> impl Fn(::std::vec::Vec<f64>) + Send + Sync + 'static {
     struct __Ctx {
@@ -203,7 +203,9 @@ pub(crate) unsafe fn __cbg_in_closure_history_batch_t(
         if let ::core::option::Option::Some(__f) = __call {
             let mut __w0_0 = ::core::mem::MaybeUninit::<*mut f64>::zeroed();
             let mut __w0_1 = ::core::mem::MaybeUninit::<usize>::zeroed();
-            let __arr: ::std::vec::Vec<f64> = __cbg_out_chain_vec_f64(__a0);
+            let __arr: ::std::vec::Vec<f64> = __c_out_convert_sequence_Vec_f64_to_wire_ad99887ef4e62c28(
+                __a0,
+            );
             let (__p, __n) = __cbg_alloc_array(__arr);
             *__w0_0.as_mut_ptr() = __p;
             *__w0_1.as_mut_ptr() = __n;
@@ -225,7 +227,7 @@ pub struct closure_maybe_grade_t {
     pub drop: ::core::option::Option<unsafe extern "C" fn(*mut ::core::ffi::c_void)>,
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) unsafe fn __cbg_in_closure_maybe_grade_t(
+pub(crate) unsafe fn __c_in_convert_wire_to_impl_Fn_Option_Grade_Send_Sync_static_c_invoke_callback_capture_5512a1f2265e79a0(
     c: closure_maybe_grade_t,
 ) -> impl Fn(::core::option::Option<example_flat::Grade>) + Send + Sync + 'static {
     struct __Ctx {
@@ -253,7 +255,9 @@ pub(crate) unsafe fn __cbg_in_closure_maybe_grade_t(
             match __a0 {
                 ::core::option::Option::Some(__x) => {
                     *__w0_0.as_mut_ptr() = true;
-                    *__w0_1.as_mut_ptr() = __cbg_out_Grade(__x);
+                    *__w0_1.as_mut_ptr() = __c_out_convert_Grade_c_terminal_output_enum_to_wire_a59c7b101e0a9e37(
+                        __x,
+                    );
                 }
                 ::core::option::Option::None => {
                     *__w0_0.as_mut_ptr() = false;
@@ -277,7 +281,7 @@ pub struct closure_maybe_value_t {
     pub drop: ::core::option::Option<unsafe extern "C" fn(*mut ::core::ffi::c_void)>,
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) unsafe fn __cbg_in_closure_maybe_value_t(
+pub(crate) unsafe fn __c_in_convert_wire_to_impl_Fn_Option_f64_Send_Sync_static_c_invoke_callback_capture_053af7d76b4f1245(
     c: closure_maybe_value_t,
 ) -> impl Fn(::core::option::Option<f64>) + Send + Sync + 'static {
     struct __Ctx {
@@ -305,7 +309,9 @@ pub(crate) unsafe fn __cbg_in_closure_maybe_value_t(
             match __a0 {
                 ::core::option::Option::Some(__x) => {
                     *__w0_0.as_mut_ptr() = true;
-                    *__w0_1.as_mut_ptr() = __cbg_out_f64(__x);
+                    *__w0_1.as_mut_ptr() = __c_out_convert_f64_c_terminal_output_scalar_to_wire_6aa94606ef14f673(
+                        __x,
+                    );
                 }
                 ::core::option::Option::None => {
                     *__w0_0.as_mut_ptr() = false;
@@ -325,7 +331,7 @@ pub struct closure_value_t {
     pub drop: ::core::option::Option<unsafe extern "C" fn(*mut ::core::ffi::c_void)>,
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) unsafe fn __cbg_in_closure_value_t(
+pub(crate) unsafe fn __c_in_convert_wire_to_impl_Fn_f64_Send_Sync_static_c_invoke_callback_capture_88739bf29d2a9906(
     c: closure_value_t,
 ) -> impl Fn(f64) + Send + Sync + 'static {
     struct __Ctx {
@@ -348,13 +354,41 @@ pub(crate) unsafe fn __cbg_in_closure_value_t(
     });
     move |__a0: f64| {
         if let ::core::option::Option::Some(__f) = __call {
-            let __w0 = __cbg_out_f64(__a0);
+            let __w0 = __c_out_convert_f64_c_terminal_output_scalar_to_wire_6aa94606ef14f673(
+                __a0,
+            );
             unsafe { __f(__w0, __ctx.context) }
         }
     }
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) unsafe fn __cbg_in_Calculator(
+pub(crate) unsafe fn __c_in_convert_wire_to_Calculator_c_borrow_mutable_input_f30bfe45043bc69c<
+    'a,
+>(
+    v: *mut calculator_t,
+) -> ::core::result::Result<&'a mut example_flat::Calculator, ::std::string::String> {
+    if v.is_null() {
+        return ::core::result::Result::Err(
+            ::std::string::String::from("null Calculator pointer"),
+        );
+    }
+    ::core::result::Result::Ok(&mut *(v as *mut example_flat::Calculator))
+}
+#[allow(non_snake_case, unused_variables, dead_code)]
+pub(crate) unsafe fn __c_in_convert_wire_to_Calculator_c_borrow_shared_input_48be88e9df13aa53<
+    'a,
+>(
+    v: *const calculator_t,
+) -> ::core::result::Result<&'a example_flat::Calculator, ::std::string::String> {
+    if v.is_null() {
+        return ::core::result::Result::Err(
+            ::std::string::String::from("null Calculator pointer"),
+        );
+    }
+    ::core::result::Result::Ok(&*(v as *const example_flat::Calculator))
+}
+#[allow(non_snake_case, unused_variables, dead_code)]
+pub(crate) unsafe fn __c_in_convert_wire_to_Calculator_c_terminal_input_owned_handle_b7bb400a642eb999(
     v: *mut calculator_t,
 ) -> ::core::result::Result<example_flat::Calculator, ::std::string::String> {
     if v.is_null() {
@@ -367,32 +401,46 @@ pub(crate) unsafe fn __cbg_in_Calculator(
     )
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) unsafe fn __cbg_in_Caption(v: caption_t) -> example_flat::Caption {
+pub(crate) unsafe fn __c_in_convert_wire_to_Caption_c_product_intermediate_repr_c_struct_a9076d1a0d6740b3(
+    v: caption_t,
+) -> example_flat::Caption {
     example_flat::Caption {
-        id: __cbg_in_u64(v.id),
-        text: __cbg_in_String_field(v.text),
-        emphatic: __cbg_in_bool(v.emphatic),
+        id: __c_in_convert_wire_to_u64_c_terminal_input_scalar_4e87470ad83635c8(v.id),
+        text: __c_in_convert_wire_to_String_c_terminal_input_string_field_b6091e2e8553ccde(
+            v.text,
+        ),
+        emphatic: __c_in_convert_wire_to_bool_c_terminal_input_bool_e48e0629cd6287b3(
+            v.emphatic,
+        ),
     }
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) unsafe fn __cbg_in_Drawing(
+pub(crate) unsafe fn __c_in_convert_wire_to_Drawing_c_product_intermediate_repr_c_struct_3b927b21caf2df63(
     v: drawing_t,
 ) -> ::core::result::Result<example_flat::Drawing, ::std::string::String> {
     ::core::result::Result::Ok(example_flat::Drawing {
-        id: __cbg_in_u64(v.id),
-        shape: __cbg_in_Shape(v.shape)?,
+        id: __c_in_convert_wire_to_u64_c_terminal_input_scalar_4e87470ad83635c8(v.id),
+        shape: __c_in_convert_wire_to_Shape_c_choice_intermediate_repr_c_tagged_union_8ddb52c185c8b923(
+            v.shape,
+        )?,
     })
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) unsafe fn __cbg_in_Foo(v: foo_t) -> example_flat::Foo {
+pub(crate) unsafe fn __c_in_convert_wire_to_Foo_c_product_intermediate_repr_c_struct_157d1b61f2a5b9d5(
+    v: foo_t,
+) -> example_flat::Foo {
     example_flat::Foo {
-        id: __cbg_in_u64(v.id),
-        x86_64_field: __cbg_in_u64(v.x86_64_field),
-        stable_field: __cbg_in_u64(v.stable_field),
+        id: __c_in_convert_wire_to_u64_c_terminal_input_scalar_4e87470ad83635c8(v.id),
+        x86_64_field: __c_in_convert_wire_to_u64_c_terminal_input_scalar_4e87470ad83635c8(
+            v.x86_64_field,
+        ),
+        stable_field: __c_in_convert_wire_to_u64_c_terminal_input_scalar_4e87470ad83635c8(
+            v.stable_field,
+        ),
     }
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) unsafe fn __cbg_in_InsideFoo(
+pub(crate) unsafe fn __c_in_convert_wire_to_InsideFoo_c_terminal_input_enum_70ed7847e05e3330(
     v: ::core::mem::MaybeUninit<inside_foo_t>,
 ) -> ::core::result::Result<example_flat::InsideFoo, ::std::string::String> {
     const _: () = {
@@ -421,11 +469,13 @@ pub(crate) unsafe fn __cbg_in_InsideFoo(
     )
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) fn __cbg_in_Millis(v: u64) -> example_flat::Millis {
+pub(crate) fn __c_in_convert_wire_to_Millis_c_terminal_custom_771f8034eae1c639(
+    v: u64,
+) -> example_flat::Millis {
     example_flat::millis_from_raw(v)
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) unsafe fn __cbg_in_Note(
+pub(crate) unsafe fn __c_in_convert_wire_to_Note_c_choice_intermediate_repr_c_tagged_union_4de1f2981255d608(
     v: ::core::mem::MaybeUninit<note_t>,
 ) -> ::core::result::Result<example_flat::Note, ::std::string::String> {
     ::core::result::Result::Ok({
@@ -451,7 +501,11 @@ pub(crate) unsafe fn __cbg_in_Note(
                         }
                     }
                 };
-                example_flat::Note::Titled(__cbg_in_Caption((__arm).0))
+                example_flat::Note::Titled(
+                    __c_in_convert_wire_to_Caption_c_product_intermediate_repr_c_struct_a9076d1a0d6740b3(
+                        (__arm).0,
+                    ),
+                )
             }
             2 => {
                 let __choice = unsafe { (v).assume_init() };
@@ -463,7 +517,11 @@ pub(crate) unsafe fn __cbg_in_Note(
                         }
                     }
                 };
-                example_flat::Note::After(__cbg_in_Millis((__arm).0))
+                example_flat::Note::After(
+                    __c_in_convert_wire_to_Millis_c_terminal_custom_771f8034eae1c639(
+                        (__arm).0,
+                    ),
+                )
             }
             3 => {
                 let __choice = unsafe { (v).assume_init() };
@@ -475,7 +533,11 @@ pub(crate) unsafe fn __cbg_in_Note(
                         }
                     }
                 };
-                example_flat::Note::Flagged(__cbg_in_bool((__arm).0))
+                example_flat::Note::Flagged(
+                    __c_in_convert_wire_to_bool_c_terminal_input_bool_e48e0629cd6287b3(
+                        (__arm).0,
+                    ),
+                )
             }
             4 => {
                 let __choice = unsafe { (v).assume_init() };
@@ -487,7 +549,11 @@ pub(crate) unsafe fn __cbg_in_Note(
                         }
                     }
                 };
-                example_flat::Note::Sketched(__cbg_in_Drawing((__arm).0)?)
+                example_flat::Note::Sketched(
+                    __c_in_convert_wire_to_Drawing_c_product_intermediate_repr_c_struct_3b927b21caf2df63(
+                        (__arm).0,
+                    )?,
+                )
             }
             _ => {
                 return ::core::result::Result::Err(
@@ -501,7 +567,7 @@ pub(crate) unsafe fn __cbg_in_Note(
     })
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) unsafe fn __cbg_in_Operation(
+pub(crate) unsafe fn __c_in_convert_wire_to_Operation_c_terminal_input_enum_a23b6023635a8da5(
     v: ::core::mem::MaybeUninit<operation_t>,
 ) -> ::core::result::Result<example_flat::Operation, ::std::string::String> {
     const _: () = {
@@ -536,7 +602,7 @@ pub(crate) unsafe fn __cbg_in_Operation(
     )
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) unsafe fn __cbg_in_Shape(
+pub(crate) unsafe fn __c_in_convert_wire_to_Shape_c_choice_intermediate_repr_c_tagged_union_8ddb52c185c8b923(
     v: ::core::mem::MaybeUninit<shape_t>,
 ) -> ::core::result::Result<example_flat::Shape, ::std::string::String> {
     ::core::result::Result::Ok({
@@ -562,7 +628,11 @@ pub(crate) unsafe fn __cbg_in_Shape(
                         }
                     }
                 };
-                example_flat::Shape::Circle(__cbg_in_f64((__arm).0))
+                example_flat::Shape::Circle(
+                    __c_in_convert_wire_to_f64_c_terminal_input_scalar_7d8a0a733495e599(
+                        (__arm).0,
+                    ),
+                )
             }
             2 => {
                 let __choice = unsafe { (v).assume_init() };
@@ -577,8 +647,12 @@ pub(crate) unsafe fn __cbg_in_Shape(
                     }
                 };
                 example_flat::Shape::Rect {
-                    width: __cbg_in_f64((__arm).0),
-                    height: __cbg_in_f64((__arm).1),
+                    width: __c_in_convert_wire_to_f64_c_terminal_input_scalar_7d8a0a733495e599(
+                        (__arm).0,
+                    ),
+                    height: __c_in_convert_wire_to_f64_c_terminal_input_scalar_7d8a0a733495e599(
+                        (__arm).1,
+                    ),
                 }
             }
             3 => {
@@ -594,8 +668,12 @@ pub(crate) unsafe fn __cbg_in_Shape(
                     }
                 };
                 example_flat::Shape::Labeled(
-                    __cbg_in_String_field((__arm).0),
-                    __cbg_in_Operation((__arm).1)?,
+                    __c_in_convert_wire_to_String_c_terminal_input_string_field_b6091e2e8553ccde(
+                        (__arm).0,
+                    ),
+                    __c_in_convert_wire_to_Operation_c_terminal_input_enum_a23b6023635a8da5(
+                        (__arm).1,
+                    )?,
                 )
             }
             _ => {
@@ -610,7 +688,7 @@ pub(crate) unsafe fn __cbg_in_Shape(
     })
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) unsafe fn __cbg_in_String_field(
+pub(crate) unsafe fn __c_in_convert_wire_to_String_c_terminal_input_string_field_b6091e2e8553ccde(
     v: *const ::core::ffi::c_char,
 ) -> ::std::string::String {
     if v.is_null() {
@@ -620,29 +698,19 @@ pub(crate) unsafe fn __cbg_in_String_field(
     }
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) unsafe fn __cbg_in___Calculator<'a>(
-    v: *const calculator_t,
-) -> ::core::result::Result<&'a example_flat::Calculator, ::std::string::String> {
-    if v.is_null() {
-        return ::core::result::Result::Err(
-            ::std::string::String::from("null Calculator pointer"),
-        );
-    }
-    ::core::result::Result::Ok(&*(v as *const example_flat::Calculator))
+pub(crate) unsafe fn __c_in_convert_wire_to_bool_c_terminal_input_bool_e48e0629cd6287b3(
+    v: ::core::mem::MaybeUninit<bool>,
+) -> bool {
+    ::core::ptr::read(v.as_ptr() as *const u8) != 0
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) unsafe fn __cbg_in___mut_Calculator<'a>(
-    v: *mut calculator_t,
-) -> ::core::result::Result<&'a mut example_flat::Calculator, ::std::string::String> {
-    if v.is_null() {
-        return ::core::result::Result::Err(
-            ::std::string::String::from("null Calculator pointer"),
-        );
-    }
-    ::core::result::Result::Ok(&mut *(v as *mut example_flat::Calculator))
+pub(crate) fn __c_in_convert_wire_to_f64_c_terminal_input_scalar_7d8a0a733495e599(
+    v: f64,
+) -> f64 {
+    v
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) unsafe fn __cbg_in___str<'a>(
+pub(crate) unsafe fn __c_in_convert_wire_to_str_c_borrow_str_input_246c2b9955bb6ef2<'a>(
     v: *const ::core::ffi::c_char,
 ) -> ::core::result::Result<&'a str, ::std::string::String> {
     if v.is_null() {
@@ -660,92 +728,132 @@ pub(crate) unsafe fn __cbg_in___str<'a>(
     }
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) unsafe fn __cbg_in_bool(v: ::core::mem::MaybeUninit<bool>) -> bool {
-    ::core::ptr::read(v.as_ptr() as *const u8) != 0
-}
-#[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) fn __cbg_in_f64(v: f64) -> f64 {
+pub(crate) fn __c_in_convert_wire_to_u64_c_terminal_input_scalar_4e87470ad83635c8(
+    v: u64,
+) -> u64 {
     v
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) fn __cbg_in_u64(v: u64) -> u64 {
-    v
-}
-#[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) fn __cbg_out_Calculator(v: example_flat::Calculator) -> *mut calculator_t {
+pub(crate) fn __c_out_convert_Calculator_c_terminal_output_owned_handle_to_wire_4d20353780559007(
+    v: example_flat::Calculator,
+) -> *mut calculator_t {
     ::std::boxed::Box::into_raw(::std::boxed::Box::new(v)) as *mut calculator_t
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) fn __cbg_out_Caption(v: example_flat::Caption) -> caption_t {
+pub(crate) fn __c_out_convert_Caption_c_product_intermediate_repr_c_struct_to_wire_3bc5d236333a6e28(
+    v: example_flat::Caption,
+) -> caption_t {
     caption_t {
-        id: __cbg_out_u64(v.id),
-        text: __cbg_out_String(v.text),
-        emphatic: __cbg_out_bool_field(v.emphatic),
+        id: __c_out_convert_u64_c_terminal_output_scalar_to_wire_518245fe60cf3590(v.id),
+        text: __c_out_convert_String_c_terminal_output_string_to_wire_182528409f6ab8d3(
+            v.text,
+        ),
+        emphatic: __c_out_convert_bool_c_terminal_output_bool_field_to_wire_6a810eb4cb986700(
+            v.emphatic,
+        ),
     }
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) fn __cbg_out_Drawing(v: example_flat::Drawing) -> drawing_t {
+pub(crate) fn __c_out_convert_Drawing_c_product_intermediate_repr_c_struct_to_wire_50eac9aa069a6838(
+    v: example_flat::Drawing,
+) -> drawing_t {
     drawing_t {
-        id: __cbg_out_u64(v.id),
-        shape: __cbg_out_Shape(v.shape),
+        id: __c_out_convert_u64_c_terminal_output_scalar_to_wire_518245fe60cf3590(v.id),
+        shape: __c_out_convert_Shape_c_choice_intermediate_repr_c_tagged_union_to_wire_1c9175b2e9cd70a6(
+            v.shape,
+        ),
     }
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) fn __cbg_out_Error(v: example_flat::Error) -> *mut ::core::ffi::c_char {
+pub(crate) fn __c_out_convert_Error_c_terminal_output_opaque_error_to_wire_9d010015abcb2259(
+    v: example_flat::Error,
+) -> *mut ::core::ffi::c_char {
     __cbg_alloc_cstr(example_flat::error_get_message(&v))
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) fn __cbg_out_Foo(v: example_flat::Foo) -> foo_t {
+pub(crate) fn __c_out_convert_Foo_c_product_intermediate_repr_c_struct_to_wire_02ab0b068798553e(
+    v: example_flat::Foo,
+) -> foo_t {
     foo_t {
-        id: __cbg_out_u64(v.id),
-        x86_64_field: __cbg_out_u64(v.x86_64_field),
-        stable_field: __cbg_out_u64(v.stable_field),
+        id: __c_out_convert_u64_c_terminal_output_scalar_to_wire_518245fe60cf3590(v.id),
+        x86_64_field: __c_out_convert_u64_c_terminal_output_scalar_to_wire_518245fe60cf3590(
+            v.x86_64_field,
+        ),
+        stable_field: __c_out_convert_u64_c_terminal_output_scalar_to_wire_518245fe60cf3590(
+            v.stable_field,
+        ),
     }
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) fn __cbg_out_Grade(v: example_flat::Grade) -> grade_t {
+pub(crate) fn __c_out_convert_Grade_c_terminal_output_enum_to_wire_a59c7b101e0a9e37(
+    v: example_flat::Grade,
+) -> grade_t {
     match v {
         example_flat::Grade::Low => grade_t::Low,
         example_flat::Grade::High => grade_t::High,
     }
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) fn __cbg_out_InsideFoo(v: example_flat::InsideFoo) -> inside_foo_t {
+pub(crate) fn __c_out_convert_InsideFoo_c_terminal_output_enum_to_wire_b103ad5e4be33376(
+    v: example_flat::InsideFoo,
+) -> inside_foo_t {
     match v {
         example_flat::InsideFoo::DouddleDee => inside_foo_t::DouddleDee,
         example_flat::InsideFoo::DouddleDum => inside_foo_t::DouddleDum,
     }
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) fn __cbg_out_Millis(v: example_flat::Millis) -> u64 {
+pub(crate) fn __c_out_convert_Millis_c_terminal_custom_to_wire_0c2f6b5f81dfcd94(
+    v: example_flat::Millis,
+) -> u64 {
     example_flat::millis_to_raw(&v)
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) fn __cbg_out_Note(v: example_flat::Note) -> ::core::mem::MaybeUninit<note_t> {
+pub(crate) fn __c_out_convert_Note_c_choice_intermediate_repr_c_tagged_union_to_wire_c9cea85d5266d21b(
+    v: example_flat::Note,
+) -> ::core::mem::MaybeUninit<note_t> {
     ::core::mem::MaybeUninit::new({
         match v {
             example_flat::Note::Silent => note_t::Silent,
             example_flat::Note::Titled(__part0) => {
-                let __built_arm = (__cbg_out_Caption(__part0),);
+                let __built_arm = (
+                    __c_out_convert_Caption_c_product_intermediate_repr_c_struct_to_wire_3bc5d236333a6e28(
+                        __part0,
+                    ),
+                );
                 note_t::Titled(__built_arm.0)
             }
             example_flat::Note::After(__part0) => {
-                let __built_arm = (__cbg_out_Millis(__part0),);
+                let __built_arm = (
+                    __c_out_convert_Millis_c_terminal_custom_to_wire_0c2f6b5f81dfcd94(
+                        __part0,
+                    ),
+                );
                 note_t::After(__built_arm.0)
             }
             example_flat::Note::Flagged(__part0) => {
-                let __built_arm = (__cbg_out_bool_field(__part0),);
+                let __built_arm = (
+                    __c_out_convert_bool_c_terminal_output_bool_field_to_wire_6a810eb4cb986700(
+                        __part0,
+                    ),
+                );
                 note_t::Flagged(__built_arm.0)
             }
             example_flat::Note::Sketched(__part0) => {
-                let __built_arm = (__cbg_out_Drawing(__part0),);
+                let __built_arm = (
+                    __c_out_convert_Drawing_c_product_intermediate_repr_c_struct_to_wire_50eac9aa069a6838(
+                        __part0,
+                    ),
+                );
                 note_t::Sketched(__built_arm.0)
             }
         }
     })
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) fn __cbg_out_Operation(v: example_flat::Operation) -> operation_t {
+pub(crate) fn __c_out_convert_Operation_c_terminal_output_enum_to_wire_457f6036394dc821(
+    v: example_flat::Operation,
+) -> operation_t {
     match v {
         example_flat::Operation::Add => operation_t::Add,
         example_flat::Operation::Sub => operation_t::Sub,
@@ -753,19 +861,34 @@ pub(crate) fn __cbg_out_Operation(v: example_flat::Operation) -> operation_t {
         example_flat::Operation::Div => operation_t::Div,
     }
 }
+#[allow(non_snake_case, dead_code, unused)]
+pub(crate) fn __c_out_convert_Option_Grade_c_marker_optional_to_wire_e2c04af90b0abd17() {}
+#[allow(non_snake_case, dead_code, unused)]
+pub(crate) fn __c_out_convert_Option_f64_c_marker_optional_to_wire_c1ba5adc99623ff4() {}
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) fn __cbg_out_Shape(
+pub(crate) fn __c_out_convert_Shape_c_choice_intermediate_repr_c_tagged_union_to_wire_1c9175b2e9cd70a6(
     v: example_flat::Shape,
 ) -> ::core::mem::MaybeUninit<shape_t> {
     ::core::mem::MaybeUninit::new({
         match v {
             example_flat::Shape::Empty => shape_t::Empty,
             example_flat::Shape::Circle(__part0) => {
-                let __built_arm = (__cbg_out_f64(__part0),);
+                let __built_arm = (
+                    __c_out_convert_f64_c_terminal_output_scalar_to_wire_6aa94606ef14f673(
+                        __part0,
+                    ),
+                );
                 shape_t::Circle(__built_arm.0)
             }
             example_flat::Shape::Rect { width: __part0, height: __part1 } => {
-                let __built_arm = (__cbg_out_f64(__part0), __cbg_out_f64(__part1));
+                let __built_arm = (
+                    __c_out_convert_f64_c_terminal_output_scalar_to_wire_6aa94606ef14f673(
+                        __part0,
+                    ),
+                    __c_out_convert_f64_c_terminal_output_scalar_to_wire_6aa94606ef14f673(
+                        __part1,
+                    ),
+                );
                 shape_t::Rect {
                     width: __built_arm.0,
                     height: __built_arm.1,
@@ -773,8 +896,14 @@ pub(crate) fn __cbg_out_Shape(
             }
             example_flat::Shape::Labeled(__part0, __part1) => {
                 let __built_arm = (
-                    __cbg_out_String(__part0),
-                    ::core::mem::MaybeUninit::new(__cbg_out_Operation(__part1)),
+                    __c_out_convert_String_c_terminal_output_string_to_wire_182528409f6ab8d3(
+                        __part0,
+                    ),
+                    ::core::mem::MaybeUninit::new(
+                        __c_out_convert_Operation_c_terminal_output_enum_to_wire_457f6036394dc821(
+                            __part1,
+                        ),
+                    ),
                 );
                 shape_t::Labeled(__built_arm.0, __built_arm.1)
             }
@@ -782,48 +911,60 @@ pub(crate) fn __cbg_out_Shape(
     })
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) fn __cbg_out_String(v: ::std::string::String) -> *mut ::core::ffi::c_char {
+pub(crate) fn __c_out_convert_String_c_terminal_output_string_to_wire_182528409f6ab8d3(
+    v: ::std::string::String,
+) -> *mut ::core::ffi::c_char {
     __cbg_alloc_cstr(v)
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) fn __cbg_out_bool(v: bool) -> bool {
-    v
-}
-#[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) fn __cbg_out_bool_field(v: bool) -> ::core::mem::MaybeUninit<bool> {
+pub(crate) fn __c_out_convert_bool_c_terminal_output_bool_field_to_wire_6a810eb4cb986700(
+    v: bool,
+) -> ::core::mem::MaybeUninit<bool> {
     ::core::mem::MaybeUninit::new(v)
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
+pub(crate) fn __c_out_convert_bool_c_terminal_output_scalar_to_wire_cc0ad9760da17efd(
+    v: bool,
+) -> bool {
+    v
+}
+#[allow(non_snake_case, unused_variables, dead_code)]
+pub(crate) fn __c_out_convert_f64_c_terminal_output_scalar_to_wire_6aa94606ef14f673(
+    v: f64,
+) -> f64 {
+    v
+}
+#[allow(non_snake_case, unused_variables, dead_code)]
+pub(crate) fn __c_out_convert_i32_c_terminal_output_scalar_to_wire_ae82162f636ebcd5(
+    v: i32,
+) -> i32 {
+    v
+}
+#[allow(non_snake_case, unused_variables, dead_code)]
 #[inline(always)]
-pub(crate) fn __cbg_out_chain_vec_f64(v: ::std::vec::Vec<f64>) -> ::std::vec::Vec<f64> {
+pub(crate) fn __c_out_convert_sequence_Vec_f64_to_wire_ad99887ef4e62c28(
+    v: ::std::vec::Vec<f64>,
+) -> ::std::vec::Vec<f64> {
     {
         let __sequence_source = v;
         let mut __sequence_output: ::std::vec::Vec<f64> = ::std::vec::Vec::with_capacity(
             (__sequence_source).len(),
         );
         for __sequence_element in __sequence_source.into_iter() {
-            let __sequence_part = __cbg_out_f64(__sequence_element);
+            let __sequence_part = __c_out_convert_f64_c_terminal_output_scalar_to_wire_6aa94606ef14f673(
+                __sequence_element,
+            );
             __sequence_output.push(__sequence_part);
         }
         __sequence_output
     }
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) fn __cbg_out_f64(v: f64) -> f64 {
+pub(crate) fn __c_out_convert_u64_c_terminal_output_scalar_to_wire_518245fe60cf3590(
+    v: u64,
+) -> u64 {
     v
 }
-#[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) fn __cbg_out_i32(v: i32) -> i32 {
-    v
-}
-#[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) fn __cbg_out_u64(v: u64) -> u64 {
-    v
-}
-#[allow(non_snake_case, dead_code, unused)]
-pub(crate) fn __cbg_outmark_option_Grade() {}
-#[allow(non_snake_case, dead_code, unused)]
-pub(crate) fn __cbg_outmark_option_f64() {}
 #[no_mangle]
 #[allow(non_snake_case, unused_mut, unused_variables, unused_unsafe, dead_code)]
 pub unsafe extern "C" fn calculator_absorb(
@@ -837,7 +978,7 @@ pub unsafe extern "C" fn calculator_absorb(
             "aliasing arguments: `a` (consumed) and `b` (borrowed) are the same `Calculator` — a consumed or exclusively-borrowed resource may not be named twice in one call",
         );
         if !e.is_null() {
-            *e = __cbg_out_Error(
+            *e = __c_out_convert_Error_c_terminal_output_opaque_error_to_wire_9d010015abcb2259(
                 <example_flat::Error as ::core::convert::From<
                     ::std::string::String,
                 >>::from(__msg),
@@ -845,11 +986,13 @@ pub unsafe extern "C" fn calculator_absorb(
         }
         return false;
     }
-    let a = match __cbg_in_Calculator(a) {
+    let a = match __c_in_convert_wire_to_Calculator_c_terminal_input_owned_handle_b7bb400a642eb999(
+        a,
+    ) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__msg) => {
             if !e.is_null() {
-                *e = __cbg_out_Error(
+                *e = __c_out_convert_Error_c_terminal_output_opaque_error_to_wire_9d010015abcb2259(
                     <example_flat::Error as ::core::convert::From<
                         ::std::string::String,
                     >>::from(__msg),
@@ -858,11 +1001,13 @@ pub unsafe extern "C" fn calculator_absorb(
             return false;
         }
     };
-    let b = match __cbg_in___Calculator(b) {
+    let b = match __c_in_convert_wire_to_Calculator_c_borrow_shared_input_48be88e9df13aa53(
+        b,
+    ) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__msg) => {
             if !e.is_null() {
-                *e = __cbg_out_Error(
+                *e = __c_out_convert_Error_c_terminal_output_opaque_error_to_wire_9d010015abcb2259(
                     <example_flat::Error as ::core::convert::From<
                         ::std::string::String,
                     >>::from(__msg),
@@ -873,12 +1018,16 @@ pub unsafe extern "C" fn calculator_absorb(
     };
     match example_flat::calculator_absorb(a, b) {
         ::core::result::Result::Ok(__v) => {
-            *out = __cbg_out_f64(__v);
+            *out = __c_out_convert_f64_c_terminal_output_scalar_to_wire_6aa94606ef14f673(
+                __v,
+            );
             true
         }
         ::core::result::Result::Err(__err) => {
             if !e.is_null() {
-                *e = __cbg_out_Error(__err);
+                *e = __c_out_convert_Error_c_terminal_output_opaque_error_to_wire_9d010015abcb2259(
+                    __err,
+                );
             }
             false
         }
@@ -893,11 +1042,13 @@ pub unsafe extern "C" fn calculator_apply(
     out: *mut f64,
     e: *mut *mut ::core::ffi::c_char,
 ) -> bool {
-    let c = match __cbg_in___mut_Calculator(c) {
+    let c = match __c_in_convert_wire_to_Calculator_c_borrow_mutable_input_f30bfe45043bc69c(
+        c,
+    ) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__msg) => {
             if !e.is_null() {
-                *e = __cbg_out_Error(
+                *e = __c_out_convert_Error_c_terminal_output_opaque_error_to_wire_9d010015abcb2259(
                     <example_flat::Error as ::core::convert::From<
                         ::std::string::String,
                     >>::from(__msg),
@@ -906,11 +1057,13 @@ pub unsafe extern "C" fn calculator_apply(
             return false;
         }
     };
-    let op = match __cbg_in_Operation(op) {
+    let op = match __c_in_convert_wire_to_Operation_c_terminal_input_enum_a23b6023635a8da5(
+        op,
+    ) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__msg) => {
             if !e.is_null() {
-                *e = __cbg_out_Error(
+                *e = __c_out_convert_Error_c_terminal_output_opaque_error_to_wire_9d010015abcb2259(
                     <example_flat::Error as ::core::convert::From<
                         ::std::string::String,
                     >>::from(__msg),
@@ -919,15 +1072,21 @@ pub unsafe extern "C" fn calculator_apply(
             return false;
         }
     };
-    let operand = __cbg_in_f64(operand);
+    let operand = __c_in_convert_wire_to_f64_c_terminal_input_scalar_7d8a0a733495e599(
+        operand,
+    );
     match example_flat::calculator_apply(c, op, operand) {
         ::core::result::Result::Ok(__v) => {
-            *out = __cbg_out_f64(__v);
+            *out = __c_out_convert_f64_c_terminal_output_scalar_to_wire_6aa94606ef14f673(
+                __v,
+            );
             true
         }
         ::core::result::Result::Err(__err) => {
             if !e.is_null() {
-                *e = __cbg_out_Error(__err);
+                *e = __c_out_convert_Error_c_terminal_output_opaque_error_to_wire_9d010015abcb2259(
+                    __err,
+                );
             }
             false
         }
@@ -939,19 +1098,25 @@ pub unsafe extern "C" fn calculator_for_each(
     c: *const calculator_t,
     f: closure_value_t,
 ) {
-    let c = match __cbg_in___Calculator(c) {
+    let c = match __c_in_convert_wire_to_Calculator_c_borrow_shared_input_48be88e9df13aa53(
+        c,
+    ) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__msg) => {
             panic!("{}", __msg);
         }
     };
-    let f = __cbg_in_closure_value_t(f);
+    let f = __c_in_convert_wire_to_impl_Fn_f64_Send_Sync_static_c_invoke_callback_capture_88739bf29d2a9906(
+        f,
+    );
     example_flat::calculator_for_each(c, f);
 }
 #[no_mangle]
 #[allow(non_snake_case, unused_mut, unused_variables, unused_unsafe, dead_code)]
 pub unsafe extern "C" fn calculator_get_count(c: *const calculator_t) -> u64 {
-    let c = match __cbg_in___Calculator(c) {
+    let c = match __c_in_convert_wire_to_Calculator_c_borrow_shared_input_48be88e9df13aa53(
+        c,
+    ) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__msg) => {
             panic!("{}", __msg);
@@ -959,7 +1124,7 @@ pub unsafe extern "C" fn calculator_get_count(c: *const calculator_t) -> u64 {
     };
     let __v = example_flat::calculator_get_count(c);
     let __ret: u64;
-    __ret = __cbg_out_u64(__v);
+    __ret = __c_out_convert_u64_c_terminal_output_scalar_to_wire_518245fe60cf3590(__v);
     __ret
 }
 #[no_mangle]
@@ -968,7 +1133,9 @@ pub unsafe extern "C" fn calculator_get_history(
     c: *const calculator_t,
     len: *mut usize,
 ) -> *mut f64 {
-    let c = match __cbg_in___Calculator(c) {
+    let c = match __c_in_convert_wire_to_Calculator_c_borrow_shared_input_48be88e9df13aa53(
+        c,
+    ) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__msg) => {
             panic!("{}", __msg);
@@ -976,7 +1143,9 @@ pub unsafe extern "C" fn calculator_get_history(
     };
     let __v = example_flat::calculator_get_history(c);
     let __ret: *mut f64;
-    let __arr: ::std::vec::Vec<f64> = __cbg_out_chain_vec_f64(__v);
+    let __arr: ::std::vec::Vec<f64> = __c_out_convert_sequence_Vec_f64_to_wire_ad99887ef4e62c28(
+        __v,
+    );
     let (__p, __n) = __cbg_alloc_array(__arr);
     __ret = __p;
     *len = __n;
@@ -985,7 +1154,9 @@ pub unsafe extern "C" fn calculator_get_history(
 #[no_mangle]
 #[allow(non_snake_case, unused_mut, unused_variables, unused_unsafe, dead_code)]
 pub unsafe extern "C" fn calculator_get_value(c: *const calculator_t) -> f64 {
-    let c = match __cbg_in___Calculator(c) {
+    let c = match __c_in_convert_wire_to_Calculator_c_borrow_shared_input_48be88e9df13aa53(
+        c,
+    ) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__msg) => {
             panic!("{}", __msg);
@@ -993,7 +1164,7 @@ pub unsafe extern "C" fn calculator_get_value(c: *const calculator_t) -> f64 {
     };
     let __v = example_flat::calculator_get_value(c);
     let __ret: f64;
-    __ret = __cbg_out_f64(__v);
+    __ret = __c_out_convert_f64_c_terminal_output_scalar_to_wire_6aa94606ef14f673(__v);
     __ret
 }
 #[no_mangle]
@@ -1002,13 +1173,17 @@ pub unsafe extern "C" fn calculator_grade_or_none(
     c: *const calculator_t,
     f: closure_maybe_grade_t,
 ) {
-    let c = match __cbg_in___Calculator(c) {
+    let c = match __c_in_convert_wire_to_Calculator_c_borrow_shared_input_48be88e9df13aa53(
+        c,
+    ) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__msg) => {
             panic!("{}", __msg);
         }
     };
-    let f = __cbg_in_closure_maybe_grade_t(f);
+    let f = __c_in_convert_wire_to_impl_Fn_Option_Grade_Send_Sync_static_c_invoke_callback_capture_5512a1f2265e79a0(
+        f,
+    );
     example_flat::calculator_grade_or_none(c, f);
 }
 #[no_mangle]
@@ -1017,28 +1192,36 @@ pub unsafe extern "C" fn calculator_history_batch(
     c: *const calculator_t,
     f: closure_history_batch_t,
 ) {
-    let c = match __cbg_in___Calculator(c) {
+    let c = match __c_in_convert_wire_to_Calculator_c_borrow_shared_input_48be88e9df13aa53(
+        c,
+    ) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__msg) => {
             panic!("{}", __msg);
         }
     };
-    let f = __cbg_in_closure_history_batch_t(f);
+    let f = __c_in_convert_wire_to_impl_Fn_Vec_f64_Send_Sync_static_c_invoke_callback_capture_3dd7f8fbc61877ce(
+        f,
+    );
     example_flat::calculator_history_batch(c, f);
 }
 #[no_mangle]
 #[allow(non_snake_case, unused_mut, unused_variables, unused_unsafe, dead_code)]
 pub unsafe extern "C" fn calculator_is(c: *const calculator_t, value: f64) -> bool {
-    let c = match __cbg_in___Calculator(c) {
+    let c = match __c_in_convert_wire_to_Calculator_c_borrow_shared_input_48be88e9df13aa53(
+        c,
+    ) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__msg) => {
             panic!("{}", __msg);
         }
     };
-    let value = __cbg_in_f64(value);
+    let value = __c_in_convert_wire_to_f64_c_terminal_input_scalar_7d8a0a733495e599(
+        value,
+    );
     let __v = example_flat::calculator_is(c, value);
     let __ret: bool;
-    __ret = __cbg_out_bool(__v);
+    __ret = __c_out_convert_bool_c_terminal_output_scalar_to_wire_cc0ad9760da17efd(__v);
     __ret
 }
 #[no_mangle]
@@ -1047,13 +1230,17 @@ pub unsafe extern "C" fn calculator_last_or_none(
     c: *const calculator_t,
     f: closure_maybe_value_t,
 ) {
-    let c = match __cbg_in___Calculator(c) {
+    let c = match __c_in_convert_wire_to_Calculator_c_borrow_shared_input_48be88e9df13aa53(
+        c,
+    ) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__msg) => {
             panic!("{}", __msg);
         }
     };
-    let f = __cbg_in_closure_maybe_value_t(f);
+    let f = __c_in_convert_wire_to_impl_Fn_Option_f64_Send_Sync_static_c_invoke_callback_capture_053af7d76b4f1245(
+        f,
+    );
     example_flat::calculator_last_or_none(c, f);
 }
 #[no_mangle]
@@ -1068,7 +1255,7 @@ pub unsafe extern "C" fn calculator_merge(
             "aliasing arguments: `a` (consumed) and `b` (consumed) are the same `Calculator` — a consumed or exclusively-borrowed resource may not be named twice in one call",
         );
         if !e.is_null() {
-            *e = __cbg_out_Error(
+            *e = __c_out_convert_Error_c_terminal_output_opaque_error_to_wire_9d010015abcb2259(
                 <example_flat::Error as ::core::convert::From<
                     ::std::string::String,
                 >>::from(__msg),
@@ -1076,11 +1263,13 @@ pub unsafe extern "C" fn calculator_merge(
         }
         return ::core::ptr::null_mut();
     }
-    let a = match __cbg_in_Calculator(a) {
+    let a = match __c_in_convert_wire_to_Calculator_c_terminal_input_owned_handle_b7bb400a642eb999(
+        a,
+    ) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__msg) => {
             if !e.is_null() {
-                *e = __cbg_out_Error(
+                *e = __c_out_convert_Error_c_terminal_output_opaque_error_to_wire_9d010015abcb2259(
                     <example_flat::Error as ::core::convert::From<
                         ::std::string::String,
                     >>::from(__msg),
@@ -1089,11 +1278,13 @@ pub unsafe extern "C" fn calculator_merge(
             return ::core::ptr::null_mut();
         }
     };
-    let b = match __cbg_in_Calculator(b) {
+    let b = match __c_in_convert_wire_to_Calculator_c_terminal_input_owned_handle_b7bb400a642eb999(
+        b,
+    ) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__msg) => {
             if !e.is_null() {
-                *e = __cbg_out_Error(
+                *e = __c_out_convert_Error_c_terminal_output_opaque_error_to_wire_9d010015abcb2259(
                     <example_flat::Error as ::core::convert::From<
                         ::std::string::String,
                     >>::from(__msg),
@@ -1105,12 +1296,16 @@ pub unsafe extern "C" fn calculator_merge(
     match example_flat::calculator_merge(a, b) {
         ::core::result::Result::Ok(__v) => {
             let __ret: *mut calculator_t;
-            __ret = __cbg_out_Calculator(__v);
+            __ret = __c_out_convert_Calculator_c_terminal_output_owned_handle_to_wire_4d20353780559007(
+                __v,
+            );
             __ret
         }
         ::core::result::Result::Err(__err) => {
             if !e.is_null() {
-                *e = __cbg_out_Error(__err);
+                *e = __c_out_convert_Error_c_terminal_output_opaque_error_to_wire_9d010015abcb2259(
+                    __err,
+                );
             }
             ::core::ptr::null_mut()
         }
@@ -1121,7 +1316,9 @@ pub unsafe extern "C" fn calculator_merge(
 pub unsafe extern "C" fn calculator_new() -> *mut calculator_t {
     let __v = example_flat::calculator_new();
     let __ret: *mut calculator_t;
-    __ret = __cbg_out_Calculator(__v);
+    __ret = __c_out_convert_Calculator_c_terminal_output_owned_handle_to_wire_4d20353780559007(
+        __v,
+    );
     __ret
 }
 #[no_mangle]
@@ -1129,7 +1326,9 @@ pub unsafe extern "C" fn calculator_new() -> *mut calculator_t {
 pub unsafe extern "C" fn calculator_new_clone(
     c: *const calculator_t,
 ) -> *mut calculator_t {
-    let c = match __cbg_in___Calculator(c) {
+    let c = match __c_in_convert_wire_to_Calculator_c_borrow_shared_input_48be88e9df13aa53(
+        c,
+    ) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__msg) => {
             panic!("{}", __msg);
@@ -1137,7 +1336,9 @@ pub unsafe extern "C" fn calculator_new_clone(
     };
     let __v = example_flat::calculator_new_clone(c);
     let __ret: *mut calculator_t;
-    __ret = __cbg_out_Calculator(__v);
+    __ret = __c_out_convert_Calculator_c_terminal_output_owned_handle_to_wire_4d20353780559007(
+        __v,
+    );
     __ret
 }
 #[no_mangle]
@@ -1146,11 +1347,11 @@ pub unsafe extern "C" fn calculator_new_from_str(
     s: *const ::core::ffi::c_char,
     e: *mut *mut ::core::ffi::c_char,
 ) -> *mut calculator_t {
-    let s = match __cbg_in___str(s) {
+    let s = match __c_in_convert_wire_to_str_c_borrow_str_input_246c2b9955bb6ef2(s) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__msg) => {
             if !e.is_null() {
-                *e = __cbg_out_Error(
+                *e = __c_out_convert_Error_c_terminal_output_opaque_error_to_wire_9d010015abcb2259(
                     <example_flat::Error as ::core::convert::From<
                         ::std::string::String,
                     >>::from(__msg),
@@ -1162,12 +1363,16 @@ pub unsafe extern "C" fn calculator_new_from_str(
     match example_flat::calculator_new_from_str(s) {
         ::core::result::Result::Ok(__v) => {
             let __ret: *mut calculator_t;
-            __ret = __cbg_out_Calculator(__v);
+            __ret = __c_out_convert_Calculator_c_terminal_output_owned_handle_to_wire_4d20353780559007(
+                __v,
+            );
             __ret
         }
         ::core::result::Result::Err(__err) => {
             if !e.is_null() {
-                *e = __cbg_out_Error(__err);
+                *e = __c_out_convert_Error_c_terminal_output_opaque_error_to_wire_9d010015abcb2259(
+                    __err,
+                );
             }
             ::core::ptr::null_mut()
         }
@@ -1178,7 +1383,9 @@ pub unsafe extern "C" fn calculator_new_from_str(
 pub unsafe extern "C" fn calculator_to_string(
     c: *const calculator_t,
 ) -> *mut ::core::ffi::c_char {
-    let c = match __cbg_in___Calculator(c) {
+    let c = match __c_in_convert_wire_to_Calculator_c_borrow_shared_input_48be88e9df13aa53(
+        c,
+    ) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__msg) => {
             panic!("{}", __msg);
@@ -1186,7 +1393,9 @@ pub unsafe extern "C" fn calculator_to_string(
     };
     let __v = example_flat::calculator_to_string(c);
     let __ret: *mut ::core::ffi::c_char;
-    __ret = __cbg_out_String(__v);
+    __ret = __c_out_convert_String_c_terminal_output_string_to_wire_182528409f6ab8d3(
+        __v,
+    );
     __ret
 }
 #[no_mangle]
@@ -1196,17 +1405,23 @@ pub unsafe extern "C" fn caption_new(
     text: *const ::core::ffi::c_char,
     emphatic: ::core::mem::MaybeUninit<bool>,
 ) -> caption_t {
-    let id = __cbg_in_u64(id);
-    let text = match __cbg_in___str(text) {
+    let id = __c_in_convert_wire_to_u64_c_terminal_input_scalar_4e87470ad83635c8(id);
+    let text = match __c_in_convert_wire_to_str_c_borrow_str_input_246c2b9955bb6ef2(
+        text,
+    ) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__msg) => {
             panic!("{}", __msg);
         }
     };
-    let emphatic = __cbg_in_bool(emphatic);
+    let emphatic = __c_in_convert_wire_to_bool_c_terminal_input_bool_e48e0629cd6287b3(
+        emphatic,
+    );
     let __v = example_flat::caption_new(id, text, emphatic);
     let __ret: caption_t;
-    __ret = __cbg_out_Caption(__v);
+    __ret = __c_out_convert_Caption_c_product_intermediate_repr_c_struct_to_wire_3bc5d236333a6e28(
+        __v,
+    );
     __ret
 }
 #[no_mangle]
@@ -1214,7 +1429,9 @@ pub unsafe extern "C" fn caption_new(
 pub unsafe extern "C" fn drawing_get_shape(
     d: drawing_t,
 ) -> ::core::mem::MaybeUninit<shape_t> {
-    let d = match __cbg_in_Drawing(d) {
+    let d = match __c_in_convert_wire_to_Drawing_c_product_intermediate_repr_c_struct_3b927b21caf2df63(
+        d,
+    ) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__msg) => {
             panic!("{}", __msg);
@@ -1222,7 +1439,9 @@ pub unsafe extern "C" fn drawing_get_shape(
     };
     let __v = example_flat::drawing_get_shape(d);
     let __ret: ::core::mem::MaybeUninit<shape_t>;
-    __ret = __cbg_out_Shape(__v);
+    __ret = __c_out_convert_Shape_c_choice_intermediate_repr_c_tagged_union_to_wire_1c9175b2e9cd70a6(
+        __v,
+    );
     __ret
 }
 #[no_mangle]
@@ -1231,8 +1450,10 @@ pub unsafe extern "C" fn drawing_new(
     id: u64,
     shape: ::core::mem::MaybeUninit<shape_t>,
 ) -> drawing_t {
-    let id = __cbg_in_u64(id);
-    let shape = match __cbg_in_Shape(shape) {
+    let id = __c_in_convert_wire_to_u64_c_terminal_input_scalar_4e87470ad83635c8(id);
+    let shape = match __c_in_convert_wire_to_Shape_c_choice_intermediate_repr_c_tagged_union_8ddb52c185c8b923(
+        shape,
+    ) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__msg) => {
             panic!("{}", __msg);
@@ -1240,25 +1461,31 @@ pub unsafe extern "C" fn drawing_new(
     };
     let __v = example_flat::drawing_new(id, shape);
     let __ret: drawing_t;
-    __ret = __cbg_out_Drawing(__v);
+    __ret = __c_out_convert_Drawing_c_product_intermediate_repr_c_struct_to_wire_50eac9aa069a6838(
+        __v,
+    );
     __ret
 }
 #[no_mangle]
 #[allow(non_snake_case, unused_mut, unused_variables, unused_unsafe, dead_code)]
 pub unsafe extern "C" fn foo_get_id(f: foo_t) -> u64 {
-    let f = __cbg_in_Foo(f);
+    let f = __c_in_convert_wire_to_Foo_c_product_intermediate_repr_c_struct_157d1b61f2a5b9d5(
+        f,
+    );
     let __v = example_flat::foo_get_id(f);
     let __ret: u64;
-    __ret = __cbg_out_u64(__v);
+    __ret = __c_out_convert_u64_c_terminal_output_scalar_to_wire_518245fe60cf3590(__v);
     __ret
 }
 #[no_mangle]
 #[allow(non_snake_case, unused_mut, unused_variables, unused_unsafe, dead_code)]
 pub unsafe extern "C" fn foo_new(id: u64) -> foo_t {
-    let id = __cbg_in_u64(id);
+    let id = __c_in_convert_wire_to_u64_c_terminal_input_scalar_4e87470ad83635c8(id);
     let __v = example_flat::foo_new(id);
     let __ret: foo_t;
-    __ret = __cbg_out_Foo(__v);
+    __ret = __c_out_convert_Foo_c_product_intermediate_repr_c_struct_to_wire_02ab0b068798553e(
+        __v,
+    );
     __ret
 }
 #[no_mangle]
@@ -1266,7 +1493,9 @@ pub unsafe extern "C" fn foo_new(id: u64) -> foo_t {
 pub unsafe extern "C" fn inside_foo_default() -> inside_foo_t {
     let __v = example_flat::inside_foo_default();
     let __ret: inside_foo_t;
-    __ret = __cbg_out_InsideFoo(__v);
+    __ret = __c_out_convert_InsideFoo_c_terminal_output_enum_to_wire_b103ad5e4be33376(
+        __v,
+    );
     __ret
 }
 #[no_mangle]
@@ -1274,7 +1503,9 @@ pub unsafe extern "C" fn inside_foo_default() -> inside_foo_t {
 pub unsafe extern "C" fn inside_foo_value(
     x: ::core::mem::MaybeUninit<inside_foo_t>,
 ) -> i32 {
-    let x = match __cbg_in_InsideFoo(x) {
+    let x = match __c_in_convert_wire_to_InsideFoo_c_terminal_input_enum_70ed7847e05e3330(
+        x,
+    ) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__msg) => {
             panic!("{}", __msg);
@@ -1282,13 +1513,15 @@ pub unsafe extern "C" fn inside_foo_value(
     };
     let __v = example_flat::inside_foo_value(x);
     let __ret: i32;
-    __ret = __cbg_out_i32(__v);
+    __ret = __c_out_convert_i32_c_terminal_output_scalar_to_wire_ae82162f636ebcd5(__v);
     __ret
 }
 #[no_mangle]
 #[allow(non_snake_case, unused_mut, unused_variables, unused_unsafe, dead_code)]
 pub unsafe extern "C" fn note_emphatic(n: ::core::mem::MaybeUninit<note_t>) -> bool {
-    let n = match __cbg_in_Note(n) {
+    let n = match __c_in_convert_wire_to_Note_c_choice_intermediate_repr_c_tagged_union_4de1f2981255d608(
+        n,
+    ) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__msg) => {
             panic!("{}", __msg);
@@ -1296,7 +1529,7 @@ pub unsafe extern "C" fn note_emphatic(n: ::core::mem::MaybeUninit<note_t>) -> b
     };
     let __v = example_flat::note_emphatic(n);
     let __ret: bool;
-    __ret = __cbg_out_bool(__v);
+    __ret = __c_out_convert_bool_c_terminal_output_scalar_to_wire_cc0ad9760da17efd(__v);
     __ret
 }
 #[no_mangle]
@@ -1304,10 +1537,14 @@ pub unsafe extern "C" fn note_emphatic(n: ::core::mem::MaybeUninit<note_t>) -> b
 pub unsafe extern "C" fn note_new_after(
     millis: u64,
 ) -> ::core::mem::MaybeUninit<note_t> {
-    let millis = __cbg_in_u64(millis);
+    let millis = __c_in_convert_wire_to_u64_c_terminal_input_scalar_4e87470ad83635c8(
+        millis,
+    );
     let __v = example_flat::note_new_after(millis);
     let __ret: ::core::mem::MaybeUninit<note_t>;
-    __ret = __cbg_out_Note(__v);
+    __ret = __c_out_convert_Note_c_choice_intermediate_repr_c_tagged_union_to_wire_c9cea85d5266d21b(
+        __v,
+    );
     __ret
 }
 #[no_mangle]
@@ -1315,10 +1552,12 @@ pub unsafe extern "C" fn note_new_after(
 pub unsafe extern "C" fn note_new_flagged(
     flag: ::core::mem::MaybeUninit<bool>,
 ) -> ::core::mem::MaybeUninit<note_t> {
-    let flag = __cbg_in_bool(flag);
+    let flag = __c_in_convert_wire_to_bool_c_terminal_input_bool_e48e0629cd6287b3(flag);
     let __v = example_flat::note_new_flagged(flag);
     let __ret: ::core::mem::MaybeUninit<note_t>;
-    __ret = __cbg_out_Note(__v);
+    __ret = __c_out_convert_Note_c_choice_intermediate_repr_c_tagged_union_to_wire_c9cea85d5266d21b(
+        __v,
+    );
     __ret
 }
 #[no_mangle]
@@ -1326,7 +1565,9 @@ pub unsafe extern "C" fn note_new_flagged(
 pub unsafe extern "C" fn note_new_silent() -> ::core::mem::MaybeUninit<note_t> {
     let __v = example_flat::note_new_silent();
     let __ret: ::core::mem::MaybeUninit<note_t>;
-    __ret = __cbg_out_Note(__v);
+    __ret = __c_out_convert_Note_c_choice_intermediate_repr_c_tagged_union_to_wire_c9cea85d5266d21b(
+        __v,
+    );
     __ret
 }
 #[no_mangle]
@@ -1335,8 +1576,10 @@ pub unsafe extern "C" fn note_new_sketched(
     id: u64,
     label: *const ::core::ffi::c_char,
 ) -> ::core::mem::MaybeUninit<note_t> {
-    let id = __cbg_in_u64(id);
-    let label = match __cbg_in___str(label) {
+    let id = __c_in_convert_wire_to_u64_c_terminal_input_scalar_4e87470ad83635c8(id);
+    let label = match __c_in_convert_wire_to_str_c_borrow_str_input_246c2b9955bb6ef2(
+        label,
+    ) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__msg) => {
             panic!("{}", __msg);
@@ -1344,7 +1587,9 @@ pub unsafe extern "C" fn note_new_sketched(
     };
     let __v = example_flat::note_new_sketched(id, label);
     let __ret: ::core::mem::MaybeUninit<note_t>;
-    __ret = __cbg_out_Note(__v);
+    __ret = __c_out_convert_Note_c_choice_intermediate_repr_c_tagged_union_to_wire_c9cea85d5266d21b(
+        __v,
+    );
     __ret
 }
 #[no_mangle]
@@ -1354,23 +1599,31 @@ pub unsafe extern "C" fn note_new_titled(
     text: *const ::core::ffi::c_char,
     emphatic: ::core::mem::MaybeUninit<bool>,
 ) -> ::core::mem::MaybeUninit<note_t> {
-    let id = __cbg_in_u64(id);
-    let text = match __cbg_in___str(text) {
+    let id = __c_in_convert_wire_to_u64_c_terminal_input_scalar_4e87470ad83635c8(id);
+    let text = match __c_in_convert_wire_to_str_c_borrow_str_input_246c2b9955bb6ef2(
+        text,
+    ) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__msg) => {
             panic!("{}", __msg);
         }
     };
-    let emphatic = __cbg_in_bool(emphatic);
+    let emphatic = __c_in_convert_wire_to_bool_c_terminal_input_bool_e48e0629cd6287b3(
+        emphatic,
+    );
     let __v = example_flat::note_new_titled(id, text, emphatic);
     let __ret: ::core::mem::MaybeUninit<note_t>;
-    __ret = __cbg_out_Note(__v);
+    __ret = __c_out_convert_Note_c_choice_intermediate_repr_c_tagged_union_to_wire_c9cea85d5266d21b(
+        __v,
+    );
     __ret
 }
 #[no_mangle]
 #[allow(non_snake_case, unused_mut, unused_variables, unused_unsafe, dead_code)]
 pub unsafe extern "C" fn note_value(n: ::core::mem::MaybeUninit<note_t>) -> u64 {
-    let n = match __cbg_in_Note(n) {
+    let n = match __c_in_convert_wire_to_Note_c_choice_intermediate_repr_c_tagged_union_4de1f2981255d608(
+        n,
+    ) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__msg) => {
             panic!("{}", __msg);
@@ -1378,13 +1631,15 @@ pub unsafe extern "C" fn note_value(n: ::core::mem::MaybeUninit<note_t>) -> u64 
     };
     let __v = example_flat::note_value(n);
     let __ret: u64;
-    __ret = __cbg_out_u64(__v);
+    __ret = __c_out_convert_u64_c_terminal_output_scalar_to_wire_518245fe60cf3590(__v);
     __ret
 }
 #[no_mangle]
 #[allow(non_snake_case, unused_mut, unused_variables, unused_unsafe, dead_code)]
 pub unsafe extern "C" fn shape_area(s: ::core::mem::MaybeUninit<shape_t>) -> f64 {
-    let s = match __cbg_in_Shape(s) {
+    let s = match __c_in_convert_wire_to_Shape_c_choice_intermediate_repr_c_tagged_union_8ddb52c185c8b923(
+        s,
+    ) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__msg) => {
             panic!("{}", __msg);
@@ -1392,7 +1647,7 @@ pub unsafe extern "C" fn shape_area(s: ::core::mem::MaybeUninit<shape_t>) -> f64
     };
     let __v = example_flat::shape_area(s);
     let __ret: f64;
-    __ret = __cbg_out_f64(__v);
+    __ret = __c_out_convert_f64_c_terminal_output_scalar_to_wire_6aa94606ef14f673(__v);
     __ret
 }
 #[no_mangle]
@@ -1400,7 +1655,9 @@ pub unsafe extern "C" fn shape_area(s: ::core::mem::MaybeUninit<shape_t>) -> f64
 pub unsafe extern "C" fn shape_get_label(
     s: ::core::mem::MaybeUninit<shape_t>,
 ) -> *mut ::core::ffi::c_char {
-    let s = match __cbg_in_Shape(s) {
+    let s = match __c_in_convert_wire_to_Shape_c_choice_intermediate_repr_c_tagged_union_8ddb52c185c8b923(
+        s,
+    ) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__msg) => {
             panic!("{}", __msg);
@@ -1408,7 +1665,9 @@ pub unsafe extern "C" fn shape_get_label(
     };
     let __v = example_flat::shape_get_label(s);
     let __ret: *mut ::core::ffi::c_char;
-    __ret = __cbg_out_String(__v);
+    __ret = __c_out_convert_String_c_terminal_output_string_to_wire_182528409f6ab8d3(
+        __v,
+    );
     __ret
 }
 #[no_mangle]
@@ -1416,10 +1675,14 @@ pub unsafe extern "C" fn shape_get_label(
 pub unsafe extern "C" fn shape_new_circle(
     radius: f64,
 ) -> ::core::mem::MaybeUninit<shape_t> {
-    let radius = __cbg_in_f64(radius);
+    let radius = __c_in_convert_wire_to_f64_c_terminal_input_scalar_7d8a0a733495e599(
+        radius,
+    );
     let __v = example_flat::shape_new_circle(radius);
     let __ret: ::core::mem::MaybeUninit<shape_t>;
-    __ret = __cbg_out_Shape(__v);
+    __ret = __c_out_convert_Shape_c_choice_intermediate_repr_c_tagged_union_to_wire_1c9175b2e9cd70a6(
+        __v,
+    );
     __ret
 }
 #[no_mangle]
@@ -1427,7 +1690,9 @@ pub unsafe extern "C" fn shape_new_circle(
 pub unsafe extern "C" fn shape_new_empty() -> ::core::mem::MaybeUninit<shape_t> {
     let __v = example_flat::shape_new_empty();
     let __ret: ::core::mem::MaybeUninit<shape_t>;
-    __ret = __cbg_out_Shape(__v);
+    __ret = __c_out_convert_Shape_c_choice_intermediate_repr_c_tagged_union_to_wire_1c9175b2e9cd70a6(
+        __v,
+    );
     __ret
 }
 #[no_mangle]
@@ -1436,13 +1701,17 @@ pub unsafe extern "C" fn shape_new_labeled(
     label: *const ::core::ffi::c_char,
     op: ::core::mem::MaybeUninit<operation_t>,
 ) -> ::core::mem::MaybeUninit<shape_t> {
-    let label = match __cbg_in___str(label) {
+    let label = match __c_in_convert_wire_to_str_c_borrow_str_input_246c2b9955bb6ef2(
+        label,
+    ) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__msg) => {
             panic!("{}", __msg);
         }
     };
-    let op = match __cbg_in_Operation(op) {
+    let op = match __c_in_convert_wire_to_Operation_c_terminal_input_enum_a23b6023635a8da5(
+        op,
+    ) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__msg) => {
             panic!("{}", __msg);
@@ -1450,7 +1719,9 @@ pub unsafe extern "C" fn shape_new_labeled(
     };
     let __v = example_flat::shape_new_labeled(label, op);
     let __ret: ::core::mem::MaybeUninit<shape_t>;
-    __ret = __cbg_out_Shape(__v);
+    __ret = __c_out_convert_Shape_c_choice_intermediate_repr_c_tagged_union_to_wire_1c9175b2e9cd70a6(
+        __v,
+    );
     __ret
 }
 #[no_mangle]
@@ -1459,11 +1730,17 @@ pub unsafe extern "C" fn shape_new_rect(
     width: f64,
     height: f64,
 ) -> ::core::mem::MaybeUninit<shape_t> {
-    let width = __cbg_in_f64(width);
-    let height = __cbg_in_f64(height);
+    let width = __c_in_convert_wire_to_f64_c_terminal_input_scalar_7d8a0a733495e599(
+        width,
+    );
+    let height = __c_in_convert_wire_to_f64_c_terminal_input_scalar_7d8a0a733495e599(
+        height,
+    );
     let __v = example_flat::shape_new_rect(width, height);
     let __ret: ::core::mem::MaybeUninit<shape_t>;
-    __ret = __cbg_out_Shape(__v);
+    __ret = __c_out_convert_Shape_c_choice_intermediate_repr_c_tagged_union_to_wire_1c9175b2e9cd70a6(
+        __v,
+    );
     __ret
 }
 #[no_mangle]
@@ -1473,11 +1750,13 @@ pub unsafe extern "C" fn shape_try_area(
     out: *mut f64,
     e: *mut *mut ::core::ffi::c_char,
 ) -> bool {
-    let s = match __cbg_in_Shape(s) {
+    let s = match __c_in_convert_wire_to_Shape_c_choice_intermediate_repr_c_tagged_union_8ddb52c185c8b923(
+        s,
+    ) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__msg) => {
             if !e.is_null() {
-                *e = __cbg_out_Error(
+                *e = __c_out_convert_Error_c_terminal_output_opaque_error_to_wire_9d010015abcb2259(
                     <example_flat::Error as ::core::convert::From<
                         ::std::string::String,
                     >>::from(__msg),
@@ -1488,12 +1767,16 @@ pub unsafe extern "C" fn shape_try_area(
     };
     match example_flat::shape_try_area(s) {
         ::core::result::Result::Ok(__v) => {
-            *out = __cbg_out_f64(__v);
+            *out = __c_out_convert_f64_c_terminal_output_scalar_to_wire_6aa94606ef14f673(
+                __v,
+            );
             true
         }
         ::core::result::Result::Err(__err) => {
             if !e.is_null() {
-                *e = __cbg_out_Error(__err);
+                *e = __c_out_convert_Error_c_terminal_output_opaque_error_to_wire_9d010015abcb2259(
+                    __err,
+                );
             }
             false
         }

--- a/examples/example-cbindgen/generated/example_flat_x86_64_internal_unstable.rs
+++ b/examples/example-cbindgen/generated/example_flat_x86_64_internal_unstable.rs
@@ -178,7 +178,7 @@ pub struct closure_history_batch_t {
     pub drop: ::core::option::Option<unsafe extern "C" fn(*mut ::core::ffi::c_void)>,
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) unsafe fn __cbg_in_closure_history_batch_t(
+pub(crate) unsafe fn __c_in_convert_wire_to_impl_Fn_Vec_f64_Send_Sync_static_c_invoke_callback_capture_3dd7f8fbc61877ce(
     c: closure_history_batch_t,
 ) -> impl Fn(::std::vec::Vec<f64>) + Send + Sync + 'static {
     struct __Ctx {
@@ -203,7 +203,9 @@ pub(crate) unsafe fn __cbg_in_closure_history_batch_t(
         if let ::core::option::Option::Some(__f) = __call {
             let mut __w0_0 = ::core::mem::MaybeUninit::<*mut f64>::zeroed();
             let mut __w0_1 = ::core::mem::MaybeUninit::<usize>::zeroed();
-            let __arr: ::std::vec::Vec<f64> = __cbg_out_chain_vec_f64(__a0);
+            let __arr: ::std::vec::Vec<f64> = __c_out_convert_sequence_Vec_f64_to_wire_ad99887ef4e62c28(
+                __a0,
+            );
             let (__p, __n) = __cbg_alloc_array(__arr);
             *__w0_0.as_mut_ptr() = __p;
             *__w0_1.as_mut_ptr() = __n;
@@ -225,7 +227,7 @@ pub struct closure_maybe_grade_t {
     pub drop: ::core::option::Option<unsafe extern "C" fn(*mut ::core::ffi::c_void)>,
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) unsafe fn __cbg_in_closure_maybe_grade_t(
+pub(crate) unsafe fn __c_in_convert_wire_to_impl_Fn_Option_Grade_Send_Sync_static_c_invoke_callback_capture_5512a1f2265e79a0(
     c: closure_maybe_grade_t,
 ) -> impl Fn(::core::option::Option<example_flat::Grade>) + Send + Sync + 'static {
     struct __Ctx {
@@ -253,7 +255,9 @@ pub(crate) unsafe fn __cbg_in_closure_maybe_grade_t(
             match __a0 {
                 ::core::option::Option::Some(__x) => {
                     *__w0_0.as_mut_ptr() = true;
-                    *__w0_1.as_mut_ptr() = __cbg_out_Grade(__x);
+                    *__w0_1.as_mut_ptr() = __c_out_convert_Grade_c_terminal_output_enum_to_wire_a59c7b101e0a9e37(
+                        __x,
+                    );
                 }
                 ::core::option::Option::None => {
                     *__w0_0.as_mut_ptr() = false;
@@ -277,7 +281,7 @@ pub struct closure_maybe_value_t {
     pub drop: ::core::option::Option<unsafe extern "C" fn(*mut ::core::ffi::c_void)>,
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) unsafe fn __cbg_in_closure_maybe_value_t(
+pub(crate) unsafe fn __c_in_convert_wire_to_impl_Fn_Option_f64_Send_Sync_static_c_invoke_callback_capture_053af7d76b4f1245(
     c: closure_maybe_value_t,
 ) -> impl Fn(::core::option::Option<f64>) + Send + Sync + 'static {
     struct __Ctx {
@@ -305,7 +309,9 @@ pub(crate) unsafe fn __cbg_in_closure_maybe_value_t(
             match __a0 {
                 ::core::option::Option::Some(__x) => {
                     *__w0_0.as_mut_ptr() = true;
-                    *__w0_1.as_mut_ptr() = __cbg_out_f64(__x);
+                    *__w0_1.as_mut_ptr() = __c_out_convert_f64_c_terminal_output_scalar_to_wire_6aa94606ef14f673(
+                        __x,
+                    );
                 }
                 ::core::option::Option::None => {
                     *__w0_0.as_mut_ptr() = false;
@@ -325,7 +331,7 @@ pub struct closure_value_t {
     pub drop: ::core::option::Option<unsafe extern "C" fn(*mut ::core::ffi::c_void)>,
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) unsafe fn __cbg_in_closure_value_t(
+pub(crate) unsafe fn __c_in_convert_wire_to_impl_Fn_f64_Send_Sync_static_c_invoke_callback_capture_88739bf29d2a9906(
     c: closure_value_t,
 ) -> impl Fn(f64) + Send + Sync + 'static {
     struct __Ctx {
@@ -348,13 +354,41 @@ pub(crate) unsafe fn __cbg_in_closure_value_t(
     });
     move |__a0: f64| {
         if let ::core::option::Option::Some(__f) = __call {
-            let __w0 = __cbg_out_f64(__a0);
+            let __w0 = __c_out_convert_f64_c_terminal_output_scalar_to_wire_6aa94606ef14f673(
+                __a0,
+            );
             unsafe { __f(__w0, __ctx.context) }
         }
     }
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) unsafe fn __cbg_in_Calculator(
+pub(crate) unsafe fn __c_in_convert_wire_to_Calculator_c_borrow_mutable_input_f30bfe45043bc69c<
+    'a,
+>(
+    v: *mut calculator_t,
+) -> ::core::result::Result<&'a mut example_flat::Calculator, ::std::string::String> {
+    if v.is_null() {
+        return ::core::result::Result::Err(
+            ::std::string::String::from("null Calculator pointer"),
+        );
+    }
+    ::core::result::Result::Ok(&mut *(v as *mut example_flat::Calculator))
+}
+#[allow(non_snake_case, unused_variables, dead_code)]
+pub(crate) unsafe fn __c_in_convert_wire_to_Calculator_c_borrow_shared_input_48be88e9df13aa53<
+    'a,
+>(
+    v: *const calculator_t,
+) -> ::core::result::Result<&'a example_flat::Calculator, ::std::string::String> {
+    if v.is_null() {
+        return ::core::result::Result::Err(
+            ::std::string::String::from("null Calculator pointer"),
+        );
+    }
+    ::core::result::Result::Ok(&*(v as *const example_flat::Calculator))
+}
+#[allow(non_snake_case, unused_variables, dead_code)]
+pub(crate) unsafe fn __c_in_convert_wire_to_Calculator_c_terminal_input_owned_handle_b7bb400a642eb999(
     v: *mut calculator_t,
 ) -> ::core::result::Result<example_flat::Calculator, ::std::string::String> {
     if v.is_null() {
@@ -367,32 +401,46 @@ pub(crate) unsafe fn __cbg_in_Calculator(
     )
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) unsafe fn __cbg_in_Caption(v: caption_t) -> example_flat::Caption {
+pub(crate) unsafe fn __c_in_convert_wire_to_Caption_c_product_intermediate_repr_c_struct_a9076d1a0d6740b3(
+    v: caption_t,
+) -> example_flat::Caption {
     example_flat::Caption {
-        id: __cbg_in_u64(v.id),
-        text: __cbg_in_String_field(v.text),
-        emphatic: __cbg_in_bool(v.emphatic),
+        id: __c_in_convert_wire_to_u64_c_terminal_input_scalar_4e87470ad83635c8(v.id),
+        text: __c_in_convert_wire_to_String_c_terminal_input_string_field_b6091e2e8553ccde(
+            v.text,
+        ),
+        emphatic: __c_in_convert_wire_to_bool_c_terminal_input_bool_e48e0629cd6287b3(
+            v.emphatic,
+        ),
     }
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) unsafe fn __cbg_in_Drawing(
+pub(crate) unsafe fn __c_in_convert_wire_to_Drawing_c_product_intermediate_repr_c_struct_3b927b21caf2df63(
     v: drawing_t,
 ) -> ::core::result::Result<example_flat::Drawing, ::std::string::String> {
     ::core::result::Result::Ok(example_flat::Drawing {
-        id: __cbg_in_u64(v.id),
-        shape: __cbg_in_Shape(v.shape)?,
+        id: __c_in_convert_wire_to_u64_c_terminal_input_scalar_4e87470ad83635c8(v.id),
+        shape: __c_in_convert_wire_to_Shape_c_choice_intermediate_repr_c_tagged_union_8ddb52c185c8b923(
+            v.shape,
+        )?,
     })
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) unsafe fn __cbg_in_Foo(v: foo_t) -> example_flat::Foo {
+pub(crate) unsafe fn __c_in_convert_wire_to_Foo_c_product_intermediate_repr_c_struct_157d1b61f2a5b9d5(
+    v: foo_t,
+) -> example_flat::Foo {
     example_flat::Foo {
-        id: __cbg_in_u64(v.id),
-        x86_64_field: __cbg_in_u64(v.x86_64_field),
-        unstable_field: __cbg_in_u64(v.unstable_field),
+        id: __c_in_convert_wire_to_u64_c_terminal_input_scalar_4e87470ad83635c8(v.id),
+        x86_64_field: __c_in_convert_wire_to_u64_c_terminal_input_scalar_4e87470ad83635c8(
+            v.x86_64_field,
+        ),
+        unstable_field: __c_in_convert_wire_to_u64_c_terminal_input_scalar_4e87470ad83635c8(
+            v.unstable_field,
+        ),
     }
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) unsafe fn __cbg_in_InsideFoo(
+pub(crate) unsafe fn __c_in_convert_wire_to_InsideFoo_c_terminal_input_enum_70ed7847e05e3330(
     v: ::core::mem::MaybeUninit<inside_foo_t>,
 ) -> ::core::result::Result<example_flat::InsideFoo, ::std::string::String> {
     const _: () = {
@@ -421,11 +469,13 @@ pub(crate) unsafe fn __cbg_in_InsideFoo(
     )
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) fn __cbg_in_Millis(v: u64) -> example_flat::Millis {
+pub(crate) fn __c_in_convert_wire_to_Millis_c_terminal_custom_771f8034eae1c639(
+    v: u64,
+) -> example_flat::Millis {
     example_flat::millis_from_raw(v)
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) unsafe fn __cbg_in_Note(
+pub(crate) unsafe fn __c_in_convert_wire_to_Note_c_choice_intermediate_repr_c_tagged_union_4de1f2981255d608(
     v: ::core::mem::MaybeUninit<note_t>,
 ) -> ::core::result::Result<example_flat::Note, ::std::string::String> {
     ::core::result::Result::Ok({
@@ -451,7 +501,11 @@ pub(crate) unsafe fn __cbg_in_Note(
                         }
                     }
                 };
-                example_flat::Note::Titled(__cbg_in_Caption((__arm).0))
+                example_flat::Note::Titled(
+                    __c_in_convert_wire_to_Caption_c_product_intermediate_repr_c_struct_a9076d1a0d6740b3(
+                        (__arm).0,
+                    ),
+                )
             }
             2 => {
                 let __choice = unsafe { (v).assume_init() };
@@ -463,7 +517,11 @@ pub(crate) unsafe fn __cbg_in_Note(
                         }
                     }
                 };
-                example_flat::Note::After(__cbg_in_Millis((__arm).0))
+                example_flat::Note::After(
+                    __c_in_convert_wire_to_Millis_c_terminal_custom_771f8034eae1c639(
+                        (__arm).0,
+                    ),
+                )
             }
             3 => {
                 let __choice = unsafe { (v).assume_init() };
@@ -475,7 +533,11 @@ pub(crate) unsafe fn __cbg_in_Note(
                         }
                     }
                 };
-                example_flat::Note::Flagged(__cbg_in_bool((__arm).0))
+                example_flat::Note::Flagged(
+                    __c_in_convert_wire_to_bool_c_terminal_input_bool_e48e0629cd6287b3(
+                        (__arm).0,
+                    ),
+                )
             }
             4 => {
                 let __choice = unsafe { (v).assume_init() };
@@ -487,7 +549,11 @@ pub(crate) unsafe fn __cbg_in_Note(
                         }
                     }
                 };
-                example_flat::Note::Sketched(__cbg_in_Drawing((__arm).0)?)
+                example_flat::Note::Sketched(
+                    __c_in_convert_wire_to_Drawing_c_product_intermediate_repr_c_struct_3b927b21caf2df63(
+                        (__arm).0,
+                    )?,
+                )
             }
             _ => {
                 return ::core::result::Result::Err(
@@ -501,7 +567,7 @@ pub(crate) unsafe fn __cbg_in_Note(
     })
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) unsafe fn __cbg_in_Operation(
+pub(crate) unsafe fn __c_in_convert_wire_to_Operation_c_terminal_input_enum_a23b6023635a8da5(
     v: ::core::mem::MaybeUninit<operation_t>,
 ) -> ::core::result::Result<example_flat::Operation, ::std::string::String> {
     const _: () = {
@@ -536,7 +602,7 @@ pub(crate) unsafe fn __cbg_in_Operation(
     )
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) unsafe fn __cbg_in_Shape(
+pub(crate) unsafe fn __c_in_convert_wire_to_Shape_c_choice_intermediate_repr_c_tagged_union_8ddb52c185c8b923(
     v: ::core::mem::MaybeUninit<shape_t>,
 ) -> ::core::result::Result<example_flat::Shape, ::std::string::String> {
     ::core::result::Result::Ok({
@@ -562,7 +628,11 @@ pub(crate) unsafe fn __cbg_in_Shape(
                         }
                     }
                 };
-                example_flat::Shape::Circle(__cbg_in_f64((__arm).0))
+                example_flat::Shape::Circle(
+                    __c_in_convert_wire_to_f64_c_terminal_input_scalar_7d8a0a733495e599(
+                        (__arm).0,
+                    ),
+                )
             }
             2 => {
                 let __choice = unsafe { (v).assume_init() };
@@ -577,8 +647,12 @@ pub(crate) unsafe fn __cbg_in_Shape(
                     }
                 };
                 example_flat::Shape::Rect {
-                    width: __cbg_in_f64((__arm).0),
-                    height: __cbg_in_f64((__arm).1),
+                    width: __c_in_convert_wire_to_f64_c_terminal_input_scalar_7d8a0a733495e599(
+                        (__arm).0,
+                    ),
+                    height: __c_in_convert_wire_to_f64_c_terminal_input_scalar_7d8a0a733495e599(
+                        (__arm).1,
+                    ),
                 }
             }
             3 => {
@@ -594,8 +668,12 @@ pub(crate) unsafe fn __cbg_in_Shape(
                     }
                 };
                 example_flat::Shape::Labeled(
-                    __cbg_in_String_field((__arm).0),
-                    __cbg_in_Operation((__arm).1)?,
+                    __c_in_convert_wire_to_String_c_terminal_input_string_field_b6091e2e8553ccde(
+                        (__arm).0,
+                    ),
+                    __c_in_convert_wire_to_Operation_c_terminal_input_enum_a23b6023635a8da5(
+                        (__arm).1,
+                    )?,
                 )
             }
             _ => {
@@ -610,7 +688,7 @@ pub(crate) unsafe fn __cbg_in_Shape(
     })
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) unsafe fn __cbg_in_String_field(
+pub(crate) unsafe fn __c_in_convert_wire_to_String_c_terminal_input_string_field_b6091e2e8553ccde(
     v: *const ::core::ffi::c_char,
 ) -> ::std::string::String {
     if v.is_null() {
@@ -620,29 +698,19 @@ pub(crate) unsafe fn __cbg_in_String_field(
     }
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) unsafe fn __cbg_in___Calculator<'a>(
-    v: *const calculator_t,
-) -> ::core::result::Result<&'a example_flat::Calculator, ::std::string::String> {
-    if v.is_null() {
-        return ::core::result::Result::Err(
-            ::std::string::String::from("null Calculator pointer"),
-        );
-    }
-    ::core::result::Result::Ok(&*(v as *const example_flat::Calculator))
+pub(crate) unsafe fn __c_in_convert_wire_to_bool_c_terminal_input_bool_e48e0629cd6287b3(
+    v: ::core::mem::MaybeUninit<bool>,
+) -> bool {
+    ::core::ptr::read(v.as_ptr() as *const u8) != 0
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) unsafe fn __cbg_in___mut_Calculator<'a>(
-    v: *mut calculator_t,
-) -> ::core::result::Result<&'a mut example_flat::Calculator, ::std::string::String> {
-    if v.is_null() {
-        return ::core::result::Result::Err(
-            ::std::string::String::from("null Calculator pointer"),
-        );
-    }
-    ::core::result::Result::Ok(&mut *(v as *mut example_flat::Calculator))
+pub(crate) fn __c_in_convert_wire_to_f64_c_terminal_input_scalar_7d8a0a733495e599(
+    v: f64,
+) -> f64 {
+    v
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) unsafe fn __cbg_in___str<'a>(
+pub(crate) unsafe fn __c_in_convert_wire_to_str_c_borrow_str_input_246c2b9955bb6ef2<'a>(
     v: *const ::core::ffi::c_char,
 ) -> ::core::result::Result<&'a str, ::std::string::String> {
     if v.is_null() {
@@ -660,92 +728,132 @@ pub(crate) unsafe fn __cbg_in___str<'a>(
     }
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) unsafe fn __cbg_in_bool(v: ::core::mem::MaybeUninit<bool>) -> bool {
-    ::core::ptr::read(v.as_ptr() as *const u8) != 0
-}
-#[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) fn __cbg_in_f64(v: f64) -> f64 {
+pub(crate) fn __c_in_convert_wire_to_u64_c_terminal_input_scalar_4e87470ad83635c8(
+    v: u64,
+) -> u64 {
     v
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) fn __cbg_in_u64(v: u64) -> u64 {
-    v
-}
-#[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) fn __cbg_out_Calculator(v: example_flat::Calculator) -> *mut calculator_t {
+pub(crate) fn __c_out_convert_Calculator_c_terminal_output_owned_handle_to_wire_4d20353780559007(
+    v: example_flat::Calculator,
+) -> *mut calculator_t {
     ::std::boxed::Box::into_raw(::std::boxed::Box::new(v)) as *mut calculator_t
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) fn __cbg_out_Caption(v: example_flat::Caption) -> caption_t {
+pub(crate) fn __c_out_convert_Caption_c_product_intermediate_repr_c_struct_to_wire_3bc5d236333a6e28(
+    v: example_flat::Caption,
+) -> caption_t {
     caption_t {
-        id: __cbg_out_u64(v.id),
-        text: __cbg_out_String(v.text),
-        emphatic: __cbg_out_bool_field(v.emphatic),
+        id: __c_out_convert_u64_c_terminal_output_scalar_to_wire_518245fe60cf3590(v.id),
+        text: __c_out_convert_String_c_terminal_output_string_to_wire_182528409f6ab8d3(
+            v.text,
+        ),
+        emphatic: __c_out_convert_bool_c_terminal_output_bool_field_to_wire_6a810eb4cb986700(
+            v.emphatic,
+        ),
     }
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) fn __cbg_out_Drawing(v: example_flat::Drawing) -> drawing_t {
+pub(crate) fn __c_out_convert_Drawing_c_product_intermediate_repr_c_struct_to_wire_50eac9aa069a6838(
+    v: example_flat::Drawing,
+) -> drawing_t {
     drawing_t {
-        id: __cbg_out_u64(v.id),
-        shape: __cbg_out_Shape(v.shape),
+        id: __c_out_convert_u64_c_terminal_output_scalar_to_wire_518245fe60cf3590(v.id),
+        shape: __c_out_convert_Shape_c_choice_intermediate_repr_c_tagged_union_to_wire_1c9175b2e9cd70a6(
+            v.shape,
+        ),
     }
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) fn __cbg_out_Error(v: example_flat::Error) -> *mut ::core::ffi::c_char {
+pub(crate) fn __c_out_convert_Error_c_terminal_output_opaque_error_to_wire_9d010015abcb2259(
+    v: example_flat::Error,
+) -> *mut ::core::ffi::c_char {
     __cbg_alloc_cstr(example_flat::error_get_message(&v))
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) fn __cbg_out_Foo(v: example_flat::Foo) -> foo_t {
+pub(crate) fn __c_out_convert_Foo_c_product_intermediate_repr_c_struct_to_wire_02ab0b068798553e(
+    v: example_flat::Foo,
+) -> foo_t {
     foo_t {
-        id: __cbg_out_u64(v.id),
-        x86_64_field: __cbg_out_u64(v.x86_64_field),
-        unstable_field: __cbg_out_u64(v.unstable_field),
+        id: __c_out_convert_u64_c_terminal_output_scalar_to_wire_518245fe60cf3590(v.id),
+        x86_64_field: __c_out_convert_u64_c_terminal_output_scalar_to_wire_518245fe60cf3590(
+            v.x86_64_field,
+        ),
+        unstable_field: __c_out_convert_u64_c_terminal_output_scalar_to_wire_518245fe60cf3590(
+            v.unstable_field,
+        ),
     }
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) fn __cbg_out_Grade(v: example_flat::Grade) -> grade_t {
+pub(crate) fn __c_out_convert_Grade_c_terminal_output_enum_to_wire_a59c7b101e0a9e37(
+    v: example_flat::Grade,
+) -> grade_t {
     match v {
         example_flat::Grade::Low => grade_t::Low,
         example_flat::Grade::High => grade_t::High,
     }
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) fn __cbg_out_InsideFoo(v: example_flat::InsideFoo) -> inside_foo_t {
+pub(crate) fn __c_out_convert_InsideFoo_c_terminal_output_enum_to_wire_b103ad5e4be33376(
+    v: example_flat::InsideFoo,
+) -> inside_foo_t {
     match v {
         example_flat::InsideFoo::DouddleDee => inside_foo_t::DouddleDee,
         example_flat::InsideFoo::DouddleDum => inside_foo_t::DouddleDum,
     }
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) fn __cbg_out_Millis(v: example_flat::Millis) -> u64 {
+pub(crate) fn __c_out_convert_Millis_c_terminal_custom_to_wire_0c2f6b5f81dfcd94(
+    v: example_flat::Millis,
+) -> u64 {
     example_flat::millis_to_raw(&v)
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) fn __cbg_out_Note(v: example_flat::Note) -> ::core::mem::MaybeUninit<note_t> {
+pub(crate) fn __c_out_convert_Note_c_choice_intermediate_repr_c_tagged_union_to_wire_c9cea85d5266d21b(
+    v: example_flat::Note,
+) -> ::core::mem::MaybeUninit<note_t> {
     ::core::mem::MaybeUninit::new({
         match v {
             example_flat::Note::Silent => note_t::Silent,
             example_flat::Note::Titled(__part0) => {
-                let __built_arm = (__cbg_out_Caption(__part0),);
+                let __built_arm = (
+                    __c_out_convert_Caption_c_product_intermediate_repr_c_struct_to_wire_3bc5d236333a6e28(
+                        __part0,
+                    ),
+                );
                 note_t::Titled(__built_arm.0)
             }
             example_flat::Note::After(__part0) => {
-                let __built_arm = (__cbg_out_Millis(__part0),);
+                let __built_arm = (
+                    __c_out_convert_Millis_c_terminal_custom_to_wire_0c2f6b5f81dfcd94(
+                        __part0,
+                    ),
+                );
                 note_t::After(__built_arm.0)
             }
             example_flat::Note::Flagged(__part0) => {
-                let __built_arm = (__cbg_out_bool_field(__part0),);
+                let __built_arm = (
+                    __c_out_convert_bool_c_terminal_output_bool_field_to_wire_6a810eb4cb986700(
+                        __part0,
+                    ),
+                );
                 note_t::Flagged(__built_arm.0)
             }
             example_flat::Note::Sketched(__part0) => {
-                let __built_arm = (__cbg_out_Drawing(__part0),);
+                let __built_arm = (
+                    __c_out_convert_Drawing_c_product_intermediate_repr_c_struct_to_wire_50eac9aa069a6838(
+                        __part0,
+                    ),
+                );
                 note_t::Sketched(__built_arm.0)
             }
         }
     })
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) fn __cbg_out_Operation(v: example_flat::Operation) -> operation_t {
+pub(crate) fn __c_out_convert_Operation_c_terminal_output_enum_to_wire_457f6036394dc821(
+    v: example_flat::Operation,
+) -> operation_t {
     match v {
         example_flat::Operation::Add => operation_t::Add,
         example_flat::Operation::Sub => operation_t::Sub,
@@ -753,19 +861,34 @@ pub(crate) fn __cbg_out_Operation(v: example_flat::Operation) -> operation_t {
         example_flat::Operation::Div => operation_t::Div,
     }
 }
+#[allow(non_snake_case, dead_code, unused)]
+pub(crate) fn __c_out_convert_Option_Grade_c_marker_optional_to_wire_e2c04af90b0abd17() {}
+#[allow(non_snake_case, dead_code, unused)]
+pub(crate) fn __c_out_convert_Option_f64_c_marker_optional_to_wire_c1ba5adc99623ff4() {}
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) fn __cbg_out_Shape(
+pub(crate) fn __c_out_convert_Shape_c_choice_intermediate_repr_c_tagged_union_to_wire_1c9175b2e9cd70a6(
     v: example_flat::Shape,
 ) -> ::core::mem::MaybeUninit<shape_t> {
     ::core::mem::MaybeUninit::new({
         match v {
             example_flat::Shape::Empty => shape_t::Empty,
             example_flat::Shape::Circle(__part0) => {
-                let __built_arm = (__cbg_out_f64(__part0),);
+                let __built_arm = (
+                    __c_out_convert_f64_c_terminal_output_scalar_to_wire_6aa94606ef14f673(
+                        __part0,
+                    ),
+                );
                 shape_t::Circle(__built_arm.0)
             }
             example_flat::Shape::Rect { width: __part0, height: __part1 } => {
-                let __built_arm = (__cbg_out_f64(__part0), __cbg_out_f64(__part1));
+                let __built_arm = (
+                    __c_out_convert_f64_c_terminal_output_scalar_to_wire_6aa94606ef14f673(
+                        __part0,
+                    ),
+                    __c_out_convert_f64_c_terminal_output_scalar_to_wire_6aa94606ef14f673(
+                        __part1,
+                    ),
+                );
                 shape_t::Rect {
                     width: __built_arm.0,
                     height: __built_arm.1,
@@ -773,8 +896,14 @@ pub(crate) fn __cbg_out_Shape(
             }
             example_flat::Shape::Labeled(__part0, __part1) => {
                 let __built_arm = (
-                    __cbg_out_String(__part0),
-                    ::core::mem::MaybeUninit::new(__cbg_out_Operation(__part1)),
+                    __c_out_convert_String_c_terminal_output_string_to_wire_182528409f6ab8d3(
+                        __part0,
+                    ),
+                    ::core::mem::MaybeUninit::new(
+                        __c_out_convert_Operation_c_terminal_output_enum_to_wire_457f6036394dc821(
+                            __part1,
+                        ),
+                    ),
                 );
                 shape_t::Labeled(__built_arm.0, __built_arm.1)
             }
@@ -782,48 +911,60 @@ pub(crate) fn __cbg_out_Shape(
     })
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) fn __cbg_out_String(v: ::std::string::String) -> *mut ::core::ffi::c_char {
+pub(crate) fn __c_out_convert_String_c_terminal_output_string_to_wire_182528409f6ab8d3(
+    v: ::std::string::String,
+) -> *mut ::core::ffi::c_char {
     __cbg_alloc_cstr(v)
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) fn __cbg_out_bool(v: bool) -> bool {
-    v
-}
-#[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) fn __cbg_out_bool_field(v: bool) -> ::core::mem::MaybeUninit<bool> {
+pub(crate) fn __c_out_convert_bool_c_terminal_output_bool_field_to_wire_6a810eb4cb986700(
+    v: bool,
+) -> ::core::mem::MaybeUninit<bool> {
     ::core::mem::MaybeUninit::new(v)
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
+pub(crate) fn __c_out_convert_bool_c_terminal_output_scalar_to_wire_cc0ad9760da17efd(
+    v: bool,
+) -> bool {
+    v
+}
+#[allow(non_snake_case, unused_variables, dead_code)]
+pub(crate) fn __c_out_convert_f64_c_terminal_output_scalar_to_wire_6aa94606ef14f673(
+    v: f64,
+) -> f64 {
+    v
+}
+#[allow(non_snake_case, unused_variables, dead_code)]
+pub(crate) fn __c_out_convert_i32_c_terminal_output_scalar_to_wire_ae82162f636ebcd5(
+    v: i32,
+) -> i32 {
+    v
+}
+#[allow(non_snake_case, unused_variables, dead_code)]
 #[inline(always)]
-pub(crate) fn __cbg_out_chain_vec_f64(v: ::std::vec::Vec<f64>) -> ::std::vec::Vec<f64> {
+pub(crate) fn __c_out_convert_sequence_Vec_f64_to_wire_ad99887ef4e62c28(
+    v: ::std::vec::Vec<f64>,
+) -> ::std::vec::Vec<f64> {
     {
         let __sequence_source = v;
         let mut __sequence_output: ::std::vec::Vec<f64> = ::std::vec::Vec::with_capacity(
             (__sequence_source).len(),
         );
         for __sequence_element in __sequence_source.into_iter() {
-            let __sequence_part = __cbg_out_f64(__sequence_element);
+            let __sequence_part = __c_out_convert_f64_c_terminal_output_scalar_to_wire_6aa94606ef14f673(
+                __sequence_element,
+            );
             __sequence_output.push(__sequence_part);
         }
         __sequence_output
     }
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) fn __cbg_out_f64(v: f64) -> f64 {
+pub(crate) fn __c_out_convert_u64_c_terminal_output_scalar_to_wire_518245fe60cf3590(
+    v: u64,
+) -> u64 {
     v
 }
-#[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) fn __cbg_out_i32(v: i32) -> i32 {
-    v
-}
-#[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) fn __cbg_out_u64(v: u64) -> u64 {
-    v
-}
-#[allow(non_snake_case, dead_code, unused)]
-pub(crate) fn __cbg_outmark_option_Grade() {}
-#[allow(non_snake_case, dead_code, unused)]
-pub(crate) fn __cbg_outmark_option_f64() {}
 #[no_mangle]
 #[allow(non_snake_case, unused_mut, unused_variables, unused_unsafe, dead_code)]
 pub unsafe extern "C" fn calculator_absorb(
@@ -837,7 +978,7 @@ pub unsafe extern "C" fn calculator_absorb(
             "aliasing arguments: `a` (consumed) and `b` (borrowed) are the same `Calculator` — a consumed or exclusively-borrowed resource may not be named twice in one call",
         );
         if !e.is_null() {
-            *e = __cbg_out_Error(
+            *e = __c_out_convert_Error_c_terminal_output_opaque_error_to_wire_9d010015abcb2259(
                 <example_flat::Error as ::core::convert::From<
                     ::std::string::String,
                 >>::from(__msg),
@@ -845,11 +986,13 @@ pub unsafe extern "C" fn calculator_absorb(
         }
         return false;
     }
-    let a = match __cbg_in_Calculator(a) {
+    let a = match __c_in_convert_wire_to_Calculator_c_terminal_input_owned_handle_b7bb400a642eb999(
+        a,
+    ) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__msg) => {
             if !e.is_null() {
-                *e = __cbg_out_Error(
+                *e = __c_out_convert_Error_c_terminal_output_opaque_error_to_wire_9d010015abcb2259(
                     <example_flat::Error as ::core::convert::From<
                         ::std::string::String,
                     >>::from(__msg),
@@ -858,11 +1001,13 @@ pub unsafe extern "C" fn calculator_absorb(
             return false;
         }
     };
-    let b = match __cbg_in___Calculator(b) {
+    let b = match __c_in_convert_wire_to_Calculator_c_borrow_shared_input_48be88e9df13aa53(
+        b,
+    ) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__msg) => {
             if !e.is_null() {
-                *e = __cbg_out_Error(
+                *e = __c_out_convert_Error_c_terminal_output_opaque_error_to_wire_9d010015abcb2259(
                     <example_flat::Error as ::core::convert::From<
                         ::std::string::String,
                     >>::from(__msg),
@@ -873,12 +1018,16 @@ pub unsafe extern "C" fn calculator_absorb(
     };
     match example_flat::calculator_absorb(a, b) {
         ::core::result::Result::Ok(__v) => {
-            *out = __cbg_out_f64(__v);
+            *out = __c_out_convert_f64_c_terminal_output_scalar_to_wire_6aa94606ef14f673(
+                __v,
+            );
             true
         }
         ::core::result::Result::Err(__err) => {
             if !e.is_null() {
-                *e = __cbg_out_Error(__err);
+                *e = __c_out_convert_Error_c_terminal_output_opaque_error_to_wire_9d010015abcb2259(
+                    __err,
+                );
             }
             false
         }
@@ -893,11 +1042,13 @@ pub unsafe extern "C" fn calculator_apply(
     out: *mut f64,
     e: *mut *mut ::core::ffi::c_char,
 ) -> bool {
-    let c = match __cbg_in___mut_Calculator(c) {
+    let c = match __c_in_convert_wire_to_Calculator_c_borrow_mutable_input_f30bfe45043bc69c(
+        c,
+    ) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__msg) => {
             if !e.is_null() {
-                *e = __cbg_out_Error(
+                *e = __c_out_convert_Error_c_terminal_output_opaque_error_to_wire_9d010015abcb2259(
                     <example_flat::Error as ::core::convert::From<
                         ::std::string::String,
                     >>::from(__msg),
@@ -906,11 +1057,13 @@ pub unsafe extern "C" fn calculator_apply(
             return false;
         }
     };
-    let op = match __cbg_in_Operation(op) {
+    let op = match __c_in_convert_wire_to_Operation_c_terminal_input_enum_a23b6023635a8da5(
+        op,
+    ) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__msg) => {
             if !e.is_null() {
-                *e = __cbg_out_Error(
+                *e = __c_out_convert_Error_c_terminal_output_opaque_error_to_wire_9d010015abcb2259(
                     <example_flat::Error as ::core::convert::From<
                         ::std::string::String,
                     >>::from(__msg),
@@ -919,15 +1072,21 @@ pub unsafe extern "C" fn calculator_apply(
             return false;
         }
     };
-    let operand = __cbg_in_f64(operand);
+    let operand = __c_in_convert_wire_to_f64_c_terminal_input_scalar_7d8a0a733495e599(
+        operand,
+    );
     match example_flat::calculator_apply(c, op, operand) {
         ::core::result::Result::Ok(__v) => {
-            *out = __cbg_out_f64(__v);
+            *out = __c_out_convert_f64_c_terminal_output_scalar_to_wire_6aa94606ef14f673(
+                __v,
+            );
             true
         }
         ::core::result::Result::Err(__err) => {
             if !e.is_null() {
-                *e = __cbg_out_Error(__err);
+                *e = __c_out_convert_Error_c_terminal_output_opaque_error_to_wire_9d010015abcb2259(
+                    __err,
+                );
             }
             false
         }
@@ -939,19 +1098,25 @@ pub unsafe extern "C" fn calculator_for_each(
     c: *const calculator_t,
     f: closure_value_t,
 ) {
-    let c = match __cbg_in___Calculator(c) {
+    let c = match __c_in_convert_wire_to_Calculator_c_borrow_shared_input_48be88e9df13aa53(
+        c,
+    ) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__msg) => {
             panic!("{}", __msg);
         }
     };
-    let f = __cbg_in_closure_value_t(f);
+    let f = __c_in_convert_wire_to_impl_Fn_f64_Send_Sync_static_c_invoke_callback_capture_88739bf29d2a9906(
+        f,
+    );
     example_flat::calculator_for_each(c, f);
 }
 #[no_mangle]
 #[allow(non_snake_case, unused_mut, unused_variables, unused_unsafe, dead_code)]
 pub unsafe extern "C" fn calculator_get_count(c: *const calculator_t) -> u64 {
-    let c = match __cbg_in___Calculator(c) {
+    let c = match __c_in_convert_wire_to_Calculator_c_borrow_shared_input_48be88e9df13aa53(
+        c,
+    ) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__msg) => {
             panic!("{}", __msg);
@@ -959,7 +1124,7 @@ pub unsafe extern "C" fn calculator_get_count(c: *const calculator_t) -> u64 {
     };
     let __v = example_flat::calculator_get_count(c);
     let __ret: u64;
-    __ret = __cbg_out_u64(__v);
+    __ret = __c_out_convert_u64_c_terminal_output_scalar_to_wire_518245fe60cf3590(__v);
     __ret
 }
 #[no_mangle]
@@ -968,7 +1133,9 @@ pub unsafe extern "C" fn calculator_get_history(
     c: *const calculator_t,
     len: *mut usize,
 ) -> *mut f64 {
-    let c = match __cbg_in___Calculator(c) {
+    let c = match __c_in_convert_wire_to_Calculator_c_borrow_shared_input_48be88e9df13aa53(
+        c,
+    ) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__msg) => {
             panic!("{}", __msg);
@@ -976,7 +1143,9 @@ pub unsafe extern "C" fn calculator_get_history(
     };
     let __v = example_flat::calculator_get_history(c);
     let __ret: *mut f64;
-    let __arr: ::std::vec::Vec<f64> = __cbg_out_chain_vec_f64(__v);
+    let __arr: ::std::vec::Vec<f64> = __c_out_convert_sequence_Vec_f64_to_wire_ad99887ef4e62c28(
+        __v,
+    );
     let (__p, __n) = __cbg_alloc_array(__arr);
     __ret = __p;
     *len = __n;
@@ -985,7 +1154,9 @@ pub unsafe extern "C" fn calculator_get_history(
 #[no_mangle]
 #[allow(non_snake_case, unused_mut, unused_variables, unused_unsafe, dead_code)]
 pub unsafe extern "C" fn calculator_get_value(c: *const calculator_t) -> f64 {
-    let c = match __cbg_in___Calculator(c) {
+    let c = match __c_in_convert_wire_to_Calculator_c_borrow_shared_input_48be88e9df13aa53(
+        c,
+    ) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__msg) => {
             panic!("{}", __msg);
@@ -993,7 +1164,7 @@ pub unsafe extern "C" fn calculator_get_value(c: *const calculator_t) -> f64 {
     };
     let __v = example_flat::calculator_get_value(c);
     let __ret: f64;
-    __ret = __cbg_out_f64(__v);
+    __ret = __c_out_convert_f64_c_terminal_output_scalar_to_wire_6aa94606ef14f673(__v);
     __ret
 }
 #[no_mangle]
@@ -1002,13 +1173,17 @@ pub unsafe extern "C" fn calculator_grade_or_none(
     c: *const calculator_t,
     f: closure_maybe_grade_t,
 ) {
-    let c = match __cbg_in___Calculator(c) {
+    let c = match __c_in_convert_wire_to_Calculator_c_borrow_shared_input_48be88e9df13aa53(
+        c,
+    ) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__msg) => {
             panic!("{}", __msg);
         }
     };
-    let f = __cbg_in_closure_maybe_grade_t(f);
+    let f = __c_in_convert_wire_to_impl_Fn_Option_Grade_Send_Sync_static_c_invoke_callback_capture_5512a1f2265e79a0(
+        f,
+    );
     example_flat::calculator_grade_or_none(c, f);
 }
 #[no_mangle]
@@ -1017,28 +1192,36 @@ pub unsafe extern "C" fn calculator_history_batch(
     c: *const calculator_t,
     f: closure_history_batch_t,
 ) {
-    let c = match __cbg_in___Calculator(c) {
+    let c = match __c_in_convert_wire_to_Calculator_c_borrow_shared_input_48be88e9df13aa53(
+        c,
+    ) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__msg) => {
             panic!("{}", __msg);
         }
     };
-    let f = __cbg_in_closure_history_batch_t(f);
+    let f = __c_in_convert_wire_to_impl_Fn_Vec_f64_Send_Sync_static_c_invoke_callback_capture_3dd7f8fbc61877ce(
+        f,
+    );
     example_flat::calculator_history_batch(c, f);
 }
 #[no_mangle]
 #[allow(non_snake_case, unused_mut, unused_variables, unused_unsafe, dead_code)]
 pub unsafe extern "C" fn calculator_is(c: *const calculator_t, value: f64) -> bool {
-    let c = match __cbg_in___Calculator(c) {
+    let c = match __c_in_convert_wire_to_Calculator_c_borrow_shared_input_48be88e9df13aa53(
+        c,
+    ) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__msg) => {
             panic!("{}", __msg);
         }
     };
-    let value = __cbg_in_f64(value);
+    let value = __c_in_convert_wire_to_f64_c_terminal_input_scalar_7d8a0a733495e599(
+        value,
+    );
     let __v = example_flat::calculator_is(c, value);
     let __ret: bool;
-    __ret = __cbg_out_bool(__v);
+    __ret = __c_out_convert_bool_c_terminal_output_scalar_to_wire_cc0ad9760da17efd(__v);
     __ret
 }
 #[no_mangle]
@@ -1047,13 +1230,17 @@ pub unsafe extern "C" fn calculator_last_or_none(
     c: *const calculator_t,
     f: closure_maybe_value_t,
 ) {
-    let c = match __cbg_in___Calculator(c) {
+    let c = match __c_in_convert_wire_to_Calculator_c_borrow_shared_input_48be88e9df13aa53(
+        c,
+    ) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__msg) => {
             panic!("{}", __msg);
         }
     };
-    let f = __cbg_in_closure_maybe_value_t(f);
+    let f = __c_in_convert_wire_to_impl_Fn_Option_f64_Send_Sync_static_c_invoke_callback_capture_053af7d76b4f1245(
+        f,
+    );
     example_flat::calculator_last_or_none(c, f);
 }
 #[no_mangle]
@@ -1068,7 +1255,7 @@ pub unsafe extern "C" fn calculator_merge(
             "aliasing arguments: `a` (consumed) and `b` (consumed) are the same `Calculator` — a consumed or exclusively-borrowed resource may not be named twice in one call",
         );
         if !e.is_null() {
-            *e = __cbg_out_Error(
+            *e = __c_out_convert_Error_c_terminal_output_opaque_error_to_wire_9d010015abcb2259(
                 <example_flat::Error as ::core::convert::From<
                     ::std::string::String,
                 >>::from(__msg),
@@ -1076,11 +1263,13 @@ pub unsafe extern "C" fn calculator_merge(
         }
         return ::core::ptr::null_mut();
     }
-    let a = match __cbg_in_Calculator(a) {
+    let a = match __c_in_convert_wire_to_Calculator_c_terminal_input_owned_handle_b7bb400a642eb999(
+        a,
+    ) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__msg) => {
             if !e.is_null() {
-                *e = __cbg_out_Error(
+                *e = __c_out_convert_Error_c_terminal_output_opaque_error_to_wire_9d010015abcb2259(
                     <example_flat::Error as ::core::convert::From<
                         ::std::string::String,
                     >>::from(__msg),
@@ -1089,11 +1278,13 @@ pub unsafe extern "C" fn calculator_merge(
             return ::core::ptr::null_mut();
         }
     };
-    let b = match __cbg_in_Calculator(b) {
+    let b = match __c_in_convert_wire_to_Calculator_c_terminal_input_owned_handle_b7bb400a642eb999(
+        b,
+    ) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__msg) => {
             if !e.is_null() {
-                *e = __cbg_out_Error(
+                *e = __c_out_convert_Error_c_terminal_output_opaque_error_to_wire_9d010015abcb2259(
                     <example_flat::Error as ::core::convert::From<
                         ::std::string::String,
                     >>::from(__msg),
@@ -1105,12 +1296,16 @@ pub unsafe extern "C" fn calculator_merge(
     match example_flat::calculator_merge(a, b) {
         ::core::result::Result::Ok(__v) => {
             let __ret: *mut calculator_t;
-            __ret = __cbg_out_Calculator(__v);
+            __ret = __c_out_convert_Calculator_c_terminal_output_owned_handle_to_wire_4d20353780559007(
+                __v,
+            );
             __ret
         }
         ::core::result::Result::Err(__err) => {
             if !e.is_null() {
-                *e = __cbg_out_Error(__err);
+                *e = __c_out_convert_Error_c_terminal_output_opaque_error_to_wire_9d010015abcb2259(
+                    __err,
+                );
             }
             ::core::ptr::null_mut()
         }
@@ -1121,7 +1316,9 @@ pub unsafe extern "C" fn calculator_merge(
 pub unsafe extern "C" fn calculator_new() -> *mut calculator_t {
     let __v = example_flat::calculator_new();
     let __ret: *mut calculator_t;
-    __ret = __cbg_out_Calculator(__v);
+    __ret = __c_out_convert_Calculator_c_terminal_output_owned_handle_to_wire_4d20353780559007(
+        __v,
+    );
     __ret
 }
 #[no_mangle]
@@ -1129,7 +1326,9 @@ pub unsafe extern "C" fn calculator_new() -> *mut calculator_t {
 pub unsafe extern "C" fn calculator_new_clone(
     c: *const calculator_t,
 ) -> *mut calculator_t {
-    let c = match __cbg_in___Calculator(c) {
+    let c = match __c_in_convert_wire_to_Calculator_c_borrow_shared_input_48be88e9df13aa53(
+        c,
+    ) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__msg) => {
             panic!("{}", __msg);
@@ -1137,7 +1336,9 @@ pub unsafe extern "C" fn calculator_new_clone(
     };
     let __v = example_flat::calculator_new_clone(c);
     let __ret: *mut calculator_t;
-    __ret = __cbg_out_Calculator(__v);
+    __ret = __c_out_convert_Calculator_c_terminal_output_owned_handle_to_wire_4d20353780559007(
+        __v,
+    );
     __ret
 }
 #[no_mangle]
@@ -1146,11 +1347,11 @@ pub unsafe extern "C" fn calculator_new_from_str(
     s: *const ::core::ffi::c_char,
     e: *mut *mut ::core::ffi::c_char,
 ) -> *mut calculator_t {
-    let s = match __cbg_in___str(s) {
+    let s = match __c_in_convert_wire_to_str_c_borrow_str_input_246c2b9955bb6ef2(s) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__msg) => {
             if !e.is_null() {
-                *e = __cbg_out_Error(
+                *e = __c_out_convert_Error_c_terminal_output_opaque_error_to_wire_9d010015abcb2259(
                     <example_flat::Error as ::core::convert::From<
                         ::std::string::String,
                     >>::from(__msg),
@@ -1162,12 +1363,16 @@ pub unsafe extern "C" fn calculator_new_from_str(
     match example_flat::calculator_new_from_str(s) {
         ::core::result::Result::Ok(__v) => {
             let __ret: *mut calculator_t;
-            __ret = __cbg_out_Calculator(__v);
+            __ret = __c_out_convert_Calculator_c_terminal_output_owned_handle_to_wire_4d20353780559007(
+                __v,
+            );
             __ret
         }
         ::core::result::Result::Err(__err) => {
             if !e.is_null() {
-                *e = __cbg_out_Error(__err);
+                *e = __c_out_convert_Error_c_terminal_output_opaque_error_to_wire_9d010015abcb2259(
+                    __err,
+                );
             }
             ::core::ptr::null_mut()
         }
@@ -1176,7 +1381,9 @@ pub unsafe extern "C" fn calculator_new_from_str(
 #[no_mangle]
 #[allow(non_snake_case, unused_mut, unused_variables, unused_unsafe, dead_code)]
 pub unsafe extern "C" fn calculator_reset(c: *mut calculator_t) {
-    let c = match __cbg_in___mut_Calculator(c) {
+    let c = match __c_in_convert_wire_to_Calculator_c_borrow_mutable_input_f30bfe45043bc69c(
+        c,
+    ) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__msg) => {
             panic!("{}", __msg);
@@ -1189,7 +1396,9 @@ pub unsafe extern "C" fn calculator_reset(c: *mut calculator_t) {
 pub unsafe extern "C" fn calculator_to_string(
     c: *const calculator_t,
 ) -> *mut ::core::ffi::c_char {
-    let c = match __cbg_in___Calculator(c) {
+    let c = match __c_in_convert_wire_to_Calculator_c_borrow_shared_input_48be88e9df13aa53(
+        c,
+    ) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__msg) => {
             panic!("{}", __msg);
@@ -1197,7 +1406,9 @@ pub unsafe extern "C" fn calculator_to_string(
     };
     let __v = example_flat::calculator_to_string(c);
     let __ret: *mut ::core::ffi::c_char;
-    __ret = __cbg_out_String(__v);
+    __ret = __c_out_convert_String_c_terminal_output_string_to_wire_182528409f6ab8d3(
+        __v,
+    );
     __ret
 }
 #[no_mangle]
@@ -1207,17 +1418,23 @@ pub unsafe extern "C" fn caption_new(
     text: *const ::core::ffi::c_char,
     emphatic: ::core::mem::MaybeUninit<bool>,
 ) -> caption_t {
-    let id = __cbg_in_u64(id);
-    let text = match __cbg_in___str(text) {
+    let id = __c_in_convert_wire_to_u64_c_terminal_input_scalar_4e87470ad83635c8(id);
+    let text = match __c_in_convert_wire_to_str_c_borrow_str_input_246c2b9955bb6ef2(
+        text,
+    ) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__msg) => {
             panic!("{}", __msg);
         }
     };
-    let emphatic = __cbg_in_bool(emphatic);
+    let emphatic = __c_in_convert_wire_to_bool_c_terminal_input_bool_e48e0629cd6287b3(
+        emphatic,
+    );
     let __v = example_flat::caption_new(id, text, emphatic);
     let __ret: caption_t;
-    __ret = __cbg_out_Caption(__v);
+    __ret = __c_out_convert_Caption_c_product_intermediate_repr_c_struct_to_wire_3bc5d236333a6e28(
+        __v,
+    );
     __ret
 }
 #[no_mangle]
@@ -1225,7 +1442,9 @@ pub unsafe extern "C" fn caption_new(
 pub unsafe extern "C" fn drawing_get_shape(
     d: drawing_t,
 ) -> ::core::mem::MaybeUninit<shape_t> {
-    let d = match __cbg_in_Drawing(d) {
+    let d = match __c_in_convert_wire_to_Drawing_c_product_intermediate_repr_c_struct_3b927b21caf2df63(
+        d,
+    ) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__msg) => {
             panic!("{}", __msg);
@@ -1233,7 +1452,9 @@ pub unsafe extern "C" fn drawing_get_shape(
     };
     let __v = example_flat::drawing_get_shape(d);
     let __ret: ::core::mem::MaybeUninit<shape_t>;
-    __ret = __cbg_out_Shape(__v);
+    __ret = __c_out_convert_Shape_c_choice_intermediate_repr_c_tagged_union_to_wire_1c9175b2e9cd70a6(
+        __v,
+    );
     __ret
 }
 #[no_mangle]
@@ -1242,8 +1463,10 @@ pub unsafe extern "C" fn drawing_new(
     id: u64,
     shape: ::core::mem::MaybeUninit<shape_t>,
 ) -> drawing_t {
-    let id = __cbg_in_u64(id);
-    let shape = match __cbg_in_Shape(shape) {
+    let id = __c_in_convert_wire_to_u64_c_terminal_input_scalar_4e87470ad83635c8(id);
+    let shape = match __c_in_convert_wire_to_Shape_c_choice_intermediate_repr_c_tagged_union_8ddb52c185c8b923(
+        shape,
+    ) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__msg) => {
             panic!("{}", __msg);
@@ -1251,25 +1474,31 @@ pub unsafe extern "C" fn drawing_new(
     };
     let __v = example_flat::drawing_new(id, shape);
     let __ret: drawing_t;
-    __ret = __cbg_out_Drawing(__v);
+    __ret = __c_out_convert_Drawing_c_product_intermediate_repr_c_struct_to_wire_50eac9aa069a6838(
+        __v,
+    );
     __ret
 }
 #[no_mangle]
 #[allow(non_snake_case, unused_mut, unused_variables, unused_unsafe, dead_code)]
 pub unsafe extern "C" fn foo_get_id(f: foo_t) -> u64 {
-    let f = __cbg_in_Foo(f);
+    let f = __c_in_convert_wire_to_Foo_c_product_intermediate_repr_c_struct_157d1b61f2a5b9d5(
+        f,
+    );
     let __v = example_flat::foo_get_id(f);
     let __ret: u64;
-    __ret = __cbg_out_u64(__v);
+    __ret = __c_out_convert_u64_c_terminal_output_scalar_to_wire_518245fe60cf3590(__v);
     __ret
 }
 #[no_mangle]
 #[allow(non_snake_case, unused_mut, unused_variables, unused_unsafe, dead_code)]
 pub unsafe extern "C" fn foo_new(id: u64) -> foo_t {
-    let id = __cbg_in_u64(id);
+    let id = __c_in_convert_wire_to_u64_c_terminal_input_scalar_4e87470ad83635c8(id);
     let __v = example_flat::foo_new(id);
     let __ret: foo_t;
-    __ret = __cbg_out_Foo(__v);
+    __ret = __c_out_convert_Foo_c_product_intermediate_repr_c_struct_to_wire_02ab0b068798553e(
+        __v,
+    );
     __ret
 }
 #[no_mangle]
@@ -1277,7 +1506,9 @@ pub unsafe extern "C" fn foo_new(id: u64) -> foo_t {
 pub unsafe extern "C" fn inside_foo_default() -> inside_foo_t {
     let __v = example_flat::inside_foo_default();
     let __ret: inside_foo_t;
-    __ret = __cbg_out_InsideFoo(__v);
+    __ret = __c_out_convert_InsideFoo_c_terminal_output_enum_to_wire_b103ad5e4be33376(
+        __v,
+    );
     __ret
 }
 #[no_mangle]
@@ -1285,7 +1516,9 @@ pub unsafe extern "C" fn inside_foo_default() -> inside_foo_t {
 pub unsafe extern "C" fn inside_foo_value(
     x: ::core::mem::MaybeUninit<inside_foo_t>,
 ) -> i32 {
-    let x = match __cbg_in_InsideFoo(x) {
+    let x = match __c_in_convert_wire_to_InsideFoo_c_terminal_input_enum_70ed7847e05e3330(
+        x,
+    ) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__msg) => {
             panic!("{}", __msg);
@@ -1293,13 +1526,15 @@ pub unsafe extern "C" fn inside_foo_value(
     };
     let __v = example_flat::inside_foo_value(x);
     let __ret: i32;
-    __ret = __cbg_out_i32(__v);
+    __ret = __c_out_convert_i32_c_terminal_output_scalar_to_wire_ae82162f636ebcd5(__v);
     __ret
 }
 #[no_mangle]
 #[allow(non_snake_case, unused_mut, unused_variables, unused_unsafe, dead_code)]
 pub unsafe extern "C" fn note_emphatic(n: ::core::mem::MaybeUninit<note_t>) -> bool {
-    let n = match __cbg_in_Note(n) {
+    let n = match __c_in_convert_wire_to_Note_c_choice_intermediate_repr_c_tagged_union_4de1f2981255d608(
+        n,
+    ) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__msg) => {
             panic!("{}", __msg);
@@ -1307,7 +1542,7 @@ pub unsafe extern "C" fn note_emphatic(n: ::core::mem::MaybeUninit<note_t>) -> b
     };
     let __v = example_flat::note_emphatic(n);
     let __ret: bool;
-    __ret = __cbg_out_bool(__v);
+    __ret = __c_out_convert_bool_c_terminal_output_scalar_to_wire_cc0ad9760da17efd(__v);
     __ret
 }
 #[no_mangle]
@@ -1315,10 +1550,14 @@ pub unsafe extern "C" fn note_emphatic(n: ::core::mem::MaybeUninit<note_t>) -> b
 pub unsafe extern "C" fn note_new_after(
     millis: u64,
 ) -> ::core::mem::MaybeUninit<note_t> {
-    let millis = __cbg_in_u64(millis);
+    let millis = __c_in_convert_wire_to_u64_c_terminal_input_scalar_4e87470ad83635c8(
+        millis,
+    );
     let __v = example_flat::note_new_after(millis);
     let __ret: ::core::mem::MaybeUninit<note_t>;
-    __ret = __cbg_out_Note(__v);
+    __ret = __c_out_convert_Note_c_choice_intermediate_repr_c_tagged_union_to_wire_c9cea85d5266d21b(
+        __v,
+    );
     __ret
 }
 #[no_mangle]
@@ -1326,10 +1565,12 @@ pub unsafe extern "C" fn note_new_after(
 pub unsafe extern "C" fn note_new_flagged(
     flag: ::core::mem::MaybeUninit<bool>,
 ) -> ::core::mem::MaybeUninit<note_t> {
-    let flag = __cbg_in_bool(flag);
+    let flag = __c_in_convert_wire_to_bool_c_terminal_input_bool_e48e0629cd6287b3(flag);
     let __v = example_flat::note_new_flagged(flag);
     let __ret: ::core::mem::MaybeUninit<note_t>;
-    __ret = __cbg_out_Note(__v);
+    __ret = __c_out_convert_Note_c_choice_intermediate_repr_c_tagged_union_to_wire_c9cea85d5266d21b(
+        __v,
+    );
     __ret
 }
 #[no_mangle]
@@ -1337,7 +1578,9 @@ pub unsafe extern "C" fn note_new_flagged(
 pub unsafe extern "C" fn note_new_silent() -> ::core::mem::MaybeUninit<note_t> {
     let __v = example_flat::note_new_silent();
     let __ret: ::core::mem::MaybeUninit<note_t>;
-    __ret = __cbg_out_Note(__v);
+    __ret = __c_out_convert_Note_c_choice_intermediate_repr_c_tagged_union_to_wire_c9cea85d5266d21b(
+        __v,
+    );
     __ret
 }
 #[no_mangle]
@@ -1346,8 +1589,10 @@ pub unsafe extern "C" fn note_new_sketched(
     id: u64,
     label: *const ::core::ffi::c_char,
 ) -> ::core::mem::MaybeUninit<note_t> {
-    let id = __cbg_in_u64(id);
-    let label = match __cbg_in___str(label) {
+    let id = __c_in_convert_wire_to_u64_c_terminal_input_scalar_4e87470ad83635c8(id);
+    let label = match __c_in_convert_wire_to_str_c_borrow_str_input_246c2b9955bb6ef2(
+        label,
+    ) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__msg) => {
             panic!("{}", __msg);
@@ -1355,7 +1600,9 @@ pub unsafe extern "C" fn note_new_sketched(
     };
     let __v = example_flat::note_new_sketched(id, label);
     let __ret: ::core::mem::MaybeUninit<note_t>;
-    __ret = __cbg_out_Note(__v);
+    __ret = __c_out_convert_Note_c_choice_intermediate_repr_c_tagged_union_to_wire_c9cea85d5266d21b(
+        __v,
+    );
     __ret
 }
 #[no_mangle]
@@ -1365,23 +1612,31 @@ pub unsafe extern "C" fn note_new_titled(
     text: *const ::core::ffi::c_char,
     emphatic: ::core::mem::MaybeUninit<bool>,
 ) -> ::core::mem::MaybeUninit<note_t> {
-    let id = __cbg_in_u64(id);
-    let text = match __cbg_in___str(text) {
+    let id = __c_in_convert_wire_to_u64_c_terminal_input_scalar_4e87470ad83635c8(id);
+    let text = match __c_in_convert_wire_to_str_c_borrow_str_input_246c2b9955bb6ef2(
+        text,
+    ) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__msg) => {
             panic!("{}", __msg);
         }
     };
-    let emphatic = __cbg_in_bool(emphatic);
+    let emphatic = __c_in_convert_wire_to_bool_c_terminal_input_bool_e48e0629cd6287b3(
+        emphatic,
+    );
     let __v = example_flat::note_new_titled(id, text, emphatic);
     let __ret: ::core::mem::MaybeUninit<note_t>;
-    __ret = __cbg_out_Note(__v);
+    __ret = __c_out_convert_Note_c_choice_intermediate_repr_c_tagged_union_to_wire_c9cea85d5266d21b(
+        __v,
+    );
     __ret
 }
 #[no_mangle]
 #[allow(non_snake_case, unused_mut, unused_variables, unused_unsafe, dead_code)]
 pub unsafe extern "C" fn note_value(n: ::core::mem::MaybeUninit<note_t>) -> u64 {
-    let n = match __cbg_in_Note(n) {
+    let n = match __c_in_convert_wire_to_Note_c_choice_intermediate_repr_c_tagged_union_4de1f2981255d608(
+        n,
+    ) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__msg) => {
             panic!("{}", __msg);
@@ -1389,13 +1644,15 @@ pub unsafe extern "C" fn note_value(n: ::core::mem::MaybeUninit<note_t>) -> u64 
     };
     let __v = example_flat::note_value(n);
     let __ret: u64;
-    __ret = __cbg_out_u64(__v);
+    __ret = __c_out_convert_u64_c_terminal_output_scalar_to_wire_518245fe60cf3590(__v);
     __ret
 }
 #[no_mangle]
 #[allow(non_snake_case, unused_mut, unused_variables, unused_unsafe, dead_code)]
 pub unsafe extern "C" fn shape_area(s: ::core::mem::MaybeUninit<shape_t>) -> f64 {
-    let s = match __cbg_in_Shape(s) {
+    let s = match __c_in_convert_wire_to_Shape_c_choice_intermediate_repr_c_tagged_union_8ddb52c185c8b923(
+        s,
+    ) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__msg) => {
             panic!("{}", __msg);
@@ -1403,7 +1660,7 @@ pub unsafe extern "C" fn shape_area(s: ::core::mem::MaybeUninit<shape_t>) -> f64
     };
     let __v = example_flat::shape_area(s);
     let __ret: f64;
-    __ret = __cbg_out_f64(__v);
+    __ret = __c_out_convert_f64_c_terminal_output_scalar_to_wire_6aa94606ef14f673(__v);
     __ret
 }
 #[no_mangle]
@@ -1411,7 +1668,9 @@ pub unsafe extern "C" fn shape_area(s: ::core::mem::MaybeUninit<shape_t>) -> f64
 pub unsafe extern "C" fn shape_get_label(
     s: ::core::mem::MaybeUninit<shape_t>,
 ) -> *mut ::core::ffi::c_char {
-    let s = match __cbg_in_Shape(s) {
+    let s = match __c_in_convert_wire_to_Shape_c_choice_intermediate_repr_c_tagged_union_8ddb52c185c8b923(
+        s,
+    ) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__msg) => {
             panic!("{}", __msg);
@@ -1419,7 +1678,9 @@ pub unsafe extern "C" fn shape_get_label(
     };
     let __v = example_flat::shape_get_label(s);
     let __ret: *mut ::core::ffi::c_char;
-    __ret = __cbg_out_String(__v);
+    __ret = __c_out_convert_String_c_terminal_output_string_to_wire_182528409f6ab8d3(
+        __v,
+    );
     __ret
 }
 #[no_mangle]
@@ -1427,10 +1688,14 @@ pub unsafe extern "C" fn shape_get_label(
 pub unsafe extern "C" fn shape_new_circle(
     radius: f64,
 ) -> ::core::mem::MaybeUninit<shape_t> {
-    let radius = __cbg_in_f64(radius);
+    let radius = __c_in_convert_wire_to_f64_c_terminal_input_scalar_7d8a0a733495e599(
+        radius,
+    );
     let __v = example_flat::shape_new_circle(radius);
     let __ret: ::core::mem::MaybeUninit<shape_t>;
-    __ret = __cbg_out_Shape(__v);
+    __ret = __c_out_convert_Shape_c_choice_intermediate_repr_c_tagged_union_to_wire_1c9175b2e9cd70a6(
+        __v,
+    );
     __ret
 }
 #[no_mangle]
@@ -1438,7 +1703,9 @@ pub unsafe extern "C" fn shape_new_circle(
 pub unsafe extern "C" fn shape_new_empty() -> ::core::mem::MaybeUninit<shape_t> {
     let __v = example_flat::shape_new_empty();
     let __ret: ::core::mem::MaybeUninit<shape_t>;
-    __ret = __cbg_out_Shape(__v);
+    __ret = __c_out_convert_Shape_c_choice_intermediate_repr_c_tagged_union_to_wire_1c9175b2e9cd70a6(
+        __v,
+    );
     __ret
 }
 #[no_mangle]
@@ -1447,13 +1714,17 @@ pub unsafe extern "C" fn shape_new_labeled(
     label: *const ::core::ffi::c_char,
     op: ::core::mem::MaybeUninit<operation_t>,
 ) -> ::core::mem::MaybeUninit<shape_t> {
-    let label = match __cbg_in___str(label) {
+    let label = match __c_in_convert_wire_to_str_c_borrow_str_input_246c2b9955bb6ef2(
+        label,
+    ) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__msg) => {
             panic!("{}", __msg);
         }
     };
-    let op = match __cbg_in_Operation(op) {
+    let op = match __c_in_convert_wire_to_Operation_c_terminal_input_enum_a23b6023635a8da5(
+        op,
+    ) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__msg) => {
             panic!("{}", __msg);
@@ -1461,7 +1732,9 @@ pub unsafe extern "C" fn shape_new_labeled(
     };
     let __v = example_flat::shape_new_labeled(label, op);
     let __ret: ::core::mem::MaybeUninit<shape_t>;
-    __ret = __cbg_out_Shape(__v);
+    __ret = __c_out_convert_Shape_c_choice_intermediate_repr_c_tagged_union_to_wire_1c9175b2e9cd70a6(
+        __v,
+    );
     __ret
 }
 #[no_mangle]
@@ -1470,11 +1743,17 @@ pub unsafe extern "C" fn shape_new_rect(
     width: f64,
     height: f64,
 ) -> ::core::mem::MaybeUninit<shape_t> {
-    let width = __cbg_in_f64(width);
-    let height = __cbg_in_f64(height);
+    let width = __c_in_convert_wire_to_f64_c_terminal_input_scalar_7d8a0a733495e599(
+        width,
+    );
+    let height = __c_in_convert_wire_to_f64_c_terminal_input_scalar_7d8a0a733495e599(
+        height,
+    );
     let __v = example_flat::shape_new_rect(width, height);
     let __ret: ::core::mem::MaybeUninit<shape_t>;
-    __ret = __cbg_out_Shape(__v);
+    __ret = __c_out_convert_Shape_c_choice_intermediate_repr_c_tagged_union_to_wire_1c9175b2e9cd70a6(
+        __v,
+    );
     __ret
 }
 #[no_mangle]
@@ -1484,11 +1763,13 @@ pub unsafe extern "C" fn shape_try_area(
     out: *mut f64,
     e: *mut *mut ::core::ffi::c_char,
 ) -> bool {
-    let s = match __cbg_in_Shape(s) {
+    let s = match __c_in_convert_wire_to_Shape_c_choice_intermediate_repr_c_tagged_union_8ddb52c185c8b923(
+        s,
+    ) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__msg) => {
             if !e.is_null() {
-                *e = __cbg_out_Error(
+                *e = __c_out_convert_Error_c_terminal_output_opaque_error_to_wire_9d010015abcb2259(
                     <example_flat::Error as ::core::convert::From<
                         ::std::string::String,
                     >>::from(__msg),
@@ -1499,12 +1780,16 @@ pub unsafe extern "C" fn shape_try_area(
     };
     match example_flat::shape_try_area(s) {
         ::core::result::Result::Ok(__v) => {
-            *out = __cbg_out_f64(__v);
+            *out = __c_out_convert_f64_c_terminal_output_scalar_to_wire_6aa94606ef14f673(
+                __v,
+            );
             true
         }
         ::core::result::Result::Err(__err) => {
             if !e.is_null() {
-                *e = __cbg_out_Error(__err);
+                *e = __c_out_convert_Error_c_terminal_output_opaque_error_to_wire_9d010015abcb2259(
+                    __err,
+                );
             }
             false
         }

--- a/examples/perftest-c/generated/perftest.rs
+++ b/examples/perftest-c/generated/perftest.rs
@@ -145,7 +145,7 @@ pub struct closure_payload_t {
     pub drop: ::core::option::Option<unsafe extern "C" fn(*mut ::core::ffi::c_void)>,
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) unsafe fn __cbg_in_closure_payload_t(
+pub(crate) unsafe fn __c_in_convert_wire_to_impl_Fn_Payload_Send_Sync_static_c_invoke_callback_capture_1f115f7d391197ee(
     c: closure_payload_t,
 ) -> impl Fn(&perftest_flat::Payload) + Send + Sync + 'static {
     struct __Ctx {
@@ -168,7 +168,9 @@ pub(crate) unsafe fn __cbg_in_closure_payload_t(
     });
     move |__a0: &perftest_flat::Payload| {
         if let ::core::option::Option::Some(__f) = __call {
-            let __w0 = __cbg_out_ref_Payload(__a0);
+            let __w0 = __c_out_convert_Payload_c_borrow_shared_output_to_wire_5d954ba915ba18c7(
+                __a0,
+            );
             unsafe { __f(__w0, __ctx.context) }
         }
     }
@@ -183,7 +185,7 @@ pub struct closure_payload_vec_t {
     pub drop: ::core::option::Option<unsafe extern "C" fn(*mut ::core::ffi::c_void)>,
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) unsafe fn __cbg_in_closure_payload_vec_t(
+pub(crate) unsafe fn __c_in_convert_wire_to_impl_Fn_Payload_Send_Sync_static_c_invoke_callback_capture_6d4224db8a8b8070(
     c: closure_payload_vec_t,
 ) -> impl Fn(&[perftest_flat::Payload]) + Send + Sync + 'static {
     struct __Ctx {
@@ -211,22 +213,20 @@ pub(crate) unsafe fn __cbg_in_closure_payload_vec_t(
     }
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) unsafe fn __cbg_in_Payload(
-    v: *mut payload_t,
-) -> ::core::result::Result<perftest_flat::Payload, ::std::string::String> {
+pub(crate) unsafe fn __c_in_convert_wire_to_PayloadHandler_c_borrow_shared_input_9caa5450154416a9<
+    'a,
+>(
+    v: *const payload_handler_t,
+) -> ::core::result::Result<&'a perftest_flat::PayloadHandler, ::std::string::String> {
     if v.is_null() {
         return ::core::result::Result::Err(
-            ::std::string::String::from("null Payload value passed by value"),
+            ::std::string::String::from("null PayloadHandler pointer"),
         );
     }
-    let __live = <payload_t as ::prebindgen_c_runtime::Transmute>::into_rust(
-        ::core::ptr::read(v),
-    );
-    (*v).label = ::core::ptr::null_mut();
-    ::core::result::Result::Ok(__live)
+    ::core::result::Result::Ok(&*(v as *const perftest_flat::PayloadHandler))
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) unsafe fn __cbg_in_PayloadHandler(
+pub(crate) unsafe fn __c_in_convert_wire_to_PayloadHandler_c_terminal_input_owned_handle_bbf919ff94219da7(
     v: *mut payload_handler_t,
 ) -> ::core::result::Result<perftest_flat::PayloadHandler, ::std::string::String> {
     if v.is_null() {
@@ -239,68 +239,9 @@ pub(crate) unsafe fn __cbg_in_PayloadHandler(
     )
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) unsafe fn __cbg_in_PayloadVecHandler(
-    v: *mut payload_vec_handler_t,
-) -> ::core::result::Result<perftest_flat::PayloadVecHandler, ::std::string::String> {
-    if v.is_null() {
-        return ::core::result::Result::Err(
-            ::std::string::String::from("null PayloadVecHandler handle passed by value"),
-        );
-    }
-    ::core::result::Result::Ok(
-        *::std::boxed::Box::from_raw(v as *mut perftest_flat::PayloadVecHandler),
-    )
-}
-#[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) unsafe fn __cbg_in_Storage(
-    v: *mut storage_t,
-) -> ::core::result::Result<perftest_flat::Storage, ::std::string::String> {
-    if v.is_null() {
-        return ::core::result::Result::Err(
-            ::std::string::String::from("null Storage handle passed by value"),
-        );
-    }
-    ::core::result::Result::Ok(
-        *::std::boxed::Box::from_raw(v as *mut perftest_flat::Storage),
-    )
-}
-#[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) unsafe fn __cbg_in_String(
-    v: *mut string_t,
-) -> ::core::result::Result<::std::string::String, ::std::string::String> {
-    if v.is_null() {
-        return ::core::result::Result::Err(
-            ::std::string::String::from("null String handle passed by value"),
-        );
-    }
-    ::core::result::Result::Ok(
-        *::std::boxed::Box::from_raw(v as *mut ::std::string::String),
-    )
-}
-#[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) unsafe fn __cbg_in___Payload<'a>(
-    v: *const payload_t,
-) -> ::core::result::Result<&'a perftest_flat::Payload, ::std::string::String> {
-    if v.is_null() {
-        return ::core::result::Result::Err(
-            ::std::string::String::from("null Payload pointer"),
-        );
-    }
-    ::core::result::Result::Ok(&*(v as *const perftest_flat::Payload))
-}
-#[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) unsafe fn __cbg_in___PayloadHandler<'a>(
-    v: *const payload_handler_t,
-) -> ::core::result::Result<&'a perftest_flat::PayloadHandler, ::std::string::String> {
-    if v.is_null() {
-        return ::core::result::Result::Err(
-            ::std::string::String::from("null PayloadHandler pointer"),
-        );
-    }
-    ::core::result::Result::Ok(&*(v as *const perftest_flat::PayloadHandler))
-}
-#[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) unsafe fn __cbg_in___PayloadVecHandler<'a>(
+pub(crate) unsafe fn __c_in_convert_wire_to_PayloadVecHandler_c_borrow_shared_input_9362e4165ce71691<
+    'a,
+>(
     v: *const payload_vec_handler_t,
 ) -> ::core::result::Result<
     &'a perftest_flat::PayloadVecHandler,
@@ -314,29 +255,35 @@ pub(crate) unsafe fn __cbg_in___PayloadVecHandler<'a>(
     ::core::result::Result::Ok(&*(v as *const perftest_flat::PayloadVecHandler))
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) unsafe fn __cbg_in___Storage<'a>(
-    v: *const storage_t,
-) -> ::core::result::Result<&'a perftest_flat::Storage, ::std::string::String> {
+pub(crate) unsafe fn __c_in_convert_wire_to_PayloadVecHandler_c_terminal_input_owned_handle_b1c246bc53a8947f(
+    v: *mut payload_vec_handler_t,
+) -> ::core::result::Result<perftest_flat::PayloadVecHandler, ::std::string::String> {
     if v.is_null() {
         return ::core::result::Result::Err(
-            ::std::string::String::from("null Storage pointer"),
+            ::std::string::String::from("null PayloadVecHandler handle passed by value"),
         );
     }
-    ::core::result::Result::Ok(&*(v as *const perftest_flat::Storage))
+    ::core::result::Result::Ok(
+        *::std::boxed::Box::from_raw(v as *mut perftest_flat::PayloadVecHandler),
+    )
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) unsafe fn __cbg_in___String<'a>(
-    v: *const string_t,
-) -> ::core::result::Result<&'a ::std::string::String, ::std::string::String> {
+pub(crate) unsafe fn __c_in_convert_wire_to_Payload_c_borrow_mutable_input_580822629a1eb85c<
+    'a,
+>(
+    v: *mut payload_t,
+) -> ::core::result::Result<&'a mut perftest_flat::Payload, ::std::string::String> {
     if v.is_null() {
         return ::core::result::Result::Err(
-            ::std::string::String::from("null String pointer"),
+            ::std::string::String::from("null Payload pointer"),
         );
     }
-    ::core::result::Result::Ok(&*(v as *const ::std::string::String))
+    ::core::result::Result::Ok(&mut *(v as *mut perftest_flat::Payload))
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) unsafe fn __cbg_in___mut_MaybeUninit___Payload__<'a>(
+pub(crate) unsafe fn __c_in_convert_wire_to_Payload_c_borrow_mutable_uninit_input_ad1f621c5ea6e082<
+    'a,
+>(
     v: *mut payload_t,
 ) -> ::core::result::Result<
     &'a mut ::core::mem::MaybeUninit<perftest_flat::Payload>,
@@ -352,18 +299,39 @@ pub(crate) unsafe fn __cbg_in___mut_MaybeUninit___Payload__<'a>(
     )
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) unsafe fn __cbg_in___mut_Payload<'a>(
-    v: *mut payload_t,
-) -> ::core::result::Result<&'a mut perftest_flat::Payload, ::std::string::String> {
+pub(crate) unsafe fn __c_in_convert_wire_to_Payload_c_borrow_shared_input_9c9dcfae3e193513<
+    'a,
+>(
+    v: *const payload_t,
+) -> ::core::result::Result<&'a perftest_flat::Payload, ::std::string::String> {
     if v.is_null() {
         return ::core::result::Result::Err(
             ::std::string::String::from("null Payload pointer"),
         );
     }
-    ::core::result::Result::Ok(&mut *(v as *mut perftest_flat::Payload))
+    ::core::result::Result::Ok(&*(v as *const perftest_flat::Payload))
+}
+#[allow(non_snake_case, dead_code, unused)]
+pub(crate) fn __c_in_convert_wire_to_Payload_c_slice_input_reinterpret_45029be4ad5be227() {}
+#[allow(non_snake_case, unused_variables, dead_code)]
+pub(crate) unsafe fn __c_in_convert_wire_to_Payload_c_terminal_input_value_opaque_1025354dd257d200(
+    v: *mut payload_t,
+) -> ::core::result::Result<perftest_flat::Payload, ::std::string::String> {
+    if v.is_null() {
+        return ::core::result::Result::Err(
+            ::std::string::String::from("null Payload value passed by value"),
+        );
+    }
+    let __live = <payload_t as ::prebindgen_c_runtime::Transmute>::into_rust(
+        ::core::ptr::read(v),
+    );
+    (*v).label = ::core::ptr::null_mut();
+    ::core::result::Result::Ok(__live)
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) unsafe fn __cbg_in___mut_Storage<'a>(
+pub(crate) unsafe fn __c_in_convert_wire_to_Storage_c_borrow_mutable_input_8ce0ec1505140f75<
+    'a,
+>(
     v: *mut storage_t,
 ) -> ::core::result::Result<&'a mut perftest_flat::Storage, ::std::string::String> {
     if v.is_null() {
@@ -374,7 +342,59 @@ pub(crate) unsafe fn __cbg_in___mut_Storage<'a>(
     ::core::result::Result::Ok(&mut *(v as *mut perftest_flat::Storage))
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) unsafe fn __cbg_in___str<'a>(
+pub(crate) unsafe fn __c_in_convert_wire_to_Storage_c_borrow_shared_input_5ce0e04c530e69b0<
+    'a,
+>(
+    v: *const storage_t,
+) -> ::core::result::Result<&'a perftest_flat::Storage, ::std::string::String> {
+    if v.is_null() {
+        return ::core::result::Result::Err(
+            ::std::string::String::from("null Storage pointer"),
+        );
+    }
+    ::core::result::Result::Ok(&*(v as *const perftest_flat::Storage))
+}
+#[allow(non_snake_case, unused_variables, dead_code)]
+pub(crate) unsafe fn __c_in_convert_wire_to_Storage_c_terminal_input_owned_handle_0940f8aedc25ac46(
+    v: *mut storage_t,
+) -> ::core::result::Result<perftest_flat::Storage, ::std::string::String> {
+    if v.is_null() {
+        return ::core::result::Result::Err(
+            ::std::string::String::from("null Storage handle passed by value"),
+        );
+    }
+    ::core::result::Result::Ok(
+        *::std::boxed::Box::from_raw(v as *mut perftest_flat::Storage),
+    )
+}
+#[allow(non_snake_case, unused_variables, dead_code)]
+pub(crate) unsafe fn __c_in_convert_wire_to_String_c_borrow_shared_input_1342bc21c35103c2<
+    'a,
+>(
+    v: *const string_t,
+) -> ::core::result::Result<&'a ::std::string::String, ::std::string::String> {
+    if v.is_null() {
+        return ::core::result::Result::Err(
+            ::std::string::String::from("null String pointer"),
+        );
+    }
+    ::core::result::Result::Ok(&*(v as *const ::std::string::String))
+}
+#[allow(non_snake_case, unused_variables, dead_code)]
+pub(crate) unsafe fn __c_in_convert_wire_to_String_c_terminal_input_owned_handle_23e92025a440d7c8(
+    v: *mut string_t,
+) -> ::core::result::Result<::std::string::String, ::std::string::String> {
+    if v.is_null() {
+        return ::core::result::Result::Err(
+            ::std::string::String::from("null String handle passed by value"),
+        );
+    }
+    ::core::result::Result::Ok(
+        *::std::boxed::Box::from_raw(v as *mut ::std::string::String),
+    )
+}
+#[allow(non_snake_case, unused_variables, dead_code)]
+pub(crate) unsafe fn __c_in_convert_wire_to_str_c_borrow_str_input_246c2b9955bb6ef2<'a>(
     v: *const ::core::ffi::c_char,
 ) -> ::core::result::Result<&'a str, ::std::string::String> {
     if v.is_null() {
@@ -392,38 +412,56 @@ pub(crate) unsafe fn __cbg_in___str<'a>(
     }
 }
 #[allow(non_snake_case, dead_code, unused)]
-pub(crate) fn __cbg_inmark_slice_Payload() {}
+pub(crate) fn __c_out_convert_Option_Payload_c_marker_optional_to_wire_0d65bf71671af35a() {}
+#[allow(non_snake_case, dead_code, unused)]
+pub(crate) fn __c_out_convert_Option_Vec_Payload_c_marker_optional_to_wire_7a54934e42568ea6() {}
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) fn __cbg_out_Payload(v: perftest_flat::Payload) -> payload_t {
-    <payload_t as ::prebindgen_c_runtime::Transmute>::from_rust(v)
-}
-#[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) fn __cbg_out_PayloadHandler(
+pub(crate) fn __c_out_convert_PayloadHandler_c_terminal_output_owned_handle_to_wire_138a2e3a98f0b6c1(
     v: perftest_flat::PayloadHandler,
 ) -> *mut payload_handler_t {
     ::std::boxed::Box::into_raw(::std::boxed::Box::new(v)) as *mut payload_handler_t
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) fn __cbg_out_PayloadVecHandler(
+pub(crate) fn __c_out_convert_PayloadVecHandler_c_terminal_output_owned_handle_to_wire_90de88c77a3ca699(
     v: perftest_flat::PayloadVecHandler,
 ) -> *mut payload_vec_handler_t {
     ::std::boxed::Box::into_raw(::std::boxed::Box::new(v)) as *mut payload_vec_handler_t
 }
+#[allow(non_snake_case, dead_code, unused)]
+pub(crate) unsafe fn __c_out_convert_Payload_c_borrow_shared_output_to_wire_5d954ba915ba18c7(
+    v: &perftest_flat::Payload,
+) -> *const payload_t {
+    v as *const perftest_flat::Payload as *const payload_t
+}
+#[allow(non_snake_case, dead_code, unused)]
+pub(crate) fn __c_out_convert_Payload_c_marker_sequence_to_wire_2e9a65c76a50a9dc() {}
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) fn __cbg_out_Storage(v: perftest_flat::Storage) -> *mut storage_t {
+pub(crate) fn __c_out_convert_Payload_c_terminal_output_value_opaque_to_wire_ce0f5eae80482d02(
+    v: perftest_flat::Payload,
+) -> payload_t {
+    <payload_t as ::prebindgen_c_runtime::Transmute>::from_rust(v)
+}
+#[allow(non_snake_case, unused_variables, dead_code)]
+pub(crate) fn __c_out_convert_Storage_c_terminal_output_owned_handle_to_wire_1aad3d8ed7ca5bfa(
+    v: perftest_flat::Storage,
+) -> *mut storage_t {
     ::std::boxed::Box::into_raw(::std::boxed::Box::new(v)) as *mut storage_t
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) fn __cbg_out_String(v: ::std::string::String) -> *mut string_t {
+pub(crate) fn __c_out_convert_String_c_terminal_output_owned_handle_to_wire_da496556652b0d98(
+    v: ::std::string::String,
+) -> *mut string_t {
     ::std::boxed::Box::into_raw(::std::boxed::Box::new(v)) as *mut string_t
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) fn __cbg_out_bool(v: bool) -> bool {
+pub(crate) fn __c_out_convert_bool_c_terminal_output_scalar_to_wire_cc0ad9760da17efd(
+    v: bool,
+) -> bool {
     v
 }
 #[allow(non_snake_case, unused_variables, dead_code)]
 #[inline(always)]
-pub(crate) fn __cbg_out_chain_vec_Payload(
+pub(crate) fn __c_out_convert_sequence_Vec_Payload_to_wire_dc890ff48c52049e(
     v: ::std::vec::Vec<perftest_flat::Payload>,
 ) -> ::std::vec::Vec<payload_t> {
     {
@@ -432,37 +470,33 @@ pub(crate) fn __cbg_out_chain_vec_Payload(
             (__sequence_source).len(),
         );
         for __sequence_element in __sequence_source.into_iter() {
-            let __sequence_part = __cbg_out_Payload(__sequence_element);
+            let __sequence_part = __c_out_convert_Payload_c_terminal_output_value_opaque_to_wire_ce0f5eae80482d02(
+                __sequence_element,
+            );
             __sequence_output.push(__sequence_part);
         }
         __sequence_output
     }
 }
-#[allow(non_snake_case, dead_code, unused)]
-pub(crate) unsafe fn __cbg_out_ref_Payload(
-    v: &perftest_flat::Payload,
-) -> *const payload_t {
-    v as *const perftest_flat::Payload as *const payload_t
-}
 #[allow(non_snake_case, unused_variables, dead_code)]
-pub(crate) fn __cbg_out_usize(v: usize) -> usize {
+pub(crate) fn __c_out_convert_usize_c_terminal_output_scalar_to_wire_4b27414858b3ddc9(
+    v: usize,
+) -> usize {
     v
 }
-#[allow(non_snake_case, dead_code, unused)]
-pub(crate) fn __cbg_outmark_option_Payload() {}
-#[allow(non_snake_case, dead_code, unused)]
-pub(crate) fn __cbg_outmark_option_Vec___Payload__() {}
-#[allow(non_snake_case, dead_code, unused)]
-pub(crate) fn __cbg_outmark_vec_Payload() {}
 #[no_mangle]
 #[allow(non_snake_case, unused_mut, unused_variables, unused_unsafe, dead_code)]
 pub unsafe extern "C" fn payload_handler_new(
     f: closure_payload_t,
 ) -> *mut payload_handler_t {
-    let f = __cbg_in_closure_payload_t(f);
+    let f = __c_in_convert_wire_to_impl_Fn_Payload_Send_Sync_static_c_invoke_callback_capture_1f115f7d391197ee(
+        f,
+    );
     let __v = perftest_flat::payload_handler_new(f);
     let __ret: *mut payload_handler_t;
-    __ret = __cbg_out_PayloadHandler(__v);
+    __ret = __c_out_convert_PayloadHandler_c_terminal_output_owned_handle_to_wire_138a2e3a98f0b6c1(
+        __v,
+    );
     __ret
 }
 #[no_mangle]
@@ -470,10 +504,14 @@ pub unsafe extern "C" fn payload_handler_new(
 pub unsafe extern "C" fn payload_vec_handler_new(
     f: closure_payload_vec_t,
 ) -> *mut payload_vec_handler_t {
-    let f = __cbg_in_closure_payload_vec_t(f);
+    let f = __c_in_convert_wire_to_impl_Fn_Payload_Send_Sync_static_c_invoke_callback_capture_6d4224db8a8b8070(
+        f,
+    );
     let __v = perftest_flat::payload_vec_handler_new(f);
     let __ret: *mut payload_vec_handler_t;
-    __ret = __cbg_out_PayloadVecHandler(__v);
+    __ret = __c_out_convert_PayloadVecHandler_c_terminal_output_owned_handle_to_wire_90de88c77a3ca699(
+        __v,
+    );
     __ret
 }
 #[no_mangle]
@@ -482,13 +520,17 @@ pub unsafe extern "C" fn storage_callback(
     s: *const storage_t,
     handler: *const payload_handler_t,
 ) {
-    let s = match __cbg_in___Storage(s) {
+    let s = match __c_in_convert_wire_to_Storage_c_borrow_shared_input_5ce0e04c530e69b0(
+        s,
+    ) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__msg) => {
             panic!("{}", __msg);
         }
     };
-    let handler = match __cbg_in___PayloadHandler(handler) {
+    let handler = match __c_in_convert_wire_to_PayloadHandler_c_borrow_shared_input_9caa5450154416a9(
+        handler,
+    ) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__msg) => {
             panic!("{}", __msg);
@@ -502,13 +544,17 @@ pub unsafe extern "C" fn storage_callback_vec(
     s: *const storage_t,
     handler: *const payload_vec_handler_t,
 ) {
-    let s = match __cbg_in___Storage(s) {
+    let s = match __c_in_convert_wire_to_Storage_c_borrow_shared_input_5ce0e04c530e69b0(
+        s,
+    ) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__msg) => {
             panic!("{}", __msg);
         }
     };
-    let handler = match __cbg_in___PayloadVecHandler(handler) {
+    let handler = match __c_in_convert_wire_to_PayloadVecHandler_c_borrow_shared_input_9362e4165ce71691(
+        handler,
+    ) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__msg) => {
             panic!("{}", __msg);
@@ -519,7 +565,9 @@ pub unsafe extern "C" fn storage_callback_vec(
 #[no_mangle]
 #[allow(non_snake_case, unused_mut, unused_variables, unused_unsafe, dead_code)]
 pub unsafe extern "C" fn storage_get(s: *const storage_t, out: *mut payload_t) -> bool {
-    let s = match __cbg_in___Storage(s) {
+    let s = match __c_in_convert_wire_to_Storage_c_borrow_shared_input_5ce0e04c530e69b0(
+        s,
+    ) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__msg) => {
             panic!("{}", __msg);
@@ -530,7 +578,9 @@ pub unsafe extern "C" fn storage_get(s: *const storage_t, out: *mut payload_t) -
     match __v {
         ::core::option::Option::Some(__x) => {
             __ret = true;
-            *out = __cbg_out_Payload(__x);
+            *out = __c_out_convert_Payload_c_terminal_output_value_opaque_to_wire_ce0f5eae80482d02(
+                __x,
+            );
         }
         ::core::option::Option::None => {
             __ret = false;
@@ -544,13 +594,17 @@ pub unsafe extern "C" fn storage_get_into_init(
     s: *const storage_t,
     payload: *mut payload_t,
 ) -> bool {
-    let s = match __cbg_in___Storage(s) {
+    let s = match __c_in_convert_wire_to_Storage_c_borrow_shared_input_5ce0e04c530e69b0(
+        s,
+    ) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__msg) => {
             panic!("{}", __msg);
         }
     };
-    let payload = match __cbg_in___mut_Payload(payload) {
+    let payload = match __c_in_convert_wire_to_Payload_c_borrow_mutable_input_580822629a1eb85c(
+        payload,
+    ) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__msg) => {
             panic!("{}", __msg);
@@ -558,7 +612,7 @@ pub unsafe extern "C" fn storage_get_into_init(
     };
     let __v = perftest_flat::storage_get_into_init(s, payload);
     let __ret: bool;
-    __ret = __cbg_out_bool(__v);
+    __ret = __c_out_convert_bool_c_terminal_output_scalar_to_wire_cc0ad9760da17efd(__v);
     __ret
 }
 #[no_mangle]
@@ -567,13 +621,17 @@ pub unsafe extern "C" fn storage_get_into_uninit(
     s: *const storage_t,
     payload: *mut payload_t,
 ) -> bool {
-    let s = match __cbg_in___Storage(s) {
+    let s = match __c_in_convert_wire_to_Storage_c_borrow_shared_input_5ce0e04c530e69b0(
+        s,
+    ) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__msg) => {
             panic!("{}", __msg);
         }
     };
-    let payload = match __cbg_in___mut_MaybeUninit___Payload__(payload) {
+    let payload = match __c_in_convert_wire_to_Payload_c_borrow_mutable_uninit_input_ad1f621c5ea6e082(
+        payload,
+    ) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__msg) => {
             panic!("{}", __msg);
@@ -581,7 +639,7 @@ pub unsafe extern "C" fn storage_get_into_uninit(
     };
     let __v = perftest_flat::storage_get_into_uninit(s, payload);
     let __ret: bool;
-    __ret = __cbg_out_bool(__v);
+    __ret = __c_out_convert_bool_c_terminal_output_scalar_to_wire_cc0ad9760da17efd(__v);
     __ret
 }
 #[no_mangle]
@@ -591,7 +649,9 @@ pub unsafe extern "C" fn storage_get_vec(
     out: *mut *mut payload_t,
     out_len: *mut usize,
 ) -> bool {
-    let s = match __cbg_in___Storage(s) {
+    let s = match __c_in_convert_wire_to_Storage_c_borrow_shared_input_5ce0e04c530e69b0(
+        s,
+    ) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__msg) => {
             panic!("{}", __msg);
@@ -602,7 +662,9 @@ pub unsafe extern "C" fn storage_get_vec(
     match __v {
         ::core::option::Option::Some(__x) => {
             __ret = true;
-            let __arr: ::std::vec::Vec<payload_t> = __cbg_out_chain_vec_Payload(__x);
+            let __arr: ::std::vec::Vec<payload_t> = __c_out_convert_sequence_Vec_Payload_to_wire_dc890ff48c52049e(
+                __x,
+            );
             let (__p, __n) = __cbg_alloc_array(__arr);
             *out = __p;
             *out_len = __n;
@@ -618,7 +680,9 @@ pub unsafe extern "C" fn storage_get_vec(
 pub unsafe extern "C" fn storage_new() -> *mut storage_t {
     let __v = perftest_flat::storage_new();
     let __ret: *mut storage_t;
-    __ret = __cbg_out_Storage(__v);
+    __ret = __c_out_convert_Storage_c_terminal_output_owned_handle_to_wire_1aad3d8ed7ca5bfa(
+        __v,
+    );
     __ret
 }
 #[no_mangle]
@@ -627,13 +691,17 @@ pub unsafe extern "C" fn storage_put_by_read(
     s: *mut storage_t,
     payload: *const payload_t,
 ) {
-    let s = match __cbg_in___mut_Storage(s) {
+    let s = match __c_in_convert_wire_to_Storage_c_borrow_mutable_input_8ce0ec1505140f75(
+        s,
+    ) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__msg) => {
             panic!("{}", __msg);
         }
     };
-    let payload = match __cbg_in___Payload(payload) {
+    let payload = match __c_in_convert_wire_to_Payload_c_borrow_shared_input_9c9dcfae3e193513(
+        payload,
+    ) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__msg) => {
             panic!("{}", __msg);
@@ -647,13 +715,17 @@ pub unsafe extern "C" fn storage_put_by_read_and_update(
     s: *mut storage_t,
     payload: *mut payload_t,
 ) {
-    let s = match __cbg_in___mut_Storage(s) {
+    let s = match __c_in_convert_wire_to_Storage_c_borrow_mutable_input_8ce0ec1505140f75(
+        s,
+    ) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__msg) => {
             panic!("{}", __msg);
         }
     };
-    let payload = match __cbg_in___mut_Payload(payload) {
+    let payload = match __c_in_convert_wire_to_Payload_c_borrow_mutable_input_580822629a1eb85c(
+        payload,
+    ) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__msg) => {
             panic!("{}", __msg);
@@ -667,13 +739,17 @@ pub unsafe extern "C" fn storage_put_by_take(
     s: *mut storage_t,
     payload: *mut payload_t,
 ) {
-    let s = match __cbg_in___mut_Storage(s) {
+    let s = match __c_in_convert_wire_to_Storage_c_borrow_mutable_input_8ce0ec1505140f75(
+        s,
+    ) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__msg) => {
             panic!("{}", __msg);
         }
     };
-    let payload = match __cbg_in_Payload(payload) {
+    let payload = match __c_in_convert_wire_to_Payload_c_terminal_input_value_opaque_1025354dd257d200(
+        payload,
+    ) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__msg) => {
             panic!("{}", __msg);
@@ -688,7 +764,9 @@ pub unsafe extern "C" fn storage_put_slice(
     payloads: *const payload_t,
     payloads_len: usize,
 ) {
-    let s = match __cbg_in___mut_Storage(s) {
+    let s = match __c_in_convert_wire_to_Storage_c_borrow_mutable_input_8ce0ec1505140f75(
+        s,
+    ) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__msg) => {
             panic!("{}", __msg);
@@ -707,7 +785,9 @@ pub unsafe extern "C" fn storage_put_slice(
 #[no_mangle]
 #[allow(non_snake_case, unused_mut, unused_variables, unused_unsafe, dead_code)]
 pub unsafe extern "C" fn string_len(s: *const string_t) -> usize {
-    let s = match __cbg_in___String(s) {
+    let s = match __c_in_convert_wire_to_String_c_borrow_shared_input_1342bc21c35103c2(
+        s,
+    ) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__msg) => {
             panic!("{}", __msg);
@@ -715,13 +795,13 @@ pub unsafe extern "C" fn string_len(s: *const string_t) -> usize {
     };
     let __v = perftest_flat::string_len(s);
     let __ret: usize;
-    __ret = __cbg_out_usize(__v);
+    __ret = __c_out_convert_usize_c_terminal_output_scalar_to_wire_4b27414858b3ddc9(__v);
     __ret
 }
 #[no_mangle]
 #[allow(non_snake_case, unused_mut, unused_variables, unused_unsafe, dead_code)]
 pub unsafe extern "C" fn string_new(s: *const ::core::ffi::c_char) -> *mut string_t {
-    let s = match __cbg_in___str(s) {
+    let s = match __c_in_convert_wire_to_str_c_borrow_str_input_246c2b9955bb6ef2(s) {
         ::core::result::Result::Ok(__v) => __v,
         ::core::result::Result::Err(__msg) => {
             panic!("{}", __msg);
@@ -729,7 +809,9 @@ pub unsafe extern "C" fn string_new(s: *const ::core::ffi::c_char) -> *mut strin
     };
     let __v = perftest_flat::string_new(s);
     let __ret: *mut string_t;
-    __ret = __cbg_out_String(__v);
+    __ret = __c_out_convert_String_c_terminal_output_owned_handle_to_wire_da496556652b0d98(
+        __v,
+    );
     __ret
 }
 /// The storage capacity limit advertised to bindings (a primitive const).

--- a/prebindgen-c/src/builder.rs
+++ b/prebindgen-c/src/builder.rs
@@ -676,17 +676,6 @@ impl CbindgenBuilder {
             .or_else(|| super::scalar_ty(elem))
     }
 
-    /// [`Self::in_name`] off the **identity**, for a caller holding a reading
-    /// rather than a node — which is every per-field site.
-    pub(super) fn in_name_of(key: &TypeKey) -> syn::Ident {
-        format_ident!("__cbg_in_{}", sanitize(key))
-    }
-
-    /// [`Self::out_name`] off the identity. See [`Self::in_name_of`].
-    pub(super) fn out_name_of(key: &TypeKey) -> syn::Ident {
-        format_ident!("__cbg_out_{}", sanitize(key))
-    }
-
     /// Config of a declared type (across the opaque/data/enum maps), by key.
     pub(super) fn type_cfg(&self, key: &TypeKey) -> Option<&TypeCfg> {
         self.opaque

--- a/prebindgen-c/src/chain.rs
+++ b/prebindgen-c/src/chain.rs
@@ -22,10 +22,13 @@ use super::{builder::qualify_source_type, *};
 pub(crate) struct CCall(chain::Call);
 
 impl CCall {
-    pub(crate) fn ident(&self) -> &syn::Ident {
-        self.0
-            .ident()
-            .expect("C compatibility calls are named during planning")
+    pub(crate) fn ident(&self, emit: &Emit) -> syn::Ident {
+        emit.operation_ident(
+            "c",
+            self.0
+                .operation_id()
+                .expect("every C converter call has registry operation identity"),
+        )
     }
 
     pub(crate) fn fallible(&self) -> bool {
@@ -42,8 +45,8 @@ impl chain::Child for CCall {
         &self.0
     }
 
-    fn invoke(&self, value: TokenStream, _emit: &prebindgen_registry::Emit) -> TokenStream {
-        let ident = self.ident();
+    fn invoke(&self, value: TokenStream, emit: &prebindgen_registry::Emit) -> TokenStream {
+        let ident = self.ident(emit);
         quote!(#ident(#value))
     }
 }
@@ -76,8 +79,8 @@ enum CBody {
 
 impl CFunction {
     pub(crate) fn product(operation: prebindgen_registry::OperationId, plan: ProductPlan) -> Self {
-        let call = CCall(chain::Call::new(
-            plan.ident.clone(),
+        let call = CCall(chain::Call::operation(
+            operation.clone(),
             plan.fields.iter().any(|field| field.converter.fallible()),
             plan.direction == Direction::Construct,
         ));
@@ -89,7 +92,11 @@ impl CFunction {
     }
 
     pub(crate) fn custom(operation: prebindgen_registry::OperationId, plan: CustomPlan) -> Self {
-        let call = CCall(chain::Call::new(plan.ident.clone(), plan.fallible(), false));
+        let call = CCall(chain::Call::operation(
+            operation.clone(),
+            plan.fallible(),
+            false,
+        ));
         Self {
             operation,
             call,
@@ -101,7 +108,7 @@ impl CFunction {
         operation: prebindgen_registry::OperationId,
         plan: OutputTerminalPlan,
     ) -> Self {
-        let call = CCall(chain::Call::new(plan.ident.clone(), false, false));
+        let call = CCall(chain::Call::operation(operation.clone(), false, false));
         Self {
             operation,
             call,
@@ -113,8 +120,8 @@ impl CFunction {
         operation: prebindgen_registry::OperationId,
         plan: InputTerminalPlan,
     ) -> Self {
-        let call = CCall(chain::Call::new(
-            plan.ident.clone(),
+        let call = CCall(chain::Call::operation(
+            operation.clone(),
             plan.operation.fallible(),
             plan.operation.unsafe_(),
         ));
@@ -126,8 +133,8 @@ impl CFunction {
     }
 
     pub(crate) fn payload(operation: prebindgen_registry::OperationId, plan: PayloadPlan) -> Self {
-        let call = CCall(chain::Call::new(
-            plan.ident.clone(),
+        let call = CCall(chain::Call::operation(
+            operation.clone(),
             plan.direction == Direction::Construct && !plan.optional,
             plan.direction == Direction::Construct,
         ));
@@ -139,8 +146,8 @@ impl CFunction {
     }
 
     pub(crate) fn borrow(operation: prebindgen_registry::OperationId, plan: BorrowPlan) -> Self {
-        let call = CCall(chain::Call::new(
-            plan.ident.clone(),
+        let call = CCall(chain::Call::operation(
+            operation.clone(),
             plan.operation.fallible(),
             true,
         ));
@@ -155,7 +162,7 @@ impl CFunction {
         operation: prebindgen_registry::OperationId,
         plan: SliceInputPlan,
     ) -> Self {
-        let call = CCall(chain::Call::new(plan.ident.clone(), false, false));
+        let call = CCall(chain::Call::operation(operation.clone(), false, false));
         Self {
             operation,
             call,
@@ -164,7 +171,7 @@ impl CFunction {
     }
 
     pub(crate) fn marker(operation: prebindgen_registry::OperationId, plan: MarkerPlan) -> Self {
-        let call = CCall(chain::Call::new(plan.ident.clone(), false, false));
+        let call = CCall(chain::Call::operation(operation.clone(), false, false));
         Self {
             operation,
             call,
@@ -176,8 +183,8 @@ impl CFunction {
         operation: prebindgen_registry::OperationId,
         plan: OptionalPlan,
     ) -> Self {
-        let call = CCall(chain::Call::new(
-            plan.ident.clone(),
+        let call = CCall(chain::Call::operation(
+            operation.clone(),
             plan.converter.fallible(),
             true,
         ));
@@ -192,8 +199,8 @@ impl CFunction {
         operation: prebindgen_registry::OperationId,
         plan: SequencePlan,
     ) -> Self {
-        let call = CCall(chain::Call::new(
-            plan.ident.clone(),
+        let call = CCall(chain::Call::operation(
+            operation.clone(),
             plan.child.fallible(),
             plan.child.unsafe_(),
         ));
@@ -211,8 +218,8 @@ impl CFunction {
                 .iter()
                 .flat_map(|arm| &arm.parts)
                 .any(|part| part.child.fallible());
-        let call = CCall(chain::Call::new(
-            plan.ident.clone(),
+        let call = CCall(chain::Call::operation(
+            operation.clone(),
             fallible,
             plan.direction == Direction::Construct,
         ));
@@ -223,13 +230,10 @@ impl CFunction {
         }
     }
 
-    pub(crate) fn deferred_invoke(
-        operation: prebindgen_registry::OperationId,
-        ident: syn::Ident,
-    ) -> Self {
+    pub(crate) fn deferred_invoke(operation: prebindgen_registry::OperationId) -> Self {
         Self {
+            call: CCall(chain::Call::operation(operation.clone(), false, true)),
             operation,
-            call: CCall(chain::Call::new(ident, false, true)),
             body: CBody::DeferredInvoke,
         }
     }
@@ -239,10 +243,19 @@ impl CFunction {
     }
 
     #[cfg(test)]
-    pub(crate) fn operation_and_compatibility_name(
+    pub(crate) fn operation_and_call_identity(
         &self,
-    ) -> (&prebindgen_registry::OperationId, &syn::Ident) {
-        (&self.operation, self.call.ident())
+    ) -> (
+        &prebindgen_registry::OperationId,
+        &prebindgen_registry::OperationId,
+    ) {
+        (
+            &self.operation,
+            self.call
+                .0
+                .operation_id()
+                .expect("C converter calls are late-named operations"),
+        )
     }
 
     #[cfg(test)]
@@ -322,18 +335,19 @@ impl RustFunction for CFunction {
     }
 
     fn render(&self, emit: &Emit) -> syn::ItemFn {
+        let name = emit.operation_ident("c", &self.operation);
         match &self.body {
-            CBody::Custom(plan) => plan.render(emit),
-            CBody::InputTerminal(plan) => plan.render(emit),
-            CBody::OutputTerminal(plan) => plan.render(emit),
-            CBody::Payload(plan) => plan.render(emit),
-            CBody::Borrow(plan) => plan.render(emit),
-            CBody::SliceInput(plan) => plan.render(),
-            CBody::Marker(plan) => plan.render(),
-            CBody::Product(plan) => plan.render(emit),
-            CBody::Choice(plan) => plan.render(emit),
-            CBody::Sequence(plan) => plan.render(emit),
-            CBody::Optional(plan) => plan.render(emit),
+            CBody::Custom(plan) => plan.render(emit, &name),
+            CBody::InputTerminal(plan) => plan.render(emit, &name),
+            CBody::OutputTerminal(plan) => plan.render(emit, &name),
+            CBody::Payload(plan) => plan.render(emit, &name),
+            CBody::Borrow(plan) => plan.render(emit, &name),
+            CBody::SliceInput(plan) => plan.render(&name),
+            CBody::Marker(plan) => plan.render(&name),
+            CBody::Product(plan) => plan.render(emit, &name),
+            CBody::Choice(plan) => plan.render(emit, &name),
+            CBody::Sequence(plan) => plan.render(emit, &name),
+            CBody::Optional(plan) => plan.render(emit, &name),
             CBody::DeferredInvoke => {
                 unreachable!("a deferred C Invoke helper is rendered by its callback artifact")
             }
@@ -353,23 +367,21 @@ pub(crate) enum MarkerOperation {
 /// A typed replacement for one legacy zero-argument marker converter.
 #[derive(Clone)]
 pub(crate) struct MarkerPlan {
-    pub(crate) ident: syn::Ident,
     pub(crate) operation: MarkerOperation,
     pub(crate) subs: Vec<TypeRef>,
 }
 
 impl MarkerPlan {
-    fn render(&self) -> syn::ItemFn {
+    fn render(&self, name: &syn::Ident) -> syn::ItemFn {
         match self.operation {
             MarkerOperation::ChoiceArm => {
-                let name = &self.ident;
                 syn::parse_quote!(
                     #[allow(dead_code)]
                     fn #name() {}
                 )
             }
             MarkerOperation::Optional | MarkerOperation::Sequence | MarkerOperation::Result => {
-                render_marker(&self.ident)
+                render_marker(name)
             }
         }
     }
@@ -378,15 +390,14 @@ impl MarkerPlan {
 /// A zero-copy shared-slice input retained without a legacy converter body.
 #[derive(Clone)]
 pub(crate) struct SliceInputPlan {
-    pub(crate) ident: syn::Ident,
     pub(crate) element: TypeRef,
     pub(crate) wire: syn::Type,
     pub(crate) reinterpret: bool,
 }
 
 impl SliceInputPlan {
-    fn render(&self) -> syn::ItemFn {
-        render_marker(&self.ident)
+    fn render(&self, name: &syn::Ident) -> syn::ItemFn {
+        render_marker(name)
     }
 }
 
@@ -416,7 +427,6 @@ impl BorrowOperation {
 /// A borrow terminal whose referent is materialized only during final emission.
 #[derive(Clone)]
 pub(crate) struct BorrowPlan {
-    pub(crate) ident: syn::Ident,
     pub(crate) source_inner: TypeRef,
     pub(crate) source_module: Option<syn::Path>,
     pub(crate) wire: syn::Type,
@@ -425,8 +435,7 @@ pub(crate) struct BorrowPlan {
 }
 
 impl BorrowPlan {
-    fn render(&self, emit: &Emit) -> syn::ItemFn {
-        let name = &self.ident;
+    fn render(&self, emit: &Emit, name: &syn::Ident) -> syn::ItemFn {
         let source_inner = qualify_source_type(
             &emit.spell_ty(&self.source_inner),
             self.source_module.as_ref(),
@@ -510,7 +519,6 @@ impl BorrowPlan {
 /// A tagged-union pointer payload retained without spelling its source types.
 #[derive(Clone)]
 pub(crate) struct PayloadPlan {
-    pub(crate) ident: syn::Ident,
     pub(crate) source: TypeRef,
     pub(crate) source_inner: TypeRef,
     pub(crate) source_module: Option<syn::Path>,
@@ -522,8 +530,7 @@ pub(crate) struct PayloadPlan {
 }
 
 impl PayloadPlan {
-    fn render(&self, emit: &Emit) -> syn::ItemFn {
-        let name = &self.ident;
+    fn render(&self, emit: &Emit, name: &syn::Ident) -> syn::ItemFn {
         let source = qualify_source_type(&emit.spell_ty(&self.source), self.source_module.as_ref());
         let source_inner = qualify_source_type(
             &emit.spell_ty(&self.source_inner),
@@ -662,7 +669,6 @@ impl InputTerminalOperation {
 /// A C input terminal retained until the final writer owns [`Emit`].
 #[derive(Clone)]
 pub(crate) struct InputTerminalPlan {
-    pub(crate) ident: syn::Ident,
     pub(crate) source: TypeRef,
     pub(crate) source_module: Option<syn::Path>,
     pub(crate) wire: syn::Type,
@@ -670,8 +676,7 @@ pub(crate) struct InputTerminalPlan {
 }
 
 impl InputTerminalPlan {
-    fn render(&self, emit: &Emit) -> syn::ItemFn {
-        let name = &self.ident;
+    fn render(&self, emit: &Emit, name: &syn::Ident) -> syn::ItemFn {
         let source = qualify_source_type(&emit.spell_ty(&self.source), self.source_module.as_ref());
         let wire = &self.wire;
         match &self.operation {
@@ -830,7 +835,6 @@ pub(crate) enum OutputTerminalOperation {
 /// A C output terminal retained until the final writer owns `Emit`.
 #[derive(Clone)]
 pub(crate) struct OutputTerminalPlan {
-    pub(crate) ident: syn::Ident,
     pub(crate) source: TypeRef,
     pub(crate) source_module: Option<syn::Path>,
     pub(crate) wire: syn::Type,
@@ -838,8 +842,7 @@ pub(crate) struct OutputTerminalPlan {
 }
 
 impl OutputTerminalPlan {
-    fn render(&self, emit: &Emit) -> syn::ItemFn {
-        let name = &self.ident;
+    fn render(&self, emit: &Emit, name: &syn::Ident) -> syn::ItemFn {
         let source = qualify_source_type(&emit.spell_ty(&self.source), self.source_module.as_ref());
         let wire = &self.wire;
         match &self.operation {
@@ -957,7 +960,6 @@ impl CustomOperation {
 /// One canonical scalar conversion, frozen before source spelling is allowed.
 #[derive(Clone)]
 pub(crate) struct CustomPlan {
-    pub(crate) ident: syn::Ident,
     pub(crate) source: TypeRef,
     pub(crate) source_module: Option<syn::Path>,
     pub(crate) wire: syn::Type,
@@ -972,8 +974,7 @@ impl CustomPlan {
         self.valid.is_some() || self.operation.fallible()
     }
 
-    fn render(&self, emit: &Emit) -> syn::ItemFn {
-        let name = &self.ident;
+    fn render(&self, emit: &Emit, name: &syn::Ident) -> syn::ItemFn {
         let source = qualify_source_type(&emit.spell_ty(&self.source), self.source_module.as_ref());
         let wire = &self.wire;
         let conversion = self.operation.expression(self.direction, &source, wire);
@@ -1088,84 +1089,11 @@ impl CallbackArgument {
     }
 
     fn invoke_part(&self, index: usize) -> InvokePart {
-        let source = invoke_argument_name(index);
-        if let Some(element) = &self.zero_copy_element {
-            return InvokePart {
-                source: source.clone(),
-                prepare: TokenStream::new(),
-                arguments: vec![
-                    quote!(#source.as_ptr() as *const #element),
-                    quote!(#source.len()),
-                ],
-                cleanup: TokenStream::new(),
-            };
-        }
-
-        let mut prepare = TokenStream::new();
-        let mut arguments = Vec::new();
-        let mut cleanup = TokenStream::new();
-        if self.takeable {
-            let (wire, converter) = self
-                .value
-                .direct()
-                .expect("a takeable callback argument must have one direct wire");
-            let target = format_ident!("__w{index}");
-            let conv = converter.ident();
-            let converted = if converter.fallible() {
-                quote!(match #conv(#source) {
-                    ::core::result::Result::Ok(__v) => __v,
-                    ::core::result::Result::Err(__e) => {
-                        ::core::panic!("cbindgen: callback argument conversion failed: {}", __e)
-                    }
-                })
-            } else {
-                quote!(#conv(#source))
-            };
-            prepare.extend(quote!(let mut #target = #converted;));
-            arguments.push(quote!(&mut #target as *mut #wire));
-            cleanup.extend(quote!(
-                let _ = <#wire as ::prebindgen_c_runtime::Transmute>::into_rust(#target);
-            ));
-        } else if let Some((_, converter)) = self.value.direct() {
-            let target = format_ident!("__w{index}");
-            let conv = converter.ident();
-            let converted = if converter.fallible() {
-                quote!(match #conv(#source) {
-                    ::core::result::Result::Ok(__v) => __v,
-                    ::core::result::Result::Err(__e) => {
-                        ::core::panic!("cbindgen: callback argument conversion failed: {}", __e)
-                    }
-                })
-            } else {
-                quote!(#conv(#source))
-            };
-            prepare.extend(quote!(let #target = #converted;));
-            arguments.push(quote!(#target));
-        } else {
-            let fields = self.value.fields();
-            let mut targets = Vec::new();
-            for (field_index, field) in fields.iter().enumerate() {
-                let target = if fields.len() == 1 {
-                    format_ident!("__w{index}")
-                } else {
-                    format_ident!("__w{index}_{field_index}")
-                };
-                let wire = &field.wire;
-                prepare
-                    .extend(quote!(let mut #target = ::core::mem::MaybeUninit::<#wire>::zeroed();));
-                targets.push(quote!(*#target.as_mut_ptr()));
-                arguments.push(quote!(#target));
-            }
-            prepare.extend(
-                self.value
-                    .encode(quote!(#source), &targets, &ErrRoute::Panic),
-            );
-        }
         InvokePart {
-            source,
-            prepare,
-            arguments,
-            cleanup,
+            source: invoke_argument_name(index),
+            value: self.value.clone(),
+            zero_copy_element: self.zero_copy_element.clone(),
+            takeable: self.takeable,
         }
     }
 }
@@ -1181,7 +1109,7 @@ pub(crate) struct CallbackArtifact {
 impl CallbackArtifact {
     pub(crate) fn new(
         c_struct: syn::Ident,
-        ident: syn::Ident,
+        operation: prebindgen_registry::OperationId,
         source: TypeRef,
         source_module: Option<syn::Path>,
         arguments: Vec<TypeRef>,
@@ -1196,7 +1124,7 @@ impl CallbackArtifact {
         Self {
             c_struct,
             invoke: InvokePlan {
-                ident,
+                operation,
                 source,
                 source_module,
                 wire,
@@ -1611,19 +1539,91 @@ impl TaggedUnionArtifact {
 #[derive(Clone)]
 pub(crate) struct InvokePart {
     pub(crate) source: syn::Ident,
-    pub(crate) prepare: TokenStream,
-    pub(crate) arguments: Vec<TokenStream>,
-    pub(crate) cleanup: TokenStream,
+    pub(crate) value: crate::compile::CValue,
+    pub(crate) zero_copy_element: Option<syn::Type>,
+    pub(crate) takeable: bool,
 }
 
 impl chain::InvokePart for InvokePart {
-    fn render(&self, value: &syn::Ident, index: usize, _emit: &Emit) -> chain::RenderedInvokePart {
+    fn render(&self, value: &syn::Ident, index: usize, emit: &Emit) -> chain::RenderedInvokePart {
         assert_eq!(value, &invoke_argument_name(index));
         assert_eq!(value, &self.source);
+
+        if let Some(element) = &self.zero_copy_element {
+            return chain::RenderedInvokePart {
+                prepare: TokenStream::new(),
+                arguments: vec![
+                    quote!(#value.as_ptr() as *const #element),
+                    quote!(#value.len()),
+                ],
+                cleanup: TokenStream::new(),
+            };
+        }
+
+        let mut prepare = TokenStream::new();
+        let mut arguments = Vec::new();
+        let mut cleanup = TokenStream::new();
+        if self.takeable {
+            let (wire, converter) = self
+                .value
+                .direct()
+                .expect("a takeable callback argument must have one direct wire");
+            let target = format_ident!("__w{index}");
+            let conv = converter.ident(emit);
+            let converted = if converter.fallible() {
+                quote!(match #conv(#value) {
+                    ::core::result::Result::Ok(__v) => __v,
+                    ::core::result::Result::Err(__e) => {
+                        ::core::panic!("cbindgen: callback argument conversion failed: {}", __e)
+                    }
+                })
+            } else {
+                quote!(#conv(#value))
+            };
+            prepare.extend(quote!(let mut #target = #converted;));
+            arguments.push(quote!(&mut #target as *mut #wire));
+            cleanup.extend(quote!(
+                let _ = <#wire as ::prebindgen_c_runtime::Transmute>::into_rust(#target);
+            ));
+        } else if let Some((_, converter)) = self.value.direct() {
+            let target = format_ident!("__w{index}");
+            let conv = converter.ident(emit);
+            let converted = if converter.fallible() {
+                quote!(match #conv(#value) {
+                    ::core::result::Result::Ok(__v) => __v,
+                    ::core::result::Result::Err(__e) => {
+                        ::core::panic!("cbindgen: callback argument conversion failed: {}", __e)
+                    }
+                })
+            } else {
+                quote!(#conv(#value))
+            };
+            prepare.extend(quote!(let #target = #converted;));
+            arguments.push(quote!(#target));
+        } else {
+            let fields = self.value.fields();
+            let mut targets = Vec::new();
+            for (field_index, field) in fields.iter().enumerate() {
+                let target = if fields.len() == 1 {
+                    format_ident!("__w{index}")
+                } else {
+                    format_ident!("__w{index}_{field_index}")
+                };
+                let wire = &field.wire;
+                prepare
+                    .extend(quote!(let mut #target = ::core::mem::MaybeUninit::<#wire>::zeroed();));
+                targets.push(quote!(*#target.as_mut_ptr()));
+                arguments.push(quote!(#target));
+            }
+            prepare.extend(
+                self.value
+                    .encode(quote!(#value), &targets, &ErrRoute::Panic, emit),
+            );
+        }
         chain::RenderedInvokePart {
-            prepare: self.prepare.clone(),
-            arguments: self.arguments.clone(),
-            cleanup: self.cleanup.clone(),
+            prepare,
+            arguments,
+            cleanup,
         }
     }
 }
@@ -1707,7 +1707,7 @@ impl chain::InvokeBridge for CInvokeBridge {
 /// A callback chain. Its `impl Fn(..)` spelling remains opaque until render.
 #[derive(Clone)]
 pub(crate) struct InvokePlan {
-    pub(crate) ident: syn::Ident,
+    pub(crate) operation: prebindgen_registry::OperationId,
     pub(crate) source: TypeRef,
     pub(crate) source_module: Option<syn::Path>,
     pub(crate) wire: syn::Type,
@@ -1729,7 +1729,7 @@ impl InvokePlan {
             parts: self.parts.clone(),
         };
         let rendered = plan.render(emit);
-        let name = &self.ident;
+        let name = emit.operation_ident("c", &self.operation);
         let source = &rendered.source;
         let intermediate = &rendered.intermediate;
         let syn::Expr::Block(body) = &rendered.body else {
@@ -1788,7 +1788,6 @@ impl chain::ProductBridge for CProductBridge {
 /// A product chain. Source syntax stays behind `source` until `render`.
 #[derive(Clone)]
 pub(crate) struct ProductPlan {
-    pub(crate) ident: syn::Ident,
     pub(crate) source: TypeRef,
     pub(crate) source_module: Option<syn::Path>,
     pub(crate) wire: syn::Type,
@@ -1797,7 +1796,7 @@ pub(crate) struct ProductPlan {
 }
 
 impl ProductPlan {
-    fn render(&self, emit: &Emit) -> syn::ItemFn {
+    fn render(&self, emit: &Emit, name: &syn::Ident) -> syn::ItemFn {
         let chain = chain::Product {
             source: self.source.clone(),
             direction: self.direction,
@@ -1819,7 +1818,6 @@ impl ProductPlan {
                 .collect(),
         };
         let rendered = chain.render(emit);
-        let name = &self.ident;
         let source = &rendered.source;
         let intermediate = &rendered.intermediate;
         let body = &rendered.body;
@@ -1901,7 +1899,6 @@ impl chain::OptionalBridge for COptionalBridge {
 /// An optional chain. Its source `Option<T>` remains opaque until rendering.
 #[derive(Clone)]
 pub(crate) struct OptionalPlan {
-    pub(crate) ident: syn::Ident,
     pub(crate) source: TypeRef,
     pub(crate) source_module: Option<syn::Path>,
     pub(crate) wire: syn::Type,
@@ -1911,7 +1908,7 @@ pub(crate) struct OptionalPlan {
 }
 
 impl OptionalPlan {
-    fn render(&self, emit: &Emit) -> syn::ItemFn {
+    fn render(&self, emit: &Emit, name: &syn::Ident) -> syn::ItemFn {
         let chain = chain::Optional {
             source: self.source.clone(),
             direction: Direction::Construct,
@@ -1925,7 +1922,6 @@ impl OptionalPlan {
             child: self.converter.clone(),
         };
         let rendered = chain.render(emit);
-        let name = &self.ident;
         let source = &rendered.source;
         let intermediate = &rendered.intermediate;
         let body = &rendered.body;
@@ -1995,7 +1991,6 @@ impl chain::SequenceBridge for CSequenceBridge {
 /// One C Vec-output converter composed by the registry.
 #[derive(Clone)]
 pub(crate) struct SequencePlan {
-    pub(crate) ident: syn::Ident,
     pub(crate) source: TypeRef,
     pub(crate) element: TypeRef,
     pub(crate) source_module: Option<syn::Path>,
@@ -2004,7 +1999,7 @@ pub(crate) struct SequencePlan {
 }
 
 impl SequencePlan {
-    fn render(&self, emit: &Emit) -> syn::ItemFn {
+    fn render(&self, emit: &Emit, name: &syn::Ident) -> syn::ItemFn {
         let composed = chain::Sequence {
             source: self.source.clone(),
             element: self.element.clone(),
@@ -2018,7 +2013,6 @@ impl SequencePlan {
             child: self.child.clone(),
         };
         let rendered = composed.render(emit);
-        let name = &self.ident;
         let source = &rendered.source;
         let intermediate = &rendered.intermediate;
         let body = &rendered.body;
@@ -2147,7 +2141,6 @@ impl chain::ChoiceBridge for CChoiceBridge {
 /// source syntax remains behind `source` until `render`.
 #[derive(Clone)]
 pub(crate) struct ChoicePlan {
-    pub(crate) ident: syn::Ident,
     pub(crate) source: TypeRef,
     pub(crate) source_module: Option<syn::Path>,
     pub(crate) wire: syn::Ident,
@@ -2156,7 +2149,7 @@ pub(crate) struct ChoicePlan {
 }
 
 impl ChoicePlan {
-    fn render(&self, emit: &Emit) -> syn::ItemFn {
+    fn render(&self, emit: &Emit, name: &syn::Ident) -> syn::ItemFn {
         let composed = chain::Choice {
             source: self.source.clone(),
             direction: self.direction,
@@ -2174,7 +2167,6 @@ impl ChoicePlan {
             arms: self.arms.clone(),
         };
         let rendered = composed.render(emit);
-        let name = &self.ident;
         let source = &rendered.source;
         let intermediate = &rendered.intermediate;
         let body = &rendered.body;

--- a/prebindgen-c/src/compile.rs
+++ b/prebindgen-c/src/compile.rs
@@ -169,10 +169,11 @@ impl CValue {
         val: TokenStream,
         targets: &[TokenStream],
         route: &ErrRoute<'_>,
+        emit: &prebindgen_registry::Emit,
     ) -> TokenStream {
         match self {
             Self::Direct { converter, .. } => {
-                let conv = converter.ident();
+                let conv = converter.ident(emit);
                 let converted = if converter.fallible() {
                     route_result(quote!(#conv(#val)), route)
                 } else {
@@ -185,7 +186,7 @@ impl CValue {
                 inner,
                 absent: Some(slot),
             } => {
-                let inner_encode = inner.encode(quote!(__x), targets, route);
+                let inner_encode = inner.encode(quote!(__x), targets, route, emit);
                 let absent = &slot.value;
                 let target = &targets[0];
                 quote!(
@@ -200,7 +201,7 @@ impl CValue {
                 absent: None,
             } => {
                 let present = &targets[0];
-                let inner_encode = inner.encode(quote!(__x), &targets[1..], route);
+                let inner_encode = inner.encode(quote!(__x), &targets[1..], route, emit);
                 quote!(
                     match #val {
                         ::core::option::Option::Some(__x) => {
@@ -215,7 +216,7 @@ impl CValue {
                 element_wire,
                 converter,
             } => {
-                let conv = converter.ident();
+                let conv = converter.ident(emit);
                 let converted = if converter.fallible() {
                     route_result(quote!(#conv(#val)), route)
                 } else {
@@ -234,7 +235,7 @@ impl CValue {
                 element_wire,
                 converter,
             } => {
-                let conv = converter.ident();
+                let conv = converter.ident(emit);
                 let pointer = &targets[0];
                 let length = &targets[1];
                 if converter.fallible() {
@@ -249,7 +250,7 @@ impl CValue {
                         #length = __n;
                     )
                 } else {
-                    let map = map_arg(conv, converter.unsafe_());
+                    let map = map_arg(&conv, converter.unsafe_());
                     quote!(
                         let __arr: ::std::vec::Vec<#element_wire> =
                             #val.iter().copied().map(#map).collect();
@@ -378,6 +379,14 @@ fn model_operation_for(
     name: impl Into<String>,
 ) -> OperationId {
     OperationId::model_artifact(source, c_artifact(kind, name), at.crossing.direction())
+}
+
+pub(crate) fn callback_operation(source: &TypeRef) -> OperationId {
+    OperationId::model_artifact(
+        source,
+        c_artifact("c-invoke", "callback-capture"),
+        Direction::Construct,
+    )
 }
 
 fn marker_name(operation: &MarkerOperation) -> &'static str {
@@ -922,7 +931,6 @@ impl<R: Conversions> Compile for CCompile<'_, R> {
         let function = CFunction::optional(
             operation,
             OptionalPlan {
-                ident: format_ident!("__cbg_in_option_{}", sanitize(&elem.key())),
                 source: at.crossing.spelled().clone(),
                 source_module: self.gen.source_module.clone(),
                 wire: wire.clone(),
@@ -969,10 +977,6 @@ impl<R: Conversions> Compile for CCompile<'_, R> {
                     let function = CFunction::sequence(
                         operation,
                         SequencePlan {
-                            ident: format_ident!(
-                                "__cbg_out_chain_vec_{}",
-                                sanitize(&element.key())
-                            ),
                             source: ty.clone(),
                             element: (**element).clone(),
                             source_module: self.gen.source_module.clone(),
@@ -1140,7 +1144,6 @@ impl<R: Conversions> Compile for CCompile<'_, R> {
             let function = CFunction::marker(
                 operation,
                 MarkerPlan {
-                    ident: format_ident!("__cbg_arm"),
                     operation: MarkerOperation::ChoiceArm,
                     // Choice retains the exact part FragmentUse edges; this
                     // transient bridge has no independent dependency.
@@ -1218,10 +1221,6 @@ impl<R: Conversions> Compile for CCompile<'_, R> {
             .collect();
         let subs: Vec<TypeKey> = parts.iter().map(|(p, _)| p.ty.key()).collect();
         let direction = at.crossing.direction();
-        let ident = match direction {
-            Direction::Construct => CbindgenBuilder::in_name_of(&key),
-            Direction::Deconstruct => CbindgenBuilder::out_name_of(&key),
-        };
         let wire: syn::Type = syn::parse_quote!(#c_struct);
         let operation = OperationId::product_converter(
             at.crossing.value(),
@@ -1232,7 +1231,6 @@ impl<R: Conversions> Compile for CCompile<'_, R> {
         let function = CFunction::product(
             operation,
             ProductPlan {
-                ident,
                 source: at.crossing.spelled().clone(),
                 source_module: self.gen.source_module.clone(),
                 wire: wire.clone(),
@@ -1310,10 +1308,6 @@ impl<R: Conversions> Compile for CCompile<'_, R> {
         }
 
         let destination: syn::Type = syn::parse_quote!(::core::mem::MaybeUninit<#cname>);
-        let ident = match direction {
-            Direction::Construct => CbindgenBuilder::in_name_of(&key),
-            Direction::Deconstruct => CbindgenBuilder::out_name_of(&key),
-        };
         let shape_arms = arms
             .iter()
             .map(|(_, fragment)| {
@@ -1336,7 +1330,6 @@ impl<R: Conversions> Compile for CCompile<'_, R> {
         let function = CFunction::choice(
             operation,
             ChoicePlan {
-                ident,
                 source: at.crossing.spelled().clone(),
                 source_module: self.gen.source_module.clone(),
                 wire: cname,
@@ -1383,11 +1376,8 @@ impl<R: Conversions> Compile for CCompile<'_, R> {
         }
         let c_struct = self.gen.callback_c_ident(&key);
         let destination: syn::Type = syn::parse_quote!(#c_struct);
-        let operation = model_operation(at, "c-invoke", "callback-capture");
-        let function = CFunction::deferred_invoke(
-            operation,
-            format_ident!("__cbg_in_{}", self.gen.callback_c_name(&key)),
-        );
+        let operation = callback_operation(at.crossing.value());
+        let function = CFunction::deferred_invoke(operation);
         let value = CValue::Direct {
             wire: destination.clone(),
             converter: function.call().clone(),

--- a/prebindgen-c/src/convert.rs
+++ b/prebindgen-c/src/convert.rs
@@ -80,10 +80,6 @@ impl CbindgenBuilder {
                 }
             );
         }
-        let ident = match direction {
-            Direction::Construct => Self::in_name_of(&key),
-            Direction::Deconstruct => Self::out_name_of(&key),
-        };
         let valid = decl
             .domain()
             .as_ref()
@@ -98,7 +94,6 @@ impl CbindgenBuilder {
         let niches = self.c_domain_niches(decl, registry, direction);
         Some((
             crate::chain::CustomPlan {
-                ident,
                 source: ty.clone(),
                 source_module: self.source_module.clone(),
                 wire: repr,

--- a/prebindgen-c/src/emit.rs
+++ b/prebindgen-c/src/emit.rs
@@ -557,7 +557,7 @@ impl CbindgenBuilder {
             else {
                 panic!("C error site must have one direct wire");
             };
-            (wire.clone(), converter.ident().clone(), self.src_ty(err_ty))
+            (wire.clone(), converter.ident(emit), self.src_ty(err_ty))
         });
 
         // No `Result` channel ⇒ a fallible input must be declared `.panic()`.
@@ -711,7 +711,7 @@ impl CbindgenBuilder {
                     let enc = value_site.map_or_else(TokenStream::new, |site| {
                         site.abi()
                             .payload()
-                            .encode(quote!(__v), &targets, &input_route)
+                            .encode(quote!(__v), &targets, &input_route, emit)
                     });
                     quote!(
                         #(#decodes)*
@@ -734,7 +734,7 @@ impl CbindgenBuilder {
                 let enc = value_site.map_or_else(TokenStream::new, |site| {
                     site.abi()
                         .payload()
-                        .encode(quote!(__v), &targets, &input_route)
+                        .encode(quote!(__v), &targets, &input_route, emit)
                 });
                 quote!(
                     #(#decodes)*
@@ -752,7 +752,7 @@ impl CbindgenBuilder {
                 let enc = value_site.map_or_else(TokenStream::new, |site| {
                     site.abi()
                         .payload()
-                        .encode(quote!(__v), &targets, &input_route)
+                        .encode(quote!(__v), &targets, &input_route, emit)
                 });
                 quote!(
                     #(#decodes)*
@@ -937,7 +937,7 @@ impl CbindgenBuilder {
                 crate::compile::CValue::Direct {
                     wire, converter, ..
                 } => {
-                    let conv = converter.ident();
+                    let conv = converter.ident(emit);
                     params.push(quote!(#ident: #wire));
                     if converter.fallible() {
                         let on_err = route_message(route);

--- a/prebindgen-c/src/tests/aliasing.rs
+++ b/prebindgen-c/src/tests/aliasing.rs
@@ -135,7 +135,7 @@ fn preflight_precedes_every_conversion() {
     let src = build(&["pub fn f(a: Thing, b: Thing) -> Result<u64, Error> { unimplemented!() }"]);
     let alias_at = src.find("aliasing arguments").expect("preflight emitted");
     let first_conv = src
-        .find("__cbg_in_Thing(a)")
+        .find("let a = match __c_in_convert_wire_to_Thing_")
         .expect("input conversion emitted");
     assert!(
         alias_at < first_conv,

--- a/prebindgen-c/src/tests/boundary_invariants.rs
+++ b/prebindgen-c/src/tests/boundary_invariants.rs
@@ -262,8 +262,8 @@ fn restricted_inbound(
 }
 
 /// Every generated function that C can call or that decodes C's bytes: the
-/// `#[no_mangle] extern "C"` wrappers and destructors, plus the `__cbg_in_*`
-/// input converters they call.
+/// `#[no_mangle] extern "C"` wrappers and destructors, plus the registry-named
+/// `__c_in_*` input converters they call.
 fn inbound_fns(file: &syn::File) -> Vec<syn::ItemFn> {
     file.items
         .iter()
@@ -271,7 +271,7 @@ fn inbound_fns(file: &syn::File) -> Vec<syn::ItemFn> {
             syn::Item::Fn(f) => Some(f.clone()),
             _ => None,
         })
-        .filter(|f| f.sig.abi.is_some() || f.sig.ident.to_string().starts_with("__cbg_in_"))
+        .filter(|f| f.sig.abi.is_some() || f.sig.ident.to_string().starts_with("__c_in_"))
         .collect()
 }
 
@@ -670,6 +670,9 @@ fn legacy_c_shape_and_callback_planners_are_deleted() {
         "Complete(syn::ItemFn)",
         "CFunction::complete",
         "compiled_fns",
+        "chain::Call::new(",
+        "fn in_name_of",
+        "fn out_name_of",
     ] {
         assert!(
             !sources.contains(deleted),

--- a/prebindgen-c/src/tests/callbacks.rs
+++ b/prebindgen-c/src/tests/callbacks.rs
@@ -155,18 +155,19 @@ fn callback_subscriber_emits_closure_structs() {
 
     // Trampoline: by-value struct in, `impl Fn(<src arg>)` out; Arc-held ctx.
     assert!(
-            compact.contains(
-                "fn__cbg_in_z_closure_sample_t(c:z_closure_sample_t,)->implFn(zenoh_flat::ZSample)+Send+Sync+'static"
-            ),
-            "{src}"
-        );
+        compact.contains(
+            "fn__c_in_convert_wire_to_impl_Fn_ZSample_Send_Sync_static_c_invoke_callback_capture_"
+        ) && compact
+            .contains("(c:z_closure_sample_t,)->implFn(zenoh_flat::ZSample)+Send+Sync+'static"),
+        "{src}"
+    );
     assert!(
         compact.contains("Arc::new(__Ctx{context:c.context,drop:c.drop"),
         "{src}"
     );
     // Arg encoded via its OUTPUT converter, then passed (owned) with context.
     assert!(
-        compact.contains("let__w0=__cbg_out_ZSample(__a0);"),
+        operation_call(&compact, "__c_out_convert_ZSample_", "__a0"),
         "{src}"
     );
     assert!(compact.contains("__f(__w0,__ctx.context)"), "{src}");
@@ -174,8 +175,8 @@ fn callback_subscriber_emits_closure_structs() {
     // Zero-arg trampoline.
     assert!(
         compact.contains(
-            "fn__cbg_in_z_closure_drop_t(c:z_closure_drop_t,)->implFn()+Send+Sync+'static"
-        ),
+            "fn__c_in_convert_wire_to_impl_Fn_Send_Sync_static_c_invoke_callback_capture_"
+        ) && compact.contains("(c:z_closure_drop_t,)->implFn()+Send+Sync+'static"),
         "{src}"
     );
     assert!(compact.contains("move||{"), "{src}");
@@ -188,11 +189,19 @@ fn callback_subscriber_emits_closure_structs() {
     assert!(compact.contains("callback:z_closure_sample_t"), "{src}");
     assert!(compact.contains("on_close:z_closure_drop_t"), "{src}");
     assert!(
-        compact.contains("letcallback=__cbg_in_z_closure_sample_t(callback);"),
+        operation_call(
+            &compact,
+            "__c_in_convert_wire_to_impl_Fn_ZSample_Send_Sync_static_c_invoke_callback_capture_",
+            "callback",
+        ),
         "{src}"
     );
     assert!(
-        compact.contains("leton_close=__cbg_in_z_closure_drop_t(on_close);"),
+        operation_call(
+            &compact,
+            "__c_in_convert_wire_to_impl_Fn_Send_Sync_static_c_invoke_callback_capture_",
+            "on_close",
+        ),
         "{src}"
     );
     // Result of an opaque handle rides the return (NULL = Err); `e` out-param.
@@ -237,8 +246,8 @@ fn callback_scalar_arg_not_module_qualified() {
     assert!(compact.contains("move|__a0:f64|"), "{src}");
     assert!(
         compact.contains(
-            "fn__cbg_in_z_closure_value_t(c:z_closure_value_t,)->implFn(f64)+Send+Sync+'static"
-        ),
+            "fn__c_in_convert_wire_to_impl_Fn_f64_Send_Sync_static_c_invoke_callback_capture_"
+        ) && compact.contains("(c:z_closure_value_t,)->implFn(f64)+Send+Sync+'static"),
         "{src}"
     );
 }
@@ -531,7 +540,7 @@ fn a_converted_optional_callback_arg_keeps_its_declared_wire() {
     // One parameter, the declared representation — not a decomposition.
     assert!(
         compact.contains("unsafeextern\"C\"fn(i64,*mut::core::ffi::c_void)")
-            && compact.contains("__cbg_out_Option___Duration__(__a0)"),
+            && operation_call(&compact, "__c_out_convert_Option_Duration_", "__a0",),
         "the declared wire survives in the closure struct:\n{src}"
     );
     // …and the closure calls that converter rather than filling lowered slots.
@@ -594,7 +603,7 @@ fn a_run_of_converted_optionals_uses_the_declared_wire() {
     );
     // …and each element goes through that converter, not through a decomposition.
     assert!(
-        compact.contains("__cbg_out_Option___Duration__"),
+        compact.contains("__c_out_convert_Option_Duration_"),
         "the declared element converter is what fills the array:\n{src}"
     );
 }

--- a/prebindgen-c/src/tests/errors.rs
+++ b/prebindgen-c/src/tests/errors.rs
@@ -119,15 +119,19 @@ fn error_out_param_is_null_guarded() {
 
     let src = write(cbindgen, registry, "err_null_guard");
     let compact: String = src.split_whitespace().collect();
+    let error_converter =
+        operation_name(&compact, "__c_out_convert_Error_").expect("semantic error converter name");
 
     // Pointer-return Err arm: guarded write, then NULL.
     assert!(
-        compact.contains("=>{if!e.is_null(){*e=__cbg_out_Error(__err);}::core::ptr::null_mut()}"),
+        compact.contains(&format!("if!e.is_null(){{*e={error_converter}(__err,);}}"))
+            && compact.contains("::core::ptr::null_mut()"),
         "{src}"
     );
     // `Result<(),E>` Err arm: guarded write, then `false`.
     assert!(
-        compact.contains("=>{if!e.is_null(){*e=__cbg_out_Error(__err);}false}"),
+        compact.contains(&format!("if!e.is_null(){{*e={error_converter}(__err,);}}"))
+            && compact.contains("false"),
         "{src}"
     );
     // The input-decode failure path also guards the write (it routes the
@@ -135,7 +139,7 @@ fn error_out_param_is_null_guarded() {
     // input plus a `Result::Err` arm, so the guarded write appears ≥4 times.
     assert!(
         compact
-            .matches("if!e.is_null(){*e=__cbg_out_Error(")
+            .matches(&format!("if!e.is_null(){{*e={error_converter}("))
             .count()
             >= 4,
         "expected ≥4 guarded `*e =` writes (2 input-decode + 2 Err arms):\n{src}"

--- a/prebindgen-c/src/tests/inputs.rs
+++ b/prebindgen-c/src/tests/inputs.rs
@@ -74,12 +74,12 @@ fn option_opaque_input_reuses_pointer() {
     );
     // Non-null path consumes through the inner handle converter.
     assert!(
-        compact.contains("::core::option::Option::Some(__cbg_in_ZZBytes(__present)?)"),
+        operation_call(&compact, "__c_in_convert_wire_to_ZZBytes_", "__present"),
         "{src}"
     );
     // Fallible inner decode routes its error through the Result channel (`*e`).
     assert!(compact.contains("e:*mutz_error"), "{src}");
-    assert!(compact.contains("__cbg_out_Error"), "{src}");
+    assert!(compact.contains("__c_out_convert_Error_"), "{src}");
 }
 
 /// `Option<i64>` input (scalar inner, no niche) is boxed behind a `*const`
@@ -148,7 +148,11 @@ fn option_data_struct_input_reads_the_pointee() {
 
     assert!(compact.contains("v:*constrec"), "{src}");
     assert!(
-        compact.contains("let__present=::core::ptr::read(v);::core::option::Option::Some(__cbg_in_Rec(__present))"),
+        compact.contains("let__present=::core::ptr::read(v);"),
+        "{src}"
+    );
+    assert!(
+        operation_call(&compact, "__c_in_convert_wire_to_Rec_", "__present"),
         "{src}"
     );
 }
@@ -290,10 +294,7 @@ fn enum_input_validates_the_discriminant() {
         compact.contains("level:::core::mem::MaybeUninit<z_intersection>"),
         "{src}"
     );
-    assert!(
-        !compact.contains("fn__cbg_in_SetIntersectionLevel(v:z_intersection)"),
-        "{src}"
-    );
+    assert!(!compact.contains("(v:z_intersection)"), "{src}");
     // The discriminant is read as a plain integer and compared against the
     // mirror's variants — a `const`-driven one needs no evaluation here.
     assert!(

--- a/prebindgen-c/src/tests/lowering.rs
+++ b/prebindgen-c/src/tests/lowering.rs
@@ -135,11 +135,12 @@ fn custom_conversion_without_domain_stays_infallible() {
     let compact: String = src.split_whitespace().collect();
 
     assert!(
-        compact.contains("fn__cbg_in_Ratio(v:f64)->myflat::Ratio"),
+        compact.contains("fn__c_in_convert_wire_to_Ratio_")
+            && compact.contains("(v:f64,)->myflat::Ratio"),
         "{src}"
     );
     assert!(
-        compact.contains("fn__cbg_out_Ratio(v:myflat::Ratio)->f64"),
+        compact.contains("fn__c_out_convert_Ratio_") && compact.contains("(v:myflat::Ratio,)->f64"),
         "{src}"
     );
     assert!(
@@ -595,7 +596,7 @@ fn keyexpr_try_from_lowering() {
         compact.contains("as::core::convert::From<::std::string::String"),
         "{src}"
     );
-    assert!(compact.contains("__cbg_out_Error"), "{src}");
+    assert!(compact.contains("__c_out_convert_Error_"), "{src}");
     assert!(compact.contains("return::core::ptr::null_mut()"), "{src}");
 }
 
@@ -718,7 +719,7 @@ fn a_declared_conversion_owns_its_own_fallibility() {
         "fallible_custom_option_panic",
     );
     assert!(
-        src.contains("__cbg_out_Option___Duration__"),
+        src.contains("__c_out_convert_Option_Duration_"),
         "the declared converter is what the wrapper calls:\n{src}"
     );
 }

--- a/prebindgen-c/src/tests/mod.rs
+++ b/prebindgen-c/src/tests/mod.rs
@@ -22,30 +22,38 @@ fn write(cbindgen: CbindgenBuilder, registry: RegistryBuilder, tag: &str) -> Str
     std::fs::create_dir_all(&dir).unwrap();
     let out = dir.join(format!("{tag}.rs"));
     let gen = cbindgen.build_with(registry).expect("resolve");
-    assert_converter_identity_matches_compatibility_names(&gen);
+    assert_converter_calls_retain_their_operation(&gen);
     let path = gen.write_rust(&out).expect("write_rust");
     std::fs::read_to_string(&path).unwrap()
 }
 
-fn assert_converter_identity_matches_compatibility_names(gen: &Cbindgen) {
-    let mut names_by_operation = std::collections::HashMap::new();
-    let mut operations_by_name = std::collections::HashMap::new();
+fn assert_converter_calls_retain_their_operation(gen: &Cbindgen) {
     for function in gen.gen.converter_functions() {
-        let (operation, name) = function.operation_and_compatibility_name();
-        let name = name.to_string();
-        if let Some(previous) = names_by_operation.insert(operation.clone(), name.clone()) {
-            assert_eq!(
-                previous, name,
-                "one semantic C operation must not select two compatibility names"
-            );
-        }
-        if let Some(previous) = operations_by_name.insert(name.clone(), operation.clone()) {
-            assert_eq!(
-                previous, *operation,
-                "one compatibility name must not hide two semantic C operations: {name}"
-            );
-        }
+        let (function, call) = function.operation_and_call_identity();
+        assert_eq!(
+            function, call,
+            "a C converter call must target its own operation"
+        );
     }
+}
+
+/// Whether a final registry-owned operation whose name starts with `stem`
+/// is called with `argument` in whitespace-compacted generated Rust.
+///
+/// Private converter names intentionally end in a stable identity hash. Tests
+/// should pin the readable semantic stem and the call shape, not that suffix.
+fn operation_call(compact: &str, stem: &str, argument: &str) -> bool {
+    compact.match_indices(stem).any(|(start, _)| {
+        let rest = &compact[start + stem.len()..];
+        rest.find('(')
+            .is_some_and(|open| rest[open + 1..].starts_with(argument))
+    })
+}
+
+fn operation_name<'a>(compact: &'a str, stem: &str) -> Option<&'a str> {
+    let start = compact.find(stem)?;
+    let end = compact[start..].find(|ch: char| !(ch.is_ascii_alphanumeric() || ch == '_'))? + start;
+    Some(&compact[start..end])
 }
 
 fn error_struct() -> syn::ItemStruct {

--- a/prebindgen-c/src/tests/returns.rs
+++ b/prebindgen-c/src/tests/returns.rs
@@ -75,9 +75,12 @@ fn result_string_uses_owned_string_wire() {
         "{src}"
     );
     // Ok arm encodes the pointer into the return slot; error → NULL.
-    assert!(compact.contains("__ret=__cbg_out_String(__v);"), "{src}");
     assert!(
-        compact.contains("=>{if!e.is_null(){*e=__cbg_out_Error(__err);}::core::ptr::null_mut()}"),
+        operation_call(&compact, "__c_out_convert_String_", "__v"),
+        "{src}"
+    );
+    assert!(
+        operation_call(&compact, "__c_out_convert_Error_", "__err"),
         "{src}"
     );
 }
@@ -115,7 +118,7 @@ fn option_string_returns_pointer_null_for_none() {
     assert!(!compact.contains("e:*mut"), "{src}");
     // Inline Option encoding into the return slot: Some → inner wire, None → NULL.
     assert!(
-        compact.contains("::core::option::Option::Some(__x)=>{__ret=__cbg_out_String(__x);}"),
+        operation_call(&compact, "__c_out_convert_String_", "__x"),
         "{src}"
     );
     assert!(
@@ -162,7 +165,10 @@ fn result_option_uses_out_param() {
     assert!(compact.contains("out:*mut*mutz_thing"), "{src}");
     assert!(compact.contains("e:*mutz_error"), "{src}");
     // Ok arm writes the Option (pointer-or-NULL) through `out`, returns true.
-    assert!(compact.contains("*out=__cbg_out_ZThing(__x);"), "{src}");
+    assert!(
+        operation_call(&compact, "__c_out_convert_ZThing_", "__x"),
+        "{src}"
+    );
     assert!(
         compact.contains("::core::option::Option::None=>{*out=::core::ptr::null_mut();}"),
         "{src}"
@@ -206,14 +212,19 @@ fn vec_string_returns_ptr_and_len() {
     assert!(!compact.contains("e:*mut"), "{src}");
     // The registry-owned Sequence loop invokes the element converter; the ABI
     // wrapper only transfers its one Vec intermediate to the array helper.
-    assert!(compact.contains("fn__cbg_out_chain_vec_String("), "{src}");
     assert!(
-        compact.contains("__cbg_out_String(__sequence_element)"),
+        compact.contains("fn__c_out_convert_sequence_Vec_String_to_wire_"),
         "{src}"
     );
     assert!(
-        compact.contains(
-            "let__arr:::std::vec::Vec<*mut::core::ffi::c_char>=__cbg_out_chain_vec_String("
+        operation_call(&compact, "__c_out_convert_String_", "__sequence_element",),
+        "{src}"
+    );
+    assert!(
+        operation_call(
+            &compact,
+            "__c_out_convert_sequence_Vec_String_to_wire_",
+            "__v",
         ),
         "{src}"
     );
@@ -288,7 +299,8 @@ fn cow_u8_returns_scalar_array() {
     assert!(compact.contains("->*mutu8"), "{src}");
     assert!(compact.contains("len:*mutusize"), "{src}");
     assert!(
-        compact.contains(".iter().copied().map(__cbg_out_u8).collect()"),
+        compact.contains(".iter().copied().map(__c_out_convert_u8_")
+            && compact.contains(").collect()"),
         "{src}"
     );
     assert!(compact.contains("__cbg_alloc_array(__arr)"), "{src}");
@@ -325,7 +337,8 @@ fn slice_returns_scalar_array() {
     assert!(compact.contains("->*mutu64"), "{src}");
     assert!(compact.contains("len:*mutusize"), "{src}");
     assert!(
-        compact.contains(".iter().copied().map(__cbg_out_u64).collect()"),
+        compact.contains(".iter().copied().map(__c_out_convert_u64_")
+            && compact.contains(").collect()"),
         "{src}"
     );
     assert!(compact.contains("__cbg_alloc_array(__arr)"), "{src}");
@@ -366,11 +379,15 @@ fn vec_of_borrows_calls_the_unsafe_element_converter() {
 
     assert!(compact.contains("->*mut*constz_handle"), "{src}");
     assert!(
-        compact.contains("unsafefn__cbg_out_chain_vec____static_ZHandle("),
+        compact.contains("unsafefn__c_out_convert_sequence_Vec_static_ZHandle_to_wire_"),
         "{src}"
     );
     assert!(
-        compact.contains("__cbg_out_ref_ZHandle(__sequence_element)"),
+        operation_call(
+            &compact,
+            "__c_out_convert_ZHandle_c_borrow_shared_output_to_wire_",
+            "__sequence_element",
+        ),
         "{src}"
     );
 }
@@ -568,7 +585,11 @@ fn borrowed_ref_output_is_const_non_owning() {
         "{src}"
     );
     assert!(
-        compact.contains("__ret=__cbg_out_ref_ZBytes(__v);"),
+        operation_call(
+            &compact,
+            "__c_out_convert_ZBytes_c_borrow_shared_output_to_wire_",
+            "__v",
+        ),
         "{src}"
     );
 }
@@ -602,6 +623,9 @@ fn borrowed_option_ref_output_nullable() {
     // Nullable const loaned pointer rides the return (no out-param needed:
     // the pointer's NULL niche encodes `None`).
     assert!(compact.contains("->*constz_timestamp_t"), "{src}");
-    assert!(compact.contains("__cbg_out_ref_ZTimestamp"), "{src}");
+    assert!(
+        compact.contains("__c_out_convert_ZTimestamp_c_borrow_shared_output_to_wire_"),
+        "{src}"
+    );
     assert!(!compact.contains("out:*mut*constz_timestamp_t"), "{src}");
 }

--- a/prebindgen-c/src/tests/tagged_unions.rs
+++ b/prebindgen-c/src/tests/tagged_unions.rs
@@ -79,18 +79,19 @@ fn tagged_union_mirror_and_converters() {
     assert!(
         // The payload converts through its own scalar conversion rather than
         // passing through inline — same value, named once.
-        compact.contains("let__built_arm=(__cbg_out_f64(__part0),);shape_t::Circle(__built_arm.0)"),
+        operation_call(&compact, "__c_out_convert_f64_", "__part0")
+            && compact.contains("shape_t::Circle(__built_arm.0)"),
         "{src}"
     );
     assert!(
         // The `String` payload allocates through `String`'s own conversion,
         // which is where `__cbg_alloc_cstr` lives — one statement of it rather
         // than one per payload position.
-        compact.contains("__cbg_out_String(__part0),"),
+        operation_call(&compact, "__c_out_convert_String_", "__part0"),
         "{src}"
     );
     assert!(
-        compact.contains("::core::mem::MaybeUninit::new(__cbg_out_Operation(__part1)),"),
+        operation_call(&compact, "__c_out_convert_Operation_", "__part1"),
         "{src}"
     );
 
@@ -98,7 +99,9 @@ fn tagged_union_mirror_and_converters() {
     // but only after the C-supplied tag has been range-checked, and the enum
     // payload's own validating decode propagates with `?`.
     assert!(
-        compact.contains("fn__cbg_in_Shape(v:::core::mem::MaybeUninit<shape_t>,)"),
+        compact
+            .contains("fn__c_in_convert_wire_to_Shape_c_choice_intermediate_repr_c_tagged_union_")
+            && compact.contains("(v:::core::mem::MaybeUninit<shape_t>,)"),
         "{src}"
     );
     assert!(
@@ -115,7 +118,10 @@ fn tagged_union_mirror_and_converters() {
         "{src}"
     );
     assert!(compact.contains("0=>example_flat::Shape::Empty"), "{src}");
-    assert!(compact.contains("__cbg_in_Operation((__arm).1)?,"), "{src}");
+    assert!(
+        operation_call(&compact, "__c_in_convert_wire_to_Operation_", "(__arm).1"),
+        "{src}"
+    );
     // A union taken by value is a fallible input like any other: with no
     // `Result` channel the declaration had to opt into aborting.
     assert!(compact.contains("panic!("), "{src}");
@@ -260,14 +266,29 @@ fn tagged_union_as_data_struct_field() {
     );
     // The field's decode carries the union's fallibility up into the struct's,
     // so a bad tag in a nested union cannot be silently skipped.
-    assert!(compact.contains("shape:__cbg_in_Shape(v.shape)?,"), "{src}");
     assert!(
-        compact.contains("fn__cbg_in_Drawing(v:drawing_t,)->::core::result::Result<"),
+        operation_call(
+            &compact,
+            "__c_in_convert_wire_to_Shape_c_choice_intermediate_repr_c_tagged_union_",
+            "v.shape",
+        ),
+        "{src}"
+    );
+    assert!(
+        compact.contains("fn__c_in_convert_wire_to_Drawing_c_product_intermediate_repr_c_struct_")
+            && compact.contains("(v:drawing_t,)->::core::result::Result<"),
         "{src}"
     );
     // The union's own conversion already produces the `MaybeUninit` the
     // mirror field holds, so the struct passes it through.
-    assert!(compact.contains("shape:__cbg_out_Shape(v.shape),"), "{src}");
+    assert!(
+        operation_call(
+            &compact,
+            "__c_out_convert_Shape_c_choice_intermediate_repr_c_tagged_union_to_wire_",
+            "v.shape",
+        ),
+        "{src}"
+    );
 }
 
 /// A union nested inside a **struct payload** of another union. The record
@@ -371,7 +392,8 @@ fn plain_data_struct_decode_stays_infallible() {
     let compact: String = src.split_whitespace().collect();
 
     assert!(
-        compact.contains("fn__cbg_in_Label(v:label_t)->example_flat::Label"),
+        compact.contains("fn__c_in_convert_wire_to_Label_c_product_intermediate_repr_c_struct_")
+            && compact.contains("(v:label_t,)->example_flat::Label"),
         "{src}"
     );
     assert!(!compact.contains("panic!("), "{src}");
@@ -571,7 +593,7 @@ fn null_opaque_payload_is_reported_not_materialised() {
     );
     assert!(compact.contains("nullpayloadfor`Blob`"), "{src}");
     assert!(
-        compact.contains("Slot::Filled(__cbg_in_Box___Blob___payload((__arm).0)?)"),
+        operation_call(&compact, "__c_in_convert_wire_to_Box_Blob_", "(__arm).0"),
         "{src}"
     );
     // The `Option` arm keeps NULL as a legitimate value.
@@ -677,14 +699,20 @@ fn payload_wires_come_from_the_converter_destination() {
     assert!(compact.contains("Titled(caption_t),"), "{src}");
     assert!(compact.contains("After(u64),"), "{src}");
     // Both directions route through the payload's own converter.
-    assert!(compact.contains("__cbg_out_Caption(__part0)"), "{src}");
-    assert!(compact.contains("__cbg_out_Millis(__part0)"), "{src}");
     assert!(
-        compact.contains("example_flat::Note::Titled(__cbg_in_Caption((__arm).0))"),
+        operation_call(&compact, "__c_out_convert_Caption_", "__part0"),
         "{src}"
     );
     assert!(
-        compact.contains("example_flat::Note::After(__cbg_in_Millis((__arm).0))"),
+        operation_call(&compact, "__c_out_convert_Millis_", "__part0"),
+        "{src}"
+    );
+    assert!(
+        operation_call(&compact, "__c_in_convert_wire_to_Caption_", "(__arm).0"),
+        "{src}"
+    );
+    assert!(
+        operation_call(&compact, "__c_in_convert_wire_to_Millis_", "(__arm).0"),
         "{src}"
     );
     // The struct payload owns a `char *`, so the union's drop reaches THROUGH
@@ -759,14 +787,18 @@ fn bool_payload_is_normalised_not_materialised() {
     // The payload converts through `bool`'s own field reading rather than
     // inline: same normalisation, named once.
     assert!(
-        compact.contains("example_flat::Flagged::On(__cbg_in_bool((__arm).0))"),
+        operation_call(&compact, "__c_in_convert_wire_to_bool_", "(__arm).0"),
         "{src}"
     );
     assert!(
-        compact.contains("__cbg_in_bool(v:::core::mem::MaybeUninit<bool>)->bool"),
+        compact.contains("fn__c_in_convert_wire_to_bool_")
+            && compact.contains("(v:::core::mem::MaybeUninit<bool>,)->bool"),
         "{src}"
     );
-    assert!(compact.contains("__cbg_out_bool_field(__part0)"), "{src}");
+    assert!(
+        operation_call(&compact, "__c_out_convert_bool_", "__part0"),
+        "{src}"
+    );
     // A bool owns nothing, so the union still gets no typed drop.
     assert!(!compact.contains("flagged_drop"), "{src}");
 }

--- a/prebindgen-c/src/trait_impl.rs
+++ b/prebindgen-c/src/trait_impl.rs
@@ -51,8 +51,7 @@ impl CbindgenBuilder {
     ) -> Option<crate::chain::InputTerminalPlan> {
         use crate::chain::InputTerminalOperation;
 
-        let plan = |ident, wire, operation| crate::chain::InputTerminalPlan {
-            ident,
+        let plan = |wire, operation| crate::chain::InputTerminalPlan {
             source: ty.clone(),
             source_module: self.source_module.clone(),
             wire,
@@ -65,7 +64,6 @@ impl CbindgenBuilder {
         if self.opaque.contains_key(&key) {
             let c_struct = self.c_type_ident(&key);
             return Some(plan(
-                Self::in_name_of(&key),
                 syn::parse_quote!(*mut #c_struct),
                 InputTerminalOperation::OwnedHandle {
                     null_message: format!("null {} handle passed by value", type_short(&key)),
@@ -79,7 +77,6 @@ impl CbindgenBuilder {
         if let Some(opaque) = self.value_opaque_ty_of(&key).cloned() {
             let writeback = self.value_opaque_writeback_plan(registry, &key)?;
             return Some(plan(
-                Self::in_name_of(&key),
                 syn::parse_quote!(*mut #opaque),
                 InputTerminalOperation::ValueOpaque {
                     opaque,
@@ -96,7 +93,6 @@ impl CbindgenBuilder {
             let c_name = self.c_type_ident(&key);
             let c_name_string = c_name.to_string();
             return Some(plan(
-                Self::in_name_of(&key),
                 syn::parse_quote!(::core::mem::MaybeUninit<#c_name>),
                 InputTerminalOperation::Enum {
                     c_name,
@@ -114,31 +110,21 @@ impl CbindgenBuilder {
 
         if r_is_string(ty) {
             return Some(plan(
-                Self::in_name_of(&key),
                 syn::parse_quote!(*const ::core::ffi::c_char),
                 InputTerminalOperation::String,
             ));
         }
         if r_is_str(ty) {
             return Some(plan(
-                Self::in_name_of(&key),
                 syn::parse_quote!(*const ::core::ffi::c_char),
                 InputTerminalOperation::StrMarker,
             ));
         }
         if r_is_bool(ty) {
-            return Some(plan(
-                Self::in_name_of(&key),
-                bool_wire(),
-                InputTerminalOperation::Bool,
-            ));
+            return Some(plan(bool_wire(), InputTerminalOperation::Bool));
         }
         if r_is_scalar(ty) {
-            return Some(plan(
-                Self::in_name_of(&key),
-                scalar_ty(ty)?,
-                InputTerminalOperation::Scalar,
-            ));
+            return Some(plan(scalar_ty(ty)?, InputTerminalOperation::Scalar));
         }
         None
     }
@@ -340,7 +326,7 @@ impl CbindgenBuilder {
                 let callback_name = self.callback_c_name(&key);
                 let callback = crate::chain::CallbackArtifact::new(
                     self.callback_c_ident(&key),
-                    format_ident!("__cbg_in_{callback_name}"),
+                    crate::compile::callback_operation(&param.ty),
                     param.ty.clone(),
                     self.source_module.clone(),
                     args.to_vec(),
@@ -469,12 +455,7 @@ impl CbindgenBuilder {
                     type_short(&inner.key()),
                 )
             };
-        let prefix = match direction {
-            Direction::Construct => Self::in_name_of(&fty.key()),
-            Direction::Deconstruct => Self::out_name_of(&fty.key()),
-        };
         Some(crate::chain::PayloadPlan {
-            ident: format_ident!("{prefix}_payload"),
             source: fty.clone(),
             source_inner,
             source_module: self.source_module.clone(),
@@ -511,7 +492,6 @@ impl CbindgenBuilder {
             return None;
         }
         Some(crate::chain::InputTerminalPlan {
-            ident: format_ident!("{}_field", Self::in_name_of(&ty.key())),
             source: ty.clone(),
             source_module: self.source_module.clone(),
             wire: syn::parse_quote!(*const ::core::ffi::c_char),
@@ -535,7 +515,6 @@ impl CbindgenBuilder {
             return None;
         }
         Some(crate::chain::OutputTerminalPlan {
-            ident: format_ident!("{}_field", Self::out_name_of(&ty.key())),
             source: ty.clone(),
             source_module: self.source_module.clone(),
             wire: bool_wire(),
@@ -1300,8 +1279,7 @@ impl CbindgenBuilder {
         ty: &TypeRef,
         registry: &impl Conversions,
     ) -> Option<crate::chain::OutputTerminalPlan> {
-        let plan = |ident, wire, operation| crate::chain::OutputTerminalPlan {
-            ident,
+        let plan = |wire, operation| crate::chain::OutputTerminalPlan {
             source: ty.clone(),
             source_module: self.source_module.clone(),
             wire,
@@ -1313,7 +1291,6 @@ impl CbindgenBuilder {
         // out-param entirely (it exists only to satisfy the resolver).
         if matches!(ty.kind(), TypeKind::Unit) {
             return Some(plan(
-                format_ident!("__cbg_out_unit"),
                 syn::parse_quote!(()),
                 crate::chain::OutputTerminalOperation::Unit,
             ));
@@ -1324,9 +1301,7 @@ impl CbindgenBuilder {
         // (held by C as `string_t *`) opts out — the opaque-handle branch below
         // owns it then (mirroring the input side, where owned-handle selection wins).
         if r_is_string(ty) && !self.opaque.contains_key(&ty.key()) {
-            let name = Self::out_name_of(&ty.key());
             return Some(plan(
-                name,
                 syn::parse_quote!(*mut ::core::ffi::c_char),
                 crate::chain::OutputTerminalOperation::String,
             ));
@@ -1334,23 +1309,16 @@ impl CbindgenBuilder {
 
         // FFI-safe scalar (`bool`, integers, floats): identity pass-through.
         if r_is_scalar(ty) {
-            let name = Self::out_name_of(&ty.key());
             let spelled = scalar_ty(ty)?;
-            return Some(plan(
-                name,
-                spelled,
-                crate::chain::OutputTerminalOperation::Scalar,
-            ));
+            return Some(plan(spelled, crate::chain::OutputTerminalOperation::Scalar));
         }
 
         let key = ty.key();
 
         // Opaque handle output: `Box::into_raw` → the bare `*mut #c_struct` handle.
         if self.opaque.contains_key(&key) {
-            let name = Self::out_name_of(&ty.key());
             let c_struct = self.c_type_ident(&ty.key());
             return Some(plan(
-                name,
                 syn::parse_quote!(*mut #c_struct),
                 crate::chain::OutputTerminalOperation::OwnedHandle { c_struct },
             ));
@@ -1361,9 +1329,7 @@ impl CbindgenBuilder {
         // String`. The error out-param of a `Result<_, E>` wrapper is thus
         // `char **e`. Freed by the universal `free_memory_function`.
         if let Some(msg_fn) = self.opaque_errors.get(&key) {
-            let name = Self::out_name_of(&ty.key());
             return Some(plan(
-                name,
                 syn::parse_quote!(*mut ::core::ffi::c_char),
                 crate::chain::OutputTerminalOperation::OpaqueError {
                     message_path: self.src_fn(msg_fn),
@@ -1376,9 +1342,7 @@ impl CbindgenBuilder {
         // type's emission site (fail-closed).
         if let Some(opaque) = self.value_opaque_ty_of(&ty.key()) {
             let opaque = opaque.clone();
-            let name = Self::out_name_of(&ty.key());
             return Some(plan(
-                name,
                 opaque,
                 crate::chain::OutputTerminalOperation::ValueOpaque,
             ));
@@ -1387,10 +1351,8 @@ impl CbindgenBuilder {
         // Enum output: `match` the source enum to the C enum.
         if self.enums.contains_key(&key) {
             let e = unit_enum(registry, &ty.key())?;
-            let name = Self::out_name_of(&ty.key());
             let cname = self.c_type_ident(&ty.key());
             return Some(plan(
-                name,
                 syn::parse_quote!(#cname),
                 crate::chain::OutputTerminalOperation::Enum {
                     c_name: cname,
@@ -1437,7 +1399,6 @@ impl CbindgenBuilder {
             }
         };
         Some(crate::chain::SliceInputPlan {
-            ident: format_ident!("__cbg_inmark_slice_{}", sanitize(&e.key())),
             element: e.clone(),
             wire,
             reinterpret: scalar.is_none(),
@@ -1468,8 +1429,7 @@ impl CbindgenBuilder {
         // or its source path, both of which the model answers.
         let elem = rf_inner;
 
-        let plan = |ident, source_inner, wire, operation, null_message| BorrowPlan {
-            ident,
+        let plan = |source_inner, wire, operation, null_message| BorrowPlan {
             source_inner,
             source_module: self.source_module.clone(),
             wire,
@@ -1489,7 +1449,6 @@ impl CbindgenBuilder {
                 self.value_opaque_ty_of(&key)?.clone()
             };
             return Some(plan(
-                format_ident!("__cbg_out_ref_{}", sanitize(&key)),
                 elem.as_ref().clone(),
                 syn::parse_quote!(*const #wire_ty),
                 BorrowOperation::SharedOutput,
@@ -1500,7 +1459,6 @@ impl CbindgenBuilder {
         // `&str`: borrow a UTF-8 C string directly from the caller.
         if !*rf_mut && r_is_str(rf_inner) {
             return Some(plan(
-                Self::in_name_of(&ty.key()),
                 elem.as_ref().clone(),
                 syn::parse_quote!(*const ::core::ffi::c_char),
                 BorrowOperation::StrInput,
@@ -1519,7 +1477,6 @@ impl CbindgenBuilder {
                 let op = self.value_opaque_ty_of(&inner.key())?.clone();
                 let short = type_short(&inner.key());
                 return Some(plan(
-                    Self::in_name_of(&ty.key()),
                     inner.as_ref().clone(),
                     syn::parse_quote!(*mut #op),
                     BorrowOperation::MutableUninitInput,
@@ -1537,7 +1494,6 @@ impl CbindgenBuilder {
             };
             let short = type_short(&elem.key());
             return Some(plan(
-                Self::in_name_of(&ty.key()),
                 elem.as_ref().clone(),
                 syn::parse_quote!(*mut #wire_ty),
                 BorrowOperation::MutableInput,
@@ -1554,7 +1510,6 @@ impl CbindgenBuilder {
         };
         let short = type_short(&elem.key());
         Some(plan(
-            Self::in_name_of(&ty.key()),
             elem.as_ref().clone(),
             syn::parse_quote!(*const #wire_ty),
             BorrowOperation::SharedInput,
@@ -1571,29 +1526,17 @@ impl CbindgenBuilder {
         operation: crate::chain::MarkerOperation,
         subject: &TypeRef,
     ) -> Option<crate::chain::MarkerPlan> {
-        let (ident, subs) = match operation {
+        let subs = match operation {
             crate::chain::MarkerOperation::ChoiceArm => return None,
-            crate::chain::MarkerOperation::Optional => (
-                format_ident!("__cbg_outmark_option_{}", sanitize(&subject.key())),
-                vec![subject.clone()],
-            ),
-            crate::chain::MarkerOperation::Sequence => (
-                format_ident!("__cbg_outmark_vec_{}", sanitize(&subject.key())),
-                vec![subject.clone()],
-            ),
+            crate::chain::MarkerOperation::Optional | crate::chain::MarkerOperation::Sequence => {
+                vec![subject.clone()]
+            }
             crate::chain::MarkerOperation::Result => {
                 let (ok, err) = subject.fallible_parts()?;
-                (
-                    format_ident!("__cbg_result_{}", sanitize(&subject.key())),
-                    vec![ok.clone(), err.clone()],
-                )
+                vec![ok.clone(), err.clone()]
             }
         };
-        Some(crate::chain::MarkerPlan {
-            ident,
-            operation,
-            subs,
-        })
+        Some(crate::chain::MarkerPlan { operation, subs })
     }
 }
 


### PR DESCRIPTION
## Why

Cbindgen still selected private converter identifiers while compiling recipes, even after every converter and composed call had registry-owned `OperationId`. That left a second identity system in the adapter and let callback plans freeze converter calls before final file assembly.

Private generated names must also remain useful to a reader. The stable hash is collision protection, not a replacement for the conversion's semantic owner and role.

Part of #513.

## What changed

- Retain only `OperationId` in C converter definitions and calls; allocate the Rust identifier through `Emit` during final rendering.
- Render callback argument preparation, delivery, and cleanup from semantic `InvokePart` plans at final emission instead of freezing converter call tokens during planning.
- Remove the legacy `in_name_of` / `out_name_of` helpers and prevent `chain::Call::new` from returning to C production code.
- Regenerate C Rust artifacts with readable names such as `__c_in_convert_wire_to_Thing_c_terminal_input_owned_handle_<hash>` and `__c_in_convert_wire_to_impl_Fn_..._c_invoke_callback_capture_<hash>`.
- Update tests and `model.md` to make the naming contract explicit: semantic stem first, deterministic hash suffix only for uniqueness.

## Compatibility

Generated private Rust helper names and their deterministic ordering change intentionally. Generated C headers, exported C ABI, ownership, conversion behavior, and JNI/Kotlin output are unchanged.

## Validation

- `cargo test -p prebindgen-c --lib` (109 passed)
- `cargo test --workspace --quiet`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `./examples/regen-check.sh` (byte-identical from committed baseline)
- `examples/covertest-kotlin/gradlew run` (61/61 sections)
- Verified no generated hash-only `__c_{in,out}_{convert,stage}_<hash>` declarations remain
- Verified generated C headers have no diff