### PR TITLE
Compose every source-value walk in the registry

### DIFF
--- a/examples/covertest-kotlin/src/generated_bindings.rs
+++ b/examples/covertest-kotlin/src/generated_bindings.rs
@@ -3463,67 +3463,83 @@ pub(crate) unsafe fn __jni_in_convert_wire_to_Hold_5a6747f2776b0f97<'env, 'v>(
     v: &jni::objects::JObject<'v>,
 ) -> ::core::result::Result<perftest_flat::Hold, __JniErr> {
     Ok({
-        let __obj = v;
-        (|| -> ::core::result::Result<perftest_flat::Hold, __JniErr> {
-            if __obj.is_null() {
+        let __tag = {
+            if v.is_null() {
                 return ::core::result::Result::Err(
                     <__JniErr as ::core::convert::From<
                         String,
                     >>::from("Hold: null value where a variant was required".to_string()),
                 );
             }
-            if env
-                .is_instance_of(__obj, "io/prebindgen/covertest/model/Hold$Indefinite")
-                .map_err(|e| <__JniErr as ::core::convert::From<
-                    String,
-                >>::from(
-                    format!(
-                        concat!("Hold", ": instanceof ",
-                        "io/prebindgen/covertest/model/Hold$Indefinite", ": {}"), e
-                    ),
-                ))?
-            {
-                return ::core::result::Result::Ok(perftest_flat::Hold::Indefinite);
-            }
-            if env
-                .is_instance_of(__obj, "io/prebindgen/covertest/model/Hold$For")
-                .map_err(|e| <__JniErr as ::core::convert::From<
-                    String,
-                >>::from(
-                    format!(
-                        concat!("Hold", ": instanceof ",
-                        "io/prebindgen/covertest/model/Hold$For", ": {}"), e
-                    ),
-                ))?
-            {
+            let __tag = (|| -> ::core::result::Result<i32, __JniErr> {
+                if env
+                    .is_instance_of(v, "io/prebindgen/covertest/model/Hold$Indefinite")
+                    .map_err(|e| <__JniErr as ::core::convert::From<
+                        String,
+                    >>::from(
+                        format!(
+                            "Hold: instanceof io/prebindgen/covertest/model/Hold$Indefinite: {}",
+                            e
+                        ),
+                    ))?
+                {
+                    return ::core::result::Result::Ok(0i32);
+                }
+                if env
+                    .is_instance_of(v, "io/prebindgen/covertest/model/Hold$For")
+                    .map_err(|e| <__JniErr as ::core::convert::From<
+                        String,
+                    >>::from(
+                        format!(
+                            "Hold: instanceof io/prebindgen/covertest/model/Hold$For: {}",
+                            e
+                        ),
+                    ))?
+                {
+                    return ::core::result::Result::Ok(1i32);
+                }
+                ::core::result::Result::Ok(-1i32)
+            })()?;
+            __tag
+        };
+        match __tag {
+            0i32 => perftest_flat::Hold::Indefinite,
+            1i32 => {
+                let __choice = v;
+                let __arm = __choice;
                 let __p_v0_raw: jni::sys::jlong = env
-                    .get_field(__obj, "v0", "J")
+                    .get_field(__arm, "v0", "J")
                     .and_then(|val| val.j())
                     .map_err(|e| <__JniErr as ::core::convert::From<
                         String,
                     >>::from(format!("Hold.For.v0: {}", e)))? as _;
-                let __p_v0 = {
-                    let __chain_s0 = __jni_in_convert_wire_to_u64_8507143745dc33b9(
-                        env,
-                        &__p_v0_raw,
-                    )?;
-                    let __chain_s1 = __jni_in_stage_0_wire_to_Duration_814bb872b19d3627(
+                perftest_flat::Hold::For(
+                    {
+                        let __chain_s0 = __jni_in_convert_wire_to_u64_8507143745dc33b9(
                             env,
-                            __chain_s0,
-                        )
-                        .map_err(|__e| <__JniErr as ::core::convert::From<
-                            String,
-                        >>::from(__e.to_string()))?;
-                    ::core::result::Result::<_, __JniErr>::Ok(__chain_s1)
-                }?;
-                return ::core::result::Result::Ok(perftest_flat::Hold::For(__p_v0));
+                            &__p_v0_raw,
+                        )?;
+                        let __chain_s1 = __jni_in_stage_0_wire_to_Duration_814bb872b19d3627(
+                                env,
+                                __chain_s0,
+                            )
+                            .map_err(|__e| <__JniErr as ::core::convert::From<
+                                String,
+                            >>::from(__e.to_string()))?;
+                        ::core::result::Result::<_, __JniErr>::Ok(__chain_s1)
+                    }?,
+                )
             }
-            ::core::result::Result::Err(
-                <__JniErr as ::core::convert::From<
-                    String,
-                >>::from("Hold: value is not one of its declared variants".to_string()),
-            )
-        })()?
+            _ => {
+                return ::core::result::Result::Err(
+                    <__JniErr as ::core::convert::From<
+                        String,
+                    >>::from(
+                        "Hold: value is not one of its declared variants".to_string(),
+                    ),
+                );
+            }
+        }
     })
 }
 #[allow(
@@ -4120,9 +4136,8 @@ pub(crate) unsafe fn __jni_in_convert_wire_to_Lookup_2fa8248a2de561a5<'env, 'v>(
     v: &jni::objects::JObject<'v>,
 ) -> ::core::result::Result<perftest_flat::Lookup, __JniErr> {
     Ok({
-        let __obj = v;
-        (|| -> ::core::result::Result<perftest_flat::Lookup, __JniErr> {
-            if __obj.is_null() {
+        let __tag = {
+            if v.is_null() {
                 return ::core::result::Result::Err(
                     <__JniErr as ::core::convert::From<
                         String,
@@ -4131,33 +4146,58 @@ pub(crate) unsafe fn __jni_in_convert_wire_to_Lookup_2fa8248a2de561a5<'env, 'v>(
                     ),
                 );
             }
-            if env
-                .is_instance_of(__obj, "io/prebindgen/covertest/model/Lookup$Absent")
-                .map_err(|e| <__JniErr as ::core::convert::From<
-                    String,
-                >>::from(
-                    format!(
-                        concat!("Lookup", ": instanceof ",
-                        "io/prebindgen/covertest/model/Lookup$Absent", ": {}"), e
-                    ),
-                ))?
-            {
-                return ::core::result::Result::Ok(perftest_flat::Lookup::Absent);
-            }
-            if env
-                .is_instance_of(__obj, "io/prebindgen/covertest/model/Lookup$Found")
-                .map_err(|e| <__JniErr as ::core::convert::From<
-                    String,
-                >>::from(
-                    format!(
-                        concat!("Lookup", ": instanceof ",
-                        "io/prebindgen/covertest/model/Lookup$Found", ": {}"), e
-                    ),
-                ))?
-            {
+            let __tag = (|| -> ::core::result::Result<i32, __JniErr> {
+                if env
+                    .is_instance_of(v, "io/prebindgen/covertest/model/Lookup$Absent")
+                    .map_err(|e| <__JniErr as ::core::convert::From<
+                        String,
+                    >>::from(
+                        format!(
+                            "Lookup: instanceof io/prebindgen/covertest/model/Lookup$Absent: {}",
+                            e
+                        ),
+                    ))?
+                {
+                    return ::core::result::Result::Ok(0i32);
+                }
+                if env
+                    .is_instance_of(v, "io/prebindgen/covertest/model/Lookup$Found")
+                    .map_err(|e| <__JniErr as ::core::convert::From<
+                        String,
+                    >>::from(
+                        format!(
+                            "Lookup: instanceof io/prebindgen/covertest/model/Lookup$Found: {}",
+                            e
+                        ),
+                    ))?
+                {
+                    return ::core::result::Result::Ok(1i32);
+                }
+                if env
+                    .is_instance_of(v, "io/prebindgen/covertest/model/Lookup$Failed")
+                    .map_err(|e| <__JniErr as ::core::convert::From<
+                        String,
+                    >>::from(
+                        format!(
+                            "Lookup: instanceof io/prebindgen/covertest/model/Lookup$Failed: {}",
+                            e
+                        ),
+                    ))?
+                {
+                    return ::core::result::Result::Ok(2i32);
+                }
+                ::core::result::Result::Ok(-1i32)
+            })()?;
+            __tag
+        };
+        match __tag {
+            0i32 => perftest_flat::Lookup::Absent,
+            1i32 => {
+                let __choice = v;
+                let __arm = __choice;
                 let __p_v0_obj: jni::objects::JObject = env
                     .get_field(
-                        __obj,
+                        __arm,
                         "v0",
                         "Lio/prebindgen/covertest/analytics/Summary;",
                     )
@@ -4174,42 +4214,40 @@ pub(crate) unsafe fn __jni_in_convert_wire_to_Lookup_2fa8248a2de561a5<'env, 'v>(
                             String,
                         >>::from(format!("Lookup.Found.v0: {}", e)))?
                 };
-                let __p_v0 = __jni_in_convert_wire_to_Summary_jni_handle_codec_consume_input_a6c328c6a2331e58(
-                    env,
-                    &__p_v0_raw,
-                )?;
-                return ::core::result::Result::Ok(perftest_flat::Lookup::Found(__p_v0));
+                perftest_flat::Lookup::Found(
+                    __jni_in_convert_wire_to_Summary_jni_handle_codec_consume_input_a6c328c6a2331e58(
+                        env,
+                        &__p_v0_raw,
+                    )?,
+                )
             }
-            if env
-                .is_instance_of(__obj, "io/prebindgen/covertest/model/Lookup$Failed")
-                .map_err(|e| <__JniErr as ::core::convert::From<
-                    String,
-                >>::from(
-                    format!(
-                        concat!("Lookup", ": instanceof ",
-                        "io/prebindgen/covertest/model/Lookup$Failed", ": {}"), e
-                    ),
-                ))?
-            {
+            2i32 => {
+                let __choice = v;
+                let __arm = __choice;
                 let __p_v0_obj: jni::objects::JObject = env
-                    .get_field(__obj, "v0", "Ljava/lang/String;")
+                    .get_field(__arm, "v0", "Ljava/lang/String;")
                     .and_then(|val| val.l())
                     .map_err(|e| <__JniErr as ::core::convert::From<
                         String,
                     >>::from(format!("Lookup.Failed.v0: {}", e)))?;
                 let __p_v0_raw: jni::objects::JString = __p_v0_obj.into();
-                let __p_v0 = __jni_in_convert_wire_to_jni_text_codec_owned_40915aa02cf8d9ce(
-                    env,
-                    &__p_v0_raw,
-                )?;
-                return ::core::result::Result::Ok(perftest_flat::Lookup::Failed(__p_v0));
+                perftest_flat::Lookup::Failed(
+                    __jni_in_convert_wire_to_jni_text_codec_owned_40915aa02cf8d9ce(
+                        env,
+                        &__p_v0_raw,
+                    )?,
+                )
             }
-            ::core::result::Result::Err(
-                <__JniErr as ::core::convert::From<
-                    String,
-                >>::from("Lookup: value is not one of its declared variants".to_string()),
-            )
-        })()?
+            _ => {
+                return ::core::result::Result::Err(
+                    <__JniErr as ::core::convert::From<
+                        String,
+                    >>::from(
+                        "Lookup: value is not one of its declared variants".to_string(),
+                    ),
+                );
+            }
+        }
     })
 }
 #[allow(
@@ -4338,9 +4376,8 @@ pub(crate) unsafe fn __jni_in_convert_wire_to_Marker_93f2fabe59a4f80d<'env, 'v>(
     v: &jni::objects::JObject<'v>,
 ) -> ::core::result::Result<perftest_flat::Marker, __JniErr> {
     Ok({
-        let __obj = v;
-        (|| -> ::core::result::Result<perftest_flat::Marker, __JniErr> {
-            if __obj.is_null() {
+        let __tag = {
+            if v.is_null() {
                 return ::core::result::Result::Err(
                     <__JniErr as ::core::convert::From<
                         String,
@@ -4349,37 +4386,49 @@ pub(crate) unsafe fn __jni_in_convert_wire_to_Marker_93f2fabe59a4f80d<'env, 'v>(
                     ),
                 );
             }
-            if env
-                .is_instance_of(__obj, "io/prebindgen/covertest/model/Marker$None_")
-                .map_err(|e| <__JniErr as ::core::convert::From<
-                    String,
-                >>::from(
-                    format!(
-                        concat!("Marker", ": instanceof ",
-                        "io/prebindgen/covertest/model/Marker$None_", ": {}"), e
-                    ),
-                ))?
-            {
-                return ::core::result::Result::Ok(perftest_flat::Marker::None_);
-            }
-            if env
-                .is_instance_of(__obj, "io/prebindgen/covertest/model/Marker$Ranked")
-                .map_err(|e| <__JniErr as ::core::convert::From<
-                    String,
-                >>::from(
-                    format!(
-                        concat!("Marker", ": instanceof ",
-                        "io/prebindgen/covertest/model/Marker$Ranked", ": {}"), e
-                    ),
-                ))?
-            {
+            let __tag = (|| -> ::core::result::Result<i32, __JniErr> {
+                if env
+                    .is_instance_of(v, "io/prebindgen/covertest/model/Marker$None_")
+                    .map_err(|e| <__JniErr as ::core::convert::From<
+                        String,
+                    >>::from(
+                        format!(
+                            "Marker: instanceof io/prebindgen/covertest/model/Marker$None_: {}",
+                            e
+                        ),
+                    ))?
+                {
+                    return ::core::result::Result::Ok(0i32);
+                }
+                if env
+                    .is_instance_of(v, "io/prebindgen/covertest/model/Marker$Ranked")
+                    .map_err(|e| <__JniErr as ::core::convert::From<
+                        String,
+                    >>::from(
+                        format!(
+                            "Marker: instanceof io/prebindgen/covertest/model/Marker$Ranked: {}",
+                            e
+                        ),
+                    ))?
+                {
+                    return ::core::result::Result::Ok(1i32);
+                }
+                ::core::result::Result::Ok(-1i32)
+            })()?;
+            __tag
+        };
+        match __tag {
+            0i32 => perftest_flat::Marker::None_,
+            1i32 => {
+                let __choice = v;
+                let __arm = __choice;
                 let __p_v0_obj: jni::objects::JObject = env
-                    .get_field(__obj, "v0", "Lio/prebindgen/covertest/model/Priority;")
+                    .get_field(__arm, "v0", "Lio/prebindgen/covertest/model/Priority;")
                     .and_then(|val| val.l())
                     .map_err(|e| <__JniErr as ::core::convert::From<
                         String,
                     >>::from(format!("Marker.Ranked.v0: {}", e)))?;
-                let __p_v0 = {
+                perftest_flat::Marker::Ranked({
                     let v = __p_v0_obj;
                     {
                         if v.is_null() {
@@ -4399,15 +4448,18 @@ pub(crate) unsafe fn __jni_in_convert_wire_to_Marker_93f2fabe59a4f80d<'env, 'v>(
                             )
                         }
                     }
-                };
-                return ::core::result::Result::Ok(perftest_flat::Marker::Ranked(__p_v0));
+                })
             }
-            ::core::result::Result::Err(
-                <__JniErr as ::core::convert::From<
-                    String,
-                >>::from("Marker: value is not one of its declared variants".to_string()),
-            )
-        })()?
+            _ => {
+                return ::core::result::Result::Err(
+                    <__JniErr as ::core::convert::From<
+                        String,
+                    >>::from(
+                        "Marker: value is not one of its declared variants".to_string(),
+                    ),
+                );
+            }
+        }
     })
 }
 #[allow(
@@ -9582,9 +9634,8 @@ pub(crate) unsafe fn __jni_in_convert_wire_to_Reading_a358e65c0c39d007<'env, 'v>
     v: &jni::objects::JObject<'v>,
 ) -> ::core::result::Result<perftest_flat::Reading, __JniErr> {
     Ok({
-        let __obj = v;
-        (|| -> ::core::result::Result<perftest_flat::Reading, __JniErr> {
-            if __obj.is_null() {
+        let __tag = {
+            if v.is_null() {
                 return ::core::result::Result::Err(
                     <__JniErr as ::core::convert::From<
                         String,
@@ -9593,102 +9644,129 @@ pub(crate) unsafe fn __jni_in_convert_wire_to_Reading_a358e65c0c39d007<'env, 'v>
                     ),
                 );
             }
-            if env
-                .is_instance_of(__obj, "io/prebindgen/covertest/model/Reading$Missing")
-                .map_err(|e| <__JniErr as ::core::convert::From<
-                    String,
-                >>::from(
-                    format!(
-                        concat!("Reading", ": instanceof ",
-                        "io/prebindgen/covertest/model/Reading$Missing", ": {}"), e
-                    ),
-                ))?
-            {
-                return ::core::result::Result::Ok(perftest_flat::Reading::Missing);
-            }
-            if env
-                .is_instance_of(__obj, "io/prebindgen/covertest/model/Reading$Exact")
-                .map_err(|e| <__JniErr as ::core::convert::From<
-                    String,
-                >>::from(
-                    format!(
-                        concat!("Reading", ": instanceof ",
-                        "io/prebindgen/covertest/model/Reading$Exact", ": {}"), e
-                    ),
-                ))?
-            {
+            let __tag = (|| -> ::core::result::Result<i32, __JniErr> {
+                if env
+                    .is_instance_of(v, "io/prebindgen/covertest/model/Reading$Missing")
+                    .map_err(|e| <__JniErr as ::core::convert::From<
+                        String,
+                    >>::from(
+                        format!(
+                            "Reading: instanceof io/prebindgen/covertest/model/Reading$Missing: {}",
+                            e
+                        ),
+                    ))?
+                {
+                    return ::core::result::Result::Ok(0i32);
+                }
+                if env
+                    .is_instance_of(v, "io/prebindgen/covertest/model/Reading$Exact")
+                    .map_err(|e| <__JniErr as ::core::convert::From<
+                        String,
+                    >>::from(
+                        format!(
+                            "Reading: instanceof io/prebindgen/covertest/model/Reading$Exact: {}",
+                            e
+                        ),
+                    ))?
+                {
+                    return ::core::result::Result::Ok(1i32);
+                }
+                if env
+                    .is_instance_of(v, "io/prebindgen/covertest/model/Reading$Range")
+                    .map_err(|e| <__JniErr as ::core::convert::From<
+                        String,
+                    >>::from(
+                        format!(
+                            "Reading: instanceof io/prebindgen/covertest/model/Reading$Range: {}",
+                            e
+                        ),
+                    ))?
+                {
+                    return ::core::result::Result::Ok(2i32);
+                }
+                if env
+                    .is_instance_of(v, "io/prebindgen/covertest/model/Reading$Tagged")
+                    .map_err(|e| <__JniErr as ::core::convert::From<
+                        String,
+                    >>::from(
+                        format!(
+                            "Reading: instanceof io/prebindgen/covertest/model/Reading$Tagged: {}",
+                            e
+                        ),
+                    ))?
+                {
+                    return ::core::result::Result::Ok(3i32);
+                }
+                if env
+                    .is_instance_of(v, "io/prebindgen/covertest/model/Reading$Companion")
+                    .map_err(|e| <__JniErr as ::core::convert::From<
+                        String,
+                    >>::from(
+                        format!(
+                            "Reading: instanceof io/prebindgen/covertest/model/Reading$Companion: {}",
+                            e
+                        ),
+                    ))?
+                {
+                    return ::core::result::Result::Ok(4i32);
+                }
+                ::core::result::Result::Ok(-1i32)
+            })()?;
+            __tag
+        };
+        match __tag {
+            0i32 => perftest_flat::Reading::Missing,
+            1i32 => {
+                let __choice = v;
+                let __arm = __choice;
                 let __p_v0_raw: jni::sys::jlong = env
-                    .get_field(__obj, "v0", "J")
+                    .get_field(__arm, "v0", "J")
                     .and_then(|val| val.j())
                     .map_err(|e| <__JniErr as ::core::convert::From<
                         String,
                     >>::from(format!("Reading.Exact.v0: {}", e)))? as _;
-                let __p_v0 = __jni_in_convert_wire_to_i64_da07d745d9e26f71(
-                    env,
-                    &__p_v0_raw,
-                )?;
-                return ::core::result::Result::Ok(perftest_flat::Reading::Exact(__p_v0));
+                perftest_flat::Reading::Exact(
+                    __jni_in_convert_wire_to_i64_da07d745d9e26f71(env, &__p_v0_raw)?,
+                )
             }
-            if env
-                .is_instance_of(__obj, "io/prebindgen/covertest/model/Reading$Range")
-                .map_err(|e| <__JniErr as ::core::convert::From<
-                    String,
-                >>::from(
-                    format!(
-                        concat!("Reading", ": instanceof ",
-                        "io/prebindgen/covertest/model/Reading$Range", ": {}"), e
-                    ),
-                ))?
-            {
+            2i32 => {
+                let __choice = v;
+                let __arm = __choice;
                 let __p_low_raw: jni::sys::jlong = env
-                    .get_field(__obj, "low", "J")
+                    .get_field(__arm, "low", "J")
                     .and_then(|val| val.j())
                     .map_err(|e| <__JniErr as ::core::convert::From<
                         String,
                     >>::from(format!("Reading.Range.low: {}", e)))? as _;
-                let __p_low = __jni_in_convert_wire_to_i64_da07d745d9e26f71(
-                    env,
-                    &__p_low_raw,
-                )?;
                 let __p_high_raw: jni::sys::jlong = env
-                    .get_field(__obj, "high", "J")
+                    .get_field(__arm, "high", "J")
                     .and_then(|val| val.j())
                     .map_err(|e| <__JniErr as ::core::convert::From<
                         String,
                     >>::from(format!("Reading.Range.high: {}", e)))? as _;
-                let __p_high = __jni_in_convert_wire_to_i64_da07d745d9e26f71(
-                    env,
-                    &__p_high_raw,
-                )?;
-                return ::core::result::Result::Ok(perftest_flat::Reading::Range {
-                    low: __p_low,
-                    high: __p_high,
-                });
+                perftest_flat::Reading::Range {
+                    low: __jni_in_convert_wire_to_i64_da07d745d9e26f71(
+                        env,
+                        &__p_low_raw,
+                    )?,
+                    high: __jni_in_convert_wire_to_i64_da07d745d9e26f71(
+                        env,
+                        &__p_high_raw,
+                    )?,
+                }
             }
-            if env
-                .is_instance_of(__obj, "io/prebindgen/covertest/model/Reading$Tagged")
-                .map_err(|e| <__JniErr as ::core::convert::From<
-                    String,
-                >>::from(
-                    format!(
-                        concat!("Reading", ": instanceof ",
-                        "io/prebindgen/covertest/model/Reading$Tagged", ": {}"), e
-                    ),
-                ))?
-            {
+            3i32 => {
+                let __choice = v;
+                let __arm = __choice;
                 let __p_v0_obj: jni::objects::JObject = env
-                    .get_field(__obj, "v0", "Ljava/lang/String;")
+                    .get_field(__arm, "v0", "Ljava/lang/String;")
                     .and_then(|val| val.l())
                     .map_err(|e| <__JniErr as ::core::convert::From<
                         String,
                     >>::from(format!("Reading.Tagged.v0: {}", e)))?;
                 let __p_v0_raw: jni::objects::JString = __p_v0_obj.into();
-                let __p_v0 = __jni_in_convert_wire_to_jni_text_codec_owned_40915aa02cf8d9ce(
-                    env,
-                    &__p_v0_raw,
-                )?;
                 let __p_v1_obj: jni::objects::JObject = env
-                    .get_field(__obj, "v1", "Lio/prebindgen/covertest/model/Priority;")
+                    .get_field(__arm, "v1", "Lio/prebindgen/covertest/model/Priority;")
                     .and_then(|val| val.l())
                     .map_err(|e| <__JniErr as ::core::convert::From<
                         String,
@@ -9699,47 +9777,37 @@ pub(crate) unsafe fn __jni_in_convert_wire_to_Reading_a358e65c0c39d007<'env, 'v>
                     .map_err(|e| <__JniErr as ::core::convert::From<
                         String,
                     >>::from(format!("Reading.Tagged.v1: {}", e)))?;
-                let __p_v1 = __jni_in_convert_wire_to_Priority_2f3eb78aa92f8bfd(
-                    env,
-                    &__p_v1_raw,
-                )?;
-                return ::core::result::Result::Ok(
-                    perftest_flat::Reading::Labeled(__p_v0, __p_v1),
-                );
+                perftest_flat::Reading::Labeled(
+                    __jni_in_convert_wire_to_jni_text_codec_owned_40915aa02cf8d9ce(
+                        env,
+                        &__p_v0_raw,
+                    )?,
+                    __jni_in_convert_wire_to_Priority_2f3eb78aa92f8bfd(env, &__p_v1_raw)?,
+                )
             }
-            if env
-                .is_instance_of(__obj, "io/prebindgen/covertest/model/Reading$Companion")
-                .map_err(|e| <__JniErr as ::core::convert::From<
-                    String,
-                >>::from(
-                    format!(
-                        concat!("Reading", ": instanceof ",
-                        "io/prebindgen/covertest/model/Reading$Companion", ": {}"), e
-                    ),
-                ))?
-            {
+            4i32 => {
+                let __choice = v;
+                let __arm = __choice;
                 let __p_v0_raw: jni::sys::jlong = env
-                    .get_field(__obj, "v0", "J")
+                    .get_field(__arm, "v0", "J")
                     .and_then(|val| val.j())
                     .map_err(|e| <__JniErr as ::core::convert::From<
                         String,
                     >>::from(format!("Reading.Companion.v0: {}", e)))? as _;
-                let __p_v0 = __jni_in_convert_wire_to_i64_da07d745d9e26f71(
-                    env,
-                    &__p_v0_raw,
-                )?;
-                return ::core::result::Result::Ok(
-                    perftest_flat::Reading::Companion(__p_v0),
+                perftest_flat::Reading::Companion(
+                    __jni_in_convert_wire_to_i64_da07d745d9e26f71(env, &__p_v0_raw)?,
+                )
+            }
+            _ => {
+                return ::core::result::Result::Err(
+                    <__JniErr as ::core::convert::From<
+                        String,
+                    >>::from(
+                        "Reading: value is not one of its declared variants".to_string(),
+                    ),
                 );
             }
-            ::core::result::Result::Err(
-                <__JniErr as ::core::convert::From<
-                    String,
-                >>::from(
-                    "Reading: value is not one of its declared variants".to_string(),
-                ),
-            )
-        })()?
+        }
     })
 }
 #[allow(

--- a/examples/covertest-kotlin/src/generated_bindings.rs
+++ b/examples/covertest-kotlin/src/generated_bindings.rs
@@ -617,18 +617,26 @@ pub(crate) unsafe fn __jni_in_convert_wire_to_Annotated_152537b2916e97e3<'env, '
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("Annotated.priority: {}", e)))?;
-        let priority = if __priority_jobj.is_null() {
-            ::core::option::Option::None
-        } else {
-            let __priority_raw: jni::sys::jint = env
-                .call_method(&__priority_jobj, "getValue", "()I", &[])
-                .and_then(|val| val.i())
-                .map_err(|e| <__JniErr as ::core::convert::From<
-                    String,
-                >>::from(format!("Annotated.priority: {}", e)))?;
-            ::core::option::Option::Some(
-                __jni_in_convert_wire_to_Priority_2f3eb78aa92f8bfd(env, &__priority_raw)?,
-            )
+        let priority = {
+            let v = __priority_jobj;
+            {
+                if v.is_null() {
+                    ::core::option::Option::None
+                } else {
+                    let __present = env
+                        .call_method(&v, "getValue", "()I", &[])
+                        .and_then(|val| val.i())
+                        .map_err(|e| <__JniErr as ::core::convert::From<
+                            String,
+                        >>::from(format!("Annotated.priority: {}", e)))?;
+                    ::core::option::Option::Some(
+                        __jni_in_convert_wire_to_Priority_2f3eb78aa92f8bfd(
+                            env,
+                            &__present,
+                        )?,
+                    )
+                }
+            }
         };
         perftest_flat::Annotated {
             payload,
@@ -714,19 +722,24 @@ pub(crate) unsafe fn __jni_in_convert_wire_to_DurationBoundary_3fd44c1cbdf7cf69<
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("DurationBoundary.delay: {}", e)))?;
-        let delay = if __delay_jobj.is_null() {
-            ::core::option::Option::None
-        } else {
-            let __delay_raw: jni::sys::jlong = env
-                .call_method(&__delay_jobj, "unbox-impl", "()J", &[])
-                .and_then(|val| val.j())
-                .map_err(|e| <__JniErr as ::core::convert::From<
-                    String,
-                >>::from(format!("DurationBoundary.delay: {}", e)))?;
-            __jni_in_convert_wire_to_Option_Duration_jni_optional_intermediate_input_niche_104bdfd3431d40b9(
-                env,
-                &__delay_raw,
-            )?
+        let delay = {
+            let v = __delay_jobj;
+            {
+                if v.is_null() {
+                    ::core::option::Option::None
+                } else {
+                    let __present = env
+                        .call_method(&v, "unbox-impl", "()J", &[])
+                        .and_then(|val| val.j())
+                        .map_err(|e| <__JniErr as ::core::convert::From<
+                            String,
+                        >>::from(format!("DurationBoundary.delay: {}", e)))?;
+                    __jni_in_convert_wire_to_Option_Duration_jni_optional_intermediate_input_niche_104bdfd3431d40b9(
+                        env,
+                        &__present,
+                    )?
+                }
+            }
         };
         perftest_flat::DurationBoundary {
             required,
@@ -1471,18 +1484,23 @@ pub(crate) unsafe fn __jni_in_convert_wire_to_Unsigned_802dffd3a2dd4ecb<'env, 'v
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("Unsigned.maybeLong: {}", e)))?;
-        let maybe_long = if __maybe_long_jobj.is_null() {
-            ::core::option::Option::None
-        } else {
-            let __maybe_long_raw: jni::sys::jlong = env
-                .call_method(&__maybe_long_jobj, "unbox-impl", "()J", &[])
-                .and_then(|val| val.j())
-                .map_err(|e| <__JniErr as ::core::convert::From<
-                    String,
-                >>::from(format!("Unsigned.maybeLong: {}", e)))?;
-            ::core::option::Option::Some(
-                __jni_in_convert_wire_to_u64_8507143745dc33b9(env, &__maybe_long_raw)?,
-            )
+        let maybe_long = {
+            let v = __maybe_long_jobj;
+            {
+                if v.is_null() {
+                    ::core::option::Option::None
+                } else {
+                    let __present = env
+                        .call_method(&v, "unbox-impl", "()J", &[])
+                        .and_then(|val| val.j())
+                        .map_err(|e| <__JniErr as ::core::convert::From<
+                            String,
+                        >>::from(format!("Unsigned.maybeLong: {}", e)))?;
+                    ::core::option::Option::Some(
+                        __jni_in_convert_wire_to_u64_8507143745dc33b9(env, &__present)?,
+                    )
+                }
+            }
         };
         perftest_flat::Unsigned {
             byte,
@@ -4404,21 +4422,26 @@ pub(crate) unsafe fn __jni_in_convert_wire_to_Marker_93f2fabe59a4f80d<'env, 'v>(
                     .map_err(|e| <__JniErr as ::core::convert::From<
                         String,
                     >>::from(format!("Marker.Ranked.v0: {}", e)))?;
-                let __p_v0 = if __p_v0_obj.is_null() {
-                    ::core::option::Option::None
-                } else {
-                    let __p_v0_raw: jni::sys::jint = env
-                        .call_method(&__p_v0_obj, "getValue", "()I", &[])
-                        .and_then(|val| val.i())
-                        .map_err(|e| <__JniErr as ::core::convert::From<
-                            String,
-                        >>::from(format!("Marker.Ranked.v0: {}", e)))?;
-                    ::core::option::Option::Some(
-                        __jni_in_convert_wire_to_Priority_2f3eb78aa92f8bfd(
-                            env,
-                            &__p_v0_raw,
-                        )?,
-                    )
+                let __p_v0 = {
+                    let v = __p_v0_obj;
+                    {
+                        if v.is_null() {
+                            ::core::option::Option::None
+                        } else {
+                            let __present = env
+                                .call_method(&v, "getValue", "()I", &[])
+                                .and_then(|val| val.i())
+                                .map_err(|e| <__JniErr as ::core::convert::From<
+                                    String,
+                                >>::from(format!("Marker.Ranked.v0: {}", e)))?;
+                            ::core::option::Option::Some(
+                                __jni_in_convert_wire_to_Priority_2f3eb78aa92f8bfd(
+                                    env,
+                                    &__present,
+                                )?,
+                            )
+                        }
+                    }
                 };
                 return ::core::result::Result::Ok(perftest_flat::Marker::Ranked(__p_v0));
             }

--- a/examples/covertest-kotlin/src/generated_bindings.rs
+++ b/examples/covertest-kotlin/src/generated_bindings.rs
@@ -587,62 +587,58 @@ pub(crate) unsafe fn __jni_in_convert_wire_to_Annotated_152537b2916e97e3<'env, '
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("Annotated.payload: {}", e)))?;
-        let payload = __jni_in_convert_wire_to_Payload_7e701167233e784f(
-            env,
-            &__payload_raw,
-        )?;
         let __alternate_raw: jni::objects::JObject = env
             .get_field(v, "alternate", "Lio/prebindgen/covertest/Payload;")
             .and_then(|val| val.l())
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("Annotated.alternate: {}", e)))?;
-        let alternate = __jni_in_convert_wire_to_Option_Payload_jni_optional_intermediate_input_niche_30b639591c34824b(
-            env,
-            &__alternate_raw,
-        )?;
         let __ttl_raw: jni::objects::JObject = env
             .get_field(v, "ttl", "Ljava/lang/Long;")
             .and_then(|val| val.l())
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("Annotated.ttl: {}", e)))?;
-        let ttl = __jni_in_convert_wire_to_Option_i64_jni_optional_intermediate_input_boxed_bebad25cf333cf7b(
-            env,
-            &__ttl_raw,
-        )?;
         let __priority_jobj: jni::objects::JObject = env
             .get_field(v, "priority", "Lio/prebindgen/covertest/model/Priority;")
             .and_then(|val| val.l())
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("Annotated.priority: {}", e)))?;
-        let priority = {
-            let v = __priority_jobj;
-            {
-                if v.is_null() {
-                    ::core::option::Option::None
-                } else {
-                    let __present = env
-                        .call_method(&v, "getValue", "()I", &[])
-                        .and_then(|val| val.i())
-                        .map_err(|e| <__JniErr as ::core::convert::From<
-                            String,
-                        >>::from(format!("Annotated.priority: {}", e)))?;
-                    ::core::option::Option::Some(
-                        __jni_in_convert_wire_to_Priority_2f3eb78aa92f8bfd(
-                            env,
-                            &__present,
-                        )?,
-                    )
-                }
-            }
-        };
         perftest_flat::Annotated {
-            payload,
-            alternate,
-            ttl,
-            priority,
+            payload: __jni_in_convert_wire_to_Payload_7e701167233e784f(
+                env,
+                &__payload_raw,
+            )?,
+            alternate: __jni_in_convert_wire_to_Option_Payload_jni_optional_intermediate_input_niche_30b639591c34824b(
+                env,
+                &__alternate_raw,
+            )?,
+            ttl: __jni_in_convert_wire_to_Option_i64_jni_optional_intermediate_input_boxed_bebad25cf333cf7b(
+                env,
+                &__ttl_raw,
+            )?,
+            priority: {
+                let v = __priority_jobj;
+                {
+                    if v.is_null() {
+                        ::core::option::Option::None
+                    } else {
+                        let __present = env
+                            .call_method(&v, "getValue", "()I", &[])
+                            .and_then(|val| val.i())
+                            .map_err(|e| <__JniErr as ::core::convert::From<
+                                String,
+                            >>::from(format!("Annotated.priority: {}", e)))?;
+                        ::core::option::Option::Some(
+                            __jni_in_convert_wire_to_Priority_2f3eb78aa92f8bfd(
+                                env,
+                                &__present,
+                            )?,
+                        )
+                    }
+                }
+            },
         }
     })
 }
@@ -702,48 +698,46 @@ pub(crate) unsafe fn __jni_in_convert_wire_to_DurationBoundary_3fd44c1cbdf7cf69<
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("DurationBoundary.required: {}", e)))?;
-        let required = {
-            let required_s0 = __jni_in_convert_wire_to_u64_8507143745dc33b9(
-                env,
-                &__required_raw,
-            )?;
-            let required_s1 = __jni_in_stage_0_wire_to_Duration_814bb872b19d3627(
-                    env,
-                    required_s0,
-                )
-                .map_err(|__e| <__JniErr as ::core::convert::From<
-                    String,
-                >>::from(__e.to_string()))?;
-            required_s1
-        };
         let __delay_jobj: jni::objects::JObject = env
             .get_field(v, "delay", "Lkotlin/ULong;")
             .and_then(|val| val.l())
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("DurationBoundary.delay: {}", e)))?;
-        let delay = {
-            let v = __delay_jobj;
-            {
-                if v.is_null() {
-                    ::core::option::Option::None
-                } else {
-                    let __present = env
-                        .call_method(&v, "unbox-impl", "()J", &[])
-                        .and_then(|val| val.j())
-                        .map_err(|e| <__JniErr as ::core::convert::From<
-                            String,
-                        >>::from(format!("DurationBoundary.delay: {}", e)))?;
-                    __jni_in_convert_wire_to_Option_Duration_jni_optional_intermediate_input_niche_104bdfd3431d40b9(
-                        env,
-                        &__present,
-                    )?
-                }
-            }
-        };
         perftest_flat::DurationBoundary {
-            required,
-            delay,
+            required: {
+                let __chain_s0 = __jni_in_convert_wire_to_u64_8507143745dc33b9(
+                    env,
+                    &__required_raw,
+                )?;
+                let __chain_s1 = __jni_in_stage_0_wire_to_Duration_814bb872b19d3627(
+                        env,
+                        __chain_s0,
+                    )
+                    .map_err(|__e| <__JniErr as ::core::convert::From<
+                        String,
+                    >>::from(__e.to_string()))?;
+                ::core::result::Result::<_, __JniErr>::Ok(__chain_s1)
+            }?,
+            delay: {
+                let v = __delay_jobj;
+                {
+                    if v.is_null() {
+                        ::core::option::Option::None
+                    } else {
+                        let __present = env
+                            .call_method(&v, "unbox-impl", "()J", &[])
+                            .and_then(|val| val.j())
+                            .map_err(|e| <__JniErr as ::core::convert::From<
+                                String,
+                            >>::from(format!("DurationBoundary.delay: {}", e)))?;
+                        __jni_in_convert_wire_to_Option_Duration_jni_optional_intermediate_input_niche_104bdfd3431d40b9(
+                            env,
+                            &__present,
+                        )?
+                    }
+                }
+            },
         }
     })
 }
