### PR TITLE
Plan the JNI prerequisites as artifacts, and delete prerequisites

### DIFF
--- a/prebindgen-jni/src/jni/emit/vec_build.rs
+++ b/prebindgen-jni/src/jni/emit/vec_build.rs
@@ -163,7 +163,7 @@ pub(crate) fn vec_build_elem(
 /// takes as a `&[T]`/`Vec<T>` input — the set the synthetic `…VecNew/Push/Free`
 /// externs are emitted for (once per type, shared across all such functions).
 /// Deduped by [`TypeKey`] and sorted for deterministic output (mirrors
-/// [`build_handle_destructor_items`]).
+/// [`crate::jni::plan_handle_destructors`]).
 ///
 /// The key is the **canonical** element's, since that is what
 /// [`vec_build_elem`] answers with — so `Vec<Payload>` and `Vec<Box<Payload>>`
@@ -262,7 +262,7 @@ fn vec_helper_symbol(ext: &Declarations, base: &str, suffix: &str) -> String {
 
 /// One `#[no_mangle] extern "C"` `…VecNew/Push/Free` trio per flattenable
 /// element type used as a `&[T]`/`Vec<T>` input — the Rust half of the
-/// build-the-Vec-incrementally path. Modeled on [`build_handle_destructor_items`]
+/// build-the-Vec-incrementally path. Modeled on [`crate::jni::plan_handle_destructors`]
 /// (deterministic symbol sort, emitted only for element types a scanned function
 /// actually takes by slice/Vec).
 ///
@@ -274,18 +274,45 @@ fn vec_helper_symbol(ext: &Declarations, base: &str, suffix: &str) -> String {
 /// error sink (the sink's typed `run` descriptor varies by caller, and `Push` is
 /// shared across all callers of a given element type). This keeps the Kotlin
 /// push loop free of a per-element failure check.
-pub(crate) fn build_vec_build_helper_items(
-    ext: &Declarations,
+pub(crate) fn plan_vec_build_helpers(ext: &Declarations) -> Vec<crate::jni::generation::JVecBuild> {
+    // Planned while the generation plan is being frozen, which is before that
+    // plan is installed on the declarations — so the helpers come from the
+    // planning store rather than through `collect_vec_build_helpers`, which
+    // every post-freeze reader uses.
+    let mut helpers: Vec<_> = ext.vec_build_plans.borrow().values().cloned().collect();
+    helpers.sort_by(|a, b| a.elem.key().as_str().cmp(b.elem.key().as_str()));
+    let mut planned: Vec<crate::jni::generation::JVecBuild> = helpers
+        .into_iter()
+        .map(|helpers| {
+            let base = helpers.base.clone();
+            crate::jni::generation::JVecBuild::new(
+                helpers,
+                vec_helper_symbol(ext, &base, "New"),
+                vec_helper_symbol(ext, &base, "Push"),
+                vec_helper_symbol(ext, &base, "Free"),
+            )
+        })
+        .collect();
+    planned.sort_by(|a, b| a.sort_key().cmp(b.sort_key()));
+    planned
+}
+
+/// The trio's Rust items, in symbol order.
+pub(crate) fn render_vec_build_helpers(
+    plan: &crate::jni::generation::JVecBuild,
     emit: &prebindgen_registry::RustWriter,
 ) -> Vec<syn::Item> {
     let mut named: Vec<(String, syn::Item)> = Vec::new();
-    for h in collect_vec_build_helpers(ext) {
+    {
+        let h = plan.helpers();
+        let (new_sym, push_sym, free_sym) = (
+            plan.new_symbol().to_string(),
+            plan.push_symbol().to_string(),
+            plan.free_symbol().to_string(),
+        );
         // Generated Rust spells `spell()`; the reading is what the plan
         // and the key are taken from.
         let elem = emit.emit_source_type(&h.elem);
-        let new_sym = vec_helper_symbol(ext, &h.base, "New");
-        let push_sym = vec_helper_symbol(ext, &h.base, "Push");
-        let free_sym = vec_helper_symbol(ext, &h.base, "Free");
         let new_id = syn::Ident::new(&new_sym, Span::call_site());
         let push_id = syn::Ident::new(&push_sym, Span::call_site());
         let free_id = syn::Ident::new(&free_sym, Span::call_site());

--- a/prebindgen-jni/src/jni/emit/vec_build.rs
+++ b/prebindgen-jni/src/jni/emit/vec_build.rs
@@ -278,9 +278,9 @@ pub(crate) fn plan_vec_build_helpers(ext: &Declarations) -> Vec<crate::jni::gene
     // Planned while the generation plan is being frozen, which is before that
     // plan is installed on the declarations — so the helpers come from the
     // planning store rather than through `collect_vec_build_helpers`, which
-    // every post-freeze reader uses.
-    let mut helpers: Vec<_> = ext.vec_build_plans.borrow().values().cloned().collect();
-    helpers.sort_by(|a, b| a.elem.key().as_str().cmp(b.elem.key().as_str()));
+    // every post-freeze reader uses. Order comes from the exported symbols
+    // below, so the store's own order does not matter here.
+    let helpers: Vec<_> = ext.vec_build_plans.borrow().values().cloned().collect();
     let mut planned: Vec<crate::jni::generation::JVecBuild> = helpers
         .into_iter()
         .map(|helpers| {

--- a/prebindgen-jni/src/jni/generation.rs
+++ b/prebindgen-jni/src/jni/generation.rs
@@ -233,7 +233,12 @@ impl prebindgen_registry::write::RustArtifact for JFinalArtifact {
     fn reachable(&self) -> bool {
         match self {
             Self::Converter(converter) => converter.should_emit(),
-            _ => true,
+            Self::Wrapper(_)
+            | Self::Const(_)
+            | Self::Prelude
+            | Self::HandleDestructor(_)
+            | Self::VecBuild(_)
+            | Self::ConstantExpr(_) => true,
         }
     }
 

--- a/prebindgen-jni/src/jni/generation.rs
+++ b/prebindgen-jni/src/jni/generation.rs
@@ -33,6 +33,14 @@ pub(crate) struct JniGenerationPlan {
     assembly: prebindgen_registry::write::Assembly<JFinalArtifact>,
 }
 
+/// An adapter-scoped artifact identity.
+fn jni_artifact(kind: &str, name: impl Into<String>) -> prebindgen_registry::write::ArtifactKey {
+    prebindgen_registry::write::ArtifactKey::Artifact(
+        prebindgen_registry::generation::ArtifactId::new(kind, name)
+            .expect("a JNI artifact name is non-empty"),
+    )
+}
+
 /// One final artifact of the generated Rust file.
 pub(crate) enum JFinalArtifact {
     /// A private converter, carrying one value across the boundary.
@@ -42,6 +50,124 @@ pub(crate) enum JFinalArtifact {
     /// One declared constant: an alias to the source item, plus the nullary
     /// extern its Kotlin `val` is initialized from.
     Const(Box<JConst>),
+    /// The error-channel prelude every extern body calls into.
+    Prelude,
+    /// One opaque handle's typed destructor.
+    HandleDestructor(Box<JHandleDestructor>),
+    /// One element type's `…VecNew/Push/Free` trio.
+    VecBuild(Box<JVecBuild>),
+    /// One binding-defined constant expression's nullary getter extern.
+    ConstantExpr(Box<crate::jni::emit::JWrapper>),
+}
+
+/// One opaque handle's typed destructor, and the alignment assertion the
+/// handle encoding rests on.
+///
+/// The source type is retained as a reading and spelled by the writer, since
+/// only the writer knows how to qualify it in the generated file.
+pub(crate) struct JHandleDestructor {
+    /// The handle's source type.
+    reading: prebindgen_registry::flat::TypeRef,
+    /// The exported `freePtr` symbol, which is also this artifact's identity.
+    symbol: String,
+}
+
+impl JHandleDestructor {
+    /// Retain one planned destructor.
+    pub(crate) fn new(reading: prebindgen_registry::flat::TypeRef, symbol: String) -> Self {
+        Self { reading, symbol }
+    }
+
+    /// The exported symbol, which orders the destructors in the file.
+    pub(crate) fn symbol(&self) -> &str {
+        &self.symbol
+    }
+
+    fn render(&self, emit: &prebindgen_registry::RustWriter) -> Vec<syn::Item> {
+        let ty = emit.emit_source_type(&self.reading);
+        let ident = syn::Ident::new(&self.symbol, Span::call_site());
+        vec![
+            syn::parse_quote!(
+                #[no_mangle]
+                #[allow(non_snake_case, unused_variables)]
+                pub(crate) unsafe extern "C" fn #ident(
+                    _env: jni::JNIEnv,
+                    _class: jni::objects::JClass,
+                    ptr: jni::sys::jlong,
+                ) {
+                    if ptr != 0 && (ptr & 1) == 0 {
+                        drop(Box::from_raw(ptr as *mut #ty));
+                    }
+                }
+            ),
+            // Bit 0 of the jlong is the Kotlin-side closed tag, so every handle
+            // type must leave it free: `Box` pointers to `T` are
+            // `align_of::<T>()` aligned, hence the compile-time floor of 2.
+            // Written after the destructor, where the symbol sort that
+            // preceded this artifact put it; an anonymous const asserts from
+            // wherever it stands.
+            syn::parse_quote!(
+                const _: () = {
+                    if ::core::mem::align_of::<#ty>() < 2 {
+                        panic!(
+                            "opaque handle types must have alignment >= 2 (bit 0 is the closed tag)"
+                        );
+                    }
+                };
+            ),
+        ]
+    }
+}
+
+/// One element type's `…VecNew/Push/Free` trio: the frozen flatten plan the
+/// push leaves come from, and the three exported symbols.
+pub(crate) struct JVecBuild {
+    helpers: Rc<VecBuildHelpers>,
+    new_symbol: String,
+    push_symbol: String,
+    free_symbol: String,
+}
+
+impl JVecBuild {
+    /// Retain one planned trio.
+    pub(crate) fn new(
+        helpers: Rc<VecBuildHelpers>,
+        new_symbol: String,
+        push_symbol: String,
+        free_symbol: String,
+    ) -> Self {
+        Self {
+            helpers,
+            new_symbol,
+            push_symbol,
+            free_symbol,
+        }
+    }
+
+    /// The frozen element flatten plan.
+    pub(crate) fn helpers(&self) -> &VecBuildHelpers {
+        &self.helpers
+    }
+
+    pub(crate) fn new_symbol(&self) -> &str {
+        &self.new_symbol
+    }
+
+    pub(crate) fn push_symbol(&self) -> &str {
+        &self.push_symbol
+    }
+
+    pub(crate) fn free_symbol(&self) -> &str {
+        &self.free_symbol
+    }
+
+    /// The first of the three symbols, which orders the trios in the file.
+    pub(crate) fn sort_key(&self) -> &str {
+        [&self.free_symbol, &self.new_symbol, &self.push_symbol]
+            .into_iter()
+            .min()
+            .expect("three symbols")
+    }
 }
 
 /// One declared `#[prebindgen]` constant, exported to Kotlin as an eagerly
@@ -94,20 +220,20 @@ impl prebindgen_registry::write::RustArtifact for JFinalArtifact {
                 prebindgen_registry::generation::ArtifactId::new("jni-wrapper", wrapper.symbol())
                     .expect("an exported symbol is a non-empty artifact name"),
             ),
-            Self::Const(constant) => prebindgen_registry::write::ArtifactKey::Artifact(
-                prebindgen_registry::generation::ArtifactId::new(
-                    "jni-const",
-                    constant.constant.name.to_string(),
-                )
-                .expect("a constant name is a non-empty artifact name"),
-            ),
+            Self::Const(constant) => jni_artifact("jni-const", constant.constant.name.to_string()),
+            Self::Prelude => jni_artifact("jni-runtime", "prelude"),
+            Self::HandleDestructor(destructor) => {
+                jni_artifact("jni-handle-destructor", destructor.symbol())
+            }
+            Self::VecBuild(helpers) => jni_artifact("jni-vec-build", helpers.sort_key()),
+            Self::ConstantExpr(getter) => jni_artifact("jni-constant-expr", getter.symbol()),
         }
     }
 
     fn reachable(&self) -> bool {
         match self {
             Self::Converter(converter) => converter.should_emit(),
-            Self::Wrapper(_) | Self::Const(_) => true,
+            _ => true,
         }
     }
 
@@ -119,6 +245,10 @@ impl prebindgen_registry::write::RustArtifact for JFinalArtifact {
                 syn::Item::Const(emit.const_alias(&constant.constant, &constant.source_module)),
                 syn::Item::Fn(constant.getter.render_fn(emit)),
             ],
+            Self::Prelude => crate::jni::trait_impl::render_prelude(),
+            Self::HandleDestructor(destructor) => destructor.render(emit),
+            Self::VecBuild(helpers) => crate::jni::emit::render_vec_build_helpers(helpers, emit),
+            Self::ConstantExpr(getter) => vec![syn::Item::Fn(getter.render_fn(emit))],
         }
     }
 }
@@ -208,8 +338,26 @@ impl JniGenerationPlan {
             .map(|constant| JConst::new(decls, registry, constant))
             .collect();
 
+        // What the extern bodies call by bare name, then the handle
+        // destructors, the Vec-building helpers and the constant-expression
+        // getters — the file opens with these, as it did when they were
+        // prerequisites.
+        let destructors = crate::jni::trait_impl::plan_handle_destructors(decls, registry);
+        let vec_builds = crate::jni::emit::plan_vec_build_helpers(decls);
+        let constant_exprs = crate::jni::trait_impl::plan_constant_expressions(decls, registry);
+
         let conversions = std::mem::take(&mut *decls.compiled.borrow_mut());
         let mut assembly = prebindgen_registry::write::AssemblyBuilder::new();
+        assembly.artifact(JFinalArtifact::Prelude);
+        for destructor in destructors {
+            assembly.artifact(JFinalArtifact::HandleDestructor(Box::new(destructor)));
+        }
+        for helpers in vec_builds {
+            assembly.artifact(JFinalArtifact::VecBuild(Box::new(helpers)));
+        }
+        for getter in constant_exprs {
+            assembly.artifact(JFinalArtifact::ConstantExpr(Box::new(getter)));
+        }
         for converter in conversions
             .fragments()
             .into_iter()

--- a/prebindgen-jni/src/jni/trait_impl.rs
+++ b/prebindgen-jni/src/jni/trait_impl.rs
@@ -209,29 +209,6 @@ pub(crate) fn build_signal_domain_error_item() -> syn::Item {
     )
 }
 
-/// One `#[no_mangle] extern "C"` destructor per opaque handle — the Rust
-/// counterpart to the `public fun free() = free {
-/// freePtr<suffix>(it) }` / `private external fun freePtr<suffix>` pair
-/// emitted by [`render_typed_handle_source`] — so the framework owns *both*
-/// halves of the destructor for every typed-handle class. Each body is the
-/// uniform `drop(Box::from_raw(ptr as *mut T))`; the inner `T`'s own `Drop`
-/// runs (e.g. `Publisher` network-undeclare) with no special casing.
-///
-/// The symbol follows the documented scheme
-/// `Java_<package_underscores>_<class_short>_<mangled-freePtr>`,
-/// where `class_short` is the last segment of the typed-handle FQN
-/// (`TypeConfig::kotlin_name`) and the `freePtr` name passes through
-/// the package/class-aware method hook — exact symmetry with the Kotlin
-/// `external fun <mangled-freePtr>` declaration in
-/// [`render_typed_handle_source`]. `ext.types` is a `HashMap`, so the
-/// artifacts are sorted by symbol to keep generated output deterministic.
-///
-/// Planning is gated on the resolved `registry`: a destructor is only planned
-/// for an opaque handle whose type a scanned `#[prebindgen]` fn actually
-/// references (as input or output). This mirrors converter emission and keeps
-/// feature-gated handles (e.g. `zenoh-ext`-only types whose declare/undeclare
-/// fns are `#[cfg]`'d out of the scan) from producing destructors that
-/// reference types not in scope.
 /// The items every extern body reaches by bare name: the framework error
 /// alias, the `OwnedObject` carrier borrowed-handle plans return, and the two
 /// error-channel functions.
@@ -292,6 +269,29 @@ pub(crate) fn plan_constant_expressions(
         .collect()
 }
 
+/// One `#[no_mangle] extern "C"` destructor per opaque handle — the Rust
+/// counterpart to the `public fun free() = free {
+/// freePtr<suffix>(it) }` / `private external fun freePtr<suffix>` pair
+/// emitted by [`render_typed_handle_source`] — so the framework owns *both*
+/// halves of the destructor for every typed-handle class. Each body is the
+/// uniform `drop(Box::from_raw(ptr as *mut T))`; the inner `T`'s own `Drop`
+/// runs (e.g. `Publisher` network-undeclare) with no special casing.
+///
+/// The symbol follows the documented scheme
+/// `Java_<package_underscores>_<class_short>_<mangled-freePtr>`,
+/// where `class_short` is the last segment of the typed-handle FQN
+/// (`TypeConfig::kotlin_name`) and the `freePtr` name passes through
+/// the package/class-aware method hook — exact symmetry with the Kotlin
+/// `external fun <mangled-freePtr>` declaration in
+/// [`render_typed_handle_source`]. `ext.types` is a `HashMap`, so the
+/// artifacts are sorted by symbol to keep generated output deterministic.
+///
+/// Planning is gated on the resolved `registry`: a destructor is only planned
+/// for an opaque handle whose type a scanned `#[prebindgen]` fn actually
+/// references (as input or output). This mirrors converter emission and keeps
+/// feature-gated handles (e.g. `zenoh-ext`-only types whose declare/undeclare
+/// fns are `#[cfg]`'d out of the scan) from producing destructors that
+/// reference types not in scope.
 pub(crate) fn plan_handle_destructors(
     ext: &Declarations,
     registry: &Registry,

--- a/prebindgen-jni/src/jni/trait_impl.rs
+++ b/prebindgen-jni/src/jni/trait_impl.rs
@@ -224,20 +224,79 @@ pub(crate) fn build_signal_domain_error_item() -> syn::Item {
 /// the package/class-aware method hook — exact symmetry with the Kotlin
 /// `external fun <mangled-freePtr>` declaration in
 /// [`render_typed_handle_source`]. `ext.types` is a `HashMap`, so the
-/// items are sorted by symbol to keep generated output deterministic.
+/// artifacts are sorted by symbol to keep generated output deterministic.
 ///
-/// Emission is gated on the resolved `registry`: a destructor is only
-/// emitted for an opaque handle whose type a scanned `#[prebindgen]` fn
-/// actually references (as input or output). This mirrors converter
-/// emission and keeps feature-gated handles (e.g. `zenoh-ext`-only types
-/// whose declare/undeclare fns are `#[cfg]`'d out of the scan) from
-/// producing destructors that reference types not in scope.
-pub(crate) fn build_handle_destructor_items(
+/// Planning is gated on the resolved `registry`: a destructor is only planned
+/// for an opaque handle whose type a scanned `#[prebindgen]` fn actually
+/// references (as input or output). This mirrors converter emission and keeps
+/// feature-gated handles (e.g. `zenoh-ext`-only types whose declare/undeclare
+/// fns are `#[cfg]`'d out of the scan) from producing destructors that
+/// reference types not in scope.
+/// The items every extern body reaches by bare name: the framework error
+/// alias, the `OwnedObject` carrier borrowed-handle plans return, and the two
+/// error-channel functions.
+///
+/// `__JniErr` is the **framework** error type alias — always the
+/// `JniBindingError` String-wrapper. Built-in converter bodies compose their
+/// `?` failures into this type via its `From<String>` impl. A `Result<T, E>`
+/// return instead binds its own raw `E`; both funnel to the per-call
+/// `signal_error` sink (generic over `Display`).
+///
+/// The two error-channel fns are `signal_binding_error` (binding/system
+/// failure → `JniErrorHandler`) and `signal_domain_error` (a fallible fn's
+/// `Err(E)` → the typed `<Src>Handler`). They are written above the converters
+/// so wrapper code references them by bare name; the binding crate reaches
+/// them as `<include_module>::signal_*` from outside the file.
+pub(crate) fn render_prelude() -> Vec<syn::Item> {
+    let error_type = framework_error_type();
+    let mut items: Vec<syn::Item> = vec![syn::parse_quote!(
+        #[allow(dead_code)]
+        pub(crate) type __JniErr = #error_type;
+    )];
+    items.extend(owned_object_prerequisite_items());
+    items.push(build_signal_binding_error_item());
+    items.push(build_signal_domain_error_item());
+    items
+}
+
+/// One nullary getter extern per binding-defined constant expression.
+///
+/// The expression is evaluated with a glob import of every source module, so
+/// it composes the source crate's items without qualification. The getter
+/// reuses the whole extern pipeline through a synthetic nullary signature,
+/// exactly like a const-backed getter.
+pub(crate) fn plan_constant_expressions(
     ext: &Declarations,
     registry: &Registry,
-    emit: &prebindgen_registry::RustWriter,
-) -> Vec<syn::Item> {
-    let mut named: Vec<(String, syn::Item)> = Vec::new();
+) -> Vec<crate::jni::emit::JWrapper> {
+    let mut glob_modules = registry.all_source_modules();
+    if glob_modules.is_empty() {
+        glob_modules.push(ext.default_module(registry));
+    }
+    ext.packages
+        .values()
+        .flat_map(|package| &package.constant_exprs)
+        .map(|decl| {
+            validate_constant_expr(ext, &decl.kotlin_name, &decl.ty);
+            let getter = const_expr_getter_fn(&decl.kotlin_name, &decl.ty, registry);
+            let expr = &decl.expr;
+            let callee: syn::Expr = syn::parse_quote!({
+                #(
+                    #[allow(unused_imports)]
+                    use #glob_modules::*;
+                )*
+                #expr
+            });
+            crate::jni::emit::JWrapper::new(ext, registry, &getter, Some(callee))
+        })
+        .collect()
+}
+
+pub(crate) fn plan_handle_destructors(
+    ext: &Declarations,
+    registry: &Registry,
+) -> Vec<crate::jni::generation::JHandleDestructor> {
+    let mut planned: Vec<crate::jni::generation::JHandleDestructor> = Vec::new();
     for (key, cfg) in &ext.types {
         if !cfg.is_opaque() {
             continue;
@@ -252,14 +311,13 @@ pub(crate) fn build_handle_destructor_items(
         if ext.in_frag(&reading).is_none() && ext.out_frag(&reading).is_none() {
             continue;
         }
-        let ty = emit.emit_source_type(&reading);
         let class_fqn = cfg
             .name_spec
             .as_ref()
             .map(|s| ext.fqn_of(s))
             .unwrap_or_else(|| {
                 panic!(
-                    "build_handle_destructor_items: opaque handle `{}` has no \
+                    "plan_handle_destructors: opaque handle `{}` has no \
                      name spec to derive a destructor symbol from",
                     key.as_str()
                 )
@@ -267,39 +325,13 @@ pub(crate) fn build_handle_destructor_items(
         let class_short = class_fqn.rsplit('.').next().unwrap_or(&class_fqn);
         let class_package = class_fqn.rsplit_once('.').map(|(pkg, _)| pkg).unwrap_or("");
         let free_ptr = ext.mangle_method(class_package, class_short, "freePtr");
-        let symbol = super::symbol::native_symbol(class_package, class_short, &free_ptr);
-        let ident = syn::Ident::new(&symbol, Span::call_site());
-        // Bit 0 of the jlong is the Kotlin-side closed tag, so every handle
-        // type must leave it free: `Box` pointers to `T` are `align_of::<T>()`
-        // aligned, hence the compile-time floor of 2. `ty` is already the
-        // registry-owned final output fragment before it enters this macro.
-        let item: syn::Item = syn::parse_quote!(
-            const _: () = {
-                if ::core::mem::align_of::<#ty>() < 2 {
-                    panic!(
-                        "opaque handle types must have alignment >= 2 (bit 0 is the closed tag)"
-                    );
-                }
-            };
-        );
-        named.push((format!("{symbol}__align_assert"), item));
-        let item: syn::Item = syn::parse_quote!(
-            #[no_mangle]
-            #[allow(non_snake_case, unused_variables)]
-            pub(crate) unsafe extern "C" fn #ident(
-                _env: jni::JNIEnv,
-                _class: jni::objects::JClass,
-                ptr: jni::sys::jlong,
-            ) {
-                if ptr != 0 && (ptr & 1) == 0 {
-                    drop(Box::from_raw(ptr as *mut #ty));
-                }
-            }
-        );
-        named.push((symbol, item));
+        planned.push(crate::jni::generation::JHandleDestructor::new(
+            reading,
+            super::symbol::native_symbol(class_package, class_short, &free_ptr),
+        ));
     }
-    named.sort_by(|a, b| a.0.cmp(&b.0));
-    named.into_iter().map(|(_, item)| item).collect()
+    planned.sort_by(|a, b| a.symbol().cmp(b.symbol()));
+    planned
 }
 
 /// What generated Rust can do with one wrapper the model
@@ -1270,75 +1302,6 @@ impl Prebindgen for Declarations {
     fn validate_resolved(&self, registry: &Registry) -> Result<(), String> {
         validate_bindings(self, registry)
     }
-
-    /// Emit shared Rust items needed by JNI wrappers and late converters.
-    ///
-    /// This includes the `OwnedObject<T>` carrier used by borrowed opaque
-    /// handle plans. It is referenced unqualified from the same generated
-    /// file, so no `use` path leaks into the host crate's source tree.
-    fn prerequisites(
-        &self,
-        registry: &Registry,
-        emit: &prebindgen_registry::RustWriter,
-    ) -> Vec<syn::Item> {
-        // `__JniErr` is the **framework** error type alias — always the
-        // `JniBindingError` String-wrapper. Built-in converter bodies compose
-        // their `?` failures into this type via its `From<String>` impl. A
-        // `Result<T, E>` return instead binds its own raw `E`; both funnel to
-        // the per-call `signal_error` sink (generic over `Display`).
-        let error_type = framework_error_type();
-        let alias: syn::Item = syn::parse_quote!(
-            #[allow(dead_code)]
-            pub(crate) type __JniErr = #error_type;
-        );
-        let mut items = vec![alias];
-        items.extend(owned_object_prerequisite_items());
-        // The two error-channel fns the extern bodies call: `signal_binding_error`
-        // (binding/system failure → `JniErrorHandler`) and `signal_domain_error`
-        // (a fallible fn's `Err(E)` → the typed `<Src>Handler`). Emitted above the
-        // converters so wrapper code references them by bare name; the binding
-        // crate reaches them as `<include_module>::signal_*` from outside the file.
-        items.push(build_signal_binding_error_item());
-        items.push(build_signal_domain_error_item());
-        let _ = registry;
-        // Handle destructors — one `extern "C" freePtr<suffix>` per
-        // non-suppressed opaque handle (the Rust half of the typed-handle
-        // `free()` pair the Kotlin emitter generates).
-        items.extend(build_handle_destructor_items(self, registry, emit));
-        // Slice/Vec input helpers — a `…VecNew/Push/Free` trio per flattenable
-        // element type a scanned `&[T]`/`Vec<T>` param takes. Kotlin builds the
-        // Rust-side `Vec` by pushing each element's decoupled leaves, then passes
-        // the handle (see `ParamMode::VecBuild`), avoiding per-element
-        // `env.get_field(...)` upcalls on the Rust side.
-        items.extend(build_vec_build_helper_items(self, emit));
-        // Expression constants — one nullary JNI getter extern per
-        // `PackageDecl::constant_expr`, its value the binding-defined
-        // expression evaluated with a glob import of every source module (so
-        // it composes the source crate's items without qualification). The
-        // getter reuses the whole function-wrapper pipeline via the
-        // synthetic signature, exactly like a const-backed getter.
-        let mut glob_modules = registry.all_source_modules();
-        if glob_modules.is_empty() {
-            glob_modules.push(self.default_module(registry));
-        }
-        for decl in self.packages.values().flat_map(|p| &p.constant_exprs) {
-            validate_constant_expr(self, &decl.kotlin_name, &decl.ty);
-            let getter = const_expr_getter_fn(&decl.kotlin_name, &decl.ty, registry);
-            let expr = &decl.expr;
-            let callee: syn::Expr = syn::parse_quote!({
-                #(
-                    #[allow(unused_imports)]
-                    use #glob_modules::*;
-                )*
-                #expr
-            });
-            let wrapper = crate::jni::emit::JWrapper::new(self, registry, &getter, Some(callee));
-            items.push(syn::Item::Fn(wrapper.render_fn(emit)));
-        }
-        items
-    }
-
-    // ── Item methods ─────────────────────────────────────────────────
 }
 
 /// The declaration surface, stated once.

--- a/prebindgen-registry/src/prebindgen.rs
+++ b/prebindgen-registry/src/prebindgen.rs
@@ -200,20 +200,6 @@ impl<M> ConverterImpl<M> {
 /// Reusing a mirror's spelling test in a converted position is how the rule
 /// gets broken (prebindgen#230, #292).
 pub trait Prebindgen {
-    /// Rust items the adapter's emitted converters depend on (helper
-    /// structs, type aliases, runtime-support code). Emitted at the top
-    /// of the destination file, before all auto-generated converters.
-    ///
-    /// Default: none. Wrapper adapters that compose a base adapter should
-    /// forward to or extend the base's `prerequisites()`. The resolved
-    /// `registry` is supplied so prerequisites can be gated on what the
-    /// (feature-aware) scan actually contains — e.g. emitting a
-    /// per-opaque-handle item only for handles a scanned `#[prebindgen]`
-    /// fn references.
-    fn prerequisites(&self, _registry: &Registry, _emit: &crate::RustWriter) -> Vec<syn::Item> {
-        Vec::new()
-    }
-
     // ── Declaration queries ────────────────────────────────────────
 
     /// Adapter-invariant checks that need registry **signatures** — the

--- a/prebindgen-registry/src/write.rs
+++ b/prebindgen-registry/src/write.rs
@@ -154,9 +154,22 @@ impl<A: RustArtifact> AssemblyBuilder<A> {
     /// an unreachable one already held under the same identity, which is what
     /// lets an adapter add a dormant artifact before the parent that reaches
     /// it has been planned.
+    ///
+    /// Two *reachable* artifacts sharing one identity are a planning error,
+    /// not a choice to make: keeping either would drop an item the file needs,
+    /// and the reader would meet it as a missing name in the generated crate
+    /// rather than as a diagnostic here. Converters are exempt — one
+    /// registry operation is legitimately reached from several sites, and
+    /// de-duplicating those is what this method is for.
     pub fn artifact(&mut self, artifact: A) -> &mut Self {
         match self.positions.get(&artifact.key()).copied() {
             Some(position) => {
+                if let ArtifactKey::Artifact(id) = artifact.key() {
+                    assert!(
+                        !(self.artifacts[position].reachable() && artifact.reachable()),
+                        "two reachable artifacts share the identity {id}"
+                    );
+                }
                 if !self.artifacts[position].reachable() && artifact.reachable() {
                     self.artifacts[position] = artifact;
                 }
@@ -215,13 +228,6 @@ pub fn write_rust<P: AsRef<Path>, E: Prebindgen, A: RustArtifact>(
     // deliberately does not.
     let emit = crate::RustWriter::new(registry, ext.source_module());
     let mut items: Vec<syn::Item> = Vec::new();
-
-    // 1. Adapter prerequisites — runtime-support items (helper structs,
-    //    type aliases) the converter bodies depend on. Emitted first so
-    //    everything below can reference them. The last thing an adapter
-    //    still produces while the file is written; #581 step 4 plans these
-    //    as artifacts too.
-    items.extend(ext.prerequisites(registry, &emit));
 
     // Every artifact renders, including the ones the adapter surface does not
     // reach: an unreachable artifact still contributes its function names, so

--- a/prebindgen-registry/src/write/tests.rs
+++ b/prebindgen-registry/src/write/tests.rs
@@ -138,10 +138,15 @@ impl RustArtifact for LateOrCaller {
 /// A converter plan that is dormant when the assembly is frozen and reachable
 /// by the time the file is written is emitted.
 ///
-/// This is not hypothetical: JniGen shares one reachability cell between every
-/// clone of a plan, and marks a plan reachable when a parent that calls it is
-/// compiled. The writer asks each artifact whether it is reachable while it
-/// renders, which is what makes that legal.
+/// What this pins is that reachability is read when the file is written and
+/// not snapshotted while the assembly is frozen. It does not pin *when* during
+/// writing: nothing marks an artifact reachable while another renders, so
+/// reading every artifact's reachability just before the render loop would
+/// satisfy this too.
+///
+/// The property is not hypothetical. JniGen shares one reachability cell
+/// between every clone of a plan and sets it when a parent that calls the plan
+/// is compiled, which can happen after the plan has been added to the builder.
 #[test]
 fn an_artifact_reached_after_freezing_is_emitted() {
     let registry = late_test_registry();
@@ -266,6 +271,14 @@ fn registry_operations_are_deduplicated_before_rendering() {
         rendered_reachable: rendered_reachable.clone(),
     };
     let reachable = OperationPlan {
+        operation: operation.clone(),
+        reachable: true,
+        renders: renders.clone(),
+        rendered_reachable: rendered_reachable.clone(),
+    };
+    // One registry operation reached from a second site: legal, and the
+    // exemption the duplicate-identity guard states.
+    let reached_again = OperationPlan {
         operation,
         reachable: true,
         renders: renders.clone(),
@@ -277,7 +290,7 @@ fn registry_operations_are_deduplicated_before_rendering() {
     write_rust(
         &registry,
         &IdentityExt,
-        &assembly_of([dormant, reachable]),
+        &assembly_of([dormant, reachable, reached_again]),
         dir.join("gen.rs"),
     )
     .expect("write Rust");
@@ -285,7 +298,8 @@ fn registry_operations_are_deduplicated_before_rendering() {
     assert_eq!(
         renders.get(),
         1,
-        "a shared registry operation must be rendered exactly once"
+        "a shared registry operation must be rendered exactly once, however \
+         many sites reached it"
     );
     assert!(
         rendered_reachable.get(),

--- a/prebindgen-registry/src/write/tests.rs
+++ b/prebindgen-registry/src/write/tests.rs
@@ -80,118 +80,117 @@ impl RustArtifact for LatePlan {
     }
 }
 
-struct LateExt {
-    reachable: Rc<Cell<bool>>,
-    activate: bool,
-    call_converter: bool,
+/// An artifact that renders `a_fn`, calling the late converter plan.
+///
+/// Its own reachability is fixed; what varies is whether the plan it calls is
+/// reachable by the time the file is written.
+#[derive(Clone)]
+struct CallerPlan {
     operation: crate::generation::OperationId,
 }
 
-impl Prebindgen for LateExt {
-    /// Emits `a_fn`, and (when `call_converter`) calls the late converter
-    /// plan from it. Prerequisites are the adapter's remaining output
-    /// produced while the file is written, so this is where a caller that
-    /// races the assembly's reachability filtering can still come from.
-    fn prerequisites(&self, _registry: &Registry, emit: &crate::RustWriter) -> Vec<syn::Item> {
-        if self.activate {
-            self.reachable.set(true);
+impl RustArtifact for CallerPlan {
+    fn key(&self) -> ArtifactKey {
+        ArtifactKey::Artifact(
+            crate::generation::ArtifactId::new("test", "caller").expect("identity"),
+        )
+    }
+
+    fn render(&self, emit: &crate::RustWriter) -> Vec<syn::Item> {
+        let converter = emit.operation_ident("test", &self.operation);
+        vec![syn::Item::Fn(
+            syn::parse_quote!(fn a_fn() { #converter(); }),
+        )]
+    }
+}
+
+/// Either artifact of this test's assembly: a converter plan whose
+/// reachability can flip after the assembly is frozen, or the caller.
+#[derive(Clone)]
+enum LateOrCaller {
+    Converter(LatePlan),
+    Caller(CallerPlan),
+}
+
+impl RustArtifact for LateOrCaller {
+    fn key(&self) -> ArtifactKey {
+        match self {
+            Self::Converter(plan) => plan.key(),
+            Self::Caller(plan) => plan.key(),
         }
-        if self.call_converter {
-            let converter = emit.operation_ident("test", &self.operation);
-            vec![syn::Item::Fn(
-                syn::parse_quote!(fn a_fn() { #converter(); }),
-            )]
-        } else {
-            vec![syn::parse_quote!(
-                fn a_fn() {}
-            )]
+    }
+
+    fn reachable(&self) -> bool {
+        match self {
+            Self::Converter(plan) => plan.reachable(),
+            Self::Caller(plan) => plan.reachable(),
+        }
+    }
+
+    fn render(&self, emit: &crate::RustWriter) -> Vec<syn::Item> {
+        match self {
+            Self::Converter(plan) => plan.render(emit),
+            Self::Caller(plan) => plan.render(emit),
         }
     }
 }
 
+/// A converter plan that is dormant when the assembly is frozen and reachable
+/// by the time the file is written is emitted.
+///
+/// This is not hypothetical: JniGen shares one reachability cell between every
+/// clone of a plan, and marks a plan reachable when a parent that calls it is
+/// compiled. The writer asks each artifact whether it is reachable while it
+/// renders, which is what makes that legal.
 #[test]
-fn per_item_planning_precedes_late_converter_filtering() {
-    let item: syn::ItemStruct = syn::parse_quote!(
-        pub struct AStruct;
-    );
-    let registry = crate::test_util::reg_from_items(vec![(
-        syn::Item::Struct(item),
-        SourceLocation::default(),
-    )])
-    .expect("index")
-    .export_type(crate::test_util::declared_origin(syn::parse_quote!(
-        AStruct
-    )))
-    .scanned()
-    .expect("scan");
+fn an_artifact_reached_after_freezing_is_emitted() {
+    let registry = late_test_registry();
     let reachable = Rc::new(Cell::new(false));
     let operation = crate::generation::OperationId::shared(
         crate::generation::ArtifactId::new("test", "late-converter").expect("identity"),
         crate::recipe::Direction::Construct,
     );
-    let ext = LateExt {
-        reachable: reachable.clone(),
-        activate: true,
-        call_converter: false,
-        operation: operation.clone(),
-    };
-    let plan = LatePlan {
+    let assembly = assembly_of([LateOrCaller::Converter(LatePlan {
         operation,
-        reachable,
-    };
+        reachable: reachable.clone(),
+    })]);
     let dir = crate::test_util::unique_test_dir("write_late_plan");
     std::fs::create_dir_all(&dir).unwrap();
 
+    // Frozen dormant, reached afterwards — as a parent compiled later does.
+    reachable.set(true);
     let path =
-        write_rust(&registry, &ext, &assembly_of([plan]), dir.join("gen.rs")).expect("write_rust");
+        write_rust(&registry, &IdentityExt, &assembly, dir.join("gen.rs")).expect("write_rust");
     let source = std::fs::read_to_string(path).expect("read generated file");
 
     assert!(
         source.contains("fn __test_in_convert_wire_to_test_late_converter_"),
         "{source}"
     );
-    // Prerequisites are written before the assembly, so the caller precedes
-    // the converter it activated. What the test pins is that the activation
-    // was seen at all: a plan marked reachable while the file is assembled
-    // survives the filter.
-    assert!(source.find("fn a_fn").unwrap() < source.find("fn __test_in_convert").unwrap());
 }
 
 #[test]
 fn a_call_to_a_filtered_converter_is_a_writer_error() {
-    let item: syn::ItemStruct = syn::parse_quote!(
-        pub struct AStruct;
-    );
-    let registry = crate::test_util::reg_from_items(vec![(
-        syn::Item::Struct(item),
-        SourceLocation::default(),
-    )])
-    .expect("index")
-    .export_type(crate::test_util::declared_origin(syn::parse_quote!(
-        AStruct
-    )))
-    .scanned()
-    .expect("scan");
+    let registry = late_test_registry();
     let reachable = Rc::new(Cell::new(false));
     let operation = crate::generation::OperationId::shared(
         crate::generation::ArtifactId::new("test", "late-converter").expect("identity"),
         crate::recipe::Direction::Construct,
     );
-    let ext = LateExt {
-        reachable: reachable.clone(),
-        activate: false,
-        call_converter: true,
-        operation: operation.clone(),
-    };
-    let plan = LatePlan {
-        operation: operation.clone(),
-        reachable,
-    };
+    let assembly = assembly_of([
+        LateOrCaller::Converter(LatePlan {
+            operation: operation.clone(),
+            reachable,
+        }),
+        LateOrCaller::Caller(CallerPlan {
+            operation: operation.clone(),
+        }),
+    ]);
     let dir = crate::test_util::unique_test_dir("write_missing_converter");
     std::fs::create_dir_all(&dir).unwrap();
     let path = dir.join("gen.rs");
 
-    let err = write_rust(&registry, &ext, &assembly_of([plan]), &path)
+    let err = write_rust(&registry, &IdentityExt, &assembly, &path)
         .expect_err("a call to a filtered private converter must fail in the writer");
 
     match err {
@@ -206,6 +205,40 @@ fn a_call_to_a_filtered_converter_is_a_writer_error() {
         !path.exists(),
         "an invalid generated file must not reach the destination"
     );
+}
+
+/// A registry with one declared type, which is all these two tests need of it.
+fn late_test_registry() -> Registry {
+    crate::test_util::reg_from_items(vec![(
+        syn::Item::Struct(syn::parse_quote!(
+            pub struct AStruct;
+        )),
+        SourceLocation::default(),
+    )])
+    .expect("index")
+    .export_type(crate::test_util::declared_origin(syn::parse_quote!(
+        AStruct
+    )))
+    .scanned()
+    .expect("scan")
+}
+
+/// Two reachable artifacts under one identity are a planning error. A
+/// converter is exempt: one registry operation is legitimately reached from
+/// several sites, which is what the de-duplication above is for.
+#[test]
+#[should_panic(expected = "two reachable artifacts share the identity")]
+fn two_reachable_artifacts_may_not_share_an_identity() {
+    let operation = crate::generation::OperationId::shared(
+        crate::generation::ArtifactId::new("test", "shared-converter").expect("identity"),
+        crate::recipe::Direction::Construct,
+    );
+    let caller = || {
+        LateOrCaller::Caller(CallerPlan {
+            operation: operation.clone(),
+        })
+    };
+    let _ = assembly_of([caller(), caller()]);
 }
 
 #[test]
@@ -350,15 +383,16 @@ fn declared_items_reach_the_file_only_as_artifacts() {
     }
 }
 
-/// What an adapter still hands the writer is typed Rust items, and the writer
-/// never turns tokens back into items itself.
+/// The adapter hands the writer no Rust items at all — everything it emits is
+/// an artifact of its assembly — and the writer never turns tokens back into
+/// items itself.
 #[test]
-fn adapter_emission_carries_typed_items_without_reparsing() {
+fn the_adapter_emits_no_items_and_the_writer_reparses_none() {
     let contract = include_str!("../prebindgen.rs");
     assert_eq!(
         contract.matches("-> Vec<syn::Item>").count(),
-        1,
-        "`prerequisites` is the one method that still returns items to the writer"
+        0,
+        "no method of the trait may return items for the writer to place"
     );
 
     let writer = include_str!("../write.rs");


### PR DESCRIPTION
## What this changes

JniGen answered `Prebindgen::prerequisites` with four groups built while the
file was written:

- the **prelude** every extern body calls by bare name — the `__JniErr` alias,
  the `OwnedObject` carrier borrowed-handle plans return, and the two
  error-channel functions;
- one **destructor** per opaque handle, gated on the handle being referenced by
  a scanned `#[prebindgen]` function;
- one **`…VecNew/Push/Free` trio** per flattenable element type a `&[T]`/`Vec<T>`
  parameter takes;
- one nullary **getter** per binding-defined constant expression.

All four become artifacts, planned while the generation plan is frozen and
placed ahead of the converters in the order they were emitted in.

`JHandleDestructor` retains the handle's source type as a reading — the writer
spells it, since only the writer knows how to qualify it — plus the exported
symbol, which is both its identity and its position. `JVecBuild` retains the
frozen element flatten plan and the three symbols, mangled while planning. The
constant-expression getters are `JWrapper`s, like every other extern, and the
check that a constant expression's type is not an opaque handle moves to
planning with them.

One subtlety: `plan_vec_build_helpers` reads the planning store directly rather
than going through `collect_vec_build_helpers`, because it runs *during*
`JniGenerationPlan::freeze`, before the frozen plan is installed on the
declarations. The frozen reader is untouched — Kotlin emission uses it, and
routing the planner through it produced Kotlin missing every `Vec` helper.

## `Prebindgen` has no emission method left

With both adapters off it, `prerequisites` is deleted. Nothing an adapter
implements returns Rust items for the writer to place any more, which
`the_adapter_emits_no_items_and_the_writer_reparses_none` states as a test.
What remains on the trait is `validate`, `validate_resolved` and
`source_module`.

`write_rust` still takes `&impl Prebindgen`, for `source_module` alone. Taking
the frozen graph and nothing else is step 6.

## The duplicate-identity guard from #587's review

`AssemblyBuilder::artifact` now refuses two *reachable* artifacts under one
identity. Keeping either would silently drop an item the file needs, and the
reader would meet it as a missing name in the generated crate rather than as a
diagnostic here. Converters are exempt, since one registry operation is
legitimately reached from several sites — that is what the de-duplication
exists for. `two_reachable_artifacts_may_not_share_an_identity` covers it.

## Verification

Workspace tests, strict Clippy, `cargo fmt --check` and
`RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps` pass. Every
generated artifact — C bindings, C headers, JNI Rust, Kotlin — is byte-for-byte
unchanged.

Keeping the JNI Rust identical needed one deliberate choice. A handle's
destructor and its alignment assertion used to be two entries in one
symbol-sorted list, `Java_…_freePtr` before `Java_…_freePtr__align_assert`, so
the artifact renders them in that order — the assertion second. An anonymous
const asserts from wherever it stands, so this is placement, not meaning.

The registry's two writer tests move to the assembly, since there is no
callback left to emit their caller from. Both now state their property
directly:

- `an_artifact_reached_after_freezing_is_emitted` — an artifact frozen dormant
  and reached afterwards is still emitted. That is not hypothetical: JniGen
  shares one reachability cell between every clone of a plan and marks it when
  a parent that calls it is compiled, which is why the writer asks each
  artifact whether it is reachable as it renders.
- `a_call_to_a_filtered_converter_is_a_writer_error` — the caller is now an
  artifact of the test assembly rather than callback output, and the assertion
  on the reported `(caller, missing converter)` pair is unchanged.

Step 4b of #581.

— Claude Code (Opus 5)
