### PR TITLE
Group imports the way CI checks them

### DIFF
--- a/prebindgen-registry/src/domain.rs
+++ b/prebindgen-registry/src/domain.rs
@@ -542,8 +542,9 @@ fn dedup(values: Vec<ScalarValue>) -> Vec<ScalarValue> {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use quote::ToTokens;
+
+    use super::*;
 
     #[test]
     fn integer_range_derives_extreme_niches() {

--- a/prebindgen-registry/src/unfold/walk.rs
+++ b/prebindgen-registry/src/unfold/walk.rs
@@ -11,10 +11,9 @@
 //! this module cannot know: where a source item is qualified from
 //! (`qualify`), and what each leaf is ([`DecomposedLeaf`]).
 
+use prebindgen_flat::flat::TypeRef;
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
-
-use prebindgen_flat::flat::TypeRef;
 
 use crate::unfold::{steps_are_movable, PathStep};
 


### PR DESCRIPTION
`build (stable)` and `build (1.85.0)` fail on #513 at the rustfmt step, in two
files this branch gained from #596: `prebindgen-registry/src/domain.rs` and
`prebindgen-registry/src/unfold/walk.rs`. Both are import ordering, and both are
now grouped the way the check wants — `quote::ToTokens` before `super::*`, and
`prebindgen_flat::flat::TypeRef` in the external-crate group with
`proc_macro2` and `quote` rather than in a paragraph of its own.

**Why a plain `cargo fmt --check` passed on them.** CI runs the check with two
unstable options that are not the default:

```
cargo fmt --check -- --config "unstable_features=true,imports_granularity=Crate,group_imports=StdExternalCrate"
```

`group_imports=StdExternalCrate` is what orders the two blocks above; without
it, both files are correctly formatted, which is what every local check on the
#596 children reported. That command is the one to run, and it is what I
verified this with.

No behaviour change: imports only. `cargo clippy --all-targets --all-features -- --deny warnings` is clean, 835 workspace tests pass, and both the CI-configured and the default `cargo fmt --check` are clean.

— Claude Code (Opus 5)
