### PR TITLE
Compose the whole-object struct decode

### DIFF
--- a/examples/covertest-kotlin/src/generated_bindings.rs
+++ b/examples/covertest-kotlin/src/generated_bindings.rs
@@ -587,62 +587,58 @@ pub(crate) unsafe fn __jni_in_convert_wire_to_Annotated_152537b2916e97e3<'env, '
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("Annotated.payload: {}", e)))?;
-        let payload = __jni_in_convert_wire_to_Payload_7e701167233e784f(
-            env,
-            &__payload_raw,
-        )?;
         let __alternate_raw: jni::objects::JObject = env
             .get_field(v, "alternate", "Lio/prebindgen/covertest/Payload;")
             .and_then(|val| val.l())
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("Annotated.alternate: {}", e)))?;
-        let alternate = __jni_in_convert_wire_to_Option_Payload_jni_optional_intermediate_input_niche_30b639591c34824b(
-            env,
-            &__alternate_raw,
-        )?;
         let __ttl_raw: jni::objects::JObject = env
             .get_field(v, "ttl", "Ljava/lang/Long;")
             .and_then(|val| val.l())
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("Annotated.ttl: {}", e)))?;
-        let ttl = __jni_in_convert_wire_to_Option_i64_jni_optional_intermediate_input_boxed_bebad25cf333cf7b(
-            env,
-            &__ttl_raw,
-        )?;
         let __priority_jobj: jni::objects::JObject = env
             .get_field(v, "priority", "Lio/prebindgen/covertest/model/Priority;")
             .and_then(|val| val.l())
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("Annotated.priority: {}", e)))?;
-        let priority = {
-            let v = __priority_jobj;
-            {
-                if v.is_null() {
-                    ::core::option::Option::None
-                } else {
-                    let __present = env
-                        .call_method(&v, "getValue", "()I", &[])
-                        .and_then(|val| val.i())
-                        .map_err(|e| <__JniErr as ::core::convert::From<
-                            String,
-                        >>::from(format!("Annotated.priority: {}", e)))?;
-                    ::core::option::Option::Some(
-                        __jni_in_convert_wire_to_Priority_2f3eb78aa92f8bfd(
-                            env,
-                            &__present,
-                        )?,
-                    )
-                }
-            }
-        };
         perftest_flat::Annotated {
-            payload,
-            alternate,
-            ttl,
-            priority,
+            payload: __jni_in_convert_wire_to_Payload_7e701167233e784f(
+                env,
+                &__payload_raw,
+            )?,
+            alternate: __jni_in_convert_wire_to_Option_Payload_jni_optional_intermediate_input_niche_30b639591c34824b(
+                env,
+                &__alternate_raw,
+            )?,
+            ttl: __jni_in_convert_wire_to_Option_i64_jni_optional_intermediate_input_boxed_bebad25cf333cf7b(
+                env,
+                &__ttl_raw,
+            )?,
+            priority: {
+                let v = __priority_jobj;
+                {
+                    if v.is_null() {
+                        ::core::option::Option::None
+                    } else {
+                        let __present = env
+                            .call_method(&v, "getValue", "()I", &[])
+                            .and_then(|val| val.i())
+                            .map_err(|e| <__JniErr as ::core::convert::From<
+                                String,
+                            >>::from(format!("Annotated.priority: {}", e)))?;
+                        ::core::option::Option::Some(
+                            __jni_in_convert_wire_to_Priority_2f3eb78aa92f8bfd(
+                                env,
+                                &__present,
+                            )?,
+                        )
+                    }
+                }
+            },
         }
     })
 }
@@ -702,48 +698,46 @@ pub(crate) unsafe fn __jni_in_convert_wire_to_DurationBoundary_3fd44c1cbdf7cf69<
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("DurationBoundary.required: {}", e)))?;
-        let required = {
-            let required_s0 = __jni_in_convert_wire_to_u64_8507143745dc33b9(
-                env,
-                &__required_raw,
-            )?;
-            let required_s1 = __jni_in_stage_0_wire_to_Duration_814bb872b19d3627(
-                    env,
-                    required_s0,
-                )
-                .map_err(|__e| <__JniErr as ::core::convert::From<
-                    String,
-                >>::from(__e.to_string()))?;
-            required_s1
-        };
         let __delay_jobj: jni::objects::JObject = env
             .get_field(v, "delay", "Lkotlin/ULong;")
             .and_then(|val| val.l())
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("DurationBoundary.delay: {}", e)))?;
-        let delay = {
-            let v = __delay_jobj;
-            {
-                if v.is_null() {
-                    ::core::option::Option::None
-                } else {
-                    let __present = env
-                        .call_method(&v, "unbox-impl", "()J", &[])
-                        .and_then(|val| val.j())
-                        .map_err(|e| <__JniErr as ::core::convert::From<
-                            String,
-                        >>::from(format!("DurationBoundary.delay: {}", e)))?;
-                    __jni_in_convert_wire_to_Option_Duration_jni_optional_intermediate_input_niche_104bdfd3431d40b9(
-                        env,
-                        &__present,
-                    )?
-                }
-            }
-        };
         perftest_flat::DurationBoundary {
-            required,
-            delay,
+            required: {
+                let __chain_s0 = __jni_in_convert_wire_to_u64_8507143745dc33b9(
+                    env,
+                    &__required_raw,
+                )?;
+                let __chain_s1 = __jni_in_stage_0_wire_to_Duration_814bb872b19d3627(
+                        env,
+                        __chain_s0,
+                    )
+                    .map_err(|__e| <__JniErr as ::core::convert::From<
+                        String,
+                    >>::from(__e.to_string()))?;
+                ::core::result::Result::<_, __JniErr>::Ok(__chain_s1)
+            }?,
+            delay: {
+                let v = __delay_jobj;
+                {
+                    if v.is_null() {
+                        ::core::option::Option::None
+                    } else {
+                        let __present = env
+                            .call_method(&v, "unbox-impl", "()J", &[])
+                            .and_then(|val| val.j())
+                            .map_err(|e| <__JniErr as ::core::convert::From<
+                                String,
+                            >>::from(format!("DurationBoundary.delay: {}", e)))?;
+                        __jni_in_convert_wire_to_Option_Duration_jni_optional_intermediate_input_niche_104bdfd3431d40b9(
+                            env,
+                            &__present,
+                        )?
+                    }
+                }
+            },
         }
     })
 }
@@ -829,23 +823,21 @@ pub(crate) unsafe fn __jni_in_convert_wire_to_ObjectBoundary_22ff055237fda473<'e
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("ObjectBoundary.left: {}", e)))?;
-        let left = __jni_in_convert_wire_to_ObjectBoundary64_9d95f2f133e7e0ab(
-            env,
-            &__left_raw,
-        )?;
         let __right_raw: jni::objects::JObject = env
             .get_field(v, "right", "Lio/prebindgen/covertest/model/ObjectBoundary63;")
             .and_then(|val| val.l())
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("ObjectBoundary.right: {}", e)))?;
-        let right = __jni_in_convert_wire_to_ObjectBoundary63_abd593b6b57968fd(
-            env,
-            &__right_raw,
-        )?;
         perftest_flat::ObjectBoundary {
-            left,
-            right,
+            left: __jni_in_convert_wire_to_ObjectBoundary64_9d95f2f133e7e0ab(
+                env,
+                &__left_raw,
+            )?,
+            right: __jni_in_convert_wire_to_ObjectBoundary63_abd593b6b57968fd(
+                env,
+                &__right_raw,
+            )?,
         }
     })
 }
@@ -911,28 +903,24 @@ pub(crate) unsafe fn __jni_in_convert_wire_to_Payload_7e701167233e784f<'env, 'v>
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("Payload.id: {}", e)))? as _;
-        let id = __jni_in_convert_wire_to_i64_da07d745d9e26f71(env, &__id_raw)?;
         let __seq_raw: jni::sys::jint = env
             .get_field(v, "seq", "I")
             .and_then(|val| val.i())
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("Payload.seq: {}", e)))? as _;
-        let seq = __jni_in_convert_wire_to_i32_83b133e23cc76fc5(env, &__seq_raw)?;
         let __value_raw: jni::sys::jdouble = env
             .get_field(v, "value", "D")
             .and_then(|val| val.d())
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("Payload.value: {}", e)))? as _;
-        let value = __jni_in_convert_wire_to_f64_b312e1b95182cdfd(env, &__value_raw)?;
         let __flag_raw: jni::sys::jboolean = env
             .get_field(v, "flag", "Z")
             .and_then(|val| val.z())
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("Payload.flag: {}", e)))? as _;
-        let flag = __jni_in_convert_wire_to_bool_1be2f6c32f925207(env, &__flag_raw)?;
         let __label_jobj: jni::objects::JObject = env
             .get_field(v, "label", "Ljava/lang/String;")
             .and_then(|val| val.l())
@@ -940,16 +928,15 @@ pub(crate) unsafe fn __jni_in_convert_wire_to_Payload_7e701167233e784f<'env, 'v>
                 String,
             >>::from(format!("Payload.label: {}", e)))?;
         let __label_raw: jni::objects::JString = __label_jobj.into();
-        let label = __jni_in_convert_wire_to_Option_Box_String_jni_optional_intermediate_input_niche_87b03b4201168b29(
-            env,
-            &__label_raw,
-        )?;
         perftest_flat::Payload {
-            id,
-            seq,
-            value,
-            flag,
-            label,
+            id: __jni_in_convert_wire_to_i64_da07d745d9e26f71(env, &__id_raw)?,
+            seq: __jni_in_convert_wire_to_i32_83b133e23cc76fc5(env, &__seq_raw)?,
+            value: __jni_in_convert_wire_to_f64_b312e1b95182cdfd(env, &__value_raw)?,
+            flag: __jni_in_convert_wire_to_bool_1be2f6c32f925207(env, &__flag_raw)?,
+            label: __jni_in_convert_wire_to_Option_Box_String_jni_optional_intermediate_input_niche_87b03b4201168b29(
+                env,
+                &__label_raw,
+            )?,
         }
     })
 }
@@ -1243,17 +1230,15 @@ pub(crate) unsafe fn __jni_in_convert_wire_to_Stamp_cccc3794c11688eb<'env, 'v>(
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("Stamp.secs: {}", e)))? as _;
-        let secs = __jni_in_convert_wire_to_i64_da07d745d9e26f71(env, &__secs_raw)?;
         let __nanos_raw: jni::sys::jlong = env
             .get_field(v, "nanos", "J")
             .and_then(|val| val.j())
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("Stamp.nanos: {}", e)))? as _;
-        let nanos = __jni_in_convert_wire_to_i64_da07d745d9e26f71(env, &__nanos_raw)?;
         perftest_flat::Stamp {
-            secs,
-            nanos,
+            secs: __jni_in_convert_wire_to_i64_da07d745d9e26f71(env, &__secs_raw)?,
+            nanos: __jni_in_convert_wire_to_i64_da07d745d9e26f71(env, &__nanos_raw)?,
         }
     })
 }
