### PR TITLE
Delete the part read nobody speaks, and reconcile #513

### DIFF
--- a/prebindgen-registry/src/chain.rs
+++ b/prebindgen-registry/src/chain.rs
@@ -120,13 +120,18 @@ fn child_value<C: Child>(child: &C, value: TokenStream, emit: &RustWriter) -> To
 ///
 /// A bridge whose read is a projection — a tuple index, a field access —
 /// answers with [`Self::expression`]. One whose read is not an expression at
-/// all answers with [`Self::statements`] or [`Self::fallible`]: reading a
-/// property off a JVM object binds two locals and can fail, and a bridge that
-/// had only an expression to return could not say either.
+/// all answers with [`Self::fallible`]: reading a property off a JVM object
+/// binds two locals and can fail, neither of which a bridge that could only
+/// return an expression can say.
 ///
 /// The composer runs the preludes in part order, before the source value is
 /// constructed, and a fallible read makes the whole composed conversion
 /// fallible even when no child converter can fail.
+///
+/// Whether a read can fail is kept as its own fact rather than read off "has a
+/// prelude". The two coincide across today's two constructors, but a fallible
+/// read that needs no statements — an expression carrying its own `?` — would
+/// be silently demoted to infallible by the shorter rule.
 pub struct PartRead {
     prelude: TokenStream,
     value: TokenStream,
@@ -138,15 +143,6 @@ impl PartRead {
     pub fn expression(value: TokenStream) -> Self {
         Self {
             prelude: TokenStream::new(),
-            value,
-            fallible: false,
-        }
-    }
-
-    /// A part reached by running `prelude` first, which cannot fail.
-    pub fn statements(prelude: TokenStream, value: TokenStream) -> Self {
-        Self {
-            prelude,
             value,
             fallible: false,
         }
@@ -1126,30 +1122,6 @@ mod tests {
         }
     }
 
-    /// A bridge whose part read binds a local and cannot fail — the middle
-    /// constructor, whose behaviour is not implied by its neighbours.
-    #[derive(Clone)]
-    struct TestBoundParts;
-
-    impl ProductBridge for TestBoundParts {
-        fn intermediate(&self) -> syn::Type {
-            syn::parse_quote!(TestObject)
-        }
-
-        fn part(&self, value: TokenStream, index: usize, _name: &syn::Ident) -> PartRead {
-            let local = format_ident!("__bound{index}");
-            let position = syn::Index::from(index);
-            PartRead::statements(
-                quote::quote!(let #local = (#value).#position;),
-                quote::quote!(#local),
-            )
-        }
-
-        fn build(&self, _parts: &[(syn::Ident, TokenStream)]) -> TokenStream {
-            unreachable!("this fixture only constructs")
-        }
-    }
-
     /// A bridge may read its part with statements that can fail, and the
     /// composer runs them before it constructs the source value.
     ///
@@ -1200,41 +1172,6 @@ mod tests {
         assert!(
             body.contains("__read0") && body.contains("__read1"),
             "each part is read into its own local:\n{body}"
-        );
-    }
-
-    /// A prelude that cannot fail leaves the conversion infallible.
-    ///
-    /// This is the whole difference between `PartRead::statements` and
-    /// `PartRead::fallible`, and the only place it is visible: both emit their
-    /// prelude, and only one makes the caller handle an error.
-    #[test]
-    fn an_infallible_prelude_leaves_the_chain_infallible() {
-        let plan = Product {
-            source: TypeRef::scalar(ScalarKind::I64),
-            direction: Direction::Construct,
-            source_policy: TestSource {
-                spells: Rc::new(Cell::new(0)),
-            },
-            bridge: TestBoundParts,
-            parts: vec![ProductPart {
-                name: format_ident!("only"),
-                child: TestChild::new("only", false, false),
-                mode: Mode::Owned,
-                hold_uninit: false,
-            }],
-        };
-
-        let rendered = plan.render(&RustWriter::for_test());
-        let body = rendered.body.to_token_stream().to_string();
-
-        assert!(
-            body.contains("let __bound0"),
-            "the prelude is emitted:\n{body}"
-        );
-        assert!(
-            !rendered.fallible,
-            "a prelude that cannot fail leaves the conversion infallible:\n{body}"
         );
     }
 


### PR DESCRIPTION
Step 7 of #596, the umbrella for registry-composed source walks, and its last.
The step has two halves: delete what the umbrella stranded, and state on #513 —
the umbrella above this one, which asked for one registry-driven Rust
generation pipeline — what its branch now is.

## The code half

`PartRead` is what a **bridge** — the adapter-supplied half of a composed
conversion — returns when the registry's `Product` composer asks it to read one
part out of an intermediate value. It had three constructors: `expression` (a
projection), `statements` (a prelude that binds but cannot fail) and `fallible`
(a prelude that can fail).

`statements` has no production caller. Step 2b reached for `fallible`, because
every JVM property read can fail, and steps 3 to 5 reached for neither. It is
deleted here, with its test fixture and the one test that separated it from
`fallible`, as #596 said it would be if nothing spoke it.

The `fallible` flag stays a fact of its own rather than being read off "has a
prelude", and the struct now says why: the two coincide across the remaining two
constructors, but a fallible read needing no statements — an expression carrying
its own `?` — would be silently demoted by the shorter rule.

## The #513 half

Nothing is posted to #513 until this PR is approved. The text below is what
goes there on merge: one comment, and the body edits it describes.

### Proposed comment

> ## Where this branch stands after #581 and #596
>
> **#581 made the writer a pure consumer.** `write_rust` takes one frozen
> `Assembly` — the artifacts, the rendering capability minted at freeze, and
> prebindgen's injected feature guards — and no registry. Dependency
> completeness is proven from edges each artifact declares (`calls`, `provides`)
> instead of by walking rendered syntax, and `Prebindgen` is down to `validate`
> and `validate_resolved`, so no item callback carries a registry. Walking
> `syn` survives only as test support.
>
> **#596 moved the source walks the adapters still owned.** The registry gained
> fallible part reads, one complete child per whole-object property, composed
> `Product` and `Choice` for JVM whole-object input and sealed sums, and the
> delivery walk itself. Three of the four walks over a source value that JniGen
> owned are gone — whole-object struct input, sealed-sum whole-object input and
> delivery; the fourth is gate 6's remainder. A representation domain now
> carries its scalar kind, so no adapter decides a scalar's identity from a
> rendered spelling (#589).
>
> ### The completion gates, one by one
>
> 1. **No planning or validation path can obtain `Emit`, source `syn::Type`, or
>    rendered source tokens** — holds, and a compile-fail suite is what holds
>    it. Nine `compile_fail` doctests cover the gate's three subjects, and
>    because a doctest compiles against the public API they cover them across
>    the crate boundary: three on `RustWriter` — its constructor is
>    registry-private, a registry-only adapter cannot name the flat rendering
>    protocol to supply a receiver of its own, and the facade exposes no
>    `spell` — and six in the flat rendering module, closing `spell` on a type
>    and on a function's origin, `as_syn` on a type and on an element,
>    `stripped_syntax`, and `to_syn`. #375 restored the first three. Per-module
>    source fences and the `pub(crate)` rendering capability sit under them.
>    Three further compile-fail doctests seal model construction rather than
>    rendering, so the boundary has twelve in all.
> 2. **No final renderer receives `&Registry`, resumes compilation, or selects a
>    fallback** — holds for Rust: `RustArtifact::render(&self, emit)` is the
>    whole interface. **It does not hold for Kotlin**: `write_kotlin` still takes
>    `&Registry`. It reads the frozen plan rather than resuming compilation, so
>    the second half of the gate holds and the first does not.
> 3. **One intermediate type per reached fragment, one ABI layout per reached
>    site** — unchanged by these two umbrellas; whatever #521 and #536 left.
> 4. **C ordinary calls and callbacks reuse the same plans** — unchanged (#523).
> 5. **Every JNI consumer reads one `JniGenerationPlan`** — unchanged (#524 and
>    the slices under parent 7).
> 6. **Product, Optional, Sequence, Choice and Invoke source traversal exists
>    only in the registry composer** — nearly. What remains adapter-side is one
>    walk: the whole-object output encode, which flattens a struct's fields into
>    the leaves a JVM constructor is called with. It is a **superset** of the
>    registry-facing decomposition, which refuses a nested data class behind
>    `Option` or `Vec` — 11 of 29 declared structs — so composing it out of that
>    decomposition would drop delivery coverage. #602 carries the missing
>    support. Until then a standing check compares the two derivations on every
>    declared data class, over leaf names and nesting depth.
> 7. **#506's legacy carriers and the compatibility writer path are deleted** —
>    the writer path is (#581). The carriers are not, and the gate is the wrong
>    question for them; see below.
>
> ### #506's carriers are current machinery, not legacy
>
> #506 asked for the deletion of `expand`, `unfold`, `Decompositions`,
> `ConverterImpl`, `Stage` and `fn_plan.rs` as "what the registry API replaced".
> After the two umbrellas that is true of none of them:
>
> - **`unfold`** is the registry's own decomposition walk, and since #600 it is
>   where the delivery walk lives too. Deleting it would delete the composer.
> - **`expand`** is the declared surface behind `expand_param!` /
>   `expand_return!`, not a second pipeline.
> - **`Decompositions`** is a public input: a binding states the output
>   decompositions it demands before `resolve`, which is the only route for a
>   registry built with no adapter declarations at all.
> - **`ConverterImpl` and `Stage`** have been identity-only rows since #570 —
>   they carry no function bodies, and the identity they carry is what the
>   writer groups and names by.
> - **`fn_plan.rs` and `struct_plan.rs`** hold JNI policy — JVM property reads,
>   `jvalue` layout, locking — rather than a second source walk. #596 emptied
>   them of walking, not of policy.
>
> One carrier from that list is gone outright: `InputKind`, deleted by #536.
>
> So #506 is not a deletion waiting to happen. What is still true of its subject
> is narrower and belongs to parent 5 below: `pre_stages` is not yet folded into
> the converter operation graph.
>
> ### Parents
>
> - **Parent 7 is complete** and is ticked. Every terminal codec is a frozen
>   operation, `CFunction::Complete` and `JFunction::Complete` are gone (#552,
>   #569), the shared rows are identity-only (#570), and source spelling happens
>   in final rendering.
> - **Parent 8 is complete except its last clause.** The writer cutover, the
>   removal of planning-time `Emit`, the mutable compiler caches, `compiled_fns`,
>   registry-bearing item callbacks, token reparsing, rendered-name
>   deduplication and the whole-file post-process rewrite all landed (#571 to
>   #578, #581). What remains is "complete #506 and add call-graph/compile-fail
>   checks enforcing both sides of the planning/rendering boundary". Both check
>   kinds exist: the writer refuses an artifact whose declared callee is not
>   reached, a test asserts the declared edges cover every rendered call, and the
>   compile-fail doctests of gate 1 seal the planning side. #506 is re-scoped by
>   the section above rather than completed, and the rendering side is sealed by
>   an interface rather than by a check — `RustArtifact::render` cannot reach a
>   registry, and `write_kotlin` still receives one.
> - **Parent 5 is re-scoped.** Its slices all landed, and its deletion list
>   (`flat_input`, `delivery`, `struct_plan`, `fn_plan`, `InputKind`, selectors)
>   named modules that are now policy homes rather than superseded duplicates —
>   `InputKind` is the only one that was deletable, and it is deleted. What is
>   left of the parent is `pre_stages`, and the whole-object output encode that
>   #602 tracks.
>
> ### What #596 stranded
>
> `PartRead::statements` — a part read that binds without failing — had no
> production caller and is deleted.

### Proposed body edits

1. Tick parent 7.
2. Under parent 8, add `#506` as the one remaining sub-bullet and tick the rest
   of its prose — the checks that clause asks for exist, so they are not
   re-filed as outstanding.
3. Replace parent 5's deletion clause with what remains of it.
4. Replace the "Why the migration is not complete yet" bullet that reads "The
   legacy deletion targets in #506 … remain live" with the reclassification.
5. Mark gates 1, 4, 5 and the writer half of 7 as holding; annotate 2 with the
   Kotlin exception and 6 with #602.

## Verification

835 tests pass (836 minus the deleted one), 0 clippy warnings (strict),
`cargo fmt --check` clean, `RUSTDOCFLAGS='-D warnings' cargo doc` clean,
`examples/regen-check.sh` reports `PASS - regen check clean`. Generated output
is byte-identical — no production path called what this deletes.

— Claude Code (Opus 5)



