### PR TITLE
Close the umbrella's own review

### DIFF
--- a/prebindgen-c/src/assembly.rs
+++ b/prebindgen-c/src/assembly.rs
@@ -62,6 +62,16 @@ impl RustArtifact for CFinalArtifact {
         }
     }
 
+    fn reachable(&self) -> bool {
+        // Every C artifact reaches the file. Unreached converters are pruned
+        // from the generation plan before the assembly sees them, and every
+        // other kind is planned only when something needs it — the memory
+        // helpers because an artifact says it calls them, a mirror because its
+        // type crosses. Stated rather than inherited: an artifact that needs a
+        // different answer should be a deliberate change here.
+        true
+    }
+
     fn calls(&self) -> Vec<ArtifactKey> {
         match self {
             Self::Converter(converter) => converter.calls(),

--- a/prebindgen-c/src/trait_impl.rs
+++ b/prebindgen-c/src/trait_impl.rs
@@ -518,9 +518,9 @@ impl CbindgenBuilder {
     }
 }
 
-/// Per-section [`CbindgenBuilder::prerequisites`] emitters. Each returns the runtime-
-/// support items for one concern; the trait method concatenates them in order,
-/// so the emitted preamble is identical to the former single function.
+/// Declaration queries the planned artifacts read. Each answers one concern
+/// of the runtime support the file opens with; the artifacts that carry those
+/// items are in [`crate::assembly`].
 impl CbindgenBuilder {
     /// Converter fragments consumed by one type-level final artifact.
     fn artifact_fragment_inputs(
@@ -773,9 +773,8 @@ impl CbindgenBuilder {
     /// State this binding into `registry` — see `JniGenBuilder::declare_into`.
     ///
     /// Push, not pull: the build script calls this, and the registry never
-    /// calls back. cbindgen declares no selective const surface (its
-    /// `on_const` policy generates a source-module alias for every captured
-    /// const) and no decompositions.
+    /// calls back. cbindgen declares no selective const surface — it plans a
+    /// source-module alias for every captured const — and no decompositions.
     /// Binding-local fns declared by `convert!(..).local(..)`.
     fn collect_local_functions(&self) -> Vec<(syn::ItemFn, String)> {
         let mut result = Vec::new();

--- a/prebindgen-jni/src/jni/emit/wrapper.rs
+++ b/prebindgen-jni/src/jni/emit/wrapper.rs
@@ -73,8 +73,8 @@ impl JWrapper {
 
 /// The synthetic nullary getter signature a declared const is emitted
 /// through: `pub fn const_get_<ident_lower>() -> <const ty>`. Both sides —
-/// the Rust extern ([`Declarations::on_const`] via
-/// [`emit_jni_function_wrapper_with_callee`]) and the Kotlin `val`
+/// the Rust extern (the constant artifact's getter, a [`JWrapper`] whose
+/// callee is a path to the const) and the Kotlin `val`
 /// initializer (`render_const_val`) — derive the extern symbol from this one
 /// ident, so they stay in sync by construction. The body is never used.
 pub(crate) fn const_getter_fn(
@@ -230,7 +230,7 @@ pub(crate) fn validate_constant_expr(ext: &Declarations, kotlin_name: &str, ty: 
 /// [`emit_jni_function_wrapper`] with the raw callee expression overridable:
 /// `None` = the ordinary `<origin module>::<fn ident>(args)` call; `Some(e)`
 /// splices `e` verbatim as the value the output phase converts. Used by the
-/// const getter emission (`Declarations::on_const`), whose synthetic nullary `f`
+/// const getter emission (the constant artifact's), whose synthetic nullary `f`
 /// carries the signature while the value comes from
 /// `<origin module>::<CONST_IDENT>` — a path, not a call.
 impl JWrapper {

--- a/prebindgen-jni/src/jni/fn_plan.rs
+++ b/prebindgen-jni/src/jni/fn_plan.rs
@@ -488,7 +488,7 @@ impl PlanError {
         let at = self.location_suffix();
         match self {
             PlanError::Unresolved { ty } => format!(
-                "JniGen::on_function: input type `{}` for `{}` is unresolved{at}",
+                "JniGen extern: input type `{}` for `{}` is unresolved{at}",
                 ty.key(),
                 fn_ident,
             ),
@@ -498,7 +498,7 @@ impl PlanError {
                 param,
             ),
             PlanError::UnresolvedOutput { ty } => format!(
-                "JniGen::on_function: return type `{}` of `{}` has no registered output \
+                "JniGen extern: return type `{}` of `{}` has no registered output \
                  converter — register one via `Declarations::output_wrapper(pat, |…| Some((ty, exc, body)))` \
                  (exc = `None` for non-throwing, `Some(parse_quote!(<full path>))` \
                   to bind a domain exception){at}",
@@ -506,16 +506,16 @@ impl PlanError {
                 fn_ident,
             ),
             PlanError::UnknownOutputType { ty } => format!(
-                "JniGen::on_function: return type `{}` of `{}` is not registered — the \
+                "JniGen extern: return type `{}` of `{}` is not registered — the \
                  resolver never saw this type, so no converter can be selected for it. \
                  Declare the type (or the function that produces it) before binding `{}`",
                 ty, fn_ident, fn_ident,
             ),
             PlanError::UnflattenableDataClass(error) => {
-                format!("JniGen::on_function `{fn_ident}`: {}", error.message())
+                format!("JniGen extern `{fn_ident}`: {}", error.message())
             }
             PlanError::JvmParameterLimit { slots } => format!(
-                "JniGen::on_function `{fn_ident}`: flattened JNI signature uses {slots} JVM parameter slots (maximum 255, including the JNINative receiver); reduce the data-class shape or declare an intentional `data_class!(T).jobject_input()` boundary"
+                "JniGen extern `{fn_ident}`: flattened JNI signature uses {slots} JVM parameter slots (maximum 255, including the JNINative receiver); reduce the data-class shape or declare an intentional `data_class!(T).jobject_input()` boundary"
             ),
         }
     }
@@ -575,7 +575,7 @@ pub(crate) fn validate_bindings(ext: &Declarations, registry: &Registry) -> Resu
     }
 
     // Declared consts: their synthetic nullary getters run through the same
-    // plan machinery (`Declarations::on_const`).
+    // plan machinery, and reach the file as constant artifacts.
     if let Some(declared_consts) = ext.declared_consts() {
         let mut consts: Vec<&prebindgen_registry::flat::Constant> =
             registry.flat().constants().collect();

--- a/prebindgen-registry/src/lib.rs
+++ b/prebindgen-registry/src/lib.rs
@@ -21,9 +21,12 @@
 //!   [`ConverterImpl`] (a converter artifact identity plus its wire type) for
 //!   each crossing the registry hands it, and gives them all back through
 //!   `RegistryBuilder::convert_with`.
-//! * **Owns the Rust-emission key** and emits wrapper code per item —
-//!   `on_function` / `on_struct` / `on_enum` / `on_const` on the
-//!   [`Prebindgen`] trait.
+//! * **Plans what the generated file holds** — every wrapper, converter,
+//!   helper, mirror and constant is an artifact of the adapter's frozen
+//!   [`Assembly`](write::Assembly), which the registry orders and
+//!   [`write::write_rust`] renders. The adapter emits nothing per item while
+//!   the file is written, and the [`Prebindgen`] trait it implements is two
+//!   validation hooks.
 //!
 //! Everything language-specific that must travel through the pipeline rides on
 //! the adapter's own conversions — a JNI back-end's Kotlin class names and

--- a/prebindgen-registry/src/registry/declare.rs
+++ b/prebindgen-registry/src/registry/declare.rs
@@ -116,9 +116,11 @@ impl RegistryBuilder {
     /// A const this binding exports.
     ///
     /// Separate from [`Self::export`] only because *having a const mechanism at
-    /// all* is itself a fact: a binding that never calls this applies its
-    /// `on_const` policy to every captured const, while one that calls it emits
-    /// exactly what it names. See [`Self::declares_consts`].
+    /// all* is itself a fact, and the unclaimed-item report reads it: a binding
+    /// that never calls this claims no const, so none is reported as skipped,
+    /// while one that calls it claims exactly what it names. Which consts reach
+    /// the file is the adapter's own business — its constant artifacts decide
+    /// that. See [`Self::declares_consts`].
     pub fn export_const(mut self, name: &syn::Ident) -> Self {
         self.registry
             .declared
@@ -129,8 +131,8 @@ impl RegistryBuilder {
     }
 
     /// Declare that this binding has a const mechanism, even if it exports no
-    /// consts. Without it every captured const reaches the adapter's mandatory
-    /// `on_const` policy.
+    /// consts — which is what makes an unexported const a deliberate omission
+    /// rather than an unclaimed item.
     pub fn declares_consts(mut self) -> Self {
         self.registry
             .declared

--- a/prebindgen-registry/src/write.rs
+++ b/prebindgen-registry/src/write.rs
@@ -1,10 +1,10 @@
 //! Rust file emission for the resolved `Registry`.
 //!
 //! `write_rust` takes the [`Assembly`] the adapter compiled — the frozen set
-//! of final artifacts the file is made of; renders each with the writer-owned
-//! [`crate::RustWriter`], surrounds them with the adapter's prerequisites and
-//! prebindgen's own anonymous feature-check consts, and hands the assembled
-//! file to `Destination::write`.
+//! of final artifacts the file is made of; renders each with the
+//! [`crate::RustWriter`] frozen alongside them, ends the file with prebindgen's
+//! own anonymous feature-check consts, and hands the result to
+//! `Destination::write`.
 //!
 //! The artifacts arrive from the adapter rather than being collected from the
 //! registry, which is what lets one crossing contribute more than one function
@@ -16,7 +16,7 @@
 //! identity; final Rust names are never used as planning identity.
 
 use std::{
-    collections::{BTreeSet, HashMap},
+    collections::{BTreeSet, HashMap, HashSet},
     path::{Path, PathBuf},
 };
 
@@ -137,9 +137,6 @@ pub trait RustArtifact {
 /// sharing never depends on the Rust symbol final emission allocates.
 pub struct Assembly<A> {
     artifacts: Vec<A>,
-    /// Every identity the held artifacts answer for, including the ones an
-    /// artifact provides beyond its own key.
-    provided: HashMap<ArtifactKey, usize>,
     /// The rendering capability, minted while freezing. Writing an assembly
     /// therefore needs no registry: what the writer needs of one — how to
     /// qualify a source type, and the feature checks below — was taken when
@@ -153,8 +150,9 @@ pub struct Assembly<A> {
 
 impl<A: RustArtifact> Assembly<A> {
     /// The artifacts, in emission order, including the ones no reachable
-    /// artifact calls. The writer skips those; they are held so that
-    /// [`Self::reaches`] can tell "planned but unreached" from "never
+    /// artifact calls. The writer skips those; they are held because an
+    /// adapter may reach one after adding it, and because keeping them lets
+    /// the dependency check tell "planned but unreached" from "never
     /// planned".
     pub fn artifacts(&self) -> impl ExactSizeIterator<Item = &A> {
         self.artifacts.iter()
@@ -170,20 +168,10 @@ impl<A: RustArtifact> Assembly<A> {
         &self.emit
     }
 
-    /// Prebindgen's injected feature checks, in stream order.
-    pub fn guards(&self) -> impl ExactSizeIterator<Item = &prebindgen_flat::flat::Guard> {
+    /// Prebindgen's injected feature checks, in stream order. Crate-private,
+    /// like [`Self::writer`]: the file's own writer is their only reader.
+    pub(crate) fn guards(&self) -> impl ExactSizeIterator<Item = &prebindgen_flat::flat::Guard> {
         self.guards.iter()
-    }
-
-    /// Whether an artifact answering for this identity reaches the file.
-    ///
-    /// Reachability is read here rather than when the assembly was frozen: an
-    /// adapter may reach an artifact after adding it, and the file is what
-    /// settles the answer.
-    pub fn reaches(&self, key: &ArtifactKey) -> bool {
-        self.provided
-            .get(key)
-            .is_some_and(|position| self.artifacts[*position].reachable())
     }
 }
 
@@ -249,15 +237,8 @@ impl<A: RustArtifact> AssemblyBuilder<A> {
     /// reference to the item's own origin module. Both arguments are read here
     /// and not again: a frozen assembly is everything writing its file needs.
     pub fn build(self, registry: &Registry, source_module: Option<&syn::Path>) -> Assembly<A> {
-        let mut provided = self.positions;
-        for (position, artifact) in self.artifacts.iter().enumerate() {
-            for key in artifact.provides() {
-                provided.insert(key, position);
-            }
-        }
         Assembly {
             artifacts: self.artifacts,
-            provided,
             emit: crate::RustWriter::new(registry, source_module),
             guards: registry.flat().guards().cloned().collect(),
         }
@@ -406,10 +387,21 @@ pub fn write_rust<P: AsRef<Path>, A: RustArtifact>(
     // Dependency completeness, proven from the artifacts' own edges before
     // anything is rendered: whatever a reachable artifact calls must itself
     // reach the file.
+    // Every identity the file answers for, read now rather than when the
+    // assembly was frozen: an adapter may reach an artifact after adding it,
+    // and the file is what settles the answer. Held as identities rather than
+    // as positions in the artifact list, so that filtering or reordering that
+    // list cannot leave a stale index behind.
+    let reached: HashSet<ArtifactKey> = assembly
+        .artifacts()
+        .filter(|artifact| artifact.reachable())
+        .flat_map(RustArtifact::provides)
+        .collect();
+
     let mut unreached: BTreeSet<(String, String)> = BTreeSet::new();
     for artifact in assembly.artifacts().filter(|artifact| artifact.reachable()) {
         for callee in artifact.calls() {
-            if !assembly.reaches(&callee) {
+            if !reached.contains(&callee) {
                 unreached.insert((artifact.key().to_string(), callee.to_string()));
             }
         }

--- a/prebindgen-registry/src/write/tests.rs
+++ b/prebindgen-registry/src/write/tests.rs
@@ -278,6 +278,51 @@ fn a_call_to_a_filtered_converter_is_a_writer_error() {
     );
 }
 
+/// The contract `Assembly`'s own documentation states: artifacts reach the
+/// file in the order the adapter added them.
+///
+/// Held here because the sentence is written here. Each adapter's chosen
+/// section order is pinned by its committed generated files, but reversing the
+/// envelope's own order is invisible to those: it moves every adapter's output
+/// at once, and nothing in this crate noticed.
+#[test]
+fn artifacts_reach_the_file_in_the_order_they_were_added() {
+    let operation = |name: &str| {
+        crate::generation::OperationId::shared(
+            crate::generation::ArtifactId::new("test", name).expect("identity"),
+            crate::recipe::Direction::Construct,
+        )
+    };
+    let (first, second) = (operation("first-converter"), operation("second-converter"));
+    let assembly = assembly_of([
+        LateOrCaller::Converter(LatePlan {
+            operation: first.clone(),
+            reachable: Rc::new(Cell::new(true)),
+        }),
+        LateOrCaller::Converter(LatePlan {
+            operation: second.clone(),
+            reachable: Rc::new(Cell::new(true)),
+        }),
+    ]);
+    let dir = crate::test_util::unique_test_dir("write_order");
+    std::fs::create_dir_all(&dir).unwrap();
+
+    let path = write_rust(&assembly, dir.join("gen.rs")).expect("write_rust");
+    let source = std::fs::read_to_string(path).expect("read generated file");
+
+    let emit = crate::RustWriter::for_test();
+    let position = |operation| {
+        let ident = emit.operation_ident("test", operation).to_string();
+        source
+            .find(&ident)
+            .unwrap_or_else(|| panic!("`{ident}` is missing:\n{source}"))
+    };
+    assert!(
+        position(&first) < position(&second),
+        "the order artifacts were added is the order they are written:\n{source}"
+    );
+}
+
 /// An assembly whose artifacts state their edges honestly passes the check
 /// both adapters run on every binding they build.
 #[test]


### PR DESCRIPTION
## What this changes

The five findings from the review of #581 as a whole. Each is small; two were
called out as worth fixing before the umbrella reaches `main`.

**The ordering test.** `Assembly`'s own documentation states the property the
design rests on — artifacts reach the file in the order the adapter added them
— and no test in the crate that defines it held that. Reversing emission order
in `write_rust` left all 218 registry tests green; only the adapters' committed
generated files noticed.
`artifacts_reach_the_file_in_the_order_they_were_added` fails on that reversal.
Each adapter's own section order stays pinned by its goldens, which is the
right place for it.

**`reaches` and `guards` were `pub`** with no caller outside the crate — the
shape #593 sealed `writer` for. `guards` is `pub(crate)`. `reaches` is deleted
outright: the set of reached identities is built in `write_rust`, from the
artifacts, where it is used.

**Which removes the index class the review found.** `Assembly` held a map from
identity to a *position* in the artifact list. The two had to stay in step,
nothing enforced it, and desynchronising them produced a plausible-looking
dependency failure naming unrelated artifacts rather than a panic. Anything
that filtered or reordered the list would have done it. The reached set holds
identities, so there is no index to go stale.

**Cbindgen states `reachable`.** Every C artifact does reach the file — its
converters are pruned from the generation plan before the assembly sees them,
and every other kind is planned only when something needs it — but that was
inherited from the default rather than said. JniGen spells out its six
always-reachable kinds; the reason applies to both.

**The deleted extension mechanism is no longer documented.** Eight comments
across five files still described the `on_*` callbacks, including the two a
reader meets first:

- `prebindgen-registry`'s crate documentation said a generator "emits wrapper
  code per item — `on_function` / `on_struct` / `on_enum` / `on_const` on the
  `Prebindgen` trait", which is the inverse of what the branch delivers.
- `export_const` and `declares_consts` explained themselves through an
  `on_const` policy that no longer exists. What the flag drives now is the
  unclaimed-item report; which constants reach the file is decided by the
  adapter's constant artifacts.

The rest were in `prebindgen-c/src/trait_impl.rs`,
`prebindgen-jni/src/jni/fn_plan.rs` (including four user-visible error
messages that named `JniGen::on_function`) and `emit/wrapper.rs`.

## Verification

Workspace tests, strict Clippy, `cargo fmt --check` and
`RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps` pass. Every
generated artifact is byte-for-byte unchanged.

The new test was checked against the mutation it exists for: reversing the
render loop's order fails it with "the order artifacts were added is the order
they are written".

Closes out the review of #581.

— Claude Code (Opus 5)