@@ -1456,58 +1441,56 @@ pub(crate) unsafe fn __jni_in_convert_wire_to_Unsigned_802dffd3a2dd4ecb<'env, 'v
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("Unsigned.byte: {}", e)))? as _;
-        let byte = __jni_in_convert_wire_to_u8_8a73e47df9fc7921(env, &__byte_raw)?;
         let __short_raw: jni::sys::jint = env
             .get_field(v, "short", "I")
             .and_then(|val| val.i())
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("Unsigned.short: {}", e)))? as _;
-        let short = __jni_in_convert_wire_to_u16_fc24f387ddcec321(env, &__short_raw)?;
         let __int_raw: jni::sys::jlong = env
             .get_field(v, "int", "J")
             .and_then(|val| val.j())
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("Unsigned.int: {}", e)))? as _;
-        let int = __jni_in_convert_wire_to_u32_25dff6d476799035(env, &__int_raw)?;
         let __long_raw: jni::sys::jlong = env
             .get_field(v, "long", "J")
             .and_then(|val| val.j())
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("Unsigned.long: {}", e)))?;
-        let long = __jni_in_convert_wire_to_u64_8507143745dc33b9(env, &__long_raw)?;
         let __maybe_long_jobj: jni::objects::JObject = env
             .get_field(v, "maybeLong", "Lkotlin/ULong;")
             .and_then(|val| val.l())
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("Unsigned.maybeLong: {}", e)))?;
-        let maybe_long = {
-            let v = __maybe_long_jobj;
-            {
-                if v.is_null() {
-                    ::core::option::Option::None
-                } else {
-                    let __present = env
-                        .call_method(&v, "unbox-impl", "()J", &[])
-                        .and_then(|val| val.j())
-                        .map_err(|e| <__JniErr as ::core::convert::From<
-                            String,
-                        >>::from(format!("Unsigned.maybeLong: {}", e)))?;
-                    ::core::option::Option::Some(
-                        __jni_in_convert_wire_to_u64_8507143745dc33b9(env, &__present)?,
-                    )
-                }
-            }
-        };
         perftest_flat::Unsigned {
-            byte,
-            short,
-            int,
-            long,
-            maybe_long,
+            byte: __jni_in_convert_wire_to_u8_8a73e47df9fc7921(env, &__byte_raw)?,
+            short: __jni_in_convert_wire_to_u16_fc24f387ddcec321(env, &__short_raw)?,
+            int: __jni_in_convert_wire_to_u32_25dff6d476799035(env, &__int_raw)?,
+            long: __jni_in_convert_wire_to_u64_8507143745dc33b9(env, &__long_raw)?,
+            maybe_long: {
+                let v = __maybe_long_jobj;
+                {
+                    if v.is_null() {
+                        ::core::option::Option::None
+                    } else {
+                        let __present = env
+                            .call_method(&v, "unbox-impl", "()J", &[])
+                            .and_then(|val| val.j())
+                            .map_err(|e| <__JniErr as ::core::convert::From<
+                                String,
+                            >>::from(format!("Unsigned.maybeLong: {}", e)))?;
+                        ::core::option::Option::Some(
+                            __jni_in_convert_wire_to_u64_8507143745dc33b9(
+                                env,
+                                &__present,
+                            )?,
+                        )
+                    }
+                }
+            },
         }
     })
 }
@@ -1859,7 +1842,6 @@ pub(crate) unsafe fn __jni_in_convert_wire_to_Arrays_0394c6e5ac3eb91d<'env, 'v>(
                 String,
             >>::from(format!("Arrays.bytes: {}", e)))?;
         let __bytes_raw: jni::objects::JByteArray = __bytes_jobj.into();
-        let bytes = __jni_in_convert_wire_to_u8_4_86a2b86806cb23e9(env, &__bytes_raw)?;
         let __shorts_jobj: jni::objects::JObject = env
             .get_field(v, "shorts", "[S")
             .and_then(|val| val.l())
@@ -1867,10 +1849,6 @@ pub(crate) unsafe fn __jni_in_convert_wire_to_Arrays_0394c6e5ac3eb91d<'env, 'v>(
                 String,
             >>::from(format!("Arrays.shorts: {}", e)))?;
         let __shorts_raw: jni::objects::JShortArray = __shorts_jobj.into();
-        let shorts = __jni_in_convert_wire_to_i16_2_018133ba02a34157(
-            env,
-            &__shorts_raw,
-        )?;
         let __ints_jobj: jni::objects::JObject = env
             .get_field(v, "ints", "[I")
             .and_then(|val| val.l())
@@ -1878,7 +1856,6 @@ pub(crate) unsafe fn __jni_in_convert_wire_to_Arrays_0394c6e5ac3eb91d<'env, 'v>(
                 String,
             >>::from(format!("Arrays.ints: {}", e)))?;
         let __ints_raw: jni::objects::JIntArray = __ints_jobj.into();
-        let ints = __jni_in_convert_wire_to_i32_3_8cd5d1633507beb7(env, &__ints_raw)?;
         let __longs_jobj: jni::objects::JObject = env
             .get_field(v, "longs", "[J")
             .and_then(|val| val.l())
@@ -1886,7 +1863,6 @@ pub(crate) unsafe fn __jni_in_convert_wire_to_Arrays_0394c6e5ac3eb91d<'env, 'v>(
                 String,
             >>::from(format!("Arrays.longs: {}", e)))?;
         let __longs_raw: jni::objects::JLongArray = __longs_jobj.into();
-        let longs = __jni_in_convert_wire_to_i64_2_cf35a75ca7b37f53(env, &__longs_raw)?;
         let __doubles_jobj: jni::objects::JObject = env
             .get_field(v, "doubles", "[D")
             .and_then(|val| val.l())
@@ -1894,10 +1870,6 @@ pub(crate) unsafe fn __jni_in_convert_wire_to_Arrays_0394c6e5ac3eb91d<'env, 'v>(
                 String,
             >>::from(format!("Arrays.doubles: {}", e)))?;
         let __doubles_raw: jni::objects::JDoubleArray = __doubles_jobj.into();
-        let doubles = __jni_in_convert_wire_to_f64_2_60cd70210ac4ab83(
-            env,
-            &__doubles_raw,
-        )?;
         let __flags_jobj: jni::objects::JObject = env
             .get_field(v, "flags", "[Z")
             .and_then(|val| val.l())
@@ -1905,7 +1877,6 @@ pub(crate) unsafe fn __jni_in_convert_wire_to_Arrays_0394c6e5ac3eb91d<'env, 'v>(
                 String,
             >>::from(format!("Arrays.flags: {}", e)))?;
         let __flags_raw: jni::objects::JBooleanArray = __flags_jobj.into();
-        let flags = __jni_in_convert_wire_to_bool_3_7afc83abc6385c11(env, &__flags_raw)?;
         let __raw_jobj: jni::objects::JObject = env
             .get_field(v, "raw", "[J")
             .and_then(|val| val.l())
@@ -1913,15 +1884,17 @@ pub(crate) unsafe fn __jni_in_convert_wire_to_Arrays_0394c6e5ac3eb91d<'env, 'v>(
                 String,
             >>::from(format!("Arrays.raw: {}", e)))?;
         let __raw_raw: jni::objects::JLongArray = __raw_jobj.into();
-        let raw = __jni_in_convert_wire_to_u64_2_fb06d7eda96c221b(env, &__raw_raw)?;
         perftest_flat::Arrays {
-            bytes,
-            shorts,
-            ints,
-            longs,
-            doubles,
-            flags,
-            raw,
+            bytes: __jni_in_convert_wire_to_u8_4_86a2b86806cb23e9(env, &__bytes_raw)?,
+            shorts: __jni_in_convert_wire_to_i16_2_018133ba02a34157(env, &__shorts_raw)?,
+            ints: __jni_in_convert_wire_to_i32_3_8cd5d1633507beb7(env, &__ints_raw)?,
+            longs: __jni_in_convert_wire_to_i64_2_cf35a75ca7b37f53(env, &__longs_raw)?,
+            doubles: __jni_in_convert_wire_to_f64_2_60cd70210ac4ab83(
+                env,
+                &__doubles_raw,
+            )?,
+            flags: __jni_in_convert_wire_to_bool_3_7afc83abc6385c11(env, &__flags_raw)?,
+            raw: __jni_in_convert_wire_to_u64_2_fb06d7eda96c221b(env, &__raw_raw)?,
         }
     })
 }
@@ -2065,7 +2038,6 @@ pub(crate) unsafe fn __jni_in_convert_wire_to_BlobValue_bb484d67a0d3c3af<'env, '
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("BlobValue.stamp: {}", e)))?;
-        let stamp = __jni_in_convert_wire_to_Stamp_cccc3794c11688eb(env, &__stamp_raw)?;
         let __id_jobj: jni::objects::JObject = env
             .get_field(v, "id", "[B")
             .and_then(|val| val.l())
@@ -2073,21 +2045,19 @@ pub(crate) unsafe fn __jni_in_convert_wire_to_BlobValue_bb484d67a0d3c3af<'env, '
                 String,
             >>::from(format!("BlobValue.id: {}", e)))?;
         let __id_raw: jni::objects::JByteArray = __id_jobj.into();
-        let id = __jni_in_convert_wire_to_Vec_u8_80984e9556387695(env, &__id_raw)?;
         let __chunks_raw: jni::objects::JObject = env
             .get_field(v, "chunks", "Ljava/util/List;")
             .and_then(|val| val.l())
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("BlobValue.chunks: {}", e)))?;
-        let chunks = __jni_in_convert_wire_to_sequence_Vec_Vec_u8_6085b26606355944(
-            env,
-            &__chunks_raw,
-        )?;
         perftest_flat::BlobValue {
-            stamp,
-            id,
-            chunks,
+            stamp: __jni_in_convert_wire_to_Stamp_cccc3794c11688eb(env, &__stamp_raw)?,
+            id: __jni_in_convert_wire_to_Vec_u8_80984e9556387695(env, &__id_raw)?,
+            chunks: __jni_in_convert_wire_to_sequence_Vec_Vec_u8_6085b26606355944(
+                env,
+                &__chunks_raw,
+            )?,
         }
     })
 }