@@ -829,23 +823,21 @@ pub(crate) unsafe fn __jni_in_convert_wire_to_ObjectBoundary_22ff055237fda473<'e
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("ObjectBoundary.left: {}", e)))?;
-        let left = __jni_in_convert_wire_to_ObjectBoundary64_9d95f2f133e7e0ab(
-            env,
-            &__left_raw,
-        )?;
         let __right_raw: jni::objects::JObject = env
             .get_field(v, "right", "Lio/prebindgen/covertest/model/ObjectBoundary63;")
             .and_then(|val| val.l())
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("ObjectBoundary.right: {}", e)))?;
-        let right = __jni_in_convert_wire_to_ObjectBoundary63_abd593b6b57968fd(
-            env,
-            &__right_raw,
-        )?;
         perftest_flat::ObjectBoundary {
-            left,
-            right,
+            left: __jni_in_convert_wire_to_ObjectBoundary64_9d95f2f133e7e0ab(
+                env,
+                &__left_raw,
+            )?,
+            right: __jni_in_convert_wire_to_ObjectBoundary63_abd593b6b57968fd(
+                env,
+                &__right_raw,
+            )?,
         }
     })
 }
@@ -911,28 +903,24 @@ pub(crate) unsafe fn __jni_in_convert_wire_to_Payload_7e701167233e784f<'env, 'v>
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("Payload.id: {}", e)))? as _;
-        let id = __jni_in_convert_wire_to_i64_da07d745d9e26f71(env, &__id_raw)?;
         let __seq_raw: jni::sys::jint = env
             .get_field(v, "seq", "I")
             .and_then(|val| val.i())
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("Payload.seq: {}", e)))? as _;
-        let seq = __jni_in_convert_wire_to_i32_83b133e23cc76fc5(env, &__seq_raw)?;
         let __value_raw: jni::sys::jdouble = env
             .get_field(v, "value", "D")
             .and_then(|val| val.d())
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("Payload.value: {}", e)))? as _;
-        let value = __jni_in_convert_wire_to_f64_b312e1b95182cdfd(env, &__value_raw)?;
         let __flag_raw: jni::sys::jboolean = env
             .get_field(v, "flag", "Z")
             .and_then(|val| val.z())
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("Payload.flag: {}", e)))? as _;
-        let flag = __jni_in_convert_wire_to_bool_1be2f6c32f925207(env, &__flag_raw)?;
         let __label_jobj: jni::objects::JObject = env
             .get_field(v, "label", "Ljava/lang/String;")
             .and_then(|val| val.l())
@@ -940,16 +928,15 @@ pub(crate) unsafe fn __jni_in_convert_wire_to_Payload_7e701167233e784f<'env, 'v>
                 String,
             >>::from(format!("Payload.label: {}", e)))?;
         let __label_raw: jni::objects::JString = __label_jobj.into();
-        let label = __jni_in_convert_wire_to_Option_Box_String_jni_optional_intermediate_input_niche_87b03b4201168b29(
-            env,
-            &__label_raw,
-        )?;
         perftest_flat::Payload {
-            id,
-            seq,
-            value,
-            flag,
-            label,
+            id: __jni_in_convert_wire_to_i64_da07d745d9e26f71(env, &__id_raw)?,
+            seq: __jni_in_convert_wire_to_i32_83b133e23cc76fc5(env, &__seq_raw)?,
+            value: __jni_in_convert_wire_to_f64_b312e1b95182cdfd(env, &__value_raw)?,
+            flag: __jni_in_convert_wire_to_bool_1be2f6c32f925207(env, &__flag_raw)?,
+            label: __jni_in_convert_wire_to_Option_Box_String_jni_optional_intermediate_input_niche_87b03b4201168b29(
+                env,
+                &__label_raw,
+            )?,
         }
     })
 }
@@ -1243,17 +1230,15 @@ pub(crate) unsafe fn __jni_in_convert_wire_to_Stamp_cccc3794c11688eb<'env, 'v>(
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("Stamp.secs: {}", e)))? as _;
-        let secs = __jni_in_convert_wire_to_i64_da07d745d9e26f71(env, &__secs_raw)?;
         let __nanos_raw: jni::sys::jlong = env
             .get_field(v, "nanos", "J")
             .and_then(|val| val.j())
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("Stamp.nanos: {}", e)))? as _;
-        let nanos = __jni_in_convert_wire_to_i64_da07d745d9e26f71(env, &__nanos_raw)?;
         perftest_flat::Stamp {
-            secs,
-            nanos,
+            secs: __jni_in_convert_wire_to_i64_da07d745d9e26f71(env, &__secs_raw)?,
+            nanos: __jni_in_convert_wire_to_i64_da07d745d9e26f71(env, &__nanos_raw)?,
         }
     })
 }
@@ -1456,58 +1441,56 @@ pub(crate) unsafe fn __jni_in_convert_wire_to_Unsigned_802dffd3a2dd4ecb<'env, 'v
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("Unsigned.byte: {}", e)))? as _;
-        let byte = __jni_in_convert_wire_to_u8_8a73e47df9fc7921(env, &__byte_raw)?;
         let __short_raw: jni::sys::jint = env
             .get_field(v, "short", "I")
             .and_then(|val| val.i())
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("Unsigned.short: {}", e)))? as _;
-        let short = __jni_in_convert_wire_to_u16_fc24f387ddcec321(env, &__short_raw)?;
         let __int_raw: jni::sys::jlong = env
             .get_field(v, "int", "J")
             .and_then(|val| val.j())
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("Unsigned.int: {}", e)))? as _;
-        let int = __jni_in_convert_wire_to_u32_25dff6d476799035(env, &__int_raw)?;
         let __long_raw: jni::sys::jlong = env
             .get_field(v, "long", "J")
             .and_then(|val| val.j())
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("Unsigned.long: {}", e)))?;
-        let long = __jni_in_convert_wire_to_u64_8507143745dc33b9(env, &__long_raw)?;
         let __maybe_long_jobj: jni::objects::JObject = env
             .get_field(v, "maybeLong", "Lkotlin/ULong;")
             .and_then(|val| val.l())
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("Unsigned.maybeLong: {}", e)))?;
-        let maybe_long = {
-            let v = __maybe_long_jobj;
-            {
-                if v.is_null() {
-                    ::core::option::Option::None
-                } else {
-                    let __present = env
-                        .call_method(&v, "unbox-impl", "()J", &[])
-                        .and_then(|val| val.j())
-                        .map_err(|e| <__JniErr as ::core::convert::From<
-                            String,
-                        >>::from(format!("Unsigned.maybeLong: {}", e)))?;
-                    ::core::option::Option::Some(
-                        __jni_in_convert_wire_to_u64_8507143745dc33b9(env, &__present)?,
-                    )
-                }
-            }
-        };
         perftest_flat::Unsigned {
-            byte,
-            short,
-            int,
-            long,
-            maybe_long,
+            byte: __jni_in_convert_wire_to_u8_8a73e47df9fc7921(env, &__byte_raw)?,
+            short: __jni_in_convert_wire_to_u16_fc24f387ddcec321(env, &__short_raw)?,
+            int: __jni_in_convert_wire_to_u32_25dff6d476799035(env, &__int_raw)?,
+            long: __jni_in_convert_wire_to_u64_8507143745dc33b9(env, &__long_raw)?,
+            maybe_long: {
+                let v = __maybe_long_jobj;
+                {
+                    if v.is_null() {
+                        ::core::option::Option::None
+                    } else {
+                        let __present = env
+                            .call_method(&v, "unbox-impl", "()J", &[])
+                            .and_then(|val| val.j())
+                            .map_err(|e| <__JniErr as ::core::convert::From<
+                                String,
+                            >>::from(format!("Unsigned.maybeLong: {}", e)))?;
+                        ::core::option::Option::Some(
+                            __jni_in_convert_wire_to_u64_8507143745dc33b9(
+                                env,
+                                &__present,
+                            )?,
+                        )
+                    }
+                }
+            },
         }
     })
 }
@@ -1859,7 +1842,6 @@ pub(crate) unsafe fn __jni_in_convert_wire_to_Arrays_0394c6e5ac3eb91d<'env, 'v>(
                 String,
             >>::from(format!("Arrays.bytes: {}", e)))?;
         let __bytes_raw: jni::objects::JByteArray = __bytes_jobj.into();
-        let bytes = __jni_in_convert_wire_to_u8_4_86a2b86806cb23e9(env, &__bytes_raw)?;
         let __shorts_jobj: jni::objects::JObject = env
             .get_field(v, "shorts", "[S")
             .and_then(|val| val.l())
@@ -1867,10 +1849,6 @@ pub(crate) unsafe fn __jni_in_convert_wire_to_Arrays_0394c6e5ac3eb91d<'env, 'v>(
                 String,
             >>::from(format!("Arrays.shorts: {}", e)))?;
         let __shorts_raw: jni::objects::JShortArray = __shorts_jobj.into();
-        let shorts = __jni_in_convert_wire_to_i16_2_018133ba02a34157(
-            env,
-            &__shorts_raw,
-        )?;
         let __ints_jobj: jni::objects::JObject = env
             .get_field(v, "ints", "[I")
             .and_then(|val| val.l())
@@ -1878,7 +1856,6 @@ pub(crate) unsafe fn __jni_in_convert_wire_to_Arrays_0394c6e5ac3eb91d<'env, 'v>(
                 String,
             >>::from(format!("Arrays.ints: {}", e)))?;
         let __ints_raw: jni::objects::JIntArray = __ints_jobj.into();
-        let ints = __jni_in_convert_wire_to_i32_3_8cd5d1633507beb7(env, &__ints_raw)?;
         let __longs_jobj: jni::objects::JObject = env
             .get_field(v, "longs", "[J")
             .and_then(|val| val.l())
@@ -1886,7 +1863,6 @@ pub(crate) unsafe fn __jni_in_convert_wire_to_Arrays_0394c6e5ac3eb91d<'env, 'v>(
                 String,
             >>::from(format!("Arrays.longs: {}", e)))?;
         let __longs_raw: jni::objects::JLongArray = __longs_jobj.into();
-        let longs = __jni_in_convert_wire_to_i64_2_cf35a75ca7b37f53(env, &__longs_raw)?;
         let __doubles_jobj: jni::objects::JObject = env
             .get_field(v, "doubles", "[D")
             .and_then(|val| val.l())
@@ -1894,10 +1870,6 @@ pub(crate) unsafe fn __jni_in_convert_wire_to_Arrays_0394c6e5ac3eb91d<'env, 'v>(
                 String,
             >>::from(format!("Arrays.doubles: {}", e)))?;
         let __doubles_raw: jni::objects::JDoubleArray = __doubles_jobj.into();
-        let doubles = __jni_in_convert_wire_to_f64_2_60cd70210ac4ab83(
-            env,
-            &__doubles_raw,
-        )?;
         let __flags_jobj: jni::objects::JObject = env
             .get_field(v, "flags", "[Z")
             .and_then(|val| val.l())
@@ -1905,7 +1877,6 @@ pub(crate) unsafe fn __jni_in_convert_wire_to_Arrays_0394c6e5ac3eb91d<'env, 'v>(
                 String,
             >>::from(format!("Arrays.flags: {}", e)))?;
         let __flags_raw: jni::objects::JBooleanArray = __flags_jobj.into();
-        let flags = __jni_in_convert_wire_to_bool_3_7afc83abc6385c11(env, &__flags_raw)?;
         let __raw_jobj: jni::objects::JObject = env
             .get_field(v, "raw", "[J")
             .and_then(|val| val.l())
@@ -1913,15 +1884,17 @@ pub(crate) unsafe fn __jni_in_convert_wire_to_Arrays_0394c6e5ac3eb91d<'env, 'v>(
                 String,
             >>::from(format!("Arrays.raw: {}", e)))?;
         let __raw_raw: jni::objects::JLongArray = __raw_jobj.into();
-        let raw = __jni_in_convert_wire_to_u64_2_fb06d7eda96c221b(env, &__raw_raw)?;
         perftest_flat::Arrays {
-            bytes,
-            shorts,
-            ints,
-            longs,
-            doubles,
-            flags,
-            raw,
+            bytes: __jni_in_convert_wire_to_u8_4_86a2b86806cb23e9(env, &__bytes_raw)?,
+            shorts: __jni_in_convert_wire_to_i16_2_018133ba02a34157(env, &__shorts_raw)?,
+            ints: __jni_in_convert_wire_to_i32_3_8cd5d1633507beb7(env, &__ints_raw)?,
+            longs: __jni_in_convert_wire_to_i64_2_cf35a75ca7b37f53(env, &__longs_raw)?,
+            doubles: __jni_in_convert_wire_to_f64_2_60cd70210ac4ab83(
+                env,
+                &__doubles_raw,
+            )?,
+            flags: __jni_in_convert_wire_to_bool_3_7afc83abc6385c11(env, &__flags_raw)?,
+            raw: __jni_in_convert_wire_to_u64_2_fb06d7eda96c221b(env, &__raw_raw)?,
         }
     })
 }
@@ -2065,7 +2038,6 @@ pub(crate) unsafe fn __jni_in_convert_wire_to_BlobValue_bb484d67a0d3c3af<'env, '
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("BlobValue.stamp: {}", e)))?;
-        let stamp = __jni_in_convert_wire_to_Stamp_cccc3794c11688eb(env, &__stamp_raw)?;
         let __id_jobj: jni::objects::JObject = env
             .get_field(v, "id", "[B")
             .and_then(|val| val.l())
@@ -2073,21 +2045,19 @@ pub(crate) unsafe fn __jni_in_convert_wire_to_BlobValue_bb484d67a0d3c3af<'env, '
                 String,
             >>::from(format!("BlobValue.id: {}", e)))?;
         let __id_raw: jni::objects::JByteArray = __id_jobj.into();
-        let id = __jni_in_convert_wire_to_Vec_u8_80984e9556387695(env, &__id_raw)?;
         let __chunks_raw: jni::objects::JObject = env
             .get_field(v, "chunks", "Ljava/util/List;")
             .and_then(|val| val.l())
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("BlobValue.chunks: {}", e)))?;
-        let chunks = __jni_in_convert_wire_to_sequence_Vec_Vec_u8_6085b26606355944(
-            env,
-            &__chunks_raw,
-        )?;
         perftest_flat::BlobValue {
-            stamp,
-            id,
-            chunks,
+            stamp: __jni_in_convert_wire_to_Stamp_cccc3794c11688eb(env, &__stamp_raw)?,
+            id: __jni_in_convert_wire_to_Vec_u8_80984e9556387695(env, &__id_raw)?,
+            chunks: __jni_in_convert_wire_to_sequence_Vec_Vec_u8_6085b26606355944(
+                env,
+                &__chunks_raw,
+            )?,
         }
     })
 }
@@ -2699,20 +2669,18 @@ pub(crate) unsafe fn __jni_in_convert_wire_to_CacheConfig_cf33c287d7f35ae3<'env,
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("CacheConfig.replies: {}", e)))?;
-        let replies = __jni_in_convert_wire_to_RepliesConfig_7a81db0e8d2214ef(
-            env,
-            &__replies_raw,
-        )?;
         let __ttl_raw: jni::sys::jlong = env
             .get_field(v, "ttl", "J")
             .and_then(|val| val.j())
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("CacheConfig.ttl: {}", e)))? as _;
-        let ttl = __jni_in_convert_wire_to_i64_da07d745d9e26f71(env, &__ttl_raw)?;
         perftest_flat::CacheConfig {
-            replies,
-            ttl,
+            replies: __jni_in_convert_wire_to_RepliesConfig_7a81db0e8d2214ef(
+                env,
+                &__replies_raw,
+            )?,
+            ttl: __jni_in_convert_wire_to_i64_da07d745d9e26f71(env, &__ttl_raw)?,
         }
     })
 }
@@ -2788,20 +2756,18 @@ pub(crate) unsafe fn __jni_in_convert_wire_to_CallbackHolder_38c8a01137bd5e33<'e
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("CallbackHolder.tag: {}", e)))? as _;
-        let tag = __jni_in_convert_wire_to_i64_da07d745d9e26f71(env, &__tag_raw)?;
         let __token_raw: jni::objects::JObject = env
             .get_field(v, "token", "Ljava/lang/Object;")
             .and_then(|val| val.l())
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("CallbackHolder.token: {}", e)))?;
-        let token = __jni_in_convert_wire_to_CallbackToken_9b692010fd44b7e3(
-            env,
-            &__token_raw,
-        )?;
         perftest_flat::CallbackHolder {
-            tag,
-            token,
+            tag: __jni_in_convert_wire_to_i64_da07d745d9e26f71(env, &__tag_raw)?,
+            token: __jni_in_convert_wire_to_CallbackToken_9b692010fd44b7e3(
+                env,
+                &__token_raw,
+            )?,
         }
     })
 }
@@ -2927,12 +2893,11 @@ pub(crate) unsafe fn __jni_in_convert_wire_to_CallbackToken_9b692010fd44b7e3<'en
                     String,
                 >>::from(format!("CallbackToken.ingot: {}", e)))?
         };
-        let ingot = __jni_in_convert_wire_to_Ingot_jni_handle_codec_consume_input_b897008e06c95a05(
-            env,
-            &__ingot_raw,
-        )?;
         perftest_flat::CallbackToken {
-            ingot,
+            ingot: __jni_in_convert_wire_to_Ingot_jni_handle_codec_consume_input_b897008e06c95a05(
+                env,
+                &__ingot_raw,
+            )?,
         }
     })
 }
@@ -3105,11 +3070,12 @@ pub(crate) unsafe fn __jni_in_convert_wire_to_ConstArray_a949f4efa5050dbd<'env, 
                 String,
             >>::from(format!("ConstArray.bytes: {}", e)))?;
         let __bytes_raw: jni::objects::JByteArray = __bytes_jobj.into();
-        let bytes = __jni_in_convert_wire_to_u8_CONST_ARRAY_LEN_a01385174c7f0f63(
-            env,
-            &__bytes_raw,
-        )?;
-        cov_helpers::ConstArray { bytes }
+        cov_helpers::ConstArray {
+            bytes: __jni_in_convert_wire_to_u8_CONST_ARRAY_LEN_a01385174c7f0f63(
+                env,
+                &__bytes_raw,
+            )?,
+        }
     })
 }
 #[allow(
@@ -3197,20 +3163,15 @@ pub(crate) unsafe fn __jni_in_convert_wire_to_Dossier_5316a15bb0813dfb<'env, 'v>
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("Dossier.note: {}", e)))? as _;
-        let note = __jni_in_convert_wire_to_i64_da07d745d9e26f71(env, &__note_raw)?;
         let __holder_raw: jni::objects::JObject = env
             .get_field(v, "holder", "Lio/prebindgen/covertest/Holder;")
             .and_then(|val| val.l())
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("Dossier.holder: {}", e)))?;
-        let holder = __jni_in_convert_wire_to_Holder_e0a7dbed55dd2865(
-            env,
-            &__holder_raw,
-        )?;
         perftest_flat::Dossier {
-            note,
-            holder,
+            note: __jni_in_convert_wire_to_i64_da07d745d9e26f71(env, &__note_raw)?,
+            holder: __jni_in_convert_wire_to_Holder_e0a7dbed55dd2865(env, &__holder_raw)?,
         }
     })
 }
@@ -3542,19 +3503,19 @@ pub(crate) unsafe fn __jni_in_convert_wire_to_Hold_5a6747f2776b0f97<'env, 'v>(
                         String,
                     >>::from(format!("Hold.For.v0: {}", e)))? as _;
                 let __p_v0 = {
-                    let __p_v0_s0 = __jni_in_convert_wire_to_u64_8507143745dc33b9(
+                    let __chain_s0 = __jni_in_convert_wire_to_u64_8507143745dc33b9(
                         env,
                         &__p_v0_raw,
                     )?;
-                    let __p_v0_s1 = __jni_in_stage_0_wire_to_Duration_814bb872b19d3627(
+                    let __chain_s1 = __jni_in_stage_0_wire_to_Duration_814bb872b19d3627(
                             env,
-                            __p_v0_s0,
+                            __chain_s0,
                         )
                         .map_err(|__e| <__JniErr as ::core::convert::From<
                             String,
                         >>::from(__e.to_string()))?;
-                    __p_v0_s1
-                };
+                    ::core::result::Result::<_, __JniErr>::Ok(__chain_s1)
+                }?;
                 return ::core::result::Result::Ok(perftest_flat::Hold::For(__p_v0));
             }
             ::core::result::Result::Err(
@@ -3665,20 +3626,18 @@ pub(crate) unsafe fn __jni_in_convert_wire_to_HoldPolicy_eb93c1846b0d934b<'env, 
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("HoldPolicy.hold: {}", e)))?;
-        let hold = __jni_in_convert_wire_to_Hold_5a6747f2776b0f97(env, &__hold_raw)?;
         let __grace_raw: jni::objects::JObject = env
             .get_field(v, "grace", "Lio/prebindgen/covertest/model/Hold;")
             .and_then(|val| val.l())
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("HoldPolicy.grace: {}", e)))?;
-        let grace = __jni_in_convert_wire_to_Option_Hold_jni_optional_intermediate_input_niche_d1e632bbd99fbe2e(
-            env,
-            &__grace_raw,
-        )?;
         perftest_flat::HoldPolicy {
-            hold,
-            grace,
+            hold: __jni_in_convert_wire_to_Hold_5a6747f2776b0f97(env, &__hold_raw)?,
+            grace: __jni_in_convert_wire_to_Option_Hold_jni_optional_intermediate_input_niche_d1e632bbd99fbe2e(
+                env,
+                &__grace_raw,
+            )?,
         }
     })
 }
@@ -3835,7 +3794,6 @@ pub(crate) unsafe fn __jni_in_convert_wire_to_Holder_e0a7dbed55dd2865<'env, 'v>(
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("Holder.tag: {}", e)))? as _;
-        let tag = __jni_in_convert_wire_to_i64_da07d745d9e26f71(env, &__tag_raw)?;
         let __summary_jobj: jni::objects::JObject = env
             .get_field(v, "summary", "Lio/prebindgen/covertest/analytics/Summary;")
             .and_then(|val| val.l())
@@ -3851,13 +3809,12 @@ pub(crate) unsafe fn __jni_in_convert_wire_to_Holder_e0a7dbed55dd2865<'env, 'v>(
                     String,
                 >>::from(format!("Holder.summary: {}", e)))?
         };
-        let summary = __jni_in_convert_wire_to_Summary_jni_handle_codec_consume_input_a6c328c6a2331e58(
-            env,
-            &__summary_raw,
-        )?;
         perftest_flat::Holder {
-            tag,
-            summary,
+            tag: __jni_in_convert_wire_to_i64_da07d745d9e26f71(env, &__tag_raw)?,
+            summary: __jni_in_convert_wire_to_Summary_jni_handle_codec_consume_input_a6c328c6a2331e58(
+                env,
+                &__summary_raw,
+            )?,
         }
     })
 }
@@ -4515,7 +4472,6 @@ pub(crate) unsafe fn __jni_in_convert_wire_to_MaybeHolder_fcb77d18203824e3<'env,
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("MaybeHolder.tag: {}", e)))? as _;
-        let tag = __jni_in_convert_wire_to_i64_da07d745d9e26f71(env, &__tag_raw)?;
         let __summary_jobj: jni::objects::JObject = env
             .get_field(v, "summary", "Lio/prebindgen/covertest/analytics/Summary;")
             .and_then(|val| val.l())
@@ -4531,13 +4487,12 @@ pub(crate) unsafe fn __jni_in_convert_wire_to_MaybeHolder_fcb77d18203824e3<'env,
                     String,
                 >>::from(format!("MaybeHolder.summary: {}", e)))?
         };
-        let summary = __jni_in_convert_wire_to_Option_Summary_jni_optional_intermediate_input_niche_7efd102cd40f1e81(
-            env,
-            &__summary_raw,
-        )?;
         perftest_flat::MaybeHolder {
-            tag,
-            summary,
+            tag: __jni_in_convert_wire_to_i64_da07d745d9e26f71(env, &__tag_raw)?,
+            summary: __jni_in_convert_wire_to_Option_Summary_jni_optional_intermediate_input_niche_7efd102cd40f1e81(
+                env,
+                &__summary_raw,
+            )?,
         }
     })
 }
@@ -5579,23 +5534,21 @@ pub(crate) unsafe fn __jni_in_convert_wire_to_ObjectBoundary16_3944a3a904c1510d<
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("ObjectBoundary16.left: {}", e)))?;
-        let left = __jni_in_convert_wire_to_ObjectBoundary8_cca4b20df6695267(
-            env,
-            &__left_raw,
-        )?;
         let __right_raw: jni::objects::JObject = env
             .get_field(v, "right", "Lio/prebindgen/covertest/model/ObjectBoundary8;")
             .and_then(|val| val.l())
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("ObjectBoundary16.right: {}", e)))?;
-        let right = __jni_in_convert_wire_to_ObjectBoundary8_cca4b20df6695267(
-            env,
-            &__right_raw,
-        )?;
         perftest_flat::ObjectBoundary16 {
-            left,
-            right,
+            left: __jni_in_convert_wire_to_ObjectBoundary8_cca4b20df6695267(
+                env,
+                &__left_raw,
+            )?,
+            right: __jni_in_convert_wire_to_ObjectBoundary8_cca4b20df6695267(
+                env,
+                &__right_raw,
+            )?,
         }
     })
 }
@@ -5736,23 +5689,21 @@ pub(crate) unsafe fn __jni_in_convert_wire_to_ObjectBoundary2_a3195430eb031edb<'
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("ObjectBoundary2.left: {}", e)))?;
-        let left = __jni_in_convert_wire_to_ObjectBoundaryLeaf_3132a7517e2ab837(
-            env,
-            &__left_raw,
-        )?;
         let __right_raw: jni::objects::JObject = env
             .get_field(v, "right", "Lio/prebindgen/covertest/model/ObjectBoundaryLeaf;")
             .and_then(|val| val.l())
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("ObjectBoundary2.right: {}", e)))?;
-        let right = __jni_in_convert_wire_to_ObjectBoundaryLeaf_3132a7517e2ab837(
-            env,
-            &__right_raw,
-        )?;
         perftest_flat::ObjectBoundary2 {
-            left,
-            right,
+            left: __jni_in_convert_wire_to_ObjectBoundaryLeaf_3132a7517e2ab837(
+                env,
+                &__left_raw,
+            )?,
+            right: __jni_in_convert_wire_to_ObjectBoundaryLeaf_3132a7517e2ab837(
+                env,
+                &__right_raw,
+            )?,
         }
     })
 }
