### PR TITLE
Carry typed items across emission callbacks

### DIFF
--- a/docs/model.md
+++ b/docs/model.md
@@ -248,6 +248,16 @@ keeps those items directly; no arbitrary token stream crosses the callback
 boundary and no generated source is reparsed there. A callback may return zero
 or several items: JniGen's constant hook returns two, a getter and an alias.
 
+Typed output is not a route back to captured Rust syntax. Adapters construct
+those items from Flat facts and may ask `Emit` to spell a `TypeRef` or another
+leaf only while assembling the final item. `Emit` deliberately has no API that
+returns a captured function, struct or enum as `syn`; doing so would let an
+adapter inspect the source item instead of using its Flat representation. A
+named const alias is likewise generated from the modeled name and type. If an
+adapter has no source module and therefore no model-defined value to reference,
+it must declare another value policy explicitly: `on_const` has no default and
+the captured initializer is not an available fallback.
+
 **Finally the file.** The writer concatenates, in this order:
 
 1. the adapter's **prerequisites** — helper functions, type aliases, the

--- a/docs/model.md
+++ b/docs/model.md
@@ -243,10 +243,10 @@ facts, not generated source Rust syntax.
 
 The writer then goes over the declared items in name order and calls the
 adapter back once per kind — `on_function`, `on_struct`, `on_enum`, `on_const`
-— handing over the model element and taking a `TokenStream`. It parses that as
-Rust items and keeps them all. Nothing else is checked: not that a function
-comes out, not that it is one item, not that it mentions the item declared.
-JniGen's constant hook returns two, a getter and an alias.
+— handing over the model element and taking typed `syn::Item`s. The writer
+keeps those items directly; no arbitrary token stream crosses the callback
+boundary and no generated source is reparsed there. A callback may return zero
+or several items: JniGen's constant hook returns two, a getter and an alias.
 
 **Finally the file.** The writer concatenates, in this order:
 

--- a/prebindgen-c/src/emit.rs
+++ b/prebindgen-c/src/emit.rs
@@ -507,7 +507,7 @@ impl CbindgenBuilder {
         &self,
         f: &prebindgen_registry::flat::Function,
         emit: &prebindgen_registry::Emit,
-    ) -> TokenStream {
+    ) -> syn::ItemFn {
         let orig = &f.name;
         let call_path = self.src_fn(orig);
         let sym = self.fn_symbol(orig);
@@ -767,7 +767,7 @@ impl CbindgenBuilder {
             }
         };
 
