### PR TITLE
Write from the frozen assembly alone

### DIFF
--- a/prebindgen-c/src/lib.rs
+++ b/prebindgen-c/src/lib.rs
@@ -351,11 +351,7 @@ impl Cbindgen {
         // dependency edges name every call its artifacts render — the
         // completeness the emission-time check reasons from.
         #[cfg(test)]
-        prebindgen_registry::write::assert_edges_cover_rendered_calls(
-            self.gen.assembly(),
-            self.gen.assembly().writer(),
-            "c",
-        );
+        prebindgen_registry::write::assert_edges_cover_rendered_calls(self.gen.assembly(), "c");
         Ok(prebindgen_registry::write::write_rust(
             self.gen.assembly(),
             out_path,

--- a/prebindgen-c/src/lib.rs
+++ b/prebindgen-c/src/lib.rs
@@ -353,12 +353,10 @@ impl Cbindgen {
         #[cfg(test)]
         prebindgen_registry::write::assert_edges_cover_rendered_calls(
             self.gen.assembly(),
-            &prebindgen_registry::RustWriter::for_registry_test(&self.registry),
+            self.gen.assembly().writer(),
             "c",
         );
         Ok(prebindgen_registry::write::write_rust(
-            &self.registry,
-            &self.gen,
             self.gen.assembly(),
             out_path,
         )?)

--- a/prebindgen-c/src/trait_impl.rs
+++ b/prebindgen-c/src/trait_impl.rs
@@ -991,7 +991,7 @@ impl CbindgenBuilder {
         for artifact in artifacts {
             assembly.artifact(artifact);
         }
-        self.assembly = Some(assembly.build());
+        self.assembly = Some(assembly.build(&registry, self.source_module.as_ref()));
         self.generation = Some(generation);
         self.validate_resolved(&registry)
             .map_err(|message| prebindgen_registry::ScanError::AdapterInvariant { message })?;
@@ -1073,16 +1073,6 @@ impl Prebindgen for CbindgenBuilder {
             },
         );
         Ok(())
-    }
-
-    // Consts have no declaration mechanism here (`declared_consts` stays
-    // `None`), so every indexed const re-emits through the default
-    // `on_const` — a path-alias against this source module, keeping consts
-    // with non-portable initializers valid in the generated file. (cbindgen
-    // cannot evaluate a path initializer, so aliased consts don't surface
-    // as `#define`s in the C header.)
-    fn source_module(&self) -> Option<&syn::Path> {
-        self.source_module.as_ref()
     }
 
     // ── Structural type resolution ──────────────────────────────────────

--- a/prebindgen-jni/src/jni/generation.rs
+++ b/prebindgen-jni/src/jni/generation.rs
@@ -419,7 +419,9 @@ impl JniGenerationPlan {
         for constant in constants {
             assembly.artifact(JFinalArtifact::Const(Box::new(constant)));
         }
-        let assembly = assembly.build();
+        // JniGen qualifies each source reference by the item's own origin
+        // module, so it declares no single one for the writer to fall back on.
+        let assembly = assembly.build(registry, None);
         Self {
             conversions,
             assembly,

--- a/prebindgen-jni/src/jni/mod.rs
+++ b/prebindgen-jni/src/jni/mod.rs
@@ -907,12 +907,6 @@ impl JniGen {
                 .as_ref()
                 .expect("resolved JniGen has no frozen generation plan")
                 .assembly(),
-            self.decls
-                .generation
-                .as_ref()
-                .expect("resolved JniGen has no frozen generation plan")
-                .assembly()
-                .writer(),
             "jni",
         );
         Ok(prebindgen_registry::write::write_rust(

--- a/prebindgen-jni/src/jni/mod.rs
+++ b/prebindgen-jni/src/jni/mod.rs
@@ -907,12 +907,15 @@ impl JniGen {
                 .as_ref()
                 .expect("resolved JniGen has no frozen generation plan")
                 .assembly(),
-            &prebindgen_registry::RustWriter::for_registry_test(&self.registry),
+            self.decls
+                .generation
+                .as_ref()
+                .expect("resolved JniGen has no frozen generation plan")
+                .assembly()
+                .writer(),
             "jni",
         );
         Ok(prebindgen_registry::write::write_rust(
-            &self.registry,
-            &self.decls,
             self.decls
                 .generation
                 .as_ref()

--- a/prebindgen-registry/src/prebindgen.rs
+++ b/prebindgen-registry/src/prebindgen.rs
@@ -1,10 +1,9 @@
 //! `Prebindgen` — what a generator still hands the emitter.
 //!
-//! The items an adapter's converters depend on (`prerequisites`), two
-//! invariant checks, and the source module emitted references are qualified
-//! against. Nothing here is per `#[prebindgen]` item any more: wrappers,
-//! constants and type artifacts are all planned into the adapter's frozen
-//! assembly.
+//! Two invariant checks, and nothing else. Everything an adapter emits is
+//! planned into its frozen assembly, and what the writer needs of the registry
+//! is frozen with it — so a generator hands the emitter no items, no
+//! prerequisites, and no questions to ask back.
 //!
 //! **Conversion is not here.** A generator builds those itself, one per
 //! crossing, inside `RegistryBuilder::convert_with` — so there is no
@@ -144,9 +143,9 @@ impl<M> ConverterImpl<M> {
 /// on the wire and what wrapper code to emit.
 ///
 /// The trait has no language-specific concepts of its own, and — since the
-/// registry stopped asking it questions and per-item emission became frozen
-/// artifacts — what is left is `prerequisites`, the two `validate` hooks for
-/// adapter invariants, and `source_module`.
+/// registry stopped asking it questions and every emitted item became an
+/// artifact of the adapter's frozen assembly — what is left is the two
+/// `validate` hooks for adapter invariants.
 ///
 /// What used to be here and is not any more: which items to build, how
 /// composites decompose, and the wire form of each type. A generator states the
@@ -228,14 +227,5 @@ pub trait Prebindgen {
     /// Default: no checks.
     fn validate_resolved(&self, _registry: &Registry) -> Result<(), String> {
         Ok(())
-    }
-
-    /// Absolute path under which the source crate's items are reachable
-    /// from the generated file (e.g. `zenoh_flat`), for adapters that
-    /// qualify emitted references against one. An adapter's constant artifact
-    /// commonly uses it to generate a path-alias to the source item instead of
-    /// copying initializer tokens. Default: `None`.
-    fn source_module(&self) -> Option<&syn::Path> {
-        None
     }
 }

--- a/prebindgen-registry/src/write.rs
+++ b/prebindgen-registry/src/write.rs
@@ -20,13 +20,14 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use crate::{destination::Destination, prebindgen::Prebindgen, registry::Registry};
+use crate::{destination::Destination, registry::Registry};
 
 /// Errors surfaced by the file-emission phase.
 ///
 /// Binding validation is NOT here — it runs once in
 /// [`RegistryBuilder::build`](crate::RegistryBuilder::build)
-/// (see [`Prebindgen::validate_resolved`]), so an invalid binding fails
+/// (see [`Prebindgen::validate_resolved`](crate::Prebindgen::validate_resolved)),
+/// so an invalid binding fails
 /// before a built generator exists and never reaches a writer.
 /// Emission-integrity checks still run here because reachability is finalized
 /// while per-item output is assembled.
@@ -139,6 +140,15 @@ pub struct Assembly<A> {
     /// Every identity the held artifacts answer for, including the ones an
     /// artifact provides beyond its own key.
     provided: HashMap<ArtifactKey, usize>,
+    /// The rendering capability, minted while freezing. Writing an assembly
+    /// therefore needs no registry: what the writer needs of one — how to
+    /// qualify a source type, and the feature checks below — was taken when
+    /// the assembly was frozen and cannot change afterwards.
+    emit: crate::RustWriter,
+    /// Prebindgen's own injected feature checks, in stream order. Identical
+    /// for every adapter and named by none, so they are the registry's to
+    /// carry rather than any artifact's.
+    guards: Vec<prebindgen_flat::flat::Guard>,
 }
 
 impl<A: RustArtifact> Assembly<A> {
@@ -155,6 +165,16 @@ impl<A: RustArtifact> Assembly<A> {
     /// Reachability is read here rather than when the assembly was frozen: an
     /// adapter may reach an artifact after adding it, and the file is what
     /// settles the answer.
+    /// The rendering capability frozen with this assembly.
+    pub fn writer(&self) -> &crate::RustWriter {
+        &self.emit
+    }
+
+    /// Prebindgen's injected feature checks, in stream order.
+    pub fn guards(&self) -> impl ExactSizeIterator<Item = &prebindgen_flat::flat::Guard> {
+        self.guards.iter()
+    }
+
     pub fn reaches(&self, key: &ArtifactKey) -> bool {
         self.provided
             .get(key)
@@ -217,8 +237,13 @@ impl<A: RustArtifact> AssemblyBuilder<A> {
         self
     }
 
-    /// Freeze the assembly.
-    pub fn build(self) -> Assembly<A> {
+    /// Freeze the assembly against the resolved registry it was planned from.
+    ///
+    /// `source_module` is the path emitted references to source items are
+    /// qualified against, for an adapter that declares one; `None` leaves each
+    /// reference to the item's own origin module. Both arguments are read here
+    /// and not again: a frozen assembly is everything writing its file needs.
+    pub fn build(self, registry: &Registry, source_module: Option<&syn::Path>) -> Assembly<A> {
         let mut provided = self.positions;
         for (position, artifact) in self.artifacts.iter().enumerate() {
             for key in artifact.provides() {
@@ -228,17 +253,9 @@ impl<A: RustArtifact> AssemblyBuilder<A> {
         Assembly {
             artifacts: self.artifacts,
             provided,
+            emit: crate::RustWriter::new(registry, source_module),
+            guards: registry.flat().guards().cloned().collect(),
         }
-    }
-}
-
-impl<A: RustArtifact> FromIterator<A> for Assembly<A> {
-    fn from_iter<I: IntoIterator<Item = A>>(artifacts: I) -> Self {
-        let mut builder = AssemblyBuilder::new();
-        for artifact in artifacts {
-            builder.artifact(artifact);
-        }
-        builder.build()
     }
 }
 
@@ -366,21 +383,17 @@ impl syn::visit_mut::VisitMut for CalledIdents {
 ///
 /// `out_path` may be relative (resolved against `OUT_DIR` by prebindgen) or
 /// absolute. Returns the path actually written.
-pub fn write_rust<P: AsRef<Path>, E: Prebindgen, A: RustArtifact>(
-    registry: &Registry,
-    ext: &E,
+pub fn write_rust<P: AsRef<Path>, A: RustArtifact>(
     assembly: &Assembly<A>,
     out_path: P,
 ) -> Result<PathBuf, WriteError> {
-    // Validation already ran ONCE in the generator's `build` — a built generator
-    // (the only source of a resolved registry) is valid by construction, so
-    // this writer does no binding resolution. It does validate the assembled
-    // private call graph before handing the file to the destination.
-    // The capability, minted here and nowhere else in this function's reach.
-    // Every artifact below is handed a borrow; nothing else in the pipeline is.
-    // See `prebindgen_flat::flat::emit` for what that buys and what it
-    // deliberately does not.
-    let emit = crate::RustWriter::new(registry, ext.source_module());
+    // Nothing here can resolve anything. Validation ran once in the
+    // generator's `build`, planning ran once while the assembly was frozen,
+    // and what reaches this function is that frozen assembly and a path. The
+    // rendering capability comes with it; every artifact is handed a borrow of
+    // it and nothing else. See `prebindgen_flat::flat::emit` for what that
+    // buys and what it deliberately does not.
+    let emit = assembly.writer();
     let mut items: Vec<syn::Item> = Vec::new();
 
     // Dependency completeness, proven from the artifacts' own edges before
@@ -404,14 +417,11 @@ pub fn write_rust<P: AsRef<Path>, E: Prebindgen, A: RustArtifact>(
     // rendered anyway, for its function names alone, so that a caller of one
     // could be named; the edges above answer that question without it.
     for artifact in assembly.artifacts().filter(|artifact| artifact.reachable()) {
-        items.extend(artifact.render(&emit));
+        items.extend(artifact.render(emit));
     }
 
-    // 2. Anonymous consts, verbatim. Last, and in stream order. These are
-    //    prebindgen's own injected feature checks, identical for every
-    //    adapter and named by none, so they are written here rather than
-    //    planned as an artifact of one adapter's assembly.
-    for guard in registry.flat().guards() {
+    // Anonymous consts, verbatim. Last, and in stream order.
+    for guard in assembly.guards() {
         items.push(syn::Item::Const(emit.guard(guard)));
     }
 

--- a/prebindgen-registry/src/write.rs
+++ b/prebindgen-registry/src/write.rs
@@ -160,13 +160,13 @@ impl<A: RustArtifact> Assembly<A> {
         self.artifacts.iter()
     }
 
-    /// Whether an artifact answering for this identity reaches the file.
-    ///
-    /// Reachability is read here rather than when the assembly was frozen: an
-    /// adapter may reach an artifact after adding it, and the file is what
-    /// settles the answer.
     /// The rendering capability frozen with this assembly.
-    pub fn writer(&self) -> &crate::RustWriter {
+    ///
+    /// Crate-private on purpose. `RustWriter` is minted at file assembly and
+    /// handed to each artifact as it renders; handing it out here would let
+    /// any holder of an assembly spell Rust source types outside that
+    /// boundary — Kotlin emission holds one for the generator's whole life.
+    pub(crate) fn writer(&self) -> &crate::RustWriter {
         &self.emit
     }
 
@@ -175,6 +175,11 @@ impl<A: RustArtifact> Assembly<A> {
         self.guards.iter()
     }
 
+    /// Whether an artifact answering for this identity reaches the file.
+    ///
+    /// Reachability is read here rather than when the assembly was frozen: an
+    /// adapter may reach an artifact after adding it, and the file is what
+    /// settles the answer.
     pub fn reaches(&self, key: &ArtifactKey) -> bool {
         self.provided
             .get(key)
@@ -271,18 +276,20 @@ impl<A: RustArtifact> AssemblyBuilder<A> {
 /// edges, and this checks the edges against what rendering actually emits.
 ///
 /// `namespace` is the adapter's operation namespace, the one it passes to
-/// [`RustWriter::operation_ident`](crate::RustWriter::operation_ident).
+/// [`RustWriter::operation_ident`](crate::RustWriter::operation_ident). The
+/// writer itself comes from the assembly, so the names this computes are the
+/// ones its emission will emit.
 ///
 /// # Panics
 ///
 /// Naming the caller, the callee and the undeclared call, if a rendered body
 /// calls a converter its artifact did not declare.
 #[cfg(any(test, feature = "testing"))]
-pub fn assert_edges_cover_rendered_calls<A: RustArtifact>(
-    assembly: &Assembly<A>,
-    emit: &crate::RustWriter,
-    namespace: &str,
-) {
+pub fn assert_edges_cover_rendered_calls<A: RustArtifact>(assembly: &Assembly<A>, namespace: &str) {
+    // The assembly's own writer, so the names checked here are the names its
+    // emission will emit. A separately supplied one could differ and the check
+    // would still pass, having examined different names.
+    let emit = assembly.writer();
     // What every artifact actually renders, which is the ground truth both
     // halves are checked against: a call resolves to an artifact by the name
     // that artifact defines, whether the identity is an operation or an

--- a/prebindgen-registry/src/write/tests.rs
+++ b/prebindgen-registry/src/write/tests.rs
@@ -7,11 +7,33 @@ use std::{
 use prebindgen::SourceLocation;
 
 use super::*;
-use crate::registry::RegistryBuilder;
+use crate::{prebindgen::Prebindgen, registry::RegistryBuilder};
 
-/// Freeze a test assembly from artifacts stated in emission order.
+/// Freeze a test assembly from artifacts stated in emission order, against a
+/// registry with nothing in it — enough for artifacts that spell no source
+/// type.
 fn assembly_of<A: RustArtifact, I: IntoIterator<Item = A>>(artifacts: I) -> Assembly<A> {
-    artifacts.into_iter().collect()
+    assembly_from(&empty_registry(), artifacts)
+}
+
+/// Freeze a test assembly against a given registry.
+fn assembly_from<A: RustArtifact, I: IntoIterator<Item = A>>(
+    registry: &Registry,
+    artifacts: I,
+) -> Assembly<A> {
+    let mut builder = AssemblyBuilder::new();
+    for artifact in artifacts {
+        builder.artifact(artifact);
+    }
+    builder.build(registry, None)
+}
+
+/// A resolved registry holding no items.
+fn empty_registry() -> Registry {
+    crate::test_util::reg_from_items(Vec::new())
+        .expect("index")
+        .scanned()
+        .expect("scan")
 }
 
 struct IdentityExt;
@@ -187,7 +209,6 @@ impl RustArtifact for LateOrCaller {
 /// is compiled, which can happen after the plan has been added to the builder.
 #[test]
 fn an_artifact_reached_after_freezing_is_emitted() {
-    let registry = late_test_registry();
     let reachable = Rc::new(Cell::new(false));
     let operation = crate::generation::OperationId::shared(
         crate::generation::ArtifactId::new("test", "late-converter").expect("identity"),
@@ -202,8 +223,7 @@ fn an_artifact_reached_after_freezing_is_emitted() {
 
     // Frozen dormant, reached afterwards — as a parent compiled later does.
     reachable.set(true);
-    let path =
-        write_rust(&registry, &IdentityExt, &assembly, dir.join("gen.rs")).expect("write_rust");
+    let path = write_rust(&assembly, dir.join("gen.rs")).expect("write_rust");
     let source = std::fs::read_to_string(path).expect("read generated file");
 
     assert!(
@@ -216,7 +236,6 @@ fn an_artifact_reached_after_freezing_is_emitted() {
 fn a_call_to_a_filtered_converter_is_a_writer_error() {
     // The identities are semantic, not Rust symbols: the check runs before
     // anything is rendered, so no name has been allocated yet.
-    let registry = late_test_registry();
     let reachable = Rc::new(Cell::new(false));
     let operation = crate::generation::OperationId::shared(
         crate::generation::ArtifactId::new("test", "late-converter").expect("identity"),
@@ -236,7 +255,7 @@ fn a_call_to_a_filtered_converter_is_a_writer_error() {
     std::fs::create_dir_all(&dir).unwrap();
     let path = dir.join("gen.rs");
 
-    let err = write_rust(&registry, &IdentityExt, &assembly, &path)
+    let err = write_rust(&assembly, &path)
         .expect_err("a call to a filtered private converter must fail in the writer");
 
     match err {
@@ -302,22 +321,6 @@ fn a_claimed_identity_must_be_rendered() {
     assert_edges_cover_rendered_calls(&assembly, &crate::RustWriter::for_test(), "test");
 }
 
-/// A registry with one declared type, which is all these two tests need of it.
-fn late_test_registry() -> Registry {
-    crate::test_util::reg_from_items(vec![(
-        syn::Item::Struct(syn::parse_quote!(
-            pub struct AStruct;
-        )),
-        SourceLocation::default(),
-    )])
-    .expect("index")
-    .export_type(crate::test_util::declared_origin(syn::parse_quote!(
-        AStruct
-    )))
-    .scanned()
-    .expect("scan")
-}
-
 /// Two reachable artifacts under one identity are a planning error. A
 /// converter is exempt: one registry operation is legitimately reached from
 /// several sites, which is what the de-duplication above is for.
@@ -339,16 +342,6 @@ fn two_reachable_artifacts_may_not_share_an_identity() {
 
 #[test]
 fn registry_operations_are_deduplicated_before_rendering() {
-    let item: syn::ItemFn = syn::parse_quote!(
-        fn a_fn() {}
-    );
-    let ident: syn::Ident = syn::parse_quote!(a_fn);
-    let registry =
-        crate::test_util::reg_from_items(vec![(syn::Item::Fn(item), SourceLocation::default())])
-            .expect("index")
-            .export(&ident)
-            .scanned()
-            .expect("scan");
     let operation = crate::generation::OperationId::shared(
         crate::generation::ArtifactId::new("test", "shared-converter").expect("identity"),
         crate::recipe::Direction::Construct,
@@ -379,8 +372,6 @@ fn registry_operations_are_deduplicated_before_rendering() {
     std::fs::create_dir_all(&dir).unwrap();
 
     write_rust(
-        &registry,
-        &IdentityExt,
         &assembly_of([dormant, reachable, reached_again]),
         dir.join("gen.rs"),
     )
@@ -468,13 +459,8 @@ fn declared_items_reach_the_file_only_as_artifacts() {
         .expect("clock drift")
         .as_nanos();
     let path = std::env::temp_dir().join(format!("prebindgen-write-rust-{unique}.rs"));
-    let written = write_rust(
-        &reg,
-        &IdentityExt,
-        &assembly_of([] as [OperationPlan; 0]),
-        &path,
-    )
-    .expect("write_rust");
+    let written =
+        write_rust(&assembly_from(&reg, [] as [OperationPlan; 0]), &path).expect("write_rust");
     let content = std::fs::read_to_string(&written).expect("read generated file");
     let _ = std::fs::remove_file(&written);
 
@@ -569,9 +555,7 @@ fn guards_emit_ungated_and_in_stream_order() {
     std::fs::create_dir_all(&dir).unwrap();
     let registry = registry.resolve_gating(ConstGatingExt).expect("resolve");
     let path = crate::write::write_rust(
-        &registry,
-        &ConstGatingExt,
-        &assembly_of([] as [OperationPlan; 0]),
+        &assembly_from(&registry, [] as [OperationPlan; 0]),
         dir.join("gen.rs"),
     )
     .expect("write_rust");

--- a/prebindgen-registry/src/write/tests.rs
+++ b/prebindgen-registry/src/write/tests.rs
@@ -297,7 +297,7 @@ fn honest_edges_pass_the_evidence_check() {
         }),
     ]);
 
-    assert_edges_cover_rendered_calls(&assembly, &crate::RustWriter::for_test(), "test");
+    assert_edges_cover_rendered_calls(&assembly, "test");
 }
 
 /// Claiming an identity the artifact does not render would satisfy
@@ -318,7 +318,7 @@ fn a_claimed_identity_must_be_rendered() {
         over_claims: true,
     })]);
 
-    assert_edges_cover_rendered_calls(&assembly, &crate::RustWriter::for_test(), "test");
+    assert_edges_cover_rendered_calls(&assembly, "test");
 }
 
 /// Two reachable artifacts under one identity are a planning error. A


### PR DESCRIPTION
## What this changes

`write_rust` still took two things beyond the assembly: `&Registry`, for
prebindgen's injected feature checks and for minting the `RustWriter`, and
`&impl Prebindgen`, for one question — the module emitted references are
qualified against.

Both are read while the assembly is frozen now.

- `AssemblyBuilder::build(&Registry, Option<&syn::Path>)` mints the
  `RustWriter` and carries the guards. Freezing an assembly is a registry
  operation, so `Assembly` is no longer `FromIterator`.
- `Assembly::writer` hands that capability to every artifact it renders, and
  `Assembly::guards` carries the feature checks the file ends with.
- `write_rust(&Assembly<A>, out_path)` takes nothing else. There is no registry
  in scope to resolve against and no adapter to call back into.

`Prebindgen::source_module` goes with it: only Cbindgen implemented it, only
Cbindgen called it, and it reads its own field now. What is left of the trait is
`validate` and `validate_resolved`.

## Where #581 stands

Reading the umbrella's success criteria against the branch:

- Final writing consumes one frozen artifact graph and takes no adapter-produced
  converter vector — this PR completes it.
- Prerequisites, private converters, exported wrappers, type artifacts, constant
  artifacts and guards all participate in the assembly's ordering and
  reachability (#586, #587, #591), guards as a registry-carried list rather
  than an adapter's artifact.
- Final renderers receive one frozen artifact and the writer, and no live
  registry (#584, #585, fenced per adapter).
- `prerequisites` and the five `on_*` callbacks are gone (#585, #586, #591);
  no second item-kind walk survives.
- Dependency completeness is proven from artifact edges before rendering, and
  production code no longer inspects generated Rust (#592).
- Cbindgen and JniGen fill the same assembly with their own payloads (#583).
- JNI Rust and Kotlin still read the same frozen plan; Kotlin emission is
  untouched throughout, which every byte-identical regeneration confirms.
- The old assembly path is deleted rather than kept behind a branch.

## Which carriers this umbrella deletes, and which belong to #506

The umbrella asked step 6 to separate the two. Surveying what is left:

- **Deleted here, because only the old writer kept them alive**:
  `RustFunction` (#583), the five `on_*` callbacks and the item walk (#585,
  #586), `prerequisites` (#591), `Registry::declared` and the writer's
  name-sorting helper (#586), `render_artifacts` (#587),
  `validate_converter_calls` (#592), `produces_array` and `needs_free` (#592),
  `Prebindgen::source_module` (here).
- **Still load-bearing, so untouched**: `Stage` and `ConverterImpl` are how an
  adapter answers a crossing during resolution; `Decompositions` is a
  declaration input; `expand` and `unfold` are resolution machinery; `fn_plan`
  and `struct_plan` are JniGen's frozen plans, which the artifacts read.

None of those is a compatibility carrier for the old writer — they are the
public-input surface #506 asks about, and that question is unaffected by this
umbrella either way.

## Verification

Workspace tests, strict Clippy, `cargo fmt --check` and
`RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps` pass. Every
generated artifact — C bindings, C headers, JNI Rust, Kotlin — is byte-for-byte
unchanged, as it has been at every step of #581.

Step 6 of #581, and the last one.

— Claude Code (Opus 5)