@@ -2699,20 +2669,18 @@ pub(crate) unsafe fn __jni_in_convert_wire_to_CacheConfig_cf33c287d7f35ae3<'env,
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("CacheConfig.replies: {}", e)))?;
-        let replies = __jni_in_convert_wire_to_RepliesConfig_7a81db0e8d2214ef(
-            env,
-            &__replies_raw,
-        )?;
         let __ttl_raw: jni::sys::jlong = env
             .get_field(v, "ttl", "J")
             .and_then(|val| val.j())
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("CacheConfig.ttl: {}", e)))? as _;
-        let ttl = __jni_in_convert_wire_to_i64_da07d745d9e26f71(env, &__ttl_raw)?;
         perftest_flat::CacheConfig {
-            replies,
-            ttl,
+            replies: __jni_in_convert_wire_to_RepliesConfig_7a81db0e8d2214ef(
+                env,
+                &__replies_raw,
+            )?,
+            ttl: __jni_in_convert_wire_to_i64_da07d745d9e26f71(env, &__ttl_raw)?,
         }
     })
 }
@@ -2788,20 +2756,18 @@ pub(crate) unsafe fn __jni_in_convert_wire_to_CallbackHolder_38c8a01137bd5e33<'e
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("CallbackHolder.tag: {}", e)))? as _;
-        let tag = __jni_in_convert_wire_to_i64_da07d745d9e26f71(env, &__tag_raw)?;
         let __token_raw: jni::objects::JObject = env
             .get_field(v, "token", "Ljava/lang/Object;")
             .and_then(|val| val.l())
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("CallbackHolder.token: {}", e)))?;
-        let token = __jni_in_convert_wire_to_CallbackToken_9b692010fd44b7e3(
-            env,
-            &__token_raw,
-        )?;
         perftest_flat::CallbackHolder {
-            tag,
-            token,
+            tag: __jni_in_convert_wire_to_i64_da07d745d9e26f71(env, &__tag_raw)?,
+            token: __jni_in_convert_wire_to_CallbackToken_9b692010fd44b7e3(
+                env,
+                &__token_raw,
+            )?,
         }
     })
 }
@@ -2927,12 +2893,11 @@ pub(crate) unsafe fn __jni_in_convert_wire_to_CallbackToken_9b692010fd44b7e3<'en
                     String,
                 >>::from(format!("CallbackToken.ingot: {}", e)))?
         };
-        let ingot = __jni_in_convert_wire_to_Ingot_jni_handle_codec_consume_input_b897008e06c95a05(
-            env,
-            &__ingot_raw,
-        )?;
         perftest_flat::CallbackToken {
-            ingot,
+            ingot: __jni_in_convert_wire_to_Ingot_jni_handle_codec_consume_input_b897008e06c95a05(
+                env,
+                &__ingot_raw,
+            )?,
         }
     })
 }
@@ -3105,11 +3070,12 @@ pub(crate) unsafe fn __jni_in_convert_wire_to_ConstArray_a949f4efa5050dbd<'env, 
                 String,
             >>::from(format!("ConstArray.bytes: {}", e)))?;
         let __bytes_raw: jni::objects::JByteArray = __bytes_jobj.into();
-        let bytes = __jni_in_convert_wire_to_u8_CONST_ARRAY_LEN_a01385174c7f0f63(
-            env,
-            &__bytes_raw,
-        )?;
-        cov_helpers::ConstArray { bytes }
+        cov_helpers::ConstArray {
+            bytes: __jni_in_convert_wire_to_u8_CONST_ARRAY_LEN_a01385174c7f0f63(
+                env,
+                &__bytes_raw,
+            )?,
+        }
     })
 }
 #[allow(
@@ -3197,20 +3163,15 @@ pub(crate) unsafe fn __jni_in_convert_wire_to_Dossier_5316a15bb0813dfb<'env, 'v>
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("Dossier.note: {}", e)))? as _;
-        let note = __jni_in_convert_wire_to_i64_da07d745d9e26f71(env, &__note_raw)?;
         let __holder_raw: jni::objects::JObject = env
             .get_field(v, "holder", "Lio/prebindgen/covertest/Holder;")
             .and_then(|val| val.l())
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("Dossier.holder: {}", e)))?;
-        let holder = __jni_in_convert_wire_to_Holder_e0a7dbed55dd2865(
-            env,
-            &__holder_raw,
-        )?;
         perftest_flat::Dossier {
-            note,
-            holder,
+            note: __jni_in_convert_wire_to_i64_da07d745d9e26f71(env, &__note_raw)?,
+            holder: __jni_in_convert_wire_to_Holder_e0a7dbed55dd2865(env, &__holder_raw)?,
         }
     })
 }
@@ -3542,19 +3503,19 @@ pub(crate) unsafe fn __jni_in_convert_wire_to_Hold_5a6747f2776b0f97<'env, 'v>(
                         String,
                     >>::from(format!("Hold.For.v0: {}", e)))? as _;
                 let __p_v0 = {
-                    let __p_v0_s0 = __jni_in_convert_wire_to_u64_8507143745dc33b9(
+                    let __chain_s0 = __jni_in_convert_wire_to_u64_8507143745dc33b9(
                         env,
                         &__p_v0_raw,
                     )?;
-                    let __p_v0_s1 = __jni_in_stage_0_wire_to_Duration_814bb872b19d3627(
+                    let __chain_s1 = __jni_in_stage_0_wire_to_Duration_814bb872b19d3627(
                             env,
-                            __p_v0_s0,
+                            __chain_s0,
                         )
                         .map_err(|__e| <__JniErr as ::core::convert::From<
                             String,
                         >>::from(__e.to_string()))?;
-                    __p_v0_s1
-                };
+                    ::core::result::Result::<_, __JniErr>::Ok(__chain_s1)
+                }?;
                 return ::core::result::Result::Ok(perftest_flat::Hold::For(__p_v0));
             }
             ::core::result::Result::Err(
@@ -3665,20 +3626,18 @@ pub(crate) unsafe fn __jni_in_convert_wire_to_HoldPolicy_eb93c1846b0d934b<'env, 
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("HoldPolicy.hold: {}", e)))?;
-        let hold = __jni_in_convert_wire_to_Hold_5a6747f2776b0f97(env, &__hold_raw)?;
         let __grace_raw: jni::objects::JObject = env
             .get_field(v, "grace", "Lio/prebindgen/covertest/model/Hold;")
             .and_then(|val| val.l())
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("HoldPolicy.grace: {}", e)))?;
-        let grace = __jni_in_convert_wire_to_Option_Hold_jni_optional_intermediate_input_niche_d1e632bbd99fbe2e(
-            env,
-            &__grace_raw,
-        )?;
         perftest_flat::HoldPolicy {
-            hold,
-            grace,
+            hold: __jni_in_convert_wire_to_Hold_5a6747f2776b0f97(env, &__hold_raw)?,
+            grace: __jni_in_convert_wire_to_Option_Hold_jni_optional_intermediate_input_niche_d1e632bbd99fbe2e(
+                env,
+                &__grace_raw,
+            )?,
         }
     })
 }
@@ -3835,7 +3794,6 @@ pub(crate) unsafe fn __jni_in_convert_wire_to_Holder_e0a7dbed55dd2865<'env, 'v>(
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("Holder.tag: {}", e)))? as _;
-        let tag = __jni_in_convert_wire_to_i64_da07d745d9e26f71(env, &__tag_raw)?;
         let __summary_jobj: jni::objects::JObject = env
             .get_field(v, "summary", "Lio/prebindgen/covertest/analytics/Summary;")
             .and_then(|val| val.l())
@@ -3851,13 +3809,12 @@ pub(crate) unsafe fn __jni_in_convert_wire_to_Holder_e0a7dbed55dd2865<'env, 'v>(
                     String,
                 >>::from(format!("Holder.summary: {}", e)))?
         };
-        let summary = __jni_in_convert_wire_to_Summary_jni_handle_codec_consume_input_a6c328c6a2331e58(
-            env,
-            &__summary_raw,
-        )?;
         perftest_flat::Holder {
-            tag,
-            summary,
+            tag: __jni_in_convert_wire_to_i64_da07d745d9e26f71(env, &__tag_raw)?,
+            summary: __jni_in_convert_wire_to_Summary_jni_handle_codec_consume_input_a6c328c6a2331e58(
+                env,
+                &__summary_raw,
+            )?,
         }
     })
 }
@@ -4515,7 +4472,6 @@ pub(crate) unsafe fn __jni_in_convert_wire_to_MaybeHolder_fcb77d18203824e3<'env,
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("MaybeHolder.tag: {}", e)))? as _;
-        let tag = __jni_in_convert_wire_to_i64_da07d745d9e26f71(env, &__tag_raw)?;
         let __summary_jobj: jni::objects::JObject = env
             .get_field(v, "summary", "Lio/prebindgen/covertest/analytics/Summary;")
             .and_then(|val| val.l())
@@ -4531,13 +4487,12 @@ pub(crate) unsafe fn __jni_in_convert_wire_to_MaybeHolder_fcb77d18203824e3<'env,
                     String,
                 >>::from(format!("MaybeHolder.summary: {}", e)))?
         };
-        let summary = __jni_in_convert_wire_to_Option_Summary_jni_optional_intermediate_input_niche_7efd102cd40f1e81(
-            env,
-            &__summary_raw,
-        )?;
         perftest_flat::MaybeHolder {
-            tag,
-            summary,
+            tag: __jni_in_convert_wire_to_i64_da07d745d9e26f71(env, &__tag_raw)?,
+            summary: __jni_in_convert_wire_to_Option_Summary_jni_optional_intermediate_input_niche_7efd102cd40f1e81(
+                env,
+                &__summary_raw,
+            )?,
         }
     })
 }
@@ -5579,23 +5534,21 @@ pub(crate) unsafe fn __jni_in_convert_wire_to_ObjectBoundary16_3944a3a904c1510d<
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("ObjectBoundary16.left: {}", e)))?;
-        let left = __jni_in_convert_wire_to_ObjectBoundary8_cca4b20df6695267(
-            env,
-            &__left_raw,
-        )?;
         let __right_raw: jni::objects::JObject = env
             .get_field(v, "right", "Lio/prebindgen/covertest/model/ObjectBoundary8;")
             .and_then(|val| val.l())
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("ObjectBoundary16.right: {}", e)))?;
-        let right = __jni_in_convert_wire_to_ObjectBoundary8_cca4b20df6695267(
-            env,
-            &__right_raw,
-        )?;
         perftest_flat::ObjectBoundary16 {
-            left,
-            right,
+            left: __jni_in_convert_wire_to_ObjectBoundary8_cca4b20df6695267(
+                env,
+                &__left_raw,
+            )?,
+            right: __jni_in_convert_wire_to_ObjectBoundary8_cca4b20df6695267(
+                env,
+                &__right_raw,
+            )?,
         }
     })
 }