@@ -5826,23 +5777,21 @@ pub(crate) unsafe fn __jni_in_convert_wire_to_ObjectBoundary32_79abada03cc29a21<
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("ObjectBoundary32.left: {}", e)))?;
-        let left = __jni_in_convert_wire_to_ObjectBoundary16_3944a3a904c1510d(
-            env,
-            &__left_raw,
-        )?;
         let __right_raw: jni::objects::JObject = env
             .get_field(v, "right", "Lio/prebindgen/covertest/model/ObjectBoundary16;")
             .and_then(|val| val.l())
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("ObjectBoundary32.right: {}", e)))?;
-        let right = __jni_in_convert_wire_to_ObjectBoundary16_3944a3a904c1510d(
-            env,
-            &__right_raw,
-        )?;
         perftest_flat::ObjectBoundary32 {
-            left,
-            right,
+            left: __jni_in_convert_wire_to_ObjectBoundary16_3944a3a904c1510d(
+                env,
+                &__left_raw,
+            )?,
+            right: __jni_in_convert_wire_to_ObjectBoundary16_3944a3a904c1510d(
+                env,
+                &__right_raw,
+            )?,
         }
     })
 }
@@ -6063,23 +6012,21 @@ pub(crate) unsafe fn __jni_in_convert_wire_to_ObjectBoundary4_feb5834d3248e52f<'
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("ObjectBoundary4.left: {}", e)))?;
-        let left = __jni_in_convert_wire_to_ObjectBoundary2_a3195430eb031edb(
-            env,
-            &__left_raw,
-        )?;
         let __right_raw: jni::objects::JObject = env
             .get_field(v, "right", "Lio/prebindgen/covertest/model/ObjectBoundary2;")
             .and_then(|val| val.l())
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("ObjectBoundary4.right: {}", e)))?;
-        let right = __jni_in_convert_wire_to_ObjectBoundary2_a3195430eb031edb(
-            env,
-            &__right_raw,
-        )?;
         perftest_flat::ObjectBoundary4 {
-            left,
-            right,
+            left: __jni_in_convert_wire_to_ObjectBoundary2_a3195430eb031edb(
+                env,
+                &__left_raw,
+            )?,
+            right: __jni_in_convert_wire_to_ObjectBoundary2_a3195430eb031edb(
+                env,
+                &__right_raw,
+            )?,
         }
     })
 }
@@ -6163,67 +6110,61 @@ pub(crate) unsafe fn __jni_in_convert_wire_to_ObjectBoundary63_abd593b6b57968fd<
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("ObjectBoundary63.leaves32: {}", e)))?;
-        let leaves32 = __jni_in_convert_wire_to_ObjectBoundary32_79abada03cc29a21(
-            env,
-            &__leaves32_raw,
-        )?;
         let __leaves16_raw: jni::objects::JObject = env
             .get_field(v, "leaves16", "Lio/prebindgen/covertest/model/ObjectBoundary16;")
             .and_then(|val| val.l())
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("ObjectBoundary63.leaves16: {}", e)))?;
-        let leaves16 = __jni_in_convert_wire_to_ObjectBoundary16_3944a3a904c1510d(
-            env,
-            &__leaves16_raw,
-        )?;
         let __leaves8_raw: jni::objects::JObject = env
             .get_field(v, "leaves8", "Lio/prebindgen/covertest/model/ObjectBoundary8;")
             .and_then(|val| val.l())
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("ObjectBoundary63.leaves8: {}", e)))?;
-        let leaves8 = __jni_in_convert_wire_to_ObjectBoundary8_cca4b20df6695267(
-            env,
-            &__leaves8_raw,
-        )?;
         let __leaves4_raw: jni::objects::JObject = env
             .get_field(v, "leaves4", "Lio/prebindgen/covertest/model/ObjectBoundary4;")
             .and_then(|val| val.l())
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("ObjectBoundary63.leaves4: {}", e)))?;
-        let leaves4 = __jni_in_convert_wire_to_ObjectBoundary4_feb5834d3248e52f(
-            env,
-            &__leaves4_raw,
-        )?;
         let __leaves2_raw: jni::objects::JObject = env
             .get_field(v, "leaves2", "Lio/prebindgen/covertest/model/ObjectBoundary2;")
             .and_then(|val| val.l())
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("ObjectBoundary63.leaves2: {}", e)))?;
-        let leaves2 = __jni_in_convert_wire_to_ObjectBoundary2_a3195430eb031edb(
-            env,
-            &__leaves2_raw,
-        )?;
         let __leaf_raw: jni::objects::JObject = env
             .get_field(v, "leaf", "Lio/prebindgen/covertest/model/ObjectBoundaryLeaf;")
             .and_then(|val| val.l())
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("ObjectBoundary63.leaf: {}", e)))?;
-        let leaf = __jni_in_convert_wire_to_ObjectBoundaryLeaf_3132a7517e2ab837(
-            env,
-            &__leaf_raw,
-        )?;
         perftest_flat::ObjectBoundary63 {
-            leaves32,
-            leaves16,
-            leaves8,
-            leaves4,
-            leaves2,
-            leaf,
+            leaves32: __jni_in_convert_wire_to_ObjectBoundary32_79abada03cc29a21(
+                env,
+                &__leaves32_raw,
+            )?,
+            leaves16: __jni_in_convert_wire_to_ObjectBoundary16_3944a3a904c1510d(
+                env,
+                &__leaves16_raw,
+            )?,
+            leaves8: __jni_in_convert_wire_to_ObjectBoundary8_cca4b20df6695267(
+                env,
+                &__leaves8_raw,
+            )?,
+            leaves4: __jni_in_convert_wire_to_ObjectBoundary4_feb5834d3248e52f(
+                env,
+                &__leaves4_raw,
+            )?,
+            leaves2: __jni_in_convert_wire_to_ObjectBoundary2_a3195430eb031edb(
+                env,
+                &__leaves2_raw,
+            )?,
+            leaf: __jni_in_convert_wire_to_ObjectBoundaryLeaf_3132a7517e2ab837(
+                env,
+                &__leaf_raw,
+            )?,
         }
     })
 }
@@ -6668,23 +6609,21 @@ pub(crate) unsafe fn __jni_in_convert_wire_to_ObjectBoundary64_9d95f2f133e7e0ab<
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("ObjectBoundary64.left: {}", e)))?;
-        let left = __jni_in_convert_wire_to_ObjectBoundary32_79abada03cc29a21(
-            env,
-            &__left_raw,
-        )?;
         let __right_raw: jni::objects::JObject = env
             .get_field(v, "right", "Lio/prebindgen/covertest/model/ObjectBoundary32;")
             .and_then(|val| val.l())
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("ObjectBoundary64.right: {}", e)))?;
-        let right = __jni_in_convert_wire_to_ObjectBoundary32_79abada03cc29a21(
-            env,
-            &__right_raw,
-        )?;
         perftest_flat::ObjectBoundary64 {
-            left,
-            right,
+            left: __jni_in_convert_wire_to_ObjectBoundary32_79abada03cc29a21(
+                env,
+                &__left_raw,
+            )?,
+            right: __jni_in_convert_wire_to_ObjectBoundary32_79abada03cc29a21(
+                env,
+                &__right_raw,
+            )?,
         }
     })
 }
@@ -7149,23 +7088,21 @@ pub(crate) unsafe fn __jni_in_convert_wire_to_ObjectBoundary8_cca4b20df6695267<'
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("ObjectBoundary8.left: {}", e)))?;
-        let left = __jni_in_convert_wire_to_ObjectBoundary4_feb5834d3248e52f(
-            env,
-            &__left_raw,
-        )?;
         let __right_raw: jni::objects::JObject = env
             .get_field(v, "right", "Lio/prebindgen/covertest/model/ObjectBoundary4;")
             .and_then(|val| val.l())
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("ObjectBoundary8.right: {}", e)))?;
-        let right = __jni_in_convert_wire_to_ObjectBoundary4_feb5834d3248e52f(
-            env,
-            &__right_raw,
-        )?;
         perftest_flat::ObjectBoundary8 {
-            left,
-            right,
+            left: __jni_in_convert_wire_to_ObjectBoundary4_feb5834d3248e52f(
+                env,
+                &__left_raw,
+            )?,
+            right: __jni_in_convert_wire_to_ObjectBoundary4_feb5834d3248e52f(
+                env,
+                &__right_raw,
+            )?,
         }
     })
 }
@@ -7269,9 +7206,8 @@ pub(crate) unsafe fn __jni_in_convert_wire_to_ObjectBoundaryLeaf_3132a7517e2ab83
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("ObjectBoundaryLeaf.value: {}", e)))? as _;
-        let value = __jni_in_convert_wire_to_i64_da07d745d9e26f71(env, &__value_raw)?;
         perftest_flat::ObjectBoundaryLeaf {
-            value,
+            value: __jni_in_convert_wire_to_i64_da07d745d9e26f71(env, &__value_raw)?,
         }
     })
 }
@@ -7394,27 +7330,18 @@ pub(crate) unsafe fn __jni_in_convert_wire_to_Observation_32843a8b8dec0a4b<'env,
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("Observation.id: {}", e)))? as _;
-        let id = __jni_in_convert_wire_to_i64_da07d745d9e26f71(env, &__id_raw)?;
         let __reading_raw: jni::objects::JObject = env
             .get_field(v, "reading", "Lio/prebindgen/covertest/model/Reading;")
             .and_then(|val| val.l())
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("Observation.reading: {}", e)))?;
-        let reading = __jni_in_convert_wire_to_Reading_a358e65c0c39d007(
-            env,
-            &__reading_raw,
-        )?;
         let __fallback_raw: jni::objects::JObject = env
             .get_field(v, "fallback", "Lio/prebindgen/covertest/model/Reading;")
             .and_then(|val| val.l())
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("Observation.fallback: {}", e)))?;
-        let fallback = __jni_in_convert_wire_to_Option_Reading_jni_optional_intermediate_input_niche_edb3520bad0ebf25(
-            env,
-            &__fallback_raw,
-        )?;
         let __note_jobj: jni::objects::JObject = env
             .get_field(v, "note", "Ljava/lang/String;")
             .and_then(|val| val.l())
@@ -7422,15 +7349,20 @@ pub(crate) unsafe fn __jni_in_convert_wire_to_Observation_32843a8b8dec0a4b<'env,
                 String,
             >>::from(format!("Observation.note: {}", e)))?;
         let __note_raw: jni::objects::JString = __note_jobj.into();
-        let note = __jni_in_convert_wire_to_jni_text_codec_owned_40915aa02cf8d9ce(
-            env,
-            &__note_raw,
-        )?;
         perftest_flat::Observation {
-            id,
-            reading,
-            fallback,
-            note,
+            id: __jni_in_convert_wire_to_i64_da07d745d9e26f71(env, &__id_raw)?,
+            reading: __jni_in_convert_wire_to_Reading_a358e65c0c39d007(
+                env,
+                &__reading_raw,
+            )?,
+            fallback: __jni_in_convert_wire_to_Option_Reading_jni_optional_intermediate_input_niche_edb3520bad0ebf25(
+                env,
+                &__fallback_raw,
+            )?,
+            note: __jni_in_convert_wire_to_jni_text_codec_owned_40915aa02cf8d9ce(
+                env,
+                &__note_raw,
+            )?,
         }
     })
 }
@@ -9963,23 +9895,21 @@ pub(crate) unsafe fn __jni_in_convert_wire_to_RepliesConfig_7a81db0e8d2214ef<'en
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("RepliesConfig.priority: {}", e)))?;
-        let priority = __jni_in_convert_wire_to_Priority_2f3eb78aa92f8bfd(
-            env,
-            &__priority_raw,
-        )?;
         let __max_samples_raw: jni::sys::jlong = env
             .get_field(v, "maxSamples", "J")
             .and_then(|val| val.j())
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("RepliesConfig.maxSamples: {}", e)))? as _;
-        let max_samples = __jni_in_convert_wire_to_i64_da07d745d9e26f71(
-            env,
-            &__max_samples_raw,
-        )?;
         perftest_flat::RepliesConfig {
-            priority,
-            max_samples,
+            priority: __jni_in_convert_wire_to_Priority_2f3eb78aa92f8bfd(
+                env,
+                &__priority_raw,
+            )?,
+            max_samples: __jni_in_convert_wire_to_i64_da07d745d9e26f71(
+                env,
+                &__max_samples_raw,
+            )?,
         }
     })
 }
@@ -10325,20 +10255,15 @@ pub(crate) unsafe fn __jni_in_convert_wire_to_Tagged_279b04b60843d675<'env, 'v>(
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("Tagged.id: {}", e)))? as _;
-        let id = __jni_in_convert_wire_to_i64_da07d745d9e26f71(env, &__id_raw)?;
         let __marker_raw: jni::objects::JObject = env
             .get_field(v, "marker", "Lio/prebindgen/covertest/model/Marker;")
             .and_then(|val| val.l())
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("Tagged.marker: {}", e)))?;
-        let marker = __jni_in_convert_wire_to_Marker_93f2fabe59a4f80d(
-            env,
-            &__marker_raw,
-        )?;
         perftest_flat::Tagged {
-            id,
-            marker,
+            id: __jni_in_convert_wire_to_i64_da07d745d9e26f71(env, &__id_raw)?,
+            marker: __jni_in_convert_wire_to_Marker_93f2fabe59a4f80d(env, &__marker_raw)?,
         }
     })
 }
@@ -10896,20 +10821,18 @@ pub(crate) unsafe fn __jni_in_convert_wire_to_Verdict_21661560f50a2bdb<'env, 'v>
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("Verdict.id: {}", e)))? as _;
-        let id = __jni_in_convert_wire_to_i64_da07d745d9e26f71(env, &__id_raw)?;
         let __outcome_raw: jni::objects::JObject = env
             .get_field(v, "outcome", "Lio/prebindgen/covertest/model/Lookup;")
             .and_then(|val| val.l())
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("Verdict.outcome: {}", e)))?;
-        let outcome = __jni_in_convert_wire_to_Lookup_2fa8248a2de561a5(
-            env,
-            &__outcome_raw,
-        )?;
         perftest_flat::Verdict {
-            id,
-            outcome,
+            id: __jni_in_convert_wire_to_i64_da07d745d9e26f71(env, &__id_raw)?,
+            outcome: __jni_in_convert_wire_to_Lookup_2fa8248a2de561a5(
+                env,
+                &__outcome_raw,
+            )?,
         }
     })
 }
@@ -11051,27 +10974,18 @@ pub(crate) unsafe fn __jni_in_convert_wire_to_WrappedFields_34734732a60d048b<'en
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("WrappedFields.id: {}", e)))? as _;
-        let id = __jni_in_convert_wire_to_i64_da07d745d9e26f71(env, &__id_raw)?;
         let __boxed_raw: jni::objects::JObject = env
             .get_field(v, "boxed", "Ljava/lang/Long;")
             .and_then(|val| val.l())
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("WrappedFields.boxed: {}", e)))?;
-        let boxed = __jni_in_convert_wire_to_Box_Option_i64_jni_optional_intermediate_input_boxed_9c68bc2a7a3540b4(
-            env,
-            &__boxed_raw,
-        )?;
         let __plain_raw: jni::objects::JObject = env
             .get_field(v, "plain", "Ljava/lang/Long;")
             .and_then(|val| val.l())
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("WrappedFields.plain: {}", e)))?;
-        let plain = __jni_in_convert_wire_to_Option_i64_jni_optional_intermediate_input_boxed_bebad25cf333cf7b(
-            env,
-            &__plain_raw,
-        )?;
         let __boxed_enum_jobj: jni::objects::JObject = env
             .get_field(v, "boxedEnum", "Lio/prebindgen/covertest/model/Priority;")
             .and_then(|val| val.l())
@@ -11084,10 +10998,6 @@ pub(crate) unsafe fn __jni_in_convert_wire_to_WrappedFields_34734732a60d048b<'en
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("WrappedFields.boxedEnum: {}", e)))?;
-        let boxed_enum = __jni_in_convert_wire_to_Box_Priority_781460985a632f7e(
-            env,
-            &__boxed_enum_raw,
-        )?;
         let __plain_enum_jobj: jni::objects::JObject = env
             .get_field(v, "plainEnum", "Lio/prebindgen/covertest/model/Priority;")
             .and_then(|val| val.l())
@@ -11100,16 +11010,24 @@ pub(crate) unsafe fn __jni_in_convert_wire_to_WrappedFields_34734732a60d048b<'en
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("WrappedFields.plainEnum: {}", e)))?;
-        let plain_enum = __jni_in_convert_wire_to_Priority_2f3eb78aa92f8bfd(
-            env,
-            &__plain_enum_raw,
-        )?;
         perftest_flat::WrappedFields {
-            id,
-            boxed,
-            plain,
-            boxed_enum,
-            plain_enum,
+            id: __jni_in_convert_wire_to_i64_da07d745d9e26f71(env, &__id_raw)?,
+            boxed: __jni_in_convert_wire_to_Box_Option_i64_jni_optional_intermediate_input_boxed_9c68bc2a7a3540b4(
+                env,
+                &__boxed_raw,
+            )?,
+            plain: __jni_in_convert_wire_to_Option_i64_jni_optional_intermediate_input_boxed_bebad25cf333cf7b(
+                env,
+                &__plain_raw,
+            )?,
+            boxed_enum: __jni_in_convert_wire_to_Box_Priority_781460985a632f7e(
+                env,
+                &__boxed_enum_raw,
+            )?,
+            plain_enum: __jni_in_convert_wire_to_Priority_2f3eb78aa92f8bfd(
+                env,
+                &__plain_enum_raw,
+            )?,
         }
     })
 }

--- a/examples/perftest-kotlin/src/generated_bindings.rs
+++ b/examples/perftest-kotlin/src/generated_bindings.rs
@@ -405,23 +405,21 @@ pub(crate) unsafe fn __jni_in_convert_wire_to_ObjectBoundary64_9d95f2f133e7e0ab<
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("ObjectBoundary64.left: {}", e)))?;
-        let left = __jni_in_convert_wire_to_ObjectBoundary32_79abada03cc29a21(
-            env,
-            &__left_raw,
-        )?;
         let __right_raw: jni::objects::JObject = env
             .get_field(v, "right", "Lio/prebindgen/perftest/ObjectBoundary32;")
             .and_then(|val| val.l())
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("ObjectBoundary64.right: {}", e)))?;
-        let right = __jni_in_convert_wire_to_ObjectBoundary32_79abada03cc29a21(
-            env,
-            &__right_raw,
-        )?;
         perftest_flat::ObjectBoundary64 {
-            left,
-            right,
+            left: __jni_in_convert_wire_to_ObjectBoundary32_79abada03cc29a21(
+                env,
+                &__left_raw,
+            )?,
+            right: __jni_in_convert_wire_to_ObjectBoundary32_79abada03cc29a21(
+                env,
+                &__right_raw,
+            )?,
         }
     })
 }
@@ -452,23 +450,21 @@ pub(crate) unsafe fn __jni_in_convert_wire_to_ObjectBoundary64Object_3c7cf869ff4
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("ObjectBoundary64Object.left: {}", e)))?;
-        let left = __jni_in_convert_wire_to_ObjectBoundary32_79abada03cc29a21(
-            env,
-            &__left_raw,
-        )?;
         let __right_raw: jni::objects::JObject = env
             .get_field(v, "right", "Lio/prebindgen/perftest/ObjectBoundary32;")
             .and_then(|val| val.l())
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("ObjectBoundary64Object.right: {}", e)))?;
-        let right = __jni_in_convert_wire_to_ObjectBoundary32_79abada03cc29a21(
-            env,
-            &__right_raw,
-        )?;
         perftest_flat::ObjectBoundary64Object {
-            left,
-            right,
+            left: __jni_in_convert_wire_to_ObjectBoundary32_79abada03cc29a21(
+                env,
+                &__left_raw,
+            )?,
+            right: __jni_in_convert_wire_to_ObjectBoundary32_79abada03cc29a21(
+                env,
+                &__right_raw,
+            )?,
         }
     })
 }
@@ -534,28 +530,24 @@ pub(crate) unsafe fn __jni_in_convert_wire_to_Payload_7e701167233e784f<'env, 'v>
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("Payload.id: {}", e)))? as _;
-        let id = __jni_in_convert_wire_to_i64_da07d745d9e26f71(env, &__id_raw)?;
         let __seq_raw: jni::sys::jint = env
             .get_field(v, "seq", "I")
             .and_then(|val| val.i())
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("Payload.seq: {}", e)))? as _;
-        let seq = __jni_in_convert_wire_to_i32_83b133e23cc76fc5(env, &__seq_raw)?;
         let __value_raw: jni::sys::jdouble = env
             .get_field(v, "value", "D")
             .and_then(|val| val.d())
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("Payload.value: {}", e)))? as _;
-        let value = __jni_in_convert_wire_to_f64_b312e1b95182cdfd(env, &__value_raw)?;
         let __flag_raw: jni::sys::jboolean = env
             .get_field(v, "flag", "Z")
             .and_then(|val| val.z())
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("Payload.flag: {}", e)))? as _;
-        let flag = __jni_in_convert_wire_to_bool_1be2f6c32f925207(env, &__flag_raw)?;
         let __label_jobj: jni::objects::JObject = env
             .get_field(v, "label", "Ljava/lang/String;")
             .and_then(|val| val.l())
@@ -563,16 +555,15 @@ pub(crate) unsafe fn __jni_in_convert_wire_to_Payload_7e701167233e784f<'env, 'v>
                 String,
             >>::from(format!("Payload.label: {}", e)))?;
         let __label_raw: jni::objects::JString = __label_jobj.into();
-        let label = __jni_in_convert_wire_to_Option_Box_String_jni_optional_intermediate_input_niche_87b03b4201168b29(
-            env,
-            &__label_raw,
-        )?;
         perftest_flat::Payload {
-            id,
-            seq,
-            value,
-            flag,
-            label,
+            id: __jni_in_convert_wire_to_i64_da07d745d9e26f71(env, &__id_raw)?,
+            seq: __jni_in_convert_wire_to_i32_83b133e23cc76fc5(env, &__seq_raw)?,
+            value: __jni_in_convert_wire_to_f64_b312e1b95182cdfd(env, &__value_raw)?,
+            flag: __jni_in_convert_wire_to_bool_1be2f6c32f925207(env, &__flag_raw)?,
+            label: __jni_in_convert_wire_to_Option_Box_String_jni_optional_intermediate_input_niche_87b03b4201168b29(
+                env,
+                &__label_raw,
+            )?,
         }
     })
 }
@@ -914,23 +905,21 @@ pub(crate) unsafe fn __jni_in_convert_wire_to_ObjectBoundary16_3944a3a904c1510d<
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("ObjectBoundary16.left: {}", e)))?;
-        let left = __jni_in_convert_wire_to_ObjectBoundary8_cca4b20df6695267(
-            env,
-            &__left_raw,
-        )?;
         let __right_raw: jni::objects::JObject = env
             .get_field(v, "right", "Lio/prebindgen/perftest/ObjectBoundary8;")
             .and_then(|val| val.l())
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("ObjectBoundary16.right: {}", e)))?;
-        let right = __jni_in_convert_wire_to_ObjectBoundary8_cca4b20df6695267(
-            env,
-            &__right_raw,
-        )?;
         perftest_flat::ObjectBoundary16 {
-            left,
-            right,
+            left: __jni_in_convert_wire_to_ObjectBoundary8_cca4b20df6695267(
+                env,
+                &__left_raw,
+            )?,
+            right: __jni_in_convert_wire_to_ObjectBoundary8_cca4b20df6695267(
+                env,
+                &__right_raw,
+            )?,
         }
     })
 }
@@ -1103,23 +1092,21 @@ pub(crate) unsafe fn __jni_in_convert_wire_to_ObjectBoundary2_a3195430eb031edb<'
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("ObjectBoundary2.left: {}", e)))?;
-        let left = __jni_in_convert_wire_to_ObjectBoundaryLeaf_3132a7517e2ab837(
-            env,
-            &__left_raw,
-        )?;
         let __right_raw: jni::objects::JObject = env
             .get_field(v, "right", "Lio/prebindgen/perftest/ObjectBoundaryLeaf;")
             .and_then(|val| val.l())
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("ObjectBoundary2.right: {}", e)))?;
-        let right = __jni_in_convert_wire_to_ObjectBoundaryLeaf_3132a7517e2ab837(
-            env,
-            &__right_raw,
-        )?;
         perftest_flat::ObjectBoundary2 {
-            left,
-            right,
+            left: __jni_in_convert_wire_to_ObjectBoundaryLeaf_3132a7517e2ab837(
+                env,
+                &__left_raw,
+            )?,
+            right: __jni_in_convert_wire_to_ObjectBoundaryLeaf_3132a7517e2ab837(
+                env,
+                &__right_raw,
+            )?,
         }
     })
 }
@@ -1270,23 +1257,21 @@ pub(crate) unsafe fn __jni_in_convert_wire_to_ObjectBoundary32_79abada03cc29a21<
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("ObjectBoundary32.left: {}", e)))?;
-        let left = __jni_in_convert_wire_to_ObjectBoundary16_3944a3a904c1510d(
-            env,
-            &__left_raw,
-        )?;
         let __right_raw: jni::objects::JObject = env
             .get_field(v, "right", "Lio/prebindgen/perftest/ObjectBoundary16;")
             .and_then(|val| val.l())
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("ObjectBoundary32.right: {}", e)))?;
-        let right = __jni_in_convert_wire_to_ObjectBoundary16_3944a3a904c1510d(
-            env,
-            &__right_raw,
-        )?;
         perftest_flat::ObjectBoundary32 {
-            left,
-            right,
+            left: __jni_in_convert_wire_to_ObjectBoundary16_3944a3a904c1510d(
+                env,
+                &__left_raw,
+            )?,
+            right: __jni_in_convert_wire_to_ObjectBoundary16_3944a3a904c1510d(
+                env,
+                &__right_raw,
+            )?,
         }
     })
 }
@@ -1542,23 +1527,21 @@ pub(crate) unsafe fn __jni_in_convert_wire_to_ObjectBoundary4_feb5834d3248e52f<'
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("ObjectBoundary4.left: {}", e)))?;
-        let left = __jni_in_convert_wire_to_ObjectBoundary2_a3195430eb031edb(
-            env,
-            &__left_raw,
-        )?;
         let __right_raw: jni::objects::JObject = env
             .get_field(v, "right", "Lio/prebindgen/perftest/ObjectBoundary2;")
             .and_then(|val| val.l())
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("ObjectBoundary4.right: {}", e)))?;
-        let right = __jni_in_convert_wire_to_ObjectBoundary2_a3195430eb031edb(
-            env,
-            &__right_raw,
-        )?;
         perftest_flat::ObjectBoundary4 {
-            left,
-            right,
+            left: __jni_in_convert_wire_to_ObjectBoundary2_a3195430eb031edb(
+                env,
+                &__left_raw,
+            )?,
+            right: __jni_in_convert_wire_to_ObjectBoundary2_a3195430eb031edb(
+                env,
+                &__right_raw,
+            )?,
         }
     })
 }
@@ -2556,23 +2539,21 @@ pub(crate) unsafe fn __jni_in_convert_wire_to_ObjectBoundary8_cca4b20df6695267<'
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("ObjectBoundary8.left: {}", e)))?;
-        let left = __jni_in_convert_wire_to_ObjectBoundary4_feb5834d3248e52f(
-            env,
-            &__left_raw,
-        )?;
         let __right_raw: jni::objects::JObject = env
             .get_field(v, "right", "Lio/prebindgen/perftest/ObjectBoundary4;")
             .and_then(|val| val.l())
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("ObjectBoundary8.right: {}", e)))?;
-        let right = __jni_in_convert_wire_to_ObjectBoundary4_feb5834d3248e52f(
-            env,
-            &__right_raw,
-        )?;
         perftest_flat::ObjectBoundary8 {
-            left,
-            right,
+            left: __jni_in_convert_wire_to_ObjectBoundary4_feb5834d3248e52f(
+                env,
+                &__left_raw,
+            )?,
+            right: __jni_in_convert_wire_to_ObjectBoundary4_feb5834d3248e52f(
+                env,
+                &__right_raw,
+            )?,
         }
     })
 }
@@ -2701,9 +2682,8 @@ pub(crate) unsafe fn __jni_in_convert_wire_to_ObjectBoundaryLeaf_3132a7517e2ab83
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("ObjectBoundaryLeaf.value: {}", e)))? as _;
-        let value = __jni_in_convert_wire_to_i64_da07d745d9e26f71(env, &__value_raw)?;
         perftest_flat::ObjectBoundaryLeaf {
-            value,
+            value: __jni_in_convert_wire_to_i64_da07d745d9e26f71(env, &__value_raw)?,
         }
     })
 }

--- a/prebindgen-c/src/chain.rs
+++ b/prebindgen-c/src/chain.rs
@@ -1833,8 +1833,10 @@ impl chain::ProductBridge for CProductBridge {
         self.wire.clone()
     }
 
