### PR TITLE
Add a rustdoc site with per-PR previews

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -19,21 +19,21 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
+      # No `path:` override here (unlike rust.yml): the deploy action below
+      # runs its own git commands from $GITHUB_WORKSPACE and has no notion of
+      # a nested repo root, so the checkout must land there directly.
       - uses: actions/checkout@v4
-        with:
-          path: prebindgen
 
       - name: Install Rust
         run: rustup toolchain install stable --profile minimal
 
       - name: Build site
-        working-directory: prebindgen
         run: ./site/build.sh site-build
 
       - name: Deploy to gh-pages branch
         uses: JamesIves/github-pages-deploy-action@v4
         with:
-          folder: prebindgen/site-build
+          folder: site-build
           branch: gh-pages
           # PR previews live under pr-preview/ on the same branch; a main
           # deploy must not delete them.

--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -1,0 +1,41 @@
+name: Deploy docs site
+
+# Builds the static home page (site/) plus rustdoc for the published crates,
+# and pushes it to the gh-pages branch, which GitHub Pages serves.
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+# Allow one concurrent deployment; don't cancel an in-progress production deploy.
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          path: prebindgen
+
+      - name: Install Rust
+        run: rustup toolchain install stable --profile minimal
+
+      - name: Build site
+        working-directory: prebindgen
+        run: ./site/build.sh site-build
+
+      - name: Deploy to gh-pages branch
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          folder: prebindgen/site-build
+          branch: gh-pages
+          # PR previews live under pr-preview/ on the same branch; a main
+          # deploy must not delete them.
+          clean-exclude: pr-preview/
+          force: false

--- a/.github/workflows/docs-pr-preview.yml
+++ b/.github/workflows/docs-pr-preview.yml
@@ -1,0 +1,37 @@
+name: Docs PR preview
+
+# Pushes a docs-site preview to the gh-pages branch under pr-preview/pr-<N>/
+# and keeps a sticky PR comment with the link updated.
+# Note: fork PRs get a read-only token, so previews only work for
+# same-repository branches.
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, closed]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency: docs-preview-${{ github.ref }}
+
+jobs:
+  preview:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          path: prebindgen
+
+      - name: Install Rust
+        if: github.event.action != 'closed'
+        run: rustup toolchain install stable --profile minimal
+
+      - name: Build site
+        if: github.event.action != 'closed'
+        working-directory: prebindgen
+        run: ./site/build.sh site-build
+
+      - name: Deploy preview
+        uses: rossjrw/pr-preview-action@v1
+        with:
+          source-dir: prebindgen/site-build

--- a/.github/workflows/docs-pr-preview.yml
+++ b/.github/workflows/docs-pr-preview.yml
@@ -18,9 +18,10 @@ jobs:
   preview:
     runs-on: ubuntu-latest
     steps:
+      # No `path:` override here (unlike rust.yml): the deploy action below
+      # runs its own git commands from $GITHUB_WORKSPACE and has no notion of
+      # a nested repo root, so the checkout must land there directly.
       - uses: actions/checkout@v4
-        with:
-          path: prebindgen
 
       - name: Install Rust
         if: github.event.action != 'closed'
@@ -28,10 +29,9 @@ jobs:
 
       - name: Build site
         if: github.event.action != 'closed'
-        working-directory: prebindgen
         run: ./site/build.sh site-build
 
       - name: Deploy preview
         uses: rossjrw/pr-preview-action@v1
         with:
-          source-dir: prebindgen/site-build
+          source-dir: site-build

--- a/site/build.sh
+++ b/site/build.sh
@@ -30,3 +30,5 @@ rm -rf "$out"
 mkdir -p "$out"
 cp site/index.html "$out/index.html"
 cp -r target/doc "$out/doc"
+# cargo's own build lock, not part of the site.
+rm -f "$out/doc/.lock"

--- a/site/build.sh
+++ b/site/build.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Builds the docs site into $1: rustdoc for the 8 published crates plus the
+# static home page. Output uses only relative links, so this same tree works
+# whether it's deployed at the site root or nested under pr-preview/pr-<N>/.
+set -euo pipefail
+
+out="${1:?usage: build.sh <out-dir>}"
+
+# Same crate list as the `package` job in .github/workflows/rust.yml —
+# published crates only, no examples/*.
+crates=(
+  prebindgen
+  prebindgen-flat
+  prebindgen-registry
+  prebindgen-c
+  prebindgen-jni
+  prebindgen-proc-macro
+  prebindgen-c-runtime
+  prebindgen-jni-runtime
+)
+
+args=()
+for c in "${crates[@]}"; do
+  args+=(-p "$c")
+done
+
+cargo doc --no-deps "${args[@]}"
+
+rm -rf "$out"
+mkdir -p "$out"
+cp site/index.html "$out/index.html"
+cp -r target/doc "$out/doc"