@@ -5736,23 +5689,21 @@ pub(crate) unsafe fn __jni_in_convert_wire_to_ObjectBoundary2_a3195430eb031edb<'
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("ObjectBoundary2.left: {}", e)))?;
-        let left = __jni_in_convert_wire_to_ObjectBoundaryLeaf_3132a7517e2ab837(
-            env,
-            &__left_raw,
-        )?;
         let __right_raw: jni::objects::JObject = env
             .get_field(v, "right", "Lio/prebindgen/covertest/model/ObjectBoundaryLeaf;")
             .and_then(|val| val.l())
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("ObjectBoundary2.right: {}", e)))?;
-        let right = __jni_in_convert_wire_to_ObjectBoundaryLeaf_3132a7517e2ab837(
-            env,
-            &__right_raw,
-        )?;
         perftest_flat::ObjectBoundary2 {
-            left,
-            right,
+            left: __jni_in_convert_wire_to_ObjectBoundaryLeaf_3132a7517e2ab837(
+                env,
+                &__left_raw,
+            )?,
+            right: __jni_in_convert_wire_to_ObjectBoundaryLeaf_3132a7517e2ab837(
+                env,
+                &__right_raw,
+            )?,
         }
     })
 }
@@ -5826,23 +5777,21 @@ pub(crate) unsafe fn __jni_in_convert_wire_to_ObjectBoundary32_79abada03cc29a21<
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("ObjectBoundary32.left: {}", e)))?;
-        let left = __jni_in_convert_wire_to_ObjectBoundary16_3944a3a904c1510d(
-            env,
-            &__left_raw,
-        )?;
         let __right_raw: jni::objects::JObject = env
             .get_field(v, "right", "Lio/prebindgen/covertest/model/ObjectBoundary16;")
             .and_then(|val| val.l())
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("ObjectBoundary32.right: {}", e)))?;
-        let right = __jni_in_convert_wire_to_ObjectBoundary16_3944a3a904c1510d(
-            env,
-            &__right_raw,
-        )?;
         perftest_flat::ObjectBoundary32 {
-            left,
-            right,
+            left: __jni_in_convert_wire_to_ObjectBoundary16_3944a3a904c1510d(
+                env,
+                &__left_raw,
+            )?,
+            right: __jni_in_convert_wire_to_ObjectBoundary16_3944a3a904c1510d(
+                env,
+                &__right_raw,
+            )?,
         }
     })
 }
@@ -6063,23 +6012,21 @@ pub(crate) unsafe fn __jni_in_convert_wire_to_ObjectBoundary4_feb5834d3248e52f<'
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("ObjectBoundary4.left: {}", e)))?;
-        let left = __jni_in_convert_wire_to_ObjectBoundary2_a3195430eb031edb(
-            env,
-            &__left_raw,
-        )?;
         let __right_raw: jni::objects::JObject = env
             .get_field(v, "right", "Lio/prebindgen/covertest/model/ObjectBoundary2;")
             .and_then(|val| val.l())
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("ObjectBoundary4.right: {}", e)))?;
-        let right = __jni_in_convert_wire_to_ObjectBoundary2_a3195430eb031edb(
-            env,
-            &__right_raw,
-        )?;
         perftest_flat::ObjectBoundary4 {
-            left,
-            right,
+            left: __jni_in_convert_wire_to_ObjectBoundary2_a3195430eb031edb(
+                env,
+                &__left_raw,
+            )?,
+            right: __jni_in_convert_wire_to_ObjectBoundary2_a3195430eb031edb(
+                env,
+                &__right_raw,
+            )?,
         }
     })
 }
@@ -6163,67 +6110,61 @@ pub(crate) unsafe fn __jni_in_convert_wire_to_ObjectBoundary63_abd593b6b57968fd<
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("ObjectBoundary63.leaves32: {}", e)))?;
-        let leaves32 = __jni_in_convert_wire_to_ObjectBoundary32_79abada03cc29a21(
-            env,
-            &__leaves32_raw,
-        )?;
         let __leaves16_raw: jni::objects::JObject = env
             .get_field(v, "leaves16", "Lio/prebindgen/covertest/model/ObjectBoundary16;")
             .and_then(|val| val.l())
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("ObjectBoundary63.leaves16: {}", e)))?;
-        let leaves16 = __jni_in_convert_wire_to_ObjectBoundary16_3944a3a904c1510d(
-            env,
-            &__leaves16_raw,
-        )?;
         let __leaves8_raw: jni::objects::JObject = env
             .get_field(v, "leaves8", "Lio/prebindgen/covertest/model/ObjectBoundary8;")
             .and_then(|val| val.l())
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("ObjectBoundary63.leaves8: {}", e)))?;
-        let leaves8 = __jni_in_convert_wire_to_ObjectBoundary8_cca4b20df6695267(
-            env,
-            &__leaves8_raw,
-        )?;
         let __leaves4_raw: jni::objects::JObject = env
             .get_field(v, "leaves4", "Lio/prebindgen/covertest/model/ObjectBoundary4;")
             .and_then(|val| val.l())
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("ObjectBoundary63.leaves4: {}", e)))?;
-        let leaves4 = __jni_in_convert_wire_to_ObjectBoundary4_feb5834d3248e52f(
-            env,
-            &__leaves4_raw,
-        )?;
         let __leaves2_raw: jni::objects::JObject = env
             .get_field(v, "leaves2", "Lio/prebindgen/covertest/model/ObjectBoundary2;")
             .and_then(|val| val.l())
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("ObjectBoundary63.leaves2: {}", e)))?;
-        let leaves2 = __jni_in_convert_wire_to_ObjectBoundary2_a3195430eb031edb(
-            env,
-            &__leaves2_raw,
-        )?;
         let __leaf_raw: jni::objects::JObject = env
             .get_field(v, "leaf", "Lio/prebindgen/covertest/model/ObjectBoundaryLeaf;")
             .and_then(|val| val.l())
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("ObjectBoundary63.leaf: {}", e)))?;
-        let leaf = __jni_in_convert_wire_to_ObjectBoundaryLeaf_3132a7517e2ab837(
-            env,
-            &__leaf_raw,
-        )?;
         perftest_flat::ObjectBoundary63 {
-            leaves32,
-            leaves16,
-            leaves8,
-            leaves4,
-            leaves2,
-            leaf,
+            leaves32: __jni_in_convert_wire_to_ObjectBoundary32_79abada03cc29a21(
+                env,
+                &__leaves32_raw,
+            )?,
+            leaves16: __jni_in_convert_wire_to_ObjectBoundary16_3944a3a904c1510d(
+                env,
+                &__leaves16_raw,
+            )?,
+            leaves8: __jni_in_convert_wire_to_ObjectBoundary8_cca4b20df6695267(
+                env,
+                &__leaves8_raw,
+            )?,
+            leaves4: __jni_in_convert_wire_to_ObjectBoundary4_feb5834d3248e52f(
+                env,
+                &__leaves4_raw,
+            )?,
+            leaves2: __jni_in_convert_wire_to_ObjectBoundary2_a3195430eb031edb(
+                env,
+                &__leaves2_raw,
+            )?,
+            leaf: __jni_in_convert_wire_to_ObjectBoundaryLeaf_3132a7517e2ab837(
+                env,
+                &__leaf_raw,
+            )?,
         }
     })
 }
@@ -6668,23 +6609,21 @@ pub(crate) unsafe fn __jni_in_convert_wire_to_ObjectBoundary64_9d95f2f133e7e0ab<
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("ObjectBoundary64.left: {}", e)))?;
-        let left = __jni_in_convert_wire_to_ObjectBoundary32_79abada03cc29a21(
-            env,
-            &__left_raw,
-        )?;
         let __right_raw: jni::objects::JObject = env
             .get_field(v, "right", "Lio/prebindgen/covertest/model/ObjectBoundary32;")
             .and_then(|val| val.l())
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("ObjectBoundary64.right: {}", e)))?;
-        let right = __jni_in_convert_wire_to_ObjectBoundary32_79abada03cc29a21(
-            env,
-            &__right_raw,
-        )?;
         perftest_flat::ObjectBoundary64 {
-            left,
-            right,
+            left: __jni_in_convert_wire_to_ObjectBoundary32_79abada03cc29a21(
+                env,
+                &__left_raw,
+            )?,
+            right: __jni_in_convert_wire_to_ObjectBoundary32_79abada03cc29a21(
+                env,
+                &__right_raw,
+            )?,
         }
     })
 }
@@ -7149,23 +7088,21 @@ pub(crate) unsafe fn __jni_in_convert_wire_to_ObjectBoundary8_cca4b20df6695267<'
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("ObjectBoundary8.left: {}", e)))?;
-        let left = __jni_in_convert_wire_to_ObjectBoundary4_feb5834d3248e52f(
-            env,
-            &__left_raw,
-        )?;
         let __right_raw: jni::objects::JObject = env
             .get_field(v, "right", "Lio/prebindgen/covertest/model/ObjectBoundary4;")
             .and_then(|val| val.l())
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("ObjectBoundary8.right: {}", e)))?;
-        let right = __jni_in_convert_wire_to_ObjectBoundary4_feb5834d3248e52f(
-            env,
-            &__right_raw,
-        )?;
         perftest_flat::ObjectBoundary8 {
-            left,
-            right,
+            left: __jni_in_convert_wire_to_ObjectBoundary4_feb5834d3248e52f(
+                env,
+                &__left_raw,
+            )?,
+            right: __jni_in_convert_wire_to_ObjectBoundary4_feb5834d3248e52f(
+                env,
+                &__right_raw,
+            )?,
         }
     })
 }
@@ -7269,9 +7206,8 @@ pub(crate) unsafe fn __jni_in_convert_wire_to_ObjectBoundaryLeaf_3132a7517e2ab83
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("ObjectBoundaryLeaf.value: {}", e)))? as _;
-        let value = __jni_in_convert_wire_to_i64_da07d745d9e26f71(env, &__value_raw)?;
         perftest_flat::ObjectBoundaryLeaf {
-            value,
+            value: __jni_in_convert_wire_to_i64_da07d745d9e26f71(env, &__value_raw)?,
         }
     })
 }
