### PR TITLE
Delete the vestigial Emit token

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ runtime crate (~350 lines), not the generator.
 | `prebindgen` | Base: reads what `#[prebindgen]` captured and hands out `(syn::Item, SourceLocation)` pairs via `Source` | — |
 | `prebindgen-proc-macro` | The `#[prebindgen]` macro itself | `prebindgen` |
 | `prebindgen-flat` | Independent flat parser/model and Rust-rendering protocol | `prebindgen` |
-| `prebindgen-registry` | Collector/resolver; owns the callback-only `Emit` key | `prebindgen-flat`, `prebindgen` |
+| `prebindgen-registry` | Collector/resolver; owns the callback-only `RustWriter` | `prebindgen-flat`, `prebindgen` |
 | `prebindgen-c` | C / cbindgen adapter (`CbindgenBuilder`) — experimental proof of concept | `prebindgen-registry` |
 | `prebindgen-jni` | JNI / Kotlin adapter (`JniGenBuilder`) | `prebindgen-registry`, [`kotlin-codegen`](https://github.com/milyin/kotlin-codegen) |
 | `prebindgen-c-runtime` | Leaf, ~65 lines, no deps — traits the generated C converters call at run time | — |

--- a/docs/crate-split.md
+++ b/docs/crate-split.md
@@ -38,7 +38,7 @@ prebindgen                BASE. Source stream only. No adapters, no registry.
 prebindgen-flat           the flat model + TypeKey + the RustEmitter protocol
   deps: prebindgen
 
-prebindgen-registry       language-agnostic pipeline + Emit key + shared decl vocabulary
+prebindgen-registry       language-agnostic pipeline + RustWriter + shared decl vocabulary
   deps: prebindgen-flat
 
 prebindgen-jni            JNI/Kotlin generator
@@ -88,10 +88,10 @@ The boundary is therefore split into protocol and key:
   methods emit source types from `TypeKind`/identities, constructors from
   `FieldShape`, and private output fragments recorded by Flat. It has no method
   returning a captured spelling or typed source AST.
-- `prebindgen-registry::Emit` is the concrete, zero-sized registry key. Its
-  constructor is registry-private and it carries no qualification or model state.
-- `prebindgen-registry::RustWriter` owns the frozen source-module map and the
-  private `Emit` token. Emission callbacks receive `&RustWriter`; its narrow
+- `prebindgen-registry::RustWriter` is the concrete registry capability. Its
+  constructor is registry-private, it owns the frozen source-module map, and it
+  implements the protocol through a private zero-sized receiver that is unnamed
+  in any public API. Emission callbacks receive `&RustWriter`; its narrow
   surface generates inert fragments and never returns a captured or typed AST.
 
 This preserves the dependency and mental model:
@@ -107,9 +107,10 @@ gaining access to retained source syntax.
 
 The registry's default path is compiler-checked. `prebindgen-registry` does
 not re-export `RustEmitter` through its `flat` model path, so an adapter that
-depends only on the registry cannot name the protocol or construct
-`prebindgen-registry::Emit`; it can render only after receiving `&RustWriter` in
-an emission callback. A compile-fail doctest pins both restrictions.
+depends only on the registry cannot name the protocol, and `RustWriter`'s
+constructor is registry-private; it can render only after receiving
+`&RustWriter` in an emission callback. Compile-fail doctests pin both
+restrictions.
 
 An adapter could add a direct `prebindgen-flat` dependency and implement the
 public protocol, but that only reproduces the same generate-only operations.
@@ -140,7 +141,7 @@ reversing the crate dependency.
 | **A2** | `prebindgen-{jni,c}-runtime` carved out; emitted paths repointed | done |
 | **A3** | shared decl vocabulary → `core::decl`; breaks `cbindgen → jnigen` | done |
 | **A5** | drop the `unstable-cbindgen` feature | done |
-| **A4** | rendering protocol → `flat`; registry-owned `Emit` key → `registry` | done |
+| **A4** | rendering protocol → `flat`; registry-owned `RustWriter` → `registry` | done |
 | **B1** | carve `prebindgen-c` | done |
 | **B2** | carve `prebindgen-jni` | done |
 | **B3** | carve `prebindgen-registry` | done |

--- a/docs/model.md
+++ b/docs/model.md
@@ -379,10 +379,10 @@ identity a map can be keyed by.
 
 Recipe compilation may inspect those model facts and retain a `TypeRef`, but
 it has no capability to recover or emit the captured Rust syntax. In
-particular, `Cx` carries neither `RustWriter` nor `Emit`, converter calls retain registry-owned
+particular, `Cx` carries no `RustWriter`, converter calls retain registry-owned
 `OperationId` values rather than names derived from `TypeKey`, and language
 adapters must not parse or classify a key's diagnostic text. Only the final
-`write_rust` pass constructs `RustWriter`, which privately owns the zero-sized `Emit` token; at that point resolution and glue planning are
+`write_rust` pass constructs `RustWriter`; at that point resolution and glue planning are
 complete, and the renderer may generate source-type token fragments and
 allocate private Rust symbols while assembling the file. Even there, the
 adapter cannot recover a typed source AST. Needing to inspect source Rust

--- a/prebindgen-c/src/chain.rs
+++ b/prebindgen-c/src/chain.rs
@@ -2,7 +2,7 @@
 //!
 //! A plan keeps Flat [`TypeRef`]s opaque and records only shape operations,
 //! wire-side types and child converter contracts. [`RustFunction::render`]
-//! receives the writer-owned [`Emit`] after resolution and validation, which is
+//! receives the writer-owned [`RustWriter`] after resolution and validation, which is
 //! the first point at which the captured Rust types and function bodies are
 //! materialized.
 
@@ -647,7 +647,7 @@ impl InputTerminalOperation {
     }
 }
 