-    fn part(&self, value: TokenStream, _index: usize, name: &syn::Ident) -> TokenStream {
-        quote!(#value.#name)
+    fn part(&self, value: TokenStream, _index: usize, name: &syn::Ident) -> chain::PartRead {
+        // A C mirror's field is reached by naming it, and reaching it cannot
+        // fail: the struct is already in scope, by value.
+        chain::PartRead::expression(quote!(#value.#name))
     }
 
     fn build(&self, parts: &[(syn::Ident, TokenStream)]) -> TokenStream {

--- a/prebindgen-c/src/convert.rs
+++ b/prebindgen-c/src/convert.rs
@@ -74,9 +74,12 @@ impl CbindgenBuilder {
             "Cbindgen custom representations must be C scalar types"
         );
         if let Some(domain) = decl.domain() {
+            // Both sides are reduced to their kind first: a representation and
+            // a domain naming one scalar are the same type however either was
+            // spelled.
             assert_eq!(
-                TypeKey::from_type(domain.ty()),
-                TypeKey::from_type(&repr),
+                Some(domain.kind()),
+                prebindgen_registry::DomainKind::from_type(&repr),
                 "Cbindgen conversion domain type does not match its {} representation",
                 match direction {
                     Direction::Construct => "input",

--- a/prebindgen-c/src/lib.rs
+++ b/prebindgen-c/src/lib.rs
@@ -103,7 +103,6 @@ use std::collections::{HashMap, HashSet};
 // `TypeRef` now, so what is left here serves the two node populations that
 // remain — a build-script declaration, and a converter's own generated
 // signature.
-pub(crate) use prebindgen_registry::types_util::path_tail_ident as type_path_tail;
 use prebindgen_registry::{
     decl::{ConvertDecl, ConvertSpec},
     flat::{extract_fn_trait_args, Field, Origin, ScalarKind, TypeKind, TypeRef},
@@ -525,7 +524,7 @@ fn sanitize(key: &TypeKey) -> String {
 /// The short name a C symbol is built from — the key's last path segment, or a
 /// sanitized rendering of the whole key when it is not a path.
 ///
-/// Off the **identity**: `type_path_tail` took the last segment of a node, and
+/// Off the **identity**: this took the last path segment of a node, and
 /// `TypeKey::short_name` is the same question asked of the canonical string, so
 /// the name no longer depends on holding the node it was derived from.
 fn type_short(key: &TypeKey) -> String {
@@ -697,27 +696,13 @@ fn bool_out_expr(value: TokenStream) -> TokenStream {
 
 /// Whether `ty` is an FFI-safe scalar primitive that passes through unchanged
 /// (`bool`, the fixed-width / pointer-width integers, and floats).
+///
+/// The set is `ScalarKind`'s, asked of the model rather than spelled out again
+/// here — the same reason [`r_is_scalar`] asks the classification. This one
+/// takes a written type because its caller has one: a `from!` / `into!`
+/// representation is a type the binding wrote, not a lowered `TypeRef`.
 fn is_scalar(ty: &syn::Type) -> bool {
-    type_path_tail(ty)
-        .map(|i| {
-            matches!(
-                i.to_string().as_str(),
-                "bool"
-                    | "i8"
-                    | "i16"
-                    | "i32"
-                    | "i64"
-                    | "isize"
-                    | "u8"
-                    | "u16"
-                    | "u32"
-                    | "u64"
-                    | "usize"
-                    | "f32"
-                    | "f64"
-            )
-        })
-        .unwrap_or(false)
+    ScalarKind::from_type(ty).is_some()
 }
 
 /// The element of a shared slice borrow (`&[E]`), off the classification.

--- a/prebindgen-c/src/tests/boundary_invariants.rs
+++ b/prebindgen-c/src/tests/boundary_invariants.rs
@@ -230,7 +230,7 @@ fn restricted_inbound(
     if let syn::Type::Reference(r) = ty {
         return restricted_inbound(&r.elem, structs, enums, seen);
     }
-    let tail = type_path_tail(ty)?.to_string();
+    let tail = prebindgen_registry::types_util::path_tail_ident(ty)?.to_string();
     if tail == "MaybeUninit" {
         return None;
     }

--- a/prebindgen-c/src/tests/lowering.rs
+++ b/prebindgen-c/src/tests/lowering.rs
@@ -213,6 +213,41 @@ fn trait_backed_custom_conversion_renders_from_the_late_plan() {
     );
 }
 
+/// `::core::primitive::u64` and `u64` name one scalar, and a domain declared
+/// over that scalar matches a representation written either way. Before the
+/// domain carried its kind, this fixture failed to build: the check compared
+/// the two spellings and reported "domain type does not match its input
+/// representation" for a type that does match.
+#[test]
+fn a_domain_matches_its_representation_however_the_representation_is_spelled() {
+    let loc = SourceLocation::default();
+    let items: Vec<(syn::Item, SourceLocation)> =
+        ["pub fn duration_echo(v: Duration) -> Duration { unimplemented!() }"]
+            .into_iter()
+            .map(|source| (syn::parse_str(source).unwrap(), loc.clone()))
+            .collect();
+    let registry = crate::test_util::reg_from_items(declare_referenced(items)).unwrap();
+    let cbindgen = CbindgenBuilder::new()
+        .source_module(syn::parse_quote!(myflat))
+        .convert(
+            prebindgen_registry::convert!(Duration)
+                .input(prebindgen_registry::from!(::core::primitive::u64))
+                .output(prebindgen_registry::into!(::core::primitive::u64))
+                .valid_range(0u64..=1_000_000u64),
+        )
+        .base_name("z_duration")
+        .function(syn::parse_quote!(duration_echo))
+        .panic();
+
+    let src = write(cbindgen, registry, "qualified_representation");
+    let compact: String = src.split_whitespace().collect();
+    assert!(
+        compact.contains("extern\"C\"fnduration_echo(v:::core::primitive::u64"),
+        "{src}"
+    );
+    assert!(compact.contains("(v)<=1000000u64"), "{src}");
+}
+
 #[test]
 fn output_terminals_stay_unrendered_until_final_write() {
     let loc = SourceLocation::default();

--- a/prebindgen-flat/src/flat/tests/acceptance.rs
+++ b/prebindgen-flat/src/flat/tests/acceptance.rs
@@ -2037,3 +2037,23 @@ fn a_raw_identifier_survives_typeid() {
     };
     assert!(qualified.ident().is_none());
 }
+
+/// `ScalarKind` is the closed set of the scalars a source may write, and it
+/// answers for a written type however that type is spelled — so a caller
+/// asking "is this an FFI-safe scalar primitive" needs no name table of its
+/// own.
+#[test]
+fn a_scalar_kind_is_recovered_from_any_spelling_of_its_type() {
+    use crate::flat::ScalarKind;
+
+    assert_eq!(
+        ScalarKind::from_type(&syn::parse_quote!(usize)),
+        Some(ScalarKind::Usize)
+    );
+    assert_eq!(
+        ScalarKind::from_type(&syn::parse_quote!(::core::primitive::usize)),
+        Some(ScalarKind::Usize)
+    );
+    assert_eq!(ScalarKind::from_type(&syn::parse_quote!(String)), None);
+    assert_eq!(ScalarKind::from_type(&syn::parse_quote!(&u8)), None);
+}

--- a/prebindgen-flat/src/flat/ty.rs
+++ b/prebindgen-flat/src/flat/ty.rs
@@ -1124,6 +1124,16 @@ impl ScalarKind {
         })
     }
 
+    /// The kind a written scalar type names, off its last path segment.
+    /// `None` for anything that is not one of these scalars.
+    ///
+    /// The closed set below is the whole answer to "is this an FFI-safe scalar
+    /// primitive", so a caller asking that question asks it here rather than
+    /// keeping a name table of its own.
+    pub fn from_type(ty: &syn::Type) -> Option<Self> {
+        Self::from_name(&crate::types_util::path_tail_ident(ty)?.to_string())
+    }
+
     /// The Rust spelling — the identity this was lowered from.
     pub fn as_str(self) -> &'static str {
         match self {

--- a/prebindgen-jni/src/jni/builder.rs
+++ b/prebindgen-jni/src/jni/builder.rs
@@ -1625,7 +1625,7 @@ impl Declarations {
         else {
             return (Niches::empty(), Vec::new());
         };
-        if TypeKey::from_type(domain.ty()).as_str() != "u64"
+        if domain.kind() != prebindgen_registry::DomainKind::U64
             || prebindgen_registry::types_util::path_tail_ident(wire)
                 .is_none_or(|ident| ident != "jlong")
         {

--- a/prebindgen-jni/src/jni/chain.rs
+++ b/prebindgen-jni/src/jni/chain.rs
@@ -1180,6 +1180,17 @@ impl JPipeline {
     /// `env` is already the borrowed `JNIEnv` rather than an owned wrapper
     /// parameter. Whole-object property plans use this to retain child chains
     /// without retaining their generated Rust expressions.
+    /// The child converter this pipeline invokes.
+    ///
+    /// A whole-object property is decoded by one child; the transient
+    /// Vec-handle site ABI is a parameter-only shape and never reaches here.
+    pub(crate) fn converter_child(&self) -> &JChild {
+        let JPipelineBody::Converter(child) = &self.body else {
+            unreachable!("a whole-object property cannot use the transient Vec-handle site ABI")
+        };
+        child
+    }
+
     pub(crate) fn invoke_converter(
         &self,
         env: TokenStream,

--- a/prebindgen-jni/src/jni/chain.rs
+++ b/prebindgen-jni/src/jni/chain.rs
@@ -1191,19 +1191,6 @@ impl JPipeline {
         child
     }
 
-    pub(crate) fn invoke_converter(
-        &self,
-        env: TokenStream,
-        value: TokenStream,
-        stage_base: &syn::Ident,
-        emit: &RustWriter,
-    ) -> TokenStream {
-        let JPipelineBody::Converter(child) = &self.body else {
-            unreachable!("a whole-object field cannot use the transient Vec-handle site ABI")
-        };
-        child.invoke_input_value_with_env(env, value, stage_base, emit)
-    }
-
     /// Render the already-planned call graph around `value`.
     pub(crate) fn invoke(&self, value: TokenStream, emit: &RustWriter) -> TokenStream {
         match &self.body {
@@ -1247,46 +1234,6 @@ impl JVecHandleInput {
 }
 
 impl JChild {
-    /// Render a constructing child as the value it yields inside an enclosing
-    /// converter. Unlike the ordinary chain API this consumes `Result` here,
-    /// because the enclosing function already owns the error channel. Stage
-    /// bindings are named by the property that owns them, preventing sibling
-    /// fields from colliding.
-    fn invoke_input_value_with_env(
-        &self,
-        env: TokenStream,
-        value: TokenStream,
-        stage_base: &syn::Ident,
-        emit: &RustWriter,
-    ) -> TokenStream {
-        assert_eq!(self.direction, Direction::Construct);
-        let converter = emit.operation_ident("jni", self.call.operation_id());
-        let value = match self.value_use {
-            JValueUse::Direct => value,
-            JValueUse::SharedRef => shared_ref(value),
-            JValueUse::Cloned => quote!((*#value).clone()),
-        };
-        let first = quote!(#converter(#env, #value));
-        if self.stages.is_empty() {
-            return quote!(#first?);
-        }
-        let first_name = format_ident!("{}_s0", stage_base);
-        let mut body = quote!(let #first_name = #first?;);
-        let mut previous = first_name;
-        for (index, stage) in self.stages.iter().enumerate() {
-            let stage = emit.operation_ident("jni", stage);
-            let next = format_ident!("{}_s{}", stage_base, index + 1);
-            body.extend(quote!(
-                let #next = #stage(#env, #previous)
-                    .map_err(|__e| <__JniErr as ::core::convert::From<String>>::from(
-                        __e.to_string()
-                    ))?;
-            ));
-            previous = next;
-        }
-        quote!({ #body #previous })
-    }
-
     /// Render this child in a context that supplies its own `JNIEnv` expression.
     /// Registry-composed converter bodies receive an `&mut JNIEnv` named
     /// `env`; exported wrappers own a mutable `JNIEnv` and pass `&mut env`.

--- a/prebindgen-jni/src/jni/compile.rs
+++ b/prebindgen-jni/src/jni/compile.rs
@@ -555,10 +555,6 @@ impl prebindgen_registry::unfold::DecomposedLeaf for OutWire {
     fn source(&self) -> &TypeRef {
         &self.out_ty
     }
-
-    fn is_field_read(&self) -> bool {
-        OutWire::is_field_read(self)
-    }
 }
 
 impl OutWire {
@@ -624,19 +620,6 @@ impl OutWire {
     /// no reach describes — the selector, or a payload its arm's pattern binds.
     pub(crate) fn reach(&self) -> &[prebindgen_registry::unfold::PathStep] {
         &self.reach
-    }
-
-    /// Whether this value is **read off** a place rather than produced by a
-    /// call — so it is cloned out of the value that holds it.
-    ///
-    /// The last step being a field read is the whole question, and it is what
-    /// `LeafSource::Reach` meant: a value form's field leaf reads a field off
-    /// what the accessor returned, and an accessor leaf ends at the call.
-    pub(crate) fn is_field_read(&self) -> bool {
-        matches!(
-            self.reach.last(),
-            Some(prebindgen_registry::unfold::PathStep::Field { .. })
-        )
     }
 
     /// Whether this value is the synthesized selector.

--- a/prebindgen-jni/src/jni/compile.rs
+++ b/prebindgen-jni/src/jni/compile.rs
@@ -539,6 +539,28 @@ impl OutAbi {
     }
 }
 
+impl prebindgen_registry::unfold::DecomposedLeaf for OutWire {
+    fn reach(&self) -> &[prebindgen_registry::unfold::PathStep] {
+        OutWire::reach(self)
+    }
+
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn identity(&self) -> bool {
+        self.identity
+    }
+
+    fn source(&self) -> &TypeRef {
+        &self.out_ty
+    }
+
+    fn is_field_read(&self) -> bool {
+        OutWire::is_field_read(self)
+    }
+}
+
 impl OutWire {
     /// The converters encoding this leaf calls.
     pub(crate) fn calls(&self, out: &mut Vec<prebindgen_registry::write::ArtifactKey>) {

--- a/prebindgen-jni/src/jni/compile.rs
+++ b/prebindgen-jni/src/jni/compile.rs
@@ -1727,13 +1727,25 @@ impl<R: Conversions> JCompile<'_, R> {
             }
         };
         if let Some(domain) = decl.domain() {
-            let domain_key = TypeKey::from_type(domain.ty());
+            // A `TypeKey` is not reduced to a canonical spelling — the model's
+            // normalization covers constructors, not scalars — so this compares
+            // two spellings. It is exact anyway, from both sides: the domain's
+            // spelling is derived from its kind, and a path-qualified scalar
+            // reaches here by neither route it could take. A `fun!`
+            // representation names a captured source function, and the flat
+            // model refuses that function outright, because marked items live
+            // in one flat namespace of bare names. A `from!` / `into!`
+            // representation names a type directly, and its qualified key
+            // resolves to nothing — the route
+            // `a_qualified_scalar_representation_never_reaches_the_domain_check`
+            // takes.
+            let domain_key = TypeKey::from_type(&domain.ty());
             if domain_key != representation_key {
                 let direction = match direction {
                     Direction::Construct => "input",
                     Direction::Deconstruct => "output",
                 };
-                let domain = declared_type_name(domain.ty());
+                let domain = declared_type_name(&domain.ty());
                 match &representation {
                     crate::jni::chain::JCustomType::Model(reading) => panic!(
                         "convert!({source}): domain type {domain} does not match {direction} representation {reading}"

--- a/prebindgen-jni/src/jni/compile.rs
+++ b/prebindgen-jni/src/jni/compile.rs
@@ -4226,6 +4226,17 @@ impl Declarations {
                 // A nested `data_class` inlines when it is reached directly.
                 // Behind an `Option` or a `Vec` there is no chain to reach
                 // through, so the whole value stays object-shaped.
+                //
+                // This refusal is why the whole-object output encode
+                // (`emit/struct_out.rs`) is not rendered from this
+                // decomposition: it supports the shapes refused here — an
+                // optional nested class becomes a `present` flag plus a
+                // defaulted group, and a sum field a tag plus one group per
+                // variant. Delivering those to a foreign builder is a feature
+                // this decomposition does not have: the encode is a superset
+                // rather than a second implementation. Where both apply they
+                // name the same leaves, which `assert_leaf_derivations_agree`
+                // checks. See #596 step 5, and #602.
                 crate::jni::classify::TypeKind::DataStruct {
                     st: _,
                     cfg: Some(_),

--- a/prebindgen-jni/src/jni/emit/delivery.rs
+++ b/prebindgen-jni/src/jni/emit/delivery.rs
@@ -1,7 +1,10 @@
 //! Output-expansion delivery: unfold plans and leaf encoding.
 
 use prebindgen_registry::{
-    unfold::{bind_hoists, fold_steps, project_leading_fields, steps_are_movable, PathStep},
+    unfold::{
+        bind_hoists, fold_steps, project_leading_fields, steps_are_movable, DecomposedLeaf,
+        PathStep,
+    },
     Conversions,
 };
 

--- a/prebindgen-jni/src/jni/emit/delivery.rs
+++ b/prebindgen-jni/src/jni/emit/delivery.rs
@@ -1,7 +1,7 @@
 //! Output-expansion delivery: unfold plans and leaf encoding.
 
 use prebindgen_registry::{
-    unfold::{steps_are_movable, PathStep},
+    unfold::{bind_hoists, fold_steps, project_leading_fields, steps_are_movable, PathStep},
     Conversions,
 };
 
@@ -323,202 +323,6 @@ pub(crate) fn cast_wire_to_jobject(
     }
 }
 
-/// Compose one [`PathStep`] onto the reference expression reached so far.
-/// A `Call` applies its accessor (origin-qualified); a `Field` reads the field
-/// and re-borrows, so the result is a reference either way and steps chain
-/// uniformly.
-pub(crate) fn compose_step(
-    qualify: &dyn Fn(&syn::Ident) -> syn::Path,
-    step: &PathStep,
-    e: TokenStream,
-) -> TokenStream {
-    match step {
-        PathStep::Call { ident, .. } => {
-            let m = qualify(ident);
-            quote!(#m::#ident(#e))
-        }
-        PathStep::Field { ident, .. } => quote!(&(#e).#ident),
-    }
-}
-
-/// Fold a run of steps onto `e`, borrowing wherever ownership demands it.
-///
-/// [`compose_step`] hands a `Call` its receiver as written, and an accessor
-/// takes that receiver **by reference** — so an owned value in hand has to be
-/// borrowed before the next call composes onto it. A value is in hand whenever
-/// the previous step returned one (`f(..) -> T` rather than `-> &T`), which is
-/// what [`PathStep::yields_owned`] records; `owned` says whether `e` itself
-/// started that way.
-///
-/// A `Field` step needs no borrow either way — it composes as `&(e).f`, which
-/// reads through a value and a reference alike.
-///
-/// This is the ONE place the rule lives, so every fold — a leaf's reach, a
-/// conditional hoist's prefix, a sum's matched value — answers it the same way.
-/// Splitting it produced exactly the bug it exists to prevent: ownership was
-/// handled at the optional binding and at the value form, and lost at every
-/// ordinary call in between.
-fn fold_steps(
-    qualify: &dyn Fn(&syn::Ident) -> syn::Path,
-    steps: &[PathStep],
-    mut e: TokenStream,
-    mut owned: bool,
-) -> TokenStream {
-    for step in steps {
-        if owned && matches!(step, PathStep::Call { .. }) {
-            e = quote!(&#e);
-        }
-        e = compose_step(qualify, step, e);
-        owned = step.yields_owned();
-    }
-    e
-}
-
-/// Compose a value form's OWN call — the one step in the whole system whose
-/// receiver may be by value.
-///
-/// Four cases, from what the fold ended up holding crossed with what the
-/// accessor takes. A CONSUMING form takes its receiver by value: hand it the
-/// value when that is ours, clone when it is not — the same cost the borrowing
-/// form of the accessor would have paid, which keeps one declaration usable by
-/// both owned and `&T` roots. A borrowing form takes a reference, so an owned
-/// value is borrowed for it.
-///
-/// The decision is made from the fold's RESULT, never from where the fold
-/// began: that is what lets a consuming form sit behind ordinary accessors,
-/// where the chain in front borrows and the form itself still moves.
-///
-/// One function because both hoist paths — the conditional binding and the
-/// ordinary one — need exactly this rule, and stating it twice is what turned
-/// each new shape into a new defect.
-fn compose_value_form_call(
-    qualify: &dyn Fn(&syn::Ident) -> syn::Path,
-    call: &PathStep,
-    e: TokenStream,
-    e_owned: bool,
-    consuming: bool,
-) -> TokenStream {
-    match (consuming, e_owned) {
-        (true, owned) => {
-            let (m, f) = (qualify(call.ident()), call.ident());
-            // Parenthesized: the clone applies to whatever the fold holds, and
-            // `&x.clone()` would parse as `&(x.clone())`.
-            let arg = if owned { e } else { quote!((#e).clone()) };
-            quote!(#m::#f(#arg))
-        }
-        (false, true) => compose_step(qualify, call, quote!(&#e)),
-        (false, false) => compose_step(qualify, call, e),
-    }
-}
-
-/// Start a reach from `base`, projecting the **leading run of plain field
-/// steps** directly (`&base.a.b`) instead of through a borrow of the base
-/// (`&(&base).a.b`). Returns the expression and how many steps it consumed.
-///
-/// The two forms name the same value, but the second borrows the base **as a
-/// whole**, which the borrow checker rejects once a sibling leaf has moved a
-/// different field out of it. Projecting directly makes each leaf's borrow
-/// disjoint, so a consuming value form's field moves are order-independent
-/// rather than compiling only while the borrowing leaves happen to be declared
-/// first.
-fn project_leading_fields(
-    base: &TokenStream,
-    base_is_ref: bool,
-    path: &[PathStep],
-) -> (TokenStream, usize) {
-    if base_is_ref {
-        return (base.clone(), 0);
-    }
-    let n = path.iter().take_while(|s| s.is_plain_field()).count();
-    if n == 0 {
-        return (quote!(&#base), 0);
-    }
-    let segs: Vec<&syn::Ident> = path[..n].iter().map(PathStep::ident).collect();
-    (quote!(&#base #(.#segs)*), n)
-}
-
-/// Fold a leaf's whole `path` over `base` with no optional-step handling, then
-/// apply the terminal treatment its [`LeafSource`] calls for: a `Field` leaf is
-/// **cloned** out of the place it reached, because its converter takes the field
-/// type as written (owned); every other leaf keeps the borrow its converter
-/// expects.
-///
-/// This is the derivation the single-leaf [`Delivery::Return`] shortcut uses
-/// (`emit/wrapper.rs`). It exists here, beside [`reach_leaf`], so the two are
-/// read and changed together: they drifted once already — the shortcut was
-/// missing the `Field` clone and handed `&F` to an `F` converter.
-///
-/// [`Delivery::Return`]: prebindgen_registry::unfold::Delivery::Return
-pub(crate) fn reach_leaf_flat(
-    qualify: &dyn Fn(&syn::Ident) -> syn::Path,
-    leaf: &crate::jni::compile::OutWire,
-    path: &[PathStep],
-    base: TokenStream,
-    base_is_ref: bool,
-    consuming: bool,
-) -> TokenStream {
-    // An optional step BEFORE the last one needs a `match` whose `None` arm has
-    // somewhere to go. This derivation has none — it yields a plain Rust value,
-    // not a `JObject` that could be null — so the shape is refused here rather
-    // than composed into code that cannot type-check in the consumer's crate.
-    //
-    // Asked of the leaf's OWN path, not of `path`. The caller may hand a
-    // suffix: `wrapper.rs` rebases onto a hoisted local, and `Hoisted::innermost`
-    // strips the prefix that bound it — including any optional step inside it.
-    // Checking the parameter would therefore pass exactly when the hoist is the
-    // conditional one, which is the case that cannot compose (an `Option<T>`
-    // local with a field read hung off it). The full path is what the shape
-    // question is about.
-    let own_path = leaf.reach();
-    assert!(
-        !own_path.iter().rev().skip(1).any(PathStep::is_optional),
-        "jnigen unfold: leaf `{}` reaches through an optional step but is \
-         delivered as a single return value, which has no `None` arm — this \
-         shape needs callback delivery",
-        leaf.name,
-    );
-    // Whether what this leaf reaches is OURS, and so is moved rather than
-    // borrowed or cloned. The two leaf kinds say it differently:
-    //
-    // * an IDENTITY leaf carries the answer in its `out_ty` — the plan resolved
-    //   it to the owned type exactly when the value is the plan's to give away
-    //   (`place_is_owned`: an owned root, or a field of a CONSUMING value form),
-    //   and that is also what selected the owning converter, which boxes the
-    //   move rather than cloning a borrow;
-    // * a FIELD leaf's `out_ty` is the field type as written, owned either way,
-    //   so ownership is the enclosing form's: only a consuming one gives its
-    //   fields away.
-    //
-    // How to project that place is `steps_are_movable`'s question, and it is
-    // asked there rather than restated here. This used to spell it
-    // `all(is_plain_field)`, defending the restatement on the grounds that a
-    // trailing `Option` cannot reach return delivery anyway — true, and enforced
-    // in `single_return` (`core/unfold.rs`), which is precisely why a local
-    // restatement could disagree with the rule for as long as the invariant held
-    // somewhere else. `plan.rs` says two readings would drift and the
-    // disagreement would be a borrow handed to an owning converter; this is the
-    // second reading, removed.
-    let reached_is_ours = if leaf.identity {
-        !matches!(
-            leaf.out_ty.kind(),
-            prebindgen_registry::flat::TypeKind::Ref { .. }
-        )
-    } else {
-        consuming
-    };
-    if reached_is_ours && steps_are_movable(path) {
-        let segs: Vec<&syn::Ident> = path.iter().map(PathStep::ident).collect();
-        return quote!(#base #(.#segs)*);
-    }
-    let (e, lead) = project_leading_fields(&base, base_is_ref, path);
-    let e = fold_steps(qualify, &path[lead..], e, false);
-    if leaf.is_field_read() {
-        quote!((#e).clone())
-    } else {
-        e
-    }
-}
-
 /// One delivery site, as the encoder sees it: what it hands out, and the value
 /// forms it evaluates once on the way.
 ///
@@ -716,233 +520,6 @@ impl<'a> Delivered<'a> {
             optional: plan.is_optional_base(),
         }
     }
-}
-
-/// Every value form on a plan, evaluated **once** and bound to a local
-/// (`__vf0`, `__vf1`, …), so a struct is built once per delivery rather than
-/// once per field. The bound prefixes come back with the statements, since
-/// reaching a leaf means starting from the innermost local it sits under.
-///
-/// Shared by both delivery paths — the multi-leaf encoder below and the
-/// single-leaf `Delivery::Return` shortcut in `emit/wrapper.rs`. The shortcut
-/// used to compose its reach straight off the raw value, which for a consuming
-/// value form emitted `f(&v)` against a by-value receiver: ill-typed Rust in
-/// the consumer's crate. One binder, so the two cannot disagree about what a
-/// hoist is or who owns it.
-pub(crate) struct Hoisted {
-    /// The `let __vfN = …;` bindings, outermost-first.
-    pub(crate) stmts: TokenStream,
-    /// Each hoist's path prefix and the local it was bound to.
-    bound: Vec<(Vec<PathStep>, syn::Ident)>,
-    /// Whether each bound hoist consumed the value it decomposed.
-    consuming: Vec<bool>,
-    /// Whether each bound local is `Option<TStruct>` rather than `TStruct` —
-    /// the hoist sits under an optional step, so the value form ran only where
-    /// the value was present. Its leaves cannot be emitted as independent
-    /// statements: they share ONE `match` on the local (see
-    /// [`encode_plan_leaves`]), taken by value, so a consuming form's fields
-    /// still move out inside the arm.
-    optional: Vec<bool>,
-}
-
-impl Hoisted {
-    /// Index of the innermost bound hoist `path` sits under, with that prefix
-    /// already consumed. `None` for a leaf under no value form at all — a
-    /// sibling `.field()` / `.field_self()`, which still reaches from the value
-    /// itself.
-    fn innermost(&self, path: &[PathStep]) -> Option<(usize, Vec<PathStep>)> {
-        self.bound
-            .iter()
-            .enumerate()
-            .filter(|(_, (p, _))| p.len() < path.len() && path.starts_with(p))
-            .max_by_key(|(_, (p, _))| p.len())
-            .map(|(i, (p, _))| (i, path[p.len()..].to_vec()))
-    }
-
-    /// The innermost bound local `path` sits under, with that prefix already
-    /// consumed, and whether that hoist gave its value away.
-    pub(crate) fn rebase(&self, path: &[PathStep]) -> Option<(syn::Ident, Vec<PathStep>, bool)> {
-        self.innermost(path)
-            .map(|(i, rest)| (self.bound[i].1.clone(), rest, self.consuming[i]))
-    }
-
-    /// The innermost **conditional** hoist `path` sits under: its index, the
-    /// local holding the `Option`, the name its `Some` arm binds, and the steps
-    /// left to reach the leaf from there. `None` when the leaf's innermost
-    /// hoist is unconditional (or there is none) — then [`Self::rebase`]
-    /// applies and the leaf is an ordinary standalone statement.
-    pub(crate) fn conditional(
-        &self,
-        path: &[PathStep],
-    ) -> Option<(usize, syn::Ident, syn::Ident, Vec<PathStep>)> {
-        let (i, rest) = self.innermost(path)?;
-        self.optional[i].then(|| (i, self.bound[i].1.clone(), format_ident!("__u{}", i), rest))
-    }
-
-    /// The local a hoist was bound to.
-    pub(crate) fn local(&self, i: usize) -> syn::Ident {
-        self.bound[i].1.clone()
-    }
-
-    /// Whether a hoist consumed the value it decomposed.
-    pub(crate) fn consumed(&self, i: usize) -> bool {
-        self.consuming[i]
-    }
-}
-
-/// Fold `path` over `base` the way [`reach_leaf`] does, but yielding an
-/// `Option<…>` rather than a `JObject`: the optional steps become a
-/// `map`/`and_then` chain, so an absent value short-circuits to `None` instead
-/// of to a null object. `body` renders the innermost reached expression as a
-/// BARE value — the chain's last link wraps it.
-///
-/// This is how a CONDITIONAL value form is bound — the accessor runs only where
-/// the value it decomposes is actually present.
-fn reach_optional(
-    qualify: &dyn Fn(&syn::Ident) -> syn::Path,
-    path: &[PathStep],
-    base: TokenStream,
-    base_is_ref: bool,
-    depth: usize,
-    body: &dyn Fn(TokenStream) -> TokenStream,
-) -> TokenStream {
-    let (e, lead) = project_leading_fields(&base, base_is_ref, path);
-    match (lead..path.len()).find(|&i| path[i].is_optional()) {
-        None => body(fold_steps(qualify, &path[lead..], e, false)),
-        Some(k) => {
-            // Through the optional step INCLUSIVE: the same fold, so the
-            // borrow in front of it is the ordinary rule rather than a second
-            // statement of it.
-            let opt_e = fold_steps(qualify, &path[lead..=k], e, false);
-            let bind = format_ident!("__hb{}", depth);
-            // What the arm binds is the step's own value: an OWNED payload is a
-            // bare `T`, so composing the next step onto it directly would hand
-            // `T` to an accessor typed for `&T`. Say it is not a reference and
-            // let `project_leading_fields` borrow it; a borrowed payload is
-            // already one and passes through.
-            //
-            // With NO steps left the binding goes to `body` untouched — that is
-            // what lets a consuming value form MOVE an owned payload rather than
-            // borrow it straight back, so the terminal case stays "already a
-            // reference" whatever the payload is.
-            let rest = &path[k + 1..];
-            let inner = reach_optional(
-                qualify,
-                rest,
-                quote!(#bind),
-                rest.is_empty() || !path[k].yields_owned(),
-                depth + 1,
-                body,
-            );
-            // `map` when this is the LAST optional step (the body yields a bare
-            // value) and `and_then` when another follows (the recursion yields
-            // an `Option` that must not nest). The equivalent `match` reads the
-            // same but generated code runs through the consumer's lints, where
-            // `clippy::manual_map` is a denial.
-            let combinator = if rest.iter().any(PathStep::is_optional) {
-                format_ident!("and_then")
-            } else {
-                format_ident!("map")
-            };
-            quote! {
-                #opt_e.#combinator(|#bind| #inner)
-            }
-        }
-    }
-}
-
-pub(crate) fn bind_hoists(
-    qualify: &dyn Fn(&syn::Ident) -> syn::Path,
-    hoists: &[prebindgen_registry::unfold::Hoist],
-    value: &TokenStream,
-    by_ref: bool,
-) -> Hoisted {
-    let mut out = Hoisted {
-        stmts: TokenStream::new(),
-        bound: Vec::new(),
-        consuming: Vec::new(),
-        optional: Vec::new(),
-    };
-    // Value forms COMPOSE, so each hoist is built from the longest hoist that
-    // is already a proper prefix of it (they arrive outermost-first), and from
-    // `value` otherwise.
-    for (i, h) in hoists.iter().enumerate() {
-        let local = format_ident!("__vf{}", i);
-        // A hoist under an optional step binds `Option<TStruct>`: the value
-        // form runs in the `Some` arm only. Core refuses to nest these, so the
-        // enclosing value is always the plan's own — no rebase to consider.
-        if h.prefix.iter().any(PathStep::is_optional) {
-            let (last, lead) = h
-                .prefix
-                .split_last()
-                .expect("a hoist prefix ends in its value-form call");
-            let consuming = h.consuming;
-            // The value form is handed the payload only when the optional step
-            // is the LAST thing before it; any step in between composes as a
-            // borrow, so what arrives is a reference either way.
-            let owned = lead.last().is_some_and(PathStep::yields_owned);
-            let expr = reach_optional(qualify, lead, value.clone(), by_ref, 0, &|reached| {
-                compose_value_form_call(qualify, last, reached, owned, consuming)
-            });
-            out.stmts.extend(quote! { let #local = #expr; });
-            out.bound.push((h.prefix.clone(), local));
-            out.consuming.push(h.consuming);
-            out.optional.push(true);
-            continue;
-        }
-        // Where the fold starts, and whether what it starts from is OWNED. The
-        // value form's own boundary is decided below, from what the fold ends
-        // up holding — never from where it began.
-        let (from, start, start_owned) = match out.rebase(&h.prefix) {
-            // A NESTED consuming form is handed the parent's field by MOVE: a
-            // hoisted value form is an owned struct and its fields are
-            // disjoint, so moving one out leaves every sibling leaf readable.
-            // `compose_step` borrows (`&(e).f`), so a plain field run to that
-            // field is projected here instead of going through it.
-            Some((outer, rest, _))
-                if h.consuming && rest[..rest.len() - 1].iter().all(PathStep::is_plain_field) =>
-            {
-                let lead = &rest[..rest.len() - 1];
-                let segs: Vec<&syn::Ident> = lead.iter().map(PathStep::ident).collect();
-                (h.prefix.len() - 1, quote!(#outer #(.#segs)*), true)
-            }
-            // Any other rebased hoist: project its own leading field run
-            // DIRECTLY off the parent local rather than reaching it through a
-            // borrow of the parent. A sibling hoist may already have moved a
-            // different field out — that is what a consuming value form does —
-            // and `&(&__vf0).wrapper` borrows the partially moved parent as a
-            // whole where `&__vf0.wrapper` is a disjoint borrow that survives.
-            // Same invariant `project_leading_fields` states for leaf reaches,
-            // and the same reason.
-            Some((outer, rest, _)) => {
-                let (e, lead) = project_leading_fields(&quote!(#outer), false, &rest);
-                (h.prefix.len() - rest.len() + lead, e, false)
-            }
-            None if by_ref => (0, value.clone(), false),
-            None => (0, value.clone(), true),
-        };
-        // Everything before the value form is an ordinary accessor chain.
-        let last = h.prefix.len() - 1;
-        let head = &h.prefix[from..last];
-        let e = fold_steps(qualify, head, start, start_owned);
-        let e_owned = head.last().map_or(start_owned, PathStep::yields_owned);
-        // The value form itself. A CONSUMING one takes its receiver BY VALUE —
-        // that is the move the whole declaration exists for — so it is handed
-        // what the fold holds when that is ours, and a clone when it is not:
-        // the same cost the borrowing form of the accessor would have paid,
-        // which keeps one declaration usable by both owned and `&T` returns.
-        // A borrowing one takes a reference, so an owned value is borrowed.
-        //
-        // Deciding this from the fold's RESULT rather than from its start is
-        // what lets a consuming form sit behind ordinary accessors: the chain
-        // in front borrows, the form itself still moves.
-        let expr = compose_value_form_call(qualify, &h.prefix[last], e, e_owned, h.consuming);
-        out.stmts.extend(quote! { let #local = #expr; });
-        out.bound.push((h.prefix.clone(), local));
-        out.consuming.push(h.consuming);
-        out.optional.push(false);
-    }
-    out
 }
 
 /// Bind `e` so it can be destructured as an `Option` **whatever Rust
@@ -1832,7 +1409,7 @@ mod tests {
                 true,
                 LeafSource::Reach,
             );
-            let got = reach_leaf_flat(
+            let got = prebindgen_registry::unfold::reach_leaf_flat(
                 &qualify,
                 &crate::jni::compile::OutWire::from_leaf(&l),
                 &path,
@@ -1859,7 +1436,7 @@ mod tests {
             true,
             LeafSource::Reach,
         );
-        let got = reach_leaf_flat(
+        let got = prebindgen_registry::unfold::reach_leaf_flat(
             &qualify,
             &crate::jni::compile::OutWire::from_leaf(&l),
             &path,
@@ -1891,7 +1468,7 @@ mod tests {
             false,
             LeafSource::Reach,
         );
-        let got = reach_leaf_flat(
+        let got = prebindgen_registry::unfold::reach_leaf_flat(
             &qualify,
             &crate::jni::compile::OutWire::from_leaf(&l),
             &path,
@@ -1923,7 +1500,7 @@ mod tests {
         // The suffix a rebase would hand over — the optional call is gone from
         // it, and used to take the guard with it.
         let rest = vec![PathStep::field(syn::parse_quote!(a), false)];
-        let _ = reach_leaf_flat(
+        let _ = prebindgen_registry::unfold::reach_leaf_flat(
             &qualify,
             &crate::jni::compile::OutWire::from_leaf(&l),
             &rest,

--- a/prebindgen-jni/src/jni/emit/flat_input.rs
+++ b/prebindgen-jni/src/jni/emit/flat_input.rs
@@ -117,6 +117,85 @@ impl prebindgen_registry::chain::OptionalBridge for JNullableProperty {
     }
 }
 
+/// The sealed interface a whole-object sum crosses as: one JVM object whose
+/// class names the live alternative.
+///
+/// Selection is a run of `instanceof` tests, in declaration order, which this
+/// reads once into a tag the composed `Choice` matches on. Absence of a match
+/// and a null reference are distinct failures, and both keep the message they
+/// had.
+#[derive(Clone)]
+struct JSumBridge {
+    /// One JVM class per alternative, in declaration order.
+    classes: Vec<String>,
+    /// The sum's Kotlin name, for the two failure messages.
+    enum_name: String,
+}
+
+impl prebindgen_registry::chain::ChoiceBridge for JSumBridge {
+    fn intermediate(&self) -> syn::Type {
+        syn::parse_quote!(jni::objects::JObject)
+    }
+
+    fn tag(&self, value: TokenStream) -> TokenStream {
+        let enum_name = &self.enum_name;
+        let null = format!("{enum_name}: null value where a variant was required");
+        let tests = self.classes.iter().enumerate().map(|(index, class)| {
+            let index = index as i32;
+            let error = format!("{enum_name}: instanceof {class}: {{}}");
+            quote! {
+                if env.is_instance_of(#value, #class)
+                    .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(
+                        format!(#error, e)
+                    ))?
+                {
+                    return ::core::result::Result::Ok(#index);
+                }
+            }
+        });
+        quote!({
+            if #value.is_null() {
+                return ::core::result::Result::Err(
+                    <__JniErr as ::core::convert::From<String>>::from(#null.to_string()),
+                );
+            }
+            let __tag = (|| -> ::core::result::Result<i32, __JniErr> {
+                #(#tests)*
+                ::core::result::Result::Ok(-1i32)
+            })()?;
+            __tag
+        })
+    }
+
+    fn arm(
+        &self,
+        _emit: &prebindgen_registry::RustWriter,
+        value: TokenStream,
+        _index: usize,
+    ) -> TokenStream {
+        // Every alternative's payload is read off the same object; which
+        // properties belong to it is the arm's own bridge.
+        value
+    }
+
+    fn build(
+        &self,
+        _emit: &prebindgen_registry::RustWriter,
+        _active: usize,
+        _value: TokenStream,
+    ) -> TokenStream {
+        unreachable!("a whole-object sum is decoded, never encoded, through this bridge")
+    }
+
+    fn invalid_tag(&self, _tag: TokenStream) -> TokenStream {
+        let message = format!(
+            "{}: value is not one of its declared variants",
+            self.enum_name
+        );
+        quote!(<__JniErr as ::core::convert::From<String>>::from(#message.to_string()))
+    }
+}
+
 /// The source struct a whole-object decode builds, spelled through the shape
 /// the model holds.
 ///
@@ -681,7 +760,6 @@ impl JObjectStructFieldPlan {
 #[derive(Clone)]
 pub(crate) struct JObjectSumInputPlan {
     shape: flat::Variant,
-    source_module: syn::Path,
     enum_name: String,
     alternatives: Vec<JObjectSumAlternativePlan>,
 }
@@ -690,13 +768,9 @@ pub(crate) struct JObjectSumInputPlan {
 struct JObjectSumAlternativePlan {
     shape: flat::Alternative,
     jvm_class: String,
-    fields: Vec<JObjectSumFieldPlan>,
-}
-
-#[derive(Clone)]
-struct JObjectSumFieldPlan {
-    shape: flat::Field,
-    property: JObjectStructFieldPlan,
+    /// One property per payload field, in declaration order — the same plan a
+    /// struct's field carries, since a payload is read exactly as a field is.
+    fields: Vec<JObjectStructFieldPlan>,
 }
 
 impl JObjectSumInputPlan {
@@ -708,7 +782,7 @@ impl JObjectSumInputPlan {
             .iter()
             .flat_map(|alternative| &alternative.fields)
         {
-            field.property.kind.calls(out);
+            field.kind.calls(out);
         }
     }
 }
@@ -733,10 +807,9 @@ pub(crate) fn build_jobject_sum_input_plan(
             let property = crate::jni::struct_plan::sum_field_prop_name(&field.member());
             let bind = format_ident!("__p_{}", property);
             let error = format!("{enum_name}.{kotlin_name}.{property}: {{}}");
-            fields.push(JObjectSumFieldPlan {
-                shape: field.clone(),
-                property: build_jobject_property_plan(ext, &field.ty, bind, property, error, true)?,
-            });
+            fields.push(build_jobject_property_plan(
+                ext, &field.ty, bind, property, error, true,
+            )?);
         }
         alternatives.push(JObjectSumAlternativePlan {
             shape: alt.clone(),
@@ -744,78 +817,62 @@ pub(crate) fn build_jobject_sum_input_plan(
             fields,
         });
     }
+    let _ = registry;
     Some(JObjectSumInputPlan {
         shape: v.clone(),
-        source_module: ext.fn_module(registry, &v.name),
         enum_name,
         alternatives,
     })
 }
 
 impl JObjectSumInputPlan {
+    /// The decode, composed by the registry: it reads the tag, selects the
+    /// arm, reads that arm's payload properties through the same bridge the
+    /// struct decode uses, and constructs the alternative.
     pub(crate) fn render(&self, emit: &prebindgen_registry::RustWriter) -> syn::Expr {
-        let source_module = &self.source_module;
-        let enum_ident = &self.shape.name;
-        let enum_name = &self.enum_name;
-        let mut arms = Vec::new();
-        for alternative in &self.alternatives {
-            let vident = &alternative.shape.name;
-            let jvm_class = &alternative.jvm_class;
-            let mut preludes = Vec::new();
-            let mut inits = Vec::new();
-            for field in &alternative.fields {
-                // The sum still walks its payload itself — step 4 of #596 is
-                // what composes this as a `Choice`. It reads and converts each
-                // property through the same two halves the struct's composed
-                // `Product` uses.
-                let (read, value) = field.property.read(quote!(__obj));
-                let bind = &field.property.name;
-                let convert =
-                    prebindgen_registry::chain::Child::invoke(&field.property.child(), value, emit);
-                let convert = if prebindgen_registry::chain::Child::call(&field.property.child())
-                    .fallible()
-                {
-                    quote!(#convert?)
-                } else {
-                    convert
-                };
-                preludes.push(quote! {
-                    #read
-                    let #bind = #convert;
-                });
-                inits.push(field.shape.bind(&quote!(#bind)));
-            }
-            let ctor = emit.shape_alternative(
-                &alternative.shape,
-                quote!(#source_module::#enum_ident::#vident),
-                &inits,
-            );
-            arms.push(quote! {
-                if env.is_instance_of(__obj, #jvm_class)
-                    .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(
-                        format!(concat!(#enum_name, ": instanceof ", #jvm_class, ": {}"), e)))?
-                {
-                    #(#preludes)*
-                    return ::core::result::Result::Ok(#ctor);
-                }
-            });
-        }
-        let no_match = format!("{enum_name}: value is not one of its declared variants");
-        let null_msg = format!("{enum_name}: null value where a variant was required");
-        syn::parse_quote!({
-            let __obj = v;
-            (|| -> ::core::result::Result<#source_module::#enum_ident, __JniErr> {
-                if __obj.is_null() {
-                    return ::core::result::Result::Err(
-                        <__JniErr as ::core::convert::From<String>>::from(#null_msg.to_string()),
-                    );
-                }
-                #(#arms)*
-                ::core::result::Result::Err(
-                    <__JniErr as ::core::convert::From<String>>::from(#no_match.to_string()),
+        let choice = prebindgen_registry::chain::Choice {
+            source: self.shape.type_ref().clone(),
+            direction: prebindgen_registry::recipe::Direction::Construct,
+            source_policy: crate::jni::chain::JSource {
+                wrappers: Vec::new(),
+            },
+            bridge: JSumBridge {
+                classes: self
+                    .alternatives
+                    .iter()
+                    .map(|alternative| alternative.jvm_class.clone())
+                    .collect(),
+                enum_name: self.enum_name.clone(),
+            },
+            arms: self
+                .alternatives
+                .iter()
+                .enumerate()
+                .map(
+                    |(index, alternative)| prebindgen_registry::chain::ChoiceArm {
+                        alternative: alternative.shape.clone(),
+                        tag: {
+                            let index = index as i32;
+                            syn::parse_quote!(#index)
+                        },
+                        bridge: JObjectBridge {
+                            properties: alternative.fields.to_vec(),
+                        },
+                        parts: alternative
+                            .fields
+                            .iter()
+                            .map(|field| prebindgen_registry::chain::ChoicePart {
+                                child: field.child(),
+                                mode: prebindgen_registry::recipe::Mode::Owned,
+                                hold_uninit: false,
+                            })
+                            .collect(),
+                    },
                 )
-            })()?
-        })
+                .collect(),
+        };
+        let body = prebindgen_registry::chain::Chain::render(&choice, emit).body;
+        syn::parse_quote!(#body)
     }
 }
 

--- a/prebindgen-jni/src/jni/emit/flat_input.rs
+++ b/prebindgen-jni/src/jni/emit/flat_input.rs
@@ -19,7 +19,6 @@ use crate::jni::trait_impl::build_through_erased_wrappers;
 #[derive(Clone)]
 pub(crate) struct JObjectStructInputPlan {
     shape: flat::Struct,
-    source_module: syn::Path,
     fields: Vec<JObjectStructFieldPlan>,
 }
 
@@ -115,6 +114,123 @@ impl prebindgen_registry::chain::OptionalBridge for JNullableProperty {
 
     fn build_present(&self, _child: TokenStream) -> TokenStream {
         unreachable!("a whole-object property is decoded, never encoded")
+    }
+}
+
+/// The source struct a whole-object decode builds, spelled through the shape
+/// the model holds.
+///
+/// A `data_class` is normally a named-field struct, and the registry's default
+/// construction is exactly that. A unit or tuple struct is not, and only the
+/// element knows which — so it travels with the policy that constructs it.
+#[derive(Clone)]
+struct JStructSource {
+    ordinary: crate::jni::chain::JSource,
+    shape: flat::Struct,
+}
+
+impl prebindgen_registry::chain::Source for JStructSource {
+    fn spell(&self, source: &TypeRef, emit: &prebindgen_registry::RustWriter) -> TokenStream {
+        prebindgen_registry::chain::Source::spell(&self.ordinary, source, emit)
+    }
+
+    fn build(&self, canonical: TokenStream) -> TokenStream {
+        prebindgen_registry::chain::Source::build(&self.ordinary, canonical)
+    }
+
+    fn construct(
+        &self,
+        head: TokenStream,
+        parts: &[(syn::Ident, TokenStream)],
+        emit: &prebindgen_registry::RustWriter,
+    ) -> TokenStream {
+        let bound: Vec<TokenStream> = self
+            .shape
+            .fields
+            .iter()
+            .zip(parts)
+            .map(|(field, (_, value))| field.bind(value))
+            .collect();
+        emit.shape_struct(&self.shape, head, &bound)
+    }
+}
+
+/// The JVM object a whole-object struct crosses as, read one property at a
+/// time.
+///
+/// This is the adapter half of the composed `Product`: the registry walks the
+/// struct's fields and builds the source value; this says what a part *is* —
+/// a property fetched off the object, which can fail.
+#[derive(Clone)]
+struct JObjectBridge {
+    properties: Vec<JObjectStructFieldPlan>,
+}
+
+impl prebindgen_registry::chain::ProductBridge for JObjectBridge {
+    fn intermediate(&self) -> syn::Type {
+        syn::parse_quote!(jni::objects::JObject)
+    }
+
+    fn part(
+        &self,
+        value: TokenStream,
+        index: usize,
+        _name: &syn::Ident,
+    ) -> prebindgen_registry::chain::PartRead {
+        let (prelude, value) = self.properties[index].read(value);
+        prebindgen_registry::chain::PartRead::fallible(prelude, value)
+    }
+
+    fn build(&self, _parts: &[(syn::Ident, TokenStream)]) -> TokenStream {
+        unreachable!("a whole-object struct is decoded, never encoded, through this bridge")
+    }
+}
+
+/// What converts one property once its wire value has been read.
+///
+/// Either the property's own child converter, or — for a nullable property —
+/// the `Optional` layer composed over it, which decides absence before the
+/// child is reached.
+#[derive(Clone)]
+pub(crate) struct JPropertyChild {
+    call: prebindgen_registry::chain::Call,
+    conversion: JPropertyConversion,
+}
+
+#[derive(Clone)]
+enum JPropertyConversion {
+    Converter(crate::jni::chain::JChild),
+    Nullable(
+        Box<
+            prebindgen_registry::chain::Optional<
+                crate::jni::chain::JSource,
+                JNullableProperty,
+                crate::jni::chain::JChild,
+            >,
+        >,
+    ),
+}
+
+impl prebindgen_registry::chain::Child for JPropertyChild {
+    fn call(&self) -> &prebindgen_registry::chain::Call {
+        &self.call
+    }
+
+    fn invoke(&self, value: TokenStream, emit: &prebindgen_registry::RustWriter) -> TokenStream {
+        match &self.conversion {
+            JPropertyConversion::Converter(child) => {
+                prebindgen_registry::chain::Child::invoke(child, value, emit)
+            }
+            // The composed layer names its input `v`, as every chain does, so
+            // the block is what keeps that name local to this property.
+            JPropertyConversion::Nullable(chain) => {
+                let body = prebindgen_registry::chain::Chain::render(chain.as_ref(), emit).body;
+                quote!({
+                    let v = #value;
+                    #body
+                })
+            }
+        }
     }
 }
 
@@ -217,9 +333,9 @@ pub(crate) fn build_jobject_struct_input_plan(
             ext, &field.ty, name, property, error, false,
         )?);
     }
+    let _ = registry;
     Some(JObjectStructInputPlan {
         shape: s.clone(),
-        source_module: struct_module_path(ext, registry, &s.name),
         fields,
     })
 }
@@ -369,26 +485,45 @@ fn build_jobject_property_plan(
 }
 
 impl JObjectStructInputPlan {
+    /// The decode, composed by the registry: it walks the struct's fields,
+    /// reads each part through [`JObjectBridge`], calls each property's
+    /// conversion, and builds the source value.
     pub(crate) fn render(&self, emit: &prebindgen_registry::RustWriter) -> syn::Expr {
-        let mut preludes = Vec::new();
-        let mut inits = Vec::new();
-        for field in &self.fields {
-            preludes.push(field.render(quote!(v), emit));
-            let name = &field.name;
-            inits.push(quote!(#name));
-        }
-        let module = &self.source_module;
-        let ident = &self.shape.name;
-        let ctor = emit.shape_struct(&self.shape, quote!(#module::#ident), &inits);
-        syn::parse_quote!({
-            #(#preludes)*
-            #ctor
-        })
+        let product = prebindgen_registry::chain::Product {
+            source: self.shape.type_ref().clone(),
+            direction: prebindgen_registry::recipe::Direction::Construct,
+            source_policy: JStructSource {
+                ordinary: crate::jni::chain::JSource {
+                    wrappers: Vec::new(),
+                },
+                shape: self.shape.clone(),
+            },
+            bridge: JObjectBridge {
+                properties: self.fields.clone(),
+            },
+            parts: self
+                .fields
+                .iter()
+                .map(|field| prebindgen_registry::chain::ProductPart {
+                    name: field.name.clone(),
+                    child: field.child(),
+                    mode: prebindgen_registry::recipe::Mode::Owned,
+                    hold_uninit: false,
+                })
+                .collect(),
+        };
+        let body = prebindgen_registry::chain::Chain::render(&product, emit).body;
+        syn::parse_quote!(#body)
     }
 }
 
 impl JObjectStructFieldPlan {
-    fn render(&self, receiver: TokenStream, emit: &prebindgen_registry::RustWriter) -> TokenStream {
+    /// The statements that read this property's wire value off `receiver`,
+    /// and the expression naming it.
+    ///
+    /// Every read can fail — a JVM field access returns a `Result` — which is
+    /// why the composed `Product` above takes this as a fallible part.
+    fn read(&self, receiver: TokenStream) -> (TokenStream, TokenStream) {
         let name = &self.name;
         let property = &self.property;
         let error = &self.error;
@@ -402,109 +537,123 @@ impl JObjectStructFieldPlan {
         } else {
             format_ident!("__{}_jobj", name)
         };
-        match &self.kind {
-            JObjectStructFieldKind::Handle {
-                descriptor,
-                pipeline,
-            } => {
-                let decode = pipeline.invoke_converter(quote!(env), quote!(#raw), name, emit);
-                quote! {
-                    let #object: jni::objects::JObject = env.get_field(#receiver, #property, #descriptor)
-                        .and_then(|val| val.l())
-                        .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(format!(#error, e)))?;
-                    let #raw: jni::sys::jlong = if #object.is_null() {
-                        0
-                    } else {
-                        env.call_method(&#object, "peek", "()J", &[])
-                            .and_then(|val| val.j())
-                            .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(format!(#error, e)))?
-                    };
-                    let #name = #decode;
-                }
+        let fetch_object = |descriptor: &String| {
+            quote! {
+                let #object: jni::objects::JObject = env.get_field(#receiver, #property, #descriptor)
+                    .and_then(|val| val.l())
+                    .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(format!(#error, e)))?;
             }
-            JObjectStructFieldKind::Unsigned64 { pipeline } => {
-                let decode = pipeline.invoke_converter(quote!(env), quote!(#raw), name, emit);
+        };
+        match &self.kind {
+            JObjectStructFieldKind::Handle { descriptor, .. } => {
+                let fetch = fetch_object(descriptor);
+                (
+                    quote! {
+                        #fetch
+                        let #raw: jni::sys::jlong = if #object.is_null() {
+                            0
+                        } else {
+                            env.call_method(&#object, "peek", "()J", &[])
+                                .and_then(|val| val.j())
+                                .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(format!(#error, e)))?
+                        };
+                    },
+                    quote!(#raw),
+                )
+            }
+            JObjectStructFieldKind::Unsigned64 { .. } => (
                 quote! {
                     let #raw: jni::sys::jlong = env
                         .get_field(#receiver, #property, "J")
                         .and_then(|val| val.j())
                         .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(format!(#error, e)))?;
-                    let #name = #decode;
-                }
+                },
+                quote!(#raw),
+            ),
+            JObjectStructFieldKind::Enum { descriptor, .. } => {
+                let fetch = fetch_object(descriptor);
+                (
+                    quote! {
+                        #fetch
+                        let #raw: jni::sys::jint = env.call_method(&#object, "getValue", "()I", &[])
+                            .and_then(|val| val.i())
+                            .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(format!(#error, e)))?;
+                    },
+                    quote!(#raw),
+                )
             }
-            JObjectStructFieldKind::Enum {
-                descriptor,
-                pipeline,
-            } => {
-                let decode = pipeline.invoke_converter(quote!(env), quote!(#raw), name, emit);
-                quote! {
-                    let #object: jni::objects::JObject = env.get_field(#receiver, #property, #descriptor)
-                        .and_then(|val| val.l())
-                        .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(format!(#error, e)))?;
-                    let #raw: jni::sys::jint = env.call_method(&#object, "getValue", "()I", &[])
-                        .and_then(|val| val.i())
-                        .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(format!(#error, e)))?;
-                    let #name = #decode;
-                }
-            }
-            // A nullable property: the reference is fetched here, and what it
-            // means — absent, or a value one unboxing call away — is decided
-            // by the registry-composed `Optional` layer.
+            // The reference itself is the wire value: whether it means absence
+            // is the composed `Optional` layer's decision, not the read's.
             JObjectStructFieldKind::Nullable(plan) => {
-                let descriptor = &plan.descriptor;
-                let optional =
-                    prebindgen_registry::chain::Chain::render(plan.chain.as_ref(), emit).body;
-                quote! {
-                    let #object: jni::objects::JObject = env.get_field(#receiver, #property, #descriptor)
-                        .and_then(|val| val.l())
-                        .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(format!(#error, e)))?;
-                    let #name = {
-                        let v = #object;
-                        #optional
-                    };
-                }
+                (fetch_object(&plan.descriptor), quote!(#object))
             }
             JObjectStructFieldKind::Primitive {
                 wire,
                 descriptor,
                 accessor,
-                pipeline,
-            } => {
-                let decode = pipeline.invoke_converter(quote!(env), quote!(#raw), name, emit);
+                ..
+            } => (
                 quote! {
                     let #raw: #wire = env.get_field(#receiver, #property, #descriptor)
                         .and_then(|val| val.#accessor())
                         .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(format!(#error, e)))? as _;
-                    let #name = #decode;
-                }
-            }
+                },
+                quote!(#raw),
+            ),
             JObjectStructFieldKind::IntoObject {
-                wire,
-                descriptor,
-                pipeline,
+                wire, descriptor, ..
             } => {
-                let decode = pipeline.invoke_converter(quote!(env), quote!(#raw), name, emit);
-                quote! {
-                    let #object: jni::objects::JObject = env.get_field(#receiver, #property, #descriptor)
-                        .and_then(|val| val.l())
-                        .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(format!(#error, e)))?;
-                    let #raw: #wire = #object.into();
-                    let #name = #decode;
-                }
+                let fetch = fetch_object(descriptor);
+                (
+                    quote! {
+                        #fetch
+                        let #raw: #wire = #object.into();
+                    },
+                    quote!(#raw),
+                )
             }
-            JObjectStructFieldKind::Object {
-                descriptor,
-                pipeline,
-            } => {
-                let decode = pipeline.invoke_converter(quote!(env), quote!(#raw), name, emit);
+            JObjectStructFieldKind::Object { descriptor, .. } => (
                 quote! {
                     let #raw: jni::objects::JObject = env.get_field(#receiver, #property, #descriptor)
                         .and_then(|val| val.l())
                         .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(format!(#error, e)))?;
-                    let #name = #decode;
-                }
-            }
+                },
+                quote!(#raw),
+            ),
         }
+    }
+
+    /// What converts this property once it is read.
+    fn child(&self) -> JPropertyChild {
+        let conversion = match &self.kind {
+            JObjectStructFieldKind::Nullable(plan) => {
+                JPropertyConversion::Nullable(plan.chain.clone())
+            }
+            JObjectStructFieldKind::Handle { pipeline, .. }
+            | JObjectStructFieldKind::Unsigned64 { pipeline }
+            | JObjectStructFieldKind::Enum { pipeline, .. }
+            | JObjectStructFieldKind::Primitive { pipeline, .. }
+            | JObjectStructFieldKind::IntoObject { pipeline, .. }
+            | JObjectStructFieldKind::Object { pipeline, .. } => {
+                JPropertyConversion::Converter(pipeline.converter_child().clone())
+            }
+        };
+        let call = match &conversion {
+            JPropertyConversion::Converter(child) => {
+                prebindgen_registry::chain::Child::call(child).clone()
+            }
+            // The layer propagates its own failures with `?`, so the composer
+            // adds none of its own; the identity is the child's, which is what
+            // the property depends on.
+            JPropertyConversion::Nullable(chain) => prebindgen_registry::chain::Call::operation(
+                prebindgen_registry::chain::Child::call(&chain.child)
+                    .operation_id()
+                    .clone(),
+                false,
+                false,
+            ),
+        };
+        JPropertyChild { call, conversion }
     }
 }
 
@@ -615,8 +764,25 @@ impl JObjectSumInputPlan {
             let mut preludes = Vec::new();
             let mut inits = Vec::new();
             for field in &alternative.fields {
-                preludes.push(field.property.render(quote!(__obj), emit));
+                // The sum still walks its payload itself — step 4 of #596 is
+                // what composes this as a `Choice`. It reads and converts each
+                // property through the same two halves the struct's composed
+                // `Product` uses.
+                let (read, value) = field.property.read(quote!(__obj));
                 let bind = &field.property.name;
+                let convert =
+                    prebindgen_registry::chain::Child::invoke(&field.property.child(), value, emit);
+                let convert = if prebindgen_registry::chain::Child::call(&field.property.child())
+                    .fallible()
+                {
+                    quote!(#convert?)
+                } else {
+                    convert
+                };
+                preludes.push(quote! {
+                    #read
+                    let #bind = #convert;
+                });
                 inits.push(field.shape.bind(&quote!(#bind)));
             }
             let ctor = emit.shape_alternative(

--- a/prebindgen-jni/src/jni/emit/flat_input.rs
+++ b/prebindgen-jni/src/jni/emit/flat_input.rs
@@ -51,8 +51,117 @@ impl JObjectStructFieldKind {
             | Self::Primitive { pipeline, .. }
             | Self::IntoObject { pipeline, .. }
             | Self::Object { pipeline, .. } => pipeline.calls(out),
+            Self::Nullable(plan) => plan.chain.child.calls(out),
         }
     }
+}
+
+/// The null-reference `Optional` layer a nullable whole-object property
+/// crosses as.
+///
+/// A `ULong?` property arrives as a boxed `kotlin.ULong` and a nullable enum
+/// class as its own class: absence is a null reference, and the value is one
+/// unboxing call away. The registry composes the layer; this supplies the two
+/// answers only JniGen can give — how to test absence, and how to unbox.
+#[derive(Clone)]
+struct JNullableProperty {
+    /// JVM method that unboxes the property, its signature, and the `JValue`
+    /// accessor for the result.
+    method: &'static str,
+    signature: &'static str,
+    accessor: syn::Ident,
+    /// Per-property error text.
+    error: String,
+    /// Whether the child already yields the optional, because its own wire
+    /// carries a niche encoding of absence. Then a non-null reference is not
+    /// yet a value: the child still has to read its sentinel.
+    flattens: bool,
+}
+
+impl prebindgen_registry::chain::OptionalBridge for JNullableProperty {
+    fn intermediate(&self) -> syn::Type {
+        syn::parse_quote!(jni::objects::JObject)
+    }
+
+    fn is_absent(&self) -> TokenStream {
+        quote!(v.is_null())
+    }
+
+    fn present(&self, value: TokenStream) -> TokenStream {
+        let (method, signature, accessor, error) =
+            (self.method, self.signature, &self.accessor, &self.error);
+        // The accessor already yields the wire type, so the composer's own
+        // binding needs no annotation of its own.
+        quote!(
+            env.call_method(&#value, #method, #signature, &[])
+                .and_then(|val| val.#accessor())
+                .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(
+                    format!(#error, e)
+                ))?
+        )
+    }
+
+    fn source_present(&self, child: TokenStream) -> TokenStream {
+        if self.flattens {
+            child
+        } else {
+            quote!(::core::option::Option::Some(#child))
+        }
+    }
+
+    fn build_absent(&self) -> TokenStream {
+        unreachable!("a whole-object property is decoded, never encoded")
+    }
+
+    fn build_present(&self, _child: TokenStream) -> TokenStream {
+        unreachable!("a whole-object property is decoded, never encoded")
+    }
+}
+
+/// One nullable property: the reference fetched off the JVM object, and the
+/// registry-composed `Optional` that turns it into the source value.
+#[derive(Clone)]
+struct JNullablePlan {
+    descriptor: String,
+    chain: Box<
+        prebindgen_registry::chain::Optional<
+            crate::jni::chain::JSource,
+            JNullableProperty,
+            crate::jni::chain::JChild,
+        >,
+    >,
+}
+
+/// Compose one nullable property's `Optional` layer over its child converter.
+#[allow(clippy::too_many_arguments)]
+fn nullable_property(
+    reading: &TypeRef,
+    pipeline: crate::jni::chain::JPipeline,
+    descriptor: String,
+    method: &'static str,
+    signature: &'static str,
+    accessor: syn::Ident,
+    error: String,
+    flattens: bool,
+) -> JObjectStructFieldKind {
+    JObjectStructFieldKind::Nullable(Box::new(JNullablePlan {
+        descriptor,
+        chain: Box::new(prebindgen_registry::chain::Optional {
+            source: reading.clone(),
+            direction: prebindgen_registry::recipe::Direction::Construct,
+            source_policy: crate::jni::chain::JSource {
+                wrappers: Vec::new(),
+            },
+            bridge: JNullableProperty {
+                method,
+                signature,
+                accessor,
+                error,
+                flattens,
+            },
+            child: pipeline.converter_child().clone(),
+        }),
+    }))
 }
 
 #[derive(Clone)]
@@ -62,15 +171,16 @@ enum JObjectStructFieldKind {
         pipeline: crate::jni::chain::JPipeline,
     },
     Unsigned64 {
-        optional: bool,
-        wrap_some: bool,
         pipeline: crate::jni::chain::JPipeline,
     },
     Enum {
         descriptor: String,
-        optional: bool,
         pipeline: crate::jni::chain::JPipeline,
     },
+    /// A property whose absence is a null reference: either shape above, when
+    /// the source reads optional. Its `Optional` layer is composed by the
+    /// registry rather than walked here.
+    Nullable(Box<JNullablePlan>),
     Primitive {
         wire: syn::Type,
         descriptor: String,
@@ -148,18 +258,30 @@ fn build_jobject_property_plan(
                 projection.strategy,
                 FoldStrategy::Optional(NullableKind::Niche, _)
             );
-        let pipeline = if optional && !niche {
-            ext.in_frag(inner)?.pipeline(
-                prebindgen_registry::recipe::Direction::Construct,
-                prebindgen_registry::recipe::Mode::Owned,
+        if optional {
+            // A niche-encoded child reads its own absence out of the unboxed
+            // value, so the null reference is only the first of two tests and
+            // the child's answer is the whole answer.
+            let pipeline = if niche {
+                whole
+            } else {
+                ext.in_frag(inner)?.pipeline(
+                    prebindgen_registry::recipe::Direction::Construct,
+                    prebindgen_registry::recipe::Mode::Owned,
+                )
+            };
+            nullable_property(
+                reading,
+                pipeline,
+                "Lkotlin/ULong;".to_string(),
+                "unbox-impl",
+                "()J",
+                format_ident!("j"),
+                error.clone(),
+                niche,
             )
         } else {
-            whole
-        };
-        JObjectStructFieldKind::Unsigned64 {
-            optional,
-            wrap_some: optional && !niche,
-            pipeline,
+            JObjectStructFieldKind::Unsigned64 { pipeline: whole }
         }
     } else if ext.is_kotlin_enum_reading(inner) {
         let fqn = match inner.unwrapped().kind() {
@@ -167,18 +289,27 @@ fn build_jobject_property_plan(
             _ => None,
         }
         .and_then(|ident| ext.kotlin_fqn(&TypeKey::from_ident(&ident)))?;
-        let pipeline = if optional {
-            ext.in_frag(inner)?.pipeline(
+        let descriptor = format!("L{};", fqn.replace('.', "/"));
+        if optional {
+            let pipeline = ext.in_frag(inner)?.pipeline(
                 prebindgen_registry::recipe::Direction::Construct,
                 prebindgen_registry::recipe::Mode::Owned,
+            );
+            nullable_property(
+                reading,
+                pipeline,
+                descriptor,
+                "getValue",
+                "()I",
+                format_ident!("i"),
+                error.clone(),
+                false,
             )
         } else {
-            whole
-        };
-        JObjectStructFieldKind::Enum {
-            descriptor: format!("L{};", fqn.replace('.', "/")),
-            optional,
-            pipeline,
+            JObjectStructFieldKind::Enum {
+                descriptor,
+                pipeline: whole,
+            }
         }
     } else {
         match jni_field_access(&wire) {
@@ -291,73 +422,46 @@ impl JObjectStructFieldPlan {
                     let #name = #decode;
                 }
             }
-            JObjectStructFieldKind::Unsigned64 {
-                optional,
-                wrap_some,
-                pipeline,
-            } => {
+            JObjectStructFieldKind::Unsigned64 { pipeline } => {
                 let decode = pipeline.invoke_converter(quote!(env), quote!(#raw), name, emit);
-                if *optional {
-                    let decoded = if *wrap_some {
-                        quote!(::core::option::Option::Some(#decode))
-                    } else {
-                        quote!(#decode)
-                    };
-                    quote! {
-                        let #object: jni::objects::JObject = env
-                            .get_field(#receiver, #property, "Lkotlin/ULong;")
-                            .and_then(|val| val.l())
-                            .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(format!(#error, e)))?;
-                        let #name = if #object.is_null() {
-                            ::core::option::Option::None
-                        } else {
-                            let #raw: jni::sys::jlong = env
-                                .call_method(&#object, "unbox-impl", "()J", &[])
-                                .and_then(|val| val.j())
-                                .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(format!(#error, e)))?;
-                            #decoded
-                        };
-                    }
-                } else {
-                    quote! {
-                        let #raw: jni::sys::jlong = env
-                            .get_field(#receiver, #property, "J")
-                            .and_then(|val| val.j())
-                            .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(format!(#error, e)))?;
-                        let #name = #decode;
-                    }
+                quote! {
+                    let #raw: jni::sys::jlong = env
+                        .get_field(#receiver, #property, "J")
+                        .and_then(|val| val.j())
+                        .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(format!(#error, e)))?;
+                    let #name = #decode;
                 }
             }
             JObjectStructFieldKind::Enum {
                 descriptor,
-                optional,
                 pipeline,
             } => {
                 let decode = pipeline.invoke_converter(quote!(env), quote!(#raw), name, emit);
-                if *optional {
-                    quote! {
-                        let #object: jni::objects::JObject = env.get_field(#receiver, #property, #descriptor)
-                            .and_then(|val| val.l())
-                            .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(format!(#error, e)))?;
-                        let #name = if #object.is_null() {
-                            ::core::option::Option::None
-                        } else {
-                            let #raw: jni::sys::jint = env.call_method(&#object, "getValue", "()I", &[])
-                                .and_then(|val| val.i())
-                                .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(format!(#error, e)))?;
-                            ::core::option::Option::Some(#decode)
-                        };
-                    }
-                } else {
-                    quote! {
-                        let #object: jni::objects::JObject = env.get_field(#receiver, #property, #descriptor)
-                            .and_then(|val| val.l())
-                            .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(format!(#error, e)))?;
-                        let #raw: jni::sys::jint = env.call_method(&#object, "getValue", "()I", &[])
-                            .and_then(|val| val.i())
-                            .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(format!(#error, e)))?;
-                        let #name = #decode;
-                    }
+                quote! {
+                    let #object: jni::objects::JObject = env.get_field(#receiver, #property, #descriptor)
+                        .and_then(|val| val.l())
+                        .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(format!(#error, e)))?;
+                    let #raw: jni::sys::jint = env.call_method(&#object, "getValue", "()I", &[])
+                        .and_then(|val| val.i())
+                        .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(format!(#error, e)))?;
+                    let #name = #decode;
+                }
+            }
+            // A nullable property: the reference is fetched here, and what it
+            // means — absent, or a value one unboxing call away — is decided
+            // by the registry-composed `Optional` layer.
+            JObjectStructFieldKind::Nullable(plan) => {
+                let descriptor = &plan.descriptor;
+                let optional =
+                    prebindgen_registry::chain::Chain::render(plan.chain.as_ref(), emit).body;
+                quote! {
+                    let #object: jni::objects::JObject = env.get_field(#receiver, #property, #descriptor)
+                        .and_then(|val| val.l())
+                        .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(format!(#error, e)))?;
+                    let #name = {
+                        let v = #object;
+                        #optional
+                    };
                 }
             }
             JObjectStructFieldKind::Primitive {

--- a/prebindgen-jni/src/jni/emit/struct_out.rs
+++ b/prebindgen-jni/src/jni/emit/struct_out.rs
@@ -41,6 +41,17 @@ pub(crate) fn handle_field_fqn(ext: &Declarations, h: &Projection) -> String {
 /// an absent `Option<nested>` parent.
 pub(crate) struct EncSlot {
     ident: proc_macro2::Ident,
+    /// How deeply nested the field this slot came from is: 0 for the struct's
+    /// own field, one more per inlined `data_class`.
+    ///
+    /// Read only by [`encode_leaves`], which
+    /// `JniGen::assert_leaf_derivations_agree` compares against the
+    /// registry-facing decomposition's own nesting — that one spells it with
+    /// the reserved `__` separator, this one counts it. The encode itself
+    /// needs the number while it recurses, not after, which is why nothing
+    /// else reads the field.
+    #[allow(dead_code)]
+    depth: usize,
     wire_ty: TokenStream,
     descriptor: String,
     is_object: bool,
@@ -105,6 +116,46 @@ pub(crate) fn synth_value_struct_leaves(
 /// an [`EncSlot`] describing its `JValue` slot. `access` is the Rust
 /// expression yielding the current struct value (`v`, `v.field`, or the
 /// matched `__cN` under an Option); `prefix` namespaces the generated idents.
+/// Walk the struct's fields and encode each leaf into a `fromParts` argument.
+///
+/// This is a source-value walk that the registry does not perform, and the
+/// reason is coverage rather than ownership. The registry-facing decomposition
+/// of a struct (`Declarations::struct_out_wires_at`) refuses a nested
+/// `data_class` behind an `Option` or a `Vec`; this encode supports both, an
+/// optional nested class as a `present` flag plus a defaulted group and a sum
+/// field as a tag plus one group per variant.
+///
+/// Rendering this through the registry's decomposition walk would therefore
+/// mean teaching that decomposition the gated shapes — which would also change
+/// what a foreign builder can be delivered, a feature rather than a
+/// refactoring. #596 step 5 records that decision; #602 proposes the feature.
+///
+/// Where both derivations do apply, they must name the same leaves in the same
+/// order: `JniGen::assert_leaf_derivations_agree` checks that on every binding
+/// a test writes, since that agreement is what #602 would rest on.
+/// The leaves this encode emits, flattened — the `fromParts` argument list,
+/// in order, each with how deeply nested the field it came from is.
+///
+/// Test support: the registry-facing decomposition of the same struct must
+/// agree with this wherever it exists, and #603 recorded that agreement as
+/// measured rather than checked. `JniGen::write_rust` checks it now.
+#[cfg(test)]
+pub(crate) fn encode_leaves(
+    plan: &StructPlan,
+    emit: &prebindgen_registry::RustWriter,
+) -> Vec<(String, usize)> {
+    let (_, slots) = encode_plan(plan, &quote!(v), "", 0, &quote!(env), emit);
+    slots
+        .iter()
+        .map(|slot| {
+            (
+                slot.ident.to_string().trim_start_matches('_').to_string(),
+                slot.depth,
+            )
+        })
+        .collect()
+}
+
 fn encode_plan(
     plan: &StructPlan,
     access: &TokenStream,
@@ -157,6 +208,7 @@ fn encode_field(
                     ProjectionKind::Handle => {
                         preludes.extend(quote! { let #id: jni::sys::jlong = #value_expr; });
                         slots.push(EncSlot {
+                            depth,
                             ident: id,
                             wire_ty: quote!(jni::sys::jlong),
                             descriptor: "J".to_string(),
@@ -168,6 +220,7 @@ fn encode_field(
                         FoldStrategy::Base => {
                             preludes.extend(quote! { let #id: jni::sys::jlong = #value_expr; });
                             slots.push(EncSlot {
+                                depth,
                                 ident: id,
                                 wire_ty: quote!(jni::sys::jlong),
                                 descriptor: "J".to_string(),
@@ -178,6 +231,7 @@ fn encode_field(
                         FoldStrategy::Optional(NullableKind::Niche, _) => {
                             preludes.extend(quote! { let #id: jni::sys::jlong = #value_expr; });
                             slots.push(EncSlot {
+                                depth,
                                 ident: id,
                                 wire_ty: quote!(jni::sys::jlong),
                                 descriptor: "J".to_string(),
@@ -189,6 +243,7 @@ fn encode_field(
                             preludes
                                 .extend(quote! { let #id: jni::objects::JObject = #value_expr; });
                             slots.push(EncSlot {
+                                depth,
                                 ident: id,
                                 wire_ty: quote!(jni::objects::JObject),
                                 descriptor: "Ljava/lang/Long;".to_string(),
@@ -207,6 +262,7 @@ fn encode_field(
                 let value_expr = conv_value(conv);
                 preludes.extend(quote! { let #id: jni::sys::jint = #value_expr; });
                 slots.push(EncSlot {
+                    depth,
                     ident: id,
                     wire_ty: quote!(jni::sys::jint),
                     descriptor: "I".to_string(),
@@ -221,6 +277,7 @@ fn encode_field(
                 if niche.is_some() {
                     preludes.extend(quote! { let #id: jni::sys::jint = #value_expr; });
                     slots.push(EncSlot {
+                        depth,
                         ident: id,
                         wire_ty: quote!(jni::sys::jint),
                         descriptor: "I".to_string(),
@@ -230,6 +287,7 @@ fn encode_field(
                 } else {
                     preludes.extend(quote! { let #id: jni::objects::JObject = #value_expr; });
                     slots.push(EncSlot {
+                        depth,
                         ident: id,
                         wire_ty: quote!(jni::objects::JObject),
                         descriptor: "Ljava/lang/Integer;".to_string(),
@@ -287,6 +345,7 @@ fn encode_field(
                         }
                     });
                     slots.push(EncSlot {
+                        depth,
                         ident: flag_id,
                         wire_ty: quote!(jni::sys::jboolean),
                         descriptor: "Z".to_string(),
@@ -295,6 +354,7 @@ fn encode_field(
                     });
                     for (i, sl) in child_slots.iter().enumerate() {
                         slots.push(EncSlot {
+                            depth,
                             ident: outer_ids[i].clone(),
                             wire_ty: sl.wire_ty.clone(),
                             descriptor: sl.descriptor.clone(),
@@ -445,6 +505,7 @@ fn encode_field(
                         }
                     });
                     slots.push(EncSlot {
+                        depth,
                         ident: flag_id,
                         wire_ty: quote!(jni::sys::jboolean),
                         descriptor: "Z".to_string(),
@@ -453,6 +514,7 @@ fn encode_field(
                     });
                 }
                 slots.push(EncSlot {
+                    depth,
                     ident: tag_id,
                     wire_ty: quote!(jni::sys::jint),
                     descriptor: "I".to_string(),
@@ -461,6 +523,7 @@ fn encode_field(
                 });
                 for (i, sl) in all.iter().enumerate() {
                     slots.push(EncSlot {
+                        depth,
                         ident: outer_ids[i].clone(),
                         wire_ty: sl.wire_ty.clone(),
                         descriptor: sl.descriptor.clone(),
@@ -482,6 +545,7 @@ fn encode_field(
                     LeafForm::Prim => {
                         preludes.extend(quote! { let #id: #wire = #value_expr; });
                         slots.push(EncSlot {
+                            depth,
                             ident: id,
                             wire_ty: quote!(#wire),
                             descriptor: descriptor.clone(),
@@ -494,6 +558,7 @@ fn encode_field(
                             quote! { let #id: jni::objects::JObject = #value_expr.into(); },
                         );
                         slots.push(EncSlot {
+                            depth,
                             ident: id,
                             wire_ty: quote!(jni::objects::JObject),
                             descriptor: descriptor.clone(),
@@ -504,6 +569,7 @@ fn encode_field(
                     LeafForm::Object => {
                         preludes.extend(quote! { let #id: jni::objects::JObject = #value_expr; });
                         slots.push(EncSlot {
+                            depth,
                             ident: id,
                             wire_ty: quote!(jni::objects::JObject),
                             descriptor: descriptor.clone(),

--- a/prebindgen-jni/src/jni/emit/wrapper.rs
+++ b/prebindgen-jni/src/jni/emit/wrapper.rs
@@ -1,7 +1,11 @@
 //! Extern `"C"` JNI wrapper functions: signature lowering, input
 //! params, and the expanded-param path.
 
-use prebindgen_registry::{types_util::result_ok_type, Conversions};
+use prebindgen_registry::{
+    types_util::result_ok_type,
+    unfold::{bind_hoists, reach_leaf_flat},
+    Conversions,
+};
 
 use super::*;
 use crate::jni::trait_impl::read_through_erased_wrappers;

--- a/prebindgen-jni/src/jni/mod.rs
+++ b/prebindgen-jni/src/jni/mod.rs
@@ -897,6 +897,12 @@ impl JniGen {
         &self,
         out_path: impl AsRef<std::path::Path>,
     ) -> Result<std::path::PathBuf, prebindgen_registry::WriteRustError> {
+        // Every binding a test writes also checks that a data class's two
+        // leaf derivations agree wherever both exist — the property #603
+        // measured and #602 needs before it can unify them.
+        #[cfg(test)]
+        self.assert_leaf_derivations_agree();
+
         // Every binding a test writes also checks that the assembly's
         // dependency edges name every call its artifacts render — the
         // completeness the emission-time check reasons from.
@@ -917,6 +923,79 @@ impl JniGen {
                 .assembly(),
             out_path,
         )?)
+    }
+
+    /// A declared data class is decomposed twice — by `struct_out_wires_of`,
+    /// whose leaves the registry receives, and by `StructPlan`, whose leaves
+    /// the whole-object encode emits and Kotlin's `fromParts` declares. Where
+    /// both exist they must name the same leaves in the same order.
+    ///
+    /// #603 records why the two are not one derivation: the first refuses
+    /// shapes the second supports, so unifying them is the feature #602
+    /// proposes. Until then this is what says they still agree — the
+    /// precondition that unification rests on.
+    ///
+    /// Both are available only after resolve, which is why this runs here and
+    /// not while planning.
+    #[cfg(test)]
+    fn assert_leaf_derivations_agree(&self) {
+        let emit = prebindgen_registry::RustWriter::for_registry_test(&self.registry);
+        for item in self.registry.flat().types() {
+            let prebindgen_registry::flat::Type::Struct(item) = item else {
+                continue;
+            };
+            // Only a declared data class has a frozen plan; the lookup is
+            // panic-backed for anything else, and an opaque handle's struct
+            // decomposes without ever having one.
+            let declared = self
+                .decls
+                .types
+                .get(&item.type_ref().key())
+                .is_some_and(|cfg| !cfg.special_decl() && cfg.name_spec.is_some());
+            if !declared {
+                continue;
+            }
+            let Some(wires) = self.decls.struct_out_wires_of(&self.registry, &item.name) else {
+                continue;
+            };
+            let Some(plan) = self.decls.struct_plan(&self.registry, item, 0) else {
+                continue;
+            };
+            // The two spell a leaf for different audiences: the decomposition
+            // names it as Kotlin will see it (`maybeLong`), the encode as Rust
+            // wrote it (`maybe_long`), and a keyword-colliding name keeps a
+            // trailing underscore on one side only. The property here is which
+            // leaves, in which order — so the comparison drops the spelling.
+            // Two comparisons, because a leaf has two properties that must
+            // agree and one that need not. Its *name* is spelled for two
+            // audiences — the decomposition names it as Kotlin will see it
+            // (`maybeLong`), the encode as Rust wrote it (`maybe_long`), and a
+            // keyword-colliding name keeps a trailing underscore on one side —
+            // so the comparison drops the spelling. Its *nesting* is structure:
+            // the decomposition joins an inlined class's path with the reserved
+            // `__` separator, and the encode counts the same inlining as depth.
+            let plain = |name: &str| name.replace('_', "").to_lowercase();
+            let decomposed: Vec<String> = wires.iter().map(|wire| plain(&wire.name)).collect();
+            let decomposed_depth: Vec<usize> = wires
+                .iter()
+                .map(|wire| wire.name.matches("__").count())
+                .collect();
+            let leaves = crate::jni::emit::encode_leaves(&plan, &emit);
+            let encoded: Vec<String> = leaves.iter().map(|(name, _)| plain(name)).collect();
+            let encoded_depth: Vec<usize> = leaves.iter().map(|(_, depth)| *depth).collect();
+            assert_eq!(
+                encoded, decomposed,
+                "`{}`: the whole-object encode and the registry-facing \
+                 decomposition name different leaves",
+                item.name
+            );
+            assert_eq!(
+                encoded_depth, decomposed_depth,
+                "`{}`: the whole-object encode and the registry-facing \
+                 decomposition flatten nesting differently",
+                item.name
+            );
+        }
     }
 
     /// The resolved registry — conversions, decompositions, and the model.

--- a/prebindgen-jni/src/jni/tests/flatten.rs
+++ b/prebindgen-jni/src/jni/tests/flatten.rs
@@ -2383,6 +2383,160 @@ fn a_gate_inside_a_gate_supplies_one_absent_value() {
     );
 }
 
+/// A nested `data_class` inlines its leaves into its parent's `fromParts`, and
+/// the two derivations of that flattening must agree on the leaves *and* on
+/// how deep each one is.
+///
+/// `assert_leaf_derivations_agree` runs on every binding a test writes, and
+/// before this fixture existed every struct it compared was flat — so the
+/// property it was written for, how a nested path flattens and in what order,
+/// was never reached. This is the binding that reaches it.
+#[test]
+fn the_two_derivations_agree_on_a_nested_data_class() {
+    let loc = myflat_loc();
+    let items: Vec<(syn::Item, prebindgen::SourceLocation)> = vec![
+        (
+            syn::Item::Struct(syn::parse_quote!(
+                pub struct Stamp {
+                    pub secs: i64,
+                    pub nanos: i32,
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Struct(syn::parse_quote!(
+                pub struct Entry {
+                    pub stamp: Stamp,
+                    pub weight: i64,
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Struct(syn::parse_quote!(
+                pub struct Page {
+                    pub head: Entry,
+                    pub count: i32,
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn page_count(p: Page) -> i32 {
+                    unimplemented!()
+                }
+            )),
+            loc.clone(),
+        ),
+    ];
+    let registry = crate::test_util::reg_from_items(declare_referenced(items)).expect("index");
+    let jni = JniGenBuilder::new()
+        .set_package_prefix("io.test.jni")
+        .package(
+            crate::package!()
+                .class(crate::data_class!(Stamp))
+                .class(crate::data_class!(Entry))
+                .class(crate::data_class!(Page))
+                .fun(prebindgen_registry::fun!(page_count)),
+        );
+    let gen = jni.build_with(registry).expect("resolve");
+
+    // Two levels of inlining, so the comparison sees depth 0, 1 and 2.
+    let page: syn::Ident = syn::parse_quote!(Page);
+    let wires = gen
+        .declarations()
+        .struct_out_wires_of(gen.registry(), &page)
+        .expect("a nested data class decomposes");
+    let names: Vec<&str> = wires.iter().map(|wire| wire.name.as_str()).collect();
+    assert_eq!(
+        names,
+        [
+            "head__stamp__secs",
+            "head__stamp__nanos",
+            "head__weight",
+            "count"
+        ],
+        "the decomposition inlines both levels"
+    );
+
+    // Writing the binding is what runs `assert_leaf_derivations_agree` over it.
+    let dir = unique_test_dir("jnigen_nested_agreement");
+    std::fs::create_dir_all(&dir).unwrap();
+    gen.write_rust(dir.join("gen.rs")).expect("write_rust");
+}
+
+/// The whole-object encode covers a shape the registry-facing decomposition
+/// refuses, and that divergence is deliberate.
+///
+/// `struct_out_wires_of` returns `None` for a struct with a nested
+/// `data_class` behind an `Option`, because there is no chain to reach the
+/// inlined leaves through. The whole-object output encode supports it as a
+/// `present` flag plus a defaulted group — which is why #596 step 5 records
+/// the two as different coverage rather than composing one from the other.
+///
+/// If this ever starts returning `Some`, the encode should be rendered from
+/// the decomposition and this test deleted; see #602.
+#[test]
+fn the_decomposition_refuses_what_the_whole_object_encode_supports() {
+    let loc = myflat_loc();
+    let items: Vec<(syn::Item, prebindgen::SourceLocation)> = vec![
+        (
+            syn::Item::Struct(syn::parse_quote!(
+                pub struct Leaf {
+                    pub id: i64,
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Struct(syn::parse_quote!(
+                pub struct Holder {
+                    pub inner: Option<Leaf>,
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn holder_id(h: Holder) -> i64 {
+                    unimplemented!()
+                }
+            )),
+            loc.clone(),
+        ),
+    ];
+    let registry = crate::test_util::reg_from_items(declare_referenced(items)).expect("index");
+    let jni = JniGenBuilder::new()
+        .set_package_prefix("io.test.jni")
+        .package(
+            crate::package!()
+                .class(crate::data_class!(Leaf))
+                .class(crate::data_class!(Holder))
+                .fun(prebindgen_registry::fun!(holder_id)),
+        );
+    let gen = jni.build_with(registry).expect("resolve");
+
+    let holder: syn::Ident = syn::parse_quote!(Holder);
+    assert!(
+        gen.declarations()
+            .struct_out_wires_of(gen.registry(), &holder)
+            .is_none(),
+        "the decomposition refuses an optional nested data class"
+    );
+
+    let dir = unique_test_dir("jnigen_decomposition_refusal");
+    std::fs::create_dir_all(&dir).unwrap();
+    let rust = std::fs::read_to_string(gen.write_rust(dir.join("gen.rs")).expect("write_rust"))
+        .expect("read generated file");
+    let compact: String = rust.split_whitespace().collect();
+    assert!(
+        compact.contains("__inner_present"),
+        "the whole-object encode still supports it, as a present flag:\n{rust}"
+    );
+}
+
 /// A nullable primitive keeps the allocation-free `(present, value)` pair
 /// rather than boxing, at field depth as at parameter depth.
 ///

--- a/prebindgen-jni/src/jni/tests/values.rs
+++ b/prebindgen-jni/src/jni/tests/values.rs
@@ -787,8 +787,11 @@ fn flattened_field_composes_bounded_conversion_stages() {
     );
     assert!(rc.contains("__jni_in_stage_0_"), "{rust}");
     assert!(
-        rc.contains("__jni_in_convert_") && rc.contains("env,&__delay_raw"),
-        "whole-JObject input must invoke the complete optional Duration converter:\n{rust}"
+        rc.contains(
+            "__jni_in_convert_wire_to_Option_Duration_jni_optional_intermediate_input_niche"
+        ) && rc.contains("env,&__present"),
+        "whole-JObject input must invoke the complete optional Duration converter, on the \
+         value the composed Optional bound:\n{rust}"
     );
     assert!(
         rc.contains("let___delay:jni::sys::jlong=__jni_out_convert_")

--- a/prebindgen-jni/src/jni/tests/values.rs
+++ b/prebindgen-jni/src/jni/tests/values.rs
@@ -1204,6 +1204,37 @@ fn conversion_domain_must_match_the_representation() {
     let _ = jni.build_with(registry);
 }
 
+/// A path-qualified scalar never reaches the domain check above: a marked item
+/// lives in one flat namespace of bare names, so a representation written
+/// `::core::primitive::u64` fails to resolve first. This pins that order —
+/// JniGen compares model type keys, which are not reduced to a canonical
+/// spelling, and would report a mismatch between two spellings of one scalar if
+/// such a representation ever got that far.
+#[test]
+fn a_qualified_scalar_representation_never_reaches_the_domain_check() {
+    let loc = myflat_loc();
+    let items: Vec<(syn::Item, SourceLocation)> =
+        ["pub fn duration_use(v: Duration) { unimplemented!() }"]
+            .into_iter()
+            .map(|source| {
+                let item: syn::Item = syn::parse_str(source).unwrap();
+                (item, loc.clone())
+            })
+            .collect();
+    let registry = crate::test_util::reg_from_items(declare_referenced(items)).unwrap();
+    let jni = JniGenBuilder::new()
+        .convert(
+            prebindgen_registry::convert!(Duration)
+                .input(prebindgen_registry::from!(::core::primitive::u64))
+                .valid_range(0u64..=1_000u64),
+        )
+        .package(crate::package!("time").fun(prebindgen_registry::fun!(duration_use)));
+
+    let error = format!("{:?}", jni.build_with(registry).err());
+    assert!(error.contains("core :: primitive :: u64"), "{error}");
+    assert!(!error.contains("domain type"), "{error}");
+}
+
 /// Phase 4: a bare `Option<primitive>` with no niche crosses as a decoupled
 /// `(present: Boolean, value: <prim>)` pair instead of a boxed
 /// `java.lang.*` `JObject`. An enum terminal contributes unused discriminants,

--- a/prebindgen-jni/src/jni/tests/values.rs
+++ b/prebindgen-jni/src/jni/tests/values.rs
@@ -794,6 +794,11 @@ fn flattened_field_composes_bounded_conversion_stages() {
          value the composed Optional bound:\n{rust}"
     );
     assert!(
+        !rc.contains("Some(__jni_in_convert_wire_to_Option_Duration"),
+        "the niche converter already yields the Option, so the composed layer must pass its \
+         answer through rather than wrap it:\n{rust}"
+    );
+    assert!(
         rc.contains("let___delay:jni::sys::jlong=__jni_out_convert_")
             && rc.contains("\"(J)Lio/test/jni/Timed;\""),
         "whole-struct output must pass the niche as primitive jlong:\n{rust}"

--- a/prebindgen-registry/src/chain.rs
+++ b/prebindgen-registry/src/chain.rs
@@ -66,6 +66,25 @@ pub trait Source: Clone {
         source
     }
 
+    /// Construct the source value from its converted parts.
+    ///
+    /// The default is a named-field literal, which is what a Product's parts
+    /// are addressed by. A policy whose source has another shape — a tuple
+    /// struct, a unit struct — overrides it: the model element that says which
+    /// is the adapter's to hold, and [`RustWriter::shape_struct`] is what
+    /// spells it.
+    fn construct(
+        &self,
+        head: TokenStream,
+        parts: &[(syn::Ident, TokenStream)],
+        emit: &RustWriter,
+    ) -> TokenStream {
+        let _ = emit;
+        let names = parts.iter().map(|(name, _)| name);
+        let values = parts.iter().map(|(_, value)| value);
+        quote::quote!(#head { #(#names: #values),* })
+    }
+
     /// Read one named Product field from the exact source spelling.
     ///
     /// The default keeps the common unwrapped access free of redundant
@@ -597,9 +616,9 @@ where
                         (name, value)
                     })
                     .collect();
-                let names = fields.iter().map(|(name, _)| name);
-                let values = fields.iter().map(|(_, value)| value);
-                let canonical = quote::quote!(#canonical_source { #(#names: #values),* });
+                let canonical = self
+                    .source_policy
+                    .construct(canonical_source, &fields, emit);
                 let built = self.source_policy.build(canonical);
                 // A bridge that reads its parts by expression alone keeps the
                 // bare constructor it always emitted; only a bridge with a

--- a/prebindgen-registry/src/chain.rs
+++ b/prebindgen-registry/src/chain.rs
@@ -120,13 +120,18 @@ fn child_value<C: Child>(child: &C, value: TokenStream, emit: &RustWriter) -> To
 ///
 /// A bridge whose read is a projection — a tuple index, a field access —
 /// answers with [`Self::expression`]. One whose read is not an expression at
-/// all answers with [`Self::statements`] or [`Self::fallible`]: reading a
-/// property off a JVM object binds two locals and can fail, and a bridge that
-/// had only an expression to return could not say either.
+/// all answers with [`Self::fallible`]: reading a property off a JVM object
+/// binds two locals and can fail, neither of which a bridge that could only
+/// return an expression can say.
 ///
 /// The composer runs the preludes in part order, before the source value is
 /// constructed, and a fallible read makes the whole composed conversion
 /// fallible even when no child converter can fail.
+///
+/// Whether a read can fail is kept as its own fact rather than read off "has a
+/// prelude". The two coincide across today's two constructors, but a fallible
+/// read that needs no statements — an expression carrying its own `?` — would
+/// be silently demoted to infallible by the shorter rule.
 pub struct PartRead {
     prelude: TokenStream,
     value: TokenStream,
@@ -138,15 +143,6 @@ impl PartRead {
     pub fn expression(value: TokenStream) -> Self {
         Self {
             prelude: TokenStream::new(),
-            value,
-            fallible: false,
-        }
-    }
-
-    /// A part reached by running `prelude` first, which cannot fail.
-    pub fn statements(prelude: TokenStream, value: TokenStream) -> Self {
-        Self {
-            prelude,
             value,
             fallible: false,
         }
@@ -1126,30 +1122,6 @@ mod tests {
         }
     }
 
-    /// A bridge whose part read binds a local and cannot fail — the middle
-    /// constructor, whose behaviour is not implied by its neighbours.
-    #[derive(Clone)]
-    struct TestBoundParts;
-
-    impl ProductBridge for TestBoundParts {
-        fn intermediate(&self) -> syn::Type {
-            syn::parse_quote!(TestObject)
-        }
-
-        fn part(&self, value: TokenStream, index: usize, _name: &syn::Ident) -> PartRead {
-            let local = format_ident!("__bound{index}");
-            let position = syn::Index::from(index);
-            PartRead::statements(
-                quote::quote!(let #local = (#value).#position;),
-                quote::quote!(#local),
-            )
-        }
-
-        fn build(&self, _parts: &[(syn::Ident, TokenStream)]) -> TokenStream {
-            unreachable!("this fixture only constructs")
-        }
-    }
-
     /// A bridge may read its part with statements that can fail, and the
     /// composer runs them before it constructs the source value.
     ///
@@ -1200,41 +1172,6 @@ mod tests {
         assert!(
             body.contains("__read0") && body.contains("__read1"),
             "each part is read into its own local:\n{body}"
-        );
-    }
-
-    /// A prelude that cannot fail leaves the conversion infallible.
-    ///
-    /// This is the whole difference between `PartRead::statements` and
-    /// `PartRead::fallible`, and the only place it is visible: both emit their
-    /// prelude, and only one makes the caller handle an error.
-    #[test]
-    fn an_infallible_prelude_leaves_the_chain_infallible() {
-        let plan = Product {
-            source: TypeRef::scalar(ScalarKind::I64),
-            direction: Direction::Construct,
-            source_policy: TestSource {
-                spells: Rc::new(Cell::new(0)),
-            },
-            bridge: TestBoundParts,
-            parts: vec![ProductPart {
-                name: format_ident!("only"),
-                child: TestChild::new("only", false, false),
-                mode: Mode::Owned,
-                hold_uninit: false,
-            }],
-        };
-
-        let rendered = plan.render(&RustWriter::for_test());
-        let body = rendered.body.to_token_stream().to_string();
-
-        assert!(
-            body.contains("let __bound0"),
-            "the prelude is emitted:\n{body}"
-        );
-        assert!(
-            !rendered.fallible,
-            "a prelude that cannot fail leaves the conversion infallible:\n{body}"
         );
     }
 

--- a/prebindgen-registry/src/chain.rs
+++ b/prebindgen-registry/src/chain.rs
@@ -97,13 +97,61 @@ fn child_value<C: Child>(child: &C, value: TokenStream, emit: &RustWriter) -> To
     }
 }
 
+/// One part read out of a Product's intermediate value.
+///
+/// A bridge whose read is a projection — a tuple index, a field access —
+/// answers with [`Self::expression`]. One whose read is not an expression at
+/// all answers with [`Self::statements`] or [`Self::fallible`]: reading a
+/// property off a JVM object binds two locals and can fail, and a bridge that
+/// had only an expression to return could not say either.
+///
+/// The composer runs the preludes in part order, before the source value is
+/// constructed, and a fallible read makes the whole composed conversion
+/// fallible even when no child converter can fail.
+pub struct PartRead {
+    prelude: TokenStream,
+    value: TokenStream,
+    fallible: bool,
+}
+
+impl PartRead {
+    /// A part reached by an expression alone.
+    pub fn expression(value: TokenStream) -> Self {
+        Self {
+            prelude: TokenStream::new(),
+            value,
+            fallible: false,
+        }
+    }
+
+    /// A part reached by running `prelude` first, which cannot fail.
+    pub fn statements(prelude: TokenStream, value: TokenStream) -> Self {
+        Self {
+            prelude,
+            value,
+            fallible: false,
+        }
+    }
+
+    /// A part reached by running `prelude` first, which can fail. The prelude
+    /// propagates its own failure — with `?`, or by returning — so the
+    /// composer only has to know that the conversion around it is fallible.
+    pub fn fallible(prelude: TokenStream, value: TokenStream) -> Self {
+        Self {
+            prelude,
+            value,
+            fallible: true,
+        }
+    }
+}
+
 /// Adapter-selected representation protocol for one Product shape.
 pub trait ProductBridge: Clone {
     /// The one intermediate Rust type assigned to this fragment.
     fn intermediate(&self) -> syn::Type;
 
     /// Read one child intermediate value from `value`.
-    fn part(&self, value: TokenStream, index: usize, name: &syn::Ident) -> TokenStream;
+    fn part(&self, value: TokenStream, index: usize, name: &syn::Ident) -> PartRead;
 
     /// Construct the intermediate value from converted children.
     fn build(&self, parts: &[(syn::Ident, TokenStream)]) -> TokenStream;
@@ -126,9 +174,9 @@ impl ProductBridge for TupleProduct {
         syn::parse_quote!((#(#parts,)*))
     }
 
-    fn part(&self, value: TokenStream, index: usize, _name: &syn::Ident) -> TokenStream {
+    fn part(&self, value: TokenStream, index: usize, _name: &syn::Ident) -> PartRead {
         let index = syn::Index::from(index);
-        quote::quote!((#value).#index)
+        PartRead::expression(quote::quote!((#value).#index))
     }
 
     fn build(&self, parts: &[(syn::Ident, TokenStream)]) -> TokenStream {
@@ -517,18 +565,23 @@ where
     fn render(&self, emit: &RustWriter) -> Rendered {
         let source = self.source_policy.spell(&self.source, emit);
         let intermediate = self.bridge.intermediate();
-        let fallible = self.parts.iter().any(|part| part.child.call().fallible());
+        let mut fallible = self.parts.iter().any(|part| part.child.call().fallible());
         let body = match self.direction {
             Direction::Construct => {
                 let canonical_source = self.source_policy.spell(self.source.unwrapped(), emit);
+                let mut preludes: Vec<TokenStream> = Vec::new();
                 let fields: Vec<_> = self
                     .parts
                     .iter()
                     .enumerate()
                     .map(|(index, part)| {
                         let name = part.name.clone();
-                        let value = self.bridge.part(quote::quote!(v), index, &name);
-                        let value = child_value(&part.child, value, emit);
+                        let read = self.bridge.part(quote::quote!(v), index, &name);
+                        if !read.prelude.is_empty() {
+                            preludes.push(read.prelude);
+                        }
+                        fallible |= read.fallible;
+                        let value = child_value(&part.child, read.value, emit);
                         (name, value)
                     })
                     .collect();
@@ -536,6 +589,14 @@ where
                 let values = fields.iter().map(|(_, value)| value);
                 let canonical = quote::quote!(#canonical_source { #(#names: #values),* });
                 let built = self.source_policy.build(canonical);
+                // A bridge that reads its parts by expression alone keeps the
+                // bare constructor it always emitted; only a bridge with a
+                // prelude to run gets a block.
+                let built = if preludes.is_empty() {
+                    built
+                } else {
+                    quote::quote!({ #(#preludes)* #built })
+                };
                 syn::parse2(built).expect("a Product source constructor is a valid expression")
             }
             Direction::Deconstruct => {
@@ -691,6 +752,9 @@ where
             .iter()
             .flat_map(|arm| &arm.parts)
             .any(|part| part.child.call().fallible());
+        // A fallible part read needs no flag of its own here: parts are read
+        // only when constructing, and construction is already fallible for
+        // every choice — an unrecognized tag returns an error.
         let body = match self.direction {
             Direction::Construct => {
                 let canonical_source = self.source_policy.spell(self.source.unwrapped(), emit);
@@ -698,6 +762,7 @@ where
                 let arms = self.arms.iter().enumerate().map(|(arm_index, arm)| {
                     let tag_pattern = &arm.tag;
                     let variant = &arm.alternative.name;
+                    let mut preludes: Vec<TokenStream> = Vec::new();
                     let fields: Vec<_> = arm
                         .parts
                         .iter()
@@ -710,8 +775,11 @@ where
                                     syn::Ident::new(&format!("v{}", index.index), index.span)
                                 }
                             };
-                            let value = arm.bridge.part(quote::quote!(__arm), part_index, &name);
-                            child_value(&part.child, value, emit)
+                            let read = arm.bridge.part(quote::quote!(__arm), part_index, &name);
+                            if !read.prelude.is_empty() {
+                                preludes.push(read.prelude);
+                            }
+                            child_value(&part.child, read.value, emit)
                         })
                         .collect();
                     let shaped: Vec<_> = arm
@@ -735,6 +803,7 @@ where
                         quote::quote!(#tag_pattern => {
                             let __choice = #prepared;
                             let __arm = #arm_value;
+                            #(#preludes)*
                             #built
                         })
                     }
@@ -876,7 +945,7 @@ where
 mod tests {
     use std::{cell::Cell, rc::Rc};
 
-    use quote::{quote, ToTokens};
+    use quote::{format_ident, quote, ToTokens};
 
     use super::*;
     use crate::{
@@ -999,6 +1068,111 @@ mod tests {
             "{body}"
         );
         assert!(rendered.fallible);
+    }
+
+    /// A bridge whose part read is neither an expression nor infallible: it
+    /// binds a local first and can fail, as a JVM property read does.
+    #[derive(Clone)]
+    struct TestFallibleParts;
+
+    impl ProductBridge for TestFallibleParts {
+        fn intermediate(&self) -> syn::Type {
+            syn::parse_quote!(TestObject)
+        }
+
+        fn part(&self, value: TokenStream, index: usize, name: &syn::Ident) -> PartRead {
+            let local = format_ident!("__read{index}");
+            let property = name.to_string();
+            PartRead::fallible(
+                quote::quote!(let #local = read_property(&#value, #property)?;),
+                quote::quote!(#local),
+            )
+        }
+
+        fn build(&self, _parts: &[(syn::Ident, TokenStream)]) -> TokenStream {
+            unreachable!("this fixture only constructs")
+        }
+    }
+
+    /// A bridge may read its part with statements that can fail, and the
+    /// composer runs them before it constructs the source value.
+    ///
+    /// This is what a Product over a JVM object needs: `env.get_field(..)`
+    /// returns a `Result` and binds a local, so a bridge that could answer
+    /// only with an expression could not express the read at all.
+    #[test]
+    fn a_fallible_part_read_runs_before_construction_and_makes_the_chain_fallible() {
+        let spells = Rc::new(Cell::new(0));
+        let plan = Product {
+            source: TypeRef::scalar(ScalarKind::I64),
+            direction: Direction::Construct,
+            source_policy: TestSource {
+                spells: spells.clone(),
+            },
+            bridge: TestFallibleParts,
+            parts: vec![
+                ProductPart {
+                    name: format_ident!("first"),
+                    // Infallible children: whatever fallibility the rendered
+                    // chain reports comes from the reads alone.
+                    child: TestChild::new("first", false, false),
+                    mode: Mode::Owned,
+                    hold_uninit: false,
+                },
+                ProductPart {
+                    name: format_ident!("second"),
+                    child: TestChild::new("second", false, false),
+                    mode: Mode::Owned,
+                    hold_uninit: false,
+                },
+            ],
+        };
+
+        let rendered = plan.render(&RustWriter::for_test());
+        let body = rendered.body.to_token_stream().to_string();
+
+        assert!(
+            rendered.fallible,
+            "a fallible read makes the conversion fallible with no fallible child:\n{body}"
+        );
+        let first = body.find("read_property").expect(&body);
+        let construction = body.find("first :").expect(&body);
+        assert!(
+            first < construction,
+            "the reads run before the source value is constructed:\n{body}"
+        );
+        assert!(
+            body.contains("__read0") && body.contains("__read1"),
+            "each part is read into its own local:\n{body}"
+        );
+    }
+
+    /// A bridge that reads by expression alone keeps the bare constructor it
+    /// always emitted — no block, no locals.
+    #[test]
+    fn an_expression_part_read_adds_no_prelude() {
+        let plan = Product {
+            source: TypeRef::scalar(ScalarKind::I64),
+            direction: Direction::Construct,
+            source_policy: TestSource {
+                spells: Rc::new(Cell::new(0)),
+            },
+            bridge: TupleProduct {
+                parts: vec![syn::parse_quote!(i64)],
+            },
+            parts: vec![ProductPart {
+                name: format_ident!("only"),
+                child: TestChild::new("only", false, false),
+                mode: Mode::Owned,
+                hold_uninit: false,
+            }],
+        };
+
+        let rendered = plan.render(&RustWriter::for_test());
+        let body = rendered.body.to_token_stream().to_string();
+
+        assert!(!rendered.fallible, "{body}");
+        assert!(!body.starts_with('{'), "no block is introduced:\n{body}");
     }
 
     #[derive(Clone)]

--- a/prebindgen-registry/src/chain.rs
+++ b/prebindgen-registry/src/chain.rs
@@ -1094,6 +1094,30 @@ mod tests {
         }
     }
 
+    /// A bridge whose part read binds a local and cannot fail — the middle
+    /// constructor, whose behaviour is not implied by its neighbours.
+    #[derive(Clone)]
+    struct TestBoundParts;
+
+    impl ProductBridge for TestBoundParts {
+        fn intermediate(&self) -> syn::Type {
+            syn::parse_quote!(TestObject)
+        }
+
+        fn part(&self, value: TokenStream, index: usize, _name: &syn::Ident) -> PartRead {
+            let local = format_ident!("__bound{index}");
+            let position = syn::Index::from(index);
+            PartRead::statements(
+                quote::quote!(let #local = (#value).#position;),
+                quote::quote!(#local),
+            )
+        }
+
+        fn build(&self, _parts: &[(syn::Ident, TokenStream)]) -> TokenStream {
+            unreachable!("this fixture only constructs")
+        }
+    }
+
     /// A bridge may read its part with statements that can fail, and the
     /// composer runs them before it constructs the source value.
     ///
@@ -1144,6 +1168,41 @@ mod tests {
         assert!(
             body.contains("__read0") && body.contains("__read1"),
             "each part is read into its own local:\n{body}"
+        );
+    }
+
+    /// A prelude that cannot fail leaves the conversion infallible.
+    ///
+    /// This is the whole difference between `PartRead::statements` and
+    /// `PartRead::fallible`, and the only place it is visible: both emit their
+    /// prelude, and only one makes the caller handle an error.
+    #[test]
+    fn an_infallible_prelude_leaves_the_chain_infallible() {
+        let plan = Product {
+            source: TypeRef::scalar(ScalarKind::I64),
+            direction: Direction::Construct,
+            source_policy: TestSource {
+                spells: Rc::new(Cell::new(0)),
+            },
+            bridge: TestBoundParts,
+            parts: vec![ProductPart {
+                name: format_ident!("only"),
+                child: TestChild::new("only", false, false),
+                mode: Mode::Owned,
+                hold_uninit: false,
+            }],
+        };
+
+        let rendered = plan.render(&RustWriter::for_test());
+        let body = rendered.body.to_token_stream().to_string();
+
+        assert!(
+            body.contains("let __bound0"),
+            "the prelude is emitted:\n{body}"
+        );
+        assert!(
+            !rendered.fallible,
+            "a prelude that cannot fail leaves the conversion infallible:\n{body}"
         );
     }
 
@@ -1298,6 +1357,63 @@ mod tests {
                 },
             ],
         }
+    }
+
+    /// A Choice arm reads its parts through the same bridge call, so a
+    /// fallible prelude lands inside the arm — after the arm value is bound,
+    /// and before the value that reads it.
+    ///
+    /// That ordering is what a whole-object sealed sum will rest on: each
+    /// alternative binds its own payload object first, then reads properties
+    /// off it.
+    #[test]
+    fn a_choice_arm_runs_its_part_prelude_after_binding_the_arm() {
+        let plan: Choice<TestSource, TupleChoice, TestFallibleParts, TestChild> = Choice {
+            source: TypeRef::scalar(ScalarKind::I64),
+            direction: Direction::Construct,
+            source_policy: TestSource {
+                spells: Rc::new(Cell::new(0)),
+            },
+            bridge: TupleChoice {
+                tag: syn::parse_quote!(i32),
+                arms: vec![syn::parse_quote!(()), syn::parse_quote!((i64,))],
+                tags: vec![syn::parse_quote!(0), syn::parse_quote!(1)],
+                inactive: vec![quote!(()), quote!((0,))],
+                invalid: quote!("invalid tag"),
+            },
+            arms: vec![
+                ChoiceArm {
+                    alternative: alternative(syn::parse_quote!(A), 0),
+                    tag: syn::parse_quote!(0),
+                    bridge: TestFallibleParts,
+                    parts: Vec::new(),
+                },
+                ChoiceArm {
+                    alternative: alternative(syn::parse_quote!(B(i64)), 1),
+                    tag: syn::parse_quote!(1),
+                    bridge: TestFallibleParts,
+                    parts: vec![ChoicePart {
+                        child: TestChild::new("decode", true, false),
+                        mode: Mode::Owned,
+                        hold_uninit: false,
+                    }],
+                },
+            ],
+        };
+
+        let body = plan
+            .render(&RustWriter::for_test())
+            .body
+            .to_token_stream()
+            .to_string();
+
+        let arm = body.find("let __arm").expect(&body);
+        let prelude = body.find("read_property").expect(&body);
+        let construction = body.find("i64 :: B").expect(&body);
+        assert!(
+            arm < prelude && prelude < construction,
+            "the arm binds, then its prelude runs, then the value is built:\n{body}"
+        );
     }
 
     #[test]

--- a/prebindgen-registry/src/chain.rs
+++ b/prebindgen-registry/src/chain.rs
@@ -232,6 +232,18 @@ pub trait OptionalBridge: Clone {
 
     /// Construct the outbound representation of a converted present child.
     fn build_present(&self, child: TokenStream) -> TokenStream;
+
+    /// The source-side `Some` arm, given the converted child.
+    ///
+    /// The default wraps, which is what an optional layer normally is: the
+    /// child yields the value, and this layer decides whether there is one.
+    /// A bridge overrides it when its child **already** yields the optional —
+    /// a nullable property whose inner converter carries its own niche
+    /// encoding of absence tests two things, a null reference and then that
+    /// niche, and the second answer is the whole answer.
+    fn source_present(&self, child: TokenStream) -> TokenStream {
+        quote::quote!(::core::option::Option::Some(#child))
+    }
 }
 
 /// Registry-composed converter plan for an Optional recipe.
@@ -649,12 +661,13 @@ where
                 let absent = self.bridge.is_absent();
                 let present = self.bridge.present(quote::quote!(v));
                 let child = child_value(&self.child, quote::quote!(__present), emit);
+                let present_arm = self.bridge.source_present(child);
                 let canonical = quote::quote!({
                     if #absent {
                         ::core::option::Option::None
                     } else {
                         let __present = #present;
-                        ::core::option::Option::Some(#child)
+                        #present_arm
                     }
                 });
                 let built = self.source_policy.build(canonical);

--- a/prebindgen-registry/src/domain.rs
+++ b/prebindgen-registry/src/domain.rs
@@ -3,21 +3,92 @@
 use std::ops::{Bound, RangeBounds};
 
 use proc_macro2::TokenStream;
-use quote::{quote, ToTokens};
+use quote::quote;
+
+/// The scalars a [`RepresentationDomain`] can be declared over: the variants,
+/// their spellings and the reduction from a written type all come from this one
+/// list, so a kind cannot be added to the set without answering for both.
+macro_rules! domain_kinds {
+    ($(($variant:ident, $name:literal)),* $(,)?) => {
+        /// The scalar a [`RepresentationDomain`] is declared over.
+        ///
+        /// This is the identity every domain question is decided on — whether a
+        /// bounds check needs a NaN test, which candidate values a niche is
+        /// picked from, and whether a domain and a conversion's representation
+        /// are the same type. Its spelling is derived from it and never the
+        /// other way round, so a domain written `::core::primitive::u64` and one
+        /// written `u64` are one kind.
+        #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+        pub enum DomainKind {
+            $(
+                #[doc = concat!("The `", $name, "` scalar.")]
+                $variant
+            ),*
+        }
+
+        impl DomainKind {
+            /// The one canonical Rust spelling of this scalar.
+            pub fn as_str(self) -> &'static str {
+                match self {
+                    $(Self::$variant => $name),*
+                }
+            }
+
+            /// The kind a written scalar type names, off its last path segment,
+            /// so every spelling of one scalar answers alike. `None` for a type
+            /// no domain can be declared over — `bool`, `isize` and `usize`
+            /// among them.
+            pub fn from_type(ty: &syn::Type) -> Option<Self> {
+                let ident = prebindgen_flat::types_util::path_tail_ident(ty)?;
+                $(if ident == $name {
+                    return Some(Self::$variant);
+                })*
+                None
+            }
+        }
+    };
+}
+
+domain_kinds!(
+    (I8, "i8"),
+    (I16, "i16"),
+    (I32, "i32"),
+    (I64, "i64"),
+    (I128, "i128"),
+    (U8, "u8"),
+    (U16, "u16"),
+    (U32, "u32"),
+    (U64, "u64"),
+    (U128, "u128"),
+    (F32, "f32"),
+    (F64, "f64"),
+);
+
+impl DomainKind {
+    /// The scalar's Rust type, built from [`Self::as_str`].
+    pub fn ty(self) -> syn::Type {
+        let ident = syn::Ident::new(self.as_str(), proc_macro2::Span::call_site());
+        syn::parse_quote!(#ident)
+    }
+
+    fn is_float(self) -> bool {
+        matches!(self, Self::F32 | Self::F64)
+    }
+}
 
 /// Scalar representations that can carry a declarative domain.
 pub trait DomainScalar: Copy + 'static {
     #[doc(hidden)]
     fn domain_value(self) -> ScalarValue;
     #[doc(hidden)]
-    fn domain_type() -> syn::Type;
+    fn domain_kind() -> DomainKind;
 }
 
 macro_rules! impl_ints {
     ($(($t:ty, $v:ident)),* $(,)?) => {$(
         impl DomainScalar for $t {
             fn domain_value(self) -> ScalarValue { ScalarValue::$v(self) }
-            fn domain_type() -> syn::Type { syn::parse_quote!($t) }
+            fn domain_kind() -> DomainKind { DomainKind::$v }
         }
     )*};
 }
@@ -38,16 +109,16 @@ impl DomainScalar for f32 {
     fn domain_value(self) -> ScalarValue {
         ScalarValue::F32(self.to_bits())
     }
-    fn domain_type() -> syn::Type {
-        syn::parse_quote!(f32)
+    fn domain_kind() -> DomainKind {
+        DomainKind::F32
     }
 }
 impl DomainScalar for f64 {
     fn domain_value(self) -> ScalarValue {
         ScalarValue::F64(self.to_bits())
     }
-    fn domain_type() -> syn::Type {
-        syn::parse_quote!(f64)
+    fn domain_kind() -> DomainKind {
+        DomainKind::F64
     }
 }
 
@@ -190,7 +261,7 @@ enum Base {
 /// Legal values of a custom conversion's scalar representation.
 #[derive(Clone)]
 pub struct RepresentationDomain {
-    ty: syn::Type,
+    kind: DomainKind,
     base: Base,
     excluded: Vec<ScalarValue>,
 }
@@ -213,7 +284,7 @@ impl RepresentationDomain {
             "representation-domain range cannot be empty"
         );
         Self {
-            ty: T::domain_type(),
+            kind: T::domain_kind(),
             base: Base::Range { start, end },
             excluded: vec![],
         }
@@ -226,7 +297,7 @@ impl RepresentationDomain {
             "representation-domain valid set cannot be empty"
         );
         Self {
-            ty: T::domain_type(),
+            kind: T::domain_kind(),
             base: Base::Values(values),
             excluded: vec![],
         }
@@ -234,8 +305,8 @@ impl RepresentationDomain {
 
     pub fn exclude<T: DomainScalar>(&mut self, values: impl IntoIterator<Item = T>) {
         assert_eq!(
-            prebindgen_flat::flat::TypeKey::from_type(&self.ty),
-            prebindgen_flat::flat::TypeKey::from_type(&T::domain_type()),
+            self.kind,
+            T::domain_kind(),
             "representation-domain exclusions must use the base domain's scalar type"
         );
         self.excluded
@@ -243,8 +314,14 @@ impl RepresentationDomain {
         self.excluded = dedup(std::mem::take(&mut self.excluded));
     }
 
-    pub fn ty(&self) -> &syn::Type {
-        &self.ty
+    /// The scalar this domain is declared over.
+    pub fn kind(&self) -> DomainKind {
+        self.kind
+    }
+
+    /// The scalar's Rust type, built from [`Self::kind`].
+    pub fn ty(&self) -> syn::Type {
+        self.kind.ty()
     }
 
     /// An expression testing whether `value` lies inside the legal domain —
@@ -254,10 +331,7 @@ impl RepresentationDomain {
             Base::Range { start, end } => {
                 let lo = bound_expr(start, &value, true);
                 let hi = bound_expr(end, &value, false);
-                let not_nan = if matches!(
-                    self.ty.to_token_stream().to_string().as_str(),
-                    "f32" | "f64"
-                ) {
+                let not_nan = if self.kind.is_float() {
                     quote!(!(#value).is_nan())
                 } else {
                     quote!(true)
@@ -284,20 +358,19 @@ impl RepresentationDomain {
             _ => 0,
         };
         let budget = limit.saturating_add(extra).max(1);
-        match self.ty.to_token_stream().to_string().as_str() {
-            "i8" => ints!(out, self, i8, I8, budget),
-            "i16" => ints!(out, self, i16, I16, budget),
-            "i32" => ints!(out, self, i32, I32, budget),
-            "i64" => ints!(out, self, i64, I64, budget),
-            "i128" => ints!(out, self, i128, I128, budget),
-            "u8" => ints!(out, self, u8, U8, budget),
-            "u16" => ints!(out, self, u16, U16, budget),
-            "u32" => ints!(out, self, u32, U32, budget),
-            "u64" => ints!(out, self, u64, U64, budget),
-            "u128" => ints!(out, self, u128, U128, budget),
-            "f32" => float32_candidates(&mut out, budget),
-            "f64" => float64_candidates(&mut out, budget),
-            _ => unreachable!(),
+        match self.kind {
+            DomainKind::I8 => ints!(out, self, i8, I8, budget),
+            DomainKind::I16 => ints!(out, self, i16, I16, budget),
+            DomainKind::I32 => ints!(out, self, i32, I32, budget),
+            DomainKind::I64 => ints!(out, self, i64, I64, budget),
+            DomainKind::I128 => ints!(out, self, i128, I128, budget),
+            DomainKind::U8 => ints!(out, self, u8, U8, budget),
+            DomainKind::U16 => ints!(out, self, u16, U16, budget),
+            DomainKind::U32 => ints!(out, self, u32, U32, budget),
+            DomainKind::U64 => ints!(out, self, u64, U64, budget),
+            DomainKind::U128 => ints!(out, self, u128, U128, budget),
+            DomainKind::F32 => float32_candidates(&mut out, budget),
+            DomainKind::F64 => float64_candidates(&mut out, budget),
         }
         out.extend(self.excluded.iter().copied());
         let mut selected = Vec::new();
@@ -470,6 +543,7 @@ fn dedup(values: Vec<ScalarValue>) -> Vec<ScalarValue> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use quote::ToTokens;
 
     #[test]
     fn integer_range_derives_extreme_niches() {
@@ -507,6 +581,46 @@ mod tests {
         range.exclude([0.5f64]);
         assert!(!range.contains(ScalarValue::F64(0.5f64.to_bits())));
         assert!(!range.contains(ScalarValue::F64(f64::NAN.to_bits())));
+    }
+
+    /// The NaN test in a range check is decided by the domain's kind, and only
+    /// a float range carries one.
+    #[test]
+    fn only_a_float_range_guards_against_nan() {
+        let float = RepresentationDomain::range(0.0f64..=1.0f64);
+        assert!(float
+            .contains_expr(quote!(value))
+            .to_string()
+            .contains("is_nan"));
+
+        let integer = RepresentationDomain::range(0u64..=1u64);
+        assert!(!integer
+            .contains_expr(quote!(value))
+            .to_string()
+            .contains("is_nan"));
+    }
+
+    /// Every spelling of one scalar is one kind, and a domain's own spelling
+    /// is derived from that kind rather than kept from how it was declared.
+    #[test]
+    fn one_scalar_is_one_kind_however_it_is_written() {
+        assert_eq!(
+            DomainKind::from_type(&syn::parse_quote!(::core::primitive::u64)),
+            Some(DomainKind::U64)
+        );
+        assert_eq!(
+            DomainKind::from_type(&syn::parse_quote!(u64)),
+            Some(DomainKind::U64)
+        );
+        // `bool` is a scalar, but not one a domain can be declared over.
+        assert_eq!(DomainKind::from_type(&syn::parse_quote!(bool)), None);
+
+        let domain = RepresentationDomain::range(0u64..=1u64);
+        assert_eq!(domain.kind(), DomainKind::U64);
+        assert_eq!(
+            domain.ty().to_token_stream().to_string(),
+            quote!(u64).to_string()
+        );
     }
 
     #[test]

--- a/prebindgen-registry/src/lib.rs
+++ b/prebindgen-registry/src/lib.rs
@@ -133,7 +133,7 @@ pub use self::{
         FieldsDecl, FunctionDecl, LocalField, LocalVariant,
     },
     diagnostics::{warn_unclaimed, Claimed},
-    domain::{DomainScalar, RepresentationDomain, ScalarValue},
+    domain::{DomainKind, DomainScalar, RepresentationDomain, ScalarValue},
     emit::RustWriter,
     generation::{
         AbiLayout, ArtifactId, ArtifactInput, ArtifactPlan, ChainValue, ChoiceArity, Cleanup,

--- a/prebindgen-registry/src/unfold.rs
+++ b/prebindgen-registry/src/unfold.rs
@@ -33,6 +33,12 @@ use crate::{
 };
 
 mod error;
+mod walk;
+pub use walk::{
+    bind_hoists, compose_step, fold_steps, project_leading_fields, reach_leaf_flat, DecomposedLeaf,
+    Hoisted,
+};
+
 mod plan;
 
 pub use self::{

--- a/prebindgen-registry/src/unfold/walk.rs
+++ b/prebindgen-registry/src/unfold/walk.rs
@@ -36,7 +36,13 @@ pub trait DecomposedLeaf {
     fn source(&self) -> &TypeRef;
 
     /// Whether the last step reaching it is a field read rather than a call.
-    fn is_field_read(&self) -> bool;
+    ///
+    /// Derived from [`Self::reach`], so no implementation can disagree with
+    /// its own path — and the answer decides whether the reached place is
+    /// cloned, which is an ownership decision rather than a spelling.
+    fn is_field_read(&self) -> bool {
+        matches!(self.reach().last(), Some(PathStep::Field { .. }))
+    }
 }
 
 /// Compose one [`PathStep`] onto the reference expression reached so far.
@@ -183,7 +189,7 @@ pub fn reach_leaf_flat<L: DecomposedLeaf>(
     let own_path = leaf.reach();
     assert!(
         !own_path.iter().rev().skip(1).any(PathStep::is_optional),
-        "jnigen unfold: leaf `{}` reaches through an optional step but is \
+        "unfold: leaf `{}` reaches through an optional step but is \
          delivered as a single return value, which has no `None` arm — this \
          shape needs callback delivery",
         leaf.name(),

--- a/prebindgen-registry/src/unfold/walk.rs
+++ b/prebindgen-registry/src/unfold/walk.rs
@@ -1,0 +1,454 @@
+//! The walk over a decomposed value.
+//!
+//! A decomposition — an [`UnfoldPlan`](crate::unfold::UnfoldPlan) — says which
+//! **leaves** a value is delivered as and which **hoists** (intermediate value
+//! forms) they are reached through. Performing that walk is the registry's:
+//! binding each hoist once, reaching each leaf through its own path, and
+//! deciding at every step whether what it holds is owned or borrowed.
+//!
+//! What an adapter supplies is the target-language half — how a leaf is
+//! encoded, and how the delivered values are handed over — plus the two facts
+//! this module cannot know: where a source item is qualified from
+//! (`qualify`), and what each leaf is ([`DecomposedLeaf`]).
+
+use proc_macro2::TokenStream;
+use quote::{format_ident, quote};
+
+use prebindgen_flat::flat::TypeRef;
+
+use crate::unfold::{steps_are_movable, PathStep};
+
+/// What the walk needs to know about one delivered leaf.
+///
+/// The adapter's own leaf carries far more — its wire type, its JNI or C
+/// encoding, its projection — and none of that reaches here.
+pub trait DecomposedLeaf {
+    /// Steps from the decomposed value to this leaf.
+    fn reach(&self) -> &[PathStep];
+
+    /// The leaf's own name, used in diagnostics and in local names.
+    fn name(&self) -> &str;
+
+    /// Whether this leaf *is* the decomposed value rather than a part of it.
+    fn identity(&self) -> bool;
+
+    /// The reading the leaf delivers.
+    fn source(&self) -> &TypeRef;
+
+    /// Whether the last step reaching it is a field read rather than a call.
+    fn is_field_read(&self) -> bool;
+}
+
+/// Compose one [`PathStep`] onto the reference expression reached so far.
+/// A `Call` applies its accessor (origin-qualified); a `Field` reads the field
+/// and re-borrows, so the result is a reference either way and steps chain
+/// uniformly.
+pub fn compose_step(
+    qualify: &dyn Fn(&syn::Ident) -> syn::Path,
+    step: &PathStep,
+    e: TokenStream,
+) -> TokenStream {
+    match step {
+        PathStep::Call { ident, .. } => {
+            let m = qualify(ident);
+            quote!(#m::#ident(#e))
+        }
+        PathStep::Field { ident, .. } => quote!(&(#e).#ident),
+    }
+}
+/// Fold a run of steps onto `e`, borrowing wherever ownership demands it.
+///
+/// [`compose_step`] hands a `Call` its receiver as written, and an accessor
+/// takes that receiver **by reference** — so an owned value in hand has to be
+/// borrowed before the next call composes onto it. A value is in hand whenever
+/// the previous step returned one (`f(..) -> T` rather than `-> &T`), which is
+/// what [`PathStep::yields_owned`] records; `owned` says whether `e` itself
+/// started that way.
+///
+/// A `Field` step needs no borrow either way — it composes as `&(e).f`, which
+/// reads through a value and a reference alike.
+///
+/// This is the ONE place the rule lives, so every fold — a leaf's reach, a
+/// conditional hoist's prefix, a sum's matched value — answers it the same way.
+/// Splitting it produced exactly the bug it exists to prevent: ownership was
+/// handled at the optional binding and at the value form, and lost at every
+/// ordinary call in between.
+pub fn fold_steps(
+    qualify: &dyn Fn(&syn::Ident) -> syn::Path,
+    steps: &[PathStep],
+    mut e: TokenStream,
+    mut owned: bool,
+) -> TokenStream {
+    for step in steps {
+        if owned && matches!(step, PathStep::Call { .. }) {
+            e = quote!(&#e);
+        }
+        e = compose_step(qualify, step, e);
+        owned = step.yields_owned();
+    }
+    e
+}
+/// Compose a value form's OWN call — the one step in the whole system whose
+/// receiver may be by value.
+///
+/// Four cases, from what the fold ended up holding crossed with what the
+/// accessor takes. A CONSUMING form takes its receiver by value: hand it the
+/// value when that is ours, clone when it is not — the same cost the borrowing
+/// form of the accessor would have paid, which keeps one declaration usable by
+/// both owned and `&T` roots. A borrowing form takes a reference, so an owned
+/// value is borrowed for it.
+///
+/// The decision is made from the fold's RESULT, never from where the fold
+/// began: that is what lets a consuming form sit behind ordinary accessors,
+/// where the chain in front borrows and the form itself still moves.
+///
+/// One function because both hoist paths — the conditional binding and the
+/// ordinary one — need exactly this rule, and stating it twice is what turned
+/// each new shape into a new defect.
+fn compose_value_form_call(
+    qualify: &dyn Fn(&syn::Ident) -> syn::Path,
+    call: &PathStep,
+    e: TokenStream,
+    e_owned: bool,
+    consuming: bool,
+) -> TokenStream {
+    match (consuming, e_owned) {
+        (true, owned) => {
+            let (m, f) = (qualify(call.ident()), call.ident());
+            // Parenthesized: the clone applies to whatever the fold holds, and
+            // `&x.clone()` would parse as `&(x.clone())`.
+            let arg = if owned { e } else { quote!((#e).clone()) };
+            quote!(#m::#f(#arg))
+        }
+        (false, true) => compose_step(qualify, call, quote!(&#e)),
+        (false, false) => compose_step(qualify, call, e),
+    }
+}
+/// Start a reach from `base`, projecting the **leading run of plain field
+/// steps** directly (`&base.a.b`) instead of through a borrow of the base
+/// (`&(&base).a.b`). Returns the expression and how many steps it consumed.
+///
+/// The two forms name the same value, but the second borrows the base **as a
+/// whole**, which the borrow checker rejects once a sibling leaf has moved a
+/// different field out of it. Projecting directly makes each leaf's borrow
+/// disjoint, so a consuming value form's field moves are order-independent
+/// rather than compiling only while the borrowing leaves happen to be declared
+/// first.
+pub fn project_leading_fields(
+    base: &TokenStream,
+    base_is_ref: bool,
+    path: &[PathStep],
+) -> (TokenStream, usize) {
+    if base_is_ref {
+        return (base.clone(), 0);
+    }
+    let n = path.iter().take_while(|s| s.is_plain_field()).count();
+    if n == 0 {
+        return (quote!(&#base), 0);
+    }
+    let segs: Vec<&syn::Ident> = path[..n].iter().map(PathStep::ident).collect();
+    (quote!(&#base #(.#segs)*), n)
+}
+
+/// Fold a leaf's whole `path` over `base` with no optional-step handling, then
+/// apply the terminal treatment the leaf calls for: a leaf reached by a field
+/// read is **cloned** out of the place it reached, because its converter takes
+/// the field type as written (owned); every other leaf keeps the borrow its
+/// converter expects.
+///
+/// One derivation, used by every delivery an adapter renders and by the
+/// single-leaf shortcut a decomposed return takes. They drifted once while
+/// they were two — the shortcut was missing the field clone and handed `&F` to
+/// an `F` converter — which is why the walk is the registry's.
+pub fn reach_leaf_flat<L: DecomposedLeaf>(
+    qualify: &dyn Fn(&syn::Ident) -> syn::Path,
+    leaf: &L,
+    path: &[PathStep],
+    base: TokenStream,
+    base_is_ref: bool,
+    consuming: bool,
+) -> TokenStream {
+    // An optional step BEFORE the last one needs a `match` whose `None` arm has
+    // somewhere to go. This derivation has none — it yields a plain Rust value,
+    // not a `JObject` that could be null — so the shape is refused here rather
+    // than composed into code that cannot type-check in the consumer's crate.
+    //
+    // Asked of the leaf's OWN path, not of `path`. The caller may hand a
+    // suffix: `wrapper.rs` rebases onto a hoisted local, and `Hoisted::innermost`
+    // strips the prefix that bound it — including any optional step inside it.
+    // Checking the parameter would therefore pass exactly when the hoist is the
+    // conditional one, which is the case that cannot compose (an `Option<T>`
+    // local with a field read hung off it). The full path is what the shape
+    // question is about.
+    let own_path = leaf.reach();
+    assert!(
+        !own_path.iter().rev().skip(1).any(PathStep::is_optional),
+        "jnigen unfold: leaf `{}` reaches through an optional step but is \
+         delivered as a single return value, which has no `None` arm — this \
+         shape needs callback delivery",
+        leaf.name(),
+    );
+    // Whether what this leaf reaches is OURS, and so is moved rather than
+    // borrowed or cloned. The two leaf kinds say it differently:
+    //
+    // * an IDENTITY leaf carries the answer in its `out_ty` — the plan resolved
+    //   it to the owned type exactly when the value is the plan's to give away
+    //   (`place_is_owned`: an owned root, or a field of a CONSUMING value form),
+    //   and that is also what selected the owning converter, which boxes the
+    //   move rather than cloning a borrow;
+    // * a FIELD leaf's `out_ty` is the field type as written, owned either way,
+    //   so ownership is the enclosing form's: only a consuming one gives its
+    //   fields away.
+    //
+    // How to project that place is `steps_are_movable`'s question, and it is
+    // asked there rather than restated here. This used to spell it
+    // `all(is_plain_field)`, defending the restatement on the grounds that a
+    // trailing `Option` cannot reach return delivery anyway — true, and enforced
+    // in `single_return` (`core/unfold.rs`), which is precisely why a local
+    // restatement could disagree with the rule for as long as the invariant held
+    // somewhere else. `plan.rs` says two readings would drift and the
+    // disagreement would be a borrow handed to an owning converter; this is the
+    // second reading, removed.
+    let reached_is_ours = if leaf.identity() {
+        !matches!(
+            leaf.source().kind(),
+            prebindgen_flat::flat::TypeKind::Ref { .. }
+        )
+    } else {
+        consuming
+    };
+    if reached_is_ours && steps_are_movable(path) {
+        let segs: Vec<&syn::Ident> = path.iter().map(PathStep::ident).collect();
+        return quote!(#base #(.#segs)*);
+    }
+    let (e, lead) = project_leading_fields(&base, base_is_ref, path);
+    let e = fold_steps(qualify, &path[lead..], e, false);
+    if leaf.is_field_read() {
+        quote!((#e).clone())
+    } else {
+        e
+    }
+}
+/// Every value form on a plan, evaluated **once** and bound to a local
+/// (`__vf0`, `__vf1`, …), so a struct is built once per delivery rather than
+/// once per field. The bound prefixes come back with the statements, since
+/// reaching a leaf means starting from the innermost local it sits under.
+///
+/// Shared by both delivery paths — the multi-leaf encoder below and the
+/// single-leaf `Delivery::Return` shortcut in `emit/wrapper.rs`. The shortcut
+/// used to compose its reach straight off the raw value, which for a consuming
+/// value form emitted `f(&v)` against a by-value receiver: ill-typed Rust in
+/// the consumer's crate. One binder, so the two cannot disagree about what a
+/// hoist is or who owns it.
+pub struct Hoisted {
+    /// The `let __vfN = …;` bindings, outermost-first.
+    pub stmts: TokenStream,
+    /// Each hoist's path prefix and the local it was bound to.
+    bound: Vec<(Vec<PathStep>, syn::Ident)>,
+    /// Whether each bound hoist consumed the value it decomposed.
+    consuming: Vec<bool>,
+    /// Whether each bound local is `Option<TStruct>` rather than `TStruct` —
+    /// the hoist sits under an optional step, so the value form ran only where
+    /// the value was present. Its leaves cannot be emitted as independent
+    /// statements: they share ONE `match` on the local (see
+    /// [`encode_plan_leaves`]), taken by value, so a consuming form's fields
+    /// still move out inside the arm.
+    optional: Vec<bool>,
+}
+impl Hoisted {
+    /// Index of the innermost bound hoist `path` sits under, with that prefix
+    /// already consumed. `None` for a leaf under no value form at all — a
+    /// sibling `.field()` / `.field_self()`, which still reaches from the value
+    /// itself.
+    fn innermost(&self, path: &[PathStep]) -> Option<(usize, Vec<PathStep>)> {
+        self.bound
+            .iter()
+            .enumerate()
+            .filter(|(_, (p, _))| p.len() < path.len() && path.starts_with(p))
+            .max_by_key(|(_, (p, _))| p.len())
+            .map(|(i, (p, _))| (i, path[p.len()..].to_vec()))
+    }
+
+    /// The innermost bound local `path` sits under, with that prefix already
+    /// consumed, and whether that hoist gave its value away.
+    pub fn rebase(&self, path: &[PathStep]) -> Option<(syn::Ident, Vec<PathStep>, bool)> {
+        self.innermost(path)
+            .map(|(i, rest)| (self.bound[i].1.clone(), rest, self.consuming[i]))
+    }
+
+    /// The innermost **conditional** hoist `path` sits under: its index, the
+    /// local holding the `Option`, the name its `Some` arm binds, and the steps
+    /// left to reach the leaf from there. `None` when the leaf's innermost
+    /// hoist is unconditional (or there is none) — then [`Self::rebase`]
+    /// applies and the leaf is an ordinary standalone statement.
+    pub fn conditional(
+        &self,
+        path: &[PathStep],
+    ) -> Option<(usize, syn::Ident, syn::Ident, Vec<PathStep>)> {
+        let (i, rest) = self.innermost(path)?;
+        self.optional[i].then(|| (i, self.bound[i].1.clone(), format_ident!("__u{}", i), rest))
+    }
+
+    /// The local a hoist was bound to.
+    pub fn local(&self, i: usize) -> syn::Ident {
+        self.bound[i].1.clone()
+    }
+
+    /// Whether a hoist consumed the value it decomposed.
+    pub fn consumed(&self, i: usize) -> bool {
+        self.consuming[i]
+    }
+}
+/// Fold `path` over `base` the way [`reach_leaf`] does, but yielding an
+/// `Option<…>` rather than a `JObject`: the optional steps become a
+/// `map`/`and_then` chain, so an absent value short-circuits to `None` instead
+/// of to a null object. `body` renders the innermost reached expression as a
+/// BARE value — the chain's last link wraps it.
+///
+/// This is how a CONDITIONAL value form is bound — the accessor runs only where
+/// the value it decomposes is actually present.
+fn reach_optional(
+    qualify: &dyn Fn(&syn::Ident) -> syn::Path,
+    path: &[PathStep],
+    base: TokenStream,
+    base_is_ref: bool,
+    depth: usize,
+    body: &dyn Fn(TokenStream) -> TokenStream,
+) -> TokenStream {
+    let (e, lead) = project_leading_fields(&base, base_is_ref, path);
+    match (lead..path.len()).find(|&i| path[i].is_optional()) {
+        None => body(fold_steps(qualify, &path[lead..], e, false)),
+        Some(k) => {
+            // Through the optional step INCLUSIVE: the same fold, so the
+            // borrow in front of it is the ordinary rule rather than a second
+            // statement of it.
+            let opt_e = fold_steps(qualify, &path[lead..=k], e, false);
+            let bind = format_ident!("__hb{}", depth);
+            // What the arm binds is the step's own value: an OWNED payload is a
+            // bare `T`, so composing the next step onto it directly would hand
+            // `T` to an accessor typed for `&T`. Say it is not a reference and
+            // let `project_leading_fields` borrow it; a borrowed payload is
+            // already one and passes through.
+            //
+            // With NO steps left the binding goes to `body` untouched — that is
+            // what lets a consuming value form MOVE an owned payload rather than
+            // borrow it straight back, so the terminal case stays "already a
+            // reference" whatever the payload is.
+            let rest = &path[k + 1..];
+            let inner = reach_optional(
+                qualify,
+                rest,
+                quote!(#bind),
+                rest.is_empty() || !path[k].yields_owned(),
+                depth + 1,
+                body,
+            );
+            // `map` when this is the LAST optional step (the body yields a bare
+            // value) and `and_then` when another follows (the recursion yields
+            // an `Option` that must not nest). The equivalent `match` reads the
+            // same but generated code runs through the consumer's lints, where
+            // `clippy::manual_map` is a denial.
+            let combinator = if rest.iter().any(PathStep::is_optional) {
+                format_ident!("and_then")
+            } else {
+                format_ident!("map")
+            };
+            quote! {
+                #opt_e.#combinator(|#bind| #inner)
+            }
+        }
+    }
+}
+pub fn bind_hoists(
+    qualify: &dyn Fn(&syn::Ident) -> syn::Path,
+    hoists: &[crate::unfold::Hoist],
+    value: &TokenStream,
+    by_ref: bool,
+) -> Hoisted {
+    let mut out = Hoisted {
+        stmts: TokenStream::new(),
+        bound: Vec::new(),
+        consuming: Vec::new(),
+        optional: Vec::new(),
+    };
+    // Value forms COMPOSE, so each hoist is built from the longest hoist that
+    // is already a proper prefix of it (they arrive outermost-first), and from
+    // `value` otherwise.
+    for (i, h) in hoists.iter().enumerate() {
+        let local = format_ident!("__vf{}", i);
+        // A hoist under an optional step binds `Option<TStruct>`: the value
+        // form runs in the `Some` arm only. Core refuses to nest these, so the
+        // enclosing value is always the plan's own — no rebase to consider.
+        if h.prefix.iter().any(PathStep::is_optional) {
+            let (last, lead) = h
+                .prefix
+                .split_last()
+                .expect("a hoist prefix ends in its value-form call");
+            let consuming = h.consuming;
+            // The value form is handed the payload only when the optional step
+            // is the LAST thing before it; any step in between composes as a
+            // borrow, so what arrives is a reference either way.
+            let owned = lead.last().is_some_and(PathStep::yields_owned);
+            let expr = reach_optional(qualify, lead, value.clone(), by_ref, 0, &|reached| {
+                compose_value_form_call(qualify, last, reached, owned, consuming)
+            });
+            out.stmts.extend(quote! { let #local = #expr; });
+            out.bound.push((h.prefix.clone(), local));
+            out.consuming.push(h.consuming);
+            out.optional.push(true);
+            continue;
+        }
+        // Where the fold starts, and whether what it starts from is OWNED. The
+        // value form's own boundary is decided below, from what the fold ends
+        // up holding — never from where it began.
+        let (from, start, start_owned) = match out.rebase(&h.prefix) {
+            // A NESTED consuming form is handed the parent's field by MOVE: a
+            // hoisted value form is an owned struct and its fields are
+            // disjoint, so moving one out leaves every sibling leaf readable.
+            // `compose_step` borrows (`&(e).f`), so a plain field run to that
+            // field is projected here instead of going through it.
+            Some((outer, rest, _))
+                if h.consuming && rest[..rest.len() - 1].iter().all(PathStep::is_plain_field) =>
+            {
+                let lead = &rest[..rest.len() - 1];
+                let segs: Vec<&syn::Ident> = lead.iter().map(PathStep::ident).collect();
+                (h.prefix.len() - 1, quote!(#outer #(.#segs)*), true)
+            }
+            // Any other rebased hoist: project its own leading field run
+            // DIRECTLY off the parent local rather than reaching it through a
+            // borrow of the parent. A sibling hoist may already have moved a
+            // different field out — that is what a consuming value form does —
+            // and `&(&__vf0).wrapper` borrows the partially moved parent as a
+            // whole where `&__vf0.wrapper` is a disjoint borrow that survives.
+            // Same invariant `project_leading_fields` states for leaf reaches,
+            // and the same reason.
+            Some((outer, rest, _)) => {
+                let (e, lead) = project_leading_fields(&quote!(#outer), false, &rest);
+                (h.prefix.len() - rest.len() + lead, e, false)
+            }
+            None if by_ref => (0, value.clone(), false),
+            None => (0, value.clone(), true),
+        };
+        // Everything before the value form is an ordinary accessor chain.
+        let last = h.prefix.len() - 1;
+        let head = &h.prefix[from..last];
+        let e = fold_steps(qualify, head, start, start_owned);
+        let e_owned = head.last().map_or(start_owned, PathStep::yields_owned);
+        // The value form itself. A CONSUMING one takes its receiver BY VALUE —
+        // that is the move the whole declaration exists for — so it is handed
+        // what the fold holds when that is ours, and a clone when it is not:
+        // the same cost the borrowing form of the accessor would have paid,
+        // which keeps one declaration usable by both owned and `&T` returns.
+        // A borrowing one takes a reference, so an owned value is borrowed.
+        //
+        // Deciding this from the fold's RESULT rather than from its start is
+        // what lets a consuming form sit behind ordinary accessors: the chain
+        // in front borrows, the form itself still moves.
+        let expr = compose_value_form_call(qualify, &h.prefix[last], e, e_owned, h.consuming);
+        out.stmts.extend(quote! { let #local = #expr; });
+        out.bound.push((h.prefix.clone(), local));
+        out.consuming.push(h.consuming);
+        out.optional.push(false);
+    }
+    out
+}


### PR DESCRIPTION
## Relationship to #513

This is the successor umbrella to #513 and is stacked directly on its branch,
as #581 was.

#581 made final Rust **assembly** registry-driven: one frozen artifact graph,
dependency completeness proven from declared edges, and no adapter callback
left in the writer. Reviewing #513 against the merged branch found what that
did not reach — three places where JniGen still walks a source value itself,
and one where planning decides a type's identity from its spelling.

This description restates those from the code at the #513 head. #513's own
"why the migration is not complete" section is stale in both directions: it
still names `post_process_item`, `compiled_fns`, the `on_*` callbacks and the
adapter vector seam, all of which #581 deleted, and it does not name what is
actually left.

## Vocabulary

- **Source-value walk** — the recursive traversal of a Rust value's structure
  that a converter body performs: reading a struct's fields, matching a sum's
  alternatives, reaching a leaf through a chain of accessors.
- **Composed shape** — one of the registry's five compositions of that walk —
  `Product`, `Optional`, `Sequence`, `Choice`, `Invoke`, in
  `prebindgen-registry/src/chain.rs`. The registry performs the walk once and
  calls an adapter-supplied *bridge* for the target-representation half.
- **Bridge** — the adapter's half of a composed shape. For a `Product` it is
  three answers: the intermediate type the wire carries, how to read *part i*
  out of that intermediate, and how to build the intermediate from converted
  parts (`ProductBridge`).
- **Whole-object codec** — JniGen's conversion for a data class declared
  `data_class!(T).jobject_input()`, or for a sealed sum: the value crosses as
  one JVM object whose properties are read by JNI field access, rather than as
  flattened primitive leaves.
- **Delivery** — the encoding of a decomposed return value or callback
  argument. The registry's `UnfoldPlan` decides the decomposition: the
  **leaves** (the values handed to the foreign builder) and the **hoists**
  (intermediate value forms bound once and reached through). The adapter
  encodes each leaf into a JVM value and performs the call.
- **Representation domain** — the scalar a conversion's wire values live in,
  as stated by `convert!(T).domain(...)`, and the type generated niche
  constants are given.

## Goal

Every source-value walk in generated Rust is composed by the registry.

Adapters keep what is theirs: target representation, ABI layout, and the
bridge operations that express them. What no adapter keeps is a second walk
over a structure the registry already knows how to walk.

Planning decides a type's identity from Flat facts, never from a spelling.

## Success criteria

- JniGen's whole-object struct input and output are registry-composed
  `Product`s. The adapter supplies the bridge; the registry performs the walk.
- Sealed-sum whole-object input is a registry-composed `Choice`.
- Decomposed delivery is **relocated** to the registry, not composed there.
  The walk over an `UnfoldPlan` — bind the hoists, reach each leaf — moves out
  of the adapter and behind a `DecomposedLeaf` trait, and `emit/delivery.rs`
  calls those registry functions instead of running the traversal itself. It
  does not become a `Product` or a `Sequence`: no registry composer participates.
  The registry is where it lives because a decomposition walk is the registry's
  subject, and having it there means only one implementation of it exists — not
  because a second adapter reuses it. Cbindgen has no decomposition feature, and
  none is proposed here, so `walk.rs` has one consumer and `DecomposedLeaf` one
  production implementation. That is layering, and the 460 lines buy exactly
  that.
- The whole-object struct output encode is the one walk this umbrella does not
  move, and #603 records why with a test: it covers gated shapes the
  registry-facing decomposition refuses, so composing it would change what a
  foreign builder can be delivered. #602 proposes that as the feature it is.
- After those, `emit/flat_input.rs`, `struct_plan.rs` and `emit/delivery.rs`
  hold bridge operations, JVM policy and Kotlin-facing plan data, and no
  source-value traversal. Whatever remains in them is named in the final step
  rather than left unexplained.
- `RepresentationDomain` answers "which scalar is this" from a tag carried
  with the domain. No production code matches a rendered type string to decide
  identity.
- Cbindgen's converter composition stays registry-owned, and the two recursive
  walks it keeps are the ones named below as deliberately out of scope, not
  ones nobody looked at.
- Kotlin emission continues to read the same frozen plans. Its `fromParts`
  factories, descriptors, class surfaces and file layout do not move —
  `StructPlan` is read by both the Rust encode and the Kotlin factory, and
  that stays true.
- #513's description reflects its branch when this lands: what its unchecked
  parents still cover, and which #506 carriers are current machinery rather
  than legacy.

## Restrictions

- **Analyze Flat; generate Rust only.** Planning may inspect Flat facts and
  retain `TypeRef`, and may not spell or reparse a captured Rust type, or read
  `TypeKey` text as a type.
- `RustWriter` stays sealed to final rendering: constructable only inside the
  registry, reachable only through an artifact's `render`.
- A fact that planning needs and Flat does not carry is added to Flat or to
  the registry's generation model, not recovered from syntax.
- The registry stays language-agnostic. It gains no `KtType`, no packages, no
  classes, no JVM naming policy, and no Kotlin formatting or layout.
- Exported C ABI, JNI names and descriptors, and generated Kotlin behaviour
  stay semantically unchanged unless a step calls out an intentional change.
  Private Rust helper names and layout within the generated file may change.
- Byte-identical generated output is the default expectation of every step, as
  it was throughout #581. A step that cannot hold it says so in its own PR and
  says why.

## Unfinished elements at the #513 head

Line references are against `345b8a0e`.

- **Whole-object struct input walks itself.**
  `JObjectStructInputPlan::render` (`emit/flat_input.rs:241`) iterates its own
  `fields`, emits a JNI field read per property, and constructs the source
  struct with `RustWriter::shape_struct`. The per-field conversions are
  registry-composed pipelines; the traversal around them is not.
- **Whole-object struct output walks itself.** `StructPlan` (`struct_plan.rs`)
  holds one `PlanField` per field, and `PlanFieldKind::Nested` and
  `PlanFieldKind::Sum` recurse into child layouts. The Rust encode walks that
  tree. The same tree is read by the Kotlin `fromParts` factory
  (`render.rs:101`), so it is plan data for two languages, not only a walk.
- **Sealed-sum whole-object input walks itself.** `JSumCodecPlan` holds one
  alternative plan per variant, each with its own property plans, and renders
  the match over them.
- **Delivery walks itself.** `encode_plan_leaves` (`emit/delivery.rs:1063`)
  binds the plan's hoists (`bind_hoists`, `:854`) and reaches each leaf
  (`reach_leaf_flat`, `:452`). The decomposition is the registry's
  `UnfoldPlan`; walking it is the adapter's code.
- **The registry cannot yet express what those bridges need.**
  `ProductBridge::part` returns one expression
  (`chain.rs:106`). A JVM field read is fallible — `env.get_field(...)` returns
  a `Result`, and a null object needs its own arm — so it is statements, not an
  expression. The vocabulary has to grow before JniGen can adopt it, which is
  why the first step below is a registry step rather than an adapter one.
- **A domain decides identity by spelling — in both adapters.**
  `RepresentationDomain` is registry-side. It keeps its scalar as a `syn::Type`
  and recovers the kind by matching the rendered token string, in
  `contains_expr` and in `niche_values`, the latter ending
  `_ => unreachable!()` (`domain.rs:258`, `:287`). Cbindgen reaches both
  through `convert.rs`, where `niche_values` generates its reserved
  representation constants, and #587 carried the spelling one layer further by
  retaining the domain's `syn::Type` in a planned `CDomainConstant`. A third
  site, in JniGen, compares a domain's spelling against the input
  representation's, which is what makes the consequence visible: spelling one
  integer `::core::primitive::u64` instead of `u64` fails the build.
  `DomainScalar` produces the tag in the same macro arm that produces the
  spelling, and discards it. Filed separately as #589.

## Why Cbindgen needs less of this

Four of the five code steps below touch JniGen only. That is a property of the
two boundaries, not an omission — Cbindgen was checked for each.

- **C has no object-shaped boundary.** Every C wire value is flattened into
  slots: a scalar, a pointer, a pointer and a length, an out-parameter. There
  is no C counterpart to `jobject_input()`, where the wire value is one object
  whose properties are read back one at a time. So the C conversion for a
  declared `data_struct` is *already* a registry-composed `Product`
  (`CBody::Product` → `chain::Product`, `chain.rs:1859`) — the shape steps 2
  and 3 move JniGen's whole-object codecs to.
- **C has no decomposition feature.** `expand_param!` / `expand_return!` and
  the `UnfoldPlan` they produce are JNI-only; `unfold` and `expand::` appear
  nowhere in `prebindgen-c`. Step 5 therefore has no C counterpart to fix.

Cbindgen does render two recursive walks of its own, and both stay:

- `CValue::encode` recurses through an `Optional`'s inner value to split a
  converted value across wire slots (`compile.rs:205`, `:220`). That is a walk
  over the **ABI layout**, which #513 leaves with the adapter — the registry
  owns which fragment a site selects, and the adapter owns how many slots it
  occupies and which is which.
- `PayloadCleanup::render` recurses through a tagged union's payload fields
  and nested unions to free what the live arm owns (`chain.rs:1476`, `:1553`).
  That is a walk over the **C mirror type**, which the registry does not model,
  and it is a destructor rather than a conversion.

Both would come into scope if the registry ever grew a composition for
representation-side cleanup, or if C gained a boundary whose wire value is
structured. Neither is proposed here.

## Plan

Each box is one child pull request against this umbrella's branch, reviewed
and merged before the next begins. The list is the intended route rather than
a contract; a step is rewritten here when the code shows a better split — as
step 2 was, once the property kinds were counted.

- [x] **1. Let a bridge read a part fallibly (#597).** Extend the registry's `Product`
  and `Choice` composition so a bridge can contribute statements and a failure
  arm when it extracts a part, not only an expression. This is what a JVM field
  read needs, and the shape the two whole-object steps below adopt. No adapter
  changes behaviour in this step.
- [x] **2a. Every whole-object property gets one complete child (#598).** Ten of the
  twelve property kinds already read as "fetch the property, then call one
  child converter". Two do not: an optional `ULong` and an optional enum
  interleave their null test with the child call, so the conversion is spread
  between the child and the walk. Compose that layer as an `Optional` over the
  fetched object, which is what `Optional` is for, and every property becomes
  fetch-then-child. The walk stays where it is; nothing else changes.
- [x] **2b. Whole-object struct input becomes a composed `Product` (#599).** JniGen
  supplies a bridge whose intermediate is the JVM object and whose `part` is
  the property fetch — the read that step 1 made expressible. The registry
  performs the walk and builds the source struct.
  `JObjectStructInputPlan`'s traversal goes; its property policy — descriptors,
  null handling, per-property error text — becomes bridge data.
  *Two costs this step's own text understated.* The generated decode changes
  more than shape: the composer runs every part read before it constructs the
  value, so all of a struct's field reads are now hoisted ahead of all of its
  conversions where each read used to be followed by its own conversion. Every
  property read carries `?`, so the order is observable — which error surfaces
  when two properties are bad can differ, and a read now runs where an earlier
  conversion would previously have returned first. Nothing observed
  misbehaves; the covertest passes all 61 sections. And the adapter file grew:
  `emit/flat_input.rs` went 1014 to 1341 lines, trading a 16-line render loop
  for plan construction plus about 170 lines of bridge types. The trade is
  that a bridge cannot reintroduce a divergent traversal and a walk can.
- [x] **3. The registry composes the delivery walk (#600).** Add the walk over an
  `UnfoldPlan` — bind the hoists, reach each leaf — to the registry, with an
  adapter bridge for encoding a leaf and performing the delivery call.
  `bind_hoists` and `reach_leaf_flat` go; JNI keeps jvalue layout, local-frame
  sizing, cached method lookup and exception routing. Moved ahead of the
  whole-object output because that output turns out to need this composition
  rather than a `Product` — see the step below.
- [x] **5. Whole-object struct output: compose it, or record why it is layout (#603).**
  This was planned as a `Product` in the deconstruct direction and is not one.
  A `Product` part yields one value per field; `fromParts` takes the struct's
  leaves **flattened across fields**, with a nested struct contributing all of
  its own slots, an optional nested struct adding a `present` flag and
  defaulting its group, and a sum contributing a tag plus one group per
  variant. That is a decomposition into gated leaf groups, which is what step 3
  composes — so this step either expresses `StructPlan` as such a decomposition
  and reuses that walk, or records that its gated flattening is ABI layout,
  adapter-owned for the same reason C's `CValue::encode` is, and says so where
  the next reader will look.
  *Recorded.* The whole-object encode is a superset of the registry-facing
  decomposition, which refuses a nested `data_class` behind `Option` or `Vec` —
  11 of the 29 declared structs — so composing the encode out of it would drop
  delivery coverage. A standing check in `write_rust` now compares the two
  derivations on every declared data class, over leaf names and nesting depth,
  and #602 carries the missing decomposition support.
- [x] **4. Sealed-sum whole-object input becomes a composed `Choice` (#601).** One
  arm per alternative, each arm a `Product` of its payload properties, over
  the bridge step 2b introduces — sum payload properties are the same
  `JObjectStructFieldPlan`s, so this step is the arm selection, not the
  properties again.

- [x] **6. A domain carries its scalar kind (#604).** The one step that fixes both
  adapters: retain the tag `DomainScalar` already computes, decide
  `contains_expr`, `niche_values` — which Cbindgen's reserved representation
  constants come from — and JniGen's representation comparison from it, and
  delete both string matches and the `unreachable!()`. Whether Flat's
  `ScalarKind` is widened or a domain-side kind is introduced is the design
  question of that step. Closes #589.
  *Settled as a domain-side kind:* widening `ScalarKind` would make the model
  classify scalars no adapter can pass across an FFI boundary, and would keep an
  `unreachable!()` for `Bool`, `Isize` and `Usize`. `DomainKind`'s variants,
  spellings and reduction are generated from one list. Cbindgen's `is_scalar`
  went with it — it now asks the model's `ScalarKind::from_type` instead of a
  third hand-written name table.
- [x] **7. Reconcile #513, and settle what this umbrella left behind (#605).**
  `PartRead::statements` — a prelude that binds without failing — has no
  production caller: every JVM property read can fail, so step 2b reached for
  `PartRead::fallible` instead. If steps 3 to 5 do not reach for it either, it
  is deleted here rather than left as vocabulary nobody speaks. Then, on #513: State on #513 what its branch now is: tick what
  the two umbrellas completed, re-scope or close its unchecked parents, and
  record which #506 carriers — `expand`, `unfold`, `Decompositions`,
  `ConverterImpl`, `Stage`, `fn_plan.rs` — are current machinery rather than
  legacy, deleting any that this umbrella strands.
  *Done.* `PartRead::statements` is deleted — no production caller. #513 carries
  a reconciliation comment and the body edits it describes: parent 7 ticked,
  parent 8 down to one clause, parent 5 re-scoped to `pre_stages`, every
  completion gate marked with what it now is, and #506's carriers recorded as
  current machinery — `InputKind` was the only deletable item on that list.

## Verification baseline

The stacked base passes workspace tests (825), strict Clippy, `cargo fmt
--check`, strict rustdoc, the regeneration check, the C smoke test under
ASan/LSan/UBSan, and the 61-section Kotlin/JNI covertest. Each child preserves
the relevant coverage and states any intentional change to generated output.

Steps 2 to 4 are covered end to end by a JVM run rather than by Rust
compilation alone, and more widely than the explicit declarations suggest:
`planned_struct_codec` builds the whole-object input plan for **any** named
struct whose crossing carries a `JObject` wire, not only for a class declared
`data_class!(T).jobject_input()`. Of the four decodes #598 changed, none was
declared that way — two are plain `data_class!` and one is a `sealed_class!`.
That reach is the coverage these steps get and the blast radius they carry.

## What this cost

Measured from `345b8a0e`, the #513 head this started from, to `44be8b86`:

- **Production Rust: +1646 / -765, net +881 lines**, counting the adapters and
  the registry and excluding tests and the two generated files.
- **Tests: +251 / -3.**
- By crate, net across all its changed Rust including its own tests: registry
  +839, JniGen +235, Cbindgen +25, flat +30.
- **Generated output is not byte-identical**: 61 hunks across the two generated
  files, which shed 84 local bindings between them. No user-visible behaviour
  changes — the JVM covertest passes all 61 sections, alongside 835 workspace
  tests, strict Clippy, `cargo fmt --check`, strict rustdoc and `PASS - regen
  check clean`.

So the structural change costs 881 production lines that no consumer of a
generated binding can see. What it bought beyond the layering is four defects
that were latent before it: #589 (both adapters decided a scalar's identity
from a rendered spelling), an untested NaN guard in every generated float
bounds check, #602 (two decompositions of one data class disagreeing on 11 of
29 structs), and #594.

Related to #513, #506 and #589. #588 (nothing exercises the C value-opaque
artifact) and #594 (an inserted function absorbs its neighbour's doc comment)
came out of #581's reviews and are separate.

— Claude Code (Opus 5)



