@@ -7394,27 +7330,18 @@ pub(crate) unsafe fn __jni_in_convert_wire_to_Observation_32843a8b8dec0a4b<'env,
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("Observation.id: {}", e)))? as _;
-        let id = __jni_in_convert_wire_to_i64_da07d745d9e26f71(env, &__id_raw)?;
         let __reading_raw: jni::objects::JObject = env
             .get_field(v, "reading", "Lio/prebindgen/covertest/model/Reading;")
             .and_then(|val| val.l())
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("Observation.reading: {}", e)))?;
-        let reading = __jni_in_convert_wire_to_Reading_a358e65c0c39d007(
-            env,
-            &__reading_raw,
-        )?;
         let __fallback_raw: jni::objects::JObject = env
             .get_field(v, "fallback", "Lio/prebindgen/covertest/model/Reading;")
             .and_then(|val| val.l())
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("Observation.fallback: {}", e)))?;
-        let fallback = __jni_in_convert_wire_to_Option_Reading_jni_optional_intermediate_input_niche_edb3520bad0ebf25(
-            env,
-            &__fallback_raw,
-        )?;
         let __note_jobj: jni::objects::JObject = env
             .get_field(v, "note", "Ljava/lang/String;")
             .and_then(|val| val.l())
@@ -7422,15 +7349,20 @@ pub(crate) unsafe fn __jni_in_convert_wire_to_Observation_32843a8b8dec0a4b<'env,
                 String,
             >>::from(format!("Observation.note: {}", e)))?;
         let __note_raw: jni::objects::JString = __note_jobj.into();
-        let note = __jni_in_convert_wire_to_jni_text_codec_owned_40915aa02cf8d9ce(
-            env,
-            &__note_raw,
-        )?;
         perftest_flat::Observation {
-            id,
-            reading,
-            fallback,
-            note,
+            id: __jni_in_convert_wire_to_i64_da07d745d9e26f71(env, &__id_raw)?,
+            reading: __jni_in_convert_wire_to_Reading_a358e65c0c39d007(
+                env,
+                &__reading_raw,
+            )?,
+            fallback: __jni_in_convert_wire_to_Option_Reading_jni_optional_intermediate_input_niche_edb3520bad0ebf25(
+                env,
+                &__fallback_raw,
+            )?,
+            note: __jni_in_convert_wire_to_jni_text_codec_owned_40915aa02cf8d9ce(
+                env,
+                &__note_raw,
+            )?,
         }
     })
 }
@@ -9963,23 +9895,21 @@ pub(crate) unsafe fn __jni_in_convert_wire_to_RepliesConfig_7a81db0e8d2214ef<'en
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("RepliesConfig.priority: {}", e)))?;
-        let priority = __jni_in_convert_wire_to_Priority_2f3eb78aa92f8bfd(
-            env,
-            &__priority_raw,
-        )?;
         let __max_samples_raw: jni::sys::jlong = env
             .get_field(v, "maxSamples", "J")
             .and_then(|val| val.j())
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("RepliesConfig.maxSamples: {}", e)))? as _;
-        let max_samples = __jni_in_convert_wire_to_i64_da07d745d9e26f71(
-            env,
-            &__max_samples_raw,
-        )?;
         perftest_flat::RepliesConfig {
-            priority,
-            max_samples,
+            priority: __jni_in_convert_wire_to_Priority_2f3eb78aa92f8bfd(
+                env,
+                &__priority_raw,
+            )?,
+            max_samples: __jni_in_convert_wire_to_i64_da07d745d9e26f71(
+                env,
+                &__max_samples_raw,
+            )?,
         }
     })
 }
@@ -10325,20 +10255,15 @@ pub(crate) unsafe fn __jni_in_convert_wire_to_Tagged_279b04b60843d675<'env, 'v>(
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("Tagged.id: {}", e)))? as _;
-        let id = __jni_in_convert_wire_to_i64_da07d745d9e26f71(env, &__id_raw)?;
         let __marker_raw: jni::objects::JObject = env
             .get_field(v, "marker", "Lio/prebindgen/covertest/model/Marker;")
             .and_then(|val| val.l())
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("Tagged.marker: {}", e)))?;
-        let marker = __jni_in_convert_wire_to_Marker_93f2fabe59a4f80d(
-            env,
-            &__marker_raw,
-        )?;
         perftest_flat::Tagged {
-            id,
-            marker,
+            id: __jni_in_convert_wire_to_i64_da07d745d9e26f71(env, &__id_raw)?,
+            marker: __jni_in_convert_wire_to_Marker_93f2fabe59a4f80d(env, &__marker_raw)?,
         }
     })
 }
@@ -10896,20 +10821,18 @@ pub(crate) unsafe fn __jni_in_convert_wire_to_Verdict_21661560f50a2bdb<'env, 'v>
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("Verdict.id: {}", e)))? as _;
-        let id = __jni_in_convert_wire_to_i64_da07d745d9e26f71(env, &__id_raw)?;
         let __outcome_raw: jni::objects::JObject = env
             .get_field(v, "outcome", "Lio/prebindgen/covertest/model/Lookup;")
             .and_then(|val| val.l())
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("Verdict.outcome: {}", e)))?;
-        let outcome = __jni_in_convert_wire_to_Lookup_2fa8248a2de561a5(
-            env,
-            &__outcome_raw,
-        )?;
         perftest_flat::Verdict {
-            id,
-            outcome,
+            id: __jni_in_convert_wire_to_i64_da07d745d9e26f71(env, &__id_raw)?,
+            outcome: __jni_in_convert_wire_to_Lookup_2fa8248a2de561a5(
+                env,
+                &__outcome_raw,
+            )?,
         }
     })
 }
@@ -11051,27 +10974,18 @@ pub(crate) unsafe fn __jni_in_convert_wire_to_WrappedFields_34734732a60d048b<'en
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("WrappedFields.id: {}", e)))? as _;
-        let id = __jni_in_convert_wire_to_i64_da07d745d9e26f71(env, &__id_raw)?;
         let __boxed_raw: jni::objects::JObject = env
             .get_field(v, "boxed", "Ljava/lang/Long;")
             .and_then(|val| val.l())
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("WrappedFields.boxed: {}", e)))?;
-        let boxed = __jni_in_convert_wire_to_Box_Option_i64_jni_optional_intermediate_input_boxed_9c68bc2a7a3540b4(
-            env,
-            &__boxed_raw,
-        )?;
         let __plain_raw: jni::objects::JObject = env
             .get_field(v, "plain", "Ljava/lang/Long;")
             .and_then(|val| val.l())
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("WrappedFields.plain: {}", e)))?;
-        let plain = __jni_in_convert_wire_to_Option_i64_jni_optional_intermediate_input_boxed_bebad25cf333cf7b(
-            env,
-            &__plain_raw,
-        )?;
         let __boxed_enum_jobj: jni::objects::JObject = env
             .get_field(v, "boxedEnum", "Lio/prebindgen/covertest/model/Priority;")
             .and_then(|val| val.l())
@@ -11084,10 +10998,6 @@ pub(crate) unsafe fn __jni_in_convert_wire_to_WrappedFields_34734732a60d048b<'en
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("WrappedFields.boxedEnum: {}", e)))?;
-        let boxed_enum = __jni_in_convert_wire_to_Box_Priority_781460985a632f7e(
-            env,
-            &__boxed_enum_raw,
-        )?;
         let __plain_enum_jobj: jni::objects::JObject = env
             .get_field(v, "plainEnum", "Lio/prebindgen/covertest/model/Priority;")
             .and_then(|val| val.l())
@@ -11100,16 +11010,24 @@ pub(crate) unsafe fn __jni_in_convert_wire_to_WrappedFields_34734732a60d048b<'en
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("WrappedFields.plainEnum: {}", e)))?;
-        let plain_enum = __jni_in_convert_wire_to_Priority_2f3eb78aa92f8bfd(
-            env,
-            &__plain_enum_raw,
-        )?;
         perftest_flat::WrappedFields {
-            id,
-            boxed,
-            plain,
-            boxed_enum,
-            plain_enum,
+            id: __jni_in_convert_wire_to_i64_da07d745d9e26f71(env, &__id_raw)?,
+            boxed: __jni_in_convert_wire_to_Box_Option_i64_jni_optional_intermediate_input_boxed_9c68bc2a7a3540b4(
+                env,
+                &__boxed_raw,
+            )?,
+            plain: __jni_in_convert_wire_to_Option_i64_jni_optional_intermediate_input_boxed_bebad25cf333cf7b(
+                env,
+                &__plain_raw,
+            )?,
+            boxed_enum: __jni_in_convert_wire_to_Box_Priority_781460985a632f7e(
+                env,
+                &__boxed_enum_raw,
+            )?,
+            plain_enum: __jni_in_convert_wire_to_Priority_2f3eb78aa92f8bfd(
+                env,
+                &__plain_enum_raw,
+            )?,
         }
     })
 }

--- a/examples/perftest-kotlin/src/generated_bindings.rs
+++ b/examples/perftest-kotlin/src/generated_bindings.rs
@@ -405,23 +405,21 @@ pub(crate) unsafe fn __jni_in_convert_wire_to_ObjectBoundary64_9d95f2f133e7e0ab<
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("ObjectBoundary64.left: {}", e)))?;
-        let left = __jni_in_convert_wire_to_ObjectBoundary32_79abada03cc29a21(
-            env,
-            &__left_raw,
-        )?;
         let __right_raw: jni::objects::JObject = env
             .get_field(v, "right", "Lio/prebindgen/perftest/ObjectBoundary32;")
             .and_then(|val| val.l())
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("ObjectBoundary64.right: {}", e)))?;
-        let right = __jni_in_convert_wire_to_ObjectBoundary32_79abada03cc29a21(
-            env,
-            &__right_raw,
-        )?;
         perftest_flat::ObjectBoundary64 {
-            left,
-            right,
+            left: __jni_in_convert_wire_to_ObjectBoundary32_79abada03cc29a21(
+                env,
+                &__left_raw,
+            )?,
+            right: __jni_in_convert_wire_to_ObjectBoundary32_79abada03cc29a21(
+                env,
+                &__right_raw,
+            )?,
         }
     })
 }
@@ -452,23 +450,21 @@ pub(crate) unsafe fn __jni_in_convert_wire_to_ObjectBoundary64Object_3c7cf869ff4
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("ObjectBoundary64Object.left: {}", e)))?;
-        let left = __jni_in_convert_wire_to_ObjectBoundary32_79abada03cc29a21(
-            env,
-            &__left_raw,
-        )?;
         let __right_raw: jni::objects::JObject = env
             .get_field(v, "right", "Lio/prebindgen/perftest/ObjectBoundary32;")
             .and_then(|val| val.l())
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("ObjectBoundary64Object.right: {}", e)))?;
-        let right = __jni_in_convert_wire_to_ObjectBoundary32_79abada03cc29a21(
-            env,
-            &__right_raw,
-        )?;
         perftest_flat::ObjectBoundary64Object {
-            left,
-            right,
+            left: __jni_in_convert_wire_to_ObjectBoundary32_79abada03cc29a21(
+                env,
+                &__left_raw,
+            )?,
+            right: __jni_in_convert_wire_to_ObjectBoundary32_79abada03cc29a21(
+                env,
+                &__right_raw,
+            )?,
         }
     })
 }
