### PR TITLE
Let a Product bridge read a part with statements

### DIFF
--- a/prebindgen-c/src/chain.rs
+++ b/prebindgen-c/src/chain.rs
@@ -1833,8 +1833,10 @@ impl chain::ProductBridge for CProductBridge {
         self.wire.clone()
     }
 
-    fn part(&self, value: TokenStream, _index: usize, name: &syn::Ident) -> TokenStream {
-        quote!(#value.#name)
+    fn part(&self, value: TokenStream, _index: usize, name: &syn::Ident) -> chain::PartRead {
+        // A C mirror's field is reached by naming it, and reaching it cannot
+        // fail: the struct is already in scope, by value.
+        chain::PartRead::expression(quote!(#value.#name))
     }
 
     fn build(&self, parts: &[(syn::Ident, TokenStream)]) -> TokenStream {

--- a/prebindgen-registry/src/chain.rs
+++ b/prebindgen-registry/src/chain.rs
@@ -97,13 +97,61 @@ fn child_value<C: Child>(child: &C, value: TokenStream, emit: &RustWriter) -> To
     }
 }
 
+/// One part read out of a Product's intermediate value.
+///
+/// A bridge whose read is a projection — a tuple index, a field access —
+/// answers with [`Self::expression`]. One whose read is not an expression at
+/// all answers with [`Self::statements`] or [`Self::fallible`]: reading a
+/// property off a JVM object binds two locals and can fail, and a bridge that
+/// had only an expression to return could not say either.
+///
+/// The composer runs the preludes in part order, before the source value is
+/// constructed, and a fallible read makes the whole composed conversion
+/// fallible even when no child converter can fail.
+pub struct PartRead {
+    prelude: TokenStream,
+    value: TokenStream,
+    fallible: bool,
+}
+
+impl PartRead {
+    /// A part reached by an expression alone.
+    pub fn expression(value: TokenStream) -> Self {
+        Self {
+            prelude: TokenStream::new(),
+            value,
+            fallible: false,
+        }
+    }
+
+    /// A part reached by running `prelude` first, which cannot fail.
+    pub fn statements(prelude: TokenStream, value: TokenStream) -> Self {
+        Self {
+            prelude,
+            value,
+            fallible: false,
+        }
+    }
+
+    /// A part reached by running `prelude` first, which can fail. The prelude
+    /// propagates its own failure — with `?`, or by returning — so the
+    /// composer only has to know that the conversion around it is fallible.
+    pub fn fallible(prelude: TokenStream, value: TokenStream) -> Self {
+        Self {
+            prelude,
+            value,
+            fallible: true,
+        }
+    }
+}
+
 /// Adapter-selected representation protocol for one Product shape.
 pub trait ProductBridge: Clone {
     /// The one intermediate Rust type assigned to this fragment.
     fn intermediate(&self) -> syn::Type;
 
     /// Read one child intermediate value from `value`.
-    fn part(&self, value: TokenStream, index: usize, name: &syn::Ident) -> TokenStream;
+    fn part(&self, value: TokenStream, index: usize, name: &syn::Ident) -> PartRead;
 
     /// Construct the intermediate value from converted children.
     fn build(&self, parts: &[(syn::Ident, TokenStream)]) -> TokenStream;
@@ -126,9 +174,9 @@ impl ProductBridge for TupleProduct {
         syn::parse_quote!((#(#parts,)*))
     }
 
-    fn part(&self, value: TokenStream, index: usize, _name: &syn::Ident) -> TokenStream {
+    fn part(&self, value: TokenStream, index: usize, _name: &syn::Ident) -> PartRead {
         let index = syn::Index::from(index);
-        quote::quote!((#value).#index)
+        PartRead::expression(quote::quote!((#value).#index))
     }
 
     fn build(&self, parts: &[(syn::Ident, TokenStream)]) -> TokenStream {
@@ -517,18 +565,23 @@ where
     fn render(&self, emit: &RustWriter) -> Rendered {
         let source = self.source_policy.spell(&self.source, emit);
         let intermediate = self.bridge.intermediate();
-        let fallible = self.parts.iter().any(|part| part.child.call().fallible());
+        let mut fallible = self.parts.iter().any(|part| part.child.call().fallible());
         let body = match self.direction {
             Direction::Construct => {
                 let canonical_source = self.source_policy.spell(self.source.unwrapped(), emit);
+                let mut preludes: Vec<TokenStream> = Vec::new();
                 let fields: Vec<_> = self
                     .parts
                     .iter()
                     .enumerate()
                     .map(|(index, part)| {
                         let name = part.name.clone();
-                        let value = self.bridge.part(quote::quote!(v), index, &name);
-                        let value = child_value(&part.child, value, emit);
+                        let read = self.bridge.part(quote::quote!(v), index, &name);
+                        if !read.prelude.is_empty() {
+                            preludes.push(read.prelude);
+                        }
+                        fallible |= read.fallible;
+                        let value = child_value(&part.child, read.value, emit);
                         (name, value)
                     })
                     .collect();
@@ -536,6 +589,14 @@ where
                 let values = fields.iter().map(|(_, value)| value);
                 let canonical = quote::quote!(#canonical_source { #(#names: #values),* });
                 let built = self.source_policy.build(canonical);
+                // A bridge that reads its parts by expression alone keeps the
+                // bare constructor it always emitted; only a bridge with a
+                // prelude to run gets a block.
+                let built = if preludes.is_empty() {
+                    built
+                } else {
+                    quote::quote!({ #(#preludes)* #built })
+                };
                 syn::parse2(built).expect("a Product source constructor is a valid expression")
             }
             Direction::Deconstruct => {
@@ -691,6 +752,9 @@ where
             .iter()
             .flat_map(|arm| &arm.parts)
             .any(|part| part.child.call().fallible());
+        // A fallible part read needs no flag of its own here: parts are read
+        // only when constructing, and construction is already fallible for
+        // every choice — an unrecognized tag returns an error.
         let body = match self.direction {
             Direction::Construct => {
                 let canonical_source = self.source_policy.spell(self.source.unwrapped(), emit);
@@ -698,6 +762,7 @@ where
                 let arms = self.arms.iter().enumerate().map(|(arm_index, arm)| {
                     let tag_pattern = &arm.tag;
                     let variant = &arm.alternative.name;
+                    let mut preludes: Vec<TokenStream> = Vec::new();
                     let fields: Vec<_> = arm
                         .parts
                         .iter()
@@ -710,8 +775,11 @@ where
                                     syn::Ident::new(&format!("v{}", index.index), index.span)
                                 }
                             };
-                            let value = arm.bridge.part(quote::quote!(__arm), part_index, &name);
-                            child_value(&part.child, value, emit)
+                            let read = arm.bridge.part(quote::quote!(__arm), part_index, &name);
+                            if !read.prelude.is_empty() {
+                                preludes.push(read.prelude);
+                            }
+                            child_value(&part.child, read.value, emit)
                         })
                         .collect();
                     let shaped: Vec<_> = arm
@@ -735,6 +803,7 @@ where
                         quote::quote!(#tag_pattern => {
                             let __choice = #prepared;
                             let __arm = #arm_value;
+                            #(#preludes)*
                             #built
                         })
                     }
@@ -876,7 +945,7 @@ where
 mod tests {
     use std::{cell::Cell, rc::Rc};
 
-    use quote::{quote, ToTokens};
+    use quote::{format_ident, quote, ToTokens};
 
     use super::*;
     use crate::{
@@ -999,6 +1068,111 @@ mod tests {
             "{body}"
         );
         assert!(rendered.fallible);
+    }
+
+    /// A bridge whose part read is neither an expression nor infallible: it
+    /// binds a local first and can fail, as a JVM property read does.
+    #[derive(Clone)]
+    struct TestFallibleParts;
+
+    impl ProductBridge for TestFallibleParts {
+        fn intermediate(&self) -> syn::Type {
+            syn::parse_quote!(TestObject)
+        }
+
+        fn part(&self, value: TokenStream, index: usize, name: &syn::Ident) -> PartRead {
+            let local = format_ident!("__read{index}");
+            let property = name.to_string();
+            PartRead::fallible(
+                quote::quote!(let #local = read_property(&#value, #property)?;),
+                quote::quote!(#local),
+            )
+        }
+
+        fn build(&self, _parts: &[(syn::Ident, TokenStream)]) -> TokenStream {
+            unreachable!("this fixture only constructs")
+        }
+    }
+
+    /// A bridge may read its part with statements that can fail, and the
+    /// composer runs them before it constructs the source value.
+    ///
+    /// This is what a Product over a JVM object needs: `env.get_field(..)`
+    /// returns a `Result` and binds a local, so a bridge that could answer
+    /// only with an expression could not express the read at all.
+    #[test]
+    fn a_fallible_part_read_runs_before_construction_and_makes_the_chain_fallible() {
+        let spells = Rc::new(Cell::new(0));
+        let plan = Product {
+            source: TypeRef::scalar(ScalarKind::I64),
+            direction: Direction::Construct,
+            source_policy: TestSource {
+                spells: spells.clone(),
+            },
+            bridge: TestFallibleParts,
+            parts: vec![
+                ProductPart {
+                    name: format_ident!("first"),
+                    // Infallible children: whatever fallibility the rendered
+                    // chain reports comes from the reads alone.
+                    child: TestChild::new("first", false, false),
+                    mode: Mode::Owned,
+                    hold_uninit: false,
+                },
+                ProductPart {
+                    name: format_ident!("second"),
+                    child: TestChild::new("second", false, false),
+                    mode: Mode::Owned,
+                    hold_uninit: false,
+                },
+            ],
+        };
+
+        let rendered = plan.render(&RustWriter::for_test());
+        let body = rendered.body.to_token_stream().to_string();
+
+        assert!(
+            rendered.fallible,
+            "a fallible read makes the conversion fallible with no fallible child:\n{body}"
+        );
+        let first = body.find("read_property").expect(&body);
+        let construction = body.find("first :").expect(&body);
+        assert!(
+            first < construction,
+            "the reads run before the source value is constructed:\n{body}"
+        );
+        assert!(
+            body.contains("__read0") && body.contains("__read1"),
+            "each part is read into its own local:\n{body}"
+        );
+    }
+
+    /// A bridge that reads by expression alone keeps the bare constructor it
+    /// always emitted — no block, no locals.
+    #[test]
+    fn an_expression_part_read_adds_no_prelude() {
+        let plan = Product {
+            source: TypeRef::scalar(ScalarKind::I64),
+            direction: Direction::Construct,
+            source_policy: TestSource {
+                spells: Rc::new(Cell::new(0)),
+            },
+            bridge: TupleProduct {
+                parts: vec![syn::parse_quote!(i64)],
+            },
+            parts: vec![ProductPart {
+                name: format_ident!("only"),
+                child: TestChild::new("only", false, false),
+                mode: Mode::Owned,
+                hold_uninit: false,
+            }],
+        };
+
+        let rendered = plan.render(&RustWriter::for_test());
+        let body = rendered.body.to_token_stream().to_string();
+
+        assert!(!rendered.fallible, "{body}");
+        assert!(!body.starts_with('{'), "no block is introduced:\n{body}");
     }
 
     #[derive(Clone)]

--- a/prebindgen-registry/src/chain.rs
+++ b/prebindgen-registry/src/chain.rs
@@ -1094,6 +1094,30 @@ mod tests {
         }
     }
 
+    /// A bridge whose part read binds a local and cannot fail — the middle
+    /// constructor, whose behaviour is not implied by its neighbours.
+    #[derive(Clone)]
+    struct TestBoundParts;
+
+    impl ProductBridge for TestBoundParts {
+        fn intermediate(&self) -> syn::Type {
+            syn::parse_quote!(TestObject)
+        }
+
+        fn part(&self, value: TokenStream, index: usize, _name: &syn::Ident) -> PartRead {
+            let local = format_ident!("__bound{index}");
+            let position = syn::Index::from(index);
+            PartRead::statements(
+                quote::quote!(let #local = (#value).#position;),
+                quote::quote!(#local),
+            )
+        }
+
+        fn build(&self, _parts: &[(syn::Ident, TokenStream)]) -> TokenStream {
+            unreachable!("this fixture only constructs")
+        }
+    }
+
     /// A bridge may read its part with statements that can fail, and the
     /// composer runs them before it constructs the source value.
     ///
@@ -1144,6 +1168,41 @@ mod tests {
         assert!(
             body.contains("__read0") && body.contains("__read1"),
             "each part is read into its own local:\n{body}"
+        );
+    }
+
+    /// A prelude that cannot fail leaves the conversion infallible.
+    ///
+    /// This is the whole difference between `PartRead::statements` and
+    /// `PartRead::fallible`, and the only place it is visible: both emit their
+    /// prelude, and only one makes the caller handle an error.
+    #[test]
+    fn an_infallible_prelude_leaves_the_chain_infallible() {
+        let plan = Product {
+            source: TypeRef::scalar(ScalarKind::I64),
+            direction: Direction::Construct,
+            source_policy: TestSource {
+                spells: Rc::new(Cell::new(0)),
+            },
+            bridge: TestBoundParts,
+            parts: vec![ProductPart {
+                name: format_ident!("only"),
+                child: TestChild::new("only", false, false),
+                mode: Mode::Owned,
+                hold_uninit: false,
+            }],
+        };
+
+        let rendered = plan.render(&RustWriter::for_test());
+        let body = rendered.body.to_token_stream().to_string();
+
+        assert!(
+            body.contains("let __bound0"),
+            "the prelude is emitted:\n{body}"
+        );
+        assert!(
+            !rendered.fallible,
+            "a prelude that cannot fail leaves the conversion infallible:\n{body}"
         );
     }
 
@@ -1298,6 +1357,63 @@ mod tests {
                 },
             ],
         }
+    }
+
+    /// A Choice arm reads its parts through the same bridge call, so a
+    /// fallible prelude lands inside the arm — after the arm value is bound,
+    /// and before the value that reads it.
+    ///
+    /// That ordering is what a whole-object sealed sum will rest on: each
+    /// alternative binds its own payload object first, then reads properties
+    /// off it.
+    #[test]
+    fn a_choice_arm_runs_its_part_prelude_after_binding_the_arm() {
+        let plan: Choice<TestSource, TupleChoice, TestFallibleParts, TestChild> = Choice {
+            source: TypeRef::scalar(ScalarKind::I64),
+            direction: Direction::Construct,
+            source_policy: TestSource {
+                spells: Rc::new(Cell::new(0)),
+            },
+            bridge: TupleChoice {
+                tag: syn::parse_quote!(i32),
+                arms: vec![syn::parse_quote!(()), syn::parse_quote!((i64,))],
+                tags: vec![syn::parse_quote!(0), syn::parse_quote!(1)],
+                inactive: vec![quote!(()), quote!((0,))],
+                invalid: quote!("invalid tag"),
+            },
+            arms: vec![
+                ChoiceArm {
+                    alternative: alternative(syn::parse_quote!(A), 0),
+                    tag: syn::parse_quote!(0),
+                    bridge: TestFallibleParts,
+                    parts: Vec::new(),
+                },
+                ChoiceArm {
+                    alternative: alternative(syn::parse_quote!(B(i64)), 1),
+                    tag: syn::parse_quote!(1),
+                    bridge: TestFallibleParts,
+                    parts: vec![ChoicePart {
+                        child: TestChild::new("decode", true, false),
+                        mode: Mode::Owned,
+                        hold_uninit: false,
+                    }],
+                },
+            ],
+        };
+
+        let body = plan
+            .render(&RustWriter::for_test())
+            .body
+            .to_token_stream()
+            .to_string();
+
+        let arm = body.find("let __arm").expect(&body);
+        let prelude = body.find("read_property").expect(&body);
+        let construction = body.find("i64 :: B").expect(&body);
+        assert!(
+            arm < prelude && prelude < construction,
+            "the arm binds, then its prelude runs, then the value is built:\n{body}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## What this changes

`ProductBridge::part` — how a bridge reads part *i* out of a Product's
intermediate value — returns one `TokenStream`. That is all a projection
needs: `TupleProduct` returns `(v).0`, C's mirror bridge returns `v.field`.

It is not all every representation needs. Reading a property off a JVM object
calls `env.get_field(..)`, which returns a `Result` and binds a local before
the value exists: statements, and fallible ones. A bridge that can only answer
with an expression cannot express that read at all, which is why
`JObjectStructInputPlan` performs its own walk today instead of composing a
`Product`.

`part` now returns a `PartRead`, which is one of three things:

| constructor | what it says |
|---|---|
| `PartRead::expression(value)` | the part is an expression; nothing runs first |
| `PartRead::statements(prelude, value)` | run `prelude` first; it cannot fail |
| `PartRead::fallible(prelude, value)` | run `prelude` first; it can fail |

The composer runs the preludes in part order, before the source value is
constructed, and a fallible read makes the whole conversion fallible — a
property no child converter has to have.

## What does not change

A bridge that reads by expression emits exactly what it emitted before: the
block appears only when there is a prelude to put in it. Both existing bridges
answer with `expression`, so no generated artifact moves.

Choice arms read their parts through the same call. They need no fallibility
of their own, and the code now says why: parts are read only when
constructing, and constructing a choice is already fallible, since an
unrecognized tag returns an error.

## Scope

This is vocabulary. No adapter changes behaviour, and nothing consumes the two
new constructors outside the tests yet — step 2 of #596 is what adopts them,
moving whole-object struct input onto a composed `Product`. Splitting it out
keeps that step about the walk rather than about the seam it needs.

`ProductBridge::build` keeps its expression-only signature. Step 3 (whole-object
output, where the intermediate is built by calling a Kotlin factory) is the one
that will need the same treatment there, and it can state its own need rather
than have this step guess at it.

## Verification

Workspace tests, strict Clippy, `cargo fmt --check` and
`RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps` pass. Every
generated artifact — C bindings, C headers, JNI Rust, Kotlin — is byte-for-byte
unchanged.

Two registry tests hold the new behaviour, over a fixture bridge whose read
binds a local and can fail:

- `a_fallible_part_read_runs_before_construction_and_makes_the_chain_fallible`
  — the reads precede the constructor, each part gets its own local, and the
  chain reports fallible although both children are infallible.
- `an_expression_part_read_adds_no_prelude` — the `TupleProduct` path emits no
  block, which is what keeps the existing output identical.

Step 1 of #596.

— Claude Code (Opus 5)