--- a/site/index.html
+++ b/site/index.html
@@ -1,0 +1,44 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>prebindgen docs</title>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<style>
+  body { font-family: system-ui, sans-serif; max-width: 40rem; margin: 3rem auto; padding: 0 1rem; color: #222; }
+  h1 { margin-bottom: 0.2rem; }
+  p.tagline { color: #555; margin-top: 0; }
+  ul { list-style: none; padding: 0; }
+  li { margin: 0.9rem 0; }
+  a.crate { font-weight: 600; font-size: 1.05rem; text-decoration: none; }
+  a.crate:hover { text-decoration: underline; }
+  .desc { color: #444; display: block; font-size: 0.92rem; }
+  footer { margin-top: 3rem; color: #888; font-size: 0.85rem; }
+</style>
+</head>
+<body>
+<h1>prebindgen</h1>
+<p class="tagline">Generate idiomatic multi-language FFI bindings (C, Kotlin/JNI, …) from a single annotated Rust source.</p>
+
+<ul>
+  <li><a class="crate" href="doc/prebindgen/index.html">prebindgen</a>
+    <span class="desc">Separate FFI implementation and language-specific binding into different crates</span></li>
+  <li><a class="crate" href="doc/prebindgen_flat/index.html">prebindgen-flat</a>
+    <span class="desc">The prebindgen flat model: the parser from captured #[prebindgen] records to a flat namespace of elements</span></li>
+  <li><a class="crate" href="doc/prebindgen_registry/index.html">prebindgen-registry</a>
+    <span class="desc">The language-agnostic binding pipeline for prebindgen: registry, type resolution and Rust emission</span></li>
+  <li><a class="crate" href="doc/prebindgen_c/index.html">prebindgen-c</a>
+    <span class="desc">Experimental C / cbindgen binding generator for prebindgen</span></li>
+  <li><a class="crate" href="doc/prebindgen_jni/index.html">prebindgen-jni</a>
+    <span class="desc">JNI / Kotlin binding generator for prebindgen</span></li>
+  <li><a class="crate" href="doc/prebindgen_proc_macro/index.html">prebindgen-proc-macro</a>
+    <span class="desc">Procedural macros for prebindgen - export FFI definitions for binding generation</span></li>
+  <li><a class="crate" href="doc/prebindgen_c_runtime/index.html">prebindgen-c-runtime</a>
+    <span class="desc">Runtime traits implemented by prebindgen-generated C FFI counterpart types</span></li>
+  <li><a class="crate" href="doc/prebindgen_jni_runtime/index.html">prebindgen-jni-runtime</a>
+    <span class="desc">Runtime support helpers called by prebindgen-generated JNI bindings</span></li>
+</ul>
+
+<footer>Built from <a href="https://github.com/milyin/prebindgen">github.com/milyin/prebindgen</a></footer>
+</body>
+</html>


### PR DESCRIPTION
## Summary

- Adds `site/index.html`: a static home page linking to `cargo doc` output for the 8 published prebindgen crates (prebindgen, prebindgen-flat, prebindgen-registry, prebindgen-c, prebindgen-jni, prebindgen-proc-macro, prebindgen-c-runtime, prebindgen-jni-runtime).
- Adds `site/build.sh`: runs `cargo doc --no-deps` for those 8 crates and assembles `site/index.html` plus the generated `target/doc/` into one output directory.
- Adds `.github/workflows/docs-deploy.yml`: on push to `main`, builds the site and pushes it to the `gh-pages` branch, which GitHub Pages serves.
- Adds `.github/workflows/docs-pr-preview.yml`: on every pull request, builds the same site and deploys it under `pr-preview/pr-<N>/` on the `gh-pages` branch, posting a sticky PR comment (one comment that gets updated in place rather than duplicated on each push) with the preview link; on PR close it removes that folder and the comment.

## Design notes

- The home page uses relative links (`doc/<crate>/index.html`), and rustdoc's own cross-crate links are relative too, so the identical build output works whether it is served from the site root (a `main` deploy) or nested under `pr-preview/pr-<N>/` (a PR preview) — no build-time path override is needed.
- `docs-deploy.yml` passes `clean-exclude: pr-preview/` to its deploy step so a `main`-branch deploy never removes the previews still active for open PRs.
- The preview workflow mirrors the pattern already used in `milyin/trip_planner`'s `deploy.yml`/`pr-preview.yml`, adapted from a Vite/npm build to `cargo doc`.
- This PR targets `feature/chained-rust-generation` (#513) rather than `main`; it only adds new files and does not touch anything that branch changes.

## Follow-up outside this PR

GitHub Pages itself is not yet enabled for this repository (`repos/milyin/prebindgen/pages` returns 404). After this merges and `docs-deploy.yml` has run once to create the `gh-pages` branch, a repo admin needs to enable Pages once, under Settings → Pages, with source = `gh-pages` branch, `/` root.

## Test plan

- [x] Ran `site/build.sh` locally and confirmed every link in `site/index.html` resolves to a generated `doc/<crate>/index.html`.
- [ ] After merge: confirm `docs-deploy.yml` succeeds on `main` and the `gh-pages` branch gets `index.html` + `doc/`.
- [ ] Confirm opening a test PR produces a preview comment linking to a working `pr-preview/pr-<N>/index.html`.

— Claude Code (Sonnet 5)