### PR TITLE
Prove the file complete from artifact edges

### DIFF
--- a/prebindgen-c/Cargo.toml
+++ b/prebindgen-c/Cargo.toml
@@ -17,3 +17,9 @@ prebindgen-registry = { workspace = true }
 syn = { workspace = true }
 quote = { workspace = true }
 proc-macro2 = { workspace = true }
+
+[dev-dependencies]
+# The registry's test support: `RustWriter::for_registry_test` and
+# `assert_edges_cover_rendered_calls`, which every binding these tests build
+# runs through.
+prebindgen-registry = { workspace = true, features = ["testing"] }

--- a/prebindgen-c/src/assembly.rs
+++ b/prebindgen-c/src/assembly.rs
@@ -52,6 +52,26 @@ impl RustArtifact for CFinalArtifact {
         }
     }
 
+    fn provides(&self) -> Vec<ArtifactKey> {
+        match self {
+            Self::Planned(item) => item.provides(),
+            _ => vec![self.key()],
+        }
+    }
+
+    fn calls(&self) -> Vec<ArtifactKey> {
+        match self {
+            Self::Converter(converter) => converter.calls(),
+            Self::Wrapper(wrapper) => wrapper.calls(),
+            Self::Const(constant) => constant.calls(),
+            Self::Memory(memory) => memory.calls(),
+            Self::DataStruct(item) => item.calls(),
+            Self::Enum(item) => item.calls(),
+            Self::DomainConstant(item) => item.calls(),
+            Self::Planned(item) => item.calls(),
+        }
+    }
+
     fn render(&self, emit: &prebindgen_registry::RustWriter) -> Vec<syn::Item> {
         match self {
             Self::Converter(converter) => converter.render(emit),
@@ -118,6 +138,20 @@ impl CWrapper {
                 .map(|param| decls.alias_slot_of(&param.ty))
                 .collect(),
         }
+    }
+
+    /// One boundary site of this wrapper's own function, when the function has
+    /// one in that role. A void return and an infallible function have no
+    /// return or error site.
+    fn site_if_planned(
+        &self,
+        role: prebindgen_registry::recipe::Role,
+    ) -> Option<&prebindgen_registry::generation::SitePlan<crate::compile::CRepresentation>> {
+        let id = prebindgen_registry::generation::SiteId::new(prebindgen_registry::recipe::Site {
+            owner: self.function.name.clone(),
+            role,
+        });
+        self.generation.site(&id)
     }
 
     /// One boundary site of this wrapper's own function.
@@ -549,6 +583,25 @@ impl CWrapper {
 }
 
 impl RustArtifact for CWrapper {
+    fn calls(&self) -> Vec<ArtifactKey> {
+        // One site per parameter, plus the return and the error channel when
+        // the function has them — the same sites the body decodes and encodes
+        // through.
+        let mut calls = Vec::new();
+        let roles = (0..self.function.params.len())
+            .map(|index| prebindgen_registry::recipe::Role::Param { index })
+            .chain([
+                prebindgen_registry::recipe::Role::Return,
+                prebindgen_registry::recipe::Role::Error,
+            ]);
+        for role in roles {
+            if let Some(site) = self.site_if_planned(role) {
+                site.abi().payload().calls(&mut calls);
+            }
+        }
+        calls
+    }
+
     fn key(&self) -> ArtifactKey {
         ArtifactKey::Artifact(
             prebindgen_registry::generation::ArtifactId::new("c-wrapper", self.symbol.to_string())
@@ -590,6 +643,10 @@ impl CConst {
 }
 
 impl RustArtifact for CConst {
+    fn calls(&self) -> Vec<ArtifactKey> {
+        Vec::new()
+    }
+
     fn key(&self) -> ArtifactKey {
         ArtifactKey::Artifact(
             prebindgen_registry::generation::ArtifactId::new(
@@ -645,7 +702,27 @@ impl CPlanned {
     }
 }
 
+impl CPlanned {
+    /// The plan's own artifact description.
+    fn payload(&self) -> &crate::chain::CArtifact {
+        self.generation
+            .artifact(&self.id)
+            .unwrap_or_else(|| panic!("the C generation plan lost artifact {}", self.id))
+            .payload()
+    }
+}
+
 impl RustArtifact for CPlanned {
+    fn provides(&self) -> Vec<ArtifactKey> {
+        let mut provided = vec![self.key()];
+        provided.extend(self.payload().provides());
+        provided
+    }
+
+    fn calls(&self) -> Vec<ArtifactKey> {
+        self.payload().calls()
+    }
+
     fn key(&self) -> ArtifactKey {
         ArtifactKey::Artifact(self.id.clone())
     }
@@ -695,6 +772,10 @@ impl CMemory {
 }
 
 impl RustArtifact for CMemory {
+    fn calls(&self) -> Vec<ArtifactKey> {
+        Vec::new()
+    }
+
     fn key(&self) -> ArtifactKey {
         artifact_id("c-runtime", "memory")
     }
@@ -816,6 +897,10 @@ impl CDataStruct {
 }
 
 impl RustArtifact for CDataStruct {
+    fn calls(&self) -> Vec<ArtifactKey> {
+        Vec::new()
+    }
+
     fn key(&self) -> ArtifactKey {
         artifact_id("c-data-struct", self.c_struct.to_string())
     }
@@ -877,6 +962,10 @@ impl CEnum {
 }
 
 impl RustArtifact for CEnum {
+    fn calls(&self) -> Vec<ArtifactKey> {
+        Vec::new()
+    }
+
     fn key(&self) -> ArtifactKey {
         artifact_id("c-enum", self.c_name.to_string())
     }
@@ -915,6 +1004,10 @@ pub(crate) struct CDomainConstant {
 }
 
 impl RustArtifact for CDomainConstant {
+    fn calls(&self) -> Vec<ArtifactKey> {
+        Vec::new()
+    }
+
     fn key(&self) -> ArtifactKey {
         artifact_id("c-domain-constant", self.name.to_string())
     }

--- a/prebindgen-c/src/assembly.rs
+++ b/prebindgen-c/src/assembly.rs
@@ -27,6 +27,8 @@ pub(crate) enum CFinalArtifact {
     /// The memory helpers the generated layer hands `char*` and array blocks
     /// to C through.
     Memory(Box<CMemory>),
+    /// The array builder, which copies a `Vec<T>` into a C block.
+    ArrayBuilder,
     /// One `#[repr(C)]` mirror of a declared data struct.
     DataStruct(Box<CDataStruct>),
     /// One `#[repr(C)]` mirror of a declared fieldless enum.
@@ -45,6 +47,7 @@ impl RustArtifact for CFinalArtifact {
             Self::Wrapper(wrapper) => wrapper.key(),
             Self::Const(constant) => constant.key(),
             Self::Memory(memory) => memory.key(),
+            Self::ArrayBuilder => array_builder_key(),
             Self::DataStruct(item) => item.key(),
             Self::Enum(item) => item.key(),
             Self::DomainConstant(item) => item.key(),
@@ -65,6 +68,8 @@ impl RustArtifact for CFinalArtifact {
             Self::Wrapper(wrapper) => wrapper.calls(),
             Self::Const(constant) => constant.calls(),
             Self::Memory(memory) => memory.calls(),
+            // The block it fills is malloc'd, and freed by the universal freer.
+            Self::ArrayBuilder => vec![memory_key()],
             Self::DataStruct(item) => item.calls(),
             Self::Enum(item) => item.calls(),
             Self::DomainConstant(item) => item.calls(),
@@ -78,6 +83,7 @@ impl RustArtifact for CFinalArtifact {
             Self::Wrapper(wrapper) => wrapper.render(emit),
             Self::Const(constant) => constant.render(emit),
             Self::Memory(memory) => memory.render(emit),
+            Self::ArrayBuilder => CMemory::render_array_builder(),
             Self::DataStruct(item) => item.render(emit),
             Self::Enum(item) => item.render(emit),
             Self::DomainConstant(item) => item.render(emit),
@@ -665,6 +671,18 @@ impl RustArtifact for CConst {
     }
 }
 
+/// The memory helpers' identity, which every artifact that hands `char*`
+/// memory to C — or frees any block — depends on.
+pub(crate) fn memory_key() -> ArtifactKey {
+    artifact_id("c-runtime", "memory")
+}
+
+/// The array builder's identity, which every artifact that hands C a block of
+/// converted elements depends on.
+pub(crate) fn array_builder_key() -> ArtifactKey {
+    artifact_id("c-runtime", "array-builder")
+}
+
 /// An adapter-scoped artifact identity, for the artifacts this module names
 /// itself rather than reading off the generation plan.
 fn artifact_id(kind: &str, name: impl Into<String>) -> ArtifactKey {
@@ -745,29 +763,50 @@ impl RustArtifact for CPlanned {
 pub(crate) struct CMemory {
     /// The declared freer's exported symbol.
     free_ident: syn::Ident,
-    /// Whether a `Vec<T>` return hands out an array block.
-    arrays: bool,
 }
 
 impl CMemory {
-    /// Plan the memory helpers, if this binding hands memory to C at all.
-    pub(crate) fn new(decls: &CbindgenBuilder, registry: &Registry) -> Option<Self> {
-        let arrays = decls.produces_array(registry);
-        if !(decls.needs_free(registry) || arrays) {
-            return None;
-        }
+    /// Plan the memory helpers for a binding that hands memory to C.
+    ///
+    /// Whether it does is not asked here: the artifacts that allocate say so
+    /// through their own dependencies, and the caller plans this when one of
+    /// them names it.
+    pub(crate) fn new(decls: &CbindgenBuilder) -> Self {
         let Some(free_fn) = &decls.free_fn else {
             panic!(
-                "Cbindgen: the generated layer hands `char*` string memory to C \
-                 (a `String` return or a `String` data-struct field) but no \
-                 memory-freeing function is declared — add \
+                "Cbindgen: the generated layer hands C memory it must free — a \
+                 `char*` block (a `String` return or a `String` data-struct \
+                 field) or an array block (a `Vec` returned or delivered to a \
+                 callback) — but no memory-freeing function is declared: add \
                  `.free_memory_function(\"z_free\")`"
             )
         };
-        Some(Self {
+        Self {
             free_ident: format_ident!("{}", free_fn),
-            arrays,
-        })
+        }
+    }
+
+    /// Copy a `Vec<W>` into a C-`malloc`'d block of `W` and return
+    /// `(ptr, len)` (empty ⇒ `(NULL, 0)`). The block is freed C-side via the
+    /// `z_free_array` macro (per-element drop + the universal freer).
+    fn render_array_builder() -> Vec<syn::Item> {
+        vec![syn::parse_quote!(
+            #[allow(non_snake_case, dead_code)]
+            pub(crate) unsafe fn __cbg_alloc_array<W>(v: ::std::vec::Vec<W>) -> (*mut W, usize) {
+                let n = v.len();
+                if n == 0 {
+                    return (::core::ptr::null_mut(), 0);
+                }
+                let p = malloc(n.wrapping_mul(::core::mem::size_of::<W>())) as *mut W;
+                if p.is_null() {
+                    return (::core::ptr::null_mut(), 0);
+                }
+                for (i, e) in v.into_iter().enumerate() {
+                    ::core::ptr::write(p.add(i), e);
+                }
+                (p, n)
+            }
+        )]
     }
 }
 
@@ -777,13 +816,13 @@ impl RustArtifact for CMemory {
     }
 
     fn key(&self) -> ArtifactKey {
-        artifact_id("c-runtime", "memory")
+        memory_key()
     }
 
     fn render(&self, _emit: &prebindgen_registry::RustWriter) -> Vec<syn::Item> {
         let free_ident = &self.free_ident;
         // C allocator (linked from the C runtime; no crate dependency).
-        let mut items: Vec<syn::Item> = vec![
+        let items: Vec<syn::Item> = vec![
             syn::parse_quote!(
                 extern "C" {
                     fn malloc(size: usize) -> *mut ::core::ffi::c_void;
@@ -819,31 +858,6 @@ impl RustArtifact for CMemory {
                 }
             ),
         ];
-        if self.arrays {
-            // Array builder: copy a `Vec<W>` into a C-`malloc`'d block of `W`
-            // and return `(ptr, len)` (empty ⇒ `(NULL, 0)`). The block is freed
-            // C-side via the `z_free_array` macro (per-element drop + the
-            // universal freer).
-            items.push(syn::parse_quote!(
-                #[allow(non_snake_case, dead_code)]
-                pub(crate) unsafe fn __cbg_alloc_array<W>(
-                    v: ::std::vec::Vec<W>,
-                ) -> (*mut W, usize) {
-                    let n = v.len();
-                    if n == 0 {
-                        return (::core::ptr::null_mut(), 0);
-                    }
-                    let p = malloc(n.wrapping_mul(::core::mem::size_of::<W>())) as *mut W;
-                    if p.is_null() {
-                        return (::core::ptr::null_mut(), 0);
-                    }
-                    for (i, e) in v.into_iter().enumerate() {
-                        ::core::ptr::write(p.add(i), e);
-                    }
-                    (p, n)
-                }
-            ));
-        }
         items
     }
 }

--- a/prebindgen-c/src/chain.rs
+++ b/prebindgen-c/src/chain.rs
@@ -26,6 +26,11 @@ impl CCall {
         emit.operation_ident("c", self.0.operation_id())
     }
 
+    /// The identity of the artifact this call reaches.
+    pub(crate) fn artifact_key(&self) -> prebindgen_registry::write::ArtifactKey {
+        prebindgen_registry::write::ArtifactKey::Operation(self.0.operation_id().clone())
+    }
+
     pub(crate) fn fallible(&self) -> bool {
         self.0.fallible()
     }
@@ -321,6 +326,36 @@ impl CFunction {
 impl RustArtifact for CFunction {
     fn key(&self) -> ArtifactKey {
         ArtifactKey::Operation(self.operation.clone())
+    }
+
+    fn calls(&self) -> Vec<ArtifactKey> {
+        let mut calls = Vec::new();
+        match &self.body {
+            // A terminal converts the value itself and calls no one.
+            CBody::Custom(_)
+            | CBody::InputTerminal(_)
+            | CBody::OutputTerminal(_)
+            | CBody::Payload(_)
+            | CBody::Borrow(_)
+            | CBody::SliceInput(_)
+            | CBody::Marker(_) => {}
+            CBody::Product(plan) => calls.extend(
+                plan.fields
+                    .iter()
+                    .map(|field| field.converter.artifact_key()),
+            ),
+            CBody::Optional(plan) => calls.push(plan.converter.artifact_key()),
+            CBody::Sequence(plan) => calls.push(plan.child.artifact_key()),
+            CBody::Choice(plan) => calls.extend(
+                plan.arms
+                    .iter()
+                    .flat_map(|arm| &arm.parts)
+                    .map(|part| part.child.artifact_key()),
+            ),
+            // Rendered by its callback artifact, which states the calls.
+            CBody::DeferredInvoke => {}
+        }
+        calls
     }
 
     fn render(&self, emit: &RustWriter) -> Vec<syn::Item> {
@@ -1163,6 +1198,36 @@ pub(crate) enum CArtifact {
 }
 
 impl CArtifact {
+    /// Identities this artifact's items answer for beyond its own.
+    ///
+    /// A callback renders the Invoke helper of its converter operation, whose
+    /// fragment deliberately carries no artifact of its own.
+    pub(crate) fn provides(&self) -> Vec<prebindgen_registry::write::ArtifactKey> {
+        match self {
+            Self::Callback(callback) => vec![prebindgen_registry::write::ArtifactKey::Operation(
+                callback.invoke.operation.clone(),
+            )],
+            Self::OpaqueHandle(_) | Self::TaggedUnion(_) | Self::ValueOpaque(_) => Vec::new(),
+        }
+    }
+
+    /// The converters this artifact's body calls.
+    pub(crate) fn calls(&self) -> Vec<prebindgen_registry::write::ArtifactKey> {
+        let mut calls = Vec::new();
+        match self {
+            // The Invoke helper converts each argument on its way out.
+            Self::Callback(callback) => {
+                for argument in &callback.arguments {
+                    argument.value.calls(&mut calls);
+                }
+            }
+            // A handle is a pointer, a tagged union is a layout, and a
+            // value-opaque is reinterpreted: none of them converts anything.
+            Self::OpaqueHandle(_) | Self::TaggedUnion(_) | Self::ValueOpaque(_) => {}
+        }
+        calls
+    }
+
     pub(crate) fn render(&self, emit: &RustWriter) -> Vec<syn::Item> {
         match self {
             Self::Callback(callback) => callback.render(emit),

--- a/prebindgen-c/src/chain.rs
+++ b/prebindgen-c/src/chain.rs
@@ -331,7 +331,13 @@ impl RustArtifact for CFunction {
     fn calls(&self) -> Vec<ArtifactKey> {
         let mut calls = Vec::new();
         match &self.body {
-            // A terminal converts the value itself and calls no one.
+            // A terminal converts the value itself, except the two that hand
+            // C a `char*` block: those allocate it through the memory helpers.
+            CBody::OutputTerminal(OutputTerminalPlan {
+                operation:
+                    OutputTerminalOperation::String | OutputTerminalOperation::OpaqueError { .. },
+                ..
+            }) => calls.push(crate::assembly::memory_key()),
             CBody::Custom(_)
             | CBody::InputTerminal(_)
             | CBody::OutputTerminal(_)
@@ -1221,9 +1227,18 @@ impl CArtifact {
                     argument.value.calls(&mut calls);
                 }
             }
-            // A handle is a pointer, a tagged union is a layout, and a
-            // value-opaque is reinterpreted: none of them converts anything.
-            Self::OpaqueHandle(_) | Self::TaggedUnion(_) | Self::ValueOpaque(_) => {}
+            // A tagged union's typed destructor frees what its live arm owns,
+            // which reaches a nested union's destructor and the memory helpers.
+            Self::TaggedUnion(union) => {
+                for field in union.arms.iter().flat_map(|arm| &arm.fields) {
+                    if let Some(cleanup) = &field.cleanup {
+                        cleanup.calls(&mut calls);
+                    }
+                }
+            }
+            // A handle is a pointer and a value-opaque is reinterpreted:
+            // neither converts nor frees anything of its own.
+            Self::OpaqueHandle(_) | Self::ValueOpaque(_) => {}
         }
         calls
     }
@@ -1419,6 +1434,23 @@ impl PayloadCleanup {
                 }
             }
             Self::AllocatedString | Self::BoxedPointer { .. } => {}
+        }
+    }
+
+    /// The artifacts this cleanup calls: a nested union's own destructor, and
+    /// the memory helpers whose freer releases a `char*` block.
+    pub(crate) fn calls(&self, out: &mut Vec<prebindgen_registry::write::ArtifactKey>) {
+        match self {
+            Self::NestedUnion { artifact, .. } => out.push(
+                prebindgen_registry::write::ArtifactKey::Artifact(artifact.clone()),
+            ),
+            Self::AllocatedString => out.push(crate::assembly::memory_key()),
+            Self::Fields(fields) => {
+                for (_, cleanup) in fields {
+                    cleanup.calls(out);
+                }
+            }
+            Self::BoxedPointer { .. } => {}
         }
     }
 

--- a/prebindgen-c/src/compile.rs
+++ b/prebindgen-c/src/compile.rs
@@ -69,9 +69,13 @@ impl CValue {
     /// The converters this value's decode or encode calls.
     pub(crate) fn calls(&self, out: &mut Vec<prebindgen_registry::write::ArtifactKey>) {
         match self {
-            Self::Direct { converter, .. }
-            | Self::OwnedSequence { converter, .. }
-            | Self::BorrowedSequence { converter, .. } => out.push(converter.artifact_key()),
+            Self::Direct { converter, .. } => out.push(converter.artifact_key()),
+            // A sequence hands C a malloc'd block, which the array builder
+            // among the memory helpers allocates.
+            Self::OwnedSequence { converter, .. } | Self::BorrowedSequence { converter, .. } => {
+                out.push(converter.artifact_key());
+                out.push(crate::assembly::array_builder_key());
+            }
             Self::Optional { inner, .. } => inner.calls(out),
             // A borrowed input is reinterpreted, not converted.
             Self::BorrowedInput { .. } => {}

--- a/prebindgen-c/src/compile.rs
+++ b/prebindgen-c/src/compile.rs
@@ -66,6 +66,18 @@ pub(crate) enum CValue {
 }
 
 impl CValue {
+    /// The converters this value's decode or encode calls.
+    pub(crate) fn calls(&self, out: &mut Vec<prebindgen_registry::write::ArtifactKey>) {
+        match self {
+            Self::Direct { converter, .. }
+            | Self::OwnedSequence { converter, .. }
+            | Self::BorrowedSequence { converter, .. } => out.push(converter.artifact_key()),
+            Self::Optional { inner, .. } => inner.calls(out),
+            // A borrowed input is reinterpreted, not converted.
+            Self::BorrowedInput { .. } => {}
+        }
+    }
+
     pub(crate) fn direct(&self) -> Option<(&syn::Type, &CCall)> {
         match self {
             Self::Direct {

--- a/prebindgen-c/src/emit.rs
+++ b/prebindgen-c/src/emit.rs
@@ -3,60 +3,6 @@ use prebindgen_registry::Conversions;
 use super::*;
 
 impl CbindgenBuilder {
-    /// Whether the generated layer hands `char*` data memory to C — a `String`
-    /// return value, or a declared data struct that is produced as output and has
-    /// a `String` field. When true, a `free_memory_function` must be declared.
-    pub(super) fn needs_free(&self, registry: &Registry) -> bool {
-        let string_ty: syn::Type = syn::parse_quote!(String);
-        // A `String` return hands out a `char*` — unless `String` is declared
-        // `opaque_ptr` (then it crosses as `string_t *`, freed by `string_drop`).
-        if registry
-            .reading_of(&string_ty)
-            .and_then(|tr| self.out_frag(&tr))
-            .is_some()
-            && !self.opaque.contains_key(&TypeKey::from_type(&string_ty))
-        {
-            return true;
-        }
-        // Opaque error types are marshalled to a malloc'd `char*` message.
-        if self.opaque_errors.keys().any(|key| {
-            registry
-                .reading(key)
-                .and_then(|tr| self.out_frag(&tr))
-                .is_some()
-        }) {
-            return true;
-        }
-        // A tagged union with a `String` payload hands out a `char*` per active
-        // arm — allocated by its output converter, released by its typed drop.
-        if self.tagged_unions.keys().any(|key| {
-            let Some(reading) = registry.reading(key) else {
-                return false;
-            };
-            self.out_frag(&reading).is_some()
-                && self
-                    .enum_alternatives(registry, key)
-                    .map(|alts| {
-                        alts.iter().flat_map(|a| a.fields.iter()).any(|f| {
-                            matches!(f.ty.kind(), prebindgen_registry::flat::TypeKind::String)
-                        })
-                    })
-                    .unwrap_or(false)
-        }) {
-            return true;
-        }
-        self.data.keys().any(|key| {
-            let Some(reading) = registry.reading(key) else {
-                return false;
-            };
-            self.out_frag(&reading).is_some()
-                && self
-                    .struct_fields(registry, key)
-                    .map(|fields| fields.iter().any(|(_, fty)| r_is_string(fty)))
-                    .unwrap_or(false)
-        })
-    }
-
     /// The alternatives of a declared sum, by **identity**.
     ///
     /// Off the element: an `Alternative` holds its fields already classified,
@@ -342,26 +288,6 @@ impl CbindgenBuilder {
                 Err(_) => false,
                 Ok(wire) => self.payload_wire_owns(&f.ty, &wire, registry),
             })
-    }
-
-    /// Whether any declared function returns a `Vec<_>` (possibly nested under
-    /// `Result`/`Option`), so the array builder/freer prelude must be emitted.
-    ///
-    /// A run of values is the whole question — `Vec<T>` and `[T]` alike, and
-    /// through a transparent wrapper, so `Cow<'_, [T]>` counts as the `Vec<T>`
-    /// it crosses as. [`sequence_elem`](prebindgen_registry::flat::TypeRef::sequence_elem)
-    /// answers all three, which is why the two spellings this used to test
-    /// separately need no arms of their own.
-    pub(super) fn produces_array(&self, registry: &Registry) -> bool {
-        self.functions.keys().any(|orig| {
-            registry
-                .flat()
-                .function(&orig)
-                // The model already decided that an elided return and `-> ()`
-                // are one thing, so there is no second arm to write here.
-                .map(|f| f.ret.walk().iter().any(|t| t.sequence_elem().is_some()))
-                .unwrap_or(false)
-        })
     }
 
     /// Fields (`name`, `type`) of a declared data struct, looked up from the

--- a/prebindgen-c/src/lib.rs
+++ b/prebindgen-c/src/lib.rs
@@ -347,6 +347,15 @@ impl Cbindgen {
         &self,
         out_path: impl AsRef<std::path::Path>,
     ) -> Result<std::path::PathBuf, prebindgen_registry::WriteRustError> {
+        // Every binding a test writes also checks that the assembly's
+        // dependency edges name every call its artifacts render — the
+        // completeness the emission-time check reasons from.
+        #[cfg(test)]
+        prebindgen_registry::write::assert_edges_cover_rendered_calls(
+            self.gen.assembly(),
+            &prebindgen_registry::RustWriter::for_registry_test(&self.registry),
+            "c",
+        );
         Ok(prebindgen_registry::write::write_rust(
             &self.registry,
             &self.gen,

--- a/prebindgen-c/src/lib.rs
+++ b/prebindgen-c/src/lib.rs
@@ -486,6 +486,7 @@ impl CbindgenBuilder {
                 | assembly::CFinalArtifact::DataStruct(_)
                 | assembly::CFinalArtifact::Enum(_)
                 | assembly::CFinalArtifact::DomainConstant(_)
+                | assembly::CFinalArtifact::ArrayBuilder
                 | assembly::CFinalArtifact::Planned(_) => None,
             })
     }

--- a/prebindgen-c/src/tests/callbacks.rs
+++ b/prebindgen-c/src/tests/callbacks.rs
@@ -591,10 +591,22 @@ fn a_run_of_converted_optionals_uses_the_declared_wire() {
             impl Fn(Vec<Option<Duration>>) + Send + Sync + 'static
         ))
         .base_name("z_closure_durations_t")
+        // The run hands C a malloc'd block, so the freer that releases it has
+        // to be declared — the same requirement a `Vec` return carries (#437).
+        .free_memory_function("z_free")
         .function(syn::parse_quote!(duration_each));
 
     let src = write(cbindgen, registry, "cb_vec_converted_optional");
     let compact: String = src.split_whitespace().collect();
+
+    // #437: the run is built by the array builder, and this binding returns no
+    // `Vec` at all — the helper is emitted because the callback's own encode
+    // declares it, not because a return type was scanned for one.
+    assert!(compact.contains("__cbg_alloc_array"), "{src}");
+    assert!(
+        compact.contains("fn__cbg_alloc_array<W>"),
+        "the array builder must be emitted for a callback that delivers a run:\n{src}"
+    );
 
     // The run lowers to the element's DECLARED wire, pointer and length.
     assert!(

--- a/prebindgen-c/src/trait_impl.rs
+++ b/prebindgen-c/src/trait_impl.rs
@@ -905,52 +905,45 @@ impl CbindgenBuilder {
         // dependency order, then one exported wrapper per declared function,
         // named in source order so the file's layout does not depend on how
         // the declarations were written.
-        let mut assembly = prebindgen_registry::write::AssemblyBuilder::new();
-        // The file opens with what the converter and wrapper bodies call: the
-        // memory helpers, then the type-level artifacts in the order C needs
-        // to read them, then the reserved sum-type values.
-        if let Some(memory) = crate::assembly::CMemory::new(&self, &registry) {
-            assembly.artifact(crate::assembly::CFinalArtifact::Memory(Box::new(memory)));
-        }
         let planned = |kind: &str| {
             crate::assembly::CPlanned::of_kind(&generation, kind)
                 .into_iter()
                 .map(|artifact| crate::assembly::CFinalArtifact::Planned(Box::new(artifact)))
                 .collect::<Vec<_>>()
         };
-        for artifact in planned("c-opaque-handle") {
-            assembly.artifact(artifact);
-        }
-        for mirror in crate::assembly::CDataStruct::all(&self, &registry) {
-            assembly.artifact(crate::assembly::CFinalArtifact::DataStruct(Box::new(
-                mirror,
-            )));
-        }
-        for artifact in planned("c-value-opaque") {
-            assembly.artifact(artifact);
-        }
-        for mirror in crate::assembly::CEnum::all(&self, &registry) {
-            assembly.artifact(crate::assembly::CFinalArtifact::Enum(Box::new(mirror)));
-        }
-        for artifact in planned("c-tagged-union") {
-            assembly.artifact(artifact);
-        }
-        for artifact in planned("c-callback") {
-            assembly.artifact(artifact);
-        }
-        for constant in crate::assembly::CDomainConstant::all(&self, &registry) {
-            assembly.artifact(crate::assembly::CFinalArtifact::DomainConstant(Box::new(
-                constant,
-            )));
-        }
-        for converter in generation
-            .fragments()
-            .filter_map(|fragment| fragment.artifact())
-        {
-            assembly.artifact(crate::assembly::CFinalArtifact::Converter(Box::new(
-                converter.clone(),
-            )));
-        }
+        // The type-level artifacts, in the order C needs to read them, then
+        // the reserved sum-type values. The runtime helpers they call are
+        // planned below, once these have said what they call.
+        let mut artifacts: Vec<crate::assembly::CFinalArtifact> = Vec::new();
+        artifacts.extend(planned("c-opaque-handle"));
+        artifacts.extend(
+            crate::assembly::CDataStruct::all(&self, &registry)
+                .into_iter()
+                .map(|mirror| crate::assembly::CFinalArtifact::DataStruct(Box::new(mirror))),
+        );
+        artifacts.extend(planned("c-value-opaque"));
+        artifacts.extend(
+            crate::assembly::CEnum::all(&self, &registry)
+                .into_iter()
+                .map(|mirror| crate::assembly::CFinalArtifact::Enum(Box::new(mirror))),
+        );
+        artifacts.extend(planned("c-tagged-union"));
+        artifacts.extend(planned("c-callback"));
+        artifacts.extend(
+            crate::assembly::CDomainConstant::all(&self, &registry)
+                .into_iter()
+                .map(|constant| {
+                    crate::assembly::CFinalArtifact::DomainConstant(Box::new(constant))
+                }),
+        );
+        artifacts.extend(
+            generation
+                .fragments()
+                .filter_map(|fragment| fragment.artifact())
+                .map(|converter| {
+                    crate::assembly::CFinalArtifact::Converter(Box::new(converter.clone()))
+                }),
+        );
         let declared = self.declared_functions();
         let mut wrapped: Vec<_> = registry
             .flat()
@@ -958,20 +951,45 @@ impl CbindgenBuilder {
             .filter(|function| declared.contains(&function.name))
             .collect();
         wrapped.sort_by_key(|function| function.name.to_string());
-        for function in wrapped {
-            assembly.artifact(crate::assembly::CFinalArtifact::Wrapper(Box::new(
-                crate::assembly::CWrapper::new(&self, &generation, function),
-            )));
-        }
+        artifacts.extend(wrapped.into_iter().map(|function| {
+            crate::assembly::CFinalArtifact::Wrapper(Box::new(crate::assembly::CWrapper::new(
+                &self,
+                &generation,
+                function,
+            )))
+        }));
         // Constants: this binding has no constant declaration mechanism, so
         // every captured one is aliased. Named in source order, as the
         // wrappers are.
-        let mut constants: Vec<_> = registry.flat().constants().collect();
-        constants.sort_by_key(|constant| constant.name.to_string());
-        for constant in constants {
-            assembly.artifact(crate::assembly::CFinalArtifact::Const(Box::new(
-                crate::assembly::CConst::new(&self, constant),
+        let mut sorted_constants: Vec<_> = registry.flat().constants().collect();
+        sorted_constants.sort_by_key(|constant| constant.name.to_string());
+        artifacts.extend(sorted_constants.into_iter().map(|constant| {
+            crate::assembly::CFinalArtifact::Const(Box::new(crate::assembly::CConst::new(
+                &self, constant,
+            )))
+        }));
+
+        // The runtime helpers exist because something calls them, so the
+        // planned artifacts are what decide it. Asking them is what makes the
+        // answer exact: a `Vec` delivered to a callback needs the array
+        // builder just as a `Vec` return does, which a gate over return types
+        // alone missed (#437).
+        let calls: std::collections::HashSet<_> = artifacts
+            .iter()
+            .flat_map(prebindgen_registry::write::RustArtifact::calls)
+            .collect();
+        let mut assembly = prebindgen_registry::write::AssemblyBuilder::new();
+        let arrays = calls.contains(&crate::assembly::array_builder_key());
+        if arrays || calls.contains(&crate::assembly::memory_key()) {
+            assembly.artifact(crate::assembly::CFinalArtifact::Memory(Box::new(
+                crate::assembly::CMemory::new(&self),
             )));
+        }
+        if arrays {
+            assembly.artifact(crate::assembly::CFinalArtifact::ArrayBuilder);
+        }
+        for artifact in artifacts {
+            assembly.artifact(artifact);
         }
         self.assembly = Some(assembly.build());
         self.generation = Some(generation);

--- a/prebindgen-jni/src/jni/chain.rs
+++ b/prebindgen-jni/src/jni/chain.rs
@@ -201,6 +201,58 @@ impl JFunction {
 }
 
 impl RustArtifact for JFunction {
+    fn calls(&self) -> Vec<ArtifactKey> {
+        let mut calls = Vec::new();
+        let dependency = |plan: &JFunction, out: &mut Vec<ArtifactKey>| {
+            out.push(ArtifactKey::Operation(plan.operation_id().clone()))
+        };
+        match &self.0 {
+            // A marker converts nothing, and a codec converts the value itself.
+            JBody::Marker(_) => {}
+            JBody::ValueCodec(_) => {}
+            JBody::CustomConversion(_) => {}
+            JBody::HandleCodec(_) => {}
+            JBody::BorrowedOptionalHandle(_) => {}
+            JBody::Result(plan) => dependency(&plan.success, &mut calls),
+            JBody::Transparent(plan) => {
+                dependency(&plan.inner, &mut calls);
+                plan.child.calls(&mut calls);
+            }
+            JBody::Product(plan) => {
+                for child in &plan.dependencies {
+                    dependency(child, &mut calls);
+                }
+                for part in &plan.chain.parts {
+                    part.child.calls(&mut calls);
+                }
+            }
+            JBody::Choice(plan) => {
+                for child in &plan.dependencies {
+                    dependency(child, &mut calls);
+                }
+                for part in plan.chain.arms.iter().flat_map(|arm| &arm.parts) {
+                    part.child.calls(&mut calls);
+                }
+            }
+            JBody::Sequence(plan) => {
+                for child in &plan.dependencies {
+                    dependency(child, &mut calls);
+                }
+                plan.chain.child.calls(&mut calls);
+            }
+            JBody::Optional(plan) => {
+                for child in &plan.dependencies {
+                    dependency(child, &mut calls);
+                }
+                plan.chain.child.calls(&mut calls);
+            }
+            JBody::StructCodec(plan) => plan.calls(&mut calls),
+            JBody::SumCodec(plan) => plan.body.calls(&mut calls),
+            JBody::Invoke(plan) => plan.calls(&mut calls),
+        }
+        calls
+    }
+
     fn key(&self) -> ArtifactKey {
         ArtifactKey::Operation(self.operation_id().clone())
     }
@@ -305,6 +357,14 @@ pub(crate) enum JStructCodecBody {
 }
 
 impl JStructCodecPlan {
+    /// The leaf converters this codec calls, one chain per field.
+    fn calls(&self, out: &mut Vec<ArtifactKey>) {
+        match &self.body {
+            JStructCodecBody::Input(plan) => plan.calls(out),
+            JStructCodecBody::Output { plan, .. } => plan.calls(out),
+        }
+    }
+
     fn render(&self, emit: &RustWriter) -> syn::ItemFn {
         let name = emit.operation_ident("jni", &self.operation);
         let source = emit.emit_source_type(&self.source);
@@ -968,6 +1028,17 @@ pub(crate) struct JChild {
 }
 
 impl JChild {
+    /// The converter this child calls, and the rust-side stages that compose
+    /// with it. Both are separately rendered artifacts.
+    pub(crate) fn calls(&self, out: &mut Vec<ArtifactKey>) {
+        out.push(ArtifactKey::Operation(self.call.operation_id().clone()));
+        out.extend(
+            self.stages
+                .iter()
+                .map(|stage| ArtifactKey::Operation(stage.clone())),
+        );
+    }
+
     pub(crate) fn input(
         converter: OperationId,
         stages: Vec<OperationId>,
@@ -1026,6 +1097,15 @@ struct JVecHandleInput {
 }
 
 impl JPipeline {
+    /// The converters invoking this pipeline calls. A `Vec` handle is
+    /// dereferenced rather than converted, so it calls nothing.
+    pub(crate) fn calls(&self, out: &mut Vec<ArtifactKey>) {
+        match &self.body {
+            JPipelineBody::Converter(child) => child.calls(out),
+            JPipelineBody::VecHandle(_) => {}
+        }
+    }
+
     pub(crate) fn new(wire: syn::Type, child: JChild, borrowed_optional_value: bool) -> Self {
         Self {
             wire,

--- a/prebindgen-jni/src/jni/compile.rs
+++ b/prebindgen-jni/src/jni/compile.rs
@@ -523,6 +523,15 @@ pub(crate) struct OutValueAbi {
 }
 
 impl OutAbi {
+    /// The converters encoding through this ABI calls. A tag is assigned, not
+    /// converted.
+    pub(crate) fn calls(&self, out: &mut Vec<prebindgen_registry::write::ArtifactKey>) {
+        match self {
+            Self::Tag => {}
+            Self::Value(value) => value.pipeline.calls(out),
+        }
+    }
+
     pub(crate) fn activate(&self) {
         if let Self::Value(value) = self {
             value.dependency.mark_reachable();
@@ -531,6 +540,13 @@ impl OutAbi {
 }
 
 impl OutWire {
+    /// The converters encoding this leaf calls.
+    pub(crate) fn calls(&self, out: &mut Vec<prebindgen_registry::write::ArtifactKey>) {
+        if let Some(abi) = &self.abi {
+            abi.calls(out);
+        }
+    }
+
     /// One leaf of an expansion plan, in the recipe's vocabulary.
     ///
     /// The shim that lets the sum emitters speak recipes before every plan is one:

--- a/prebindgen-jni/src/jni/emit/callback.rs
+++ b/prebindgen-jni/src/jni/emit/callback.rs
@@ -25,6 +25,16 @@ enum JInvokePart {
     },
 }
 
+impl JInvokePart {
+    /// The converters this argument crosses through.
+    fn calls(&self, out: &mut Vec<prebindgen_registry::write::ArtifactKey>) {
+        match self {
+            Self::Fold { delivery, .. } | Self::Decomposed { delivery, .. } => delivery.calls(out),
+            Self::Whole { pipeline, .. } => pipeline.calls(out),
+        }
+    }
+}
+
 impl prebindgen_registry::chain::InvokePart for JInvokePart {
     fn render(
         &self,
@@ -228,6 +238,14 @@ pub(crate) struct JInvokePlan {
 impl JInvokePlan {
     pub(crate) fn operation_id(&self) -> &prebindgen_registry::OperationId {
         &self.operation
+    }
+
+    /// The converters this callback's Invoke helper calls, argument by
+    /// argument.
+    pub(crate) fn calls(&self, out: &mut Vec<prebindgen_registry::write::ArtifactKey>) {
+        for part in &self.chain.parts {
+            part.calls(out);
+        }
     }
 
     pub(crate) fn render(&self, emit: &prebindgen_registry::RustWriter) -> syn::ItemFn {

--- a/prebindgen-jni/src/jni/emit/delivery.rs
+++ b/prebindgen-jni/src/jni/emit/delivery.rs
@@ -583,6 +583,19 @@ pub(crate) struct FrozenDelivery {
 }
 
 impl FrozenDelivery {
+    /// Every converter encoding these leaves calls: each leaf's own pipeline,
+    /// and the composed converter when the delivery has one.
+    pub(crate) fn calls(&self, out: &mut Vec<prebindgen_registry::write::ArtifactKey>) {
+        for wire in &self.wires {
+            wire.calls(out);
+        }
+        if let Some(chain) = &self.chain {
+            out.push(prebindgen_registry::write::ArtifactKey::Operation(
+                chain.operation.clone(),
+            ));
+        }
+    }
+
     pub(crate) fn new(
         ext: &Declarations,
         registry: &impl Conversions,

--- a/prebindgen-jni/src/jni/emit/flat_input.rs
+++ b/prebindgen-jni/src/jni/emit/flat_input.rs
@@ -23,6 +23,15 @@ pub(crate) struct JObjectStructInputPlan {
     fields: Vec<JObjectStructFieldPlan>,
 }
 
+impl JObjectStructInputPlan {
+    /// Every converter the decoder calls, one per property.
+    pub(crate) fn calls(&self, out: &mut Vec<prebindgen_registry::write::ArtifactKey>) {
+        for field in &self.fields {
+            field.kind.calls(out);
+        }
+    }
+}
+
 #[derive(Clone)]
 struct JObjectStructFieldPlan {
     name: syn::Ident,
@@ -30,6 +39,20 @@ struct JObjectStructFieldPlan {
     error: String,
     sum_payload: bool,
     kind: JObjectStructFieldKind,
+}
+
+impl JObjectStructFieldKind {
+    /// The pipeline this property decodes through.
+    fn calls(&self, out: &mut Vec<prebindgen_registry::write::ArtifactKey>) {
+        match self {
+            Self::Handle { pipeline, .. }
+            | Self::Unsigned64 { pipeline, .. }
+            | Self::Enum { pipeline, .. }
+            | Self::Primitive { pipeline, .. }
+            | Self::IntoObject { pipeline, .. }
+            | Self::Object { pipeline, .. } => pipeline.calls(out),
+        }
+    }
 }
 
 #[derive(Clone)]
@@ -421,6 +444,20 @@ struct JObjectSumAlternativePlan {
 struct JObjectSumFieldPlan {
     shape: flat::Field,
     property: JObjectStructFieldPlan,
+}
+
+impl JObjectSumInputPlan {
+    /// Every converter the decoder calls, one per property of every
+    /// alternative.
+    pub(crate) fn calls(&self, out: &mut Vec<prebindgen_registry::write::ArtifactKey>) {
+        for field in self
+            .alternatives
+            .iter()
+            .flat_map(|alternative| &alternative.fields)
+        {
+            field.property.kind.calls(out);
+        }
+    }
 }
 
 pub(crate) fn build_jobject_sum_input_plan(

--- a/prebindgen-jni/src/jni/emit/wrapper.rs
+++ b/prebindgen-jni/src/jni/emit/wrapper.rs
@@ -60,6 +60,13 @@ impl JWrapper {
     pub(crate) fn symbol(&self) -> &str {
         &self.plan.native_symbol
     }
+
+    /// The converters this extern's body calls, which are its plan's.
+    pub(crate) fn calls(&self) -> Vec<prebindgen_registry::write::ArtifactKey> {
+        let mut calls = Vec::new();
+        self.plan.calls(&mut calls);
+        calls
+    }
 }
 
 /// The synthetic nullary getter signature a declared const is emitted

--- a/prebindgen-jni/src/jni/emit/wrapper.rs
+++ b/prebindgen-jni/src/jni/emit/wrapper.rs
@@ -61,9 +61,11 @@ impl JWrapper {
         &self.plan.native_symbol
     }
 
-    /// The converters this extern's body calls, which are its plan's.
+    /// What this extern's body calls: the converters its plan names, and the
+    /// prelude, whose error-channel functions every failure path routes
+    /// through.
     pub(crate) fn calls(&self) -> Vec<prebindgen_registry::write::ArtifactKey> {
-        let mut calls = Vec::new();
+        let mut calls = vec![crate::jni::generation::prelude_key()];
         self.plan.calls(&mut calls);
         calls
     }

--- a/prebindgen-jni/src/jni/fn_plan.rs
+++ b/prebindgen-jni/src/jni/fn_plan.rs
@@ -84,6 +84,24 @@ pub(crate) struct PlanParam {
     pub form: ParamForm,
 }
 
+impl PlanLeaf {
+    /// The converter this leaf is decoded through, which is the one its own
+    /// Rust operation invokes: a flattened data class and an optional pair are
+    /// rebuilt by one composed converter of their own, and every other kind
+    /// runs the frozen pipeline.
+    pub(crate) fn calls(&self, out: &mut Vec<prebindgen_registry::write::ArtifactKey>) {
+        match &self.rust {
+            RustParamOp::Pipeline { .. } => self.pipeline.calls(out),
+            RustParamOp::OptionalPair(plan) => out.push(
+                prebindgen_registry::write::ArtifactKey::Operation(plan.chain.operation.clone()),
+            ),
+            RustParamOp::FlattenStruct(plan) => out.push(
+                prebindgen_registry::write::ArtifactKey::Operation(plan.chain.operation.clone()),
+            ),
+        }
+    }
+}
+
 /// How a source parameter crosses the boundary. The single leaf is boxed to
 /// keep the variants near the same size (a [`PlanLeaf`] embeds whole
 /// sub-plans; the `Expanded` payload is just a `Vec` header).
@@ -598,6 +616,49 @@ pub(crate) fn validate_bindings(ext: &Declarations, registry: &Registry) -> Resu
         Ok(())
     } else {
         Err(errors.join("\n"))
+    }
+}
+
+impl JniFunctionPlan {
+    /// Every converter the extern's body calls: one chain per parameter, the
+    /// output's, and the error arm's when the function has one.
+    pub(crate) fn calls(&self, out: &mut Vec<prebindgen_registry::write::ArtifactKey>) {
+        for param in &self.params {
+            match &param.form {
+                ParamForm::Single(leaf) => leaf.calls(out),
+                ParamForm::Expanded { leaves, .. } => {
+                    for leaf in leaves {
+                        leaf.calls(out);
+                    }
+                }
+            }
+        }
+        match &self.output {
+            FnOutputPlan::Value(value) => value.pipeline.calls(out),
+            FnOutputPlan::Unfold(unfold) => {
+                for wire in &unfold.wires {
+                    wire.calls(out);
+                }
+                if let Some(chain) = &unfold.chain {
+                    out.push(prebindgen_registry::write::ArtifactKey::Operation(
+                        chain.operation.clone(),
+                    ));
+                }
+                if let Some(pipeline) = &unfold.element_pipeline {
+                    pipeline.calls(out);
+                }
+            }
+        }
+        if let Some(error) = &self.error {
+            for wire in &error.wires {
+                wire.calls(out);
+            }
+            if let Some(chain) = &error.chain {
+                out.push(prebindgen_registry::write::ArtifactKey::Operation(
+                    chain.operation.clone(),
+                ));
+            }
+        }
     }
 }
 

--- a/prebindgen-jni/src/jni/generation.rs
+++ b/prebindgen-jni/src/jni/generation.rs
@@ -33,6 +33,12 @@ pub(crate) struct JniGenerationPlan {
     assembly: prebindgen_registry::write::Assembly<JFinalArtifact>,
 }
 
+/// The prelude's identity, which every extern depends on: its body routes
+/// failure through the error-channel functions the prelude renders.
+pub(crate) fn prelude_key() -> prebindgen_registry::write::ArtifactKey {
+    jni_artifact("jni-runtime", "prelude")
+}
+
 /// An adapter-scoped artifact identity.
 fn jni_artifact(kind: &str, name: impl Into<String>) -> prebindgen_registry::write::ArtifactKey {
     prebindgen_registry::write::ArtifactKey::Artifact(
@@ -238,7 +244,7 @@ impl prebindgen_registry::write::RustArtifact for JFinalArtifact {
                     .expect("an exported symbol is a non-empty artifact name"),
             ),
             Self::Const(constant) => jni_artifact("jni-const", constant.constant.name.to_string()),
-            Self::Prelude => jni_artifact("jni-runtime", "prelude"),
+            Self::Prelude => prelude_key(),
             Self::HandleDestructor(destructor) => {
                 jni_artifact("jni-handle-destructor", destructor.symbol())
             }
@@ -257,6 +263,14 @@ impl prebindgen_registry::write::RustArtifact for JFinalArtifact {
             | Self::VecBuild(_)
             | Self::ConstantExpr(_) => true,
         }
+    }
+
+    fn provides(&self) -> Vec<prebindgen_registry::write::ArtifactKey> {
+        // Each JNI artifact renders its own items and no one else's: unlike
+        // the C callback, nothing here stands in for an identity whose own
+        // artifact was never planned. Stated rather than inherited, so that an
+        // artifact which does needs a deliberate change here.
+        vec![self.key()]
     }
 
     fn calls(&self) -> Vec<prebindgen_registry::write::ArtifactKey> {

--- a/prebindgen-jni/src/jni/generation.rs
+++ b/prebindgen-jni/src/jni/generation.rs
@@ -161,6 +161,23 @@ impl JVecBuild {
         &self.free_symbol
     }
 
+    /// The converters `Push` calls, one per leaf of the element it builds.
+    pub(crate) fn calls(&self) -> Vec<prebindgen_registry::write::ArtifactKey> {
+        self.helpers
+            .plan
+            .leaves
+            .iter()
+            .filter(|leaf| !leaf.is_present_flag())
+            .map(|leaf| {
+                prebindgen_registry::write::ArtifactKey::Operation(
+                    leaf.conv()
+                        .expect("a non-present leaf has a converter")
+                        .clone(),
+                )
+            })
+            .collect()
+    }
+
     /// The first of the three symbols, which orders the trios in the file.
     pub(crate) fn sort_key(&self) -> &str {
         [&self.free_symbol, &self.new_symbol, &self.push_symbol]
@@ -239,6 +256,17 @@ impl prebindgen_registry::write::RustArtifact for JFinalArtifact {
             | Self::HandleDestructor(_)
             | Self::VecBuild(_)
             | Self::ConstantExpr(_) => true,
+        }
+    }
+
+    fn calls(&self) -> Vec<prebindgen_registry::write::ArtifactKey> {
+        match self {
+            Self::Converter(converter) => converter.calls(),
+            Self::Wrapper(wrapper) | Self::ConstantExpr(wrapper) => wrapper.calls(),
+            Self::Const(constant) => constant.getter.calls(),
+            Self::VecBuild(helpers) => helpers.calls(),
+            // The prelude is self-contained, and a destructor drops a box.
+            Self::Prelude | Self::HandleDestructor(_) => Vec::new(),
         }
     }
 

--- a/prebindgen-jni/src/jni/mod.rs
+++ b/prebindgen-jni/src/jni/mod.rs
@@ -897,6 +897,19 @@ impl JniGen {
         &self,
         out_path: impl AsRef<std::path::Path>,
     ) -> Result<std::path::PathBuf, prebindgen_registry::WriteRustError> {
+        // Every binding a test writes also checks that the assembly's
+        // dependency edges name every call its artifacts render — the
+        // completeness the emission-time check reasons from.
+        #[cfg(test)]
+        prebindgen_registry::write::assert_edges_cover_rendered_calls(
+            self.decls
+                .generation
+                .as_ref()
+                .expect("resolved JniGen has no frozen generation plan")
+                .assembly(),
+            &prebindgen_registry::RustWriter::for_registry_test(&self.registry),
+            "jni",
+        );
         Ok(prebindgen_registry::write::write_rust(
             &self.registry,
             &self.decls,

--- a/prebindgen-jni/src/jni/struct_plan.rs
+++ b/prebindgen-jni/src/jni/struct_plan.rs
@@ -63,6 +63,18 @@ pub(crate) struct ConvChain {
 }
 
 impl ConvChain {
+    /// The artifacts this chain calls: its stages, then the wire-facing
+    /// converter.
+    pub(crate) fn calls(&self, out: &mut Vec<prebindgen_registry::write::ArtifactKey>) {
+        out.extend(
+            self.stages
+                .iter()
+                .chain([&self.function])
+                .cloned()
+                .map(prebindgen_registry::write::ArtifactKey::Operation),
+        );
+    }
+
     /// Read the chain off a resolved output entry.
     fn of(entry: &prebindgen_registry::ConverterImpl<KotlinMeta>) -> Self {
         ConvChain {
@@ -165,6 +177,33 @@ pub(crate) enum PlanFieldKind {
         /// Kotlin-side `?` (an `Option` field whose wire is object-shaped).
         nullable: bool,
     },
+}
+
+impl StructPlan {
+    /// Every converter the encoder calls, field by field and through every
+    /// nested layout.
+    pub(crate) fn calls(&self, out: &mut Vec<prebindgen_registry::write::ArtifactKey>) {
+        for field in &self.fields {
+            field.kind.calls(out);
+        }
+    }
+}
+
+impl PlanFieldKind {
+    fn calls(&self, out: &mut Vec<prebindgen_registry::write::ArtifactKey>) {
+        match self {
+            Self::Projection { conv, .. }
+            | Self::Enum { conv, .. }
+            | Self::OptionEnum { conv, .. }
+            | Self::Leaf { conv, .. } => conv.calls(out),
+            Self::Nested { plan, .. } => plan.calls(out),
+            Self::Sum { variants, .. } => {
+                for field in variants.iter().flat_map(|variant| &variant.fields) {
+                    field.kind.calls(out);
+                }
+            }
+        }
+    }
 }
 
 /// One alternative of a [`PlanFieldKind::Sum`].

--- a/prebindgen-registry/src/write.rs
+++ b/prebindgen-registry/src/write.rs
@@ -242,8 +242,9 @@ impl<A: RustArtifact> FromIterator<A> for Assembly<A> {
     }
 }
 
-/// Check that every call a rendered artifact makes to another artifact's
-/// converter is declared as one of its [`RustArtifact::calls`] edges.
+/// Check an assembly's edges against what its artifacts render: every call to
+/// another artifact's item is declared by [`RustArtifact::calls`], and every
+/// identity [`RustArtifact::provides`] claims is one the artifact defines.
 ///
 /// Test support, like [`RustWriter::for_test`](crate::RustWriter::for_test).
 /// Emission proves the file complete from the edges alone, which is only worth
@@ -265,44 +266,72 @@ pub fn assert_edges_cover_rendered_calls<A: RustArtifact>(
     emit: &crate::RustWriter,
     namespace: &str,
 ) {
-    let ident_of = |key: &ArtifactKey| match key {
-        ArtifactKey::Operation(operation) => {
-            Some(emit.operation_ident(namespace, operation).to_string())
-        }
-        // An exported symbol is called by the destination language, never by
-        // another artifact's body.
-        ArtifactKey::Artifact(_) => None,
-    };
-    let mut converters: HashMap<String, ArtifactKey> = HashMap::new();
-    for artifact in assembly.artifacts() {
-        for key in artifact.provides() {
-            if let Some(ident) = ident_of(&key) {
-                converters.insert(ident, key);
+    // What every artifact actually renders, which is the ground truth both
+    // halves are checked against: a call resolves to an artifact by the name
+    // that artifact defines, whether the identity is an operation or an
+    // adapter-scoped artifact. A runtime helper is called by name like any
+    // converter.
+    let rendered: Vec<(ArtifactKey, BTreeSet<String>, BTreeSet<String>)> = assembly
+        .artifacts()
+        .map(|artifact| {
+            let mut called = CalledIdents(BTreeSet::new());
+            let mut defined = BTreeSet::new();
+            for mut item in artifact.render(emit) {
+                if let syn::Item::Fn(function) = &item {
+                    defined.insert(function.sig.ident.to_string());
+                }
+                syn::visit_mut::VisitMut::visit_item_mut(&mut called, &mut item);
             }
+            (artifact.key(), defined, called.0)
+        })
+        .collect();
+    let mut definer: HashMap<&str, &ArtifactKey> = HashMap::new();
+    for (key, defined, _) in &rendered {
+        for name in defined {
+            definer.insert(name.as_str(), key);
+        }
+    }
+    let mut provider: HashMap<ArtifactKey, usize> = HashMap::new();
+    for (position, artifact) in assembly.artifacts().enumerate() {
+        for key in artifact.provides() {
+            provider.insert(key, position);
         }
     }
 
-    for artifact in assembly.artifacts().filter(|artifact| artifact.reachable()) {
-        let mut allowed: BTreeSet<String> = artifact
-            .provides()
-            .iter()
-            .chain(artifact.calls().iter())
-            .filter_map(ident_of)
-            .collect();
-        // A recursive shape's converter calls itself.
-        allowed.extend(ident_of(&artifact.key()));
-        let mut called = CalledIdents(BTreeSet::new());
-        for mut item in artifact.render(emit) {
-            syn::visit_mut::VisitMut::visit_item_mut(&mut called, &mut item);
+    for (artifact, (key, defined, called)) in assembly.artifacts().zip(&rendered) {
+        // Every identity claimed must be one this artifact actually defines,
+        // or claiming it would grant reachability to an item no one renders.
+        for claimed in artifact.provides() {
+            if let ArtifactKey::Operation(operation) = &claimed {
+                let ident = emit.operation_ident(namespace, operation).to_string();
+                assert!(
+                    defined.contains(&ident),
+                    "{key} claims to provide {claimed}, but renders no `{ident}`"
+                );
+            }
         }
-        for ident in called.0 {
-            if allowed.contains(&ident) {
+        if !artifact.reachable() {
+            continue;
+        }
+        let mut allowed: BTreeSet<&str> = defined.iter().map(String::as_str).collect();
+        for callee in artifact.calls() {
+            // Resolved the way emission resolves it: through whichever
+            // artifact answers for that identity, which is not always the one
+            // whose own key it is.
+            allowed.extend(
+                provider
+                    .get(&callee)
+                    .into_iter()
+                    .flat_map(|position| rendered[*position].1.iter().map(String::as_str)),
+            );
+        }
+        for name in called {
+            if allowed.contains(name.as_str()) {
                 continue;
             }
-            if let Some(callee) = converters.get(&ident) {
+            if let Some(callee) = definer.get(name.as_str()) {
                 panic!(
-                    "{} calls {callee} as `{ident}`, which it does not declare as a dependency",
-                    artifact.key()
+                    "{key} calls {callee} as `{name}`, which it does not declare as a dependency"
                 );
             }
         }

--- a/prebindgen-registry/src/write.rs
+++ b/prebindgen-registry/src/write.rs
@@ -32,28 +32,26 @@ use crate::{destination::Destination, prebindgen::Prebindgen, registry::Registry
 /// while per-item output is assembled.
 #[derive(Debug)]
 pub enum WriteError {
-    /// Generated code calls a planned private converter whose function was
-    /// removed by reachability filtering.
-    UnrenderedConverterCalls {
-        /// `(caller, missing converter)` pairs, sorted and de-duplicated.
-        calls: Vec<(String, String)>,
+    /// A reachable artifact calls one that does not reach the file, either
+    /// because reachability filtering dropped it or because it was never
+    /// planned. Proven from the artifacts' own edges, before anything renders.
+    UnreachedDependency {
+        /// `(caller, unreached callee)` identities, sorted and de-duplicated.
+        edges: Vec<(String, String)>,
     },
 }
 
 impl std::fmt::Display for WriteError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            WriteError::UnrenderedConverterCalls { calls } => {
-                write!(
-                    f,
-                    "generated code calls private converters that were not rendered:"
-                )?;
-                for (caller, converter) in calls {
-                    write!(f, "\n  - `{caller}` calls `{converter}`")?;
+            WriteError::UnreachedDependency { edges } => {
+                write!(f, "generated artifacts call artifacts the file omits:")?;
+                for (caller, callee) in edges {
+                    write!(f, "\n  - {caller} calls {callee}")?;
                 }
                 write!(
                     f,
-                    "\nconverter reachability or dependency planning is incomplete"
+                    "\nartifact reachability or dependency planning is incomplete"
                 )
             }
         }
@@ -105,6 +103,27 @@ pub trait RustArtifact {
         true
     }
 
+    /// The identities this artifact's items answer for.
+    ///
+    /// Defaults to its own — the common case, where one artifact renders the
+    /// items of one identity. An artifact that renders another identity's item
+    /// too says so here, which is how a dependency on that identity is
+    /// satisfied. The C callback artifact does exactly that: it renders the
+    /// Invoke helper of a converter operation whose own fragment deliberately
+    /// carries no artifact.
+    fn provides(&self) -> Vec<ArtifactKey> {
+        vec![self.key()]
+    }
+
+    /// The artifacts this one's body calls.
+    ///
+    /// Deliberately without a default: an artifact that calls nothing says so
+    /// by returning an empty vector, and one that gains a call has to answer
+    /// the question again. These edges are what proves the file complete —
+    /// see [`WriteError::UnreachedDependency`] — so an unanswered one is a
+    /// silently weaker check rather than a compile error.
+    fn calls(&self) -> Vec<ArtifactKey>;
+
     /// Materialize the artifact's Rust items.
     fn render(&self, emit: &crate::RustWriter) -> Vec<syn::Item>;
 }
@@ -117,13 +136,29 @@ pub trait RustArtifact {
 /// sharing never depends on the Rust symbol final emission allocates.
 pub struct Assembly<A> {
     artifacts: Vec<A>,
+    /// Every identity the held artifacts answer for, including the ones an
+    /// artifact provides beyond its own key.
+    provided: HashMap<ArtifactKey, usize>,
 }
 
 impl<A: RustArtifact> Assembly<A> {
-    /// The artifacts, in emission order. Includes the unreachable ones — the
-    /// writer renders those to report anything that still calls them.
+    /// The artifacts, in emission order, including the ones no reachable
+    /// artifact calls. The writer skips those; they are held so that
+    /// [`Self::reaches`] can tell "planned but unreached" from "never
+    /// planned".
     pub fn artifacts(&self) -> impl ExactSizeIterator<Item = &A> {
         self.artifacts.iter()
+    }
+
+    /// Whether an artifact answering for this identity reaches the file.
+    ///
+    /// Reachability is read here rather than when the assembly was frozen: an
+    /// adapter may reach an artifact after adding it, and the file is what
+    /// settles the answer.
+    pub fn reaches(&self, key: &ArtifactKey) -> bool {
+        self.provided
+            .get(key)
+            .is_some_and(|position| self.artifacts[*position].reachable())
     }
 }
 
@@ -184,8 +219,15 @@ impl<A: RustArtifact> AssemblyBuilder<A> {
 
     /// Freeze the assembly.
     pub fn build(self) -> Assembly<A> {
+        let mut provided = self.positions;
+        for (position, artifact) in self.artifacts.iter().enumerate() {
+            for key in artifact.provides() {
+                provided.insert(key, position);
+            }
+        }
         Assembly {
             artifacts: self.artifacts,
+            provided,
         }
     }
 }
@@ -197,6 +239,89 @@ impl<A: RustArtifact> FromIterator<A> for Assembly<A> {
             builder.artifact(artifact);
         }
         builder.build()
+    }
+}
+
+/// Check that every call a rendered artifact makes to another artifact's
+/// converter is declared as one of its [`RustArtifact::calls`] edges.
+///
+/// Test support, like [`RustWriter::for_test`](crate::RustWriter::for_test).
+/// Emission proves the file complete from the edges alone, which is only worth
+/// anything if the edges name every call — and the one place the calls
+/// themselves are visible is the rendered output. So the adapters' own test
+/// suites run this over the bindings they build: production reasons from the
+/// edges, and this checks the edges against what rendering actually emits.
+///
+/// `namespace` is the adapter's operation namespace, the one it passes to
+/// [`RustWriter::operation_ident`](crate::RustWriter::operation_ident).
+///
+/// # Panics
+///
+/// Naming the caller, the callee and the undeclared call, if a rendered body
+/// calls a converter its artifact did not declare.
+#[cfg(any(test, feature = "testing"))]
+pub fn assert_edges_cover_rendered_calls<A: RustArtifact>(
+    assembly: &Assembly<A>,
+    emit: &crate::RustWriter,
+    namespace: &str,
+) {
+    let ident_of = |key: &ArtifactKey| match key {
+        ArtifactKey::Operation(operation) => {
+            Some(emit.operation_ident(namespace, operation).to_string())
+        }
+        // An exported symbol is called by the destination language, never by
+        // another artifact's body.
+        ArtifactKey::Artifact(_) => None,
+    };
+    let mut converters: HashMap<String, ArtifactKey> = HashMap::new();
+    for artifact in assembly.artifacts() {
+        for key in artifact.provides() {
+            if let Some(ident) = ident_of(&key) {
+                converters.insert(ident, key);
+            }
+        }
+    }
+
+    for artifact in assembly.artifacts().filter(|artifact| artifact.reachable()) {
+        let mut allowed: BTreeSet<String> = artifact
+            .provides()
+            .iter()
+            .chain(artifact.calls().iter())
+            .filter_map(ident_of)
+            .collect();
+        // A recursive shape's converter calls itself.
+        allowed.extend(ident_of(&artifact.key()));
+        let mut called = CalledIdents(BTreeSet::new());
+        for mut item in artifact.render(emit) {
+            syn::visit_mut::VisitMut::visit_item_mut(&mut called, &mut item);
+        }
+        for ident in called.0 {
+            if allowed.contains(&ident) {
+                continue;
+            }
+            if let Some(callee) = converters.get(&ident) {
+                panic!(
+                    "{} calls {callee} as `{ident}`, which it does not declare as a dependency",
+                    artifact.key()
+                );
+            }
+        }
+    }
+}
+
+/// Every function name called in the visited items.
+#[cfg(any(test, feature = "testing"))]
+struct CalledIdents(BTreeSet<String>);
+
+#[cfg(any(test, feature = "testing"))]
+impl syn::visit_mut::VisitMut for CalledIdents {
+    fn visit_expr_call_mut(&mut self, call: &mut syn::ExprCall) {
+        if let syn::Expr::Path(path) = call.func.as_ref() {
+            if let Some(segment) = path.path.segments.last() {
+                self.0.insert(segment.ident.to_string());
+            }
+        }
+        syn::visit_mut::visit_expr_call_mut(self, call);
     }
 }
 
@@ -229,25 +354,28 @@ pub fn write_rust<P: AsRef<Path>, E: Prebindgen, A: RustArtifact>(
     let emit = crate::RustWriter::new(registry, ext.source_module());
     let mut items: Vec<syn::Item> = Vec::new();
 
-    // Every artifact renders, including the ones the adapter surface does not
-    // reach: an unreachable artifact still contributes its function names, so
-    // a caller that survived reachability filtering can be reported below.
-    let rendered: Vec<(bool, Vec<syn::Item>)> = assembly
-        .artifacts()
-        .map(|artifact| (artifact.reachable(), artifact.render(&emit)))
-        .collect();
-    let converter_names: BTreeSet<String> = rendered
-        .iter()
-        .flat_map(|(_, artifact_items)| artifact_items)
-        .filter_map(|item| match item {
-            syn::Item::Fn(function) => Some(function.sig.ident.to_string()),
-            _ => None,
-        })
-        .collect();
-    for (reachable, artifact_items) in rendered {
-        if reachable {
-            items.extend(artifact_items);
+    // Dependency completeness, proven from the artifacts' own edges before
+    // anything is rendered: whatever a reachable artifact calls must itself
+    // reach the file.
+    let mut unreached: BTreeSet<(String, String)> = BTreeSet::new();
+    for artifact in assembly.artifacts().filter(|artifact| artifact.reachable()) {
+        for callee in artifact.calls() {
+            if !assembly.reaches(&callee) {
+                unreached.insert((artifact.key().to_string(), callee.to_string()));
+            }
         }
+    }
+    if !unreached.is_empty() {
+        return Err(WriteError::UnreachedDependency {
+            edges: unreached.into_iter().collect(),
+        });
+    }
+
+    // Only what reaches the file renders. An unreachable artifact used to be
+    // rendered anyway, for its function names alone, so that a caller of one
+    // could be named; the edges above answer that question without it.
+    for artifact in assembly.artifacts().filter(|artifact| artifact.reachable()) {
+        items.extend(artifact.render(&emit));
     }
 
     // 2. Anonymous consts, verbatim. Last, and in stream order. These are
@@ -258,76 +386,8 @@ pub fn write_rust<P: AsRef<Path>, E: Prebindgen, A: RustArtifact>(
         items.push(syn::Item::Const(emit.guard(guard)));
     }
 
-    validate_converter_calls(&mut items, &converter_names)?;
     let dest: Destination = items.into_iter().collect();
     Ok(dest.write(out_path))
-}
-
-/// Refuse a generated file whose rendered functions still call a private
-/// converter plan removed by reachability filtering.
-///
-/// This is deliberately an integrity check for planned converter functions,
-/// not a general unresolved-name check. Calls to missing prerequisites or
-/// arbitrary external functions remain rustc's responsibility.
-fn validate_converter_calls(
-    items: &mut [syn::Item],
-    candidates: &BTreeSet<String>,
-) -> Result<(), WriteError> {
-    let rendered: BTreeSet<String> = items
-        .iter()
-        .filter_map(|item| match item {
-            syn::Item::Fn(function) => Some(function.sig.ident.to_string()),
-            _ => None,
-        })
-        .collect();
-    let mut visitor = ConverterCallValidator {
-        candidates,
-        rendered: &rendered,
-        caller: None,
-        calls: BTreeSet::new(),
-    };
-    for item in items {
-        syn::visit_mut::VisitMut::visit_item_mut(&mut visitor, item);
-    }
-    if visitor.calls.is_empty() {
-        Ok(())
-    } else {
-        Err(WriteError::UnrenderedConverterCalls {
-            calls: visitor.calls.into_iter().collect(),
-        })
-    }
-}
-
-struct ConverterCallValidator<'a> {
-    candidates: &'a BTreeSet<String>,
-    rendered: &'a BTreeSet<String>,
-    caller: Option<String>,
-    calls: BTreeSet<(String, String)>,
-}
-
-impl syn::visit_mut::VisitMut for ConverterCallValidator<'_> {
-    fn visit_item_fn_mut(&mut self, function: &mut syn::ItemFn) {
-        let previous = self.caller.replace(function.sig.ident.to_string());
-        syn::visit_mut::visit_item_fn_mut(self, function);
-        self.caller = previous;
-    }
-
-    fn visit_expr_call_mut(&mut self, call: &mut syn::ExprCall) {
-        if let syn::Expr::Path(path) = call.func.as_ref() {
-            if let Some(segment) = path.path.segments.last() {
-                let name = segment.ident.to_string();
-                if self.candidates.contains(&name) && !self.rendered.contains(&name) {
-                    self.calls.insert((
-                        self.caller
-                            .clone()
-                            .unwrap_or_else(|| "<generated item>".to_string()),
-                        name,
-                    ));
-                }
-            }
-        }
-        syn::visit_mut::visit_expr_call_mut(self, call);
-    }
 }
 
 #[cfg(test)]

--- a/prebindgen-registry/src/write/tests.rs
+++ b/prebindgen-registry/src/write/tests.rs
@@ -125,6 +125,13 @@ enum LateOrCaller {
 }
 
 impl RustArtifact for LateOrCaller {
+    fn provides(&self) -> Vec<ArtifactKey> {
+        match self {
+            Self::Converter(plan) => plan.provides(),
+            Self::Caller(plan) => plan.provides(),
+        }
+    }
+
     fn calls(&self) -> Vec<ArtifactKey> {
         match self {
             Self::Converter(plan) => plan.calls(),

--- a/prebindgen-registry/src/write/tests.rs
+++ b/prebindgen-registry/src/write/tests.rs
@@ -95,9 +95,21 @@ impl RustArtifact for LatePlan {
 #[derive(Clone)]
 struct CallerPlan {
     operation: crate::generation::OperationId,
+    /// Claim to provide the converter this calls, while rendering no such
+    /// function — the over-claim that would grant reachability to an item
+    /// nothing defines.
+    over_claims: bool,
 }
 
 impl RustArtifact for CallerPlan {
+    fn provides(&self) -> Vec<ArtifactKey> {
+        let mut provided = vec![self.key()];
+        if self.over_claims {
+            provided.push(ArtifactKey::Operation(self.operation.clone()));
+        }
+        provided
+    }
+
     fn calls(&self) -> Vec<ArtifactKey> {
         vec![ArtifactKey::Operation(self.operation.clone())]
     }
@@ -217,6 +229,7 @@ fn a_call_to_a_filtered_converter_is_a_writer_error() {
         }),
         LateOrCaller::Caller(CallerPlan {
             operation: operation.clone(),
+            over_claims: false,
         }),
     ]);
     let dir = crate::test_util::unique_test_dir("write_missing_converter");
@@ -244,6 +257,49 @@ fn a_call_to_a_filtered_converter_is_a_writer_error() {
         !path.exists(),
         "an invalid generated file must not reach the destination"
     );
+}
+
+/// An assembly whose artifacts state their edges honestly passes the check
+/// both adapters run on every binding they build.
+#[test]
+fn honest_edges_pass_the_evidence_check() {
+    let operation = crate::generation::OperationId::shared(
+        crate::generation::ArtifactId::new("test", "late-converter").expect("identity"),
+        crate::recipe::Direction::Construct,
+    );
+    let assembly = assembly_of([
+        LateOrCaller::Converter(LatePlan {
+            operation: operation.clone(),
+            reachable: Rc::new(Cell::new(true)),
+        }),
+        LateOrCaller::Caller(CallerPlan {
+            operation,
+            over_claims: false,
+        }),
+    ]);
+
+    assert_edges_cover_rendered_calls(&assembly, &crate::RustWriter::for_test(), "test");
+}
+
+/// Claiming an identity the artifact does not render would satisfy
+/// [`Assembly::reaches`] with nothing behind it, so the check refuses it.
+///
+/// Held here rather than only where the adapters opt in: this guard is what
+/// makes `provides` trustworthy, and an adapter that never called the helper
+/// would otherwise have none of its coverage.
+#[test]
+#[should_panic(expected = "claims to provide")]
+fn a_claimed_identity_must_be_rendered() {
+    let operation = crate::generation::OperationId::shared(
+        crate::generation::ArtifactId::new("test", "late-converter").expect("identity"),
+        crate::recipe::Direction::Construct,
+    );
+    let assembly = assembly_of([LateOrCaller::Caller(CallerPlan {
+        operation,
+        over_claims: true,
+    })]);
+
+    assert_edges_cover_rendered_calls(&assembly, &crate::RustWriter::for_test(), "test");
 }
 
 /// A registry with one declared type, which is all these two tests need of it.
@@ -275,6 +331,7 @@ fn two_reachable_artifacts_may_not_share_an_identity() {
     let caller = || {
         LateOrCaller::Caller(CallerPlan {
             operation: operation.clone(),
+            over_claims: false,
         })
     };
     let _ = assembly_of([caller(), caller()]);

--- a/prebindgen-registry/src/write/tests.rs
+++ b/prebindgen-registry/src/write/tests.rs
@@ -47,6 +47,10 @@ struct OperationPlan {
 }
 
 impl RustArtifact for OperationPlan {
+    fn calls(&self) -> Vec<ArtifactKey> {
+        Vec::new()
+    }
+
     fn key(&self) -> ArtifactKey {
         ArtifactKey::Operation(self.operation.clone())
     }
@@ -64,6 +68,10 @@ impl RustArtifact for OperationPlan {
 }
 
 impl RustArtifact for LatePlan {
+    fn calls(&self) -> Vec<ArtifactKey> {
+        Vec::new()
+    }
+
     fn key(&self) -> ArtifactKey {
         ArtifactKey::Operation(self.operation.clone())
     }
@@ -90,6 +98,10 @@ struct CallerPlan {
 }
 
 impl RustArtifact for CallerPlan {
+    fn calls(&self) -> Vec<ArtifactKey> {
+        vec![ArtifactKey::Operation(self.operation.clone())]
+    }
+
     fn key(&self) -> ArtifactKey {
         ArtifactKey::Artifact(
             crate::generation::ArtifactId::new("test", "caller").expect("identity"),
@@ -113,6 +125,13 @@ enum LateOrCaller {
 }
 
 impl RustArtifact for LateOrCaller {
+    fn calls(&self) -> Vec<ArtifactKey> {
+        match self {
+            Self::Converter(plan) => plan.calls(),
+            Self::Caller(plan) => plan.calls(),
+        }
+    }
+
     fn key(&self) -> ArtifactKey {
         match self {
             Self::Converter(plan) => plan.key(),
@@ -176,6 +195,8 @@ fn an_artifact_reached_after_freezing_is_emitted() {
 
 #[test]
 fn a_call_to_a_filtered_converter_is_a_writer_error() {
+    // The identities are semantic, not Rust symbols: the check runs before
+    // anything is rendered, so no name has been allocated yet.
     let registry = late_test_registry();
     let reachable = Rc::new(Cell::new(false));
     let operation = crate::generation::OperationId::shared(
@@ -199,11 +220,17 @@ fn a_call_to_a_filtered_converter_is_a_writer_error() {
         .expect_err("a call to a filtered private converter must fail in the writer");
 
     match err {
-        WriteError::UnrenderedConverterCalls { calls } => {
-            let missing = crate::RustWriter::for_test()
-                .operation_ident("test", &operation)
-                .to_string();
-            assert_eq!(calls, vec![("a_fn".to_string(), missing)]);
+        WriteError::UnreachedDependency { edges } => {
+            assert_eq!(
+                edges,
+                vec![(
+                    ArtifactKey::Artifact(
+                        crate::generation::ArtifactId::new("test", "caller").expect("identity")
+                    )
+                    .to_string(),
+                    ArtifactKey::Operation(operation).to_string(),
+                )]
+            );
         }
     }
     assert!(


### PR DESCRIPTION
## What this changes

`validate_converter_calls` walked every rendered `syn::ItemFn` looking for
calls to converters that reachability filtering had dropped. It was the last
place production code read generated Rust to learn something about the
generation, and by construction it could only run once everything had been
rendered.

Artifacts state their own edges now:

- **`RustArtifact::calls`** returns the artifacts this one's body calls.
  `write_rust` checks, before rendering anything, that every callee of a
  reachable artifact itself reaches the file. There is no default: an artifact
  that calls nothing returns an empty vector, and one that gains a call has to
  answer again — an unanswered edge would be a silently weaker check rather
  than a compile error.
- **`RustArtifact::provides`** is the other half. One artifact may render an
  item belonging to another identity: the C callback artifact renders the
  Invoke helper of a converter operation whose own fragment deliberately
  carries no artifact. It defaults to the artifact's own key.

`WriteError::UnrenderedConverterCalls` becomes `UnreachedDependency` and
reports semantic identities rather than Rust symbols, since the check runs
before any name is allocated. Unreachable artifacts are no longer rendered for
their names alone; they stay in the assembly so a *planned but unreached*
dependency can be told from an *unplanned* one.

## Following what the renderer calls

The edges name what each renderer actually invokes, which is not always the
carrier nearest to hand. Two cases found by the check itself while this was
being written:

- A JNI parameter that is a flattened data class or an allocation-free optional
  pair is rebuilt by **one composed converter of its own**, not through its
  leaf pipeline. Stating the pipeline — the obvious field — named a converter
  the body never calls, and the check reported it against five covertest
  wrappers.
- A C wrapper taking a callback calls that callback's Invoke helper, which no
  converter artifact renders. That is what `provides` exists for; before it,
  the check reported two perftest wrappers.

Both were real gaps in the model of who calls whom, surfaced by the new check
rather than by inspection.

## Proving the edges complete

An edge check is only worth what its edges are worth: an artifact that
under-reports weakens the check without failing anything. So the syn walk does
not disappear — it moves to where it belongs, as evidence rather than as the
mechanism.

`prebindgen_registry::write::assert_edges_cover_rendered_calls` is test support
(like `RustWriter::for_test`, and gated the same way). It renders every
artifact of an assembly and refuses a call to any converter the artifact did
not declare. Both adapters run it on **every binding their test suites build** —
it sits in `Cbindgen::write_rust` and `JniGen::write_rust` under `#[cfg(test)]`,
which covers the C suite's `write` helper and the ~120 JNI call sites at once.

Checked that it bites: clearing `CWrapper::calls` fails 30+ C tests, and
clearing `JWrapper::calls` fails 40+ JNI tests, each naming the caller, the
callee and the undeclared call.

## Verification

Workspace tests, strict Clippy, `cargo fmt --check` and
`RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps` pass. Every
generated artifact — C bindings, C headers, JNI Rust, Kotlin — is byte-for-byte
unchanged.

`prebindgen-c` gains a dev-dependency on the registry's `testing` feature,
which is what makes the test-support helper and `RustWriter::for_registry_test`
available to its suite. `prebindgen-jni` already depended on it.

## Fixes #437

The array builder was gated on `produces_array`, a scan of declared functions'
return types — the gate that issue's "Why" section names. Deriving the runtime
artifacts from the dependency edges instead deletes that scan, so a `Vec`
delivered to a C callback plans the builder because the callback's own encode
declares it.

`a_run_of_converted_optionals_uses_the_declared_wire` is the regression test:
its binding returns no `Vec` at all, and it asserts the builder is emitted.

Fixes #437.

Step 5 of #581.

— Claude Code (Opus 5)

