### PR TITLE
Plan the C prerequisites as artifacts

### DIFF
--- a/prebindgen-c/src/assembly.rs
+++ b/prebindgen-c/src/assembly.rs
@@ -24,6 +24,18 @@ pub(crate) enum CFinalArtifact {
     Wrapper(Box<CWrapper>),
     /// One captured constant, re-stated as an alias to its source.
     Const(Box<CConst>),
+    /// The memory helpers the generated layer hands `char*` and array blocks
+    /// to C through.
+    Memory(Box<CMemory>),
+    /// One `#[repr(C)]` mirror of a declared data struct.
+    DataStruct(Box<CDataStruct>),
+    /// One `#[repr(C)]` mirror of a declared fieldless enum.
+    Enum(Box<CEnum>),
+    /// One reserved representation value a generated sum-type ABI uses.
+    DomainConstant(Box<CDomainConstant>),
+    /// One artifact the registry generation plan already holds: an opaque
+    /// handle, a value-opaque, a tagged union, or a callback.
+    Planned(Box<CPlanned>),
 }
 
 impl RustArtifact for CFinalArtifact {
@@ -32,6 +44,11 @@ impl RustArtifact for CFinalArtifact {
             Self::Converter(converter) => converter.key(),
             Self::Wrapper(wrapper) => wrapper.key(),
             Self::Const(constant) => constant.key(),
+            Self::Memory(memory) => memory.key(),
+            Self::DataStruct(item) => item.key(),
+            Self::Enum(item) => item.key(),
+            Self::DomainConstant(item) => item.key(),
+            Self::Planned(item) => item.key(),
         }
     }
 
@@ -40,6 +57,11 @@ impl RustArtifact for CFinalArtifact {
             Self::Converter(converter) => converter.render(emit),
             Self::Wrapper(wrapper) => wrapper.render(emit),
             Self::Const(constant) => constant.render(emit),
+            Self::Memory(memory) => memory.render(emit),
+            Self::DataStruct(item) => item.render(emit),
+            Self::Enum(item) => item.render(emit),
+            Self::DomainConstant(item) => item.render(emit),
+            Self::Planned(item) => item.render(emit),
         }
     }
 }