-        quote! {
+        syn::parse_quote! {
             #[no_mangle]
             #[allow(non_snake_case, unused_mut, unused_variables, unused_unsafe, dead_code)]
             pub unsafe extern "C" fn #sym(

--- a/prebindgen-c/src/trait_impl.rs
+++ b/prebindgen-c/src/trait_impl.rs
@@ -1237,8 +1237,8 @@ impl Prebindgen for CbindgenBuilder {
         f: &prebindgen_registry::flat::Function,
         _registry: &Registry,
         emit: &prebindgen_registry::Emit,
-    ) -> TokenStream {
-        self.emit_function_wrapper(f, emit)
+    ) -> Vec<syn::Item> {
+        vec![syn::Item::Fn(self.emit_function_wrapper(f, emit))]
     }
 
     fn on_struct(
@@ -1246,10 +1246,10 @@ impl Prebindgen for CbindgenBuilder {
         _s: &prebindgen_registry::flat::Struct,
         _registry: &Registry,
         _emit: &prebindgen_registry::Emit,
-    ) -> TokenStream {
+    ) -> Vec<syn::Item> {
         // The `#[repr(C)]` mirror + converters come from prerequisites /
         // on_output_type; the original (non-FFI-safe) struct is dropped.
-        TokenStream::new()
+        Vec::new()
     }
 
     fn on_variant(
@@ -1257,8 +1257,8 @@ impl Prebindgen for CbindgenBuilder {
         _v: &prebindgen_registry::flat::Variant,
         _registry: &Registry,
         _emit: &prebindgen_registry::Emit,
-    ) -> TokenStream {
-        TokenStream::new()
+    ) -> Vec<syn::Item> {
+        Vec::new()
     }
 
     fn on_enum(
@@ -1266,8 +1266,8 @@ impl Prebindgen for CbindgenBuilder {
         _e: &prebindgen_registry::flat::Enum,
         _registry: &Registry,
         _emit: &prebindgen_registry::Emit,
-    ) -> TokenStream {
-        TokenStream::new()
+    ) -> Vec<syn::Item> {
+        Vec::new()
     }
 }
 

--- a/prebindgen-c/src/trait_impl.rs
+++ b/prebindgen-c/src/trait_impl.rs
@@ -957,8 +957,9 @@ impl CbindgenBuilder {
     /// State this binding into `registry` — see `JniGenBuilder::declare_into`.
     ///
     /// Push, not pull: the build script calls this, and the registry never
-    /// calls back. cbindgen declares no consts (it has no const mechanism, so
-    /// every captured const re-emits verbatim) and no decompositions.
+    /// calls back. cbindgen declares no selective const surface (its
+    /// `on_const` policy generates a source-module alias for every captured
+    /// const) and no decompositions.
     /// Binding-local fns declared by `convert!(..).local(..)`.
     fn collect_local_functions(&self) -> Vec<(syn::ItemFn, String)> {
         let mut result = Vec::new();
@@ -1144,8 +1145,8 @@ impl Prebindgen for CbindgenBuilder {
     /// where the registry used to print these itself. Moves into
     /// `CbindgenBuilder::generate` once that exists (prebindgen#251 phase E).
     ///
-    /// `consts: None` — cbindgen has no const declaration mechanism, so every
-    /// captured const is re-emitted verbatim and none is ever a skip.
+    /// `consts: None` — cbindgen has no selective const mechanism, so every
+    /// captured const reaches its source-alias policy and none is ever a skip.
     fn validate(&self, binding: &Building<'_>) -> Result<(), String> {
         let mut functions = self.declared_functions();
         functions.extend(self.helper_functions());
@@ -1268,6 +1269,18 @@ impl Prebindgen for CbindgenBuilder {
         _emit: &prebindgen_registry::Emit,
     ) -> Vec<syn::Item> {
         Vec::new()
+    }
+
+    fn on_const(
+        &self,
+        c: &prebindgen_registry::flat::Constant,
+        _registry: &Registry,
+        emit: &prebindgen_registry::Emit,
+    ) -> Vec<syn::Item> {
+        self.source_module
+            .as_ref()
+            .map(|module| vec![syn::Item::Const(emit.const_alias(c, module))])
+            .unwrap_or_default()
     }
 }
 

--- a/prebindgen-flat/src/flat/emit.rs
+++ b/prebindgen-flat/src/flat/emit.rs
@@ -53,17 +53,6 @@ use proc_macro2::TokenStream;
 
 use super::{Alternative, Element, EnumValue, Struct, Type, TypeRef};
 
-fn const_path_alias(c: &syn::ItemConst, source_module: &syn::Path) -> TokenStream {
-    let attrs = &c.attrs;
-    let vis = &c.vis;
-    let ident = &c.ident;
-    let ty = &c.ty;
-    quote::quote! {
-        #(#attrs)*
-        #vis const #ident: #ty = #source_module::#ident;
-    }
-}
-
 /// Rendering operations supplied by a pipeline-owned callback key.
 ///
 /// All methods are renderings: they answer what the source wrote, never what
@@ -122,33 +111,36 @@ pub trait RustEmitter {
     }
 
     /// Re-emit a captured function verbatim.
-    fn verbatim_fn(&self, function: &super::Function) -> TokenStream {
-        function.origin.spell()
+    fn verbatim_fn(&self, function: &super::Function) -> syn::ItemFn {
+        function.origin.as_syn().clone()
     }
 
     /// Re-emit a captured struct verbatim.
-    fn verbatim_struct(&self, item: &Struct) -> TokenStream {
-        item.origin.spell()
+    fn verbatim_struct(&self, item: &Struct) -> syn::ItemStruct {
+        item.origin.as_syn().clone()
     }
 
     /// Re-emit a captured payload enum verbatim.
-    fn verbatim_variant(&self, item: &super::Variant) -> TokenStream {
-        item.origin.spell()
+    fn verbatim_variant(&self, item: &super::Variant) -> syn::ItemEnum {
+        item.origin.as_syn().clone()
     }
 
     /// Re-emit a captured fieldless enum verbatim.
-    fn verbatim_enum(&self, item: &super::Enum) -> TokenStream {
-        item.origin.spell()
+    fn verbatim_enum(&self, item: &super::Enum) -> syn::ItemEnum {
+        item.origin.as_syn().clone()
     }
 
     /// Re-emit a constant as an alias to its source module.
-    fn const_alias(&self, item: &super::Constant, source_module: &syn::Path) -> TokenStream {
-        const_path_alias(item.origin.as_syn(), source_module)
+    fn const_alias(&self, item: &super::Constant, source_module: &syn::Path) -> syn::ItemConst {
+        let mut alias = item.origin.as_syn().clone();
+        let ident = &alias.ident;
+        alias.expr = Box::new(syn::parse_quote!(#source_module::#ident));
+        alias
     }
 
     /// Re-emit a captured constant verbatim.
-    fn const_verbatim(&self, item: &super::Constant) -> TokenStream {
-        item.origin.spell()
+    fn const_verbatim(&self, item: &super::Constant) -> syn::ItemConst {
+        item.origin.as_syn().clone()
     }
 
     /// Re-emit an anonymous feature guard.

--- a/prebindgen-flat/src/flat/emit.rs
+++ b/prebindgen-flat/src/flat/emit.rs
@@ -51,17 +51,7 @@
 
 use proc_macro2::TokenStream;
 
-use super::{Alternative, Element, EnumValue, Struct, Type, TypeRef};
-
-/// Turn an opaque captured spelling into its final typed output item.
-///
-/// This is deliberately a rendering operation. Consumers cannot borrow the
-/// captured `syn` node and therefore cannot use it to classify or inspect the
-/// source; the parse happens only after the pipeline has entered the explicit
-/// `RustEmitter` boundary to assemble generated Rust.
-fn final_item<T: syn::parse::Parse>(tokens: TokenStream) -> T {
-    syn::parse2(tokens).expect("captured Rust item must parse at final emission")
-}
+use super::{Alternative, EnumValue, Struct, TypeRef};
 
 /// Rendering operations supplied by a pipeline-owned callback key.
 ///
@@ -110,47 +100,23 @@ pub trait RustEmitter {
         ty.stripped_syntax()
     }
 
-    /// Re-emit a captured item verbatim.
-    fn item(&self, element: &Element) -> syn::Item {
-        element.as_syn()
-    }
-
-    /// Re-emit a captured type declaration verbatim.
-    fn type_item(&self, ty: &Type) -> syn::Item {
-        ty.as_syn()
-    }
-
-    /// Re-emit a captured function verbatim.
-    fn verbatim_fn(&self, function: &super::Function) -> syn::ItemFn {
-        final_item(function.origin.spell())
-    }
-
-    /// Re-emit a captured struct verbatim.
-    fn verbatim_struct(&self, item: &Struct) -> syn::ItemStruct {
-        final_item(item.origin.spell())
-    }
-
-    /// Re-emit a captured payload enum verbatim.
-    fn verbatim_variant(&self, item: &super::Variant) -> syn::ItemEnum {
-        final_item(item.origin.spell())
-    }
-
-    /// Re-emit a captured fieldless enum verbatim.
-    fn verbatim_enum(&self, item: &super::Enum) -> syn::ItemEnum {
-        final_item(item.origin.spell())
-    }
-
     /// Re-emit a constant as an alias to its source module.
     fn const_alias(&self, item: &super::Constant, source_module: &syn::Path) -> syn::ItemConst {
-        let mut alias: syn::ItemConst = final_item(item.origin.spell());
-        let ident = &alias.ident;
-        alias.expr = Box::new(syn::parse_quote!(#source_module::#ident));
-        alias
-    }
-
-    /// Re-emit a captured constant verbatim.
-    fn const_verbatim(&self, item: &super::Constant) -> syn::ItemConst {
-        final_item(item.origin.spell())
+        let ident = &item.name;
+        let ty = self.spell(&item.ty);
+        let docs: Vec<syn::Attribute> = item
+            .docs()
+            .into_iter()
+            .flat_map(|docs| {
+                docs.lines()
+                    .map(|line| {
+                        let doc = format!(" {line}");
+                        syn::parse_quote!(#[doc = #doc])
+                    })
+                    .collect::<Vec<_>>()
+            })
+            .collect();
+        syn::parse_quote!(#(#docs)* pub const #ident: #ty = #source_module::#ident;)
     }
 
     /// Re-emit an anonymous feature guard.

--- a/prebindgen-flat/src/flat/emit.rs
+++ b/prebindgen-flat/src/flat/emit.rs
@@ -53,6 +53,16 @@ use proc_macro2::TokenStream;
 
 use super::{Alternative, Element, EnumValue, Struct, Type, TypeRef};
 
+/// Turn an opaque captured spelling into its final typed output item.
+///
+/// This is deliberately a rendering operation. Consumers cannot borrow the
+/// captured `syn` node and therefore cannot use it to classify or inspect the
+/// source; the parse happens only after the pipeline has entered the explicit
+/// `RustEmitter` boundary to assemble generated Rust.
+fn final_item<T: syn::parse::Parse>(tokens: TokenStream) -> T {
+    syn::parse2(tokens).expect("captured Rust item must parse at final emission")
+}
+
 /// Rendering operations supplied by a pipeline-owned callback key.
 ///
 /// All methods are renderings: they answer what the source wrote, never what
@@ -112,27 +122,27 @@ pub trait RustEmitter {
 
     /// Re-emit a captured function verbatim.
     fn verbatim_fn(&self, function: &super::Function) -> syn::ItemFn {
-        function.origin.as_syn().clone()
+        final_item(function.origin.spell())
     }
 
     /// Re-emit a captured struct verbatim.
     fn verbatim_struct(&self, item: &Struct) -> syn::ItemStruct {
-        item.origin.as_syn().clone()
+        final_item(item.origin.spell())
     }
 
     /// Re-emit a captured payload enum verbatim.
     fn verbatim_variant(&self, item: &super::Variant) -> syn::ItemEnum {
-        item.origin.as_syn().clone()
+        final_item(item.origin.spell())
     }
 
     /// Re-emit a captured fieldless enum verbatim.
     fn verbatim_enum(&self, item: &super::Enum) -> syn::ItemEnum {
-        item.origin.as_syn().clone()
+        final_item(item.origin.spell())
     }
 
     /// Re-emit a constant as an alias to its source module.
     fn const_alias(&self, item: &super::Constant, source_module: &syn::Path) -> syn::ItemConst {
-        let mut alias = item.origin.as_syn().clone();
+        let mut alias: syn::ItemConst = final_item(item.origin.spell());
         let ident = &alias.ident;
         alias.expr = Box::new(syn::parse_quote!(#source_module::#ident));
         alias
@@ -140,7 +150,7 @@ pub trait RustEmitter {
 
     /// Re-emit a captured constant verbatim.
     fn const_verbatim(&self, item: &super::Constant) -> syn::ItemConst {
-        item.origin.as_syn().clone()
+        final_item(item.origin.spell())
     }
 
     /// Re-emit an anonymous feature guard.

--- a/prebindgen-flat/src/flat/origin.rs
+++ b/prebindgen-flat/src/flat/origin.rs
@@ -6,7 +6,7 @@
 //! (a field has no line of its own), but the shape does not change with the
 //! level, so nothing has to copy a piece of provenance downward by hand.
 
-use std::rc::Rc;
+use std::{fmt, rc::Rc};
 
 use prebindgen::SourceLocation;
 use quote::ToTokens;
@@ -52,14 +52,15 @@ use super::key::TypeKey;
 ///
 /// The crate-private `spell` operation produces tokens and nothing else, which is all
 /// generated Rust ever needed. The typed node is reachable only inside this crate,
-/// and the field itself is `pub(super)`. Derived `Debug` remains available for
-/// diagnostics; it is not a stable or structured syntax API.
+/// and the field itself is `pub(super)`. `Debug` deliberately prints only the
+/// location: formatting an origin must not become an ungated spelling or syntax-tree
+/// API.
 ///
 /// It was a public field returning a `syn` node to anyone who asked.
 /// Outside this crate, rendering requires an explicit
 /// [`RustEmitter`](crate::RustEmitter) implementation; no raw syntax accessor is
 /// public.
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 pub struct Origin<S> {
     /// The exact tokens this node was built from.
     ///
@@ -69,6 +70,14 @@ pub struct Origin<S> {
     pub(super) syntax: S,
     /// The captured item this node belongs to, shared with every sibling.
     pub location: Rc<SourceLocation>,
+}
+
+impl<S> fmt::Debug for Origin<S> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Origin")
+            .field("location", &self.location)
+            .finish_non_exhaustive()
+    }
 }
 
 impl<S> Origin<S> {

--- a/prebindgen-flat/src/flat/tests/mod.rs
+++ b/prebindgen-flat/src/flat/tests/mod.rs
@@ -16,6 +16,22 @@ use super::*;
 mod acceptance;
 mod roundtrip;
 
+#[test]
+fn origin_debug_does_not_reveal_captured_syntax() {
+    let origin: Origin<syn::ItemFn> = Origin::new(
+        syn::parse_quote!(
+            fn secret(value: ::std::borrow::Cow<'_, [u8]>) {}
+        ),
+        Rc::new(loc()),
+    );
+
+    let debug = format!("{origin:?}");
+    assert!(debug.contains("src/lib.rs"));
+    assert!(!debug.contains("secret"));
+    assert!(!debug.contains("Cow"));
+    assert!(!debug.contains("ItemFn"));
+}
+
 /// Lower one type by putting it in a struct field, and report what the language
 /// made of it. The field path is used because a field is the position every
 /// consumer already agrees is a boundary surface.

--- a/prebindgen-flat/src/flat/ty.rs
+++ b/prebindgen-flat/src/flat/ty.rs
@@ -90,6 +90,11 @@ pub struct TypeRef {
     /// It says exactly what `kind` says — that is the invariant
     /// [`TypeKind::to_syn`] checks — and it says it in the source's own tokens,
     /// which is why generated Rust re-emits this rather than a reconstruction.
+    // Keep this narrower than `pub(crate)`, and never add a public accessor.
+    // `Origin<syn::Type>::declared_spelling` is public for build-script
+    // declarations of that same Rust type; exposing this captured origin would
+    // accidentally make that declaration-only spelling route available to
+    // adapters without an `Emit` capability.
     pub(super) origin: Origin<syn::Type>,
 }
 

--- a/prebindgen-jni/src/jni/classify.rs
+++ b/prebindgen-jni/src/jni/classify.rs
@@ -30,7 +30,8 @@ pub(crate) enum TypeKind<'r, 'c> {
     /// The **element**, not its `syn::ItemStruct`. A flattening emitter wants
     /// each field's reading, and the model already decided one per field; going
     /// through the syntax means asking some other authority for it again. An
-    /// emitter that only re-emits the struct reads `st.origin.as_syn()`.
+    /// emitter that only re-emits the struct goes through the final `Emit`
+    /// boundary instead.
     DataStruct {
         st: &'r prebindgen_registry::flat::Struct,
         cfg: Option<&'c TypeConfig>,

--- a/prebindgen-jni/src/jni/emit/wrapper.rs
+++ b/prebindgen-jni/src/jni/emit/wrapper.rs
@@ -11,7 +11,7 @@ pub(crate) fn emit_jni_function_wrapper(
     f: &prebindgen_registry::flat::Function,
     registry: &Registry,
     emit: &prebindgen_registry::Emit,
-) -> TokenStream {
+) -> syn::ItemFn {
     emit_jni_function_wrapper_with_callee(ext, f, registry, None, emit)
 }
 
@@ -183,7 +183,7 @@ pub(crate) fn emit_jni_function_wrapper_with_callee(
     registry: &Registry,
     callee: Option<syn::Expr>,
     emit: &prebindgen_registry::Emit,
-) -> TokenStream {
+) -> syn::ItemFn {
     let original_ident = &f.name;
 
     let mut wire_params: Vec<TokenStream> = Vec::new();
@@ -460,7 +460,7 @@ pub(crate) fn emit_jni_function_wrapper_with_callee(
     // `__domain_sink` (typed domain error) for a fallible fn — a capture is
     // passed for each. Declared after the wire params + builder so the order
     // matches the Kotlin `external fun`.
-    quote! {
+    syn::parse_quote! {
         #[no_mangle]
         #[allow(non_snake_case, unused_mut, unused_variables, dead_code)]
         pub unsafe extern "C" fn #wrapper_ident<'a>(

--- a/prebindgen-jni/src/jni/trait_impl.rs
+++ b/prebindgen-jni/src/jni/trait_impl.rs
@@ -1418,9 +1418,7 @@ impl Prebindgen for Declarations {
             });
             let wrapper =
                 emit_jni_function_wrapper_with_callee(self, &getter, registry, Some(callee), emit);
-            items.push(syn::parse2::<syn::Item>(wrapper).expect(
-                "constant_expr: generated getter wrapper is a single item by construction",
-            ));
+            items.push(syn::Item::Fn(wrapper));
         }
         items
     }
@@ -1441,8 +1439,10 @@ impl Prebindgen for Declarations {
         f: &prebindgen_registry::flat::Function,
         registry: &Registry,
         emit: &prebindgen_registry::Emit,
-    ) -> TokenStream {
-        emit_jni_function_wrapper(self, f, registry, emit)
+    ) -> Vec<syn::Item> {
+        vec![syn::Item::Fn(emit_jni_function_wrapper(
+            self, f, registry, emit,
+        ))]
     }
 
     fn on_struct(
@@ -1450,10 +1450,10 @@ impl Prebindgen for Declarations {
         _s: &prebindgen_registry::flat::Struct,
         _registry: &Registry,
         _emit: &prebindgen_registry::Emit,
-    ) -> TokenStream {
+    ) -> Vec<syn::Item> {
         // Struct converter bodies are emitted from retained registry plans;
         // no separate per-struct item is needed.
-        TokenStream::new()
+        Vec::new()
     }
 
     fn on_variant(
@@ -1461,8 +1461,8 @@ impl Prebindgen for Declarations {
         _v: &prebindgen_registry::flat::Variant,
         _registry: &Registry,
         _emit: &prebindgen_registry::Emit,
-    ) -> TokenStream {
-        TokenStream::new()
+    ) -> Vec<syn::Item> {
+        Vec::new()
     }
 
     fn on_enum(
@@ -1470,8 +1470,8 @@ impl Prebindgen for Declarations {
         _e: &prebindgen_registry::flat::Enum,
         _registry: &Registry,
         _emit: &prebindgen_registry::Emit,
-    ) -> TokenStream {
-        TokenStream::new()
+    ) -> Vec<syn::Item> {
+        Vec::new()
     }
 
     /// Declared consts only reach here (undeclared ones are gated out before
@@ -1486,7 +1486,7 @@ impl Prebindgen for Declarations {
         c: &prebindgen_registry::flat::Constant,
         registry: &Registry,
         emit: &prebindgen_registry::Emit,
-    ) -> TokenStream {
+    ) -> Vec<syn::Item> {
         reject_handle_const(self, c);
         let getter = const_getter_fn(c);
         let const_ident = &c.name;
@@ -1495,10 +1495,7 @@ impl Prebindgen for Declarations {
         let wrapper =
             emit_jni_function_wrapper_with_callee(self, &getter, registry, Some(callee), emit);
         let alias = emit.const_alias(c, &source_module);
-        quote! {
-            #alias
-            #wrapper
-        }
+        vec![syn::Item::Const(alias), syn::Item::Fn(wrapper)]
     }
 }
 

--- a/prebindgen-registry/src/diagnostics.rs
+++ b/prebindgen-registry/src/diagnostics.rs
@@ -29,8 +29,8 @@ pub struct Claimed {
     /// Types the binding emits, plus the ones that cross only through a plan.
     pub types: HashSet<TypeKey>,
     /// Consts the binding emits, or `None` when it has no const mechanism at
-    /// all — then every const is re-emitted verbatim, so none is ever skipped
-    /// and reporting one would be a lie.
+    /// all — then its adapter policy handles every const, so none is ever
+    /// skipped and reporting one would be a lie.
     pub consts: Option<HashSet<syn::Ident>>,
     pub ignored_functions: HashSet<syn::Ident>,
     pub ignored_types: HashSet<TypeKey>,

--- a/prebindgen-registry/src/diagnostics/tests.rs
+++ b/prebindgen-registry/src/diagnostics/tests.rs
@@ -147,9 +147,9 @@ fn an_ignore_predicate_covers_every_kind_and_is_silent_when_unmatched() {
     assert!(unclaimed_report(&flat, &claimed).is_empty());
 }
 
-/// `consts: None` means the binding has no const mechanism at all: every const
-/// is re-emitted verbatim, so none was skipped and reporting one would be a lie.
-/// This is the one asymmetry with functions and types.
+/// `consts: None` means the binding has no selective const mechanism: every
+/// const reaches its adapter policy, so none was skipped and reporting one
+/// would be a lie. This is the one asymmetry with functions and types.
 #[test]
 fn no_const_mechanism_reports_no_consts() {
     let flat = flat_with(&["pub const K: u64 = 7;"]);

--- a/prebindgen-registry/src/prebindgen.rs
+++ b/prebindgen-registry/src/prebindgen.rs
@@ -1,7 +1,7 @@
 //! `Prebindgen` — what a generator still hands the emitter.
 //!
 //! One method per `#[prebindgen]` item kind (`on_function`, `on_struct`,
-//! `on_enum`, `on_const`) returning the wrapper Rust tokens to emit, plus the
+//! `on_enum`, `on_const`) returning typed Rust items to emit, plus the
 //! items they depend on (`prerequisites`), a cross-cutting rewrite
 //! (`post_process_item`) and two invariant checks.
 //!
@@ -14,8 +14,6 @@
 //! converter. Its executable artifact is retained separately by the adapter's
 //! frozen generation plan; this shared registry carrier never stores rendered
 //! Rust syntax.
-
-use proc_macro2::TokenStream;
 
 use crate::{generation::OperationId, niches::Niches, registry::Registry};
 
@@ -284,7 +282,7 @@ pub trait Prebindgen {
         f: &prebindgen_flat::flat::Function,
         registry: &Registry,
         emit: &crate::Emit,
-    ) -> TokenStream;
+    ) -> Vec<syn::Item>;
 
     /// Per-struct emission. Typically empty for languages that get
     /// everything they need from auto-generated converters.
@@ -293,20 +291,20 @@ pub trait Prebindgen {
         s: &prebindgen_flat::flat::Struct,
         registry: &Registry,
         emit: &crate::Emit,
-    ) -> TokenStream;
+    ) -> Vec<syn::Item>;
 
     /// Per-sum emission — an `enum` whose alternatives carry payloads.
     ///
     /// Separate from [`Self::on_enum`] because the model separates them: the
     /// two are numbered differently and consumed as different constructs. An
-    /// adapter with nothing to say about one shape returns an empty stream, as
+    /// adapter with nothing to say about one shape returns an empty vector, as
     /// both in-tree adapters do for both.
     fn on_variant(
         &self,
         v: &prebindgen_flat::flat::Variant,
         registry: &Registry,
         emit: &crate::Emit,
-    ) -> TokenStream;
+    ) -> Vec<syn::Item>;
 
     /// Per-enum emission — the fieldless shape, a named set of integers.
     fn on_enum(
@@ -314,7 +312,7 @@ pub trait Prebindgen {
         e: &prebindgen_flat::flat::Enum,
         registry: &Registry,
         emit: &crate::Emit,
-    ) -> TokenStream;
+    ) -> Vec<syn::Item>;
 
     /// Per-const emission. Default: a named const re-emits as a path-alias
     /// when [`Self::source_module`] is available —
@@ -330,10 +328,10 @@ pub trait Prebindgen {
         c: &prebindgen_flat::flat::Constant,
         _registry: &Registry,
         emit: &crate::Emit,
-    ) -> TokenStream {
+    ) -> Vec<syn::Item> {
         match self.source_module() {
-            Some(m) => emit.const_alias(c, m),
-            None => emit.const_verbatim(c),
+            Some(m) => vec![syn::Item::Const(emit.const_alias(c, m))],
+            None => vec![syn::Item::Const(emit.const_verbatim(c))],
         }
     }
 }

--- a/prebindgen-registry/src/prebindgen.rs
+++ b/prebindgen-registry/src/prebindgen.rs
@@ -256,10 +256,9 @@ pub trait Prebindgen {
 
     /// Absolute path under which the source crate's items are reachable
     /// from the generated file (e.g. `zenoh_flat`), for adapters that
-    /// qualify emitted references against one. Drives the default
-    /// [`Self::on_const`]: with a source module available, a named const
-    /// re-emits as a path-alias to the source item instead of copying its
-    /// initializer tokens. Default: `None`.
+    /// qualify emitted references against one. An adapter may also use it in
+    /// its required [`Self::on_const`] policy to generate a path-alias to the
+    /// source item instead of copying initializer tokens. Default: `None`.
     fn source_module(&self) -> Option<&syn::Path> {
         None
     }
@@ -314,11 +313,11 @@ pub trait Prebindgen {
         emit: &crate::Emit,
     ) -> Vec<syn::Item>;
 
-    /// Per-const emission. Default: a named const re-emits as a path-alias
-    /// when [`Self::source_module`] is available —
-    /// initializer tokens are never copied, so a const whose initializer
-    /// references source-crate internals stays valid in the generated file.
-    /// An adapter without a source module passes the const through verbatim.
+    /// Per-const emission. There is deliberately no default: Flat models the
+    /// const's name, type and documentation, but not an arbitrary Rust
+    /// initializer expression. Each adapter must therefore state its value
+    /// policy explicitly, commonly by generating a path-alias to a source
+    /// module. Initializer tokens are never copied or parsed.
     ///
     /// A const reaching here is always named: prebindgen's own injected feature
     /// checks are [`Guard`](prebindgen_flat::flat::Guard)s, not consts, so this
@@ -326,12 +325,7 @@ pub trait Prebindgen {
     fn on_const(
         &self,
         c: &prebindgen_flat::flat::Constant,
-        _registry: &Registry,
+        registry: &Registry,
         emit: &crate::Emit,
-    ) -> Vec<syn::Item> {
-        match self.source_module() {
-            Some(m) => vec![syn::Item::Const(emit.const_alias(c, m))],
-            None => vec![syn::Item::Const(emit.const_verbatim(c))],
-        }
-    }
+    ) -> Vec<syn::Item>;
 }

--- a/prebindgen-registry/src/registry/declare.rs
+++ b/prebindgen-registry/src/registry/declare.rs
@@ -116,9 +116,9 @@ impl RegistryBuilder {
     /// A const this binding exports.
     ///
     /// Separate from [`Self::export`] only because *having a const mechanism at
-    /// all* is itself a fact: a binding that never calls this re-emits every
-    /// captured const verbatim, while one that calls it emits exactly what it
-    /// names. See [`Self::declares_consts`].
+    /// all* is itself a fact: a binding that never calls this applies its
+    /// `on_const` policy to every captured const, while one that calls it emits
+    /// exactly what it names. See [`Self::declares_consts`].
     pub fn export_const(mut self, name: &syn::Ident) -> Self {
         self.registry
             .declared
@@ -129,7 +129,8 @@ impl RegistryBuilder {
     }
 
     /// Declare that this binding has a const mechanism, even if it exports no
-    /// consts. Without it every captured const is re-emitted verbatim.
+    /// consts. Without it every captured const reaches the adapter's mandatory
+    /// `on_const` policy.
     pub fn declares_consts(mut self) -> Self {
         self.registry
             .declared

--- a/prebindgen-registry/src/registry/tests.rs
+++ b/prebindgen-registry/src/registry/tests.rs
@@ -1,7 +1,6 @@
 use std::collections::HashSet;
 
 use prebindgen_flat::flat::Flat;
-use proc_macro2::TokenStream;
 use quote::ToTokens;
 
 use super::*;
@@ -101,32 +100,32 @@ impl Prebindgen for StubExt {
         _f: &prebindgen_flat::flat::Function,
         _registry: &Registry,
         _emit: &crate::Emit,
-    ) -> TokenStream {
-        TokenStream::new()
+    ) -> Vec<syn::Item> {
+        Vec::new()
     }
     fn on_struct(
         &self,
         _s: &prebindgen_flat::flat::Struct,
         _registry: &Registry,
         _emit: &crate::Emit,
-    ) -> TokenStream {
-        TokenStream::new()
+    ) -> Vec<syn::Item> {
+        Vec::new()
     }
     fn on_variant(
         &self,
         _v: &prebindgen_flat::flat::Variant,
         _registry: &Registry,
         _emit: &crate::Emit,
-    ) -> TokenStream {
-        TokenStream::new()
+    ) -> Vec<syn::Item> {
+        Vec::new()
     }
     fn on_enum(
         &self,
         _e: &prebindgen_flat::flat::Enum,
         _registry: &Registry,
         _emit: &crate::Emit,
-    ) -> TokenStream {
-        TokenStream::new()
+    ) -> Vec<syn::Item> {
+        Vec::new()
     }
 }
 
@@ -478,7 +477,7 @@ fn resolve_surfaces_adapter_invariant_errors() {
             f: &prebindgen_flat::flat::Function,
             r: &Registry,
             _emit: &crate::Emit,
-        ) -> TokenStream {
+        ) -> Vec<syn::Item> {
             self.0.on_function(f, r, _emit)
         }
         fn on_struct(
@@ -486,7 +485,7 @@ fn resolve_surfaces_adapter_invariant_errors() {
             s: &prebindgen_flat::flat::Struct,
             r: &Registry,
             _emit: &crate::Emit,
-        ) -> TokenStream {
+        ) -> Vec<syn::Item> {
             self.0.on_struct(s, r, _emit)
         }
         fn on_variant(
@@ -494,7 +493,7 @@ fn resolve_surfaces_adapter_invariant_errors() {
             v: &prebindgen_flat::flat::Variant,
             r: &Registry,
             _emit: &crate::Emit,
-        ) -> TokenStream {
+        ) -> Vec<syn::Item> {
             self.0.on_variant(v, r, _emit)
         }
         fn on_enum(
@@ -502,7 +501,7 @@ fn resolve_surfaces_adapter_invariant_errors() {
             e: &prebindgen_flat::flat::Enum,
             r: &Registry,
             _emit: &crate::Emit,
-        ) -> TokenStream {
+        ) -> Vec<syn::Item> {
             self.0.on_enum(e, r, _emit)
         }
     }
@@ -1536,7 +1535,7 @@ fn a_type_only_a_local_fn_writes_still_has_a_reading() {
             f: &prebindgen_flat::flat::Function,
             r: &Registry,
             _emit: &crate::Emit,
-        ) -> TokenStream {
+        ) -> Vec<syn::Item> {
             self.0.on_function(f, r, _emit)
         }
         fn on_struct(
@@ -1544,7 +1543,7 @@ fn a_type_only_a_local_fn_writes_still_has_a_reading() {
             st: &prebindgen_flat::flat::Struct,
             r: &Registry,
             _emit: &crate::Emit,
-        ) -> TokenStream {
+        ) -> Vec<syn::Item> {
             self.0.on_struct(st, r, _emit)
         }
         fn on_variant(
@@ -1552,7 +1551,7 @@ fn a_type_only_a_local_fn_writes_still_has_a_reading() {
             v: &prebindgen_flat::flat::Variant,
             r: &Registry,
             _emit: &crate::Emit,
-        ) -> TokenStream {
+        ) -> Vec<syn::Item> {
             self.0.on_variant(v, r, _emit)
         }
         fn on_enum(
@@ -1560,7 +1559,7 @@ fn a_type_only_a_local_fn_writes_still_has_a_reading() {
             e: &prebindgen_flat::flat::Enum,
             r: &Registry,
             _emit: &crate::Emit,
-        ) -> TokenStream {
+        ) -> Vec<syn::Item> {
             self.0.on_enum(e, r, _emit)
         }
     }

--- a/prebindgen-registry/src/registry/tests.rs
+++ b/prebindgen-registry/src/registry/tests.rs
@@ -127,6 +127,14 @@ impl Prebindgen for StubExt {
     ) -> Vec<syn::Item> {
         Vec::new()
     }
+    fn on_const(
+        &self,
+        _c: &prebindgen_flat::flat::Constant,
+        _registry: &Registry,
+        _emit: &crate::Emit,
+    ) -> Vec<syn::Item> {
+        Vec::new()
+    }
 }
 
 // suppress unused warning on Niches — kept available for richer tests
@@ -503,6 +511,14 @@ fn resolve_surfaces_adapter_invariant_errors() {
             _emit: &crate::Emit,
         ) -> Vec<syn::Item> {
             self.0.on_enum(e, r, _emit)
+        }
+        fn on_const(
+            &self,
+            c: &prebindgen_flat::flat::Constant,
+            r: &Registry,
+            _emit: &crate::Emit,
+        ) -> Vec<syn::Item> {
+            self.0.on_const(c, r, _emit)
         }
     }
     let items = vec![fn_item("fn good(x: u64) -> u64 { x }")];
@@ -1561,6 +1577,14 @@ fn a_type_only_a_local_fn_writes_still_has_a_reading() {
             _emit: &crate::Emit,
         ) -> Vec<syn::Item> {
             self.0.on_enum(e, r, _emit)
+        }
+        fn on_const(
+            &self,
+            c: &prebindgen_flat::flat::Constant,
+            r: &Registry,
+            _emit: &crate::Emit,
+        ) -> Vec<syn::Item> {
+            self.0.on_const(c, r, _emit)
         }
     }
 

--- a/prebindgen-registry/src/write.rs
+++ b/prebindgen-registry/src/write.rs
@@ -167,7 +167,7 @@ pub fn write_rust<P: AsRef<Path>, E: Prebindgen, C: RustFunction>(
     // Consts: an adapter WITH a const declaration mechanism
     // (`declared_consts() == Some(set)`) emits declared consts only,
     // symmetric with functions; an adapter without one (`None`) gets every
-    // const passed through verbatim via the default `on_const`. Prebindgen's
+    // const through its own mandatory `on_const` policy. Prebindgen's
     // own injected feature guards are not consts at all — see the guards loop.
     let declared_consts = &declared.consts;
     body_items.extend(

--- a/prebindgen-registry/src/write.rs
+++ b/prebindgen-registry/src/write.rs
@@ -19,8 +19,6 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use proc_macro2::TokenStream;
-
 use crate::{
     destination::Destination,
     prebindgen::Prebindgen,
@@ -37,12 +35,6 @@ use crate::{
 /// while per-item output is assembled.
 #[derive(Debug)]
 pub enum WriteError {
-    /// A `TokenStream` produced by an `on_*` trait method failed to parse
-    /// as `syn::Item`s. Indicates a codegen bug in the adapter.
-    BadTokens {
-        phase: &'static str,
-        source: syn::Error,
-    },
     /// Generated code calls a planned private converter whose function was
     /// removed by reachability filtering.
     UnrenderedConverterCalls {
@@ -54,13 +46,6 @@ pub enum WriteError {
 impl std::fmt::Display for WriteError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            WriteError::BadTokens { phase, source } => {
-                write!(
-                    f,
-                    "generated tokens from {} did not parse: {}",
-                    phase, source
-                )
-            }
             WriteError::UnrenderedConverterCalls { calls } => {
                 write!(
                     f,
@@ -145,30 +130,27 @@ pub fn write_rust<P: AsRef<Path>, E: Prebindgen, C: RustFunction>(
     let declared_types = &declared.types;
     let flat = registry.flat();
     let mut body_items: Vec<syn::Item> = Vec::new();
-    body_items.extend(parse_items_from_tokens(
-        "on_function",
+    body_items.extend(
         sorted_by_name(flat.functions().map(|f| (&f.name, f)))
             .into_iter()
             .filter(|(ident, _)| declared_fns.contains(*ident))
-            .map(|(_, item)| ext.on_function(item, registry, &emit)),
-    )?);
-    body_items.extend(parse_items_from_tokens(
-        "on_struct",
+            .flat_map(|(_, item)| ext.on_function(item, registry, &emit)),
+    );
+    body_items.extend(
         sorted_by_name(flat.types().filter_map(|t| match t {
             prebindgen_flat::flat::Type::Struct(s) => Some((&s.name, s)),
             _ => None,
         }))
         .into_iter()
         .filter(|(ident, _)| declared_types.contains_key(&TypeKey::from_ident(ident)))
-        .map(|(_, item)| ext.on_struct(item, registry, &emit)),
-    )?);
+        .flat_map(|(_, item)| ext.on_struct(item, registry, &emit)),
+    );
     // Both enum shapes emit through `on_enum` and sort together: they were one
     // map here before they were two elements. They still SORT together — the
     // emission order is one sequence — but they dispatch to their own methods
     // now, because handing an adapter a `Type` it has to re-match is worse than
     // handing it the element the model already decided on.
-    body_items.extend(parse_items_from_tokens(
-        "on_enum",
+    body_items.extend(
         sorted_by_name(flat.types().filter_map(|t| match t {
             prebindgen_flat::flat::Type::Variant(v) => Some((&v.name, t)),
             prebindgen_flat::flat::Type::Enum(e) => Some((&e.name, t)),
@@ -176,20 +158,19 @@ pub fn write_rust<P: AsRef<Path>, E: Prebindgen, C: RustFunction>(
         }))
         .into_iter()
         .filter(|(ident, _)| declared_types.contains_key(&TypeKey::from_ident(ident)))
-        .map(|(_, t)| match t {
+        .flat_map(|(_, t)| match t {
             prebindgen_flat::flat::Type::Variant(v) => ext.on_variant(v, registry, &emit),
             prebindgen_flat::flat::Type::Enum(e) => ext.on_enum(e, registry, &emit),
             _ => unreachable!("filtered to the two enum shapes above"),
         }),
-    )?);
+    );
     // Consts: an adapter WITH a const declaration mechanism
     // (`declared_consts() == Some(set)`) emits declared consts only,
     // symmetric with functions; an adapter without one (`None`) gets every
     // const passed through verbatim via the default `on_const`. Prebindgen's
     // own injected feature guards are not consts at all — see the guards loop.
     let declared_consts = &declared.consts;
-    body_items.extend(parse_items_from_tokens(
-        "on_const",
+    body_items.extend(
         sorted_by_name(flat.constants().map(|c| (&c.name, c)))
             .into_iter()
             .filter(|(ident, _)| {
@@ -197,8 +178,8 @@ pub fn write_rust<P: AsRef<Path>, E: Prebindgen, C: RustFunction>(
                     .as_ref()
                     .is_none_or(|set| set.contains(*ident))
             })
-            .map(|(_, item)| ext.on_const(item, registry, &emit)),
-    )?);
+            .flat_map(|(_, item)| ext.on_const(item, registry, &emit)),
+    );
 
     // Select one semantic operation only after per-item planning has marked
     // late plans reachable. This lets a reached twin replace an earlier
@@ -263,24 +244,6 @@ where
     let mut items: Vec<(&syn::Ident, &T)> = items.collect();
     items.sort_by_key(|(left, _)| left.to_string());
     items
-}
-
-/// Parse a per-item `TokenStream` (which may be empty) as a sequence of
-/// `syn::Item`s. Empty token streams yield zero items.
-fn parse_items_from_tokens<I: IntoIterator<Item = TokenStream>>(
-    phase: &'static str,
-    iter: I,
-) -> Result<Vec<syn::Item>, WriteError> {
-    let mut out = Vec::new();
-    for ts in iter {
-        if ts.is_empty() {
-            continue;
-        }
-        let file: syn::File =
-            syn::parse2(ts.clone()).map_err(|source| WriteError::BadTokens { phase, source })?;
-        out.extend(file.items);
-    }
-    Ok(out)
 }
 
 /// Refuse a generated file whose rendered functions still call a private

--- a/prebindgen-registry/src/write/tests.rs
+++ b/prebindgen-registry/src/write/tests.rs
@@ -5,7 +5,6 @@ use std::{
 };
 
 use prebindgen::SourceLocation;
-use proc_macro2::TokenStream;
 
 use super::*;
 use crate::registry::RegistryBuilder;
@@ -32,8 +31,8 @@ impl Prebindgen for IdentityExt {
         f: &prebindgen_flat::flat::Function,
         _registry: &Registry,
         emit: &crate::Emit,
-    ) -> TokenStream {
-        emit.verbatim_fn(f)
+    ) -> Vec<syn::Item> {
+        vec![syn::Item::Fn(emit.verbatim_fn(f))]
     }
 
     fn on_struct(
@@ -41,8 +40,8 @@ impl Prebindgen for IdentityExt {
         s: &prebindgen_flat::flat::Struct,
         _registry: &Registry,
         emit: &crate::Emit,
-    ) -> TokenStream {
-        emit.verbatim_struct(s)
+    ) -> Vec<syn::Item> {
+        vec![syn::Item::Struct(emit.verbatim_struct(s))]
     }
 
     fn on_variant(
@@ -50,8 +49,8 @@ impl Prebindgen for IdentityExt {
         v: &prebindgen_flat::flat::Variant,
         _registry: &Registry,
         emit: &crate::Emit,
-    ) -> TokenStream {
-        emit.verbatim_variant(v)
+    ) -> Vec<syn::Item> {
+        vec![syn::Item::Enum(emit.verbatim_variant(v))]
     }
 
     fn on_enum(
@@ -59,8 +58,8 @@ impl Prebindgen for IdentityExt {
         e: &prebindgen_flat::flat::Enum,
         _registry: &Registry,
         emit: &crate::Emit,
-    ) -> TokenStream {
-        emit.verbatim_enum(e)
+    ) -> Vec<syn::Item> {
+        vec![syn::Item::Enum(emit.verbatim_enum(e))]
     }
 }
 
@@ -125,16 +124,18 @@ impl Prebindgen for LateExt {
         f: &prebindgen_flat::flat::Function,
         _registry: &Registry,
         emit: &crate::Emit,
-    ) -> TokenStream {
+    ) -> Vec<syn::Item> {
         if self.activate {
             self.reachable.set(true);
         }
         if self.call_converter {
             let ident = &f.name;
             let converter = emit.operation_ident("test", &self.operation);
-            quote::quote!(fn #ident() { #converter(); })
+            vec![syn::Item::Fn(
+                syn::parse_quote!(fn #ident() { #converter(); }),
+            )]
         } else {
-            emit.verbatim_fn(f)
+            vec![syn::Item::Fn(emit.verbatim_fn(f))]
         }
     }
 
@@ -143,8 +144,8 @@ impl Prebindgen for LateExt {
         s: &prebindgen_flat::flat::Struct,
         _registry: &Registry,
         emit: &crate::Emit,
-    ) -> TokenStream {
-        emit.verbatim_struct(s)
+    ) -> Vec<syn::Item> {
+        vec![syn::Item::Struct(emit.verbatim_struct(s))]
     }
 
     fn on_variant(
@@ -152,8 +153,8 @@ impl Prebindgen for LateExt {
         v: &prebindgen_flat::flat::Variant,
         _registry: &Registry,
         emit: &crate::Emit,
-    ) -> TokenStream {
-        emit.verbatim_variant(v)
+    ) -> Vec<syn::Item> {
+        vec![syn::Item::Enum(emit.verbatim_variant(v))]
     }
 
     fn on_enum(
@@ -161,8 +162,8 @@ impl Prebindgen for LateExt {
         e: &prebindgen_flat::flat::Enum,
         _registry: &Registry,
         emit: &crate::Emit,
-    ) -> TokenStream {
-        emit.verbatim_enum(e)
+    ) -> Vec<syn::Item> {
+        vec![syn::Item::Enum(emit.verbatim_enum(e))]
     }
 }
 
@@ -247,7 +248,6 @@ fn a_call_to_a_filtered_converter_is_a_writer_error() {
                 .to_string();
             assert_eq!(calls, vec![("a_fn".to_string(), missing)]);
         }
-        other => panic!("unexpected writer error: {other}"),
     }
     assert!(
         !path.exists(),
@@ -392,14 +392,21 @@ fn write_rust_sorts_declared_items_by_ident() {
 }
 
 #[test]
-fn bad_generated_tokens_report_emission_phase() {
-    let err = parse_items_from_tokens("on_function", [quote::quote!(fn broken)])
-        .expect_err("invalid item tokens should fail");
-    assert!(
-        err.to_string().contains("on_function"),
-        "error should mention the adapter emission phase: {}",
-        err
-    );
+fn per_item_emission_carries_typed_items_without_reparsing() {
+    let contract = include_str!("../prebindgen.rs");
+    let item_methods = contract
+        .split_once("// ── Item methods")
+        .expect("item methods")
+        .1;
+    assert_eq!(item_methods.matches("-> Vec<syn::Item>").count(), 5);
+
+    let writer = include_str!("../write.rs");
+    for removed in ["parse_items_from_tokens", "BadTokens", "syn::parse2"] {
+        assert!(
+            !writer.contains(removed),
+            "typed per-item emission must not restore `{removed}`"
+        );
+    }
 }
 
 /// An adapter with a const mechanism gates **named** consts and cannot gate
@@ -432,32 +439,32 @@ fn guards_emit_ungated_and_in_stream_order() {
             f: &prebindgen_flat::flat::Function,
             _r: &Registry,
             _emit: &crate::Emit,
-        ) -> TokenStream {
-            _emit.verbatim_fn(f)
+        ) -> Vec<syn::Item> {
+            vec![syn::Item::Fn(_emit.verbatim_fn(f))]
         }
         fn on_struct(
             &self,
             s: &prebindgen_flat::flat::Struct,
             _r: &Registry,
             _emit: &crate::Emit,
-        ) -> TokenStream {
-            _emit.verbatim_struct(s)
+        ) -> Vec<syn::Item> {
+            vec![syn::Item::Struct(_emit.verbatim_struct(s))]
         }
         fn on_variant(
             &self,
             v: &prebindgen_flat::flat::Variant,
             _r: &Registry,
             _emit: &crate::Emit,
-        ) -> TokenStream {
-            _emit.verbatim_variant(v)
+        ) -> Vec<syn::Item> {
+            vec![syn::Item::Enum(_emit.verbatim_variant(v))]
         }
         fn on_enum(
             &self,
             e: &prebindgen_flat::flat::Enum,
             _r: &Registry,
             _emit: &crate::Emit,
-        ) -> TokenStream {
-            _emit.verbatim_enum(e)
+        ) -> Vec<syn::Item> {
+            vec![syn::Item::Enum(_emit.verbatim_enum(e))]
         }
     }
 

--- a/prebindgen-registry/src/write/tests.rs
+++ b/prebindgen-registry/src/write/tests.rs
@@ -30,36 +30,51 @@ impl Prebindgen for IdentityExt {
         &self,
         f: &prebindgen_flat::flat::Function,
         _registry: &Registry,
-        emit: &crate::Emit,
+        _emit: &crate::Emit,
     ) -> Vec<syn::Item> {
-        vec![syn::Item::Fn(emit.verbatim_fn(f))]
+        let ident = &f.name;
+        vec![syn::parse_quote!(fn #ident() {})]
     }
 
     fn on_struct(
         &self,
         s: &prebindgen_flat::flat::Struct,
         _registry: &Registry,
-        emit: &crate::Emit,
+        _emit: &crate::Emit,
     ) -> Vec<syn::Item> {
-        vec![syn::Item::Struct(emit.verbatim_struct(s))]
+        let ident = &s.name;
+        vec![syn::parse_quote!(pub struct #ident;)]
     }
 
     fn on_variant(
         &self,
         v: &prebindgen_flat::flat::Variant,
         _registry: &Registry,
-        emit: &crate::Emit,
+        _emit: &crate::Emit,
     ) -> Vec<syn::Item> {
-        vec![syn::Item::Enum(emit.verbatim_variant(v))]
+        let ident = &v.name;
+        vec![syn::parse_quote!(pub enum #ident {})]
     }
 
     fn on_enum(
         &self,
         e: &prebindgen_flat::flat::Enum,
         _registry: &Registry,
+        _emit: &crate::Emit,
+    ) -> Vec<syn::Item> {
+        let ident = &e.name;
+        vec![syn::parse_quote!(pub enum #ident {})]
+    }
+
+    fn on_const(
+        &self,
+        c: &prebindgen_flat::flat::Constant,
+        _registry: &Registry,
         emit: &crate::Emit,
     ) -> Vec<syn::Item> {
-        vec![syn::Item::Enum(emit.verbatim_enum(e))]
+        let ident = &c.name;
+        let ty = emit.spell(&c.ty);
+        vec![syn::parse_quote!(pub const #ident: #ty = 0;)]
     }
 }
 
@@ -135,7 +150,8 @@ impl Prebindgen for LateExt {
                 syn::parse_quote!(fn #ident() { #converter(); }),
             )]
         } else {
-            vec![syn::Item::Fn(emit.verbatim_fn(f))]
+            let ident = &f.name;
+            vec![syn::parse_quote!(fn #ident() {})]
         }
     }
 
@@ -143,27 +159,39 @@ impl Prebindgen for LateExt {
         &self,
         s: &prebindgen_flat::flat::Struct,
         _registry: &Registry,
-        emit: &crate::Emit,
+        _emit: &crate::Emit,
     ) -> Vec<syn::Item> {
-        vec![syn::Item::Struct(emit.verbatim_struct(s))]
+        let ident = &s.name;
+        vec![syn::parse_quote!(pub struct #ident;)]
     }
 
     fn on_variant(
         &self,
         v: &prebindgen_flat::flat::Variant,
         _registry: &Registry,
-        emit: &crate::Emit,
+        _emit: &crate::Emit,
     ) -> Vec<syn::Item> {
-        vec![syn::Item::Enum(emit.verbatim_variant(v))]
+        let ident = &v.name;
+        vec![syn::parse_quote!(pub enum #ident {})]
     }
 
     fn on_enum(
         &self,
         e: &prebindgen_flat::flat::Enum,
         _registry: &Registry,
-        emit: &crate::Emit,
+        _emit: &crate::Emit,
     ) -> Vec<syn::Item> {
-        vec![syn::Item::Enum(emit.verbatim_enum(e))]
+        let ident = &e.name;
+        vec![syn::parse_quote!(pub enum #ident {})]
+    }
+
+    fn on_const(
+        &self,
+        _c: &prebindgen_flat::flat::Constant,
+        _registry: &Registry,
+        _emit: &crate::Emit,
+    ) -> Vec<syn::Item> {
+        Vec::new()
     }
 }
 
@@ -436,35 +464,43 @@ fn guards_emit_ungated_and_in_stream_order() {
     impl Prebindgen for ConstGatingExt {
         fn on_function(
             &self,
-            f: &prebindgen_flat::flat::Function,
+            _f: &prebindgen_flat::flat::Function,
             _r: &Registry,
             _emit: &crate::Emit,
         ) -> Vec<syn::Item> {
-            vec![syn::Item::Fn(_emit.verbatim_fn(f))]
+            Vec::new()
         }
         fn on_struct(
             &self,
-            s: &prebindgen_flat::flat::Struct,
+            _s: &prebindgen_flat::flat::Struct,
             _r: &Registry,
             _emit: &crate::Emit,
         ) -> Vec<syn::Item> {
-            vec![syn::Item::Struct(_emit.verbatim_struct(s))]
+            Vec::new()
         }
         fn on_variant(
             &self,
-            v: &prebindgen_flat::flat::Variant,
+            _v: &prebindgen_flat::flat::Variant,
             _r: &Registry,
             _emit: &crate::Emit,
         ) -> Vec<syn::Item> {
-            vec![syn::Item::Enum(_emit.verbatim_variant(v))]
+            Vec::new()
         }
         fn on_enum(
             &self,
-            e: &prebindgen_flat::flat::Enum,
+            _e: &prebindgen_flat::flat::Enum,
             _r: &Registry,
             _emit: &crate::Emit,
         ) -> Vec<syn::Item> {
-            vec![syn::Item::Enum(_emit.verbatim_enum(e))]
+            Vec::new()
+        }
+        fn on_const(
+            &self,
+            _c: &prebindgen_flat::flat::Constant,
+            _r: &Registry,
+            _emit: &crate::Emit,
+        ) -> Vec<syn::Item> {
+            Vec::new()
         }
     }
 


### PR DESCRIPTION
## Summary

- Change every per-item `Prebindgen` callback to return `Vec<syn::Item>`, so generated Rust is typed at the adapter boundary and the writer no longer reparses arbitrary callback tokens.
- Keep generation model-driven: remove `RustEmitter` whole captured-item accessors, build C/JNI wrappers from Flat elements, and generate const aliases only from `Constant` name/type/docs plus the adapter source-module policy. No captured function, struct, enum, or const initializer is parsed or exposed to an adapter.
- Seal the diagnostic side channel as well: `Origin<S>` now has an opaque manual `Debug` that reports location without rendering `S`, and `TypeRef::origin` documents why it must remain inaccessible outside Flat.
- Make `on_const` mandatory because Flat intentionally does not model arbitrary Rust initializer expressions. Each adapter must state its value policy; C generates source aliases and JNI retains its getter-plus-alias policy.
- Delete `parse_items_from_tokens` and `WriteError::BadTokens`, then document and test the typed, generate-only boundary.

This is a breaking adapter API migration: out-of-tree `Prebindgen` implementations must return `Vec<syn::Item>` from all item callbacks and implement `on_const`; removed whole-item `RustEmitter` helpers have no replacement because adapters must generate from Flat facts; the public `WriteError` no longer has a `BadTokens` variant.

Generated Rust, Kotlin, and C headers remain byte-for-byte unchanged.

## Verification

- `cargo check --workspace --all-features` — passed
- `cargo test --workspace --all-features --quiet` — passed
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` — passed
- `cargo fmt --all -- --check` — passed
- `./examples/regen-check.sh` — passed; committed generated output is byte-identical
- `cd examples/covertest-kotlin && ./gradlew run` — passed all 61 sections