### PR TITLE
Compose the nullable whole-object property's optional layer

### DIFF
--- a/examples/covertest-kotlin/src/generated_bindings.rs
+++ b/examples/covertest-kotlin/src/generated_bindings.rs
@@ -617,18 +617,26 @@ pub(crate) unsafe fn __jni_in_convert_wire_to_Annotated_152537b2916e97e3<'env, '
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("Annotated.priority: {}", e)))?;
-        let priority = if __priority_jobj.is_null() {
-            ::core::option::Option::None
-        } else {
-            let __priority_raw: jni::sys::jint = env
-                .call_method(&__priority_jobj, "getValue", "()I", &[])
-                .and_then(|val| val.i())
-                .map_err(|e| <__JniErr as ::core::convert::From<
-                    String,
-                >>::from(format!("Annotated.priority: {}", e)))?;
-            ::core::option::Option::Some(
-                __jni_in_convert_wire_to_Priority_2f3eb78aa92f8bfd(env, &__priority_raw)?,
-            )
+        let priority = {
+            let v = __priority_jobj;
+            {
+                if v.is_null() {
+                    ::core::option::Option::None
+                } else {
+                    let __present = env
+                        .call_method(&v, "getValue", "()I", &[])
+                        .and_then(|val| val.i())
+                        .map_err(|e| <__JniErr as ::core::convert::From<
+                            String,
+                        >>::from(format!("Annotated.priority: {}", e)))?;
+                    ::core::option::Option::Some(
+                        __jni_in_convert_wire_to_Priority_2f3eb78aa92f8bfd(
+                            env,
+                            &__present,
+                        )?,
+                    )
+                }
+            }
         };
         perftest_flat::Annotated {
             payload,
@@ -714,19 +722,24 @@ pub(crate) unsafe fn __jni_in_convert_wire_to_DurationBoundary_3fd44c1cbdf7cf69<
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("DurationBoundary.delay: {}", e)))?;
-        let delay = if __delay_jobj.is_null() {
-            ::core::option::Option::None
-        } else {
-            let __delay_raw: jni::sys::jlong = env
-                .call_method(&__delay_jobj, "unbox-impl", "()J", &[])
-                .and_then(|val| val.j())
-                .map_err(|e| <__JniErr as ::core::convert::From<
-                    String,
-                >>::from(format!("DurationBoundary.delay: {}", e)))?;
-            __jni_in_convert_wire_to_Option_Duration_jni_optional_intermediate_input_niche_104bdfd3431d40b9(
-                env,
-                &__delay_raw,
-            )?
+        let delay = {
+            let v = __delay_jobj;
+            {
+                if v.is_null() {
+                    ::core::option::Option::None
+                } else {
+                    let __present = env
+                        .call_method(&v, "unbox-impl", "()J", &[])
+                        .and_then(|val| val.j())
+                        .map_err(|e| <__JniErr as ::core::convert::From<
+                            String,
+                        >>::from(format!("DurationBoundary.delay: {}", e)))?;
+                    __jni_in_convert_wire_to_Option_Duration_jni_optional_intermediate_input_niche_104bdfd3431d40b9(
+                        env,
+                        &__present,
+                    )?
+                }
+            }
         };
         perftest_flat::DurationBoundary {
             required,
@@ -1471,18 +1484,23 @@ pub(crate) unsafe fn __jni_in_convert_wire_to_Unsigned_802dffd3a2dd4ecb<'env, 'v
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("Unsigned.maybeLong: {}", e)))?;
-        let maybe_long = if __maybe_long_jobj.is_null() {
-            ::core::option::Option::None
-        } else {
-            let __maybe_long_raw: jni::sys::jlong = env
-                .call_method(&__maybe_long_jobj, "unbox-impl", "()J", &[])
-                .and_then(|val| val.j())
-                .map_err(|e| <__JniErr as ::core::convert::From<
-                    String,
-                >>::from(format!("Unsigned.maybeLong: {}", e)))?;
-            ::core::option::Option::Some(
-                __jni_in_convert_wire_to_u64_8507143745dc33b9(env, &__maybe_long_raw)?,
-            )
+        let maybe_long = {
+            let v = __maybe_long_jobj;
+            {
+                if v.is_null() {
+                    ::core::option::Option::None
+                } else {
+                    let __present = env
+                        .call_method(&v, "unbox-impl", "()J", &[])
+                        .and_then(|val| val.j())
+                        .map_err(|e| <__JniErr as ::core::convert::From<
+                            String,
+                        >>::from(format!("Unsigned.maybeLong: {}", e)))?;
+                    ::core::option::Option::Some(
+                        __jni_in_convert_wire_to_u64_8507143745dc33b9(env, &__present)?,
+                    )
+                }
+            }
         };
         perftest_flat::Unsigned {
             byte,
@@ -4404,21 +4422,26 @@ pub(crate) unsafe fn __jni_in_convert_wire_to_Marker_93f2fabe59a4f80d<'env, 'v>(
                     .map_err(|e| <__JniErr as ::core::convert::From<
                         String,
                     >>::from(format!("Marker.Ranked.v0: {}", e)))?;
-                let __p_v0 = if __p_v0_obj.is_null() {
-                    ::core::option::Option::None
-                } else {
-                    let __p_v0_raw: jni::sys::jint = env
-                        .call_method(&__p_v0_obj, "getValue", "()I", &[])
-                        .and_then(|val| val.i())
-                        .map_err(|e| <__JniErr as ::core::convert::From<
-                            String,
-                        >>::from(format!("Marker.Ranked.v0: {}", e)))?;
-                    ::core::option::Option::Some(
-                        __jni_in_convert_wire_to_Priority_2f3eb78aa92f8bfd(
-                            env,
-                            &__p_v0_raw,
-                        )?,
-                    )
+                let __p_v0 = {
+                    let v = __p_v0_obj;
+                    {
+                        if v.is_null() {
+                            ::core::option::Option::None
+                        } else {
+                            let __present = env
+                                .call_method(&v, "getValue", "()I", &[])
+                                .and_then(|val| val.i())
+                                .map_err(|e| <__JniErr as ::core::convert::From<
+                                    String,
+                                >>::from(format!("Marker.Ranked.v0: {}", e)))?;
+                            ::core::option::Option::Some(
+                                __jni_in_convert_wire_to_Priority_2f3eb78aa92f8bfd(
+                                    env,
+                                    &__present,
+                                )?,
+                            )
+                        }
+                    }
                 };
                 return ::core::result::Result::Ok(perftest_flat::Marker::Ranked(__p_v0));
             }

--- a/prebindgen-jni/src/jni/chain.rs
+++ b/prebindgen-jni/src/jni/chain.rs
@@ -1180,6 +1180,17 @@ impl JPipeline {
     /// `env` is already the borrowed `JNIEnv` rather than an owned wrapper
     /// parameter. Whole-object property plans use this to retain child chains
     /// without retaining their generated Rust expressions.
+    /// The child converter this pipeline invokes.
+    ///
+    /// A whole-object property is decoded by one child; the transient
+    /// Vec-handle site ABI is a parameter-only shape and never reaches here.
+    pub(crate) fn converter_child(&self) -> &JChild {
+        let JPipelineBody::Converter(child) = &self.body else {
+            unreachable!("a whole-object property cannot use the transient Vec-handle site ABI")
+        };
+        child
+    }
+
     pub(crate) fn invoke_converter(
         &self,
         env: TokenStream,

--- a/prebindgen-jni/src/jni/emit/flat_input.rs
+++ b/prebindgen-jni/src/jni/emit/flat_input.rs
@@ -51,8 +51,117 @@ impl JObjectStructFieldKind {
             | Self::Primitive { pipeline, .. }
             | Self::IntoObject { pipeline, .. }
             | Self::Object { pipeline, .. } => pipeline.calls(out),
+            Self::Nullable(plan) => plan.chain.child.calls(out),
         }
     }
+}
+
+/// The null-reference `Optional` layer a nullable whole-object property
+/// crosses as.
+///
+/// A `ULong?` property arrives as a boxed `kotlin.ULong` and a nullable enum
+/// class as its own class: absence is a null reference, and the value is one
+/// unboxing call away. The registry composes the layer; this supplies the two
+/// answers only JniGen can give — how to test absence, and how to unbox.
+#[derive(Clone)]
+struct JNullableProperty {
+    /// JVM method that unboxes the property, its signature, and the `JValue`
+    /// accessor for the result.
+    method: &'static str,
+    signature: &'static str,
+    accessor: syn::Ident,
+    /// Per-property error text.
+    error: String,
+    /// Whether the child already yields the optional, because its own wire
+    /// carries a niche encoding of absence. Then a non-null reference is not
+    /// yet a value: the child still has to read its sentinel.
+    flattens: bool,
+}
+
+impl prebindgen_registry::chain::OptionalBridge for JNullableProperty {
+    fn intermediate(&self) -> syn::Type {
+        syn::parse_quote!(jni::objects::JObject)
+    }
+
+    fn is_absent(&self) -> TokenStream {
+        quote!(v.is_null())
+    }
+
+    fn present(&self, value: TokenStream) -> TokenStream {
+        let (method, signature, accessor, error) =
+            (self.method, self.signature, &self.accessor, &self.error);
+        // The accessor already yields the wire type, so the composer's own
+        // binding needs no annotation of its own.
+        quote!(
+            env.call_method(&#value, #method, #signature, &[])
+                .and_then(|val| val.#accessor())
+                .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(
+                    format!(#error, e)
+                ))?
+        )
+    }
+
+    fn source_present(&self, child: TokenStream) -> TokenStream {
+        if self.flattens {
+            child
+        } else {
+            quote!(::core::option::Option::Some(#child))
+        }
+    }
+
+    fn build_absent(&self) -> TokenStream {
+        unreachable!("a whole-object property is decoded, never encoded")
+    }
+
+    fn build_present(&self, _child: TokenStream) -> TokenStream {
+        unreachable!("a whole-object property is decoded, never encoded")
+    }
+}
+
+/// One nullable property: the reference fetched off the JVM object, and the
+/// registry-composed `Optional` that turns it into the source value.
+#[derive(Clone)]
+struct JNullablePlan {
+    descriptor: String,
+    chain: Box<
+        prebindgen_registry::chain::Optional<
+            crate::jni::chain::JSource,
+            JNullableProperty,
+            crate::jni::chain::JChild,
+        >,
+    >,
+}
+
+/// Compose one nullable property's `Optional` layer over its child converter.
+#[allow(clippy::too_many_arguments)]
+fn nullable_property(
+    reading: &TypeRef,
+    pipeline: crate::jni::chain::JPipeline,
+    descriptor: String,
+    method: &'static str,
+    signature: &'static str,
+    accessor: syn::Ident,
+    error: String,
+    flattens: bool,
+) -> JObjectStructFieldKind {
+    JObjectStructFieldKind::Nullable(Box::new(JNullablePlan {
+        descriptor,
+        chain: Box::new(prebindgen_registry::chain::Optional {
+            source: reading.clone(),
+            direction: prebindgen_registry::recipe::Direction::Construct,
+            source_policy: crate::jni::chain::JSource {
+                wrappers: Vec::new(),
+            },
+            bridge: JNullableProperty {
+                method,
+                signature,
+                accessor,
+                error,
+                flattens,
+            },
+            child: pipeline.converter_child().clone(),
+        }),
+    }))
 }
 
 #[derive(Clone)]
@@ -62,15 +171,16 @@ enum JObjectStructFieldKind {
         pipeline: crate::jni::chain::JPipeline,
     },
     Unsigned64 {
-        optional: bool,
-        wrap_some: bool,
         pipeline: crate::jni::chain::JPipeline,
     },
     Enum {
         descriptor: String,
-        optional: bool,
         pipeline: crate::jni::chain::JPipeline,
     },
+    /// A property whose absence is a null reference: either shape above, when
+    /// the source reads optional. Its `Optional` layer is composed by the
+    /// registry rather than walked here.
+    Nullable(Box<JNullablePlan>),
     Primitive {
         wire: syn::Type,
         descriptor: String,
@@ -148,18 +258,30 @@ fn build_jobject_property_plan(
                 projection.strategy,
                 FoldStrategy::Optional(NullableKind::Niche, _)
             );
-        let pipeline = if optional && !niche {
-            ext.in_frag(inner)?.pipeline(
-                prebindgen_registry::recipe::Direction::Construct,
-                prebindgen_registry::recipe::Mode::Owned,
+        if optional {
+            // A niche-encoded child reads its own absence out of the unboxed
+            // value, so the null reference is only the first of two tests and
+            // the child's answer is the whole answer.
+            let pipeline = if niche {
+                whole
+            } else {
+                ext.in_frag(inner)?.pipeline(
+                    prebindgen_registry::recipe::Direction::Construct,
+                    prebindgen_registry::recipe::Mode::Owned,
+                )
+            };
+            nullable_property(
+                reading,
+                pipeline,
+                "Lkotlin/ULong;".to_string(),
+                "unbox-impl",
+                "()J",
+                format_ident!("j"),
+                error.clone(),
+                niche,
             )
         } else {
-            whole
-        };
-        JObjectStructFieldKind::Unsigned64 {
-            optional,
-            wrap_some: optional && !niche,
-            pipeline,
+            JObjectStructFieldKind::Unsigned64 { pipeline: whole }
         }
     } else if ext.is_kotlin_enum_reading(inner) {
         let fqn = match inner.unwrapped().kind() {
@@ -167,18 +289,27 @@ fn build_jobject_property_plan(
             _ => None,
         }
         .and_then(|ident| ext.kotlin_fqn(&TypeKey::from_ident(&ident)))?;
-        let pipeline = if optional {
-            ext.in_frag(inner)?.pipeline(
+        let descriptor = format!("L{};", fqn.replace('.', "/"));
+        if optional {
+            let pipeline = ext.in_frag(inner)?.pipeline(
                 prebindgen_registry::recipe::Direction::Construct,
                 prebindgen_registry::recipe::Mode::Owned,
+            );
+            nullable_property(
+                reading,
+                pipeline,
+                descriptor,
+                "getValue",
+                "()I",
+                format_ident!("i"),
+                error.clone(),
+                false,
             )
         } else {
-            whole
-        };
-        JObjectStructFieldKind::Enum {
-            descriptor: format!("L{};", fqn.replace('.', "/")),
-            optional,
-            pipeline,
+            JObjectStructFieldKind::Enum {
+                descriptor,
+                pipeline: whole,
+            }
         }
     } else {
         match jni_field_access(&wire) {
@@ -291,73 +422,46 @@ impl JObjectStructFieldPlan {
                     let #name = #decode;
                 }
             }
-            JObjectStructFieldKind::Unsigned64 {
-                optional,
-                wrap_some,
-                pipeline,
-            } => {
+            JObjectStructFieldKind::Unsigned64 { pipeline } => {
                 let decode = pipeline.invoke_converter(quote!(env), quote!(#raw), name, emit);
-                if *optional {
-                    let decoded = if *wrap_some {
-                        quote!(::core::option::Option::Some(#decode))
-                    } else {
-                        quote!(#decode)
-                    };
-                    quote! {
-                        let #object: jni::objects::JObject = env
-                            .get_field(#receiver, #property, "Lkotlin/ULong;")
-                            .and_then(|val| val.l())
-                            .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(format!(#error, e)))?;
-                        let #name = if #object.is_null() {
-                            ::core::option::Option::None
-                        } else {
-                            let #raw: jni::sys::jlong = env
-                                .call_method(&#object, "unbox-impl", "()J", &[])
-                                .and_then(|val| val.j())
-                                .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(format!(#error, e)))?;
-                            #decoded
-                        };
-                    }
-                } else {
-                    quote! {
-                        let #raw: jni::sys::jlong = env
-                            .get_field(#receiver, #property, "J")
-                            .and_then(|val| val.j())
-                            .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(format!(#error, e)))?;
-                        let #name = #decode;
-                    }
+                quote! {
+                    let #raw: jni::sys::jlong = env
+                        .get_field(#receiver, #property, "J")
+                        .and_then(|val| val.j())
+                        .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(format!(#error, e)))?;
+                    let #name = #decode;
                 }
             }
             JObjectStructFieldKind::Enum {
                 descriptor,
-                optional,
                 pipeline,
             } => {
                 let decode = pipeline.invoke_converter(quote!(env), quote!(#raw), name, emit);
-                if *optional {
-                    quote! {
-                        let #object: jni::objects::JObject = env.get_field(#receiver, #property, #descriptor)
-                            .and_then(|val| val.l())
-                            .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(format!(#error, e)))?;
-                        let #name = if #object.is_null() {
-                            ::core::option::Option::None
-                        } else {
-                            let #raw: jni::sys::jint = env.call_method(&#object, "getValue", "()I", &[])
-                                .and_then(|val| val.i())
-                                .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(format!(#error, e)))?;
-                            ::core::option::Option::Some(#decode)
-                        };
-                    }
-                } else {
-                    quote! {
-                        let #object: jni::objects::JObject = env.get_field(#receiver, #property, #descriptor)
-                            .and_then(|val| val.l())
-                            .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(format!(#error, e)))?;
-                        let #raw: jni::sys::jint = env.call_method(&#object, "getValue", "()I", &[])
-                            .and_then(|val| val.i())
-                            .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(format!(#error, e)))?;
-                        let #name = #decode;
-                    }
+                quote! {
+                    let #object: jni::objects::JObject = env.get_field(#receiver, #property, #descriptor)
+                        .and_then(|val| val.l())
+                        .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(format!(#error, e)))?;
+                    let #raw: jni::sys::jint = env.call_method(&#object, "getValue", "()I", &[])
+                        .and_then(|val| val.i())
+                        .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(format!(#error, e)))?;
+                    let #name = #decode;
+                }
+            }
+            // A nullable property: the reference is fetched here, and what it
+            // means — absent, or a value one unboxing call away — is decided
+            // by the registry-composed `Optional` layer.
+            JObjectStructFieldKind::Nullable(plan) => {
+                let descriptor = &plan.descriptor;
+                let optional =
+                    prebindgen_registry::chain::Chain::render(plan.chain.as_ref(), emit).body;
+                quote! {
+                    let #object: jni::objects::JObject = env.get_field(#receiver, #property, #descriptor)
+                        .and_then(|val| val.l())
+                        .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(format!(#error, e)))?;
+                    let #name = {
+                        let v = #object;
+                        #optional
+                    };
                 }
             }
             JObjectStructFieldKind::Primitive {

--- a/prebindgen-jni/src/jni/tests/values.rs
+++ b/prebindgen-jni/src/jni/tests/values.rs
@@ -787,8 +787,11 @@ fn flattened_field_composes_bounded_conversion_stages() {
     );
     assert!(rc.contains("__jni_in_stage_0_"), "{rust}");
     assert!(
-        rc.contains("__jni_in_convert_") && rc.contains("env,&__delay_raw"),
-        "whole-JObject input must invoke the complete optional Duration converter:\n{rust}"
+        rc.contains(
+            "__jni_in_convert_wire_to_Option_Duration_jni_optional_intermediate_input_niche"
+        ) && rc.contains("env,&__present"),
+        "whole-JObject input must invoke the complete optional Duration converter, on the \
+         value the composed Optional bound:\n{rust}"
     );
     assert!(
         rc.contains("let___delay:jni::sys::jlong=__jni_out_convert_")

--- a/prebindgen-jni/src/jni/tests/values.rs
+++ b/prebindgen-jni/src/jni/tests/values.rs
@@ -794,6 +794,11 @@ fn flattened_field_composes_bounded_conversion_stages() {
          value the composed Optional bound:\n{rust}"
     );
     assert!(
+        !rc.contains("Some(__jni_in_convert_wire_to_Option_Duration"),
+        "the niche converter already yields the Option, so the composed layer must pass its \
+         answer through rather than wrap it:\n{rust}"
+    );
+    assert!(
         rc.contains("let___delay:jni::sys::jlong=__jni_out_convert_")
             && rc.contains("\"(J)Lio/test/jni/Timed;\""),
         "whole-struct output must pass the niche as primitive jlong:\n{rust}"

--- a/prebindgen-registry/src/chain.rs
+++ b/prebindgen-registry/src/chain.rs
@@ -232,6 +232,18 @@ pub trait OptionalBridge: Clone {
 
     /// Construct the outbound representation of a converted present child.
     fn build_present(&self, child: TokenStream) -> TokenStream;
+
+    /// The source-side `Some` arm, given the converted child.
+    ///
+    /// The default wraps, which is what an optional layer normally is: the
+    /// child yields the value, and this layer decides whether there is one.
+    /// A bridge overrides it when its child **already** yields the optional —
+    /// a nullable property whose inner converter carries its own niche
+    /// encoding of absence tests two things, a null reference and then that
+    /// niche, and the second answer is the whole answer.
+    fn source_present(&self, child: TokenStream) -> TokenStream {
+        quote::quote!(::core::option::Option::Some(#child))
+    }
 }
 
 /// Registry-composed converter plan for an Optional recipe.
@@ -649,12 +661,13 @@ where
                 let absent = self.bridge.is_absent();
                 let present = self.bridge.present(quote::quote!(v));
                 let child = child_value(&self.child, quote::quote!(__present), emit);
+                let present_arm = self.bridge.source_present(child);
                 let canonical = quote::quote!({
                     if #absent {
                         ::core::option::Option::None
                     } else {
                         let __present = #present;
-                        ::core::option::Option::Some(#child)
+                        #present_arm
                     }
                 });
                 let built = self.source_policy.build(canonical);


### PR DESCRIPTION
## What this changes

A whole-object property is decoded by fetching it off the JVM object and
calling one child converter — for ten of the twelve property kinds. Two were
different: a nullable `ULong` and a nullable enum class tested the null
reference in the walk, unboxed it there, and decided in the walk whether the
child's result should be wrapped in `Some`.

That split the conversion between the child and the traversal around it, and it
is the reason step 2b could not simply lift the walk into a `Product`: a part's
child has to be the whole conversion of that part.

The layer those two kinds were open-coding is an `Optional`, so the registry
composes it now. `JNullableProperty` supplies the two answers only JniGen can
give:

- absence is a null reference — `is_absent` is `v.is_null()`;
- the value is one unboxing call away — `present` is `unbox-impl`/`getValue`.

The walk fetches the reference and hands it to the composed layer. Every
whole-object property is now fetch-then-child.

## One registry addition, with both its consumers here

A nullable `ULong` whose inner converter carries a **niche** encoding of
absence tests absence twice: the null reference first, then the sentinel inside
the unboxed value. Its child therefore yields the optional already, and
wrapping that in `Some` would produce `Option<Option<T>>`.

`OptionalBridge::source_present` is where a bridge says so. It defaults to
wrapping — that is what an optional layer normally is, the child yields the
value and the layer decides whether there is one — and the niche bridge
overrides it to pass the child's answer through. Both callers are in this PR:
the wrapping shape and the flattening one.

## Generated output changes

For these two property kinds only, and in shape rather than meaning:

```rust
// before
let priority = if __priority_jobj.is_null() {
    None
} else {
    let __priority_raw: jni::sys::jint = env.call_method(..)?;
    Some(__jni_in_convert_wire_to_Priority_..(env, &__priority_raw)?)
};

// after
let priority = {
    let v = __priority_jobj;
    { if v.is_null() { None } else {
        let __present = env.call_method(..)?;
        Some(__jni_in_convert_wire_to_Priority_..(env, &__present)?)
    } }
};
```

The value the child converts is bound as `__present` by the composer rather
than as a per-property local, and the block is what keeps `v` — the composer's
input name — local to the property. The niche case still calls the whole
`Option<T>` converter with no wrapper, as it did.

Everything else in the generated file is unchanged: 75 added and 52 removed
lines, all inside the four decodes of the two nullable shapes.

## Verification

Workspace tests, strict Clippy, `cargo fmt --check` and
`RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps` pass.

`covertest-kotlin` passes its **61 sections on the JVM**, which is the evidence
this step needs: both nullable shapes are declared there — `Annotated.priority`
is the wrapping enum, `DurationBoundary.delay` the flattening niche — so the
decodes are executed, not merely compiled.

`flattened_field_composes_bounded_conversion_stages` keeps what it pinned — that
whole-object input invokes the *complete* optional `Duration` converter — and
now names the composed binding it is called with, rather than the per-property
local that no longer exists.

Step 2a of #596.

— Claude Code (Opus 5)
