### PR TITLE
Assemble the generated Rust file from a frozen assembly

### DIFF
--- a/prebindgen-c/src/chain.rs
+++ b/prebindgen-c/src/chain.rs
@@ -1,7 +1,7 @@
 //! Syntax-free plans for converters composed from recipe shapes.
 //!
 //! A plan keeps Flat [`TypeRef`]s opaque and records only shape operations,
-//! wire-side types and child converter contracts. [`RustFunction::render`]
+//! wire-side types and child converter contracts. [`RustArtifact::render`]
 //! receives the writer-owned [`RustWriter`] after resolution and validation, which is
 //! the first point at which the captured Rust types and function bodies are
 //! materialized.
@@ -11,7 +11,7 @@ use prebindgen_registry::{
     flat::{Alternative, TypeRef},
     generation::{ArtifactId, GenerationPlan, SiteId},
     recipe::Mode,
-    write::RustFunction,
+    write::{ArtifactKey, RustArtifact},
     RustWriter,
 };
 
@@ -318,12 +318,18 @@ impl CFunction {
     }
 }
 
-impl RustFunction for CFunction {
-    fn operation_id(&self) -> &prebindgen_registry::OperationId {
-        &self.operation
+impl RustArtifact for CFunction {
+    fn key(&self) -> ArtifactKey {
+        ArtifactKey::Operation(self.operation.clone())
     }
 
-    fn render(&self, emit: &RustWriter) -> syn::ItemFn {
+    fn render(&self, emit: &RustWriter) -> Vec<syn::Item> {
+        vec![syn::Item::Fn(self.render_fn(emit))]
+    }
+}
+
+impl CFunction {
+    fn render_fn(&self, emit: &RustWriter) -> syn::ItemFn {
         let name = emit.operation_ident("c", &self.operation);
         match &self.body {
             CBody::Custom(plan) => plan.render(emit, &name),

--- a/prebindgen-c/src/lib.rs
+++ b/prebindgen-c/src/lib.rs
@@ -347,11 +347,10 @@ impl Cbindgen {
         &self,
         out_path: impl AsRef<std::path::Path>,
     ) -> Result<std::path::PathBuf, prebindgen_registry::WriteRustError> {
-        let converters: Vec<_> = self.gen.converter_functions().cloned().collect();
         Ok(prebindgen_registry::write::write_rust(
             &self.registry,
             &self.gen,
-            &converters,
+            self.gen.assembly(),
             out_path,
         )?)
     }
@@ -446,16 +445,24 @@ pub struct CbindgenBuilder {
     /// argument sites, and callback artifacts.
     pub(crate) generation:
         Option<prebindgen_registry::generation::GenerationPlan<crate::compile::CRepresentation>>,
+    /// Every final artifact of the generated Rust file, frozen in the order it
+    /// is written. Filled from [`Self::generation`] once resolution is
+    /// complete, and the only thing `write_rust` reads converters from.
+    pub(crate) assembly: Option<prebindgen_registry::write::Assembly<chain::CFunction>>,
 }
 
 impl CbindgenBuilder {
-    /// Frozen converter artifacts in registry-owned dependency order.
-    pub(crate) fn converter_functions(&self) -> impl Iterator<Item = &chain::CFunction> {
-        self.generation
+    /// The frozen assembly the generated Rust file is written from.
+    pub(crate) fn assembly(&self) -> &prebindgen_registry::write::Assembly<chain::CFunction> {
+        self.assembly
             .as_ref()
-            .expect("C generation plan is frozen after resolution")
-            .fragments()
-            .filter_map(|fragment| fragment.artifact())
+            .expect("C assembly is frozen after resolution")
+    }
+
+    /// Frozen converter artifacts in registry-owned dependency order.
+    #[cfg(test)]
+    pub(crate) fn converter_functions(&self) -> impl Iterator<Item = &chain::CFunction> {
+        self.assembly().artifacts()
     }
 }
 

--- a/prebindgen-c/src/trait_impl.rs
+++ b/prebindgen-c/src/trait_impl.rs
@@ -1072,11 +1072,20 @@ impl CbindgenBuilder {
         for artifact in artifacts {
             generation.artifact(artifact);
         }
-        self.generation = Some(generation.build().map_err(|errors| {
+        let generation = generation.build().map_err(|errors| {
             prebindgen_registry::ScanError::AdapterInvariant {
                 message: errors.to_string(),
             }
-        })?);
+        })?;
+        // The file's artifacts, frozen in the plan's own dependency order.
+        self.assembly = Some(
+            generation
+                .fragments()
+                .filter_map(|fragment| fragment.artifact())
+                .cloned()
+                .collect(),
+        );
+        self.generation = Some(generation);
         self.validate_resolved(&registry)
             .map_err(|message| prebindgen_registry::ScanError::AdapterInvariant { message })?;
         Ok(Cbindgen {

--- a/prebindgen-jni/src/jni/chain.rs
+++ b/prebindgen-jni/src/jni/chain.rs
@@ -5,7 +5,7 @@ use prebindgen_registry::{
     flat::TypeRef,
     generation::OperationId,
     recipe::Mode,
-    write::RustFunction,
+    write::{ArtifactKey, RustArtifact},
     RustWriter,
 };
 
@@ -200,8 +200,22 @@ impl JFunction {
     }
 }
 
-impl RustFunction for JFunction {
-    fn operation_id(&self) -> &OperationId {
+impl RustArtifact for JFunction {
+    fn key(&self) -> ArtifactKey {
+        ArtifactKey::Operation(self.operation_id().clone())
+    }
+
+    fn reachable(&self) -> bool {
+        self.should_emit()
+    }
+
+    fn render(&self, emit: &RustWriter) -> Vec<syn::Item> {
+        vec![syn::Item::Fn(self.render_fn(emit))]
+    }
+}
+
+impl JFunction {
+    pub(crate) fn operation_id(&self) -> &OperationId {
         match &self.0 {
             JBody::Marker(operation) => operation,
             JBody::ValueCodec(plan) => &plan.operation,
@@ -220,7 +234,7 @@ impl RustFunction for JFunction {
         }
     }
 
-    fn should_emit(&self) -> bool {
+    pub(crate) fn should_emit(&self) -> bool {
         match &self.0 {
             JBody::Marker(_) => false,
             // Compatibility parents do not yet propagate reachability to the
@@ -247,7 +261,7 @@ impl RustFunction for JFunction {
         }
     }
 
-    fn render(&self, emit: &RustWriter) -> syn::ItemFn {
+    pub(crate) fn render_fn(&self, emit: &RustWriter) -> syn::ItemFn {
         match &self.0 {
             JBody::Marker(operation) => planned_marker(&emit.operation_ident("jni", operation)),
             JBody::ValueCodec(plan) => plan.render(emit),

--- a/prebindgen-jni/src/jni/generation.rs
+++ b/prebindgen-jni/src/jni/generation.rs
@@ -27,6 +27,10 @@ pub(crate) struct JniGenerationPlan {
     structs: HashMap<TypeKey, Option<Rc<StructPlan>>>,
     sums: HashMap<TypeKey, Rc<crate::jni::kotlin_emit::SealedClassPlan>>,
     vec_builds: HashMap<TypeKey, Rc<VecBuildHelpers>>,
+    /// Every final artifact of the generated Rust file, frozen in the order it
+    /// is written. Derived from [`Self::conversions`] once the last fragment is
+    /// compiled, and the only thing `write_rust` reads converters from.
+    assembly: prebindgen_registry::write::Assembly<crate::jni::chain::JFunction>,
 }
 
 impl JniGenerationPlan {
@@ -82,8 +86,16 @@ impl JniGenerationPlan {
             let _ = decls.sealed_class_plan(registry, item);
         }
 
+        let conversions = std::mem::take(&mut *decls.compiled.borrow_mut());
+        let assembly = conversions
+            .fragments()
+            .into_iter()
+            .filter(|fragment| !fragment.composed_only)
+            .flat_map(crate::jni::compile::JFrag::converter_artifacts)
+            .collect();
         Self {
-            conversions: std::mem::take(&mut *decls.compiled.borrow_mut()),
+            conversions,
+            assembly,
             functions: std::mem::take(decls.fn_plans.get_mut()),
             interfaces: std::mem::take(decls.iface_specs.get_mut()),
             structs: std::mem::take(decls.struct_plans.get_mut()),
@@ -115,17 +127,11 @@ impl JniGenerationPlan {
         &self.conversions
     }
 
-    /// Frozen private converter artifacts derived from registry fragments.
-    ///
-    /// This is deliberately an ephemeral collection at the writer boundary,
-    /// not a second cache beside the fragment graph.
-    pub(crate) fn converter_functions(&self) -> Vec<crate::jni::chain::JFunction> {
-        self.conversions
-            .fragments()
-            .into_iter()
-            .filter(|fragment| !fragment.composed_only)
-            .flat_map(crate::jni::compile::JFrag::converter_artifacts)
-            .collect()
+    /// The frozen assembly the generated Rust file is written from.
+    pub(crate) fn assembly(
+        &self,
+    ) -> &prebindgen_registry::write::Assembly<crate::jni::chain::JFunction> {
+        &self.assembly
     }
 
     pub(crate) fn function(&self, ident: &syn::Ident) -> Option<Rc<JniFunctionPlan>> {

--- a/prebindgen-jni/src/jni/mod.rs
+++ b/prebindgen-jni/src/jni/mod.rs
@@ -538,10 +538,7 @@ impl JniGen {
         direction: prebindgen_registry::recipe::Direction,
         parts: bool,
     ) -> Result<(bool, String, String), String> {
-        use prebindgen_registry::{
-            recipe::{Compiler, Crossing},
-            write::RustFunction,
-        };
+        use prebindgen_registry::recipe::{Compiler, Crossing};
 
         let reading = self
             .registry
@@ -568,11 +565,12 @@ impl JniGen {
         }
         .map_err(|e| e.to_string())?;
         fragment.rust.mark_reachable();
-        let rendered = fragment
-            .rust
-            .render(&prebindgen_registry::RustWriter::for_registry_test(
-                &self.registry,
-            ));
+        let rendered =
+            fragment
+                .rust
+                .render_fn(&prebindgen_registry::RustWriter::for_registry_test(
+                    &self.registry,
+                ));
         Ok((
             fragment.composed_only,
             rendered.sig.ident.to_string(),
@@ -868,10 +866,9 @@ impl JniGen {
         let fragment = self
             .generation_plan()
             .fragment(&key, Direction::Construct)?;
-        let rendered = prebindgen_registry::write::RustFunction::render(
-            &fragment.rust,
-            &prebindgen_registry::RustWriter::for_test(),
-        );
+        let rendered = fragment
+            .rust
+            .render_fn(&prebindgen_registry::RustWriter::for_test());
         Some((rendered.sig.ident.to_string(), fragment.rust.is_invoke()))
     }
 }
@@ -900,16 +897,14 @@ impl JniGen {
         &self,
         out_path: impl AsRef<std::path::Path>,
     ) -> Result<std::path::PathBuf, prebindgen_registry::WriteRustError> {
-        let conversions = self
-            .decls
-            .generation
-            .as_ref()
-            .expect("resolved JniGen has no frozen generation plan")
-            .converter_functions();
         Ok(prebindgen_registry::write::write_rust(
             &self.registry,
             &self.decls,
-            &conversions,
+            self.decls
+                .generation
+                .as_ref()
+                .expect("resolved JniGen has no frozen generation plan")
+                .assembly(),
             out_path,
         )?)
     }

--- a/prebindgen-registry/src/write.rs
+++ b/prebindgen-registry/src/write.rs
@@ -1,18 +1,18 @@
 //! Rust file emission for the resolved `Registry`.
 //!
-//! `write_rust` takes the conversions the adapter compiled, as a slice of
-//! [`RustFunction`] plans; renders them with the writer-owned [`crate::RustWriter`],
-//! adds every per-item `on_<kind>` output and every anonymous const, and hands
-//! the assembled file to `Destination::write`.
+//! `write_rust` takes the [`Assembly`] the adapter compiled — the frozen graph
+//! of final artifacts the file is made of; renders each with the writer-owned
+//! [`crate::RustWriter`], adds every per-item `on_<kind>` output and every
+//! anonymous const, and hands the assembled file to `Destination::write`.
 //!
-//! The conversions arrive from the adapter rather than being collected from the
+//! The artifacts arrive from the adapter rather than being collected from the
 //! registry, which is what lets one crossing contribute more than one function
 //! — or one that occupies more than a single wire value.
 //!
 //! This module is `pub`, so **every `pub` item in it is public API of the
-//! crate**. [`RustFunction`] is the deliberately narrow late-rendering seam for
-//! out-of-crate adapters. Every plan carries registry-owned semantic identity;
-//! final Rust names are never used as planning identity.
+//! crate**. [`RustArtifact`] is the deliberately narrow late-rendering seam for
+//! out-of-crate adapters. Every artifact carries registry-owned semantic
+//! identity; final Rust names are never used as planning identity.
 
 use std::{
     collections::{BTreeSet, HashMap},
@@ -65,45 +65,147 @@ impl std::fmt::Display for WriteError {
 
 impl std::error::Error for WriteError {}
 
-/// One planned private converter function.
+/// Identity of one final artifact in an [`Assembly`].
 ///
-/// Resolution may keep an adapter-specific semantic plan here instead of a
-/// rendered Rust body. The writer calls this only after planning and
-/// validation are complete, with the same [`crate::RustWriter`] capability used for
-/// the rest of final Rust emission.
-pub trait RustFunction {
-    /// Registry-owned semantic identity of this operation.
-    ///
-    /// Plans are de-duplicated before rendering, so sharing never depends on
-    /// the Rust symbol selected by final emission.
-    fn operation_id(&self) -> &crate::generation::OperationId;
+/// A private converter is identified by the registry operation it implements;
+/// every other final artifact — a helper the converter bodies call, an
+/// exported wrapper, a type mirror — is identified by the adapter-scoped
+/// [`ArtifactId`](crate::generation::ArtifactId) its plan was recorded under.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub enum ArtifactKey {
+    /// A private converter, identified by its registry operation.
+    Operation(crate::generation::OperationId),
+    /// Any other final artifact, identified by its plan's artifact identity.
+    Artifact(crate::generation::ArtifactId),
+}
 
-    /// Whether this plan is reachable from the generated adapter surface.
-    /// Validation-only plans may return false and remain available for diagnostics.
-    fn should_emit(&self) -> bool {
+impl std::fmt::Display for ArtifactKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ArtifactKey::Operation(operation) => operation.fmt(f),
+            ArtifactKey::Artifact(artifact) => artifact.fmt(f),
+        }
+    }
+}
+
+/// One final artifact of the generated Rust file.
+///
+/// Resolution decides what the artifact is and what it depends on; this trait
+/// is the one thing the artifact still owes the writer — the Rust items it
+/// becomes. [`Self::render`] runs at the final writing boundary, with the
+/// [`crate::RustWriter`] used for the rest of final Rust emission and with no
+/// access to a live [`Registry`], so an artifact cannot resume resolution
+/// while the file is being assembled.
+pub trait RustArtifact {
+    /// Semantic identity, owned by the registry rather than by the Rust
+    /// symbol final emission will choose.
+    fn key(&self) -> ArtifactKey;
+
+    /// Whether the generated adapter surface reaches this artifact.
+    /// Validation-only artifacts return false: they are still rendered so
+    /// that a caller of one can be reported, but they do not reach the file.
+    fn reachable(&self) -> bool {
         true
     }
 
-    /// Materialize the complete private converter function.
-    fn render(&self, emit: &crate::RustWriter) -> syn::ItemFn;
+    /// Materialize the artifact's Rust items.
+    fn render(&self, emit: &crate::RustWriter) -> Vec<syn::Item>;
 }
 
-/// Emit a resolved registry whose private converters are rendered at this
-/// final writing boundary.
+/// The frozen set of final artifacts a generated Rust file is assembled from.
 ///
-/// `conversions` is what the adapter's compilation produced. Registry-owned
-/// operations are de-duplicated by [`crate::generation::OperationId`] before
-/// rendering; if separate fragments retain separate reachability state, a
-/// reachable representative wins. Handing the plans over directly is what frees an
-/// adapter to emit a conversion the converter table could not hold — several
-/// functions for one crossing, or one occupying more than a single wire value.
+/// An assembly is ordered: artifacts reach the file in the order the adapter
+/// added them, which for converters is the registry-owned dependency order of
+/// the fragments they came from. It holds one artifact per [`ArtifactKey`], so
+/// sharing never depends on the Rust symbol final emission allocates.
+pub struct Assembly<A> {
+    artifacts: Vec<A>,
+}
+
+impl<A: RustArtifact> Assembly<A> {
+    /// The artifacts, in emission order. Includes the unreachable ones — the
+    /// writer renders those to report anything that still calls them.
+    pub fn artifacts(&self) -> impl ExactSizeIterator<Item = &A> {
+        self.artifacts.iter()
+    }
+}
+
+/// Collection phase preceding a frozen [`Assembly`].
+pub struct AssemblyBuilder<A> {
+    positions: HashMap<ArtifactKey, usize>,
+    artifacts: Vec<A>,
+}
+
+impl<A> Default for AssemblyBuilder<A> {
+    fn default() -> Self {
+        Self {
+            positions: HashMap::new(),
+            artifacts: Vec::new(),
+        }
+    }
+}
+
+impl<A: RustArtifact> AssemblyBuilder<A> {
+    /// Start an empty assembly.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Add one final artifact.
+    ///
+    /// An identity already present is kept once. A reachable artifact replaces
+    /// an unreachable one already held under the same identity, which is what
+    /// lets an adapter add a dormant artifact before the parent that reaches
+    /// it has been planned.
+    pub fn artifact(&mut self, artifact: A) -> &mut Self {
+        match self.positions.get(&artifact.key()).copied() {
+            Some(position) => {
+                if !self.artifacts[position].reachable() && artifact.reachable() {
+                    self.artifacts[position] = artifact;
+                }
+            }
+            None => {
+                self.positions.insert(artifact.key(), self.artifacts.len());
+                self.artifacts.push(artifact);
+            }
+        }
+        self
+    }
+
+    /// Freeze the assembly.
+    pub fn build(self) -> Assembly<A> {
+        Assembly {
+            artifacts: self.artifacts,
+        }
+    }
+}
+
+impl<A: RustArtifact> FromIterator<A> for Assembly<A> {
+    fn from_iter<I: IntoIterator<Item = A>>(artifacts: I) -> Self {
+        let mut builder = AssemblyBuilder::new();
+        for artifact in artifacts {
+            builder.artifact(artifact);
+        }
+        builder.build()
+    }
+}
+
+/// Emit a resolved registry, assembling the generated Rust file from a frozen
+/// [`Assembly`].
+///
+/// The assembly is what the adapter's compilation produced: one final artifact
+/// per item the file will contain, already deduplicated and in registry-owned
+/// dependency order. Handing artifacts over instead of a converter table is
+/// what frees an adapter to emit a conversion the table could not hold —
+/// several functions for one crossing, or one occupying more than a single
+/// wire value.
 ///
 /// `out_path` may be relative (resolved against `OUT_DIR` by prebindgen) or
 /// absolute. Returns the path actually written.
-pub fn write_rust<P: AsRef<Path>, E: Prebindgen, C: RustFunction>(
+pub fn write_rust<P: AsRef<Path>, E: Prebindgen, A: RustArtifact>(
     registry: &Registry,
     ext: &E,
-    conversions: &[C],
+    assembly: &Assembly<A>,
     out_path: P,
 ) -> Result<PathBuf, WriteError> {
     // Validation already ran ONCE in the generator's `build` — a built generator
@@ -181,35 +283,24 @@ pub fn write_rust<P: AsRef<Path>, E: Prebindgen, C: RustFunction>(
             .flat_map(|(_, item)| ext.on_const(item, registry, &emit)),
     );
 
-    // Select one semantic operation only after per-item planning has marked
-    // late plans reachable. This lets a reached twin replace an earlier
-    // dormant twin without materializing either Rust function first.
-    let mut operation_positions: HashMap<crate::generation::OperationId, usize> = HashMap::new();
-    let mut unique_conversions: Vec<&C> = Vec::new();
-    for plan in conversions {
-        let operation = plan.operation_id();
-        match operation_positions.get(operation).copied() {
-            Some(position) if !unique_conversions[position].should_emit() && plan.should_emit() => {
-                unique_conversions[position] = plan;
-            }
-            Some(_) => {}
-            None => {
-                operation_positions.insert(operation.clone(), unique_conversions.len());
-                unique_conversions.push(plan);
-            }
-        }
-    }
-    let conversions: Vec<_> = unique_conversions
-        .into_iter()
-        .map(|plan| (plan.should_emit(), plan.render(&emit)))
+    // Every artifact renders, including the ones the adapter surface does not
+    // reach: an unreachable artifact still contributes its function names, so
+    // a caller that survived reachability filtering can be reported below.
+    let rendered: Vec<(bool, Vec<syn::Item>)> = assembly
+        .artifacts()
+        .map(|artifact| (artifact.reachable(), artifact.render(&emit)))
         .collect();
-    let converter_names: BTreeSet<String> = conversions
+    let converter_names: BTreeSet<String> = rendered
         .iter()
-        .map(|(_, function)| function.sig.ident.to_string())
+        .flat_map(|(_, artifact_items)| artifact_items)
+        .filter_map(|item| match item {
+            syn::Item::Fn(function) => Some(function.sig.ident.to_string()),
+            _ => None,
+        })
         .collect();
-    for (emit, item_fn) in conversions {
-        if emit {
-            items.push(syn::Item::Fn(item_fn));
+    for (reachable, artifact_items) in rendered {
+        if reachable {
+            items.extend(artifact_items);
         }
     }
     items.extend(body_items);

--- a/prebindgen-registry/src/write/tests.rs
+++ b/prebindgen-registry/src/write/tests.rs
@@ -9,6 +9,11 @@ use prebindgen::SourceLocation;
 use super::*;
 use crate::registry::RegistryBuilder;
 
+/// Freeze a test assembly from artifacts stated in emission order.
+fn assembly_of<A: RustArtifact, I: IntoIterator<Item = A>>(artifacts: I) -> Assembly<A> {
+    artifacts.into_iter().collect()
+}
+
 struct IdentityExt;
 
 impl IdentityExt {
@@ -92,37 +97,37 @@ struct OperationPlan {
     rendered_reachable: Rc<Cell<bool>>,
 }
 
-impl RustFunction for OperationPlan {
-    fn operation_id(&self) -> &crate::generation::OperationId {
-        &self.operation
+impl RustArtifact for OperationPlan {
+    fn key(&self) -> ArtifactKey {
+        ArtifactKey::Operation(self.operation.clone())
     }
 
-    fn should_emit(&self) -> bool {
+    fn reachable(&self) -> bool {
         self.reachable
     }
 
-    fn render(&self, emit: &crate::RustWriter) -> syn::ItemFn {
+    fn render(&self, emit: &crate::RustWriter) -> Vec<syn::Item> {
         self.renders.set(self.renders.get() + 1);
         self.rendered_reachable.set(self.reachable);
         let ident = emit.operation_ident("test", &self.operation);
-        syn::parse_quote!(fn #ident() {})
+        vec![syn::parse_quote!(fn #ident() {})]
     }
 }
 
-impl RustFunction for LatePlan {
-    fn operation_id(&self) -> &crate::generation::OperationId {
-        &self.operation
+impl RustArtifact for LatePlan {
+    fn key(&self) -> ArtifactKey {
+        ArtifactKey::Operation(self.operation.clone())
     }
 
-    fn should_emit(&self) -> bool {
+    fn reachable(&self) -> bool {
         self.reachable.get()
     }
 
-    fn render(&self, emit: &crate::RustWriter) -> syn::ItemFn {
+    fn render(&self, emit: &crate::RustWriter) -> Vec<syn::Item> {
         let ident = emit.operation_ident("test", &self.operation);
-        syn::parse_quote!(
+        vec![syn::parse_quote!(
             fn #ident() {}
-        )
+        )]
     }
 }
 
@@ -225,7 +230,8 @@ fn per_item_planning_precedes_late_converter_filtering() {
     let dir = crate::test_util::unique_test_dir("write_late_plan");
     std::fs::create_dir_all(&dir).unwrap();
 
-    let path = write_rust(&registry, &ext, &[plan], dir.join("gen.rs")).expect("write_rust");
+    let path =
+        write_rust(&registry, &ext, &assembly_of([plan]), dir.join("gen.rs")).expect("write_rust");
     let source = std::fs::read_to_string(path).expect("read generated file");
 
     assert!(
@@ -266,7 +272,7 @@ fn a_call_to_a_filtered_converter_is_a_writer_error() {
     std::fs::create_dir_all(&dir).unwrap();
     let path = dir.join("gen.rs");
 
-    let err = write_rust(&registry, &ext, &[plan], &path)
+    let err = write_rust(&registry, &ext, &assembly_of([plan]), &path)
         .expect_err("a call to a filtered private converter must fail in the writer");
 
     match err {
@@ -319,7 +325,7 @@ fn registry_operations_are_deduplicated_before_rendering() {
     write_rust(
         &registry,
         &IdentityExt,
-        &[dormant, reachable],
+        &assembly_of([dormant, reachable]),
         dir.join("gen.rs"),
     )
     .expect("write Rust");
@@ -404,8 +410,13 @@ fn write_rust_sorts_declared_items_by_ident() {
         .expect("clock drift")
         .as_nanos();
     let path = std::env::temp_dir().join(format!("prebindgen-write-rust-{unique}.rs"));
-    let written =
-        write_rust(&reg, &IdentityExt, &[] as &[OperationPlan], &path).expect("write_rust");
+    let written = write_rust(
+        &reg,
+        &IdentityExt,
+        &assembly_of([] as [OperationPlan; 0]),
+        &path,
+    )
+    .expect("write_rust");
     let content = std::fs::read_to_string(&written).expect("read generated file");
     let _ = std::fs::remove_file(&written);
 
@@ -540,7 +551,7 @@ fn guards_emit_ungated_and_in_stream_order() {
     let path = crate::write::write_rust(
         &registry,
         &ConstGatingExt,
-        &[] as &[OperationPlan],
+        &assembly_of([] as [OperationPlan; 0]),
         dir.join("gen.rs"),
     )
     .expect("write_rust");


### PR DESCRIPTION
## What this changes

`prebindgen_registry::write::write_rust` used to take the private converters —
the generated helper functions that carry one value across the FFI boundary —
as a slice the adapter assembled at the call and handed over. It de-duplicated
that slice itself, picked which of two plans with the same identity to render,
and emitted them in the order the slice happened to arrive in.

Those three decisions now belong to one value that resolution freezes.

- **Final artifact**: one item the generated Rust file will contain. Today that
  is a private converter; the later steps of #581 add exported wrappers (the
  `extern "C"` or JNI function a declared `#[prebindgen]` function becomes),
  the helpers those wrappers call, type mirrors, constants and feature guards.
- **`ArtifactKey`**: the identity a final artifact is held under. A private
  converter is keyed by the registry `OperationId` it implements; every other
  final artifact is keyed by the adapter-scoped `ArtifactId` its plan was
  recorded under. Neither is a Rust symbol — final emission still allocates
  those through `RustWriter`.
- **`Assembly`**: the frozen, ordered set of final artifacts a file is
  assembled from. `AssemblyBuilder::artifact` keeps one artifact per
  `ArtifactKey`, and a reachable artifact replaces a dormant one already held
  under that key, which is the reachable-representative rule the writer applied
  before.

`write_rust` now takes `&Assembly<A>` and renders it. Cbindgen freezes its
assembly from the fragments of its `GenerationPlan` immediately after that plan
is built; JniGen freezes its assembly inside `JniGenerationPlan::freeze`, from
the same fragments its `converter_functions` collected at the write call.
Neither adapter builds a converter list while writing any more.

## The trait

`RustFunction` becomes `RustArtifact`, the seam every final artifact will
share:

| before | after |
|---|---|
| `operation_id(&self) -> &OperationId` | `key(&self) -> ArtifactKey` |
| `should_emit(&self) -> bool` | `reachable(&self) -> bool` |
| `render(&self, &RustWriter) -> syn::ItemFn` | `render(&self, &RustWriter) -> Vec<syn::Item>` |

Only converters are in the assembly so far, so both `CFunction` and `JFunction`
still render exactly one function each and keep an inherent `render_fn` that
returns it — the tests that inspect a single rendered converter call that.
`render` returns a vector because a prerequisite or a constant artifact emits
several items, and those join the assembly in the next steps.

Unreachable artifacts are kept in the assembly rather than dropped at freeze:
`write_rust` renders them for their function names alone, so that
`UnrenderedConverterCalls` can still name a caller that survived reachability
filtering. Step 5 of #581 replaces that check with dependency edges and removes
the reason to render them.

## Verification

Workspace tests, strict Clippy and `RUSTDOCFLAGS=-D warnings cargo doc` pass.
Every generated artifact in the tree — the C bindings, the C headers, the JNI
Rust and the Kotlin — is byte-for-byte unchanged, which is what the regenerated
working tree staying clean shows.

Step 1 of #581.

— Claude Code (Opus 5)
