### PR TITLE
Compose the sealed-sum whole-object decode

### DIFF
--- a/examples/covertest-kotlin/src/generated_bindings.rs
+++ b/examples/covertest-kotlin/src/generated_bindings.rs
@@ -3463,67 +3463,83 @@ pub(crate) unsafe fn __jni_in_convert_wire_to_Hold_5a6747f2776b0f97<'env, 'v>(
     v: &jni::objects::JObject<'v>,
 ) -> ::core::result::Result<perftest_flat::Hold, __JniErr> {
     Ok({
-        let __obj = v;
-        (|| -> ::core::result::Result<perftest_flat::Hold, __JniErr> {
-            if __obj.is_null() {
+        let __tag = {
+            if v.is_null() {
                 return ::core::result::Result::Err(
                     <__JniErr as ::core::convert::From<
                         String,
                     >>::from("Hold: null value where a variant was required".to_string()),
                 );
             }
-            if env
-                .is_instance_of(__obj, "io/prebindgen/covertest/model/Hold$Indefinite")
-                .map_err(|e| <__JniErr as ::core::convert::From<
-                    String,
-                >>::from(
-                    format!(
-                        concat!("Hold", ": instanceof ",
-                        "io/prebindgen/covertest/model/Hold$Indefinite", ": {}"), e
-                    ),
-                ))?
-            {
-                return ::core::result::Result::Ok(perftest_flat::Hold::Indefinite);
-            }
-            if env
-                .is_instance_of(__obj, "io/prebindgen/covertest/model/Hold$For")
-                .map_err(|e| <__JniErr as ::core::convert::From<
-                    String,
-                >>::from(
-                    format!(
-                        concat!("Hold", ": instanceof ",
-                        "io/prebindgen/covertest/model/Hold$For", ": {}"), e
-                    ),
-                ))?
-            {
+            let __tag = (|| -> ::core::result::Result<i32, __JniErr> {
+                if env
+                    .is_instance_of(v, "io/prebindgen/covertest/model/Hold$Indefinite")
+                    .map_err(|e| <__JniErr as ::core::convert::From<
+                        String,
+                    >>::from(
+                        format!(
+                            "Hold: instanceof io/prebindgen/covertest/model/Hold$Indefinite: {}",
+                            e
+                        ),
+                    ))?
+                {
+                    return ::core::result::Result::Ok(0i32);
+                }
+                if env
+                    .is_instance_of(v, "io/prebindgen/covertest/model/Hold$For")
+                    .map_err(|e| <__JniErr as ::core::convert::From<
+                        String,
+                    >>::from(
+                        format!(
+                            "Hold: instanceof io/prebindgen/covertest/model/Hold$For: {}",
+                            e
+                        ),
+                    ))?
+                {
+                    return ::core::result::Result::Ok(1i32);
+                }
+                ::core::result::Result::Ok(-1i32)
+            })()?;
+            __tag
+        };
+        match __tag {
+            0i32 => perftest_flat::Hold::Indefinite,
+            1i32 => {
+                let __choice = v;
+                let __arm = __choice;
                 let __p_v0_raw: jni::sys::jlong = env
-                    .get_field(__obj, "v0", "J")
+                    .get_field(__arm, "v0", "J")
                     .and_then(|val| val.j())
                     .map_err(|e| <__JniErr as ::core::convert::From<
                         String,
                     >>::from(format!("Hold.For.v0: {}", e)))? as _;
-                let __p_v0 = {
-                    let __chain_s0 = __jni_in_convert_wire_to_u64_8507143745dc33b9(
-                        env,
-                        &__p_v0_raw,
-                    )?;
-                    let __chain_s1 = __jni_in_stage_0_wire_to_Duration_814bb872b19d3627(
+                perftest_flat::Hold::For(
+                    {
+                        let __chain_s0 = __jni_in_convert_wire_to_u64_8507143745dc33b9(
                             env,
-                            __chain_s0,
-                        )
-                        .map_err(|__e| <__JniErr as ::core::convert::From<
-                            String,
-                        >>::from(__e.to_string()))?;
-                    ::core::result::Result::<_, __JniErr>::Ok(__chain_s1)
-                }?;
-                return ::core::result::Result::Ok(perftest_flat::Hold::For(__p_v0));
+                            &__p_v0_raw,
+                        )?;
+                        let __chain_s1 = __jni_in_stage_0_wire_to_Duration_814bb872b19d3627(
+                                env,
+                                __chain_s0,
+                            )
+                            .map_err(|__e| <__JniErr as ::core::convert::From<
+                                String,
+                            >>::from(__e.to_string()))?;
+                        ::core::result::Result::<_, __JniErr>::Ok(__chain_s1)
+                    }?,
+                )
             }
-            ::core::result::Result::Err(
-                <__JniErr as ::core::convert::From<
-                    String,
-                >>::from("Hold: value is not one of its declared variants".to_string()),
-            )
-        })()?
+            _ => {
+                return ::core::result::Result::Err(
+                    <__JniErr as ::core::convert::From<
+                        String,
+                    >>::from(
+                        "Hold: value is not one of its declared variants".to_string(),
+                    ),
+                );
+            }
+        }
     })
 }
 #[allow(
@@ -4120,9 +4136,8 @@ pub(crate) unsafe fn __jni_in_convert_wire_to_Lookup_2fa8248a2de561a5<'env, 'v>(
     v: &jni::objects::JObject<'v>,
 ) -> ::core::result::Result<perftest_flat::Lookup, __JniErr> {
     Ok({
-        let __obj = v;
-        (|| -> ::core::result::Result<perftest_flat::Lookup, __JniErr> {
-            if __obj.is_null() {
+        let __tag = {
+            if v.is_null() {
                 return ::core::result::Result::Err(
                     <__JniErr as ::core::convert::From<
                         String,
@@ -4131,33 +4146,58 @@ pub(crate) unsafe fn __jni_in_convert_wire_to_Lookup_2fa8248a2de561a5<'env, 'v>(
                     ),
                 );
             }
-            if env
-                .is_instance_of(__obj, "io/prebindgen/covertest/model/Lookup$Absent")
-                .map_err(|e| <__JniErr as ::core::convert::From<
-                    String,
-                >>::from(
-                    format!(
-                        concat!("Lookup", ": instanceof ",
-                        "io/prebindgen/covertest/model/Lookup$Absent", ": {}"), e
-                    ),
-                ))?
-            {
-                return ::core::result::Result::Ok(perftest_flat::Lookup::Absent);
-            }
-            if env
-                .is_instance_of(__obj, "io/prebindgen/covertest/model/Lookup$Found")
-                .map_err(|e| <__JniErr as ::core::convert::From<
-                    String,
-                >>::from(
-                    format!(
-                        concat!("Lookup", ": instanceof ",
-                        "io/prebindgen/covertest/model/Lookup$Found", ": {}"), e
-                    ),
-                ))?
-            {
+            let __tag = (|| -> ::core::result::Result<i32, __JniErr> {
+                if env
+                    .is_instance_of(v, "io/prebindgen/covertest/model/Lookup$Absent")
+                    .map_err(|e| <__JniErr as ::core::convert::From<
+                        String,
+                    >>::from(
+                        format!(
+                            "Lookup: instanceof io/prebindgen/covertest/model/Lookup$Absent: {}",
+                            e
+                        ),
+                    ))?
+                {
+                    return ::core::result::Result::Ok(0i32);
+                }
+                if env
+                    .is_instance_of(v, "io/prebindgen/covertest/model/Lookup$Found")
+                    .map_err(|e| <__JniErr as ::core::convert::From<
+                        String,
+                    >>::from(
+                        format!(
+                            "Lookup: instanceof io/prebindgen/covertest/model/Lookup$Found: {}",
+                            e
+                        ),
+                    ))?
+                {
+                    return ::core::result::Result::Ok(1i32);
+                }
+                if env
+                    .is_instance_of(v, "io/prebindgen/covertest/model/Lookup$Failed")
+                    .map_err(|e| <__JniErr as ::core::convert::From<
+                        String,
+                    >>::from(
+                        format!(
+                            "Lookup: instanceof io/prebindgen/covertest/model/Lookup$Failed: {}",
+                            e
+                        ),
+                    ))?
+                {
+                    return ::core::result::Result::Ok(2i32);
+                }
+                ::core::result::Result::Ok(-1i32)
+            })()?;
+            __tag
+        };
+        match __tag {
+            0i32 => perftest_flat::Lookup::Absent,
+            1i32 => {
+                let __choice = v;
+                let __arm = __choice;
                 let __p_v0_obj: jni::objects::JObject = env
                     .get_field(
-                        __obj,
+                        __arm,
                         "v0",
                         "Lio/prebindgen/covertest/analytics/Summary;",
                     )
@@ -4174,42 +4214,40 @@ pub(crate) unsafe fn __jni_in_convert_wire_to_Lookup_2fa8248a2de561a5<'env, 'v>(
                             String,
                         >>::from(format!("Lookup.Found.v0: {}", e)))?
                 };
-                let __p_v0 = __jni_in_convert_wire_to_Summary_jni_handle_codec_consume_input_a6c328c6a2331e58(
-                    env,
-                    &__p_v0_raw,
-                )?;
-                return ::core::result::Result::Ok(perftest_flat::Lookup::Found(__p_v0));
+                perftest_flat::Lookup::Found(
+                    __jni_in_convert_wire_to_Summary_jni_handle_codec_consume_input_a6c328c6a2331e58(
+                        env,
+                        &__p_v0_raw,
+                    )?,
+                )
             }
-            if env
-                .is_instance_of(__obj, "io/prebindgen/covertest/model/Lookup$Failed")
-                .map_err(|e| <__JniErr as ::core::convert::From<
-                    String,
-                >>::from(
-                    format!(
-                        concat!("Lookup", ": instanceof ",
-                        "io/prebindgen/covertest/model/Lookup$Failed", ": {}"), e
-                    ),
-                ))?
-            {
+            2i32 => {
+                let __choice = v;
+                let __arm = __choice;
                 let __p_v0_obj: jni::objects::JObject = env
-                    .get_field(__obj, "v0", "Ljava/lang/String;")
+                    .get_field(__arm, "v0", "Ljava/lang/String;")
                     .and_then(|val| val.l())
                     .map_err(|e| <__JniErr as ::core::convert::From<
                         String,
                     >>::from(format!("Lookup.Failed.v0: {}", e)))?;
                 let __p_v0_raw: jni::objects::JString = __p_v0_obj.into();
-                let __p_v0 = __jni_in_convert_wire_to_jni_text_codec_owned_40915aa02cf8d9ce(
-                    env,
-                    &__p_v0_raw,
-                )?;
-                return ::core::result::Result::Ok(perftest_flat::Lookup::Failed(__p_v0));
+                perftest_flat::Lookup::Failed(
+                    __jni_in_convert_wire_to_jni_text_codec_owned_40915aa02cf8d9ce(
+                        env,
+                        &__p_v0_raw,
+                    )?,
+                )
             }
-            ::core::result::Result::Err(
-                <__JniErr as ::core::convert::From<
-                    String,
-                >>::from("Lookup: value is not one of its declared variants".to_string()),
-            )
-        })()?
+            _ => {
+                return ::core::result::Result::Err(
+                    <__JniErr as ::core::convert::From<
+                        String,
+                    >>::from(
+                        "Lookup: value is not one of its declared variants".to_string(),
+                    ),
+                );
+            }
+        }
     })
 }
 #[allow(
@@ -4338,9 +4376,8 @@ pub(crate) unsafe fn __jni_in_convert_wire_to_Marker_93f2fabe59a4f80d<'env, 'v>(
     v: &jni::objects::JObject<'v>,
 ) -> ::core::result::Result<perftest_flat::Marker, __JniErr> {
     Ok({
-        let __obj = v;
-        (|| -> ::core::result::Result<perftest_flat::Marker, __JniErr> {
-            if __obj.is_null() {
+        let __tag = {
+            if v.is_null() {
                 return ::core::result::Result::Err(
                     <__JniErr as ::core::convert::From<
                         String,
@@ -4349,37 +4386,49 @@ pub(crate) unsafe fn __jni_in_convert_wire_to_Marker_93f2fabe59a4f80d<'env, 'v>(
                     ),
                 );
             }
-            if env
-                .is_instance_of(__obj, "io/prebindgen/covertest/model/Marker$None_")
-                .map_err(|e| <__JniErr as ::core::convert::From<
-                    String,
-                >>::from(
-                    format!(
-                        concat!("Marker", ": instanceof ",
-                        "io/prebindgen/covertest/model/Marker$None_", ": {}"), e
-                    ),
-                ))?
-            {
-                return ::core::result::Result::Ok(perftest_flat::Marker::None_);
-            }
-            if env
-                .is_instance_of(__obj, "io/prebindgen/covertest/model/Marker$Ranked")
-                .map_err(|e| <__JniErr as ::core::convert::From<
-                    String,
-                >>::from(
-                    format!(
-                        concat!("Marker", ": instanceof ",
-                        "io/prebindgen/covertest/model/Marker$Ranked", ": {}"), e
-                    ),
-                ))?
-            {
+            let __tag = (|| -> ::core::result::Result<i32, __JniErr> {
+                if env
+                    .is_instance_of(v, "io/prebindgen/covertest/model/Marker$None_")
+                    .map_err(|e| <__JniErr as ::core::convert::From<
+                        String,
+                    >>::from(
+                        format!(
+                            "Marker: instanceof io/prebindgen/covertest/model/Marker$None_: {}",
+                            e
+                        ),
+                    ))?
+                {
+                    return ::core::result::Result::Ok(0i32);
+                }
+                if env
+                    .is_instance_of(v, "io/prebindgen/covertest/model/Marker$Ranked")
+                    .map_err(|e| <__JniErr as ::core::convert::From<
+                        String,
+                    >>::from(
+                        format!(
+                            "Marker: instanceof io/prebindgen/covertest/model/Marker$Ranked: {}",
+                            e
+                        ),
+                    ))?
+                {
+                    return ::core::result::Result::Ok(1i32);
+                }
+                ::core::result::Result::Ok(-1i32)
+            })()?;
+            __tag
+        };
+        match __tag {
+            0i32 => perftest_flat::Marker::None_,
+            1i32 => {
+                let __choice = v;
+                let __arm = __choice;
                 let __p_v0_obj: jni::objects::JObject = env
-                    .get_field(__obj, "v0", "Lio/prebindgen/covertest/model/Priority;")
+                    .get_field(__arm, "v0", "Lio/prebindgen/covertest/model/Priority;")
                     .and_then(|val| val.l())
                     .map_err(|e| <__JniErr as ::core::convert::From<
                         String,
                     >>::from(format!("Marker.Ranked.v0: {}", e)))?;
-                let __p_v0 = {
+                perftest_flat::Marker::Ranked({
                     let v = __p_v0_obj;
                     {
                         if v.is_null() {
@@ -4399,15 +4448,18 @@ pub(crate) unsafe fn __jni_in_convert_wire_to_Marker_93f2fabe59a4f80d<'env, 'v>(
                             )
                         }
                     }
-                };
-                return ::core::result::Result::Ok(perftest_flat::Marker::Ranked(__p_v0));
+                })
             }
-            ::core::result::Result::Err(
-                <__JniErr as ::core::convert::From<
-                    String,
-                >>::from("Marker: value is not one of its declared variants".to_string()),
-            )
-        })()?
+            _ => {
+                return ::core::result::Result::Err(
+                    <__JniErr as ::core::convert::From<
+                        String,
+                    >>::from(
+                        "Marker: value is not one of its declared variants".to_string(),
+                    ),
+                );
+            }
+        }
     })
 }
 #[allow(
@@ -9582,9 +9634,8 @@ pub(crate) unsafe fn __jni_in_convert_wire_to_Reading_a358e65c0c39d007<'env, 'v>
     v: &jni::objects::JObject<'v>,
 ) -> ::core::result::Result<perftest_flat::Reading, __JniErr> {
     Ok({
-        let __obj = v;
-        (|| -> ::core::result::Result<perftest_flat::Reading, __JniErr> {
-            if __obj.is_null() {
+        let __tag = {
+            if v.is_null() {
                 return ::core::result::Result::Err(
                     <__JniErr as ::core::convert::From<
                         String,
@@ -9593,102 +9644,129 @@ pub(crate) unsafe fn __jni_in_convert_wire_to_Reading_a358e65c0c39d007<'env, 'v>
                     ),
                 );
             }
-            if env
-                .is_instance_of(__obj, "io/prebindgen/covertest/model/Reading$Missing")
-                .map_err(|e| <__JniErr as ::core::convert::From<
-                    String,
-                >>::from(
-                    format!(
-                        concat!("Reading", ": instanceof ",
-                        "io/prebindgen/covertest/model/Reading$Missing", ": {}"), e
-                    ),
-                ))?
-            {
-                return ::core::result::Result::Ok(perftest_flat::Reading::Missing);
-            }
-            if env
-                .is_instance_of(__obj, "io/prebindgen/covertest/model/Reading$Exact")
-                .map_err(|e| <__JniErr as ::core::convert::From<
-                    String,
-                >>::from(
-                    format!(
-                        concat!("Reading", ": instanceof ",
-                        "io/prebindgen/covertest/model/Reading$Exact", ": {}"), e
-                    ),
-                ))?
-            {
+            let __tag = (|| -> ::core::result::Result<i32, __JniErr> {
+                if env
+                    .is_instance_of(v, "io/prebindgen/covertest/model/Reading$Missing")
+                    .map_err(|e| <__JniErr as ::core::convert::From<
+                        String,
+                    >>::from(
+                        format!(
+                            "Reading: instanceof io/prebindgen/covertest/model/Reading$Missing: {}",
+                            e
+                        ),
+                    ))?
+                {
+                    return ::core::result::Result::Ok(0i32);
+                }
+                if env
+                    .is_instance_of(v, "io/prebindgen/covertest/model/Reading$Exact")
+                    .map_err(|e| <__JniErr as ::core::convert::From<
+                        String,
+                    >>::from(
+                        format!(
+                            "Reading: instanceof io/prebindgen/covertest/model/Reading$Exact: {}",
+                            e
+                        ),
+                    ))?
+                {
+                    return ::core::result::Result::Ok(1i32);
+                }
+                if env
+                    .is_instance_of(v, "io/prebindgen/covertest/model/Reading$Range")
+                    .map_err(|e| <__JniErr as ::core::convert::From<
+                        String,
+                    >>::from(
+                        format!(
+                            "Reading: instanceof io/prebindgen/covertest/model/Reading$Range: {}",
+                            e
+                        ),
+                    ))?
+                {
+                    return ::core::result::Result::Ok(2i32);
+                }
+                if env
+                    .is_instance_of(v, "io/prebindgen/covertest/model/Reading$Tagged")
+                    .map_err(|e| <__JniErr as ::core::convert::From<
+                        String,
+                    >>::from(
+                        format!(
+                            "Reading: instanceof io/prebindgen/covertest/model/Reading$Tagged: {}",
+                            e
+                        ),
+                    ))?
+                {
+                    return ::core::result::Result::Ok(3i32);
+                }
+                if env
+                    .is_instance_of(v, "io/prebindgen/covertest/model/Reading$Companion")
+                    .map_err(|e| <__JniErr as ::core::convert::From<
+                        String,
+                    >>::from(
+                        format!(
+                            "Reading: instanceof io/prebindgen/covertest/model/Reading$Companion: {}",
+                            e
+                        ),
+                    ))?
+                {
+                    return ::core::result::Result::Ok(4i32);
+                }
+                ::core::result::Result::Ok(-1i32)
+            })()?;
+            __tag
+        };
+        match __tag {
+            0i32 => perftest_flat::Reading::Missing,
+            1i32 => {
+                let __choice = v;
+                let __arm = __choice;
                 let __p_v0_raw: jni::sys::jlong = env
-                    .get_field(__obj, "v0", "J")
+                    .get_field(__arm, "v0", "J")
                     .and_then(|val| val.j())
                     .map_err(|e| <__JniErr as ::core::convert::From<
                         String,
                     >>::from(format!("Reading.Exact.v0: {}", e)))? as _;
-                let __p_v0 = __jni_in_convert_wire_to_i64_da07d745d9e26f71(
-                    env,
-                    &__p_v0_raw,
-                )?;
-                return ::core::result::Result::Ok(perftest_flat::Reading::Exact(__p_v0));
+                perftest_flat::Reading::Exact(
+                    __jni_in_convert_wire_to_i64_da07d745d9e26f71(env, &__p_v0_raw)?,
+                )
             }
-            if env
-                .is_instance_of(__obj, "io/prebindgen/covertest/model/Reading$Range")
-                .map_err(|e| <__JniErr as ::core::convert::From<
-                    String,
-                >>::from(
-                    format!(
-                        concat!("Reading", ": instanceof ",
-                        "io/prebindgen/covertest/model/Reading$Range", ": {}"), e
-                    ),
-                ))?
-            {
+            2i32 => {
+                let __choice = v;
+                let __arm = __choice;
                 let __p_low_raw: jni::sys::jlong = env
-                    .get_field(__obj, "low", "J")
+                    .get_field(__arm, "low", "J")
                     .and_then(|val| val.j())
                     .map_err(|e| <__JniErr as ::core::convert::From<
                         String,
                     >>::from(format!("Reading.Range.low: {}", e)))? as _;
-                let __p_low = __jni_in_convert_wire_to_i64_da07d745d9e26f71(
-                    env,
-                    &__p_low_raw,
-                )?;
                 let __p_high_raw: jni::sys::jlong = env
-                    .get_field(__obj, "high", "J")
+                    .get_field(__arm, "high", "J")
                     .and_then(|val| val.j())
                     .map_err(|e| <__JniErr as ::core::convert::From<
                         String,
                     >>::from(format!("Reading.Range.high: {}", e)))? as _;
-                let __p_high = __jni_in_convert_wire_to_i64_da07d745d9e26f71(
-                    env,
-                    &__p_high_raw,
-                )?;
-                return ::core::result::Result::Ok(perftest_flat::Reading::Range {
-                    low: __p_low,
-                    high: __p_high,
-                });
+                perftest_flat::Reading::Range {
+                    low: __jni_in_convert_wire_to_i64_da07d745d9e26f71(
+                        env,
+                        &__p_low_raw,
+                    )?,
+                    high: __jni_in_convert_wire_to_i64_da07d745d9e26f71(
+                        env,
+                        &__p_high_raw,
+                    )?,
+                }
             }
-            if env
-                .is_instance_of(__obj, "io/prebindgen/covertest/model/Reading$Tagged")
-                .map_err(|e| <__JniErr as ::core::convert::From<
-                    String,
-                >>::from(
-                    format!(
-                        concat!("Reading", ": instanceof ",
-                        "io/prebindgen/covertest/model/Reading$Tagged", ": {}"), e
-                    ),
-                ))?
-            {
+            3i32 => {
+                let __choice = v;
+                let __arm = __choice;
                 let __p_v0_obj: jni::objects::JObject = env
-                    .get_field(__obj, "v0", "Ljava/lang/String;")
+                    .get_field(__arm, "v0", "Ljava/lang/String;")
                     .and_then(|val| val.l())
                     .map_err(|e| <__JniErr as ::core::convert::From<
                         String,
                     >>::from(format!("Reading.Tagged.v0: {}", e)))?;
                 let __p_v0_raw: jni::objects::JString = __p_v0_obj.into();
-                let __p_v0 = __jni_in_convert_wire_to_jni_text_codec_owned_40915aa02cf8d9ce(
-                    env,
-                    &__p_v0_raw,
-                )?;
                 let __p_v1_obj: jni::objects::JObject = env
-                    .get_field(__obj, "v1", "Lio/prebindgen/covertest/model/Priority;")
+                    .get_field(__arm, "v1", "Lio/prebindgen/covertest/model/Priority;")
                     .and_then(|val| val.l())
                     .map_err(|e| <__JniErr as ::core::convert::From<
                         String,
@@ -9699,47 +9777,37 @@ pub(crate) unsafe fn __jni_in_convert_wire_to_Reading_a358e65c0c39d007<'env, 'v>
                     .map_err(|e| <__JniErr as ::core::convert::From<
                         String,
                     >>::from(format!("Reading.Tagged.v1: {}", e)))?;
-                let __p_v1 = __jni_in_convert_wire_to_Priority_2f3eb78aa92f8bfd(
-                    env,
-                    &__p_v1_raw,
-                )?;
-                return ::core::result::Result::Ok(
-                    perftest_flat::Reading::Labeled(__p_v0, __p_v1),
-                );
+                perftest_flat::Reading::Labeled(
+                    __jni_in_convert_wire_to_jni_text_codec_owned_40915aa02cf8d9ce(
+                        env,
+                        &__p_v0_raw,
+                    )?,
+                    __jni_in_convert_wire_to_Priority_2f3eb78aa92f8bfd(env, &__p_v1_raw)?,
+                )
             }
-            if env
-                .is_instance_of(__obj, "io/prebindgen/covertest/model/Reading$Companion")
-                .map_err(|e| <__JniErr as ::core::convert::From<
-                    String,
-                >>::from(
-                    format!(
-                        concat!("Reading", ": instanceof ",
-                        "io/prebindgen/covertest/model/Reading$Companion", ": {}"), e
-                    ),
-                ))?
-            {
+            4i32 => {
+                let __choice = v;
+                let __arm = __choice;
                 let __p_v0_raw: jni::sys::jlong = env
-                    .get_field(__obj, "v0", "J")
+                    .get_field(__arm, "v0", "J")
                     .and_then(|val| val.j())
                     .map_err(|e| <__JniErr as ::core::convert::From<
                         String,
                     >>::from(format!("Reading.Companion.v0: {}", e)))? as _;
-                let __p_v0 = __jni_in_convert_wire_to_i64_da07d745d9e26f71(
-                    env,
-                    &__p_v0_raw,
-                )?;
-                return ::core::result::Result::Ok(
-                    perftest_flat::Reading::Companion(__p_v0),
+                perftest_flat::Reading::Companion(
+                    __jni_in_convert_wire_to_i64_da07d745d9e26f71(env, &__p_v0_raw)?,
+                )
+            }
+            _ => {
+                return ::core::result::Result::Err(
+                    <__JniErr as ::core::convert::From<
+                        String,
+                    >>::from(
+                        "Reading: value is not one of its declared variants".to_string(),
+                    ),
                 );
             }
-            ::core::result::Result::Err(
-                <__JniErr as ::core::convert::From<
-                    String,
-                >>::from(
-                    "Reading: value is not one of its declared variants".to_string(),
-                ),
-            )
-        })()?
+        }
     })
 }
 #[allow(

--- a/prebindgen-jni/src/jni/emit/flat_input.rs
+++ b/prebindgen-jni/src/jni/emit/flat_input.rs
@@ -117,6 +117,85 @@ impl prebindgen_registry::chain::OptionalBridge for JNullableProperty {
     }
 }
 
+/// The sealed interface a whole-object sum crosses as: one JVM object whose
+/// class names the live alternative.
+///
+/// Selection is a run of `instanceof` tests, in declaration order, which this
+/// reads once into a tag the composed `Choice` matches on. Absence of a match
+/// and a null reference are distinct failures, and both keep the message they
+/// had.
+#[derive(Clone)]
+struct JSumBridge {
+    /// One JVM class per alternative, in declaration order.
+    classes: Vec<String>,
+    /// The sum's Kotlin name, for the two failure messages.
+    enum_name: String,
+}
+
+impl prebindgen_registry::chain::ChoiceBridge for JSumBridge {
+    fn intermediate(&self) -> syn::Type {
+        syn::parse_quote!(jni::objects::JObject)
+    }
+
+    fn tag(&self, value: TokenStream) -> TokenStream {
+        let enum_name = &self.enum_name;
+        let null = format!("{enum_name}: null value where a variant was required");
+        let tests = self.classes.iter().enumerate().map(|(index, class)| {
+            let index = index as i32;
+            let error = format!("{enum_name}: instanceof {class}: {{}}");
+            quote! {
+                if env.is_instance_of(#value, #class)
+                    .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(
+                        format!(#error, e)
+                    ))?
+                {
+                    return ::core::result::Result::Ok(#index);
+                }
+            }
+        });
+        quote!({
+            if #value.is_null() {
+                return ::core::result::Result::Err(
+                    <__JniErr as ::core::convert::From<String>>::from(#null.to_string()),
+                );
+            }
+            let __tag = (|| -> ::core::result::Result<i32, __JniErr> {
+                #(#tests)*
+                ::core::result::Result::Ok(-1i32)
+            })()?;
+            __tag
+        })
+    }
+
+    fn arm(
+        &self,
+        _emit: &prebindgen_registry::RustWriter,
+        value: TokenStream,
+        _index: usize,
+    ) -> TokenStream {
+        // Every alternative's payload is read off the same object; which
+        // properties belong to it is the arm's own bridge.
+        value
+    }
+
+    fn build(
+        &self,
+        _emit: &prebindgen_registry::RustWriter,
+        _active: usize,
+        _value: TokenStream,
+    ) -> TokenStream {
+        unreachable!("a whole-object sum is decoded, never encoded, through this bridge")
+    }
+
+    fn invalid_tag(&self, _tag: TokenStream) -> TokenStream {
+        let message = format!(
+            "{}: value is not one of its declared variants",
+            self.enum_name
+        );
+        quote!(<__JniErr as ::core::convert::From<String>>::from(#message.to_string()))
+    }
+}
+
 /// The source struct a whole-object decode builds, spelled through the shape
 /// the model holds.
 ///
@@ -681,7 +760,6 @@ impl JObjectStructFieldPlan {
 #[derive(Clone)]
 pub(crate) struct JObjectSumInputPlan {
     shape: flat::Variant,
-    source_module: syn::Path,
     enum_name: String,
     alternatives: Vec<JObjectSumAlternativePlan>,
 }
@@ -690,13 +768,9 @@ pub(crate) struct JObjectSumInputPlan {
 struct JObjectSumAlternativePlan {
     shape: flat::Alternative,
     jvm_class: String,
-    fields: Vec<JObjectSumFieldPlan>,
-}
-
-#[derive(Clone)]
-struct JObjectSumFieldPlan {
-    shape: flat::Field,
-    property: JObjectStructFieldPlan,
+    /// One property per payload field, in declaration order — the same plan a
+    /// struct's field carries, since a payload is read exactly as a field is.
+    fields: Vec<JObjectStructFieldPlan>,
 }
 
 impl JObjectSumInputPlan {
@@ -708,7 +782,7 @@ impl JObjectSumInputPlan {
             .iter()
             .flat_map(|alternative| &alternative.fields)
         {
-            field.property.kind.calls(out);
+            field.kind.calls(out);
         }
     }
 }
@@ -733,10 +807,9 @@ pub(crate) fn build_jobject_sum_input_plan(
             let property = crate::jni::struct_plan::sum_field_prop_name(&field.member());
             let bind = format_ident!("__p_{}", property);
             let error = format!("{enum_name}.{kotlin_name}.{property}: {{}}");
-            fields.push(JObjectSumFieldPlan {
-                shape: field.clone(),
-                property: build_jobject_property_plan(ext, &field.ty, bind, property, error, true)?,
-            });
+            fields.push(build_jobject_property_plan(
+                ext, &field.ty, bind, property, error, true,
+            )?);
         }
         alternatives.push(JObjectSumAlternativePlan {
             shape: alt.clone(),
@@ -744,78 +817,62 @@ pub(crate) fn build_jobject_sum_input_plan(
             fields,
         });
     }
+    let _ = registry;
     Some(JObjectSumInputPlan {
         shape: v.clone(),
-        source_module: ext.fn_module(registry, &v.name),
         enum_name,
         alternatives,
     })
 }
 
 impl JObjectSumInputPlan {
+    /// The decode, composed by the registry: it reads the tag, selects the
+    /// arm, reads that arm's payload properties through the same bridge the
+    /// struct decode uses, and constructs the alternative.
     pub(crate) fn render(&self, emit: &prebindgen_registry::RustWriter) -> syn::Expr {
-        let source_module = &self.source_module;
-        let enum_ident = &self.shape.name;
-        let enum_name = &self.enum_name;
-        let mut arms = Vec::new();
-        for alternative in &self.alternatives {
-            let vident = &alternative.shape.name;
-            let jvm_class = &alternative.jvm_class;
-            let mut preludes = Vec::new();
-            let mut inits = Vec::new();
-            for field in &alternative.fields {
-                // The sum still walks its payload itself — step 4 of #596 is
-                // what composes this as a `Choice`. It reads and converts each
-                // property through the same two halves the struct's composed
-                // `Product` uses.
-                let (read, value) = field.property.read(quote!(__obj));
-                let bind = &field.property.name;
-                let convert =
-                    prebindgen_registry::chain::Child::invoke(&field.property.child(), value, emit);
-                let convert = if prebindgen_registry::chain::Child::call(&field.property.child())
-                    .fallible()
-                {
-                    quote!(#convert?)
-                } else {
-                    convert
-                };
-                preludes.push(quote! {
-                    #read
-                    let #bind = #convert;
-                });
-                inits.push(field.shape.bind(&quote!(#bind)));
-            }
-            let ctor = emit.shape_alternative(
-                &alternative.shape,
-                quote!(#source_module::#enum_ident::#vident),
-                &inits,
-            );
-            arms.push(quote! {
-                if env.is_instance_of(__obj, #jvm_class)
-                    .map_err(|e| <__JniErr as ::core::convert::From<String>>::from(
-                        format!(concat!(#enum_name, ": instanceof ", #jvm_class, ": {}"), e)))?
-                {
-                    #(#preludes)*
-                    return ::core::result::Result::Ok(#ctor);
-                }
-            });
-        }
-        let no_match = format!("{enum_name}: value is not one of its declared variants");
-        let null_msg = format!("{enum_name}: null value where a variant was required");
-        syn::parse_quote!({
-            let __obj = v;
-            (|| -> ::core::result::Result<#source_module::#enum_ident, __JniErr> {
-                if __obj.is_null() {
-                    return ::core::result::Result::Err(
-                        <__JniErr as ::core::convert::From<String>>::from(#null_msg.to_string()),
-                    );
-                }
-                #(#arms)*
-                ::core::result::Result::Err(
-                    <__JniErr as ::core::convert::From<String>>::from(#no_match.to_string()),
+        let choice = prebindgen_registry::chain::Choice {
+            source: self.shape.type_ref().clone(),
+            direction: prebindgen_registry::recipe::Direction::Construct,
+            source_policy: crate::jni::chain::JSource {
+                wrappers: Vec::new(),
+            },
+            bridge: JSumBridge {
+                classes: self
+                    .alternatives
+                    .iter()
+                    .map(|alternative| alternative.jvm_class.clone())
+                    .collect(),
+                enum_name: self.enum_name.clone(),
+            },
+            arms: self
+                .alternatives
+                .iter()
+                .enumerate()
+                .map(
+                    |(index, alternative)| prebindgen_registry::chain::ChoiceArm {
+                        alternative: alternative.shape.clone(),
+                        tag: {
+                            let index = index as i32;
+                            syn::parse_quote!(#index)
+                        },
+                        bridge: JObjectBridge {
+                            properties: alternative.fields.to_vec(),
+                        },
+                        parts: alternative
+                            .fields
+                            .iter()
+                            .map(|field| prebindgen_registry::chain::ChoicePart {
+                                child: field.child(),
+                                mode: prebindgen_registry::recipe::Mode::Owned,
+                                hold_uninit: false,
+                            })
+                            .collect(),
+                    },
                 )
-            })()?
-        })
+                .collect(),
+        };
+        let body = prebindgen_registry::chain::Chain::render(&choice, emit).body;
+        syn::parse_quote!(#body)
     }
 }
 


### PR DESCRIPTION
## What this changes

`JObjectSumInputPlan::render` walked its alternatives itself: one `instanceof`
test per variant, with that variant's payload reads and constructor nested
inside it, all wrapped in a closure so an arm could return early.

That is a `Choice`, and after #599 both halves it needs already exist:

- **`JSumBridge`** reads the selector — the run of `instanceof` tests, in
  declaration order, resolved into a tag.
- **each arm is a `Product` over `JObjectBridge`** — the same bridge the struct
  decode uses, because a payload property is read exactly as a field is.

The registry matches the tag, selects the arm, reads its parts and constructs
the alternative through the model's own `shape_alternative` — which is what
keeps a tuple variant a tuple variant rather than a named-field literal.

## A deletion the composition made possible

`JObjectSumFieldPlan` held a `flat::Field` beside a property plan, to bind the
payload when constructing. The registry binds payloads from the alternative's
own fields, so the field was the composer's copy of something it already has.

An alternative now holds the same `JObjectStructFieldPlan`s a struct does. One
description of a property, for both decodes.

## Behaviour

Both failure messages survive: a null reference and a value matching no variant
are still distinct failures, and still say what they said.

The generated decode changes shape — every `instanceof` test now stands in the
tag computation, ahead of any payload read. **Executed order is unchanged**: the
tag block returns at the first match, exactly as the old `if` chain did, so no
value reaches a test the old code would have skipped.

## Verification

Workspace tests, strict Clippy, `cargo fmt --check` and
`RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps` pass.
`covertest-kotlin` passes its **61 sections on the JVM**.

566 changed lines is too many to accept on assertion, so I used the instrument
from #599's review — per generated function, the sequence of converter calls
and the sequence of JVM interactions by method, name and descriptor:

| | functions | added | removed | differing |
|---|---|---|---|---|
| converter calls | 412 | 0 | 0 | **0** |
| JVM interactions | 412 | 0 | 0 | **2** |

The two are `Lookup` and `Reading` — the sums with payload arms — and the
difference is exactly the static reordering described above:

```
BASE: instanceof Absent, instanceof Found, get_field v0, call peek, instanceof Failed, get_field v0
HEAD: instanceof Absent, instanceof Found, instanceof Failed, get_field v0, call peek, get_field v0
```

Same tests, same reads, same order per execution; what moved is where the
unexecuted tests sit in the text.

Step 4 of #596.

— Claude Code (Opus 5)
