### PR TITLE
Record why the whole-object encode is not composed

### DIFF
--- a/prebindgen-jni/src/jni/compile.rs
+++ b/prebindgen-jni/src/jni/compile.rs
@@ -4233,8 +4233,10 @@ impl Declarations {
                 // optional nested class becomes a `present` flag plus a
                 // defaulted group, and a sum field a tag plus one group per
                 // variant. Delivering those to a foreign builder is a feature
-                // this decomposition does not have, so the two are not two
-                // implementations of one thing. See #596 step 5, and #602.
+                // this decomposition does not have: the encode is a superset
+                // rather than a second implementation. Where both apply they
+                // name the same leaves, which `assert_leaf_derivations_agree`
+                // checks. See #596 step 5, and #602.
                 crate::jni::classify::TypeKind::DataStruct {
                     st: _,
                     cfg: Some(_),

--- a/prebindgen-jni/src/jni/compile.rs
+++ b/prebindgen-jni/src/jni/compile.rs
@@ -4226,6 +4226,15 @@ impl Declarations {
                 // A nested `data_class` inlines when it is reached directly.
                 // Behind an `Option` or a `Vec` there is no chain to reach
                 // through, so the whole value stays object-shaped.
+                //
+                // This refusal is why the whole-object output encode
+                // (`emit/struct_out.rs`) is not rendered from this
+                // decomposition: it supports the shapes refused here — an
+                // optional nested class becomes a `present` flag plus a
+                // defaulted group, and a sum field a tag plus one group per
+                // variant. Delivering those to a foreign builder is a feature
+                // this decomposition does not have, so the two are not two
+                // implementations of one thing. See #596 step 5, and #602.
                 crate::jni::classify::TypeKind::DataStruct {
                     st: _,
                     cfg: Some(_),

--- a/prebindgen-jni/src/jni/emit/struct_out.rs
+++ b/prebindgen-jni/src/jni/emit/struct_out.rs
@@ -118,6 +118,28 @@ pub(crate) fn synth_value_struct_leaves(
 /// mean teaching that decomposition the gated shapes — which would also change
 /// what a foreign builder can be delivered, a feature rather than a
 /// refactoring. #596 step 5 records that decision; #602 proposes the feature.
+///
+/// Where both derivations do apply, they must name the same leaves in the same
+/// order: `JniGen::assert_leaf_derivations_agree` checks that on every binding
+/// a test writes, since that agreement is what #602 would rest on.
+/// The leaf names this encode emits, flattened — the `fromParts` argument
+/// list, in order.
+///
+/// Test support: the registry-facing decomposition of the same struct must
+/// agree with this wherever it exists, and #603 recorded that agreement as
+/// measured rather than checked. `JniGen::write_rust` checks it now.
+#[cfg(test)]
+pub(crate) fn encode_leaf_names(
+    plan: &StructPlan,
+    emit: &prebindgen_registry::RustWriter,
+) -> Vec<String> {
+    let (_, slots) = encode_plan(plan, &quote!(v), "", 0, &quote!(env), emit);
+    slots
+        .iter()
+        .map(|slot| slot.ident.to_string().trim_start_matches('_').to_string())
+        .collect()
+}
+
 fn encode_plan(
     plan: &StructPlan,
     access: &TokenStream,

--- a/prebindgen-jni/src/jni/emit/struct_out.rs
+++ b/prebindgen-jni/src/jni/emit/struct_out.rs
@@ -105,6 +105,19 @@ pub(crate) fn synth_value_struct_leaves(
 /// an [`EncSlot`] describing its `JValue` slot. `access` is the Rust
 /// expression yielding the current struct value (`v`, `v.field`, or the
 /// matched `__cN` under an Option); `prefix` namespaces the generated idents.
+/// Walk the struct's fields and encode each leaf into a `fromParts` argument.
+///
+/// This is a source-value walk that the registry does not perform, and the
+/// reason is coverage rather than ownership. The registry-facing decomposition
+/// of a struct (`Declarations::struct_out_wires_at`) refuses a nested
+/// `data_class` behind an `Option` or a `Vec`; this encode supports both, an
+/// optional nested class as a `present` flag plus a defaulted group and a sum
+/// field as a tag plus one group per variant.
+///
+/// Rendering this through the registry's decomposition walk would therefore
+/// mean teaching that decomposition the gated shapes — which would also change
+/// what a foreign builder can be delivered, a feature rather than a
+/// refactoring. #596 step 5 records that decision; #602 proposes the feature.
 fn encode_plan(
     plan: &StructPlan,
     access: &TokenStream,

--- a/prebindgen-jni/src/jni/emit/struct_out.rs
+++ b/prebindgen-jni/src/jni/emit/struct_out.rs
@@ -41,6 +41,17 @@ pub(crate) fn handle_field_fqn(ext: &Declarations, h: &Projection) -> String {
 /// an absent `Option<nested>` parent.
 pub(crate) struct EncSlot {
     ident: proc_macro2::Ident,
+    /// How deeply nested the field this slot came from is: 0 for the struct's
+    /// own field, one more per inlined `data_class`.
+    ///
+    /// Read only by [`encode_leaves`], which
+    /// `JniGen::assert_leaf_derivations_agree` compares against the
+    /// registry-facing decomposition's own nesting — that one spells it with
+    /// the reserved `__` separator, this one counts it. The encode itself
+    /// needs the number while it recurses, not after, which is why nothing
+    /// else reads the field.
+    #[allow(dead_code)]
+    depth: usize,
     wire_ty: TokenStream,
     descriptor: String,
     is_object: bool,
@@ -122,21 +133,26 @@ pub(crate) fn synth_value_struct_leaves(
 /// Where both derivations do apply, they must name the same leaves in the same
 /// order: `JniGen::assert_leaf_derivations_agree` checks that on every binding
 /// a test writes, since that agreement is what #602 would rest on.
-/// The leaf names this encode emits, flattened — the `fromParts` argument
-/// list, in order.
+/// The leaves this encode emits, flattened — the `fromParts` argument list,
+/// in order, each with how deeply nested the field it came from is.
 ///
 /// Test support: the registry-facing decomposition of the same struct must
 /// agree with this wherever it exists, and #603 recorded that agreement as
 /// measured rather than checked. `JniGen::write_rust` checks it now.
 #[cfg(test)]
-pub(crate) fn encode_leaf_names(
+pub(crate) fn encode_leaves(
     plan: &StructPlan,
     emit: &prebindgen_registry::RustWriter,
-) -> Vec<String> {
+) -> Vec<(String, usize)> {
     let (_, slots) = encode_plan(plan, &quote!(v), "", 0, &quote!(env), emit);
     slots
         .iter()
-        .map(|slot| slot.ident.to_string().trim_start_matches('_').to_string())
+        .map(|slot| {
+            (
+                slot.ident.to_string().trim_start_matches('_').to_string(),
+                slot.depth,
+            )
+        })
         .collect()
 }
 
@@ -192,6 +208,7 @@ fn encode_field(
                     ProjectionKind::Handle => {
                         preludes.extend(quote! { let #id: jni::sys::jlong = #value_expr; });
                         slots.push(EncSlot {
+                            depth,
                             ident: id,
                             wire_ty: quote!(jni::sys::jlong),
                             descriptor: "J".to_string(),
@@ -203,6 +220,7 @@ fn encode_field(
                         FoldStrategy::Base => {
                             preludes.extend(quote! { let #id: jni::sys::jlong = #value_expr; });
                             slots.push(EncSlot {
+                                depth,
                                 ident: id,
                                 wire_ty: quote!(jni::sys::jlong),
                                 descriptor: "J".to_string(),
@@ -213,6 +231,7 @@ fn encode_field(
                         FoldStrategy::Optional(NullableKind::Niche, _) => {
                             preludes.extend(quote! { let #id: jni::sys::jlong = #value_expr; });
                             slots.push(EncSlot {
+                                depth,
                                 ident: id,
                                 wire_ty: quote!(jni::sys::jlong),
                                 descriptor: "J".to_string(),
@@ -224,6 +243,7 @@ fn encode_field(
                             preludes
                                 .extend(quote! { let #id: jni::objects::JObject = #value_expr; });
                             slots.push(EncSlot {
+                                depth,
                                 ident: id,
                                 wire_ty: quote!(jni::objects::JObject),
                                 descriptor: "Ljava/lang/Long;".to_string(),
@@ -242,6 +262,7 @@ fn encode_field(
                 let value_expr = conv_value(conv);
                 preludes.extend(quote! { let #id: jni::sys::jint = #value_expr; });
                 slots.push(EncSlot {
+                    depth,
                     ident: id,
                     wire_ty: quote!(jni::sys::jint),
                     descriptor: "I".to_string(),
@@ -256,6 +277,7 @@ fn encode_field(
                 if niche.is_some() {
                     preludes.extend(quote! { let #id: jni::sys::jint = #value_expr; });
                     slots.push(EncSlot {
+                        depth,
                         ident: id,
                         wire_ty: quote!(jni::sys::jint),
                         descriptor: "I".to_string(),
@@ -265,6 +287,7 @@ fn encode_field(
                 } else {
                     preludes.extend(quote! { let #id: jni::objects::JObject = #value_expr; });
                     slots.push(EncSlot {
+                        depth,
                         ident: id,
                         wire_ty: quote!(jni::objects::JObject),
                         descriptor: "Ljava/lang/Integer;".to_string(),
@@ -322,6 +345,7 @@ fn encode_field(
                         }
                     });
                     slots.push(EncSlot {
+                        depth,
                         ident: flag_id,
                         wire_ty: quote!(jni::sys::jboolean),
                         descriptor: "Z".to_string(),
@@ -330,6 +354,7 @@ fn encode_field(
                     });
                     for (i, sl) in child_slots.iter().enumerate() {
                         slots.push(EncSlot {
+                            depth,
                             ident: outer_ids[i].clone(),
                             wire_ty: sl.wire_ty.clone(),
                             descriptor: sl.descriptor.clone(),
@@ -480,6 +505,7 @@ fn encode_field(
                         }
                     });
                     slots.push(EncSlot {
+                        depth,
                         ident: flag_id,
                         wire_ty: quote!(jni::sys::jboolean),
                         descriptor: "Z".to_string(),
@@ -488,6 +514,7 @@ fn encode_field(
                     });
                 }
                 slots.push(EncSlot {
+                    depth,
                     ident: tag_id,
                     wire_ty: quote!(jni::sys::jint),
                     descriptor: "I".to_string(),
@@ -496,6 +523,7 @@ fn encode_field(
                 });
                 for (i, sl) in all.iter().enumerate() {
                     slots.push(EncSlot {
+                        depth,
                         ident: outer_ids[i].clone(),
                         wire_ty: sl.wire_ty.clone(),
                         descriptor: sl.descriptor.clone(),
@@ -517,6 +545,7 @@ fn encode_field(
                     LeafForm::Prim => {
                         preludes.extend(quote! { let #id: #wire = #value_expr; });
                         slots.push(EncSlot {
+                            depth,
                             ident: id,
                             wire_ty: quote!(#wire),
                             descriptor: descriptor.clone(),
@@ -529,6 +558,7 @@ fn encode_field(
                             quote! { let #id: jni::objects::JObject = #value_expr.into(); },
                         );
                         slots.push(EncSlot {
+                            depth,
                             ident: id,
                             wire_ty: quote!(jni::objects::JObject),
                             descriptor: descriptor.clone(),
@@ -539,6 +569,7 @@ fn encode_field(
                     LeafForm::Object => {
                         preludes.extend(quote! { let #id: jni::objects::JObject = #value_expr; });
                         slots.push(EncSlot {
+                            depth,
                             ident: id,
                             wire_ty: quote!(jni::objects::JObject),
                             descriptor: descriptor.clone(),

--- a/prebindgen-jni/src/jni/mod.rs
+++ b/prebindgen-jni/src/jni/mod.rs
@@ -897,6 +897,12 @@ impl JniGen {
         &self,
         out_path: impl AsRef<std::path::Path>,
     ) -> Result<std::path::PathBuf, prebindgen_registry::WriteRustError> {
+        // Every binding a test writes also checks that a data class's two
+        // leaf derivations agree wherever both exist — the property #603
+        // measured and #602 needs before it can unify them.
+        #[cfg(test)]
+        self.assert_leaf_derivations_agree();
+
         // Every binding a test writes also checks that the assembly's
         // dependency edges name every call its artifacts render — the
         // completeness the emission-time check reasons from.
@@ -917,6 +923,62 @@ impl JniGen {
                 .assembly(),
             out_path,
         )?)
+    }
+
+    /// A declared data class is decomposed twice — by `struct_out_wires_of`,
+    /// whose leaves the registry receives, and by `StructPlan`, whose leaves
+    /// the whole-object encode emits and Kotlin's `fromParts` declares. Where
+    /// both exist they must name the same leaves in the same order.
+    ///
+    /// #603 records why the two are not one derivation: the first refuses
+    /// shapes the second supports, so unifying them is the feature #602
+    /// proposes. Until then this is what says they still agree — the
+    /// precondition that unification rests on.
+    ///
+    /// Both are available only after resolve, which is why this runs here and
+    /// not while planning.
+    #[cfg(test)]
+    fn assert_leaf_derivations_agree(&self) {
+        let emit = prebindgen_registry::RustWriter::for_registry_test(&self.registry);
+        for item in self.registry.flat().types() {
+            let prebindgen_registry::flat::Type::Struct(item) = item else {
+                continue;
+            };
+            // Only a declared data class has a frozen plan; the lookup is
+            // panic-backed for anything else, and an opaque handle's struct
+            // decomposes without ever having one.
+            let declared = self
+                .decls
+                .types
+                .get(&item.type_ref().key())
+                .is_some_and(|cfg| !cfg.special_decl() && cfg.name_spec.is_some());
+            if !declared {
+                continue;
+            }
+            let Some(wires) = self.decls.struct_out_wires_of(&self.registry, &item.name) else {
+                continue;
+            };
+            let Some(plan) = self.decls.struct_plan(&self.registry, item, 0) else {
+                continue;
+            };
+            // The two spell a leaf for different audiences: the decomposition
+            // names it as Kotlin will see it (`maybeLong`), the encode as Rust
+            // wrote it (`maybe_long`), and a keyword-colliding name keeps a
+            // trailing underscore on one side only. The property here is which
+            // leaves, in which order — so the comparison drops the spelling.
+            let plain = |name: &str| name.replace('_', "").to_lowercase();
+            let decomposed: Vec<String> = wires.iter().map(|wire| plain(&wire.name)).collect();
+            let encoded: Vec<String> = crate::jni::emit::encode_leaf_names(&plan, &emit)
+                .iter()
+                .map(|name| plain(name))
+                .collect();
+            assert_eq!(
+                encoded, decomposed,
+                "`{}`: the whole-object encode and the registry-facing \
+                 decomposition name different leaves",
+                item.name
+            );
+        }
     }
 
     /// The resolved registry — conversions, decompositions, and the model.

--- a/prebindgen-jni/src/jni/mod.rs
+++ b/prebindgen-jni/src/jni/mod.rs
@@ -966,16 +966,33 @@ impl JniGen {
             // wrote it (`maybe_long`), and a keyword-colliding name keeps a
             // trailing underscore on one side only. The property here is which
             // leaves, in which order — so the comparison drops the spelling.
+            // Two comparisons, because a leaf has two properties that must
+            // agree and one that need not. Its *name* is spelled for two
+            // audiences — the decomposition names it as Kotlin will see it
+            // (`maybeLong`), the encode as Rust wrote it (`maybe_long`), and a
+            // keyword-colliding name keeps a trailing underscore on one side —
+            // so the comparison drops the spelling. Its *nesting* is structure:
+            // the decomposition joins an inlined class's path with the reserved
+            // `__` separator, and the encode counts the same inlining as depth.
             let plain = |name: &str| name.replace('_', "").to_lowercase();
             let decomposed: Vec<String> = wires.iter().map(|wire| plain(&wire.name)).collect();
-            let encoded: Vec<String> = crate::jni::emit::encode_leaf_names(&plan, &emit)
+            let decomposed_depth: Vec<usize> = wires
                 .iter()
-                .map(|name| plain(name))
+                .map(|wire| wire.name.matches("__").count())
                 .collect();
+            let leaves = crate::jni::emit::encode_leaves(&plan, &emit);
+            let encoded: Vec<String> = leaves.iter().map(|(name, _)| plain(name)).collect();
+            let encoded_depth: Vec<usize> = leaves.iter().map(|(_, depth)| *depth).collect();
             assert_eq!(
                 encoded, decomposed,
                 "`{}`: the whole-object encode and the registry-facing \
                  decomposition name different leaves",
+                item.name
+            );
+            assert_eq!(
+                encoded_depth, decomposed_depth,
+                "`{}`: the whole-object encode and the registry-facing \
+                 decomposition flatten nesting differently",
                 item.name
             );
         }

--- a/prebindgen-jni/src/jni/tests/flatten.rs
+++ b/prebindgen-jni/src/jni/tests/flatten.rs
@@ -2383,6 +2383,76 @@ fn a_gate_inside_a_gate_supplies_one_absent_value() {
     );
 }
 
+/// The whole-object encode covers a shape the registry-facing decomposition
+/// refuses, and that divergence is deliberate.
+///
+/// `struct_out_wires_of` returns `None` for a struct with a nested
+/// `data_class` behind an `Option`, because there is no chain to reach the
+/// inlined leaves through. The whole-object output encode supports it as a
+/// `present` flag plus a defaulted group — which is why #596 step 5 records
+/// the two as different coverage rather than composing one from the other.
+///
+/// If this ever starts returning `Some`, the encode should be rendered from
+/// the decomposition and this test deleted; see #602.
+#[test]
+fn the_decomposition_refuses_what_the_whole_object_encode_supports() {
+    let loc = myflat_loc();
+    let items: Vec<(syn::Item, prebindgen::SourceLocation)> = vec![
+        (
+            syn::Item::Struct(syn::parse_quote!(
+                pub struct Leaf {
+                    pub id: i64,
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Struct(syn::parse_quote!(
+                pub struct Holder {
+                    pub inner: Option<Leaf>,
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn holder_id(h: Holder) -> i64 {
+                    unimplemented!()
+                }
+            )),
+            loc.clone(),
+        ),
+    ];
+    let registry = crate::test_util::reg_from_items(declare_referenced(items)).expect("index");
+    let jni = JniGenBuilder::new()
+        .set_package_prefix("io.test.jni")
+        .package(
+            crate::package!()
+                .class(crate::data_class!(Leaf))
+                .class(crate::data_class!(Holder))
+                .fun(prebindgen_registry::fun!(holder_id)),
+        );
+    let gen = jni.build_with(registry).expect("resolve");
+
+    let holder: syn::Ident = syn::parse_quote!(Holder);
+    assert!(
+        gen.declarations()
+            .struct_out_wires_of(gen.registry(), &holder)
+            .is_none(),
+        "the decomposition refuses an optional nested data class"
+    );
+
+    let dir = unique_test_dir("jnigen_decomposition_refusal");
+    std::fs::create_dir_all(&dir).unwrap();
+    let rust = std::fs::read_to_string(gen.write_rust(dir.join("gen.rs")).expect("write_rust"))
+        .expect("read generated file");
+    let compact: String = rust.split_whitespace().collect();
+    assert!(
+        compact.contains("__inner_present"),
+        "the whole-object encode still supports it, as a present flag:\n{rust}"
+    );
+}
+
 /// A nullable primitive keeps the allocation-free `(present, value)` pair
 /// rather than boxing, at field depth as at parameter depth.
 ///

--- a/prebindgen-jni/src/jni/tests/flatten.rs
+++ b/prebindgen-jni/src/jni/tests/flatten.rs
@@ -2383,6 +2383,90 @@ fn a_gate_inside_a_gate_supplies_one_absent_value() {
     );
 }
 
+/// A nested `data_class` inlines its leaves into its parent's `fromParts`, and
+/// the two derivations of that flattening must agree on the leaves *and* on
+/// how deep each one is.
+///
+/// `assert_leaf_derivations_agree` runs on every binding a test writes, and
+/// before this fixture existed every struct it compared was flat — so the
+/// property it was written for, how a nested path flattens and in what order,
+/// was never reached. This is the binding that reaches it.
+#[test]
+fn the_two_derivations_agree_on_a_nested_data_class() {
+    let loc = myflat_loc();
+    let items: Vec<(syn::Item, prebindgen::SourceLocation)> = vec![
+        (
+            syn::Item::Struct(syn::parse_quote!(
+                pub struct Stamp {
+                    pub secs: i64,
+                    pub nanos: i32,
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Struct(syn::parse_quote!(
+                pub struct Entry {
+                    pub stamp: Stamp,
+                    pub weight: i64,
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Struct(syn::parse_quote!(
+                pub struct Page {
+                    pub head: Entry,
+                    pub count: i32,
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn page_count(p: Page) -> i32 {
+                    unimplemented!()
+                }
+            )),
+            loc.clone(),
+        ),
+    ];
+    let registry = crate::test_util::reg_from_items(declare_referenced(items)).expect("index");
+    let jni = JniGenBuilder::new()
+        .set_package_prefix("io.test.jni")
+        .package(
+            crate::package!()
+                .class(crate::data_class!(Stamp))
+                .class(crate::data_class!(Entry))
+                .class(crate::data_class!(Page))
+                .fun(prebindgen_registry::fun!(page_count)),
+        );
+    let gen = jni.build_with(registry).expect("resolve");
+
+    // Two levels of inlining, so the comparison sees depth 0, 1 and 2.
+    let page: syn::Ident = syn::parse_quote!(Page);
+    let wires = gen
+        .declarations()
+        .struct_out_wires_of(gen.registry(), &page)
+        .expect("a nested data class decomposes");
+    let names: Vec<&str> = wires.iter().map(|wire| wire.name.as_str()).collect();
+    assert_eq!(
+        names,
+        [
+            "head__stamp__secs",
+            "head__stamp__nanos",
+            "head__weight",
+            "count"
+        ],
+        "the decomposition inlines both levels"
+    );
+
+    // Writing the binding is what runs `assert_leaf_derivations_agree` over it.
+    let dir = unique_test_dir("jnigen_nested_agreement");
+    std::fs::create_dir_all(&dir).unwrap();
+    gen.write_rust(dir.join("gen.rs")).expect("write_rust");
+}
+
 /// The whole-object encode covers a shape the registry-facing decomposition
 /// refuses, and that divergence is deliberate.
 ///


### PR DESCRIPTION
## The decision

Step 5 of #596 was written as a decision rather than a promise: compose the
whole-object struct output through the registry's decomposition walk, or record
why it stays where it is. The code answers it, and not the way the umbrella
guessed.

**The encode is not a second implementation of the delivery walk.** It covers
shapes the registry-facing decomposition refuses:

```rust
// Declarations::struct_out_wires_at — the leaves the registry receives
if field.ty.optional_inner().is_some() || matches!(field.ty.kind(), TypeKind::Vec(_)) {
    return None;   // a nested data_class behind Option or Vec
}
```

The encode supports both: an optional nested class becomes a `present` flag
plus a defaulted group, a sum field a tag plus one group per variant.

So composing it means teaching the decomposition those gated shapes — and the
same decomposition drives fixed-builder returns and `impl Fn(T)` callback
arguments, so that would change what a foreign builder can be delivered. A
feature, not a refactoring, and this umbrella's own restriction is that
behaviour stays semantically unchanged unless a step calls the change out.

## What this PR does

Writes that down where the next reader looks, and pins it.

- `struct_out_wires_at`'s refusal and `encode_plan` each name the other and the
  divergence, so neither reads as an oversight.
- `the_decomposition_refuses_what_the_whole_object_encode_supports` holds it: a
  struct with an `Option<Leaf>` field decomposes to `None` while its
  whole-object encode still emits the `present` flag. Accepting the optional
  nested case in the decomposition fails it — checked.
- **#602** proposes the unification as the feature it is, with the coverage gap
  it would also close: a struct with an optional nested class gets no
  fixed-builder delivery today, so returning it or passing it to a callback
  falls back to the whole-object path.

## What I measured before deciding

Across both examples: 28 structs have a whole-object encode, 17 also have a
decomposition, and for all 17 the leaf counts agree. The two derivations are
consistent where they overlap — the difference is only in what they accept,
which is what makes this a coverage question rather than a duplication one.

## Verification

Workspace tests, strict Clippy, `cargo fmt --check` and
`RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps` pass. Every
generated artifact is unchanged: this step adds a test and two explanations.

Step 5 of #596 — the one box that closes with a reason rather than a deletion.

— Claude Code (Opus 5)