@@ -534,28 +530,24 @@ pub(crate) unsafe fn __jni_in_convert_wire_to_Payload_7e701167233e784f<'env, 'v>
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("Payload.id: {}", e)))? as _;
-        let id = __jni_in_convert_wire_to_i64_da07d745d9e26f71(env, &__id_raw)?;
         let __seq_raw: jni::sys::jint = env
             .get_field(v, "seq", "I")
             .and_then(|val| val.i())
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("Payload.seq: {}", e)))? as _;
-        let seq = __jni_in_convert_wire_to_i32_83b133e23cc76fc5(env, &__seq_raw)?;
         let __value_raw: jni::sys::jdouble = env
             .get_field(v, "value", "D")
             .and_then(|val| val.d())
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("Payload.value: {}", e)))? as _;
-        let value = __jni_in_convert_wire_to_f64_b312e1b95182cdfd(env, &__value_raw)?;
         let __flag_raw: jni::sys::jboolean = env
             .get_field(v, "flag", "Z")
             .and_then(|val| val.z())
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("Payload.flag: {}", e)))? as _;
-        let flag = __jni_in_convert_wire_to_bool_1be2f6c32f925207(env, &__flag_raw)?;
         let __label_jobj: jni::objects::JObject = env
             .get_field(v, "label", "Ljava/lang/String;")
             .and_then(|val| val.l())
@@ -563,16 +555,15 @@ pub(crate) unsafe fn __jni_in_convert_wire_to_Payload_7e701167233e784f<'env, 'v>
                 String,
             >>::from(format!("Payload.label: {}", e)))?;
         let __label_raw: jni::objects::JString = __label_jobj.into();
-        let label = __jni_in_convert_wire_to_Option_Box_String_jni_optional_intermediate_input_niche_87b03b4201168b29(
-            env,
-            &__label_raw,
-        )?;
         perftest_flat::Payload {
-            id,
-            seq,
-            value,
-            flag,
-            label,
+            id: __jni_in_convert_wire_to_i64_da07d745d9e26f71(env, &__id_raw)?,
+            seq: __jni_in_convert_wire_to_i32_83b133e23cc76fc5(env, &__seq_raw)?,
+            value: __jni_in_convert_wire_to_f64_b312e1b95182cdfd(env, &__value_raw)?,
+            flag: __jni_in_convert_wire_to_bool_1be2f6c32f925207(env, &__flag_raw)?,
+            label: __jni_in_convert_wire_to_Option_Box_String_jni_optional_intermediate_input_niche_87b03b4201168b29(
+                env,
+                &__label_raw,
+            )?,
         }
     })
 }
@@ -914,23 +905,21 @@ pub(crate) unsafe fn __jni_in_convert_wire_to_ObjectBoundary16_3944a3a904c1510d<
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("ObjectBoundary16.left: {}", e)))?;
-        let left = __jni_in_convert_wire_to_ObjectBoundary8_cca4b20df6695267(
-            env,
-            &__left_raw,
-        )?;
         let __right_raw: jni::objects::JObject = env
             .get_field(v, "right", "Lio/prebindgen/perftest/ObjectBoundary8;")
             .and_then(|val| val.l())
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("ObjectBoundary16.right: {}", e)))?;
-        let right = __jni_in_convert_wire_to_ObjectBoundary8_cca4b20df6695267(
-            env,
-            &__right_raw,
-        )?;
         perftest_flat::ObjectBoundary16 {
-            left,
-            right,
+            left: __jni_in_convert_wire_to_ObjectBoundary8_cca4b20df6695267(
+                env,
+                &__left_raw,
+            )?,
+            right: __jni_in_convert_wire_to_ObjectBoundary8_cca4b20df6695267(
+                env,
+                &__right_raw,
+            )?,
         }
     })
 }
@@ -1103,23 +1092,21 @@ pub(crate) unsafe fn __jni_in_convert_wire_to_ObjectBoundary2_a3195430eb031edb<'
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("ObjectBoundary2.left: {}", e)))?;
-        let left = __jni_in_convert_wire_to_ObjectBoundaryLeaf_3132a7517e2ab837(
-            env,
-            &__left_raw,
-        )?;
         let __right_raw: jni::objects::JObject = env
             .get_field(v, "right", "Lio/prebindgen/perftest/ObjectBoundaryLeaf;")
             .and_then(|val| val.l())
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("ObjectBoundary2.right: {}", e)))?;
-        let right = __jni_in_convert_wire_to_ObjectBoundaryLeaf_3132a7517e2ab837(
-            env,
-            &__right_raw,
-        )?;
         perftest_flat::ObjectBoundary2 {
-            left,
-            right,
+            left: __jni_in_convert_wire_to_ObjectBoundaryLeaf_3132a7517e2ab837(
+                env,
+                &__left_raw,
+            )?,
+            right: __jni_in_convert_wire_to_ObjectBoundaryLeaf_3132a7517e2ab837(
+                env,
+                &__right_raw,
+            )?,
         }
     })
 }
@@ -1270,23 +1257,21 @@ pub(crate) unsafe fn __jni_in_convert_wire_to_ObjectBoundary32_79abada03cc29a21<
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("ObjectBoundary32.left: {}", e)))?;
-        let left = __jni_in_convert_wire_to_ObjectBoundary16_3944a3a904c1510d(
-            env,
-            &__left_raw,
-        )?;
         let __right_raw: jni::objects::JObject = env
             .get_field(v, "right", "Lio/prebindgen/perftest/ObjectBoundary16;")
             .and_then(|val| val.l())
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("ObjectBoundary32.right: {}", e)))?;
-        let right = __jni_in_convert_wire_to_ObjectBoundary16_3944a3a904c1510d(
-            env,
-            &__right_raw,
-        )?;
         perftest_flat::ObjectBoundary32 {
-            left,
-            right,
+            left: __jni_in_convert_wire_to_ObjectBoundary16_3944a3a904c1510d(
+                env,
+                &__left_raw,
+            )?,
+            right: __jni_in_convert_wire_to_ObjectBoundary16_3944a3a904c1510d(
+                env,
+                &__right_raw,
+            )?,
         }
     })
 }
@@ -1542,23 +1527,21 @@ pub(crate) unsafe fn __jni_in_convert_wire_to_ObjectBoundary4_feb5834d3248e52f<'
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("ObjectBoundary4.left: {}", e)))?;
-        let left = __jni_in_convert_wire_to_ObjectBoundary2_a3195430eb031edb(
-            env,
-            &__left_raw,
-        )?;
         let __right_raw: jni::objects::JObject = env
             .get_field(v, "right", "Lio/prebindgen/perftest/ObjectBoundary2;")
             .and_then(|val| val.l())
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("ObjectBoundary4.right: {}", e)))?;
-        let right = __jni_in_convert_wire_to_ObjectBoundary2_a3195430eb031edb(
-            env,
-            &__right_raw,
-        )?;
         perftest_flat::ObjectBoundary4 {
-            left,
-            right,
+            left: __jni_in_convert_wire_to_ObjectBoundary2_a3195430eb031edb(
+                env,
+                &__left_raw,
+            )?,
+            right: __jni_in_convert_wire_to_ObjectBoundary2_a3195430eb031edb(
+                env,
+                &__right_raw,
+            )?,
         }
     })
 }
@@ -2556,23 +2539,21 @@ pub(crate) unsafe fn __jni_in_convert_wire_to_ObjectBoundary8_cca4b20df6695267<'
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("ObjectBoundary8.left: {}", e)))?;
-        let left = __jni_in_convert_wire_to_ObjectBoundary4_feb5834d3248e52f(
-            env,
-            &__left_raw,
-        )?;
         let __right_raw: jni::objects::JObject = env
             .get_field(v, "right", "Lio/prebindgen/perftest/ObjectBoundary4;")
             .and_then(|val| val.l())
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("ObjectBoundary8.right: {}", e)))?;
-        let right = __jni_in_convert_wire_to_ObjectBoundary4_feb5834d3248e52f(
-            env,
-            &__right_raw,
-        )?;
         perftest_flat::ObjectBoundary8 {
-            left,
-            right,
+            left: __jni_in_convert_wire_to_ObjectBoundary4_feb5834d3248e52f(
+                env,
+                &__left_raw,
+            )?,
+            right: __jni_in_convert_wire_to_ObjectBoundary4_feb5834d3248e52f(
+                env,
+                &__right_raw,
+            )?,
         }
     })
 }
@@ -2701,9 +2682,8 @@ pub(crate) unsafe fn __jni_in_convert_wire_to_ObjectBoundaryLeaf_3132a7517e2ab83
             .map_err(|e| <__JniErr as ::core::convert::From<
                 String,
             >>::from(format!("ObjectBoundaryLeaf.value: {}", e)))? as _;
-        let value = __jni_in_convert_wire_to_i64_da07d745d9e26f71(env, &__value_raw)?;
         perftest_flat::ObjectBoundaryLeaf {
-            value,
+            value: __jni_in_convert_wire_to_i64_da07d745d9e26f71(env, &__value_raw)?,
         }
     })
 }

--- a/prebindgen-jni/src/jni/chain.rs
+++ b/prebindgen-jni/src/jni/chain.rs
@@ -1191,19 +1191,6 @@ impl JPipeline {
         child
     }
 