-/// A C input terminal retained until the final writer owns [`Emit`].
+/// A C input terminal retained until final rendering.
 #[derive(Clone)]
 pub(crate) struct InputTerminalPlan {
     pub(crate) source: TypeRef,
@@ -812,7 +812,7 @@ pub(crate) enum OutputTerminalOperation {
     },
 }
 
-/// A C output terminal retained until the final writer owns `Emit`.
+/// A C output terminal retained until final rendering.
 #[derive(Clone)]
 pub(crate) struct OutputTerminalPlan {
     pub(crate) source: TypeRef,
@@ -1170,7 +1170,7 @@ impl CArtifact {
 /// Render one class of C artifacts from the frozen registry plan.
 ///
 /// The deliberately narrow signature is the artifact-rendering boundary: final
-/// emission can generate source-type tokens from Flat facts through Emit, but it cannot
+/// emission can generate source-type tokens from Flat facts through the writer, but it cannot
 /// reopen the registry or the adapter's mutable compilation cache.
 pub(crate) fn render_artifacts(
     generation: &GenerationPlan<crate::compile::CRepresentation>,

--- a/prebindgen-c/src/lib.rs
+++ b/prebindgen-c/src/lib.rs
@@ -590,7 +590,7 @@ fn r_is_bool(t: &TypeRef) -> bool {
 /// A scalar's Rust type, built from its **kind**.
 ///
 /// A scalar's spelling is its name — `ScalarKind::as_str` is the closed set the
-/// source can have written — so this needs no captured syntax and no `Emit`.
+/// source can have written — so this needs no captured syntax and no writer.
 /// Three wire policies asked `spelled()` for exactly this behind an
 /// `r_is_scalar` guard, which was a source spelling standing in for an
 /// identity that could answer.

--- a/prebindgen-c/src/trait_impl.rs
+++ b/prebindgen-c/src/trait_impl.rs
@@ -620,7 +620,7 @@ impl CbindgenBuilder {
     /// Freeze source-dependent C declaration families as registry artifacts.
     ///
     /// Planning retains source TypeRefs and target-owned wire syntax. Only the
-    /// final artifact renderer may ask Emit to spell a source type.
+    /// final artifact renderer may ask the writer to spell a source type.
     fn type_artifact_plans(
         &self,
         registry: &Registry,

--- a/prebindgen-flat/src/flat/emit.rs
+++ b/prebindgen-flat/src/flat/emit.rs
@@ -3,7 +3,8 @@
 //! Flat owns the model-driven generation protocol. A collecting pipeline owns
 //! the concrete key that implements it.
 //! `prebindgen-registry`, for example, hands its unconstructable
-//! `prebindgen_registry::Emit` inside the `RustWriter` handed to final callbacks.
+//! private receiver inside the `prebindgen_registry::RustWriter` handed to
+//! final callbacks.
 //!
 //! This direction preserves the crate pipeline:
 //!

--- a/prebindgen-flat/src/flat/ty.rs
+++ b/prebindgen-flat/src/flat/ty.rs
@@ -87,7 +87,7 @@ pub struct TypeRef {
     // `Origin<syn::Type>::declared_spelling` is public for build-script
     // declarations of that same Rust type; exposing this captured origin would
     // accidentally make that declaration-only spelling route available to
-    // adapters without an `Emit` capability.
+    // adapters without the final rendering capability.
     pub(super) origin: Origin<syn::Type>,
 }
 
@@ -268,7 +268,7 @@ impl TypeRef {
     }
 
     /// The type as `syn` — **the escape**. See [`Origin::as_syn`].
-    // Test-only as of C7: `Emit` hands out a spelling, never the node, so the
+    // Test-only as of C7: the writer hands out a spelling, never the node, so the
     // round-trip checks (`syntax_is_recoverable_from_kind`) are the last
     // callers. That is the correct end state — the check that a kind can
     // reproduce its own syntax needs both halves.

--- a/prebindgen-flat/src/lib.rs
+++ b/prebindgen-flat/src/lib.rs
@@ -20,7 +20,8 @@
 ///
 /// The flat layer supplies the operations because it owns captured syntax; each
 /// collector decides which concrete key implements them and where that key is
-/// handed out. `prebindgen-registry` supplies its own unconstructable `Emit`.
+/// handed out. `prebindgen-registry` supplies its own private receiver behind
+/// the unconstructable `RustWriter` it hands to final callbacks.
 pub use crate::flat::emit::RustEmitter;
 pub mod flat;
 pub mod shape;

--- a/prebindgen-jni/Cargo.toml
+++ b/prebindgen-jni/Cargo.toml
@@ -23,9 +23,9 @@ proc-macro2 = { workspace = true }
 
 [dev-dependencies]
 # The fixtures for niches, callback identity, sealed cells and value-form
-# deriving build a registry directly and mint an `Emit`. Those constructors are
+# deriving build a registry directly and mint a `RustWriter`. Those constructors are
 # sealed against ordinary callers and opened only for a test suite.
-# `Emit::for_test` and the `Registry` test constructors live in
+# `RustWriter::for_test` and the `Registry` test constructors live in
 # `prebindgen-registry`, which owns both callback capabilities.
 prebindgen = { workspace = true, features = ["testing"] }
 prebindgen-registry = { workspace = true, features = ["testing"] }

--- a/prebindgen-jni/src/jni/chain.rs
+++ b/prebindgen-jni/src/jni/chain.rs
@@ -270,7 +270,7 @@ impl RustFunction for JFunction {
 /// One whole-object struct terminal retained as Flat shape plus JNI policy.
 ///
 /// The plan deliberately holds no `syn::Type` or token body for the source
-/// crossing. The writer supplies [`Emit`] once resolution, glue planning, and
+/// crossing. The writer arrives once resolution, glue planning, and
 /// Kotlin planning are complete; only then is the source signature spelled and
 /// the captured struct delimiter shape assembled.
 #[derive(Clone)]
@@ -334,7 +334,7 @@ impl JStructCodecPlan {
 
 /// One whole-object sealed-sum input retained as Flat alternatives plus JNI
 /// property policy. Source spelling and alternative construction are deferred
-/// to the final writer-owned [`Emit`] pass.
+/// to the final writer-owned rendering pass.
 #[derive(Clone)]
 pub(crate) struct JSumCodecPlan {
     pub(crate) operation: OperationId,
@@ -648,7 +648,7 @@ enum JValueBody {
 
 /// How a terminal codec obtains the Rust type in its generated signature.
 ///
-/// A crossing is spelled by [`Emit`] at the final write. Text terminals can
+/// A crossing is spelled by the writer at the final write. Text terminals can
 /// instead select a semantic owned or borrowed carrier. The concrete Rust
 /// spellings for those carriers are deliberately confined to `render` too.
 #[derive(Clone, Copy)]
@@ -677,7 +677,7 @@ impl JTextCarrier {
 ///
 /// The JNI representation and source-independent conversion policy are safe
 /// to freeze during recipe compilation. Source Rust spelling is not: the plan
-/// keeps the Flat reading opaque until the writer supplies [`Emit`]. Most
+/// keeps the Flat reading opaque until the writer arrives. Most
 /// codecs retain a ready expression; fixed-size arrays retain their JNI policy
 /// and build the source-typed expression only while rendering. Text codecs
 /// retain only their ownership semantics; the concrete owned/borrowed Rust
@@ -1067,7 +1067,7 @@ impl JPipeline {
     ///
     /// Output pipelines can only contain converter children. The transient
     /// Vec-handle operation is an input-site ABI and is the sole pipeline body
-    /// that needs [`Emit`] to spell its element type. Keeping that case out of
+    /// that needs the writer to spell its element type. Keeping that case out of
     /// this API lets return, error, and callback delivery assemble their JNI
     /// protocol without gaining access to source Rust spelling.
     pub(crate) fn invoke_output(&self, value: TokenStream, emit: &RustWriter) -> TokenStream {

--- a/prebindgen-jni/src/jni/classify.rs
+++ b/prebindgen-jni/src/jni/classify.rs
@@ -30,7 +30,7 @@ pub(crate) enum TypeKind<'r, 'c> {
     /// The **element**, not its `syn::ItemStruct`. A flattening emitter wants
     /// each field's reading, and the model already decided one per field; going
     /// through the syntax means asking some other authority for it again. An
-    /// emitter that only re-emits the struct goes through the final `Emit`
+    /// emitter that only re-emits the struct goes through the final writer's
     /// boundary instead.
     DataStruct {
         st: &'r prebindgen_registry::flat::Struct,

--- a/prebindgen-jni/src/jni/compile.rs
+++ b/prebindgen-jni/src/jni/compile.rs
@@ -890,7 +890,7 @@ impl<R: Conversions> JCompile<'_, R> {
             .ok_or_else(|| refuse(at, why))
     }
 
-    /// Freeze a terminal value codec without asking `Emit` to spell its source.
+    /// Freeze a terminal value codec without asking the writer to spell its source.
     fn planned_value_codec(&self, at: At<'_>) -> Option<JFrag> {
         if let Some(fragment) = self.planned_enum_codec(at) {
             return Some(fragment);
@@ -1113,7 +1113,7 @@ impl<R: Conversions> JCompile<'_, R> {
     /// Freeze a whole-object struct terminal from the Flat declaration and
     /// already-selected child chains. No source type is spelled and no Rust
     /// body is assembled here; [`JStructCodecPlan`](crate::jni::chain::JStructCodecPlan)
-    /// performs both only when the shared writer supplies `Emit`.
+    /// performs both only when the shared writer arrives.
     fn planned_struct_codec(&self, at: At<'_>) -> Option<JFrag> {
         let source = at.crossing.spelled();
         let TypeKind::Named { id, .. } = source.kind() else {

--- a/prebindgen-jni/src/jni/emit/delivery.rs
+++ b/prebindgen-jni/src/jni/emit/delivery.rs
@@ -617,7 +617,7 @@ struct FrozenSum {
 /// Callback delivery facts frozen while the registry is available. Rust
 /// source types remain as opaque readings inside the wires/pipelines; the only
 /// syntax retained here is origin qualification and Flat alternative shape,
-/// both consumed with `Emit` by the final Invoke renderer.
+/// both consumed with the writer by the final Invoke renderer.
 #[derive(Clone)]
 pub(crate) struct FrozenDelivery {
     wires: Vec<crate::jni::compile::OutWire>,

--- a/prebindgen-jni/src/jni/tests/callbacks.rs
+++ b/prebindgen-jni/src/jni/tests/callbacks.rs
@@ -300,9 +300,9 @@ fn undeclared_expanded_callback_retains_its_registry_invoke_plan() {
 }
 
 /// Planning an Invoke may freeze Flat/model and JNI ABI facts, but only the
-/// final `RustFunction::render` boundary may receive `Emit`. Pin both sides of
+/// final `RustFunction::render` boundary may receive a `RustWriter`. Pin both sides of
 /// that seam: the recipe hook does not ask its compiler context for spelling,
-/// and the adapter planner cannot accept an `Emit` parameter later.
+/// and the adapter planner cannot accept a `RustWriter` parameter later.
 #[test]
 fn callback_planning_has_no_source_spelling_access() {
     // These delimiters deliberately follow rustfmt's stable spelling of both
@@ -326,7 +326,10 @@ fn callback_planning_has_no_source_spelling_access() {
         .split_once(") -> Option<(syn::Type, JInvokePlan)>")
         .expect("callback planner signature")
         .0;
-    assert!(!planner_signature.contains("Emit"), "{planner_signature}");
+    assert!(
+        !planner_signature.contains("RustWriter"),
+        "{planner_signature}"
+    );
 }
 
 /// Regression: a callback-delivered type that has BOTH a nested handle identity

--- a/prebindgen-jni/src/jni/tests/values.rs
+++ b/prebindgen-jni/src/jni/tests/values.rs
@@ -175,7 +175,7 @@ fn byte_vectors_retain_late_registry_plans_in_both_directions() {
 
 /// Recipe compilation selects terminal representations from Flat kinds and
 /// retains source readings; it cannot spell source Rust or recover a kind by
-/// parsing a key string. `Emit` belongs only to the final renderer.
+/// parsing a key string. `RustWriter` belongs only to the final renderer.
 #[test]
 fn jni_recipe_planning_has_no_emit_or_key_text_escape() {
     let compile = include_str!("../compile.rs");
@@ -429,8 +429,8 @@ fn fixed_primitive_arrays_retain_late_registry_plans() {
 /// Whole-object planning may inspect Flat fields/alternatives and freeze JNI
 /// property policy, but it must not receive the capability that spells
 /// captured source types. Pin both struct and sum entry points: the recipe
-/// compiler never asks its context for `Emit`, and neither JObject plan builder
-/// can accept one later.
+/// compiler never asks its context for a renderer, and neither JObject plan
+/// builder can accept a `RustWriter` later.
 #[test]
 fn whole_object_planning_has_no_source_spelling_access() {
     let compile = include_str!("../compile.rs");
@@ -459,7 +459,10 @@ fn whole_object_planning_has_no_source_spelling_access() {
         .split_once(") -> Option<JObjectStructInputPlan>")
         .expect("JObject struct plan signature")
         .0;
-    assert!(!struct_signature.contains("Emit"), "{struct_signature}");
+    assert!(
+        !struct_signature.contains("RustWriter"),
+        "{struct_signature}"
+    );
     let sum_signature = input
         .split_once("pub(crate) fn build_jobject_sum_input_plan(")
         .expect("JObject sum plan builder")
@@ -467,7 +470,7 @@ fn whole_object_planning_has_no_source_spelling_access() {
         .split_once(") -> Option<JObjectSumInputPlan>")
         .expect("JObject sum plan signature")
         .0;
-    assert!(!sum_signature.contains("Emit"), "{sum_signature}");
+    assert!(!sum_signature.contains("RustWriter"), "{sum_signature}");
 }
 
 #[test]

--- a/prebindgen-registry/Cargo.toml
+++ b/prebindgen-registry/Cargo.toml
@@ -23,6 +23,6 @@ itertools = { workspace = true }
 [features]
 # Test-support constructors for the test suites of out-of-crate adapters
 # (`prebindgen-jni`, `prebindgen-c`). Non-default and not covered by semver. It
-# exposes both `Registry` test constructors and `Emit::for_test`; the flat rendering
+# exposes both `Registry` test constructors and `RustWriter::for_test`; the flat rendering
 # protocol itself has no test-only construction API.
 testing = []

--- a/prebindgen-registry/src/emit.rs
+++ b/prebindgen-registry/src/emit.rs
@@ -2,39 +2,45 @@
 
 use std::collections::HashMap;
 
-/// The zero-sized capability proving final Rust emission has begun.
+/// The private receiver for the flat rendering protocol.
 ///
-/// Flat owns the generate-only protocol; the registry owns this concrete key and
-/// its private constructor. `RustWriter` holds it only during final file assembly.
+/// [`RustWriter`] is the capability; this exists only because
+/// [`prebindgen_flat::RustEmitter`]'s operations are trait methods and
+/// something has to be their `Self`. It is unnamed in any public API, so an
+/// adapter reaches those operations only through the writer's own methods,
+/// which supply the frozen module state a caller must not choose.
+struct Renderer;
+
+impl prebindgen_flat::RustEmitter for Renderer {}
+
+/// The capability proving final Rust emission has begun.
 ///
-/// ```compile_fail
-/// use prebindgen_registry::Emit;
-/// let emit = Emit::new();
-/// ```
+/// Flat owns the generate-only protocol; the registry owns this facade and its
+/// private constructor. Emission callbacks receive `&RustWriter` during final
+/// file assembly and at no other point, which is what keeps planning code from
+/// rendering.
 ///
-/// ```compile_fail
-/// use prebindgen_registry::Emit;
-/// let emit = Emit(());
+/// Deliberately stateful: qualifying a modeled nominal type requires the frozen
+/// registry mapping from Flat names to source modules, so a renderer cannot be
+/// pointed at a module map of its own choosing.
+///
+/// An adapter cannot construct one; the constructor is registry-private:
+///
+/// ```compile_fail,E0624
+/// # use prebindgen_registry::{Registry, RustWriter};
+/// # fn leak(registry: &Registry) -> RustWriter {
+/// RustWriter::new(registry, None)
+/// # }
 /// ```
 ///
 /// A registry-only adapter cannot name the flat rendering protocol through
-/// the registry's model re-export:
+/// the registry's model re-export, so it cannot supply its own receiver:
 ///
 /// ```compile_fail
 /// use prebindgen_registry::flat::emit::RustEmitter;
 /// ```
 ///
-/// Even code which can name the token cannot recover retained spelling:
-///
-/// ```compile_fail
-/// # use prebindgen_registry::{Emit, flat::TypeRef};
-/// use prebindgen_flat::RustEmitter;
-/// # fn leak(emit: &Emit, ty: &TypeRef) {
-/// let _ = emit.spell(ty);
-/// # }
-/// ```
-///
-/// The stateful writer facade exposes no spelling escape either:
+/// The writer facade exposes no spelling escape:
 ///
 /// ```compile_fail
 /// # use prebindgen_registry::{RustWriter, flat::TypeRef};
@@ -43,27 +49,9 @@ use std::collections::HashMap;
 /// # }
 /// ```
 #[derive(Debug)]
-pub struct Emit(());
-
-impl prebindgen_flat::RustEmitter for Emit {}
-
-/// Writer-owned context for final Rust emission.
-///
-/// Unlike [`Emit`], this is deliberately stateful: qualifying a modeled
-/// nominal type requires the frozen registry mapping from Flat names to source
-/// modules. Keeping that state here preserves the distinction between the
-/// phase token and the writer which consumes model facts.
-#[derive(Debug)]
 pub struct RustWriter {
-    emit: Emit,
     source_modules: HashMap<String, syn::Path>,
     default_module: syn::Path,
-}
-
-impl Emit {
-    fn new() -> Self {
-        Self(())
-    }
 }
 
 impl RustWriter {
@@ -82,7 +70,6 @@ impl RustWriter {
             })
             .collect();
         Self {
-            emit: Emit::new(),
             source_modules,
             default_module,
         }
@@ -95,7 +82,6 @@ impl RustWriter {
     #[cfg(any(test, feature = "testing"))]
     pub fn for_test() -> Self {
         Self {
-            emit: Emit::new(),
             source_modules: HashMap::new(),
             default_module: syn::parse_quote!(crate),
         }
@@ -118,7 +104,7 @@ impl RustWriter {
         ty: &prebindgen_flat::flat::TypeRef,
     ) -> proc_macro2::TokenStream {
         prebindgen_flat::RustEmitter::emit_source_type(
-            &self.emit,
+            &Renderer,
             ty,
             &self.source_modules,
             &self.default_module,
@@ -150,7 +136,7 @@ impl RustWriter {
 
     /// Copy the proc-macro's anonymous feature guard into the final file.
     pub(crate) fn guard(&self, guard: &prebindgen_flat::flat::Guard) -> syn::ItemConst {
-        prebindgen_flat::RustEmitter::guard(&self.emit, guard)
+        prebindgen_flat::RustEmitter::guard(&Renderer, guard)
     }
 
     /// Emit a fieldless enum's modeled discriminant spelling.
@@ -158,7 +144,7 @@ impl RustWriter {
         &self,
         value: &prebindgen_flat::flat::EnumValue,
     ) -> Option<proc_macro2::TokenStream> {
-        prebindgen_flat::RustEmitter::discriminant(&self.emit, value)
+        prebindgen_flat::RustEmitter::discriminant(&Renderer, value)
     }
 
     /// Generate a struct constructor or pattern with its modeled delimiter shape.
@@ -168,7 +154,7 @@ impl RustWriter {
         head: proc_macro2::TokenStream,
         parts: &[proc_macro2::TokenStream],
     ) -> proc_macro2::TokenStream {
-        prebindgen_flat::RustEmitter::shape_struct(&self.emit, item, head, parts)
+        prebindgen_flat::RustEmitter::shape_struct(&Renderer, item, head, parts)
     }
 
     /// Generate an enum-alternative constructor or pattern with its modeled shape.
@@ -178,7 +164,7 @@ impl RustWriter {
         head: proc_macro2::TokenStream,
         parts: &[proc_macro2::TokenStream],
     ) -> proc_macro2::TokenStream {
-        prebindgen_flat::RustEmitter::shape_alternative(&self.emit, item, head, parts)
+        prebindgen_flat::RustEmitter::shape_alternative(&Renderer, item, head, parts)
     }
 
     /// Allocate the final private Rust symbol for a registry-owned operation.
@@ -243,13 +229,8 @@ fn ident_component(label: &str) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::{ident_component, Emit, RustWriter};
+    use super::{ident_component, RustWriter};
     use crate::{ArtifactId, Direction, OperationId};
-
-    #[test]
-    fn emit_remains_only_a_zero_sized_phase_token() {
-        assert_eq!(std::mem::size_of::<Emit>(), 0);
-    }
 
     #[test]
     fn operation_symbols_are_stable_and_writer_scoped() {
@@ -257,10 +238,10 @@ mod tests {
             ArtifactId::new("test-codec", "owned").unwrap(),
             Direction::Construct,
         );
-        let emit = RustWriter::for_test();
+        let writer = RustWriter::for_test();
 
-        let first = emit.operation_ident("test", &operation);
-        let second = emit.operation_ident("test", &operation);
+        let first = writer.operation_ident("test", &operation);
+        let second = writer.operation_ident("test", &operation);
 
         assert_eq!(first, second);
         assert!(first

--- a/prebindgen-registry/src/generation.rs
+++ b/prebindgen-registry/src/generation.rs
@@ -32,7 +32,7 @@ pub struct FragmentId {
 /// Stable identity of one private operation retained by a recipe fragment.
 ///
 /// This is model identity, not a rendered Rust identifier. The final writer
-/// allocates its private symbol through `Emit`; an adapter only supplies its
+/// allocates its private symbol through `RustWriter`; an adapter only supplies its
 /// target namespace while rendering.
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct OperationId {
@@ -239,7 +239,7 @@ impl OperationId {
     /// Keeping this implementation beside the model identity prevents an
     /// adapter from reading or reinterpreting the `TypeKey` values contained
     /// by a fragment. The fingerprint deliberately has no public accessor;
-    /// final emission exposes only the completed identifier through `Emit`.
+    /// final emission exposes only the completed identifier through `RustWriter`.
     pub(crate) fn stable_fingerprint(&self) -> u64 {
         let mut hash = 0xcbf2_9ce4_8422_2325_u64;
         for byte in self.stable_key().bytes() {

--- a/prebindgen-registry/src/lib.rs
+++ b/prebindgen-registry/src/lib.rs
@@ -131,7 +131,7 @@ pub use self::{
     },
     diagnostics::{warn_unclaimed, Claimed},
     domain::{DomainScalar, RepresentationDomain, ScalarValue},
-    emit::{Emit, RustWriter},
+    emit::RustWriter,
     generation::{
         AbiLayout, ArtifactId, ArtifactInput, ArtifactPlan, ChainValue, ChoiceArity, Cleanup,
         ContractAt, ConversionChain, ConverterPlan, ConverterStep, Failure, FixedArity, FragmentId,

--- a/prebindgen-registry/src/registry/tests.rs
+++ b/prebindgen-registry/src/registry/tests.rs
@@ -320,10 +320,12 @@ fn conversion_carriers_cannot_store_complete_rust_syntax() {
     );
 }
 
-/// Recipe planning sees Flat readings and already-built answers. Restoring an
-/// `Emit` argument here would reopen source spelling before final rendering.
+/// Recipe planning sees Flat readings and already-built answers. Restoring a
+/// `RustWriter` argument here would reopen source spelling before final
+/// rendering — `RustWriter` is the rendering capability, so it is the name
+/// these fences hold out.
 #[test]
-fn conversion_planning_cannot_obtain_emit() {
+fn conversion_planning_cannot_obtain_the_writer() {
     let source = include_str!("declare.rs");
     let convert_with = source
         .split_once("pub fn convert_with")
@@ -332,7 +334,7 @@ fn conversion_planning_cannot_obtain_emit() {
         .split_once("/// The scanned registry")
         .expect("end of convert_with")
         .0;
-    assert!(!convert_with.contains("Emit"), "{convert_with}");
+    assert!(!convert_with.contains("RustWriter"), "{convert_with}");
     assert!(!convert_with.contains("spell_ty"), "{convert_with}");
 
     let recipes = include_str!("../recipe/compile.rs");
@@ -343,7 +345,7 @@ fn conversion_planning_cannot_obtain_emit() {
         .split_once("/// One part")
         .expect("end of recipe context")
         .0;
-    assert!(!cx.contains("Emit"), "{cx}");
+    assert!(!cx.contains("RustWriter"), "{cx}");
     assert!(!cx.contains("fn emit"), "{cx}");
     let compiler = recipes
         .split_once("pub struct Compiler")
@@ -352,7 +354,7 @@ fn conversion_planning_cannot_obtain_emit() {
         .split_once("impl<'a, C: Compile>")
         .expect("end of compiler fields")
         .0;
-    assert!(!compiler.contains("Emit"), "{compiler}");
+    assert!(!compiler.contains("RustWriter"), "{compiler}");
 }
 
 /// A name collision across two chained source streams fails registry

--- a/prebindgen/Cargo.toml
+++ b/prebindgen/Cargo.toml
@@ -31,7 +31,7 @@ debug = []
 # Test-support constructors for the test suites of out-of-crate adapters
 # (`prebindgen-jni`, `prebindgen-c`). Non-default and not covered by semver:
 # with it off, the seals these bypass hold exactly as documented, so a normal
-# build is unaffected and production code still cannot mint an `Emit`.
+# build is unaffected and production code still cannot mint a `RustWriter`.
 testing = []
 
 [dev-dependencies]

--- a/prebindgen/src/lib.rs
+++ b/prebindgen/src/lib.rs
@@ -178,7 +178,7 @@ pub use crate::api::{
 };
 
 // The flat model (`flat`, `shape`, `types_util`, `Element`, `Flat`, `TypeKey`,
-// `Emit`, …) moved to the separate `prebindgen-flat` crate, which depends on
+// `RustEmitter`, …) moved to the separate `prebindgen-flat` crate, which depends on
 // this crate for [`Source`] / [`SourceLocation`] and parses the
 // `(syn::Item, SourceLocation)` pairs [`Source`] hands out into one flat
 // namespace — see that crate's docs for the model.


### PR DESCRIPTION
## What this changes

`prebindgen-registry` no longer exports the type `Emit`. `RustWriter` — the
object an adapter receives in the callbacks that assemble the final Rust file —
becomes the only name for the rendering capability.

This targets `feature/chained-rust-generation` rather than `main` because
`Emit` only became vestigial on this branch.

## Why

Three types are involved. They relate like this:

- `prebindgen_flat::RustEmitter` is the trait `prebindgen-flat` defines for
  generating Rust output. Every one of its methods has a default body, so a
  crate building a pipeline over that model reaches those methods by
  implementing the trait for a type of its own.
- `prebindgen_registry::Emit` was that type: a zero-sized struct with a private
  constructor, implementing `RustEmitter` and nothing else.
- `prebindgen_registry::RustWriter` holds the frozen map from source names to
  declaration modules, and held an `Emit` in a private field.

`Emit` has no callers outside the file declaring it. Every use of the name in
the workspace — as opposed to a mention in prose — is in
`prebindgen-registry/src/emit.rs`: the declaration, the trait impl, the private
constructor, the field, and one test asserting the type is zero-sized. No
function takes an `&Emit`. No adapter constructs one. It was public API that no
crate outside the registry could construct or receive.

Its one remaining job was supplying a receiver for the five `RustEmitter`
methods, each of which `RustWriter` re-wraps with its own state before an
adapter sees it.

Two properties of this branch might look like `Emit`'s doing. Neither is:

- **An adapter cannot spell a captured Rust type.** The captured-syntax field of
  `TypeRef`, the flat model's reading of one type, is private to
  `prebindgen-flat` and has no public accessor.
  `RustWriter::emit_source_type` builds its output from the flat model's
  classification rather than from that field.
- **Planning code cannot render.** `RustWriter::new` is `pub(crate)`, so a
  writer exists only inside the registry's file-assembly pass, `write_rust`.
  That restriction sits on the writer's own constructor; `Emit` contributed
  nothing to it.

## What replaces it

A private unit struct `Renderer` in `prebindgen-registry/src/emit.rs`. It exists
for the same mechanical reason `Emit` did — `RustEmitter`'s operations are trait
methods, and something has to be their receiver — but it is not exported, not
stored in `RustWriter`, and not part of the project's vocabulary.

`RustWriter` does not implement `RustEmitter` itself. Five of its inherent
methods share names with the trait's, and the trait's `emit_source_type` takes a
module map from its caller. A `RustWriter` implementing the trait would let a
caller who can name `RustEmitter` render against a map other than the frozen
one.

## Source fences

Several tests read a source file as text and assert that a chosen name does not
appear within one signature. This is how the branch pins that planning code
cannot acquire the capability to render. Six such assertions held out the
string `Emit`.

With `Emit` deleted, no signature in the workspace can contain that string, so
all six would pass regardless of what the code did. Each now holds out
`RustWriter`, the name that must not appear:

- `prebindgen-registry/src/registry/tests.rs` — `RegistryBuilder::convert_with`,
  and the recipe compiler's `Cx` and `Compiler` types
- `prebindgen-jni/src/jni/tests/values.rs` — both JObject input-plan builders
- `prebindgen-jni/src/jni/tests/callbacks.rs` — the callback input planner

The remaining prose references to `Emit` across both adapters, both docs files
and the README are updated to name `RustWriter` or the writer.

## Verification

- Generated artifacts under `examples/` are byte-identical. The build
  regenerates them and `git status` reports no change to that directory.
- `cargo test --workspace` passes: 28 test binaries, no failures.
- `cargo clippy --workspace --all-targets` and `cargo doc --workspace --no-deps`
  report no warnings.
- The compile-fail doctest pinning the private constructor asserts `E0624`
  specifically, so it cannot start passing because of an unrelated compile
  error.

— Claude Code (Opus 5)
