### PR TITLE
Let a representation domain carry its scalar kind

### DIFF
--- a/prebindgen-c/src/convert.rs
+++ b/prebindgen-c/src/convert.rs
@@ -74,9 +74,12 @@ impl CbindgenBuilder {
             "Cbindgen custom representations must be C scalar types"
         );
         if let Some(domain) = decl.domain() {
+            // Both sides are reduced to their kind first: a representation and
+            // a domain naming one scalar are the same type however either was
+            // spelled.
             assert_eq!(
-                TypeKey::from_type(domain.ty()),
-                TypeKey::from_type(&repr),
+                Some(domain.kind()),
+                prebindgen_registry::DomainKind::from_type(&repr),
                 "Cbindgen conversion domain type does not match its {} representation",
                 match direction {
                     Direction::Construct => "input",

--- a/prebindgen-c/src/lib.rs
+++ b/prebindgen-c/src/lib.rs
@@ -103,7 +103,6 @@ use std::collections::{HashMap, HashSet};
 // `TypeRef` now, so what is left here serves the two node populations that
 // remain — a build-script declaration, and a converter's own generated
 // signature.
-pub(crate) use prebindgen_registry::types_util::path_tail_ident as type_path_tail;
 use prebindgen_registry::{
     decl::{ConvertDecl, ConvertSpec},
     flat::{extract_fn_trait_args, Field, Origin, ScalarKind, TypeKind, TypeRef},
@@ -525,7 +524,7 @@ fn sanitize(key: &TypeKey) -> String {
 /// The short name a C symbol is built from — the key's last path segment, or a
 /// sanitized rendering of the whole key when it is not a path.
 ///
-/// Off the **identity**: `type_path_tail` took the last segment of a node, and
+/// Off the **identity**: this took the last path segment of a node, and
 /// `TypeKey::short_name` is the same question asked of the canonical string, so
 /// the name no longer depends on holding the node it was derived from.
 fn type_short(key: &TypeKey) -> String {
@@ -697,27 +696,13 @@ fn bool_out_expr(value: TokenStream) -> TokenStream {
 
 /// Whether `ty` is an FFI-safe scalar primitive that passes through unchanged
 /// (`bool`, the fixed-width / pointer-width integers, and floats).
+///
+/// The set is `ScalarKind`'s, asked of the model rather than spelled out again
+/// here — the same reason [`r_is_scalar`] asks the classification. This one
+/// takes a written type because its caller has one: a `from!` / `into!`
+/// representation is a type the binding wrote, not a lowered `TypeRef`.
 fn is_scalar(ty: &syn::Type) -> bool {
-    type_path_tail(ty)
-        .map(|i| {
-            matches!(
-                i.to_string().as_str(),
-                "bool"
-                    | "i8"
-                    | "i16"
-                    | "i32"
-                    | "i64"
-                    | "isize"
-                    | "u8"
-                    | "u16"
-                    | "u32"
-                    | "u64"
-                    | "usize"
-                    | "f32"
-                    | "f64"
-            )
-        })
-        .unwrap_or(false)
+    ScalarKind::from_type(ty).is_some()
 }
 
 /// The element of a shared slice borrow (`&[E]`), off the classification.

--- a/prebindgen-c/src/tests/boundary_invariants.rs
+++ b/prebindgen-c/src/tests/boundary_invariants.rs
@@ -230,7 +230,7 @@ fn restricted_inbound(
     if let syn::Type::Reference(r) = ty {
         return restricted_inbound(&r.elem, structs, enums, seen);
     }
-    let tail = type_path_tail(ty)?.to_string();
+    let tail = prebindgen_registry::types_util::path_tail_ident(ty)?.to_string();
     if tail == "MaybeUninit" {
         return None;
     }

--- a/prebindgen-c/src/tests/lowering.rs
+++ b/prebindgen-c/src/tests/lowering.rs
@@ -213,6 +213,41 @@ fn trait_backed_custom_conversion_renders_from_the_late_plan() {
     );
 }
 
+/// `::core::primitive::u64` and `u64` name one scalar, and a domain declared
+/// over that scalar matches a representation written either way. Before the
+/// domain carried its kind, this fixture failed to build: the check compared
+/// the two spellings and reported "domain type does not match its input
+/// representation" for a type that does match.
+#[test]
+fn a_domain_matches_its_representation_however_the_representation_is_spelled() {
+    let loc = SourceLocation::default();
+    let items: Vec<(syn::Item, SourceLocation)> =
+        ["pub fn duration_echo(v: Duration) -> Duration { unimplemented!() }"]
+            .into_iter()
+            .map(|source| (syn::parse_str(source).unwrap(), loc.clone()))
+            .collect();
+    let registry = crate::test_util::reg_from_items(declare_referenced(items)).unwrap();
+    let cbindgen = CbindgenBuilder::new()
+        .source_module(syn::parse_quote!(myflat))
+        .convert(
+            prebindgen_registry::convert!(Duration)
+                .input(prebindgen_registry::from!(::core::primitive::u64))
+                .output(prebindgen_registry::into!(::core::primitive::u64))
+                .valid_range(0u64..=1_000_000u64),
+        )
+        .base_name("z_duration")
+        .function(syn::parse_quote!(duration_echo))
+        .panic();
+
+    let src = write(cbindgen, registry, "qualified_representation");
+    let compact: String = src.split_whitespace().collect();
+    assert!(
+        compact.contains("extern\"C\"fnduration_echo(v:::core::primitive::u64"),
+        "{src}"
+    );
+    assert!(compact.contains("(v)<=1000000u64"), "{src}");
+}
+
 #[test]
 fn output_terminals_stay_unrendered_until_final_write() {
     let loc = SourceLocation::default();

--- a/prebindgen-flat/src/flat/tests/acceptance.rs
+++ b/prebindgen-flat/src/flat/tests/acceptance.rs
@@ -2037,3 +2037,23 @@ fn a_raw_identifier_survives_typeid() {
     };
     assert!(qualified.ident().is_none());
 }
+
+/// `ScalarKind` is the closed set of the scalars a source may write, and it
+/// answers for a written type however that type is spelled — so a caller
+/// asking "is this an FFI-safe scalar primitive" needs no name table of its
+/// own.
+#[test]
+fn a_scalar_kind_is_recovered_from_any_spelling_of_its_type() {
+    use crate::flat::ScalarKind;
+
+    assert_eq!(
+        ScalarKind::from_type(&syn::parse_quote!(usize)),
+        Some(ScalarKind::Usize)
+    );
+    assert_eq!(
+        ScalarKind::from_type(&syn::parse_quote!(::core::primitive::usize)),
+        Some(ScalarKind::Usize)
+    );
+    assert_eq!(ScalarKind::from_type(&syn::parse_quote!(String)), None);
+    assert_eq!(ScalarKind::from_type(&syn::parse_quote!(&u8)), None);
+}

--- a/prebindgen-flat/src/flat/ty.rs
+++ b/prebindgen-flat/src/flat/ty.rs
@@ -1124,6 +1124,16 @@ impl ScalarKind {
         })
     }
 
+    /// The kind a written scalar type names, off its last path segment.
+    /// `None` for anything that is not one of these scalars.
+    ///
+    /// The closed set below is the whole answer to "is this an FFI-safe scalar
+    /// primitive", so a caller asking that question asks it here rather than
+    /// keeping a name table of its own.
+    pub fn from_type(ty: &syn::Type) -> Option<Self> {
+        Self::from_name(&crate::types_util::path_tail_ident(ty)?.to_string())
+    }
+
     /// The Rust spelling — the identity this was lowered from.
     pub fn as_str(self) -> &'static str {
         match self {

--- a/prebindgen-jni/src/jni/builder.rs
+++ b/prebindgen-jni/src/jni/builder.rs
@@ -1625,7 +1625,7 @@ impl Declarations {
         else {
             return (Niches::empty(), Vec::new());
         };
-        if TypeKey::from_type(domain.ty()).as_str() != "u64"
+        if domain.kind() != prebindgen_registry::DomainKind::U64
             || prebindgen_registry::types_util::path_tail_ident(wire)
                 .is_none_or(|ident| ident != "jlong")
         {

--- a/prebindgen-jni/src/jni/compile.rs
+++ b/prebindgen-jni/src/jni/compile.rs
@@ -1731,10 +1731,14 @@ impl<R: Conversions> JCompile<'_, R> {
             // normalization covers constructors, not scalars — so this compares
             // two spellings. It is exact anyway, from both sides: the domain's
             // spelling is derived from its kind, and a path-qualified scalar
-            // never reaches here, because a marked item lives in one flat
-            // namespace of bare names and such a representation fails to
-            // resolve first. Pinned by
-            // `a_qualified_scalar_representation_never_reaches_the_domain_check`.
+            // reaches here by neither route it could take. A `fun!`
+            // representation names a captured source function, and the flat
+            // model refuses that function outright, because marked items live
+            // in one flat namespace of bare names. A `from!` / `into!`
+            // representation names a type directly, and its qualified key
+            // resolves to nothing — the route
+            // `a_qualified_scalar_representation_never_reaches_the_domain_check`
+            // takes.
             let domain_key = TypeKey::from_type(&domain.ty());
             if domain_key != representation_key {
                 let direction = match direction {

--- a/prebindgen-jni/src/jni/compile.rs
+++ b/prebindgen-jni/src/jni/compile.rs
@@ -1727,13 +1727,16 @@ impl<R: Conversions> JCompile<'_, R> {
             }
         };
         if let Some(domain) = decl.domain() {
-            let domain_key = TypeKey::from_type(domain.ty());
+            // The domain's own spelling is derived from its kind, so this
+            // compares two canonical names: a domain cannot miss its
+            // representation by being written unusually.
+            let domain_key = TypeKey::from_type(&domain.ty());
             if domain_key != representation_key {
                 let direction = match direction {
                     Direction::Construct => "input",
                     Direction::Deconstruct => "output",
                 };
-                let domain = declared_type_name(domain.ty());
+                let domain = declared_type_name(&domain.ty());
                 match &representation {
                     crate::jni::chain::JCustomType::Model(reading) => panic!(
                         "convert!({source}): domain type {domain} does not match {direction} representation {reading}"

--- a/prebindgen-jni/src/jni/compile.rs
+++ b/prebindgen-jni/src/jni/compile.rs
@@ -1727,9 +1727,14 @@ impl<R: Conversions> JCompile<'_, R> {
             }
         };
         if let Some(domain) = decl.domain() {
-            // The domain's own spelling is derived from its kind, so this
-            // compares two canonical names: a domain cannot miss its
-            // representation by being written unusually.
+            // A `TypeKey` is not reduced to a canonical spelling — the model's
+            // normalization covers constructors, not scalars — so this compares
+            // two spellings. It is exact anyway, from both sides: the domain's
+            // spelling is derived from its kind, and a path-qualified scalar
+            // never reaches here, because a marked item lives in one flat
+            // namespace of bare names and such a representation fails to
+            // resolve first. Pinned by
+            // `a_qualified_scalar_representation_never_reaches_the_domain_check`.
             let domain_key = TypeKey::from_type(&domain.ty());
             if domain_key != representation_key {
                 let direction = match direction {

--- a/prebindgen-jni/src/jni/tests/values.rs
+++ b/prebindgen-jni/src/jni/tests/values.rs
@@ -1204,6 +1204,37 @@ fn conversion_domain_must_match_the_representation() {
     let _ = jni.build_with(registry);
 }
 
+/// A path-qualified scalar never reaches the domain check above: a marked item
+/// lives in one flat namespace of bare names, so a representation written
+/// `::core::primitive::u64` fails to resolve first. This pins that order —
+/// JniGen compares model type keys, which are not reduced to a canonical
+/// spelling, and would report a mismatch between two spellings of one scalar if
+/// such a representation ever got that far.
+#[test]
+fn a_qualified_scalar_representation_never_reaches_the_domain_check() {
+    let loc = myflat_loc();
+    let items: Vec<(syn::Item, SourceLocation)> =
+        ["pub fn duration_use(v: Duration) { unimplemented!() }"]
+            .into_iter()
+            .map(|source| {
+                let item: syn::Item = syn::parse_str(source).unwrap();
+                (item, loc.clone())
+            })
+            .collect();
+    let registry = crate::test_util::reg_from_items(declare_referenced(items)).unwrap();
+    let jni = JniGenBuilder::new()
+        .convert(
+            prebindgen_registry::convert!(Duration)
+                .input(prebindgen_registry::from!(::core::primitive::u64))
+                .valid_range(0u64..=1_000u64),
+        )
+        .package(crate::package!("time").fun(prebindgen_registry::fun!(duration_use)));
+
+    let error = format!("{:?}", jni.build_with(registry).err());
+    assert!(error.contains("core :: primitive :: u64"), "{error}");
+    assert!(!error.contains("domain type"), "{error}");
+}
+
 /// Phase 4: a bare `Option<primitive>` with no niche crosses as a decoupled
 /// `(present: Boolean, value: <prim>)` pair instead of a boxed
 /// `java.lang.*` `JObject`. An enum terminal contributes unused discriminants,

--- a/prebindgen-registry/src/domain.rs
+++ b/prebindgen-registry/src/domain.rs
@@ -5,75 +5,70 @@ use std::ops::{Bound, RangeBounds};
 use proc_macro2::TokenStream;
 use quote::quote;
 
-/// The scalar a [`RepresentationDomain`] is declared over.
-///
-/// This is the identity every domain question is decided on — whether a bounds
-/// check needs a NaN test, which candidate values a niche is picked from, and
-/// whether a domain and a conversion's representation are the same type. Its
-/// spelling is derived from it and never the other way round, so a domain
-/// written `::core::primitive::u64` and one written `u64` are one kind.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
-pub enum DomainKind {
-    I8,
-    I16,
-    I32,
-    I64,
-    I128,
-    U8,
-    U16,
-    U32,
-    U64,
-    U128,
-    F32,
-    F64,
+/// The scalars a [`RepresentationDomain`] can be declared over: the variants,
+/// their spellings and the reduction from a written type all come from this one
+/// list, so a kind cannot be added to the set without answering for both.
+macro_rules! domain_kinds {
+    ($(($variant:ident, $name:literal)),* $(,)?) => {
+        /// The scalar a [`RepresentationDomain`] is declared over.
+        ///
+        /// This is the identity every domain question is decided on — whether a
+        /// bounds check needs a NaN test, which candidate values a niche is
+        /// picked from, and whether a domain and a conversion's representation
+        /// are the same type. Its spelling is derived from it and never the
+        /// other way round, so a domain written `::core::primitive::u64` and one
+        /// written `u64` are one kind.
+        #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+        pub enum DomainKind {
+            $(
+                #[doc = concat!("The `", $name, "` scalar.")]
+                $variant
+            ),*
+        }
+
+        impl DomainKind {
+            /// The one canonical Rust spelling of this scalar.
+            pub fn as_str(self) -> &'static str {
+                match self {
+                    $(Self::$variant => $name),*
+                }
+            }
+
+            /// The kind a written scalar type names, off its last path segment,
+            /// so every spelling of one scalar answers alike. `None` for a type
+            /// no domain can be declared over — `bool`, `isize` and `usize`
+            /// among them.
+            pub fn from_type(ty: &syn::Type) -> Option<Self> {
+                let ident = prebindgen_flat::types_util::path_tail_ident(ty)?;
+                $(if ident == $name {
+                    return Some(Self::$variant);
+                })*
+                None
+            }
+        }
+    };
 }
 
-impl DomainKind {
-    /// The one canonical Rust spelling of this scalar.
-    pub fn as_str(self) -> &'static str {
-        match self {
-            Self::I8 => "i8",
-            Self::I16 => "i16",
-            Self::I32 => "i32",
-            Self::I64 => "i64",
-            Self::I128 => "i128",
-            Self::U8 => "u8",
-            Self::U16 => "u16",
-            Self::U32 => "u32",
-            Self::U64 => "u64",
-            Self::U128 => "u128",
-            Self::F32 => "f32",
-            Self::F64 => "f64",
-        }
-    }
+domain_kinds!(
+    (I8, "i8"),
+    (I16, "i16"),
+    (I32, "i32"),
+    (I64, "i64"),
+    (I128, "i128"),
+    (U8, "u8"),
+    (U16, "u16"),
+    (U32, "u32"),
+    (U64, "u64"),
+    (U128, "u128"),
+    (F32, "f32"),
+    (F64, "f64"),
+);
 
+impl DomainKind {
     /// The scalar's Rust type, built from [`Self::as_str`].
     pub fn ty(self) -> syn::Type {
         let ident = syn::Ident::new(self.as_str(), proc_macro2::Span::call_site());
         syn::parse_quote!(#ident)
-    }
-
-    /// The kind a written scalar type names, off its last path segment, so
-    /// every spelling of one scalar answers alike. `None` for a type no domain
-    /// can be declared over — `bool`, `isize` and `usize` among them.
-    pub fn from_type(ty: &syn::Type) -> Option<Self> {
-        let ident = prebindgen_flat::types_util::path_tail_ident(ty)?.to_string();
-        [
-            Self::I8,
-            Self::I16,
-            Self::I32,
-            Self::I64,
-            Self::I128,
-            Self::U8,
-            Self::U16,
-            Self::U32,
-            Self::U64,
-            Self::U128,
-            Self::F32,
-            Self::F64,
-        ]
-        .into_iter()
-        .find(|kind| kind.as_str() == ident)
     }
 
     fn is_float(self) -> bool {

--- a/prebindgen-registry/src/domain.rs
+++ b/prebindgen-registry/src/domain.rs
@@ -3,21 +3,97 @@
 use std::ops::{Bound, RangeBounds};
 
 use proc_macro2::TokenStream;
-use quote::{quote, ToTokens};
+use quote::quote;
+
+/// The scalar a [`RepresentationDomain`] is declared over.
+///
+/// This is the identity every domain question is decided on — whether a bounds
+/// check needs a NaN test, which candidate values a niche is picked from, and
+/// whether a domain and a conversion's representation are the same type. Its
+/// spelling is derived from it and never the other way round, so a domain
+/// written `::core::primitive::u64` and one written `u64` are one kind.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum DomainKind {
+    I8,
+    I16,
+    I32,
+    I64,
+    I128,
+    U8,
+    U16,
+    U32,
+    U64,
+    U128,
+    F32,
+    F64,
+}
+
+impl DomainKind {
+    /// The one canonical Rust spelling of this scalar.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::I8 => "i8",
+            Self::I16 => "i16",
+            Self::I32 => "i32",
+            Self::I64 => "i64",
+            Self::I128 => "i128",
+            Self::U8 => "u8",
+            Self::U16 => "u16",
+            Self::U32 => "u32",
+            Self::U64 => "u64",
+            Self::U128 => "u128",
+            Self::F32 => "f32",
+            Self::F64 => "f64",
+        }
+    }
+
+    /// The scalar's Rust type, built from [`Self::as_str`].
+    pub fn ty(self) -> syn::Type {
+        let ident = syn::Ident::new(self.as_str(), proc_macro2::Span::call_site());
+        syn::parse_quote!(#ident)
+    }
+
+    /// The kind a written scalar type names, off its last path segment, so
+    /// every spelling of one scalar answers alike. `None` for a type no domain
+    /// can be declared over — `bool`, `isize` and `usize` among them.
+    pub fn from_type(ty: &syn::Type) -> Option<Self> {
+        let ident = prebindgen_flat::types_util::path_tail_ident(ty)?.to_string();
+        [
+            Self::I8,
+            Self::I16,
+            Self::I32,
+            Self::I64,
+            Self::I128,
+            Self::U8,
+            Self::U16,
+            Self::U32,
+            Self::U64,
+            Self::U128,
+            Self::F32,
+            Self::F64,
+        ]
+        .into_iter()
+        .find(|kind| kind.as_str() == ident)
+    }
+
+    fn is_float(self) -> bool {
+        matches!(self, Self::F32 | Self::F64)
+    }
+}
 
 /// Scalar representations that can carry a declarative domain.
 pub trait DomainScalar: Copy + 'static {
     #[doc(hidden)]
     fn domain_value(self) -> ScalarValue;
     #[doc(hidden)]
-    fn domain_type() -> syn::Type;
+    fn domain_kind() -> DomainKind;
 }
 
 macro_rules! impl_ints {
     ($(($t:ty, $v:ident)),* $(,)?) => {$(
         impl DomainScalar for $t {
             fn domain_value(self) -> ScalarValue { ScalarValue::$v(self) }
-            fn domain_type() -> syn::Type { syn::parse_quote!($t) }
+            fn domain_kind() -> DomainKind { DomainKind::$v }
         }
     )*};
 }
@@ -38,16 +114,16 @@ impl DomainScalar for f32 {
     fn domain_value(self) -> ScalarValue {
         ScalarValue::F32(self.to_bits())
     }
-    fn domain_type() -> syn::Type {
-        syn::parse_quote!(f32)
+    fn domain_kind() -> DomainKind {
+        DomainKind::F32
     }
 }
 impl DomainScalar for f64 {
     fn domain_value(self) -> ScalarValue {
         ScalarValue::F64(self.to_bits())
     }
-    fn domain_type() -> syn::Type {
-        syn::parse_quote!(f64)
+    fn domain_kind() -> DomainKind {
+        DomainKind::F64
     }
 }
 
@@ -190,7 +266,7 @@ enum Base {
 /// Legal values of a custom conversion's scalar representation.
 #[derive(Clone)]
 pub struct RepresentationDomain {
-    ty: syn::Type,
+    kind: DomainKind,
     base: Base,
     excluded: Vec<ScalarValue>,
 }
@@ -213,7 +289,7 @@ impl RepresentationDomain {
             "representation-domain range cannot be empty"
         );
         Self {
-            ty: T::domain_type(),
+            kind: T::domain_kind(),
             base: Base::Range { start, end },
             excluded: vec![],
         }
@@ -226,7 +302,7 @@ impl RepresentationDomain {
             "representation-domain valid set cannot be empty"
         );
         Self {
-            ty: T::domain_type(),
+            kind: T::domain_kind(),
             base: Base::Values(values),
             excluded: vec![],
         }
@@ -234,8 +310,8 @@ impl RepresentationDomain {
 
     pub fn exclude<T: DomainScalar>(&mut self, values: impl IntoIterator<Item = T>) {
         assert_eq!(
-            prebindgen_flat::flat::TypeKey::from_type(&self.ty),
-            prebindgen_flat::flat::TypeKey::from_type(&T::domain_type()),
+            self.kind,
+            T::domain_kind(),
             "representation-domain exclusions must use the base domain's scalar type"
         );
         self.excluded
@@ -243,8 +319,14 @@ impl RepresentationDomain {
         self.excluded = dedup(std::mem::take(&mut self.excluded));
     }
 
-    pub fn ty(&self) -> &syn::Type {
-        &self.ty
+    /// The scalar this domain is declared over.
+    pub fn kind(&self) -> DomainKind {
+        self.kind
+    }
+
+    /// The scalar's Rust type, built from [`Self::kind`].
+    pub fn ty(&self) -> syn::Type {
+        self.kind.ty()
     }
 
     /// An expression testing whether `value` lies inside the legal domain —
@@ -254,10 +336,7 @@ impl RepresentationDomain {
             Base::Range { start, end } => {
                 let lo = bound_expr(start, &value, true);
                 let hi = bound_expr(end, &value, false);
-                let not_nan = if matches!(
-                    self.ty.to_token_stream().to_string().as_str(),
-                    "f32" | "f64"
-                ) {
+                let not_nan = if self.kind.is_float() {
                     quote!(!(#value).is_nan())
                 } else {
                     quote!(true)
@@ -284,20 +363,19 @@ impl RepresentationDomain {
             _ => 0,
         };
         let budget = limit.saturating_add(extra).max(1);
-        match self.ty.to_token_stream().to_string().as_str() {
-            "i8" => ints!(out, self, i8, I8, budget),
-            "i16" => ints!(out, self, i16, I16, budget),
-            "i32" => ints!(out, self, i32, I32, budget),
-            "i64" => ints!(out, self, i64, I64, budget),
-            "i128" => ints!(out, self, i128, I128, budget),
-            "u8" => ints!(out, self, u8, U8, budget),
-            "u16" => ints!(out, self, u16, U16, budget),
-            "u32" => ints!(out, self, u32, U32, budget),
-            "u64" => ints!(out, self, u64, U64, budget),
-            "u128" => ints!(out, self, u128, U128, budget),
-            "f32" => float32_candidates(&mut out, budget),
-            "f64" => float64_candidates(&mut out, budget),
-            _ => unreachable!(),
+        match self.kind {
+            DomainKind::I8 => ints!(out, self, i8, I8, budget),
+            DomainKind::I16 => ints!(out, self, i16, I16, budget),
+            DomainKind::I32 => ints!(out, self, i32, I32, budget),
+            DomainKind::I64 => ints!(out, self, i64, I64, budget),
+            DomainKind::I128 => ints!(out, self, i128, I128, budget),
+            DomainKind::U8 => ints!(out, self, u8, U8, budget),
+            DomainKind::U16 => ints!(out, self, u16, U16, budget),
+            DomainKind::U32 => ints!(out, self, u32, U32, budget),
+            DomainKind::U64 => ints!(out, self, u64, U64, budget),
+            DomainKind::U128 => ints!(out, self, u128, U128, budget),
+            DomainKind::F32 => float32_candidates(&mut out, budget),
+            DomainKind::F64 => float64_candidates(&mut out, budget),
         }
         out.extend(self.excluded.iter().copied());
         let mut selected = Vec::new();
@@ -470,6 +548,7 @@ fn dedup(values: Vec<ScalarValue>) -> Vec<ScalarValue> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use quote::ToTokens;
 
     #[test]
     fn integer_range_derives_extreme_niches() {
@@ -507,6 +586,46 @@ mod tests {
         range.exclude([0.5f64]);
         assert!(!range.contains(ScalarValue::F64(0.5f64.to_bits())));
         assert!(!range.contains(ScalarValue::F64(f64::NAN.to_bits())));
+    }
+
+    /// The NaN test in a range check is decided by the domain's kind, and only
+    /// a float range carries one.
+    #[test]
+    fn only_a_float_range_guards_against_nan() {
+        let float = RepresentationDomain::range(0.0f64..=1.0f64);
+        assert!(float
+            .contains_expr(quote!(value))
+            .to_string()
+            .contains("is_nan"));
+
+        let integer = RepresentationDomain::range(0u64..=1u64);
+        assert!(!integer
+            .contains_expr(quote!(value))
+            .to_string()
+            .contains("is_nan"));
+    }
+
+    /// Every spelling of one scalar is one kind, and a domain's own spelling
+    /// is derived from that kind rather than kept from how it was declared.
+    #[test]
+    fn one_scalar_is_one_kind_however_it_is_written() {
+        assert_eq!(
+            DomainKind::from_type(&syn::parse_quote!(::core::primitive::u64)),
+            Some(DomainKind::U64)
+        );
+        assert_eq!(
+            DomainKind::from_type(&syn::parse_quote!(u64)),
+            Some(DomainKind::U64)
+        );
+        // `bool` is a scalar, but not one a domain can be declared over.
+        assert_eq!(DomainKind::from_type(&syn::parse_quote!(bool)), None);
+
+        let domain = RepresentationDomain::range(0u64..=1u64);
+        assert_eq!(domain.kind(), DomainKind::U64);
+        assert_eq!(
+            domain.ty().to_token_stream().to_string(),
+            quote!(u64).to_string()
+        );
     }
 
     #[test]

--- a/prebindgen-registry/src/lib.rs
+++ b/prebindgen-registry/src/lib.rs
@@ -133,7 +133,7 @@ pub use self::{
         FieldsDecl, FunctionDecl, LocalField, LocalVariant,
     },
     diagnostics::{warn_unclaimed, Claimed},
-    domain::{DomainScalar, RepresentationDomain, ScalarValue},
+    domain::{DomainKind, DomainScalar, RepresentationDomain, ScalarValue},
     emit::RustWriter,
     generation::{
         AbiLayout, ArtifactId, ArtifactInput, ArtifactPlan, ChainValue, ChoiceArity, Cleanup,


### PR DESCRIPTION
Step 6 of #596, the umbrella for registry-composed source walks. Closes
#589.

A **representation domain** is the set of legal values of the scalar a custom
conversion crosses in — its **representation** — and it is what
`convert!(Duration).valid_range(0u64..=1_000_000)` declares. Three questions are answered from that scalar: whether a generated
bounds check needs a NaN test, which candidate values a **niche** — a value
outside the domain, reserved so that `Option<Duration>` needs no second field —
is picked from, and whether the domain and the conversion's representation are
the same type.

`RepresentationDomain` kept the scalar as a `syn::Type` and recovered it by
matching the rendered token string, so a spelling decided all three: its
`contains_expr` matched `"f32" | "f64"` for the NaN test, its `niche_values`
matched ten integer names and ended `_ => unreachable!()`, and each adapter
compared the domain's spelling against the representation's. `DomainScalar` —
the trait a Rust scalar implements to be usable as a domain's scalar — is
publicly re-exported and unsealed, so a downstream implementation was free to
spell `u64` as `::core::primitive::u64` and take the wrong branch in two of
those three, and fail the build in the third.

## What changed

`DomainKind` — twelve variants, `i8` through `u128` and the two floats — is
what `DomainScalar` now yields (`domain_kind()` replaces `domain_type()`) and
what `RepresentationDomain` stores. The spelling is derived from the kind
(`DomainKind::as_str`, `DomainKind::ty`) and never the reverse, so a domain has
no spelling left for anyone to choose. The variants, their spellings and the
reduction from a written type are all generated from one `domain_kinds!` list,
so a kind cannot enter the set while any of the three is left unanswered.

All three questions are decided on the kind. Both string matches and the
`unreachable!()` are gone: the NaN test asks `DomainKind::is_float`, and
`niche_values` matches the twelve kinds exhaustively. `DomainKind::from_type`
reduces a written scalar type to its kind off the last path segment, and
Cbindgen — the C adapter — compares that against the domain's kind, so a
representation written `::core::primitive::u64` and a domain over `u64` are one
type where they were two.

JniGen — the JNI/Kotlin adapter — keeps its comparison of model type keys, and
that comparison is exact for a reason upstream of it rather than because a key
is canonical: a `TypeKey` reduces constructors, not scalars, so two spellings of
one scalar are two keys. What JniGen is protected by is that a path-qualified
scalar cannot reach the comparison at all — a marked item lives in one flat
namespace of bare names, so such a representation fails to resolve first. The
comment there now says that, and
`a_qualified_scalar_representation_never_reaches_the_domain_check` pins it.

Two more spelling decisions go with it. `is_scalar`, which Cbindgen asks one
statement before the domain check, decided whether a written type is an
FFI-safe scalar by matching thirteen hand-written names; it now asks
`ScalarKind::from_type`, the same closed set the model already keeps, so the
scalars are spelled out in one place instead of three. JniGen asked whether a domain is the
`u64` one whose niches fit in a `jlong`, the 64-bit JVM integer its wire values
cross in, and asked it as
`TypeKey::from_type(domain.ty()).as_str() != "u64"`. It now asks
`domain.kind() != DomainKind::U64`.

**The design question #589 left open** — widen the flat model's `ScalarKind`,
its classification of the scalars a source may write, or introduce a
domain-side kind — is settled as a domain-side kind. Widening `ScalarKind` with
`I128` and `U128` would make the model classify scalars no adapter can pass
across an FFI boundary, and `ScalarKind` also carries `Bool`, `Isize` and
`Usize`, which no domain can be declared over — so sharing one enum would have
kept an `unreachable!()`, at the other end.

## Tests

Three, each mutation-checked:

- `a_domain_matches_its_representation_however_the_representation_is_spelled`
  (Cbindgen) builds the binding #589 reports as failing: a conversion whose
  representation is written `::core::primitive::u64` under a `u64` domain.
  Restoring the spelling comparison fails it with the issue's own message.
- `one_scalar_is_one_kind_however_it_is_written` (registry) pins the reduction
  itself, including that `bool` has no domain kind. Matching the whole rendered
  type instead of its last segment fails it.
- `only_a_float_range_guards_against_nan` (registry) covers the branch this
  rewrites, which had no test of its own: making `is_float` answer `false` —
  deleting the NaN guard from every generated float bounds check — passed the
  whole workspace before this test existed.
- `a_scalar_kind_is_recovered_from_any_spelling_of_its_type` (flat) pins the
  set `is_scalar` now defers to. Matching the whole rendered type instead of its
  last segment fails it, and fails the Cbindgen test above with it.
- `a_qualified_scalar_representation_never_reaches_the_domain_check` (JniGen)
  pins the resolution failure described above, and that it is not the domain
  check reporting it.

## Verification

836 tests pass, 0 clippy warnings (strict), `cargo fmt --check` clean,
`RUSTDOCFLAGS='-D warnings' cargo doc` clean, `examples/regen-check.sh` reports
`PASS - regen check clean`. Generated output is byte-identical: no adapter's
output depended on how a domain was spelled, only on which scalar it named.

— Claude Code (Opus 5)