-    pub(crate) fn invoke_converter(
-        &self,
-        env: TokenStream,
-        value: TokenStream,
-        stage_base: &syn::Ident,
-        emit: &RustWriter,
-    ) -> TokenStream {
-        let JPipelineBody::Converter(child) = &self.body else {
-            unreachable!("a whole-object field cannot use the transient Vec-handle site ABI")
-        };
-        child.invoke_input_value_with_env(env, value, stage_base, emit)
-    }
-
     /// Render the already-planned call graph around `value`.
     pub(crate) fn invoke(&self, value: TokenStream, emit: &RustWriter) -> TokenStream {
         match &self.body {
@@ -1247,46 +1234,6 @@ impl JVecHandleInput {
 }
 
 impl JChild {
-    /// Render a constructing child as the value it yields inside an enclosing
-    /// converter. Unlike the ordinary chain API this consumes `Result` here,
-    /// because the enclosing function already owns the error channel. Stage
-    /// bindings are named by the property that owns them, preventing sibling
-    /// fields from colliding.
-    fn invoke_input_value_with_env(
-        &self,
-        env: TokenStream,
-        value: TokenStream,
-        stage_base: &syn::Ident,
-        emit: &RustWriter,
-    ) -> TokenStream {
-        assert_eq!(self.direction, Direction::Construct);
-        let converter = emit.operation_ident("jni", self.call.operation_id());
-        let value = match self.value_use {
-            JValueUse::Direct => value,
-            JValueUse::SharedRef => shared_ref(value),
-            JValueUse::Cloned => quote!((*#value).clone()),
-        };
-        let first = quote!(#converter(#env, #value));
-        if self.stages.is_empty() {
-            return quote!(#first?);
-        }
-        let first_name = format_ident!("{}_s0", stage_base);
-        let mut body = quote!(let #first_name = #first?;);
-        let mut previous = first_name;
-        for (index, stage) in self.stages.iter().enumerate() {
-            let stage = emit.operation_ident("jni", stage);
-            let next = format_ident!("{}_s{}", stage_base, index + 1);
-            body.extend(quote!(
-                let #next = #stage(#env, #previous)
-                    .map_err(|__e| <__JniErr as ::core::convert::From<String>>::from(
-                        __e.to_string()
-                    ))?;
-            ));
-            previous = next;
-        }
-        quote!({ #body #previous })
-    }
-
     /// Render this child in a context that supplies its own `JNIEnv` expression.
     /// Registry-composed converter bodies receive an `&mut JNIEnv` named
     /// `env`; exported wrappers own a mutable `JNIEnv` and pass `&mut env`.

--- a/prebindgen-jni/src/jni/emit/flat_input.rs
+++ b/prebindgen-jni/src/jni/emit/flat_input.rs
@@ -19,7 +19,6 @@ use crate::jni::trait_impl::build_through_erased_wrappers;
 #[derive(Clone)]
 pub(crate) struct JObjectStructInputPlan {
     shape: flat::Struct,
-    source_module: syn::Path,
     fields: Vec<JObjectStructFieldPlan>,
 }
 
@@ -115,6 +114,123 @@ impl prebindgen_registry::chain::OptionalBridge for JNullableProperty {
 
     fn build_present(&self, _child: TokenStream) -> TokenStream {
         unreachable!("a whole-object property is decoded, never encoded")
+    }
+}
+
+/// The source struct a whole-object decode builds, spelled through the shape
+/// the model holds.
+///
+/// A `data_class` is normally a named-field struct, and the registry's default
+/// construction is exactly that. A unit or tuple struct is not, and only the
+/// element knows which — so it travels with the policy that constructs it.
+#[derive(Clone)]
+struct JStructSource {
+    ordinary: crate::jni::chain::JSource,
+    shape: flat::Struct,
+}
+
+impl prebindgen_registry::chain::Source for JStructSource {
+    fn spell(&self, source: &TypeRef, emit: &prebindgen_registry::RustWriter) -> TokenStream {
+        prebindgen_registry::chain::Source::spell(&self.ordinary, source, emit)
+    }
+
+    fn build(&self, canonical: TokenStream) -> TokenStream {
+        prebindgen_registry::chain::Source::build(&self.ordinary, canonical)
+    }
+
+    fn construct(
+        &self,
+        head: TokenStream,
+        parts: &[(syn::Ident, TokenStream)],
+        emit: &prebindgen_registry::RustWriter,
+    ) -> TokenStream {
+        let bound: Vec<TokenStream> = self
+            .shape
+            .fields
+            .iter()
+            .zip(parts)
+            .map(|(field, (_, value))| field.bind(value))
+            .collect();
+        emit.shape_struct(&self.shape, head, &bound)
+    }
+}
+
+/// The JVM object a whole-object struct crosses as, read one property at a
+/// time.
+///
+/// This is the adapter half of the composed `Product`: the registry walks the
+/// struct's fields and builds the source value; this says what a part *is* —
+/// a property fetched off the object, which can fail.
+#[derive(Clone)]
+struct JObjectBridge {
+    properties: Vec<JObjectStructFieldPlan>,
+}
+
+impl prebindgen_registry::chain::ProductBridge for JObjectBridge {
+    fn intermediate(&self) -> syn::Type {
+        syn::parse_quote!(jni::objects::JObject)
+    }
+
+    fn part(
+        &self,
+        value: TokenStream,
+        index: usize,
+        _name: &syn::Ident,
+    ) -> prebindgen_registry::chain::PartRead {
+        let (prelude, value) = self.properties[index].read(value);
+        prebindgen_registry::chain::PartRead::fallible(prelude, value)
+    }
+
+    fn build(&self, _parts: &[(syn::Ident, TokenStream)]) -> TokenStream {
+        unreachable!("a whole-object struct is decoded, never encoded, through this bridge")
+    }
+}
+
+/// What converts one property once its wire value has been read.
+///
+/// Either the property's own child converter, or — for a nullable property —
+/// the `Optional` layer composed over it, which decides absence before the
+/// child is reached.
+#[derive(Clone)]
+pub(crate) struct JPropertyChild {
+    call: prebindgen_registry::chain::Call,
+    conversion: JPropertyConversion,
+}
+
+#[derive(Clone)]
+enum JPropertyConversion {
+    Converter(crate::jni::chain::JChild),
+    Nullable(
+        Box<
+            prebindgen_registry::chain::Optional<
+                crate::jni::chain::JSource,
+                JNullableProperty,
+                crate::jni::chain::JChild,
+            >,
+        >,
+    ),
+}
+
+impl prebindgen_registry::chain::Child for JPropertyChild {
+    fn call(&self) -> &prebindgen_registry::chain::Call {
+        &self.call
+    }
+
+    fn invoke(&self, value: TokenStream, emit: &prebindgen_registry::RustWriter) -> TokenStream {
+        match &self.conversion {
+            JPropertyConversion::Converter(child) => {
+                prebindgen_registry::chain::Child::invoke(child, value, emit)
+            }
+            // The composed layer names its input `v`, as every chain does, so
+            // the block is what keeps that name local to this property.
+            JPropertyConversion::Nullable(chain) => {
+                let body = prebindgen_registry::chain::Chain::render(chain.as_ref(), emit).body;
+                quote!({
+                    let v = #value;
+                    #body
+                })
+            }
+        }
     }
 }
 
@@ -217,9 +333,9 @@ pub(crate) fn build_jobject_struct_input_plan(
             ext, &field.ty, name, property, error, false,
         )?);
     }
+    let _ = registry;
     Some(JObjectStructInputPlan {
         shape: s.clone(),
-        source_module: struct_module_path(ext, registry, &s.name),
         fields,
     })
 }
@@ -369,26 +485,45 @@ fn build_jobject_property_plan(
 }
 
 impl JObjectStructInputPlan {
+    /// The decode, composed by the registry: it walks the struct's fields,
+    /// reads each part through [`JObjectBridge`], calls each property's
+    /// conversion, and builds the source value.
     pub(crate) fn render(&self, emit: &prebindgen_registry::RustWriter) -> syn::Expr {
-        let mut preludes = Vec::new();
-        let mut inits = Vec::new();
-        for field in &self.fields {
-            preludes.push(field.render(quote!(v), emit));
-            let name = &field.name;
-            inits.push(quote!(#name));
-        }
-        let module = &self.source_module;
-        let ident = &self.shape.name;
-        let ctor = emit.shape_struct(&self.shape, quote!(#module::#ident), &inits);
-        syn::parse_quote!({
-            #(#preludes)*
-            #ctor
-        })
+        let product = prebindgen_registry::chain::Product {
+            source: self.shape.type_ref().clone(),
+            direction: prebindgen_registry::recipe::Direction::Construct,
+            source_policy: JStructSource {
+                ordinary: crate::jni::chain::JSource {
+                    wrappers: Vec::new(),
+                },
+                shape: self.shape.clone(),
+            },
+            bridge: JObjectBridge {
+                properties: self.fields.clone(),
+            },
+            parts: self
+                .fields
+                .iter()
+                .map(|field| prebindgen_registry::chain::ProductPart {
+                    name: field.name.clone(),
+                    child: field.child(),
+                    mode: prebindgen_registry::recipe::Mode::Owned,
+                    hold_uninit: false,
+                })
+                .collect(),
+        };
+        let body = prebindgen_registry::chain::Chain::render(&product, emit).body;
+        syn::parse_quote!(#body)
     }
 }
 
 impl JObjectStructFieldPlan {
-    fn render(&self, receiver: TokenStream, emit: &prebindgen_registry::RustWriter) -> TokenStream {
+    /// The statements that read this property's wire value off `receiver`,
+    /// and the expression naming it.
+    ///
+    /// Every read can fail — a JVM field access returns a `Result` — which is
+    /// why the composed `Product` above takes this as a fallible part.
+    fn read(&self, receiver: TokenStream) -> (TokenStream, TokenStream) {
         let name = &self.name;
         let property = &self.property;
         let error = &self.error;
@@ -402,109 +537,123 @@ impl JObjectStructFieldPlan {
         } else {
             format_ident!("__{}_jobj", name)
         };
-        match &self.kind {
-            JObjectStructFieldKind::Handle {
-                descriptor,
-                pipeline,
-            } => {
-                let decode = pipeline.invoke_converter(quote!(env), quote!(#raw), name, emit);
-                quote! {
-                    let #object: jni::objects::JObject = env.get_field(#receiver, #property, #descriptor)
-                        .and_then(|val| val.l())
-                        .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(format!(#error, e)))?;
-                    let #raw: jni::sys::jlong = if #object.is_null() {
-                        0
-                    } else {
-                        env.call_method(&#object, "peek", "()J", &[])
-                            .and_then(|val| val.j())
-                            .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(format!(#error, e)))?
-                    };
-                    let #name = #decode;
-                }
+        let fetch_object = |descriptor: &String| {
+            quote! {
+                let #object: jni::objects::JObject = env.get_field(#receiver, #property, #descriptor)
+                    .and_then(|val| val.l())
+                    .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(format!(#error, e)))?;
             }
-            JObjectStructFieldKind::Unsigned64 { pipeline } => {
-                let decode = pipeline.invoke_converter(quote!(env), quote!(#raw), name, emit);
+        };
+        match &self.kind {
+            JObjectStructFieldKind::Handle { descriptor, .. } => {
+                let fetch = fetch_object(descriptor);
+                (
+                    quote! {
+                        #fetch
+                        let #raw: jni::sys::jlong = if #object.is_null() {
+                            0
+                        } else {
+                            env.call_method(&#object, "peek", "()J", &[])
+                                .and_then(|val| val.j())
+                                .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(format!(#error, e)))?
+                        };
+                    },
+                    quote!(#raw),
+                )
+            }
+            JObjectStructFieldKind::Unsigned64 { .. } => (
                 quote! {
                     let #raw: jni::sys::jlong = env
                         .get_field(#receiver, #property, "J")
                         .and_then(|val| val.j())
                         .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(format!(#error, e)))?;
-                    let #name = #decode;
-                }
+                },
+                quote!(#raw),
+            ),
+            JObjectStructFieldKind::Enum { descriptor, .. } => {
+                let fetch = fetch_object(descriptor);
+                (
+                    quote! {
+                        #fetch
+                        let #raw: jni::sys::jint = env.call_method(&#object, "getValue", "()I", &[])
+                            .and_then(|val| val.i())
+                            .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(format!(#error, e)))?;
+                    },
+                    quote!(#raw),
+                )
             }
-            JObjectStructFieldKind::Enum {
-                descriptor,
-                pipeline,
-            } => {
-                let decode = pipeline.invoke_converter(quote!(env), quote!(#raw), name, emit);
-                quote! {
-                    let #object: jni::objects::JObject = env.get_field(#receiver, #property, #descriptor)
-                        .and_then(|val| val.l())
-                        .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(format!(#error, e)))?;
-                    let #raw: jni::sys::jint = env.call_method(&#object, "getValue", "()I", &[])
-                        .and_then(|val| val.i())
-                        .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(format!(#error, e)))?;
-                    let #name = #decode;
-                }
-            }
-            // A nullable property: the reference is fetched here, and what it
-            // means — absent, or a value one unboxing call away — is decided
-            // by the registry-composed `Optional` layer.
+            // The reference itself is the wire value: whether it means absence
+            // is the composed `Optional` layer's decision, not the read's.
             JObjectStructFieldKind::Nullable(plan) => {
-                let descriptor = &plan.descriptor;
-                let optional =
-                    prebindgen_registry::chain::Chain::render(plan.chain.as_ref(), emit).body;
-                quote! {
-                    let #object: jni::objects::JObject = env.get_field(#receiver, #property, #descriptor)
-                        .and_then(|val| val.l())
-                        .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(format!(#error, e)))?;
-                    let #name = {
-                        let v = #object;
-                        #optional
-                    };
-                }
+                (fetch_object(&plan.descriptor), quote!(#object))
             }
             JObjectStructFieldKind::Primitive {
                 wire,
                 descriptor,
                 accessor,
-                pipeline,
-            } => {
-                let decode = pipeline.invoke_converter(quote!(env), quote!(#raw), name, emit);
+                ..
+            } => (
                 quote! {
                     let #raw: #wire = env.get_field(#receiver, #property, #descriptor)
                         .and_then(|val| val.#accessor())
                         .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(format!(#error, e)))? as _;
-                    let #name = #decode;
-                }
-            }
+                },
+                quote!(#raw),
+            ),
             JObjectStructFieldKind::IntoObject {
-                wire,
-                descriptor,
-                pipeline,
+                wire, descriptor, ..
             } => {
-                let decode = pipeline.invoke_converter(quote!(env), quote!(#raw), name, emit);
-                quote! {
-                    let #object: jni::objects::JObject = env.get_field(#receiver, #property, #descriptor)
-                        .and_then(|val| val.l())
-                        .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(format!(#error, e)))?;
-                    let #raw: #wire = #object.into();
-                    let #name = #decode;
-                }
+                let fetch = fetch_object(descriptor);
+                (
+                    quote! {
+                        #fetch
+                        let #raw: #wire = #object.into();
+                    },
+                    quote!(#raw),
+                )
             }
-            JObjectStructFieldKind::Object {
-                descriptor,
-                pipeline,
-            } => {
-                let decode = pipeline.invoke_converter(quote!(env), quote!(#raw), name, emit);
+            JObjectStructFieldKind::Object { descriptor, .. } => (
                 quote! {
                     let #raw: jni::objects::JObject = env.get_field(#receiver, #property, #descriptor)
                         .and_then(|val| val.l())
                         .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(format!(#error, e)))?;
-                    let #name = #decode;
-                }
-            }
+                },
+                quote!(#raw),
+            ),
         }
+    }
+
+    /// What converts this property once it is read.
+    fn child(&self) -> JPropertyChild {
+        let conversion = match &self.kind {
+            JObjectStructFieldKind::Nullable(plan) => {
+                JPropertyConversion::Nullable(plan.chain.clone())
+            }
+            JObjectStructFieldKind::Handle { pipeline, .. }
+            | JObjectStructFieldKind::Unsigned64 { pipeline }
+            | JObjectStructFieldKind::Enum { pipeline, .. }
+            | JObjectStructFieldKind::Primitive { pipeline, .. }
+            | JObjectStructFieldKind::IntoObject { pipeline, .. }
+            | JObjectStructFieldKind::Object { pipeline, .. } => {
+                JPropertyConversion::Converter(pipeline.converter_child().clone())
+            }
+        };
+        let call = match &conversion {
+            JPropertyConversion::Converter(child) => {
+                prebindgen_registry::chain::Child::call(child).clone()
+            }
+            // The layer propagates its own failures with `?`, so the composer
+            // adds none of its own; the identity is the child's, which is what
+            // the property depends on.
+            JPropertyConversion::Nullable(chain) => prebindgen_registry::chain::Call::operation(
+                prebindgen_registry::chain::Child::call(&chain.child)
+                    .operation_id()
+                    .clone(),
+                false,
+                false,
+            ),
+        };
+        JPropertyChild { call, conversion }
     }
 }
 
@@ -615,8 +764,25 @@ impl JObjectSumInputPlan {
             let mut preludes = Vec::new();
             let mut inits = Vec::new();
             for field in &alternative.fields {
-                preludes.push(field.property.render(quote!(__obj), emit));
+                // The sum still walks its payload itself — step 4 of #596 is
+                // what composes this as a `Choice`. It reads and converts each
+                // property through the same two halves the struct's composed
+                // `Product` uses.
+                let (read, value) = field.property.read(quote!(__obj));
                 let bind = &field.property.name;
+                let convert =
+                    prebindgen_registry::chain::Child::invoke(&field.property.child(), value, emit);
+                let convert = if prebindgen_registry::chain::Child::call(&field.property.child())
+                    .fallible()
+                {
+                    quote!(#convert?)
+                } else {
+                    convert
+                };
+                preludes.push(quote! {
+                    #read
+                    let #bind = #convert;
+                });
                 inits.push(field.shape.bind(&quote!(#bind)));
             }
             let ctor = emit.shape_alternative(

--- a/prebindgen-registry/src/chain.rs
+++ b/prebindgen-registry/src/chain.rs
@@ -66,6 +66,25 @@ pub trait Source: Clone {
         source
     }
 
+    /// Construct the source value from its converted parts.
+    ///
+    /// The default is a named-field literal, which is what a Product's parts
+    /// are addressed by. A policy whose source has another shape — a tuple
+    /// struct, a unit struct — overrides it: the model element that says which
+    /// is the adapter's to hold, and [`RustWriter::shape_struct`] is what
+    /// spells it.
+    fn construct(
+        &self,
+        head: TokenStream,
+        parts: &[(syn::Ident, TokenStream)],
+        emit: &RustWriter,
+    ) -> TokenStream {
+        let _ = emit;
+        let names = parts.iter().map(|(name, _)| name);
+        let values = parts.iter().map(|(_, value)| value);
+        quote::quote!(#head { #(#names: #values),* })
+    }
+
     /// Read one named Product field from the exact source spelling.
     ///
     /// The default keeps the common unwrapped access free of redundant
@@ -597,9 +616,9 @@ where
                         (name, value)
                     })
                     .collect();
-                let names = fields.iter().map(|(name, _)| name);
-                let values = fields.iter().map(|(_, value)| value);
-                let canonical = quote::quote!(#canonical_source { #(#names: #values),* });
+                let canonical = self
+                    .source_policy
+                    .construct(canonical_source, &fields, emit);
                 let built = self.source_policy.build(canonical);
                 // A bridge that reads its parts by expression alone keeps the
                 // bare constructor it always emitted; only a bridge with a


### PR DESCRIPTION
## What this changes

`JObjectStructInputPlan::render` walked the struct's fields itself: fetch each
property off the JVM object, call its converter, bind the result to a local,
then construct the source value from those locals.

That walk is a `Product`. The registry knows how to perform one, and the two
previous steps made the halves it needed expressible — #597 let a bridge read a
part with fallible statements, #598 gave every property one complete child.

So the walk is gone, replaced by two answers only JniGen can give:

- **`JObjectBridge`** — what a part *is*: a property fetched off the object,
  which can fail.
- **`JPropertyChild`** — what converts it: the property's own converter, or the
  `Optional` layer #598 composed for a nullable one.

The registry walks the fields, invokes each part's conversion, and builds the
source value.

## One registry addition

`Product` built its source value as a named-field literal. That is right for a
`data_class` and wrong for a unit or tuple struct — and only the adapter holds
the model element that says which shape it is.

`Source::construct` is where a policy says. It defaults to the named-field
literal, so Cbindgen and JniGen's flattened inputs are untouched, and
`JStructSource` overrides it with the model's own `shape_struct`.

This was a latent gap, not a new one: `empty_structs_keep_their_own_constructor_delimiters`
failed the moment the composed `Product` took over, because a unit struct must
be constructed bare. That test is what pins it.

## What the sealed sum still does

`JObjectSumInputPlan` still walks its payload; composing it as a `Choice` is
step 4. It now reads and converts each property through the same two halves the
struct's `Product` uses, so a property has one description rather than two, and
step 4 is about arm selection alone.

## Deletions

`JPipeline::invoke_converter` and `JChild::invoke_input_value_with_env` go with
the walk that called them. With them goes per-property stage naming: a
converter's stages are named by the composer now, in the block that scopes
them. `JObjectStructInputPlan` also loses the source-module path it used to
spell the constructor head, which the source policy spells.

## Generated output

Whole-object decodes change shape and not meaning — the converted value inlines
into the constructor instead of binding a local first:

```rust
// before
let __left_raw: JObject = env.get_field(v, "left", ..)?;
let left = __jni_in_convert_wire_to_ObjectBoundary32_..(env, &__left_raw)?;
perftest_flat::ObjectBoundary64 { left, right }

// after
let __left_raw: JObject = env.get_field(v, "left", ..)?;
perftest_flat::ObjectBoundary64 {
    left: __jni_in_convert_wire_to_ObjectBoundary32_..(env, &__left_raw)?,
    right: ..,
}
```

## Verification

Workspace tests, strict Clippy, `cargo fmt --check` and
`RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps` pass.

`covertest-kotlin` passes its **61 sections on the JVM**. That is the evidence
this step needs, and #598's review showed the reach is wider than the explicit
declarations suggest: the whole-object input plan is built for any named struct
whose crossing carries a `JObject` wire, so these decodes are executed across
plain `data_class!` declarations too, not only `jobject_input()` ones.

Step 2b of #596.

— Claude Code (Opus 5)