@@ -583,5 +605,353 @@ impl RustArtifact for CConst {
             .as_ref()
             .map(|module| vec![syn::Item::Const(emit.const_alias(&self.constant, module))])
             .unwrap_or_default()
+    }
+}
+
+/// An adapter-scoped artifact identity, for the artifacts this module names
+/// itself rather than reading off the generation plan.
+fn artifact_id(kind: &str, name: impl Into<String>) -> ArtifactKey {
+    ArtifactKey::Artifact(
+        prebindgen_registry::generation::ArtifactId::new(kind, name)
+            .expect("a C artifact name is non-empty"),
+    )
+}
+
+/// One artifact the registry generation plan already holds.
+///
+/// Handles, value-opaques, tagged unions and callbacks are planned into the
+/// generation plan while their sites are compiled. This is the same artifact,
+/// placed in the file: the payload is the plan's, and rendering it is a lookup
+/// in a frozen plan.
+pub(crate) struct CPlanned {
+    generation: Rc<GenerationPlan<crate::compile::CRepresentation>>,
+    id: prebindgen_registry::generation::ArtifactId,
+}
+
+impl CPlanned {
+    /// Every planned artifact of one kind, in the plan's own order.
+    pub(crate) fn of_kind(
+        generation: &Rc<GenerationPlan<crate::compile::CRepresentation>>,
+        kind: &str,
+    ) -> Vec<Self> {
+        generation
+            .artifacts()
+            .filter(|artifact| artifact.id().kind() == kind)
+            .map(|artifact| Self {
+                generation: Rc::clone(generation),
+                id: artifact.id().clone(),
+            })
+            .collect()
+    }
+}
+
+impl RustArtifact for CPlanned {
+    fn key(&self) -> ArtifactKey {
+        ArtifactKey::Artifact(self.id.clone())
+    }
+
+    fn render(&self, emit: &prebindgen_registry::RustWriter) -> Vec<syn::Item> {
+        self.generation
+            .artifact(&self.id)
+            .unwrap_or_else(|| panic!("the C generation plan lost artifact {}", self.id))
+            .payload()
+            .render(emit)
+    }
+}
+
+/// The memory helpers: the C allocator the generated layer calls, the raw
+/// C-string block builder, the universal freer C calls back, and — when a
+/// `Vec<T>` return hands out a block — the array builder.
+///
+/// Planned only when the layer actually hands memory to C, which is also when
+/// a declared `.free_memory_function` becomes required.
+pub(crate) struct CMemory {
+    /// The declared freer's exported symbol.
+    free_ident: syn::Ident,
+    /// Whether a `Vec<T>` return hands out an array block.
+    arrays: bool,
+}
+
+impl CMemory {
+    /// Plan the memory helpers, if this binding hands memory to C at all.
+    pub(crate) fn new(decls: &CbindgenBuilder, registry: &Registry) -> Option<Self> {
+        let arrays = decls.produces_array(registry);
+        if !(decls.needs_free(registry) || arrays) {
+            return None;
+        }
+        let Some(free_fn) = &decls.free_fn else {
+            panic!(
+                "Cbindgen: the generated layer hands `char*` string memory to C \
+                 (a `String` return or a `String` data-struct field) but no \
+                 memory-freeing function is declared — add \
+                 `.free_memory_function(\"z_free\")`"
+            )
+        };
+        Some(Self {
+            free_ident: format_ident!("{}", free_fn),
+            arrays,
+        })
+    }
+}
+
+impl RustArtifact for CMemory {
+    fn key(&self) -> ArtifactKey {
+        artifact_id("c-runtime", "memory")
+    }
+
+    fn render(&self, _emit: &prebindgen_registry::RustWriter) -> Vec<syn::Item> {
+        let free_ident = &self.free_ident;
+        // C allocator (linked from the C runtime; no crate dependency).
+        let mut items: Vec<syn::Item> = vec![
+            syn::parse_quote!(
+                extern "C" {
+                    fn malloc(size: usize) -> *mut ::core::ffi::c_void;
+                    fn free(ptr: *mut ::core::ffi::c_void);
+                }
+            ),
+            // Raw, destructor-free C-string block. `CString::new` drops interior
+            // NULs so the terminator marks the true end for C consumers.
+            syn::parse_quote!(
+                #[allow(non_snake_case, dead_code)]
+                pub(crate) fn __cbg_alloc_cstr(
+                    s: ::std::string::String,
+                ) -> *mut ::core::ffi::c_char {
+                    let c = ::std::ffi::CString::new(s).unwrap_or_default();
+                    let bytes = c.as_bytes_with_nul();
+                    unsafe {
+                        let p = malloc(bytes.len()) as *mut u8;
+                        if p.is_null() {
+                            return ::core::ptr::null_mut();
+                        }
+                        ::core::ptr::copy_nonoverlapping(bytes.as_ptr(), p, bytes.len());
+                        p as *mut ::core::ffi::c_char
+                    }
+                }
+            ),
+            // Universal raw memory freer: type-agnostic C `free`, no length, no
+            // destructor (NULL-safe via C `free`).
+            syn::parse_quote!(
+                #[no_mangle]
+                #[allow(non_snake_case, unused_variables)]
+                pub unsafe extern "C" fn #free_ident(p: *mut ::core::ffi::c_void) {
+                    free(p);
+                }
+            ),
+        ];
+        if self.arrays {
+            // Array builder: copy a `Vec<W>` into a C-`malloc`'d block of `W`
+            // and return `(ptr, len)` (empty ⇒ `(NULL, 0)`). The block is freed
+            // C-side via the `z_free_array` macro (per-element drop + the
+            // universal freer).
+            items.push(syn::parse_quote!(
+                #[allow(non_snake_case, dead_code)]
+                pub(crate) unsafe fn __cbg_alloc_array<W>(
+                    v: ::std::vec::Vec<W>,
+                ) -> (*mut W, usize) {
+                    let n = v.len();
+                    if n == 0 {
+                        return (::core::ptr::null_mut(), 0);
+                    }
+                    let p = malloc(n.wrapping_mul(::core::mem::size_of::<W>())) as *mut W;
+                    if p.is_null() {
+                        return (::core::ptr::null_mut(), 0);
+                    }
+                    for (i, e) in v.into_iter().enumerate() {
+                        ::core::ptr::write(p.add(i), e);
+                    }
+                    (p, n)
+                }
+            ));
+        }
+        items
+    }
+}
+
+/// One declared data struct's `#[repr(C)]` mirror.
+///
+/// The mirror is a layout fact: each field is stated in its wire form, which
+/// is decided while planning, when the binding's declarations and the model
+/// are both available.
+pub(crate) struct CDataStruct {
+    /// The C-facing struct name.
+    c_struct: syn::Ident,
+    /// Field name and wire type, in source order.
+    fields: Vec<(syn::Ident, syn::Type)>,
+}
+
+impl CDataStruct {
+    /// Plan the mirrors of every declared data struct that crosses.
+    pub(crate) fn all(decls: &CbindgenBuilder, registry: &Registry) -> Vec<Self> {
+        let mut mirrors = Vec::new();
+        for (key, _cfg) in sorted_by_key(&decls.data) {
+            let Some(reading) = registry.reading(key) else {
+                continue;
+            };
+            if decls.in_frag(&reading).is_none() && decls.out_frag(&reading).is_none() {
+                continue;
+            }
+            let Some(fields) = decls.struct_fields(registry, &reading.key()) else {
+                continue;
+            };
+            mirrors.push(Self {
+                c_struct: decls.c_type_ident(&reading.key()),
+                fields: fields
+                    .iter()
+                    .map(|(name, ty)| {
+                        let wire = decls.data_field_wire(ty).unwrap_or_else(|| {
+                            panic!(
+                                "Cbindgen: field `{}` of data struct `{}` has unsupported type `{}`",
+                                name,
+                                type_short(&reading.key()),
+                                ty
+                            )
+                        });
+                        (name.clone(), wire)
+                    })
+                    .collect(),
+            });
+        }
+        mirrors
+    }
+}
+
+impl RustArtifact for CDataStruct {
+    fn key(&self) -> ArtifactKey {
+        artifact_id("c-data-struct", self.c_struct.to_string())
+    }
+
+    fn render(&self, _emit: &prebindgen_registry::RustWriter) -> Vec<syn::Item> {
+        let c_struct = &self.c_struct;
+        let fields = self
+            .fields
+            .iter()
+            .map(|(name, wire)| quote!(pub #name: #wire));
+        vec![syn::parse_quote!(
+            #[repr(C)]
+            #[allow(non_camel_case_types)]
+            pub struct #c_struct {
+                #(#fields,)*
+            }
+        )]
+    }
+}
+
+/// One declared fieldless enum's `#[repr(C)]` mirror.
+///
+/// Each discriminant is re-stated **as written** — `= 0x07` stays `0x07` —
+/// which is what keeps every value C already accepted: a `const` or
+/// `cfg`-driven expression, and anything the source's own `repr` admits.
+/// Resolving each to a number would narrow that to what `i64` and a literal
+/// can express, for no gain, since cbindgen re-reads this as Rust source.
+///
+/// That is why the model's own values are retained here and spelled by the
+/// writer, rather than the mirror being spelled while planning.
+pub(crate) struct CEnum {
+    /// The C-facing enum name.
+    c_name: syn::Ident,
+    /// The source enum's values, in declaration order.
+    values: Vec<prebindgen_registry::flat::EnumValue>,
+}
+
+impl CEnum {
+    /// Plan the mirrors of every declared fieldless enum that crosses.
+    pub(crate) fn all(decls: &CbindgenBuilder, registry: &Registry) -> Vec<Self> {
+        let mut mirrors = Vec::new();
+        for (key, _cfg) in sorted_by_key(&decls.enums) {
+            let Some(reading) = registry.reading(key) else {
+                continue;
+            };
+            if decls.in_frag(&reading).is_none() && decls.out_frag(&reading).is_none() {
+                continue;
+            }
+            let Some(item) = unit_enum(registry, &reading.key()) else {
+                continue;
+            };
+            mirrors.push(Self {
+                c_name: decls.c_type_ident(&reading.key()),
+                values: item.values.clone(),
+            });
+        }
+        mirrors
+    }
+}
+
+impl RustArtifact for CEnum {
+    fn key(&self) -> ArtifactKey {
+        artifact_id("c-enum", self.c_name.to_string())
+    }
+
+    fn render(&self, emit: &prebindgen_registry::RustWriter) -> Vec<syn::Item> {
+        let c_name = &self.c_name;
+        let variants = self.values.iter().map(|value| {
+            let id = &value.name;
+            match emit.discriminant(value) {
+                Some(expr) => quote!(#id = #expr),
+                None => quote!(#id),
+            }
+        });
+        vec![syn::parse_quote!(
+            #[repr(C)]
+            #[derive(Copy, Clone, Debug, Eq, PartialEq)]
+            #[allow(non_camel_case_types)]
+            pub enum #c_name {
+                #(#variants),*
+            }
+        )]
+    }
+}
+
+/// One reserved representation value a generated sum-type ABI uses.
+pub(crate) struct CDomainConstant {
+    /// The exported constant name.
+    name: syn::Ident,
+    /// The scalar type the value is stated in.
+    ty: syn::Type,
+    /// The value itself.
+    value: syn::Expr,
+    /// Documentation, which differs between a niche slot and the `None` of
+    /// the first optional layer.
+    doc: &'static str,
+}
+
+impl RustArtifact for CDomainConstant {
+    fn key(&self) -> ArtifactKey {
+        artifact_id("c-domain-constant", self.name.to_string())
+    }
+
+    fn render(&self, _emit: &prebindgen_registry::RustWriter) -> Vec<syn::Item> {
+        let (name, ty, value, doc) = (&self.name, &self.ty, &self.value, self.doc);
+        vec![syn::parse_quote!(
+            #[doc = #doc]
+            pub const #name: #ty = #value;
+        )]
+    }
+}
+
+impl CDomainConstant {
+    /// Plan every reserved value the declared conversions need.
+    pub(crate) fn all(decls: &CbindgenBuilder, registry: &Registry) -> Vec<Self> {
+        decls.domain_constants(registry)
+    }
+
+    /// Build one, named by its base and slot index.
+    pub(crate) fn niche(base: &str, index: usize, ty: syn::Type, value: syn::Expr) -> Self {
+        Self {
+            name: format_ident!("{}_NICHE_{}", base, index),
+            ty,
+            value,
+            doc: "Reserved representation value used by generated sum-type ABIs.",
+        }
+    }
+
+    /// Build the `None` of the first optional layer, which shares the first
+    /// niche's value.
+    pub(crate) fn none(base: &str, ty: syn::Type, value: syn::Expr) -> Self {
+        Self {
+            name: format_ident!("{}_NONE", base),
+            ty,
+            value,
+            doc: "Representation of None for the first optional layer.",
+        }
     }
 }

--- a/prebindgen-c/src/chain.rs
+++ b/prebindgen-c/src/chain.rs
@@ -9,7 +9,7 @@
 use prebindgen_registry::{
     chain::{self, Chain as _},
     flat::{Alternative, TypeRef},
-    generation::{ArtifactId, GenerationPlan, SiteId},
+    generation::{ArtifactId, SiteId},
     recipe::Mode,
     write::{ArtifactKey, RustArtifact},
     RustWriter,
@@ -1171,23 +1171,6 @@ impl CArtifact {
             Self::ValueOpaque(value) => value.render(emit),
         }
     }
-}
-
-/// Render one class of C artifacts from the frozen registry plan.
-///
-/// The deliberately narrow signature is the artifact-rendering boundary: final
-/// emission can generate source-type tokens from Flat facts through the writer, but it cannot
-/// reopen the registry or the adapter's mutable compilation cache.
-pub(crate) fn render_artifacts(
-    generation: &GenerationPlan<crate::compile::CRepresentation>,
-    kind: &str,
-    emit: &RustWriter,
-) -> Vec<syn::Item> {
-    generation
-        .artifacts()
-        .filter(|artifact| artifact.id().kind() == kind)
-        .flat_map(|artifact| artifact.payload().render(emit))
-        .collect()
 }
 
 /// One opaque C handle declaration and its typed destructor.

--- a/prebindgen-c/src/convert.rs
+++ b/prebindgen-c/src/convert.rs
@@ -3,8 +3,11 @@ use prebindgen_registry::Conversions;
 use super::*;
 
 impl CbindgenBuilder {
-    pub(crate) fn prereq_domain_constants(&self, registry: &Registry) -> Vec<syn::Item> {
-        let mut items = Vec::new();
+    pub(crate) fn domain_constants(
+        &self,
+        registry: &Registry,
+    ) -> Vec<crate::assembly::CDomainConstant> {
+        let mut constants = Vec::new();
         for decl in &self.convert_decls {
             let Some(domain) = decl.domain() else {
                 continue;
@@ -35,21 +38,22 @@ impl CbindgenBuilder {
                 .take(demand)
                 .enumerate()
             {
-                let name = format_ident!("{}_NICHE_{}", base, index);
-                items.push(syn::parse_quote!(
-                    #[doc = "Reserved representation value used by generated sum-type ABIs."]
-                    pub const #name: #ty = #value;
+                constants.push(crate::assembly::CDomainConstant::niche(
+                    &base,
+                    index,
+                    ty.clone(),
+                    value.clone(),
                 ));
                 if index == 0 {
-                    let none = format_ident!("{}_NONE", base);
-                    items.push(syn::parse_quote!(
-                        #[doc = "Representation of None for the first optional layer."]
-                        pub const #none: #ty = #value;
+                    constants.push(crate::assembly::CDomainConstant::none(
+                        &base,
+                        ty.clone(),
+                        value,
                     ));
                 }
             }
         }
-        items
+        constants
     }
 
     pub(crate) fn custom_plan(

--- a/prebindgen-c/src/lib.rs
+++ b/prebindgen-c/src/lib.rs
@@ -471,7 +471,7 @@ impl CbindgenBuilder {
             .artifacts()
             .filter_map(|artifact| match artifact {
                 assembly::CFinalArtifact::Converter(converter) => Some(&**converter),
-                assembly::CFinalArtifact::Wrapper(_) | assembly::CFinalArtifact::Const(_) => None,
+                _ => None,
             })
     }
 }

--- a/prebindgen-c/src/lib.rs
+++ b/prebindgen-c/src/lib.rs
@@ -471,7 +471,13 @@ impl CbindgenBuilder {
             .artifacts()
             .filter_map(|artifact| match artifact {
                 assembly::CFinalArtifact::Converter(converter) => Some(&**converter),
-                _ => None,
+                assembly::CFinalArtifact::Wrapper(_)
+                | assembly::CFinalArtifact::Const(_)
+                | assembly::CFinalArtifact::Memory(_)
+                | assembly::CFinalArtifact::DataStruct(_)
+                | assembly::CFinalArtifact::Enum(_)
+                | assembly::CFinalArtifact::DomainConstant(_)
+                | assembly::CFinalArtifact::Planned(_) => None,
             })
     }
 }

--- a/prebindgen-c/src/tests/boundary_invariants.rs
+++ b/prebindgen-c/src/tests/boundary_invariants.rs
@@ -455,14 +455,34 @@ fn a_planned_wrapper_holds_no_declaration_object() {
     );
 }
 
+/// A planned artifact — an opaque handle, a value-opaque, a tagged union, a
+/// callback — reaches the file through a lookup in the frozen plan and the
+/// writer, and through nothing else.
 #[test]
-fn callback_renderer_accepts_only_the_frozen_plan() {
-    let renderer: fn(
-        &prebindgen_registry::generation::GenerationPlan<crate::compile::CRepresentation>,
-        &str,
-        &prebindgen_registry::RustWriter,
-    ) -> Vec<syn::Item> = crate::chain::render_artifacts;
-    let _ = renderer;
+fn planned_artifacts_reach_the_file_through_the_frozen_plan() {
+    let source = include_str!("../assembly.rs");
+    let file = syn::parse_file(source).expect("C assembly parses");
+    let fields = file
+        .items
+        .iter()
+        .find_map(|item| match item {
+            syn::Item::Struct(item) if item.ident == "CPlanned" => {
+                Some(item.fields.to_token_stream().to_string())
+            }
+            _ => None,
+        })
+        .expect("the planned-artifact placement");
+    let fields: String = fields.split_whitespace().collect();
+    for forbidden in ["CbindgenBuilder", "Registry,", "Compiled", "RefCell"] {
+        assert!(
+            !fields.contains(forbidden),
+            "a placed artifact retains {forbidden}, so rendering could resume planning"
+        );
+    }
+    assert!(
+        fields.contains("Rc<GenerationPlan") && fields.contains("ArtifactId"),
+        "a placed artifact is a frozen plan and the identity to look up in it"
+    );
 }
 
 #[test]

--- a/prebindgen-c/src/tests/boundary_invariants.rs
+++ b/prebindgen-c/src/tests/boundary_invariants.rs
@@ -473,7 +473,7 @@ fn planned_artifacts_reach_the_file_through_the_frozen_plan() {
         })
         .expect("the planned-artifact placement");
     let fields: String = fields.split_whitespace().collect();
-    for forbidden in ["CbindgenBuilder", "Registry,", "Compiled", "RefCell"] {
+    for forbidden in ["CbindgenBuilder", "Registry", "Compiled", "RefCell"] {
         assert!(
             !fields.contains(forbidden),
             "a placed artifact retains {forbidden}, so rendering could resume planning"

--- a/prebindgen-c/src/trait_impl.rs
+++ b/prebindgen-c/src/trait_impl.rs
@@ -522,87 +522,6 @@ impl CbindgenBuilder {
 /// support items for one concern; the trait method concatenates them in order,
 /// so the emitted preamble is identical to the former single function.
 impl CbindgenBuilder {
-    /// C allocator extern + raw C-string allocator + the universal memory freer.
-    /// Emitted when the layer hands `char*`/array memory to C. Panics if such
-    /// memory is produced but no `.free_memory_function` is declared.
-    fn prereq_alloc_free(&self, registry: &Registry, produces_array: bool) -> Vec<syn::Item> {
-        let mut items: Vec<syn::Item> = Vec::new();
-        if !(self.needs_free(registry) || produces_array) {
-            return items;
-        }
-        let free_ident = match &self.free_fn {
-            Some(name) => format_ident!("{}", name),
-            None => panic!(
-                "Cbindgen: the generated layer hands `char*` string memory to C \
-                 (a `String` return or a `String` data-struct field) but no \
-                 memory-freeing function is declared — add \
-                 `.free_memory_function(\"z_free\")`"
-            ),
-        };
-        // C allocator (linked from the C runtime; no crate dependency).
-        items.push(syn::parse_quote!(
-            extern "C" {
-                fn malloc(size: usize) -> *mut ::core::ffi::c_void;
-                fn free(ptr: *mut ::core::ffi::c_void);
-            }
-        ));
-        // Raw, destructor-free C-string block. `CString::new` drops interior
-        // NULs so the terminator marks the true end for C consumers.
-        items.push(syn::parse_quote!(
-            #[allow(non_snake_case, dead_code)]
-            pub(crate) fn __cbg_alloc_cstr(s: ::std::string::String) -> *mut ::core::ffi::c_char {
-                let c = ::std::ffi::CString::new(s).unwrap_or_default();
-                let bytes = c.as_bytes_with_nul();
-                unsafe {
-                    let p = malloc(bytes.len()) as *mut u8;
-                    if p.is_null() {
-                        return ::core::ptr::null_mut();
-                    }
-                    ::core::ptr::copy_nonoverlapping(bytes.as_ptr(), p, bytes.len());
-                    p as *mut ::core::ffi::c_char
-                }
-            }
-        ));
-        // Universal raw memory freer: type-agnostic C `free`, no length, no
-        // destructor (NULL-safe via C `free`).
-        items.push(syn::parse_quote!(
-            #[no_mangle]
-            #[allow(non_snake_case, unused_variables)]
-            pub unsafe extern "C" fn #free_ident(p: *mut ::core::ffi::c_void) {
-                free(p);
-            }
-        ));
-        items
-    }
-
-    /// Array builder: copy a `Vec<W>` into a C-`malloc`'d block of `W` and
-    /// return `(ptr, len)` (empty ⇒ `(NULL, 0)`). The block is freed C-side
-    /// via the `z_free_array` macro (per-element drop + the universal freer).
-    fn prereq_array_builder(&self, produces_array: bool) -> Vec<syn::Item> {
-        let mut items: Vec<syn::Item> = Vec::new();
-        if !produces_array {
-            return items;
-        }
-        items.push(syn::parse_quote!(
-            #[allow(non_snake_case, dead_code)]
-            pub(crate) unsafe fn __cbg_alloc_array<W>(v: ::std::vec::Vec<W>) -> (*mut W, usize) {
-                let n = v.len();
-                if n == 0 {
-                    return (::core::ptr::null_mut(), 0);
-                }
-                let p = malloc(n.wrapping_mul(::core::mem::size_of::<W>())) as *mut W;
-                if p.is_null() {
-                    return (::core::ptr::null_mut(), 0);
-                }
-                for (i, e) in v.into_iter().enumerate() {
-                    ::core::ptr::write(p.add(i), e);
-                }
-                (p, n)
-            }
-        ));
-        items
-    }
-
     /// Converter fragments consumed by one type-level final artifact.
     fn artifact_fragment_inputs(
         &self,
@@ -831,101 +750,6 @@ impl CbindgenBuilder {
         Ok(artifacts)
     }
 
-    /// Data structs: `#[repr(C)]` mirror only. Heap (`String`) fields are
-    /// `char*` raw blocks the C user releases individually via the
-    /// `free_memory_function` — no per-struct destructor.
-    fn prereq_data_structs(&self, registry: &Registry) -> Vec<syn::Item> {
-        let mut items: Vec<syn::Item> = Vec::new();
-        for (key, _cfg) in sorted_by_key(&self.data) {
-            let Some(reading) = registry.reading(key) else {
-                continue;
-            };
-            if self.in_frag(&reading).is_none() && self.out_frag(&reading).is_none() {
-                continue;
-            }
-            let Some(fields) = self.struct_fields(registry, &reading.key()) else {
-                continue;
-            };
-            let c_struct = self.c_type_ident(&reading.key());
-            let mut field_defs: Vec<TokenStream> = Vec::new();
-            for (fname, fty) in &fields {
-                let wire = self.data_field_wire(fty).unwrap_or_else(|| {
-                    panic!(
-                        "Cbindgen: field `{}` of data struct `{}` has unsupported type `{}`",
-                        fname,
-                        type_short(&reading.key()),
-                        fty
-                    )
-                });
-                field_defs.push(quote!(pub #fname: #wire));
-            }
-            items.push(syn::parse_quote!(
-                #[repr(C)]
-                #[allow(non_camel_case_types)]
-                pub struct #c_struct {
-                    #(#field_defs,)*
-                }
-            ));
-        }
-        items
-    }
-
-    /// Enums: `#[repr(C)]` mirror — variant idents with each discriminant
-    /// **re-emitted verbatim**, exactly as the source wrote it.
-    ///
-    /// Deliberately NOT routed through the shared
-    /// [`enum_discriminant_values`](prebindgen_registry::types_util::enum_discriminant_values).
-    /// That helper resolves each variant to a concrete `i64`, which is what an
-    /// adapter needs when it must *know the number* — JniGenBuilder's `jint` decode
-    /// and the Kotlin `value(N)` constants. This mirror needs no number: it is
-    /// Rust source that cbindgen re-reads, so passing the expression through
-    /// keeps every discriminant C already accepted — a `const` or `cfg`-driven
-    /// expression, and any value the source's own `repr` admits, including
-    /// ones outside `i64`. Resolving here would narrow that domain to what
-    /// `i64` and a literal can express, for no gain.
-    ///
-    /// The two adapters therefore agree on the *rule* (Rust's own assignment
-    /// order, which the shared helper encodes) while differing on what they
-    /// need from it — a number versus a spelling.
-    fn prereq_enums(
-        &self,
-        registry: &Registry,
-        emit: &prebindgen_registry::RustWriter,
-    ) -> Vec<syn::Item> {
-        let mut items: Vec<syn::Item> = Vec::new();
-        for (key, _cfg) in sorted_by_key(&self.enums) {
-            let Some(reading) = registry.reading(key) else {
-                continue;
-            };
-            if self.in_frag(&reading).is_none() && self.out_frag(&reading).is_none() {
-                continue;
-            }
-            let Some(e) = unit_enum(registry, &reading.key()) else {
-                continue;
-            };
-            let cname = self.c_type_ident(&reading.key());
-            // The C mirror re-states the discriminant **as written** — `= 0x07`
-            // stays `0x07` — which is the one consumer `EnumValue`'s retained
-            // syntax exists for, and the model's own docs name it.
-            let variants = e.values.iter().map(|v| {
-                let id = &v.name;
-                match emit.discriminant(v) {
-                    Some(expr) => quote!(#id = #expr),
-                    None => quote!(#id),
-                }
-            });
-            items.push(syn::parse_quote!(
-                #[repr(C)]
-                #[derive(Copy, Clone, Debug, Eq, PartialEq)]
-                #[allow(non_camel_case_types)]
-                pub enum #cname {
-                    #(#variants),*
-                }
-            ));
-        }
-        items
-    }
-
     /// The wire of one payload field, or a generation error naming the
     /// offending variant field and the supported set.
     fn payload_wire_of(&self, key: &TypeKey, variant: &syn::Ident, field: &Field) -> syn::Type {
@@ -1082,6 +906,43 @@ impl CbindgenBuilder {
         // named in source order so the file's layout does not depend on how
         // the declarations were written.
         let mut assembly = prebindgen_registry::write::AssemblyBuilder::new();
+        // The file opens with what the converter and wrapper bodies call: the
+        // memory helpers, then the type-level artifacts in the order C needs
+        // to read them, then the reserved sum-type values.
+        if let Some(memory) = crate::assembly::CMemory::new(&self, &registry) {
+            assembly.artifact(crate::assembly::CFinalArtifact::Memory(Box::new(memory)));
+        }
+        let planned = |kind: &str| {
+            crate::assembly::CPlanned::of_kind(&generation, kind)
+                .into_iter()
+                .map(|artifact| crate::assembly::CFinalArtifact::Planned(Box::new(artifact)))
+                .collect::<Vec<_>>()
+        };
+        for artifact in planned("c-opaque-handle") {
+            assembly.artifact(artifact);
+        }
+        for mirror in crate::assembly::CDataStruct::all(&self, &registry) {
+            assembly.artifact(crate::assembly::CFinalArtifact::DataStruct(Box::new(
+                mirror,
+            )));
+        }
+        for artifact in planned("c-value-opaque") {
+            assembly.artifact(artifact);
+        }
+        for mirror in crate::assembly::CEnum::all(&self, &registry) {
+            assembly.artifact(crate::assembly::CFinalArtifact::Enum(Box::new(mirror)));
+        }
+        for artifact in planned("c-tagged-union") {
+            assembly.artifact(artifact);
+        }
+        for artifact in planned("c-callback") {
+            assembly.artifact(artifact);
+        }
+        for constant in crate::assembly::CDomainConstant::all(&self, &registry) {
+            assembly.artifact(crate::assembly::CFinalArtifact::DomainConstant(Box::new(
+                constant,
+            )));
+        }
         for converter in generation
             .fragments()
             .filter_map(|fragment| fragment.artifact())
@@ -1210,55 +1071,6 @@ impl Prebindgen for CbindgenBuilder {
     // The adapter peels `ty` itself: a rank-0 terminal category, else a
     // wrapper shape (`Option<_>`, `&`/`&mut`/`&[_]`/`&str`). See `in_wrappers`
     // / `out_wrappers`.
-
-    fn prerequisites(
-        &self,
-        registry: &Registry,
-        emit: &prebindgen_registry::RustWriter,
-    ) -> Vec<syn::Item> {
-        // C-string data memory (string returns + `String` fields of data structs)
-        // is malloc'd raw and freed by the single universal `free_memory_function`.
-        // Array returns (`Vec<T>`) also hand out a malloc'd block freed via the
-        // same function (per element through the `z_free_array` macro), so the
-        // allocator/freer prelude is needed for them too. Each section's emitter
-        // lives in the `impl CbindgenBuilder` block above; order is significant.
-        let produces_array = self.produces_array(registry);
-        let mut items: Vec<syn::Item> = Vec::new();
-        items.extend(self.prereq_alloc_free(registry, produces_array));
-        items.extend(self.prereq_array_builder(produces_array));
-        items.extend(crate::chain::render_artifacts(
-            self.generation
-                .as_ref()
-                .expect("C generation plan was not frozen"),
-            "c-opaque-handle",
-            emit,
-        ));
-        items.extend(self.prereq_data_structs(registry));
-        items.extend(crate::chain::render_artifacts(
-            self.generation
-                .as_ref()
-                .expect("C generation plan was not frozen"),
-            "c-value-opaque",
-            emit,
-        ));
-        items.extend(self.prereq_enums(registry, emit));
-        items.extend(crate::chain::render_artifacts(
-            self.generation
-                .as_ref()
-                .expect("C generation plan was not frozen"),
-            "c-tagged-union",
-            emit,
-        ));
-        items.extend(crate::chain::render_artifacts(
-            self.generation
-                .as_ref()
-                .expect("C generation plan was not frozen"),
-            "c-callback",
-            emit,
-        ));
-        items.extend(self.prereq_domain_constants(registry));
-        items
-    }
 
     // ── Item emission ──────────────────────────────────────────────────
 }


### PR DESCRIPTION
## What this changes

`Prebindgen::prerequisites` is the last callback the writer makes into an
adapter. Cbindgen answered it by building nine sections while the file was
written, five of them from live registry queries:

| section | what it asked the registry |
|---|---|
| allocator, C-string block, universal freer | whether the layer hands `char*` or array memory to C |
| array builder | whether a `Vec<T>` return hands out a block |
| opaque handles, value-opaques, tagged unions, callbacks | the frozen generation plan, filtered by artifact kind |
| data-struct mirrors | which declared data structs cross, and each field's wire |
| enum mirrors | which declared enums cross, and their values |
| domain constants | how deep the declared conversions nest optionals |

All nine become artifacts of the assembly, planned when the generation plan is
frozen and placed ahead of the converters in exactly the order they were
emitted in — which is why the generated file does not move.

## The five artifact kinds

- **`CMemory`** carries the memory helpers as one artifact, because they are
  one concern: memory handed to C. It is planned only when that happens, so the
  panic for a missing `.free_memory_function` fires while planning now.
- **`CPlanned`** places one artifact the generation plan already holds —
  handle, value-opaque, tagged union, callback — keeping the plan's order
  within each kind. The payload stays the plan's; the artifact is the identity
  to look it up by, plus an `Rc` to the plan.
- **`CDataStruct`** freezes its fields in wire form. Deciding a field's wire
  needs the binding's declarations, so it is decided while planning.
- **`CEnum`** freezes the model's own values instead, and the writer spells
  them. That is deliberate: a C enum mirror re-states each discriminant **as
  written**, so `= 0x07` stays `0x07` and a `const`- or `cfg`-driven expression
  survives. Resolving each to a number while planning would narrow the domain
  to what `i64` and a literal can express.
- **`CDomainConstant`** is one reserved representation value.

## Scope

`Prebindgen::prerequisites` stays until JniGen's prerequisites follow — its
error channel, handle destructors, vector-build helpers and constant-expression
getters. That is the next PR, and it is what removes the trait's last emission
method. Step 4 of #581 is split into these two, as step 2 was.

## Verification

Workspace tests, strict Clippy, `cargo fmt --check` and
`RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps` pass. Every
generated artifact — C bindings, C headers, JNI Rust, Kotlin — is byte-for-byte
unchanged.

`render_artifacts` is deleted with the callback that called it, and the fence
that pinned its signature —
`callback_renderer_accepts_only_the_frozen_plan` — becomes
`planned_artifacts_reach_the_file_through_the_frozen_plan`, which parses
`CPlanned`'s fields and asserts they are a frozen plan and an identity, with no
`CbindgenBuilder`, `Registry`, `Compiled` or `RefCell` among them. Pinning the
struct rather than a function type is the same instrument #584 and #585 use for
the wrapper and the extern.

Step 4a of #581.

— Claude Code (Opus 5)
