### PR TITLE
Compose the delivery walk in the registry

### DIFF
--- a/examples/covertest-kotlin/src/generated_bindings.rs
+++ b/examples/covertest-kotlin/src/generated_bindings.rs
@@ -13668,7 +13668,7 @@ pub(crate) unsafe fn __jni_in_convert_wire_to_impl_Fn_Probe_Send_Sync_static_b0d
                     let __cb0_obj0: jni::sys::jvalue = {
                         let __enc0 = match __jni_out_convert_i64_to_wire_15d458bf28dc9c80(
                             &mut env,
-                            __vf0.seq.clone(),
+                            (&__vf0.seq).clone(),
                         ) {
                             ::core::result::Result::Ok(__w) => __w,
                             ::core::result::Result::Err(__e) => {
@@ -20059,7 +20059,7 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_probeNew<'a>(
     let __obj0: jni::sys::jvalue = {
         let __enc0 = match __jni_out_convert_i64_to_wire_15d458bf28dc9c80(
             &mut env,
-            __vf0.seq.clone(),
+            (&__vf0.seq).clone(),
         ) {
             ::core::result::Result::Ok(__w) => __w,
             ::core::result::Result::Err(__e) => {
@@ -20953,7 +20953,7 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_spanHolderNew<'a
                     {
                         let __chain_s0 = __jni_out_stage_0_Duration_to_wire_37da00112022eac0(
                                 &mut env,
-                                __u0.required.clone(),
+                                (&__u0.required).clone(),
                             )
                             .map_err(|__e| <__JniErr as ::core::convert::From<
                                 String,
@@ -20995,7 +20995,7 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_spanHolderNew<'a
             let __obj1: jni::objects::JObject = {
                 let __enc1 = match __jni_out_convert_Option_Duration_jni_optional_intermediate_output_niche_to_wire_dc11bc4c611f2997(
                     &mut env,
-                    __u0.delay.clone(),
+                    (&__u0.delay).clone(),
                 ) {
                     ::core::result::Result::Ok(__w) => __w,
                     ::core::result::Result::Err(__e) => {
@@ -26073,7 +26073,7 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_vaultHolderNew<'
             let __obj0: jni::objects::JObject = {
                 let __enc0 = match __jni_out_convert_Ingot_jni_handle_codec_own_output_to_wire_c5c73cbcd23adbdb(
                     &mut env,
-                    __u0.always.clone(),
+                    (&__u0.always).clone(),
                 ) {
                     ::core::result::Result::Ok(__w) => __w,
                     ::core::result::Result::Err(__e) => {
@@ -26106,7 +26106,7 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_vaultHolderNew<'
             let __obj1: jni::objects::JObject = {
                 let __enc1 = match __jni_out_convert_Option_Ingot_jni_optional_intermediate_output_niche_to_wire_5b17cf852f44637e(
                     &mut env,
-                    __u0.maybe.clone(),
+                    (&__u0.maybe).clone(),
                 ) {
                     ::core::result::Result::Ok(__w) => __w,
                     ::core::result::Result::Err(__e) => {

--- a/examples/emitcheck/src/generated_bindings.rs
+++ b/examples/emitcheck/src/generated_bindings.rs
@@ -401,7 +401,7 @@ pub(crate) unsafe fn __jni_in_convert_wire_to_impl_Fn_ZSample_Send_Sync_static_7
                     let __cb0_obj2: jni::objects::JObject = {
                         let __enc2 = match __jni_out_convert_Vec_u8_to_wire_e9499bf0a706b1a2(
                             &mut env,
-                            __vf0.seq_plain.clone(),
+                            (&__vf0.seq_plain).clone(),
                         ) {
                             ::core::result::Result::Ok(__w) => __w,
                             ::core::result::Result::Err(__e) => {
@@ -417,7 +417,7 @@ pub(crate) unsafe fn __jni_in_convert_wire_to_impl_Fn_ZSample_Send_Sync_static_7
                     let __cb0_obj3: jni::objects::JObject = {
                         let __enc3 = match __jni_out_convert_Cow_static_u8_to_wire_d9a36c77f96791fc(
                             &mut env,
-                            __vf0.seq_cow.clone(),
+                            (&__vf0.seq_cow).clone(),
                         ) {
                             ::core::result::Result::Ok(__w) => __w,
                             ::core::result::Result::Err(__e) => {
@@ -433,7 +433,7 @@ pub(crate) unsafe fn __jni_in_convert_wire_to_impl_Fn_ZSample_Send_Sync_static_7
                     let __cb0_obj4: jni::objects::JObject = {
                         let __enc4 = match __jni_out_convert_jni_text_codec_owned_to_wire_1b6cdff0ec9adbcb(
                             &mut env,
-                            __vf0.text_plain.clone(),
+                            (&__vf0.text_plain).clone(),
                         ) {
                             ::core::result::Result::Ok(__w) => __w,
                             ::core::result::Result::Err(__e) => {
@@ -449,7 +449,7 @@ pub(crate) unsafe fn __jni_in_convert_wire_to_impl_Fn_ZSample_Send_Sync_static_7
                     let __cb0_obj5: jni::objects::JObject = {
                         let __enc5 = match __jni_out_convert_Box_String_to_wire_445d29257759cad9(
                             &mut env,
-                            __vf0.text_boxed.clone(),
+                            (&__vf0.text_boxed).clone(),
                         ) {
                             ::core::result::Result::Ok(__w) => __w,
                             ::core::result::Result::Err(__e) => {
@@ -465,7 +465,7 @@ pub(crate) unsafe fn __jni_in_convert_wire_to_impl_Fn_ZSample_Send_Sync_static_7
                     let __cb0_obj6: jni::objects::JObject = {
                         let __enc6 = match __jni_out_convert_Cow_static_str_to_wire_1c9aa86df48df08e(
                             &mut env,
-                            __vf0.text_cow.clone(),
+                            (&__vf0.text_cow).clone(),
                         ) {
                             ::core::result::Result::Ok(__w) => __w,
                             ::core::result::Result::Err(__e) => {

--- a/prebindgen-jni/src/jni/compile.rs
+++ b/prebindgen-jni/src/jni/compile.rs
@@ -555,6 +555,14 @@ impl prebindgen_registry::unfold::DecomposedLeaf for OutWire {
     fn source(&self) -> &TypeRef {
         &self.out_ty
     }
+
+    fn selects(&self) -> bool {
+        self.is_tag()
+    }
+
+    fn group(&self) -> Option<i32> {
+        self.group
+    }
 }
 
 impl OutWire {

--- a/prebindgen-jni/src/jni/emit/delivery.rs
+++ b/prebindgen-jni/src/jni/emit/delivery.rs
@@ -2,41 +2,31 @@
 //!
 //! # What this module still walks
 //!
-//! #596 moved the mechanical half of the decomposition walk into
-//! `prebindgen_registry::unfold` — folding a path onto a base, composing one
-//! step, binding hoists, and the flat leaf reach. The rules below stayed, and
-//! none of them is JNI policy: each is a fact about Rust values that any
-//! adapter decomposing a return would have to restate.
+//! The decomposition walk is the registry's: folding a path onto a base,
+//! binding the hoists, gating each optional step, deciding where a leaf's
+//! reach starts and whether what it reaches is moved, cloned or borrowed. This
+//! module supplies the target-language half through [`DeliveryBridge`] —
+//! encoding a leaf, placing it as a call argument, and what absence looks
+//! like — and keeps `jvalue` layout, local-frame sizing, cached method lookup
+//! and exception routing, which are JNI policy.
 //!
-//! * **Rebasing and ownership** — which value form a leaf reaches off (the
-//!   innermost hoist, a conditional form's `Some` binding, or the value
-//!   itself), and whether the reached place is moved or cloned.
+//! Two rules are still here, and neither is JNI policy. Each is a fact about
+//! Rust values that any adapter decomposing a return would have to restate:
+//!
 //! * **Sum segmentation** — a decomposed sum's leaves are not independent, so
 //!   the selector and the group leaves after it are emitted as one `match`.
 //! * **Optional-sum gating** — an `Option<sum>` gates the whole segment rather
 //!   than each slot, because absence cannot be the per-leaf null an ordinary
 //!   optional field gets (#220).
-//! * **Borrow projection** — a plain field chain is borrowed directly rather
-//!   than through the base, which the borrow checker rejects once a sibling
-//!   leaf has moved a field out.
-//! * **The gated leaf reach** (`reach_leaf`) — a second derivation of
-//!   `unfold::reach_leaf_flat` that handles an optional step by emitting an
-//!   absent arm. Only what absence looks like is this adapter's.
 //!
-//! They are still here, but the reason they had to be is gone: the encoding
-//! half now has somewhere to go. [`DeliveryBridge`] is the registry's, this
-//! module implements it for [`FrozenDelivery`], and two of its operations are
-//! live — a leaf's encode, and how a filled slot rides the call. What remains
-//! above is reaching, owning and grouping, which the steps after this one
-//! move onto the walk that already owns the hoists.
+//! Both belong to the segment rather than to a leaf, which is why they outlast
+//! the reach that moved: the walk hands over one leaf at a time and a segment
+//! is several. #607's next step moves them.
 //!
 //! [`DeliveryBridge`]: prebindgen_registry::unfold::DeliveryBridge
 
 use prebindgen_registry::{
-    unfold::{
-        bind_hoists, fold_steps, project_leading_fields, steps_are_movable, DeliveryBridge,
-        PathStep,
-    },
+    unfold::{bind_hoists, fold_steps, project_leading_fields, DeliveryBridge, PathStep},
     Conversions,
 };
 
@@ -764,24 +754,10 @@ pub(crate) fn encode_plan_leaves(
     let hoisted = bind_hoists(&qualify, hoists, value, by_ref);
     let mut stmts = hoisted.stmts.clone();
 
-    // Reach a leaf off the innermost value form it sits under, with that
-    // prefix's steps already consumed, and say whether that form CONSUMED its
-    // value — so the leaf owns its field and may move it out rather than clone
-    // it. A leaf under no value form at all (a sibling `.field()` /
-    // `.field_self()`) still reaches from the value itself.
-    // A leaf under a CONDITIONAL value form reaches off the name that form's
-    // `Some` arm binds — a borrow of the struct, so nothing moves out of it —
-    // and its statements are collected into that arm rather than emitted here.
-    let rebase = |leaf: &crate::jni::compile::OutWire| -> (TokenStream, bool, Vec<PathStep>, bool) {
-        let path = leaf.reach();
-        if let Some((i, _, bind, rest)) = hoisted.conditional(path) {
-            return (quote!(#bind), false, rest, hoisted.consumed(i));
-        }
-        match hoisted.rebase(path) {
-            Some((local, rest, consuming)) => (quote!(#local), false, rest, consuming),
-            None => (value.clone(), by_ref, path.to_vec(), false),
-        }
-    };
+    // Where each leaf's reach starts is the walk's answer, not this loop's:
+    // `Hoisted::place` decides which value form a leaf sits under, what is
+    // left of its path, and whether that form gave its value away.
+    let place = |leaf: &crate::jni::compile::OutWire| hoisted.place(leaf, value, by_ref);
 
     // A decomposed **sum** is the one shape whose leaves are not independent:
     // only one group is live per value, so its whole segment — the selector
@@ -820,7 +796,9 @@ pub(crate) fn encode_plan_leaves(
 
     for seg in &sum_segments {
         let leaf = &wires[seg.start];
-        let (base, base_is_ref, path, _) = rebase(leaf);
+        let at = place(leaf);
+        let at_conditional = at.conditional;
+        let (base, base_is_ref, path) = (at.base, at.base_is_ref, at.path);
         // The value to `match` on. The selector's own path reaches the sum
         // (empty when the sum IS the value), and a step on it MAY be optional:
         // the refusal that used to guarantee otherwise is gone (#220), which is
@@ -935,8 +913,8 @@ pub(crate) fn encode_plan_leaves(
         };
         // The whole segment — its slot declarations and its `match` — is
         // routed like any other leaf under the same form.
-        match hoisted.conditional(leaf.reach()) {
-            Some((i, ..)) => cond_stmts
+        match at_conditional {
+            Some(i) => cond_stmts
                 .get_mut(&i)
                 .expect("a conditional leaf's hoist has a bucket")
                 .extend(group_stmts),
@@ -956,15 +934,17 @@ pub(crate) fn encode_plan_leaves(
     for idx in order {
         let leaf = &wires[idx];
         let obj_ident = &obj_idents[idx];
+        let at = place(leaf);
         // Route this leaf's statements: into its conditional arm, or straight
-        // out. Shadows `stmts` for the rest of the body, so every `extend`
-        // below lands in the right place without knowing which case it is in.
-        let stmts: &mut TokenStream = match hoisted.conditional(leaf.reach()) {
-            Some((i, ..)) => cond_stmts.get_mut(&i).expect("collected above"),
+        // out. The arm is the place's own answer. Shadows `stmts` for the rest
+        // of the body, so every `extend` below lands in the right place
+        // without knowing which case it is in.
+        let stmts: &mut TokenStream = match at.conditional {
+            Some(i) => cond_stmts.get_mut(&i).expect("collected above"),
             None => &mut stmts,
         };
-        let (value, by_ref, path, consuming) = rebase(leaf);
-        let value = &value;
+        let owned_place = at.owned(leaf);
+        let (value, by_ref, path, consuming) = (&at.base, at.base_is_ref, &at.path, at.consuming);
         // Every reach below is the registry's, with this adapter's absence in
         // its `None` arms. The terminal treatment — move, clone or borrow —
         // comes with it, which is what let the three-way dispatch this loop
@@ -1040,28 +1020,13 @@ pub(crate) fn encode_plan_leaves(
                     leaf.out_ty.key()
                 )
             });
-            // The place this handle lives, when it is OURS to give away — the
-            // owned root, or a field of a CONSUMING value form, which handed its
+            // `owned_place` — bound above from `LeafPlace::owned` — is the
+            // place this handle lives when it is OURS to give away: the owned
+            // root, or a field of a CONSUMING value form, which handed its
             // value over so its handle fields move out like every other field
             // rather than being cloned through the borrowed converter (which
-            // would also demand a `Clone` the type need not have).
-            //
-            // Which it is was decided in the plan, not here: an owned `out_ty`
-            // IS the statement that this leaf owns what it reaches, and it is
-            // what selected the owning converter. `steps_are_movable` then says
-            // how to project it — a plain-field run directly, a trailing
-            // `Option` through the nullable branch's `match`, which moves the
-            // whole `Option` in rather than borrowing it.
-            let owned_place: Option<TokenStream> = if !matches!(
-                leaf.out_ty.kind(),
-                prebindgen_registry::flat::TypeKind::Ref { .. }
-            ) && steps_are_movable(&path)
-            {
-                let segs: Vec<&syn::Ident> = path.iter().map(PathStep::ident).collect();
-                Some(quote!(#value #(.#segs)*))
-            } else {
-                None
-            };
+            // would also demand a `Clone` the type need not have). Which it is
+            // was decided in the plan and is read there, not restated here.
             match proj.kind {
                 ProjectionKind::Handle => {
                     let handle_ident = format_ident!("__h{}", idx);
@@ -1125,7 +1090,7 @@ pub(crate) fn encode_plan_leaves(
                     } else if !leaf.nullable {
                         // Reached non-null handle: clone via the converter,
                         // raw jlong (no Option steps on the path).
-                        let expr = gated(&path, value.clone(), by_ref, true, &|reached| {
+                        let expr = gated(path, value.clone(), by_ref, true, &|reached| {
                             let __encoded = conv(quote!(#reached));
                             quote! {{
                                 let #handle_ident: jni::sys::jlong = #__encoded;
@@ -1140,7 +1105,7 @@ pub(crate) fn encode_plan_leaves(
                         // `java.lang.Long` when present (cached valueOf),
                         // JVM null when absent — matching the `Long?` param.
                         let box_fail = fail(quote!(__e.to_string()));
-                        let expr = gated(&path, value.clone(), by_ref, true, &|reached| {
+                        let expr = gated(path, value.clone(), by_ref, true, &|reached| {
                             let __encoded = conv(quote!(#reached));
                             quote! {{
                                 let #handle_ident: jni::sys::jlong = #__encoded;
@@ -1168,13 +1133,13 @@ pub(crate) fn encode_plan_leaves(
                         let expr = encode(value.clone());
                         stmts.extend(quote! { let #obj_ident: jni::sys::jvalue = #expr; });
                     } else if !leaf.nullable {
-                        let expr = gated(&path, value.clone(), by_ref, true, &|reached| {
+                        let expr = gated(path, value.clone(), by_ref, true, &|reached| {
                             encode(quote!(*#reached))
                         });
                         stmts.extend(quote! { let #obj_ident: jni::sys::jvalue = #expr; });
                     } else {
                         let box_fail = fail(quote!(__e.to_string()));
-                        let expr = gated(&path, value.clone(), by_ref, true, &|reached| {
+                        let expr = gated(path, value.clone(), by_ref, true, &|reached| {
                             let __encoded = conv(quote!(*#reached));
                             quote! {{
                                 let #enc_ident: jni::sys::jlong = #__encoded;
@@ -1207,7 +1172,7 @@ pub(crate) fn encode_plan_leaves(
         // A non-identity leaf's converter takes the final step's full type,
         // `Option` included, so the last step is not unwrapped here.
         let reach = |body: &dyn Fn(TokenStream) -> TokenStream| -> TokenStream {
-            gated(&path, value.clone(), by_ref, false, body)
+            gated(path, value.clone(), by_ref, false, body)
         };
 
         // The encode itself is the bridge's: this loop hands it the leaf's
@@ -1371,7 +1336,10 @@ mod tests {
                 PathStep::field(syn::parse_quote!(b), true),
             ],
         ] {
-            assert!(steps_are_movable(&path), "fixture must be movable");
+            assert!(
+                prebindgen_registry::unfold::steps_are_movable(&path),
+                "fixture must be movable"
+            );
             let l = leaf(
                 syn::parse_quote!(Owned),
                 path.clone(),

--- a/prebindgen-jni/src/jni/emit/delivery.rs
+++ b/prebindgen-jni/src/jni/emit/delivery.rs
@@ -744,15 +744,13 @@ pub(crate) fn encode_plan_leaves(
     // conditional form may carry a sum field and that segment has to land in
     // the arm too: emitted ahead of it, its `match` would reach a binding the
     // arm has not introduced yet.
-    let mut cond_stmts: std::collections::BTreeMap<usize, TokenStream> = hoists
+    // Which arm a leaf belongs in is its place's answer, asked here the same
+    // way every other consumer asks it — a bucket exists exactly where some
+    // leaf reports one.
+    let mut cond_stmts: std::collections::BTreeMap<usize, TokenStream> = wires
         .iter()
-        .enumerate()
-        .filter_map(|(i, _)| {
-            wires
-                .iter()
-                .any(|w| hoisted.conditional(w.reach()).is_some_and(|(j, ..)| j == i))
-                .then_some((i, TokenStream::new()))
-        })
+        .filter_map(|leaf| place(leaf).conditional)
+        .map(|i| (i, TokenStream::new()))
         .collect();
 
     for seg in &sum_segments {

--- a/prebindgen-jni/src/jni/emit/delivery.rs
+++ b/prebindgen-jni/src/jni/emit/delivery.rs
@@ -1,4 +1,31 @@
 //! Output-expansion delivery: unfold plans and leaf encoding.
+//!
+//! # What this module still walks
+//!
+//! #596 moved the mechanical half of the decomposition walk into
+//! `prebindgen_registry::unfold` — folding a path onto a base, composing one
+//! step, binding hoists, and the flat leaf reach. The rules below stayed, and
+//! none of them is JNI policy: each is a fact about Rust values that any
+//! adapter decomposing a return would have to restate.
+//!
+//! * **Rebasing and ownership** — which value form a leaf reaches off (the
+//!   innermost hoist, a conditional form's `Some` binding, or the value
+//!   itself), and whether the reached place is moved or cloned.
+//! * **Sum segmentation** — a decomposed sum's leaves are not independent, so
+//!   the selector and the group leaves after it are emitted as one `match`.
+//! * **Optional-sum gating** — an `Option<sum>` gates the whole segment rather
+//!   than each slot, because absence cannot be the per-leaf null an ordinary
+//!   optional field gets (#220).
+//! * **Borrow projection** — a plain field chain is borrowed directly rather
+//!   than through the base, which the borrow checker rejects once a sibling
+//!   leaf has moved a field out.
+//! * **The gated leaf reach** (`reach_leaf`) — a second derivation of
+//!   `unfold::reach_leaf_flat` that handles an optional step by emitting an
+//!   absent arm. Only what absence looks like is this adapter's.
+//!
+//! They are here because there is no delivery bridge to hand the encoding half
+//! to, so nothing could be lifted without lifting `jvalue` layout with it. See
+//! the umbrella that tracks moving them.
 
 use prebindgen_registry::{
     unfold::{

--- a/prebindgen-jni/src/jni/emit/delivery.rs
+++ b/prebindgen-jni/src/jni/emit/delivery.rs
@@ -23,14 +23,19 @@
 //!   `unfold::reach_leaf_flat` that handles an optional step by emitting an
 //!   absent arm. Only what absence looks like is this adapter's.
 //!
-//! They are here because there is no delivery bridge to hand the encoding half
-//! to, so nothing could be lifted without lifting `jvalue` layout with it. See
-//! the umbrella that tracks moving them.
+//! They are still here, but the reason they had to be is gone: the encoding
+//! half now has somewhere to go. [`DeliveryBridge`] is the registry's, this
+//! module implements it for [`FrozenDelivery`], and two of its operations are
+//! live — a leaf's encode, and how a filled slot rides the call. What remains
+//! above is reaching, owning and grouping, which the steps after this one
+//! move onto the walk that already owns the hoists.
+//!
+//! [`DeliveryBridge`]: prebindgen_registry::unfold::DeliveryBridge
 
 use prebindgen_registry::{
     unfold::{
         bind_hoists, fold_steps, project_leading_fields, steps_are_movable, DecomposedLeaf,
-        PathStep,
+        DeliveryBridge, PathStep,
     },
     Conversions,
 };
@@ -380,20 +385,6 @@ pub(crate) struct Delivered<'a> {
     pub(crate) chain: Option<crate::jni::compile::ComposedChain>,
 }
 
-/// Facts the leaf renderer may consult after a delivery operation has been
-/// selected. The live implementation serves ordinary wrapper rendering; an
-/// Invoke plan freezes the same answers so callback planning does not retain a
-/// registry or obtain [`prebindgen_registry::RustWriter`].
-pub(crate) trait DeliveryContext {
-    fn qualify(&self, ident: &syn::Ident) -> syn::Path;
-    fn leaf_is_prim(&self, leaf: &crate::jni::compile::OutWire) -> bool;
-    fn leaf_wire(&self, leaf: &crate::jni::compile::OutWire) -> syn::Type;
-    fn sum(
-        &self,
-        leaf: &crate::jni::compile::OutWire,
-    ) -> (syn::Path, &prebindgen_registry::flat::Variant);
-}
-
 #[derive(Clone)]
 struct FrozenSum {
     source: syn::Path,
@@ -502,20 +493,29 @@ impl FrozenDelivery {
     }
 }
 
-impl DeliveryContext for FrozenDelivery {
+impl FrozenDelivery {
+    /// Whether this leaf crosses the typed `run` as a raw primitive rather
+    /// than as an object. JNI's own question — which jvalue member a slot
+    /// carries — so it stays off the bridge.
+    pub(crate) fn leaf_is_prim(&self, leaf: &crate::jni::compile::OutWire) -> bool {
+        frozen_leaf_is_prim(leaf)
+    }
+
+    /// The Rust type this leaf's converter produces, which is what its jvalue
+    /// member and its slot default are read from.
+    pub(crate) fn leaf_wire(&self, leaf: &crate::jni::compile::OutWire) -> syn::Type {
+        frozen_leaf_wire(leaf)
+    }
+}
+
+impl prebindgen_registry::unfold::DeliveryBridge for FrozenDelivery {
+    type Leaf = crate::jni::compile::OutWire;
+
     fn qualify(&self, ident: &syn::Ident) -> syn::Path {
         self.modules
             .get(&ident.to_string())
             .unwrap_or_else(|| panic!("frozen JNI delivery has no origin for `{ident}`"))
             .clone()
-    }
-
-    fn leaf_is_prim(&self, leaf: &crate::jni::compile::OutWire) -> bool {
-        frozen_leaf_is_prim(leaf)
-    }
-
-    fn leaf_wire(&self, leaf: &crate::jni::compile::OutWire) -> syn::Type {
-        frozen_leaf_wire(leaf)
     }
 
     fn sum(
@@ -531,6 +531,84 @@ impl DeliveryContext for FrozenDelivery {
             .get(&id.name)
             .unwrap_or_else(|| panic!("frozen JNI delivery has no sum `{}`", id.name));
         (sum.source.clone(), &sum.model)
+    }
+
+    /// A leaf's own encode: run its output converter on the reached Rust
+    /// value, then present the result the way its slot carries it. A
+    /// primitive-wire leaf is a typed `jvalue` and crosses with no JNI call at
+    /// all; every other leaf becomes a `JObject`, boxing where the typed `run`
+    /// descriptor declares an object.
+    ///
+    /// Both forms encode INSIDE `reach`, so an absent value on the way to the
+    /// leaf yields this adapter's absence — a JVM null — rather than a value
+    /// the walk invented.
+    fn encode(
+        &self,
+        leaf: &crate::jni::compile::OutWire,
+        index: usize,
+        slot: &syn::Ident,
+        reach: &prebindgen_registry::unfold::Reach<'_>,
+        fail: &dyn Fn(TokenStream) -> TokenStream,
+        emit: &prebindgen_registry::RustWriter,
+    ) -> TokenStream {
+        let pipeline = match &leaf.abi {
+            Some(crate::jni::compile::OutAbi::Value(value)) => &value.pipeline,
+            Some(crate::jni::compile::OutAbi::Tag) => {
+                unreachable!("a sum selector is encoded with its own segment")
+            }
+            None => panic!(
+                "jnigen delivery: leaf `{}` reached Rust rendering without a frozen output ABI",
+                leaf.name
+            ),
+        };
+        let wire = pipeline.wire().clone();
+        let conv_fail = fail(quote!(__e.to_string()));
+        let convert = |input: TokenStream| -> TokenStream {
+            let call = pipeline.invoke(input, emit);
+            quote! {
+                match #call {
+                    ::core::result::Result::Ok(__w) => __w,
+                    ::core::result::Result::Err(__e) => {
+                        #conv_fail
+                    }
+                }
+            }
+        };
+        let encoded = format_ident!("__enc{}", index);
+        if self.leaf_is_prim(leaf) {
+            let letter = jni_field_access(&wire)
+                .expect("leaf_is_prim guarantees a primitive wire")
+                .1;
+            let expr = reach(&|reached| {
+                let converted = convert(quote!(#reached));
+                quote! {{
+                    let #encoded = #converted;
+                    jni::sys::jvalue { #letter: #encoded }
+                }}
+            });
+            return quote! { let #slot: jni::sys::jvalue = #expr; };
+        }
+        let cast = cast_wire_to_jobject(&encoded, &wire, fail);
+        let expr = reach(&|reached| {
+            let converted = convert(quote!(#reached));
+            quote! {{
+                let #encoded = #converted;
+                #cast
+            }}
+        });
+        quote! { let #slot: jni::objects::JObject = #expr; }
+    }
+
+    /// How a filled slot rides the typed `run` call: a primitive-wire leaf IS
+    /// its jvalue, and every other leaf's `JObject` passes its raw pointer in
+    /// the `l` slot. Matches the descriptor [`crate::jni::iface`] derives for
+    /// the same leaf.
+    fn argument(&self, leaf: &crate::jni::compile::OutWire, slot: &syn::Ident) -> TokenStream {
+        if self.leaf_is_prim(leaf) {
+            quote!(#slot)
+        } else {
+            quote!(jni::sys::jvalue { l: #slot.as_raw() })
+        }
     }
 }
 
@@ -668,7 +746,7 @@ fn reach_leaf(
 /// arm of fallible externs (whose `fail` routes an encoding failure to the
 /// binding-error channel).
 pub(crate) fn encode_plan_leaves(
-    context: &impl DeliveryContext,
+    context: &FrozenDelivery,
     site: Delivered<'_>,
     obj_idents: &[syn::Ident],
     value: &TokenStream,
@@ -688,19 +766,11 @@ pub(crate) fn encode_plan_leaves(
     let qualify = |id: &syn::Ident| -> syn::Path { context.qualify(id) };
     let n = wires.len();
 
-    // Typed `jvalue` argument expression per leaf, in leaf order: a non-null
-    // primitive-wire leaf passes its raw primitive (`__objN` IS the jvalue);
-    // every other leaf is a `JObject` local whose raw pointer rides the `l`
-    // slot. Matches the descriptor [`crate::jni::iface`]
-    // derives for the same leaf (primitive chunk vs object chunk).
+    // The argument expression per leaf, in leaf order — how a filled slot
+    // rides the call, which is the bridge's answer rather than this loop's.
     let mut arg_exprs: Vec<TokenStream> = Vec::with_capacity(n);
     for (idx, leaf) in wires.iter().enumerate() {
-        let obj_ident = &obj_idents[idx];
-        if context.leaf_is_prim(leaf) {
-            arg_exprs.push(quote!(#obj_ident));
-        } else {
-            arg_exprs.push(quote!(jni::sys::jvalue { l: #obj_ident.as_raw() }));
-        }
+        arg_exprs.push(context.argument(leaf, &obj_idents[idx]));
     }
 
     // A fixed decomposition has one Product, Optional or Choice intermediate.
@@ -977,7 +1047,6 @@ pub(crate) fn encode_plan_leaves(
             ),
         };
         let projection = frozen_projection;
-        let wire = frozen_pipeline.wire().clone();
         let conv_fail = fail(quote!(__e.to_string()));
         let conv = |input: TokenStream| -> TokenStream {
             let call = frozen_pipeline.invoke(input, emit);
@@ -1244,37 +1313,10 @@ pub(crate) fn encode_plan_leaves(
             }
         };
 
-        // A non-null primitive-wire leaf delivers its raw primitive as a typed
-        // `jvalue` — no boxing, no JNI call at all (the typed `run` descriptor
-        // declares the primitive). Everything else (object wires, and nullable
-        // leaves whose `None` arm must yield a JVM null) encodes the reached
-        // value with the leaf's output converter and casts to JObject.
-        let enc_ident = format_ident!("__enc{}", idx);
-        if context.leaf_is_prim(leaf) {
-            let letter = jni_field_access(&wire)
-                .expect("leaf_is_prim guarantees a primitive wire")
-                .1;
-            let expr = reach(&|reached| {
-                let __encoded = conv(quote!(#reached));
-                quote! {{
-                    let #enc_ident = #__encoded;
-                    jni::sys::jvalue { #letter: #enc_ident }
-                }}
-            });
-            stmts.extend(quote! {
-                let #obj_ident: jni::sys::jvalue = #expr;
-            });
-            continue;
-        }
-        let cast = cast_wire_to_jobject(&enc_ident, &wire, fail);
-        let expr = reach(&|reached| {
-            let __encoded = conv(quote!(#reached));
-            quote! {{
-                let #enc_ident = #__encoded;
-                #cast
-            }}
-        });
-        stmts.extend(bind_obj(obj_ident, expr));
+        // The encode itself is the bridge's: this loop hands it the leaf's
+        // reach and it says what the slot holds. Reaching is still decided
+        // here — which is what the steps after this one move.
+        stmts.extend(context.encode(leaf, idx, obj_ident, &reach, fail, emit));
     }
 
     // One `match` per conditional value form: the `Some` arm runs the leaves

--- a/prebindgen-jni/src/jni/emit/delivery.rs
+++ b/prebindgen-jni/src/jni/emit/delivery.rs
@@ -1,32 +1,22 @@
 //! Output-expansion delivery: unfold plans and leaf encoding.
 //!
-//! # What this module still walks
+//! # What this module walks
 //!
-//! The decomposition walk is the registry's: folding a path onto a base,
-//! binding the hoists, gating each optional step, deciding where a leaf's
-//! reach starts and whether what it reaches is moved, cloned or borrowed. This
-//! module supplies the target-language half through [`DeliveryBridge`] —
-//! encoding a leaf, placing it as a call argument, and what absence looks
-//! like — and keeps `jvalue` layout, local-frame sizing, cached method lookup
-//! and exception routing, which are JNI policy.
+//! Nothing. The decomposition walk is the registry's: binding the hoists,
+//! deciding where a leaf's reach starts, gating each optional step, saying
+//! what is moved and what is cloned, recognising a sum's segment and gating
+//! it, and the `match` a conditional value form's leaves share.
 //!
-//! Two rules are still here, and neither is JNI policy. Each is a fact about
-//! Rust values that any adapter decomposing a return would have to restate:
-//!
-//! * **Sum segmentation** — a decomposed sum's leaves are not independent, so
-//!   the selector and the group leaves after it are emitted as one `match`.
-//! * **Optional-sum gating** — an `Option<sum>` gates the whole segment rather
-//!   than each slot, because absence cannot be the per-leaf null an ordinary
-//!   optional field gets (#220).
-//!
-//! Both belong to the segment rather than to a leaf, which is why they outlast
-//! the reach that moved: the walk hands over one leaf at a time and a segment
-//! is several. #607's next step moves them.
+//! What is here is the target-language half — the [`DeliveryBridge`]
+//! implementation for [`FrozenDelivery`]: encoding a leaf, placing it as a
+//! call argument, what a slot holds when it is not filled, and what absence
+//! looks like — together with `jvalue` layout, local-frame sizing, cached
+//! method lookup and exception routing, which are JNI policy and stay.
 //!
 //! [`DeliveryBridge`]: prebindgen_registry::unfold::DeliveryBridge
 
 use prebindgen_registry::{
-    unfold::{bind_hoists, fold_steps, project_leading_fields, DeliveryBridge, PathStep},
+    unfold::{bind_hoists, DeliveryBridge, PathStep},
     Conversions,
 };
 
@@ -589,6 +579,17 @@ impl prebindgen_registry::unfold::DeliveryBridge for FrozenDelivery {
         quote! { let #slot: jni::objects::JObject = #expr; }
     }
 
+    /// A slot is a `jvalue` for a primitive-wire leaf and a `JObject`
+    /// otherwise, and an unfilled one carries that shape's own empty value: a
+    /// zero of the right jvalue member, or a JVM null.
+    fn slot(&self, leaf: &crate::jni::compile::OutWire) -> prebindgen_registry::unfold::Slot {
+        let slot = crate::jni::emit::sum_out::leaf_slot(self, leaf);
+        prebindgen_registry::unfold::Slot {
+            ty: slot.ty,
+            default: slot.default,
+        }
+    }
+
     /// A leaf whose value was not there delivers a JVM null. Every slot that
     /// can be absent is an object slot for exactly that reason: a primitive
     /// one has no null to carry.
@@ -625,33 +626,6 @@ impl<'a> Delivered<'a> {
             optional: plan.is_optional_base(),
         }
     }
-}
-
-/// Bind `e` so it can be destructured as an `Option` **whatever Rust
-/// representation the source used for it**.
-///
-/// `kind` says a position is optional; it deliberately does not say whether
-/// Rust spells that `Option<T>`, `Box<Option<T>>`, or something else — the flat
-/// model states the destination-language invariant, and the side interpreting
-/// it is the side that must accept any representation. Matching the reached
-/// place directly assumed one, which is `classify off kind, spell with spell()`
-/// broken in the direction nothing was watching: the classification was right
-/// and the *spelling* came from it too. `Box<Option<T>>` then produced
-/// `match &place { Some(..) => .. }` and `E0308` (#268).
-///
-/// A type-ascribed `let` is a coercion site, and deref coercion is transitive
-/// **and** a no-op when the types already match — so this one shape serves
-/// every representation, and the plain `Option<T>` case is unchanged in
-/// behaviour. The payload stays `_`: what it is, is the source's business.
-///
-/// `e` is expected to be a **reference** already — [`compose_step`] composes a
-/// field read as `&(e).f` — so nothing is borrowed here. Borrowing only: an
-/// owned position cannot be made representation-agnostic this way, because
-/// deref coercion applies to references and moving out of a wrapper is
-/// something only some of them permit (`Box` does, `Rc` cannot). A site that
-/// must MOVE the payload keeps its direct match; see `owned_place` below.
-pub(crate) fn bind_as_option(e: &TokenStream, bind: &syn::Ident) -> TokenStream {
-    quote! { let #bind: &::core::option::Option<_> = #e; }
 }
 
 /// Encode a plan's leaves off `value` (`__out`, a `Some`-bound `__inner`, a Vec
@@ -759,22 +733,9 @@ pub(crate) fn encode_plan_leaves(
     // left of its path, and whether that form gave its value away.
     let place = |leaf: &crate::jni::compile::OutWire| hoisted.place(leaf, value, by_ref);
 
-    // A decomposed **sum** is the one shape whose leaves are not independent:
-    // only one group is live per value, so its whole segment — the selector
-    // leaf plus the group leaves that follow it — is emitted as ONE `match`
-    // instead of per-leaf expressions. A plan may carry several: a sum that IS
-    // the returned value is the degenerate case of one segment covering
-    // everything, while a value form contributes one per sum-typed field.
-    let sum_segments: Vec<std::ops::Range<usize>> = (0..n)
-        .filter(|&i| wires[i].is_tag())
-        .map(|start| {
-            let end = (start + 1..n)
-                .take_while(|&i| wires[i].group.is_some())
-                .last()
-                .map_or(start + 1, |i| i + 1);
-            start..end
-        })
-        .collect();
+    // Which leaves form a segment is the plan's own answer, read by the
+    // walk: a selector plus the group leaves after it.
+    let sum_segments = prebindgen_registry::unfold::segments(&wires);
 
     // Leaves under a conditional value form are collected per hoist and emitted
     // below as ONE `match` on its `Option` local — the same treatment a sum's
@@ -795,131 +756,42 @@ pub(crate) fn encode_plan_leaves(
         .collect();
 
     for seg in &sum_segments {
-        let leaf = &wires[seg.start];
-        let at = place(leaf);
-        let at_conditional = at.conditional;
-        let (base, base_is_ref, path) = (at.base, at.base_is_ref, at.path);
-        // The value to `match` on. The selector's own path reaches the sum
-        // (empty when the sum IS the value), and a step on it MAY be optional:
-        // the refusal that used to guarantee otherwise is gone (#220), which is
-        // what the gate below exists for.
-        //
-        // A plain field chain is borrowed DIRECTLY (`&base.a.b`) rather than
-        // through the base (`&(&base).a.b`). The two are the same value, but
-        // the second borrows the base as a whole, which the borrow checker
-        // rejects once a sibling leaf has moved another field out of it — and
-        // borrowing this field while sibling fields move is exactly what a
-        // consuming value form does.
-        let (projected, lead) = project_leading_fields(&base, base_is_ref, &path);
-        // An `Option<sum>` field gates the WHOLE segment, not each slot (#220).
-        // A sum's leaves are not independent — only one group is live per value
-        // — so absence cannot be the per-leaf `null` `reach_leaf` gives an
-        // ordinary optional field. It is one tuple bind whose `None` arm carries
-        // every slot's default, which is the shape a conditional value form's
-        // hoist already emits below; this applies it to an optional step inside
-        // the segment's own path.
-        let opt_at = (lead..path.len()).find(|&i| path[i].is_optional());
-        let (matched, gate) = match opt_at {
-            None => (fold_steps(&qualify, &path[lead..], projected, false), None),
-            Some(k) => {
-                // Through the optional step INCLUSIVE, then the rest off the
-                // binding — the same split `reach_leaf` makes, so the borrow in
-                // front of it stays the ordinary rule rather than a second
-                // statement of it.
-                let opt_e = fold_steps(&qualify, &path[lead..=k], projected, false);
-                let bind = format_ident!("__sg{}", seg.start);
-                // ONE optional step is what the gate below handles. A second
-                // one in the tail would compose `match &Option<..>` against bare
-                // variant patterns — the E0308 in the consumer's crate that the
-                // deleted `builder.rs` assert used to pre-empt by name, so the
-                // named diagnostic keeps a home here.
-                //
-                // `assert!`, not `debug_assert!`: a build script inherits the
-                // consumer's profile, so a debug-only check is absent from
-                // exactly the release build where a mis-emission costs the most
-                // to diagnose. Same rule, same phrasing, as the single-return
-                // optional-step assert in `reach_leaf` above.
-                //
-                // The condition is what actually breaks, not the stronger fact
-                // that happens to hold: every sum leaf's path stops AT the sum,
-                // so the tail is empty today, but a NON-optional tail composes
-                // correctly through `fold_steps` — refusing it would refuse a
-                // shape that works.
-                assert!(
-                    !path[k + 1..].iter().any(PathStep::is_optional),
-                    "jnigen unfold: leaf `{}` reaches its sum through TWO optional \
-                     steps — the segment gate has one `None` arm, so the second \
-                     would be matched as if it were the sum itself",
-                    leaf.name,
-                );
-                // What the `match` binds, asked of the step rather than assumed:
-                // the FIELD branch scrutinizes `&Option<_>` (that is what
-                // `bind_as_option` is for), so ergonomics binds `&Sum` — a
-                // borrow. Only an owned-yielding CALL binds an owned value. The
-                // literal `true` disagreed with `reach_leaf`, which passes
-                // `false` for its analogous recursion.
-                let inner = fold_steps(
-                    &qualify,
-                    &path[k + 1..],
-                    quote!(#bind),
-                    path[k].yields_owned(),
-                );
-                (inner, Some((k, opt_e, bind)))
-            }
-        };
-        let (group_stmts, group_args) = encode_sum_group(
+        let at = place(&wires[seg.start]);
+        // The segment's own encode — which slot carries which alternative's
+        // value, and what the selector is set to — is this adapter's. Reaching
+        // the sum it is encoded from, and gating the whole segment when that
+        // reach passes through an optional step, is the walk's.
+        let group_args = std::cell::RefCell::new(Vec::new());
+        let group_stmts = prebindgen_registry::unfold::segment(
             context,
+            &qualify,
+            &at,
+            seg.start,
             &wires[seg.clone()],
             &obj_idents[seg.clone()],
-            matched,
-            fail,
-            emit,
+            &|matched| {
+                let (stmts, args) = encode_sum_group(
+                    context,
+                    &wires[seg.clone()],
+                    &obj_idents[seg.clone()],
+                    matched,
+                    fail,
+                    emit,
+                );
+                *group_args.borrow_mut() = args;
+                stmts
+            },
         );
-        let group_stmts = match gate {
-            None => group_stmts,
-            Some((k, opt_e, bind)) => {
-                let ids: Vec<&syn::Ident> = obj_idents[seg.clone()].iter().collect();
-                let slots: Vec<Slot> = wires[seg.clone()]
-                    .iter()
-                    .map(|l| leaf_slot(context, l))
-                    .collect();
-                let tys = slots.iter().map(|s| &s.ty);
-                let defaults = slots.iter().map(|s| &s.default);
-                // A FIELD step composes to a borrow, so it goes through a
-                // coercion site and the destructure stops caring which
-                // representation the source spelled the optional as (#268). A
-                // CALL yields its own owned value, whose payload downstream may
-                // move, so it keeps the direct match — the same division
-                // `reach_leaf` makes.
-                let (prelude, scrutinee) = if path[k].is_field() {
-                    let opt_bind = format_ident!("__so{}", seg.start);
-                    (bind_as_option(&opt_e, &opt_bind), quote!(#opt_bind))
-                } else {
-                    (TokenStream::new(), opt_e)
-                };
-                quote! {
-                    let (#(#ids,)*): (#(#tys,)*) = {
-                        #prelude
-                        match #scrutinee {
-                            ::core::option::Option::Some(#bind) => {
-                                #group_stmts
-                                (#(#ids,)*)
-                            }
-                            ::core::option::Option::None => (#(#defaults,)*),
-                        }
-                    };
-                }
-            }
-        };
         // The whole segment — its slot declarations and its `match` — is
         // routed like any other leaf under the same form.
-        match at_conditional {
+        match at.conditional {
             Some(i) => cond_stmts
                 .get_mut(&i)
                 .expect("a conditional leaf's hoist has a bucket")
                 .extend(group_stmts),
             None => stmts.extend(group_stmts),
         }
+        let group_args = group_args.into_inner();
         for (k, e) in group_args.into_iter().enumerate() {
             arg_exprs[seg.start + k] = e;
         }
@@ -1181,33 +1053,12 @@ pub(crate) fn encode_plan_leaves(
         stmts.extend(context.encode(leaf, idx, obj_ident, &reach, fail, emit));
     }
 
-    // One `match` per conditional value form: the `Some` arm runs the leaves
-    // that hang off it and yields their locals as a tuple; the `None` arm
-    // yields the same wire defaults an inert sum group carries. Binding the
-    // tuple outside the match is what keeps the leaves' locals in scope for the
-    // argument expressions, which are indifferent to how the slot was filled.
+    // Each conditional value form's leaves share one `match` on its `Option`
+    // local — the walk's shape, filled with this adapter's slots.
     for (i, body) in cond_stmts {
-        let local = hoisted.local(i);
-        let bind = format_ident!("__u{}", i);
-        let idxs: Vec<usize> = (0..n)
-            .filter(|&k| {
-                hoisted
-                    .conditional(wires[k].reach())
-                    .is_some_and(|(j, ..)| j == i)
-            })
-            .collect();
-        let ids: Vec<&syn::Ident> = idxs.iter().map(|&k| &obj_idents[k]).collect();
-        let tys = idxs.iter().map(|&k| leaf_slot(context, &wires[k]).ty);
-        let defaults = idxs.iter().map(|&k| leaf_slot(context, &wires[k]).default);
-        // Matched BY VALUE: the local is this arm's alone (every leaf under the
-        // hoist is in it), so a consuming value form's fields move out here
-        // exactly as they do at an unconditional one.
-        stmts.extend(quote! {
-            let (#(#ids,)*): (#(#tys,)*) = match #local {
-                ::core::option::Option::Some(#bind) => { #body (#(#ids,)*) }
-                ::core::option::Option::None => (#(#defaults,)*),
-            };
-        });
+        stmts.extend(prebindgen_registry::unfold::conditional_arm(
+            context, &hoisted, i, &wires, obj_idents, body,
+        ));
     }
     (stmts, arg_exprs, None)
 }

--- a/prebindgen-jni/src/jni/emit/delivery.rs
+++ b/prebindgen-jni/src/jni/emit/delivery.rs
@@ -34,8 +34,8 @@
 
 use prebindgen_registry::{
     unfold::{
-        bind_hoists, fold_steps, project_leading_fields, steps_are_movable, DecomposedLeaf,
-        DeliveryBridge, PathStep,
+        bind_hoists, fold_steps, project_leading_fields, steps_are_movable, DeliveryBridge,
+        PathStep,
     },
     Conversions,
 };
@@ -599,6 +599,13 @@ impl prebindgen_registry::unfold::DeliveryBridge for FrozenDelivery {
         quote! { let #slot: jni::objects::JObject = #expr; }
     }
 
+    /// A leaf whose value was not there delivers a JVM null. Every slot that
+    /// can be absent is an object slot for exactly that reason: a primitive
+    /// one has no null to carry.
+    fn absent(&self) -> TokenStream {
+        quote!(jni::objects::JObject::null())
+    }
+
     /// How a filled slot rides the typed `run` call: a primitive-wire leaf IS
     /// its jvalue, and every other leaf's `JObject` passes its raw pointer in
     /// the `l` slot. Matches the descriptor [`crate::jni::iface`] derives for
@@ -655,82 +662,6 @@ impl<'a> Delivered<'a> {
 /// must MOVE the payload keeps its direct match; see `owned_place` below.
 pub(crate) fn bind_as_option(e: &TokenStream, bind: &syn::Ident) -> TokenStream {
     quote! { let #bind: &::core::option::Option<_> = #e; }
-}
-
-/// Reach a leaf's input by folding its `path` over `base`, then hand the
-/// reached expression to `body` (which renders the encode and yields
-/// `JObject`). Every optional nesting step becomes a `match`: its `None` arm
-/// short-circuits the whole leaf to `JObject::null()` (the value is absent ⇒
-/// the leaf is null) — any number of optional steps on the path nest.
-/// With `unwrap_last == false` the final path element composes directly — a
-/// non-identity leaf's converter takes the final step's **full** type
-/// (`Option` included), so only the steps *before* it are nesting. An
-/// identity leaf (`unwrap_last == true`) delivers the reached value itself, so
-/// a final `Option` step unwraps too.
-fn reach_leaf(
-    qualify: &dyn Fn(&syn::Ident) -> syn::Path,
-    path: &[PathStep],
-    base: TokenStream,
-    base_is_ref: bool,
-    unwrap_last: bool,
-    depth: usize,
-    body: &dyn Fn(TokenStream) -> TokenStream,
-) -> TokenStream {
-    let limit = if unwrap_last {
-        path.len()
-    } else {
-        path.len().saturating_sub(1)
-    };
-    let (e, lead) = project_leading_fields(&base, base_is_ref, path);
-    match (lead..limit).find(|&i| path[i].is_optional()) {
-        // No (more) optional nesting steps: compose the rest plainly.
-        None => body(fold_steps(qualify, &path[lead..], e, false)),
-        Some(k) => {
-            // Through the optional step INCLUSIVE: the same fold, so the
-            // borrow in front of it is the ordinary rule rather than a second
-            // statement of it.
-            let opt_e = fold_steps(qualify, &path[lead..=k], e, false);
-            let nested = format_ident!("__n{}", depth);
-            let inner = reach_leaf(
-                qualify,
-                &path[k + 1..],
-                quote!(#nested),
-                true,
-                unwrap_last,
-                depth + 1,
-                body,
-            );
-            // A FIELD read composes to a borrow (`&(e).f`), so it goes through
-            // a coercion site and the destructuring stops caring which
-            // representation the source spelled the optional as.
-            //
-            // A CALL composes to the accessor's own returned value, which is
-            // owned and whose payload downstream may move. Borrowing it to
-            // coerce would change that ownership, so it keeps its direct match
-            // — and an owned position could not be made representation-agnostic
-            // this way regardless (see [`bind_as_option`]).
-            if path[k].is_field() {
-                let opt_bind = format_ident!("__o{}", depth);
-                let coerce = bind_as_option(&opt_e, &opt_bind);
-                quote! {
-                    {
-                        #coerce
-                        match #opt_bind {
-                            ::core::option::Option::Some(#nested) => { #inner }
-                            ::core::option::Option::None => jni::objects::JObject::null(),
-                        }
-                    }
-                }
-            } else {
-                quote! {
-                    match #opt_e {
-                        ::core::option::Option::Some(#nested) => { #inner }
-                        ::core::option::Option::None => jni::objects::JObject::null(),
-                    }
-                }
-            }
-        }
-    }
 }
 
 /// Encode a plan's leaves off `value` (`__out`, a `Some`-bound `__inner`, a Vec
@@ -1034,6 +965,30 @@ pub(crate) fn encode_plan_leaves(
         };
         let (value, by_ref, path, consuming) = rebase(leaf);
         let value = &value;
+        // Every reach below is the registry's, with this adapter's absence in
+        // its `None` arms. The terminal treatment — move, clone or borrow —
+        // comes with it, which is what let the three-way dispatch this loop
+        // used to make disappear.
+        let absent = || DeliveryBridge::absent(context);
+        let gated = |path: &[PathStep],
+                     base: TokenStream,
+                     base_is_ref: bool,
+                     unwrap_last: bool,
+                     body: &dyn Fn(TokenStream) -> TokenStream| {
+            prebindgen_registry::unfold::reach_leaf(
+                &qualify,
+                prebindgen_registry::unfold::LeafAt {
+                    leaf,
+                    path,
+                    base,
+                    base_is_ref,
+                    consuming,
+                    unwrap_last,
+                },
+                Some(&absent),
+                body,
+            )
+        };
         let (frozen_pipeline, frozen_projection) = match &leaf.abi {
             Some(crate::jni::compile::OutAbi::Value(value)) => {
                 (&value.pipeline, value.projection.as_ref())
@@ -1170,21 +1125,13 @@ pub(crate) fn encode_plan_leaves(
                     } else if !leaf.nullable {
                         // Reached non-null handle: clone via the converter,
                         // raw jlong (no Option steps on the path).
-                        let expr = reach_leaf(
-                            &qualify,
-                            &path,
-                            value.clone(),
-                            by_ref,
-                            true,
-                            0,
-                            &|reached| {
-                                let __encoded = conv(quote!(#reached));
-                                quote! {{
-                                    let #handle_ident: jni::sys::jlong = #__encoded;
-                                    jni::sys::jvalue { j: #handle_ident }
-                                }}
-                            },
-                        );
+                        let expr = gated(&path, value.clone(), by_ref, true, &|reached| {
+                            let __encoded = conv(quote!(#reached));
+                            quote! {{
+                                let #handle_ident: jni::sys::jlong = #__encoded;
+                                jni::sys::jvalue { j: #handle_ident }
+                            }}
+                        });
                         stmts.extend(quote! {
                             let #obj_ident: jni::sys::jvalue = #expr;
                         });
@@ -1193,26 +1140,18 @@ pub(crate) fn encode_plan_leaves(
                         // `java.lang.Long` when present (cached valueOf),
                         // JVM null when absent — matching the `Long?` param.
                         let box_fail = fail(quote!(__e.to_string()));
-                        let expr = reach_leaf(
-                            &qualify,
-                            &path,
-                            value.clone(),
-                            by_ref,
-                            true,
-                            0,
-                            &|reached| {
-                                let __encoded = conv(quote!(#reached));
-                                quote! {{
-                                    let #handle_ident: jni::sys::jlong = #__encoded;
-                                    match ::prebindgen_jni_runtime::box_jlong(&mut env, #handle_ident) {
-                                        ::core::result::Result::Ok(__o) => __o,
-                                        ::core::result::Result::Err(__e) => {
-                                            #box_fail
-                                        }
+                        let expr = gated(&path, value.clone(), by_ref, true, &|reached| {
+                            let __encoded = conv(quote!(#reached));
+                            quote! {{
+                                let #handle_ident: jni::sys::jlong = #__encoded;
+                                match ::prebindgen_jni_runtime::box_jlong(&mut env, #handle_ident) {
+                                    ::core::result::Result::Ok(__o) => __o,
+                                    ::core::result::Result::Err(__e) => {
+                                        #box_fail
                                     }
-                                }}
-                            },
-                        );
+                                }
+                            }}
+                        });
                         stmts.extend(bind_obj(obj_ident, expr));
                     }
                 }
@@ -1229,38 +1168,24 @@ pub(crate) fn encode_plan_leaves(
                         let expr = encode(value.clone());
                         stmts.extend(quote! { let #obj_ident: jni::sys::jvalue = #expr; });
                     } else if !leaf.nullable {
-                        let expr = reach_leaf(
-                            &qualify,
-                            &path,
-                            value.clone(),
-                            by_ref,
-                            true,
-                            0,
-                            &|reached| encode(quote!(*#reached)),
-                        );
+                        let expr = gated(&path, value.clone(), by_ref, true, &|reached| {
+                            encode(quote!(*#reached))
+                        });
                         stmts.extend(quote! { let #obj_ident: jni::sys::jvalue = #expr; });
                     } else {
                         let box_fail = fail(quote!(__e.to_string()));
-                        let expr = reach_leaf(
-                            &qualify,
-                            &path,
-                            value.clone(),
-                            by_ref,
-                            true,
-                            0,
-                            &|reached| {
-                                let __encoded = conv(quote!(*#reached));
-                                quote! {{
-                                    let #enc_ident: jni::sys::jlong = #__encoded;
-                                    match ::prebindgen_jni_runtime::box_jlong(&mut env, #enc_ident) {
-                                        ::core::result::Result::Ok(__o) => __o,
-                                        ::core::result::Result::Err(__e) => {
-                                            #box_fail
-                                        }
+                        let expr = gated(&path, value.clone(), by_ref, true, &|reached| {
+                            let __encoded = conv(quote!(*#reached));
+                            quote! {{
+                                let #enc_ident: jni::sys::jlong = #__encoded;
+                                match ::prebindgen_jni_runtime::box_jlong(&mut env, #enc_ident) {
+                                    ::core::result::Result::Ok(__o) => __o,
+                                    ::core::result::Result::Err(__e) => {
+                                        #box_fail
                                     }
-                                }}
-                            },
-                        );
+                                }
+                            }}
+                        });
                         stmts.extend(bind_obj(obj_ident, expr));
                     }
                 }
@@ -1279,38 +1204,10 @@ pub(crate) fn encode_plan_leaves(
         // Which of the two it is, asked of the wire: a field read ends its
         // reach in a field step, an accessor's ends at the call. That is what
         // `LeafSource` said, and saying it off the reach keeps one answer.
+        // A non-identity leaf's converter takes the final step's full type,
+        // `Option` included, so the last step is not unwrapped here.
         let reach = |body: &dyn Fn(TokenStream) -> TokenStream| -> TokenStream {
-            match leaf.is_field_read() {
-                false => reach_leaf(&qualify, &path, value.clone(), by_ref, false, 0, body),
-                // Under a CONSUMING value form the leaf owns its field, so it
-                // is **moved** out; the whole point of consuming is that this
-                // clone disappears. Each field is read by exactly one leaf, so
-                // the partial moves are disjoint — but nothing may then borrow
-                // the local as a whole, which is why the reach below projects
-                // the field directly rather than through `&(&local)`.
-                true if path.iter().all(PathStep::is_plain_field) => {
-                    let segs: Vec<&syn::Ident> = path.iter().map(PathStep::ident).collect();
-                    match consuming {
-                        true => body(quote!(#value #(.#segs)*)),
-                        false => body(quote!(#value #(.#segs)*.clone())),
-                    }
-                }
-                // A `.fields()` leaf reaches its field through the value-form
-                // accessor, so the path can be mixed: compose it like an
-                // accessor leaf — the final step composes directly, since the
-                // converter takes the field type as written (`Option` and all)
-                // — and clone the reached borrow, which is what a field leaf
-                // delivers.
-                true => reach_leaf(
-                    &qualify,
-                    &path,
-                    value.clone(),
-                    by_ref,
-                    false,
-                    0,
-                    &|reached| body(quote!((#reached).clone())),
-                ),
-            }
+            gated(&path, value.clone(), by_ref, false, body)
         };
 
         // The encode itself is the bridge's: this loop hands it the leaf's
@@ -1481,13 +1378,18 @@ mod tests {
                 true,
                 LeafSource::Reach,
             );
-            let got = prebindgen_registry::unfold::reach_leaf_flat(
+            let got = prebindgen_registry::unfold::reach_leaf(
                 &qualify,
-                &crate::jni::compile::OutWire::from_leaf(&l),
-                &path,
-                quote!(__src),
-                false,
-                false,
+                prebindgen_registry::unfold::LeafAt {
+                    leaf: &crate::jni::compile::OutWire::from_leaf(&l),
+                    path: &path,
+                    base: quote!(__src),
+                    base_is_ref: false,
+                    consuming: false,
+                    unwrap_last: false,
+                },
+                None,
+                &|reached| reached,
             )
             .to_string();
             assert!(
@@ -1508,18 +1410,65 @@ mod tests {
             true,
             LeafSource::Reach,
         );
-        let got = prebindgen_registry::unfold::reach_leaf_flat(
+        let got = prebindgen_registry::unfold::reach_leaf(
             &qualify,
-            &crate::jni::compile::OutWire::from_leaf(&l),
-            &path,
-            quote!(__src),
-            false,
-            false,
+            prebindgen_registry::unfold::LeafAt {
+                leaf: &crate::jni::compile::OutWire::from_leaf(&l),
+                path: &path,
+                base: quote!(__src),
+                base_is_ref: false,
+                consuming: false,
+                unwrap_last: false,
+            },
+            None,
+            &|reached| reached,
         )
         .to_string();
         assert!(
             got.contains('&'),
             "a borrowed out_ty keeps its borrow — got `{got}`"
+        );
+    }
+
+    /// An owned `Option` payload is borrowed for the accessor that follows it.
+    ///
+    /// The `Some(..)` arm of a gated step binds the step's own value, and an
+    /// accessor returning `Option<T>` binds a bare `T` there. Composing the
+    /// next accessor straight onto it hands `T` to a receiver typed `&T` —
+    /// ill-typed Rust in the consumer's crate, and invisible here until a
+    /// reach has BOTH an owned optional step and something after it. The gated
+    /// reach hardcoded "already a reference" for years because no declared
+    /// leaf had that shape (#609 review). The hoist side of the same rule is
+    /// pinned by `value_form::an_owned_optional_payload_is_borrowed_for_the_steps_after_it`.
+    #[test]
+    fn a_gated_owned_payload_is_borrowed_for_the_step_after_it() {
+        let path = vec![
+            PathStep::call(syn::parse_quote!(get_opt), true, true),
+            PathStep::call(syn::parse_quote!(next), false, false),
+        ];
+        let l = leaf(
+            syn::parse_quote!(Owned),
+            path.clone(),
+            false,
+            LeafSource::Reach,
+        );
+        let got = prebindgen_registry::unfold::reach_leaf(
+            &qualify,
+            prebindgen_registry::unfold::LeafAt {
+                leaf: &crate::jni::compile::OutWire::from_leaf(&l),
+                path: &path,
+                base: quote!(__src),
+                base_is_ref: false,
+                consuming: false,
+                unwrap_last: true,
+            },
+            Some(&|| quote!(__absent)),
+            &|reached| reached,
+        )
+        .to_string();
+        assert!(
+            got.contains("next (& __n0)"),
+            "the owned payload is borrowed for the accessor that follows it — got `{got}`"
         );
     }
 
@@ -1540,13 +1489,18 @@ mod tests {
             false,
             LeafSource::Reach,
         );
-        let got = prebindgen_registry::unfold::reach_leaf_flat(
+        let got = prebindgen_registry::unfold::reach_leaf(
             &qualify,
-            &crate::jni::compile::OutWire::from_leaf(&l),
-            &path,
-            quote!(__src),
-            false,
-            false,
+            prebindgen_registry::unfold::LeafAt {
+                leaf: &crate::jni::compile::OutWire::from_leaf(&l),
+                path: &path,
+                base: quote!(__src),
+                base_is_ref: false,
+                consuming: false,
+                unwrap_last: false,
+            },
+            None,
+            &|reached| reached,
         )
         .to_string();
         assert!(
@@ -1572,13 +1526,18 @@ mod tests {
         // The suffix a rebase would hand over — the optional call is gone from
         // it, and used to take the guard with it.
         let rest = vec![PathStep::field(syn::parse_quote!(a), false)];
-        let _ = prebindgen_registry::unfold::reach_leaf_flat(
+        let _ = prebindgen_registry::unfold::reach_leaf(
             &qualify,
-            &crate::jni::compile::OutWire::from_leaf(&l),
-            &rest,
-            quote!(__vf0),
-            false,
-            false,
+            prebindgen_registry::unfold::LeafAt {
+                leaf: &crate::jni::compile::OutWire::from_leaf(&l),
+                path: &rest,
+                base: quote!(__vf0),
+                base_is_ref: false,
+                consuming: false,
+                unwrap_last: false,
+            },
+            None,
+            &|reached| reached,
         );
     }
 }

--- a/prebindgen-jni/src/jni/emit/struct_out.rs
+++ b/prebindgen-jni/src/jni/emit/struct_out.rs
@@ -327,7 +327,8 @@ fn encode_field(
                     // field is optional, and how Rust spells that is the
                     // source's business (#268).
                     let obind = format_ident!("__on{}", depth);
-                    let coerce = bind_as_option(&quote!(&#value), &obind);
+                    let coerce =
+                        prebindgen_registry::unfold::bind_as_option(&quote!(&#value), &obind);
                     preludes.extend(quote! {
                         let #flag_id: jni::sys::jboolean;
                         #( let #outer_ids: #outer_tys; )*
@@ -487,7 +488,8 @@ fn encode_field(
                     // field is optional, and how Rust spells that is the
                     // source's business (#268).
                     let obind = format_ident!("__oc{}", depth);
-                    let coerce = bind_as_option(&quote!(&#value), &obind);
+                    let coerce =
+                        prebindgen_registry::unfold::bind_as_option(&quote!(&#value), &obind);
                     preludes.extend(quote! {
                         let #flag_id: jni::sys::jboolean;
                         #decls

--- a/prebindgen-jni/src/jni/emit/sum_out.rs
+++ b/prebindgen-jni/src/jni/emit/sum_out.rs
@@ -87,7 +87,7 @@ pub(crate) struct Slot {
 }
 
 pub(crate) fn leaf_slot(
-    context: &impl DeliveryContext,
+    context: &crate::jni::emit::delivery::FrozenDelivery,
     leaf: &crate::jni::compile::OutWire,
 ) -> Slot {
     if !context.leaf_is_prim(leaf) {
@@ -139,7 +139,7 @@ pub(crate) fn is_sum_row(leaves: &[crate::jni::compile::OutWire]) -> bool {
 /// is that a leaf here is not an independent expression — its slot exists in
 /// every arm and only one arm computes it.
 pub(crate) fn encode_sum_group(
-    context: &impl DeliveryContext,
+    context: &crate::jni::emit::delivery::FrozenDelivery,
     leaves: &[crate::jni::compile::OutWire],
     obj_idents: &[syn::Ident],
     matched: TokenStream,
@@ -153,7 +153,7 @@ pub(crate) fn encode_sum_group(
         .iter()
         .find(|l| l.is_tag())
         .expect("a sum segment carries its selector leaf");
-    let (source, sum) = context.sum(tag_leaf);
+    let (source, sum) = prebindgen_registry::unfold::DeliveryBridge::sum(context, tag_leaf);
 
     let slots: Vec<Slot> = leaves.iter().map(|l| leaf_slot(context, l)).collect();
 
@@ -285,7 +285,7 @@ pub(crate) fn encode_sum_group(
 /// payload and a struct field of the same type reach their converter the same
 /// way.
 fn encode_group_leaf(
-    context: &impl DeliveryContext,
+    context: &crate::jni::emit::delivery::FrozenDelivery,
     leaf: &crate::jni::compile::OutWire,
     obj_ident: &syn::Ident,
     prim: bool,

--- a/prebindgen-jni/src/jni/emit/wrapper.rs
+++ b/prebindgen-jni/src/jni/emit/wrapper.rs
@@ -3,7 +3,7 @@
 
 use prebindgen_registry::{
     types_util::result_ok_type,
-    unfold::{bind_hoists, reach_leaf_flat},
+    unfold::{bind_hoists, reach_leaf, LeafAt},
     Conversions,
 };
 
@@ -330,24 +330,30 @@ impl JWrapper {
             let compose = |base: TokenStream, base_is_ref: bool| -> Option<TokenStream> {
                 let hoisted = bind_hoists(&qualify, &uplan.hoists, &base, base_is_ref);
                 let stmts = &hoisted.stmts;
-                let reached = match hoisted.rebase(&leaf.path) {
-                    Some((local, rest, consuming)) => reach_leaf_flat(
-                        &qualify,
-                        &crate::jni::compile::OutWire::from_leaf(leaf),
-                        &rest,
-                        quote!(#local),
-                        false,
-                        consuming,
-                    ),
-                    None => reach_leaf_flat(
-                        &qualify,
-                        &crate::jni::compile::OutWire::from_leaf(leaf),
-                        &leaf.path,
-                        base.clone(),
-                        base_is_ref,
-                        false,
-                    ),
+                let wire = crate::jni::compile::OutWire::from_leaf(leaf);
+                let rebased = hoisted.rebase(&leaf.path);
+                let (path, from, from_is_ref, consuming) = match &rebased {
+                    Some((local, rest, consuming)) => {
+                        (rest.as_slice(), quote!(#local), false, *consuming)
+                    }
+                    None => (leaf.path.as_slice(), base.clone(), base_is_ref, false),
                 };
+                // `absent: None` — a single delivered return has no arm to put
+                // an absent value in, so an optional step on the way to this
+                // leaf is refused rather than gated.
+                let reached = reach_leaf(
+                    &qualify,
+                    LeafAt {
+                        leaf: &wire,
+                        path,
+                        base: from,
+                        base_is_ref: from_is_ref,
+                        consuming,
+                        unwrap_last: false,
+                    },
+                    None,
+                    &|reached| reached,
+                );
                 if stmts.is_empty() && reached.to_string() == base.to_string() {
                     return None;
                 }

--- a/prebindgen-jni/src/jni/emit/wrapper.rs
+++ b/prebindgen-jni/src/jni/emit/wrapper.rs
@@ -318,7 +318,7 @@ impl JWrapper {
                 FnOutputPlan::Unfold(_) => unreachable!("a convert has a value output plan"),
             };
             let qualify = |id: &syn::Ident| -> syn::Path {
-                crate::jni::emit::DeliveryContext::qualify(delivery, id)
+                prebindgen_registry::unfold::DeliveryBridge::qualify(delivery, id)
             };
             // `None` when the reach is the IDENTITY of `base` and no value form had
             // to be bound — the leaf IS the value, so there is nothing to compose.

--- a/prebindgen-jni/src/jni/tests/value_form.rs
+++ b/prebindgen-jni/src/jni/tests/value_form.rs
@@ -180,7 +180,7 @@ fn an_optional_field_reaches_its_converter_whole() {
     );
     for field in ["stamp", "attachment"] {
         assert!(
-            rust.contains(&format!(".{field}.clone()")),
+            rust.contains(&format!(".{field}).clone()")),
             "`{field}` must be cloned whole, not matched open:\n{rust}"
         );
         assert!(
@@ -2627,8 +2627,11 @@ fn a_consuming_value_form_moves_its_fields() {
         rust.contains("__vf0.label") && rust.contains("__vf0.count"),
         "each field is read off the one hoisted local:\n{rust}"
     );
+    // Spelled the way a clone reaches a field it does not own — off the
+    // borrow, `(&__vf0.label).clone()` — since that is what would appear here
+    // if the form stopped consuming.
     assert!(
-        !rust.contains("__vf0.label.clone()") && !rust.contains("__vf0.count.clone()"),
+        !rust.contains(".label).clone()") && !rust.contains(".count).clone()"),
         "and MOVED out of it — a consuming form exists precisely to drop these \
          clones:\n{rust}"
     );
@@ -2649,7 +2652,7 @@ fn the_borrowing_value_form_still_clones() {
         "a `&T` accessor is still handed a borrow:\n{rust}"
     );
     assert!(
-        rust.contains("__vf0.label.clone()"),
+        rust.contains("(&__vf0.label).clone()"),
         "and its fields are still cloned out:\n{rust}"
     );
 }

--- a/prebindgen-registry/src/unfold.rs
+++ b/prebindgen-registry/src/unfold.rs
@@ -36,7 +36,7 @@ mod error;
 mod walk;
 pub use walk::{
     bind_hoists, compose_step, fold_steps, project_leading_fields, reach_leaf_flat, DecomposedLeaf,
-    Hoisted,
+    DeliveryBridge, Hoisted, Reach,
 };
 
 mod plan;

--- a/prebindgen-registry/src/unfold.rs
+++ b/prebindgen-registry/src/unfold.rs
@@ -35,8 +35,9 @@ use crate::{
 mod error;
 mod walk;
 pub use walk::{
-    bind_hoists, compose_step, fold_steps, project_leading_fields, reach_leaf, reached_is_ours,
-    DecomposedLeaf, DeliveryBridge, Hoisted, LeafAt, LeafPlace, Reach,
+    bind_as_option, bind_hoists, compose_step, conditional_arm, fold_steps, project_leading_fields,
+    reach_leaf, reached_is_ours, segment, segments, DecomposedLeaf, DeliveryBridge, Hoisted,
+    LeafAt, LeafPlace, Reach, Slot,
 };
 
 mod plan;

--- a/prebindgen-registry/src/unfold.rs
+++ b/prebindgen-registry/src/unfold.rs
@@ -1,5 +1,5 @@
 //! Output (data) expansion — the dual of constructor expansion
-//! (`api/core/expand.rs`). A function returning a rich type is *decomposed* by a
+//! ([`crate::expand`]). A function returning a rich type is *decomposed* by a
 //! **deconstructor** into a set of leaf values.
 //!
 //! A **deconstructor** (a type-level `expand_return!` `.field*` list,

--- a/prebindgen-registry/src/unfold.rs
+++ b/prebindgen-registry/src/unfold.rs
@@ -35,8 +35,8 @@ use crate::{
 mod error;
 mod walk;
 pub use walk::{
-    bind_hoists, compose_step, fold_steps, project_leading_fields, reach_leaf_flat, DecomposedLeaf,
-    DeliveryBridge, Hoisted, Reach,
+    bind_hoists, compose_step, fold_steps, project_leading_fields, reach_leaf, DecomposedLeaf,
+    DeliveryBridge, Hoisted, LeafAt, Reach,
 };
 
 mod plan;

--- a/prebindgen-registry/src/unfold.rs
+++ b/prebindgen-registry/src/unfold.rs
@@ -35,8 +35,8 @@ use crate::{
 mod error;
 mod walk;
 pub use walk::{
-    bind_hoists, compose_step, fold_steps, project_leading_fields, reach_leaf, DecomposedLeaf,
-    DeliveryBridge, Hoisted, LeafAt, Reach,
+    bind_hoists, compose_step, fold_steps, project_leading_fields, reach_leaf, reached_is_ours,
+    DecomposedLeaf, DeliveryBridge, Hoisted, LeafAt, LeafPlace, Reach,
 };
 
 mod plan;

--- a/prebindgen-registry/src/unfold/walk.rs
+++ b/prebindgen-registry/src/unfold/walk.rs
@@ -175,8 +175,9 @@ pub fn reach_leaf_flat<L: DecomposedLeaf>(
 ) -> TokenStream {
     // An optional step BEFORE the last one needs a `match` whose `None` arm has
     // somewhere to go. This derivation has none — it yields a plain Rust value,
-    // not a `JObject` that could be null — so the shape is refused here rather
-    // than composed into code that cannot type-check in the consumer's crate.
+    // not a representation that can carry absence — so the shape is refused
+    // here rather than composed into code that cannot type-check in the
+    // consumer's crate.
     //
     // Asked of the leaf's OWN path, not of `path`. The caller may hand a
     // suffix: `wrapper.rs` rebases onto a hoisted local, and `Hoisted::innermost`
@@ -304,11 +305,16 @@ impl Hoisted {
         self.consuming[i]
     }
 }
-/// Fold `path` over `base` the way [`reach_leaf`] does, but yielding an
-/// `Option<…>` rather than a `JObject`: the optional steps become a
-/// `map`/`and_then` chain, so an absent value short-circuits to `None` instead
-/// of to a null object. `body` renders the innermost reached expression as a
-/// BARE value — the chain's last link wraps it.
+/// Fold `path` over `base` the way an adapter's own gated reach does, but
+/// yielding an `Option<…>` rather than the adapter's absent value: the optional
+/// steps become a `map`/`and_then` chain, so an absent value short-circuits to
+/// `None` instead of to whatever that adapter uses for absence. `body` renders
+/// the innermost reached expression as a BARE value — the chain's last link
+/// wraps it.
+///
+/// The gated reach this mirrors is not in this crate. JniGen keeps its own, as
+/// `emit::delivery::reach_leaf`, because the absent value is its
+/// representation's — which is one of the walks this module was meant to end.
 ///
 /// This is how a CONDITIONAL value form is bound — the accessor runs only where
 /// the value it decomposes is actually present.

--- a/prebindgen-registry/src/unfold/walk.rs
+++ b/prebindgen-registry/src/unfold/walk.rs
@@ -34,6 +34,15 @@ pub trait DecomposedLeaf {
     /// The reading the leaf delivers.
     fn source(&self) -> &TypeRef;
 
+    /// Whether this leaf is the synthesized **selector** — the value naming
+    /// which alternative of a decomposed sum is live. It selects between the
+    /// groups rather than joining one.
+    fn selects(&self) -> bool;
+
+    /// The alternative this leaf belongs to, when it is one of a sum's group
+    /// leaves. `None` for a leaf that is always live.
+    fn group(&self) -> Option<i32>;
+
     /// Whether the last step reaching it is a field read rather than a call.
     ///
     /// Derived from [`Self::reach`], so no implementation can disagree with
@@ -42,6 +51,16 @@ pub trait DecomposedLeaf {
     fn is_field_read(&self) -> bool {
         matches!(self.reach().last(), Some(PathStep::Field { .. }))
     }
+}
+
+/// One delivered value's slot, as the walk needs to see it: a slot exists for
+/// every leaf whether or not the value behind it does, so a gate that skips an
+/// encode still has to declare the slot and fill it.
+pub struct Slot {
+    /// The slot's type.
+    pub ty: TokenStream,
+    /// What an unfilled slot carries.
+    pub default: TokenStream,
 }
 
 /// A leaf's reach, rendered **around** an encoding body: the walk hands the
@@ -91,6 +110,11 @@ pub trait DeliveryBridge {
 
     /// The expression that passes `slot` as one argument of the delivery call.
     fn argument(&self, leaf: &Self::Leaf, slot: &syn::Ident) -> TokenStream;
+
+    /// What one leaf's slot holds when the walk fills it without running the
+    /// leaf's encode — the `None` arm of a gate, where a slot exists but the
+    /// value behind it does not.
+    fn slot(&self, leaf: &Self::Leaf) -> Slot;
 
     /// What a leaf delivers when an optional step on the way to it found
     /// nothing. [`reach_leaf`] gates on this rather than on a value of its
@@ -503,6 +527,206 @@ fn reached_place<L: DecomposedLeaf>(
         e
     }
 }
+/// The **segments** of a decomposition: each selector leaf, together with the
+/// group leaves that follow it.
+///
+/// A sum's leaves are not independent — only one alternative is live per value
+/// — so a segment is emitted as one `match` rather than as a leaf at a time.
+/// The plan already says which leaves those are: a selector says so of itself,
+/// and each of the leaves after it carries the alternative it belongs to until
+/// one does not. A decomposition may carry several segments, or none: a sum
+/// that IS the delivered value is one segment covering everything, and a value
+/// form contributes one per sum-typed field.
+///
+/// Not recognising a segment is silent rather than a compile error — the
+/// leaves are all there, and a delivery that treats them as independent reads
+/// a dead alternative's fields — which is why this is the registry's answer
+/// and not an adapter's.
+pub fn segments<L: DecomposedLeaf>(leaves: &[L]) -> Vec<std::ops::Range<usize>> {
+    let n = leaves.len();
+    (0..n)
+        .filter(|&i| leaves[i].selects())
+        .map(|start| {
+            let end = (start + 1..n)
+                .take_while(|&i| leaves[i].group().is_some())
+                .last()
+                .map_or(start + 1, |i| i + 1);
+            start..end
+        })
+        .collect()
+}
+
+/// Render one segment off `place`, gating the whole of it when the selector
+/// reaches its sum through an optional step.
+///
+/// `group` renders the segment's own encode from the expression naming the
+/// live sum — that half is the adapter's, since what a group of slots is
+/// filled with is a target-language question.
+///
+/// **An `Option<sum>` gates the segment, not each slot.** A sum's leaves are
+/// not independent, so absence cannot be the per-leaf absent value
+/// [`reach_leaf`] gives an ordinary optional field: it is one tuple bind whose
+/// `None` arm carries every slot's default. That is the same shape a
+/// conditional value form's hoist emits, applied to an optional step inside
+/// the segment's own path (#220).
+///
+/// `index` names the segment's locals, so two segments of one delivery cannot
+/// collide.
+pub fn segment<B: DeliveryBridge>(
+    bridge: &B,
+    qualify: &dyn Fn(&syn::Ident) -> syn::Path,
+    place: &LeafPlace,
+    index: usize,
+    leaves: &[B::Leaf],
+    slots: &[syn::Ident],
+    group: &dyn Fn(TokenStream) -> TokenStream,
+) -> TokenStream {
+    let path = &place.path;
+    // A plain field chain is borrowed DIRECTLY (`&base.a.b`) rather than
+    // through the base (`&(&base).a.b`). The two are the same value, but the
+    // second borrows the base as a whole, which the borrow checker rejects
+    // once a sibling leaf has moved another field out of it — and borrowing
+    // this field while sibling fields move is exactly what a consuming value
+    // form does.
+    let (projected, lead) = project_leading_fields(&place.base, place.base_is_ref, path);
+    // The selector's own path reaches the sum (empty when the sum IS the
+    // value), and a step on it MAY be optional.
+    let Some(k) = (lead..path.len()).find(|&i| path[i].is_optional()) else {
+        return group(fold_steps(qualify, &path[lead..], projected, false));
+    };
+    // Through the optional step INCLUSIVE, then the rest off the binding — the
+    // same split [`reach_leaf`] makes, so the borrow in front of it stays the
+    // ordinary rule rather than a second statement of it.
+    let opt_e = fold_steps(qualify, &path[lead..=k], projected, false);
+    let bind = format_ident!("__sg{}", index);
+    // ONE optional step is what this gate handles. A second one in the tail
+    // would compose `match &Option<..>` against bare variant patterns — an
+    // E0308 in the consumer's crate — so the named diagnostic is raised here
+    // instead.
+    //
+    // `assert!`, not `debug_assert!`: a build script inherits the consumer's
+    // profile, so a debug-only check is absent from exactly the release build
+    // where a mis-emission costs the most to diagnose. Same rule, same
+    // phrasing, as the single-return optional-step assert in [`reach_leaf`].
+    //
+    // The condition is what actually breaks, not the stronger fact that
+    // happens to hold: every sum leaf's path stops AT the sum, so the tail is
+    // empty today, but a NON-optional tail composes correctly through
+    // [`fold_steps`] — refusing it would refuse a shape that works.
+    assert!(
+        !path[k + 1..].iter().any(PathStep::is_optional),
+        "unfold: leaf `{}` reaches its sum through TWO optional steps — the \
+         segment gate has one `None` arm, so the second would be matched as if \
+         it were the sum itself",
+        leaves
+            .first()
+            .expect("a segment has at least its selector")
+            .name(),
+    );
+    // What the `match` binds, asked of the step rather than assumed: the FIELD
+    // branch scrutinizes `&Option<_>`, so ergonomics binds `&Sum` — a borrow.
+    // Only an owned-yielding CALL binds an owned value.
+    let inner = group(fold_steps(
+        qualify,
+        &path[k + 1..],
+        quote!(#bind),
+        path[k].yields_owned(),
+    ));
+    let filled: Vec<Slot> = leaves.iter().map(|leaf| bridge.slot(leaf)).collect();
+    let tys = filled.iter().map(|slot| &slot.ty);
+    let defaults = filled.iter().map(|slot| &slot.default);
+    // A FIELD step composes to a borrow, so it goes through a coercion site
+    // and the destructure stops caring which representation the source spelled
+    // the optional as (#268). A CALL yields its own owned value, whose payload
+    // downstream may move, so it keeps the direct match — the same division
+    // [`reach_leaf`] makes.
+    let (prelude, scrutinee) = if path[k].is_field() {
+        let opt_bind = format_ident!("__so{}", index);
+        (bind_as_option(&opt_e, &opt_bind), quote!(#opt_bind))
+    } else {
+        (TokenStream::new(), opt_e)
+    };
+    quote! {
+        let (#(#slots,)*): (#(#tys,)*) = {
+            #prelude
+            match #scrutinee {
+                ::core::option::Option::Some(#bind) => {
+                    #inner
+                    (#(#slots,)*)
+                }
+                ::core::option::Option::None => (#(#defaults,)*),
+            }
+        };
+    }
+}
+
+/// The `match` a **conditional** value form's leaves share.
+///
+/// A hoist under an optional step ran only where the value was present, so its
+/// leaves cannot be independent statements: their slots exist either way, and
+/// only one arm computes them. The `Some` arm runs `body` — the statements
+/// those leaves contributed — and yields their slots as a tuple; the `None`
+/// arm yields each slot's default, the same shape [`segment`] gives an absent
+/// sum. Binding the tuple outside the `match` keeps the slots in scope for the
+/// call's argument list, which is indifferent to how a slot was filled.
+///
+/// Matched BY VALUE: the local is this arm's alone, every leaf under the hoist
+/// being in it, so a consuming value form's fields move out here exactly as
+/// they do at an unconditional one.
+pub fn conditional_arm<B: DeliveryBridge>(
+    bridge: &B,
+    hoisted: &Hoisted,
+    index: usize,
+    leaves: &[B::Leaf],
+    slots: &[syn::Ident],
+    body: TokenStream,
+) -> TokenStream {
+    let local = hoisted.local(index);
+    let bind = format_ident!("__u{}", index);
+    let under: Vec<usize> = (0..leaves.len())
+        .filter(|&k| {
+            hoisted
+                .conditional(leaves[k].reach())
+                .is_some_and(|(j, ..)| j == index)
+        })
+        .collect();
+    let ids: Vec<&syn::Ident> = under.iter().map(|&k| &slots[k]).collect();
+    let filled: Vec<Slot> = under.iter().map(|&k| bridge.slot(&leaves[k])).collect();
+    let tys = filled.iter().map(|slot| &slot.ty);
+    let defaults = filled.iter().map(|slot| &slot.default);
+    quote! {
+        let (#(#ids,)*): (#(#tys,)*) = match #local {
+            ::core::option::Option::Some(#bind) => { #body (#(#ids,)*) }
+            ::core::option::Option::None => (#(#defaults,)*),
+        };
+    }
+}
+
+/// Bind `e` so it can be destructured as an `Option` **whatever Rust
+/// representation the source used for it**.
+///
+/// The model says a position is optional; it deliberately does not say whether
+/// Rust spells that `Option<T>`, `Box<Option<T>>`, or something else — the
+/// side interpreting the classification is the side that must accept any
+/// representation. Matching the reached place directly assumed one, which is
+/// "classify off the model, spell from the model" broken in the direction
+/// nothing was watching: `Box<Option<T>>` then produced
+/// `match &place { Some(..) => .. }` and an E0308 (#268).
+///
+/// A type-ascribed `let` is a coercion site, and deref coercion is transitive
+/// **and** a no-op when the types already match — so this one shape serves
+/// every representation, and the plain `Option<T>` case is unchanged.
+///
+/// `e` is expected to be a **reference** already — [`compose_step`] composes a
+/// field read as `&(e).f` — so nothing is borrowed here. Borrowing only: an
+/// owned position cannot be made representation-agnostic this way, because
+/// deref coercion applies to references and moving out of a wrapper is
+/// something only some of them permit (`Box` does, `Rc` cannot). A site that
+/// must MOVE the payload keeps its direct match.
+pub fn bind_as_option(e: &TokenStream, bind: &syn::Ident) -> TokenStream {
+    quote! { let #bind: &::core::option::Option<_> = #e; }
+}
+
 /// Every value form on a plan, evaluated **once** and bound to a local
 /// (`__vf0`, `__vf1`, …), so a struct is built once per delivery rather than
 /// once per field. The bound prefixes come back with the statements, since

--- a/prebindgen-registry/src/unfold/walk.rs
+++ b/prebindgen-registry/src/unfold/walk.rs
@@ -91,6 +91,12 @@ pub trait DeliveryBridge {
 
     /// The expression that passes `slot` as one argument of the delivery call.
     fn argument(&self, leaf: &Self::Leaf, slot: &syn::Ident) -> TokenStream;
+
+    /// What a leaf delivers when an optional step on the way to it found
+    /// nothing. [`reach_leaf`] gates on this rather than on a value of its
+    /// own: absence is a target-language representation, and this crate has
+    /// none.
+    fn absent(&self) -> TokenStream;
 }
 
 /// Compose one [`PathStep`] onto the reference expression reached so far.
@@ -204,24 +210,150 @@ pub fn project_leading_fields(
     (quote!(&#base #(.#segs)*), n)
 }
 
-/// Fold a leaf's whole `path` over `base` with no optional-step handling, then
-/// apply the terminal treatment the leaf calls for: a leaf reached by a field
-/// read is **cloned** out of the place it reached, because its converter takes
-/// the field type as written (owned); every other leaf keeps the borrow its
-/// converter expects.
+/// One leaf, and the place a reach of it starts from.
+///
+/// A caller that has already bound a hoist hands over the local it bound and
+/// the steps that are left, which is why `path` is a suffix of the leaf's own
+/// reach rather than always equal to it.
+pub struct LeafAt<'a, L> {
+    /// The leaf being reached.
+    pub leaf: &'a L,
+    /// The steps still to walk from `base`.
+    pub path: &'a [PathStep],
+    /// What the walk starts from — the delivered value, or a local a hoist or
+    /// a gate bound.
+    pub base: TokenStream,
+    /// Whether `base` is already a reference.
+    pub base_is_ref: bool,
+    /// Whether the form that produced `base` gave its value away, which is
+    /// what lets a field of it be moved rather than cloned.
+    pub consuming: bool,
+    /// Whether a FINAL optional step is gated too. An identity leaf delivers
+    /// the reached value itself, so it is; every other leaf hands the final
+    /// step's full type to its own converter, `Option` and all.
+    pub unwrap_last: bool,
+}
+
+/// Reach one leaf from `base` and hand what it reached to `body`.
+///
+/// Three things happen on the way, and all three are facts about Rust values
+/// rather than about any target language:
+///
+/// * **Gating.** An optional step before the leaf becomes a `match` whose
+///   `None` arm yields `absent()` — the adapter's own absence, since this
+///   crate has none to offer. `unwrap_last` says whether a FINAL optional step
+///   is gated too: an identity leaf delivers the reached value itself, so it
+///   is, while every other leaf hands the final step's full type to its own
+///   converter, `Option` and all.
+/// * **Refusal.** `absent` is `None` at a site that cannot express absence at
+///   all — a single delivered return value, which has no arm to put one in.
+///   An optional step before the end is then refused rather than composed into
+///   code the consumer's crate cannot type-check.
+/// * **Ownership**: the reached place is moved when it is ours, cloned when
+///   it is a field read of a place that is not, and borrowed otherwise.
 ///
 /// One derivation, used by every delivery an adapter renders and by the
 /// single-leaf shortcut a decomposed return takes. They drifted once while
 /// they were two — the shortcut was missing the field clone and handed `&F` to
-/// an `F` converter — which is why the walk is the registry's.
-pub fn reach_leaf_flat<L: DecomposedLeaf>(
+/// an `F` converter — and a second pair, ungated here and gated in JniGen,
+/// drifted the same way until #607 folded them together.
+pub fn reach_leaf<L: DecomposedLeaf>(
     qualify: &dyn Fn(&syn::Ident) -> syn::Path,
-    leaf: &L,
-    path: &[PathStep],
-    base: TokenStream,
-    base_is_ref: bool,
-    consuming: bool,
+    at: LeafAt<'_, L>,
+    absent: Option<&dyn Fn() -> TokenStream>,
+    body: &dyn Fn(TokenStream) -> TokenStream,
 ) -> TokenStream {
+    reach_leaf_at(qualify, at, absent, 0, body)
+}
+
+fn reach_leaf_at<L: DecomposedLeaf>(
+    qualify: &dyn Fn(&syn::Ident) -> syn::Path,
+    at: LeafAt<'_, L>,
+    absent: Option<&dyn Fn() -> TokenStream>,
+    depth: usize,
+    body: &dyn Fn(TokenStream) -> TokenStream,
+) -> TokenStream {
+    let LeafAt {
+        path,
+        ref base,
+        base_is_ref,
+        unwrap_last,
+        ..
+    } = at;
+    // Every optional step on the way to the leaf becomes a `match` whose
+    // `None` arm is the adapter's absent value. A site with no absent value to
+    // give — a single delivered return, which has no arm to put one in —
+    // passes `None`, and an optional step before the end is then refused
+    // rather than composed into code the consumer's crate cannot type-check.
+    if let Some(absent) = absent {
+        let limit = if unwrap_last {
+            path.len()
+        } else {
+            // A non-identity leaf's converter takes the final step's FULL type,
+            // `Option` included, so only the steps before it are nesting.
+            path.len().saturating_sub(1)
+        };
+        let (projected, lead) = project_leading_fields(base, base_is_ref, path);
+        if let Some(k) = (lead..limit).find(|&i| path[i].is_optional()) {
+            // Through the optional step INCLUSIVE: the same fold, so the borrow
+            // in front of it is the ordinary rule rather than a second
+            // statement of it.
+            let opt_e = fold_steps(qualify, &path[lead..=k], projected, false);
+            let nested = format_ident!("__n{}", depth);
+            // What the arm binds is the step's OWN value: an owned payload is
+            // a bare `T`, so composing the next step onto it directly would
+            // hand `T` to an accessor typed for `&T`. Say it is not a
+            // reference and let `project_leading_fields` borrow it; a borrowed
+            // payload is already one and passes through. With no steps left
+            // the binding goes to `body` untouched, which is what lets an
+            // owned payload be moved rather than borrowed straight back.
+            //
+            // The same rule [`reach_optional`] states for a conditional
+            // hoist's prefix. This used to be a hardcoded `true` in the gated
+            // reach JniGen owned, where an `Option<T>` accessor followed by
+            // another accessor emitted `next(__n0)` against a `&T` receiver.
+            let rest = &path[k + 1..];
+            let inner = reach_leaf_at(
+                qualify,
+                LeafAt {
+                    path: rest,
+                    base: quote!(#nested),
+                    base_is_ref: rest.is_empty() || !path[k].yields_owned(),
+                    ..at
+                },
+                Some(absent),
+                depth + 1,
+                body,
+            );
+            let gone = absent();
+            // A FIELD read composes to a borrow (`&(e).f`), so it goes through
+            // a coercion site and the destructuring stops caring which
+            // representation the source spelled the optional as (#268).
+            //
+            // A CALL composes to the accessor's own returned value, which is
+            // owned and whose payload downstream may move. Borrowing it to
+            // coerce would change that ownership, so it keeps its direct match.
+            if path[k].is_field() {
+                let opt_bind = format_ident!("__o{}", depth);
+                return quote! {
+                    {
+                        let #opt_bind: &::core::option::Option<_> = #opt_e;
+                        match #opt_bind {
+                            ::core::option::Option::Some(#nested) => { #inner }
+                            ::core::option::Option::None => #gone,
+                        }
+                    }
+                };
+            }
+            return quote! {
+                match #opt_e {
+                    ::core::option::Option::Some(#nested) => { #inner }
+                    ::core::option::Option::None => #gone,
+                }
+            };
+        }
+        return body(reached_place(qualify, &at));
+    }
     // An optional step BEFORE the last one needs a `match` whose `None` arm has
     // somewhere to go. This derivation has none — it yields a plain Rust value,
     // not a representation that can carry absence — so the shape is refused
@@ -235,13 +367,13 @@ pub fn reach_leaf_flat<L: DecomposedLeaf>(
     // conditional one, which is the case that cannot compose (an `Option<T>`
     // local with a field read hung off it). The full path is what the shape
     // question is about.
-    let own_path = leaf.reach();
+    let own_path = at.leaf.reach();
     assert!(
         !own_path.iter().rev().skip(1).any(PathStep::is_optional),
         "unfold: leaf `{}` reaches through an optional step but is \
          delivered as a single return value, which has no `None` arm — this \
          shape needs callback delivery",
-        leaf.name(),
+        at.leaf.name(),
     );
     // Whether what this leaf reaches is OURS, and so is moved rather than
     // borrowed or cloned. The two leaf kinds say it differently:
@@ -264,6 +396,25 @@ pub fn reach_leaf_flat<L: DecomposedLeaf>(
     // somewhere else. `plan.rs` says two readings would drift and the
     // disagreement would be a borrow handed to an owning converter; this is the
     // second reading, removed.
+    body(reached_place(qualify, &at))
+}
+
+/// The place a leaf reaches, with the terminal treatment its ownership calls
+/// for: moved out when it is ours and the path projects a place, cloned out
+/// when it is a field read of a place that is not, and borrowed otherwise.
+fn reached_place<L: DecomposedLeaf>(
+    qualify: &dyn Fn(&syn::Ident) -> syn::Path,
+    at: &LeafAt<'_, L>,
+) -> TokenStream {
+    let LeafAt {
+        leaf,
+        path,
+        base,
+        base_is_ref,
+        consuming,
+        ..
+    } = at;
+    let (base_is_ref, consuming) = (*base_is_ref, *consuming);
     let reached_is_ours = if leaf.identity() {
         !matches!(
             leaf.source().kind(),
@@ -276,8 +427,15 @@ pub fn reach_leaf_flat<L: DecomposedLeaf>(
         let segs: Vec<&syn::Ident> = path.iter().map(PathStep::ident).collect();
         return quote!(#base #(.#segs)*);
     }
-    let (e, lead) = project_leading_fields(&base, base_is_ref, path);
+    let (e, lead) = project_leading_fields(base, base_is_ref, path);
     let e = fold_steps(qualify, &path[lead..], e, false);
+    // Cloned out of the BORROW the reach yields, not out of the place behind
+    // it. The two agree for a field of an owned type and disagree for a field
+    // that is itself a reference: `place.clone()` there resolves through the
+    // reference and deep-clones the pointee, where the converter takes the
+    // field type as written. JniGen's own reach spelled it the short way and
+    // no declared field exercised the difference — the drift this step exists
+    // to close.
     if leaf.is_field_read() {
         quote!((#e).clone())
     } else {
@@ -361,9 +519,11 @@ impl Hoisted {
 /// the innermost reached expression as a BARE value — the chain's last link
 /// wraps it.
 ///
-/// The gated reach this mirrors is not in this crate. JniGen keeps its own, as
-/// `emit::delivery::reach_leaf`, because the absent value is its
-/// representation's — which is one of the walks this module was meant to end.
+/// The gated reach this mirrors is [`reach_leaf`], which takes the absent
+/// value from the adapter rather than choosing one. This one yields an
+/// `Option` instead, because what it binds is a hoist rather than a delivered
+/// leaf: the value form runs where the value is present, and the `None` the
+/// chain produces is the local's own.
 ///
 /// This is how a CONDITIONAL value form is bound — the accessor runs only where
 /// the value it decomposes is actually present.

--- a/prebindgen-registry/src/unfold/walk.rs
+++ b/prebindgen-registry/src/unfold/walk.rs
@@ -44,6 +44,55 @@ pub trait DecomposedLeaf {
     }
 }
 
+/// A leaf's reach, rendered **around** an encoding body: the walk hands the
+/// body the reached Rust expression and gets back the encoded value, so an
+/// absent value short-circuits to the adapter's own absence rather than to one
+/// the walk chose. `dyn` on both halves because each side is written where it
+/// is known and neither can name the other's closure.
+pub type Reach<'a> = dyn Fn(&dyn Fn(TokenStream) -> TokenStream) -> TokenStream + 'a;
+
+/// The adapter's half of a delivery.
+///
+/// The walk in this module owns how a decomposed value is reached — which
+/// hoist a leaf sits under, what is owned, what is borrowed. What a leaf
+/// becomes in the target language, and how the delivered values are handed to
+/// the call, is the adapter's, and this is where it says so. Stated over
+/// [`DecomposedLeaf`] rather than over an adapter's own leaf type, so the walk
+/// can call it.
+pub trait DeliveryBridge {
+    /// The adapter's leaf.
+    type Leaf: DecomposedLeaf;
+
+    /// Where the source item declaring `ident` is qualified from — the one
+    /// fact about a captured path this crate cannot answer for itself.
+    fn qualify(&self, ident: &syn::Ident) -> syn::Path;
+
+    /// The sum a selector leaf names: the qualified source path of the type,
+    /// and its Flat shape.
+    fn sum(&self, leaf: &Self::Leaf) -> (syn::Path, &prebindgen_flat::flat::Variant);
+
+    /// Encode one leaf into the value the delivery call receives, and bind
+    /// that value to `slot`.
+    ///
+    /// The adapter emits the binding rather than the walk, because the slot's
+    /// type is the adapter's: one leaf may cross as a scalar and the next as a
+    /// reference. `index` is the leaf's position in the delivery, which is
+    /// what any temporary the encode needs is named from. An encoding that can
+    /// fail routes its failure through `fail`.
+    fn encode(
+        &self,
+        leaf: &Self::Leaf,
+        index: usize,
+        slot: &syn::Ident,
+        reach: &Reach<'_>,
+        fail: &dyn Fn(TokenStream) -> TokenStream,
+        emit: &crate::RustWriter,
+    ) -> TokenStream;
+
+    /// The expression that passes `slot` as one argument of the delivery call.
+    fn argument(&self, leaf: &Self::Leaf, slot: &syn::Ident) -> TokenStream;
+}
+
 /// Compose one [`PathStep`] onto the reference expression reached so far.
 /// A `Call` applies its accessor (origin-qualified); a `Field` reads the field
 /// and re-borrows, so the result is a reference either way and steps chain

--- a/prebindgen-registry/src/unfold/walk.rs
+++ b/prebindgen-registry/src/unfold/walk.rs
@@ -210,6 +210,66 @@ pub fn project_leading_fields(
     (quote!(&#base #(.#segs)*), n)
 }
 
+/// Where one leaf's reach starts, once the hoists are bound.
+///
+/// Produced by [`Hoisted::place`], which is the one place that decides it: the
+/// innermost value form the leaf sits under, the name a conditional form's
+/// `Some` arm binds, or the delivered value itself.
+pub struct LeafPlace {
+    /// What to reach from.
+    pub base: TokenStream,
+    /// Whether `base` is already a reference.
+    pub base_is_ref: bool,
+    /// The steps left from `base` — the leaf's own path with the prefix that
+    /// bound the hoist already consumed.
+    pub path: Vec<PathStep>,
+    /// Whether the form that produced `base` gave its value away.
+    pub consuming: bool,
+    /// The conditional hoist whose `Some` arm this leaf belongs in. Its
+    /// statements go there rather than beside the others, because the arm is
+    /// where the binding they reach off exists.
+    pub conditional: Option<usize>,
+}
+
+impl LeafPlace {
+    /// The place this leaf may MOVE out of, or `None` when what it reaches is
+    /// not the delivery's to give away, or is not a place a move can name.
+    ///
+    /// The same question [`reach_leaf`] answers on its way to the terminal
+    /// treatment, asked separately by a leaf whose encode needs the place
+    /// itself rather than an expression reaching it — a handle that is boxed
+    /// rather than converted.
+    pub fn owned<L: DecomposedLeaf>(&self, leaf: &L) -> Option<TokenStream> {
+        (reached_is_ours(leaf, self.consuming) && steps_are_movable(&self.path)).then(|| {
+            let base = &self.base;
+            let segs: Vec<&syn::Ident> = self.path.iter().map(PathStep::ident).collect();
+            quote!(#base #(.#segs)*)
+        })
+    }
+}
+
+/// Whether what a leaf reaches is OURS, and so is moved rather than borrowed
+/// or cloned. The two leaf kinds say it differently:
+///
+/// * an IDENTITY leaf carries the answer in its own reading — the plan
+///   resolved that to the owned type exactly when the value is the plan's to
+///   give away (an owned root, or a field of a CONSUMING value form), and that
+///   is also what selected the owning converter, which boxes the move rather
+///   than cloning a borrow;
+/// * every other leaf reads a field, whose reading is the field type as
+///   written and owned either way, so ownership is the enclosing form's: only
+///   a consuming one gives its fields away.
+pub fn reached_is_ours<L: DecomposedLeaf>(leaf: &L, consuming: bool) -> bool {
+    if leaf.identity() {
+        !matches!(
+            leaf.source().kind(),
+            prebindgen_flat::flat::TypeKind::Ref { .. }
+        )
+    } else {
+        consuming
+    }
+}
+
 /// One leaf, and the place a reach of it starts from.
 ///
 /// A caller that has already bound a hoist hands over the local it bound and
@@ -415,15 +475,16 @@ fn reached_place<L: DecomposedLeaf>(
         ..
     } = at;
     let (base_is_ref, consuming) = (*base_is_ref, *consuming);
-    let reached_is_ours = if leaf.identity() {
-        !matches!(
-            leaf.source().kind(),
-            prebindgen_flat::flat::TypeKind::Ref { .. }
-        )
-    } else {
-        consuming
-    };
-    if reached_is_ours && steps_are_movable(path) {
+    // How to project a movable place is `steps_are_movable`'s question, asked
+    // there rather than restated here. This used to spell it
+    // `all(is_plain_field)`, defending the restatement on the grounds that a
+    // trailing `Option` cannot reach return delivery anyway — true, and
+    // enforced in `single_return`, which is precisely why a local restatement
+    // could disagree with the rule for as long as the invariant held somewhere
+    // else. `plan.rs` says two readings would drift and the disagreement would
+    // be a borrow handed to an owning converter; this is the second reading,
+    // removed.
+    if reached_is_ours(*leaf, consuming) && steps_are_movable(path) {
         let segs: Vec<&syn::Ident> = path.iter().map(PathStep::ident).collect();
         return quote!(#base #(.#segs)*);
     }
@@ -500,6 +561,58 @@ impl Hoisted {
     ) -> Option<(usize, syn::Ident, syn::Ident, Vec<PathStep>)> {
         let (i, rest) = self.innermost(path)?;
         self.optional[i].then(|| (i, self.bound[i].1.clone(), format_ident!("__u{}", i), rest))
+    }
+
+    /// Where a leaf's reach starts, once these hoists are bound.
+    ///
+    /// Three cases, and the leaf's own path decides which.
+    ///
+    /// A leaf under a **conditional** value form reaches off the name that
+    /// form's `Some` arm binds. That arm matches the hoist's `Option` by
+    /// value — every leaf under the hoist is inside it, so the local is the
+    /// arm's alone — which makes the binding an owned payload: a consuming
+    /// form's fields move out of it exactly as they do at an unconditional
+    /// one, and [`LeafPlace::owned`] says so. The leaf's statements belong in
+    /// that arm, because that is where the binding exists.
+    ///
+    /// A leaf under an **ordinary** value form reaches off the local that form
+    /// was bound to, with the prefix already consumed and the form's own
+    /// ownership carried along.
+    ///
+    /// A leaf under **no** value form — a sibling accessor of the delivered
+    /// value — reaches from that value.
+    pub fn place<L: DecomposedLeaf>(
+        &self,
+        leaf: &L,
+        value: &TokenStream,
+        by_ref: bool,
+    ) -> LeafPlace {
+        let path = leaf.reach();
+        if let Some((i, _, bind, rest)) = self.conditional(path) {
+            return LeafPlace {
+                base: quote!(#bind),
+                base_is_ref: false,
+                path: rest,
+                consuming: self.consumed(i),
+                conditional: Some(i),
+            };
+        }
+        match self.rebase(path) {
+            Some((local, rest, consuming)) => LeafPlace {
+                base: quote!(#local),
+                base_is_ref: false,
+                path: rest,
+                consuming,
+                conditional: None,
+            },
+            None => LeafPlace {
+                base: value.clone(),
+                base_is_ref: by_ref,
+                path: path.to_vec(),
+                consuming: false,
+                conditional: None,
+            },
+        }
     }
 
     /// The local a hoist was bound to.


### PR DESCRIPTION
## Relationship to #513

This is the third umbrella on #513's branch, after #581 and #596, and it
finishes one thing #596 set out to do and did not.

#596's goal was that every source-value walk in generated Rust is composed by
the registry. Three of the four walks JniGen owned were moved. The fourth,
delivery, was not: its mechanical half moved and its rules stayed. #596's
record says the opposite — its step-7 comment on this PR lists delivery among
the walks that are gone — so this umbrella starts by correcting that and then
closes the gap.

## Vocabulary

- **Decomposition** — splitting one returned Rust value into the several values
  a foreign function is handed. The registry produces one `UnfoldPlan` per
  decomposed function, from an `expand_return!` declaration.
- **Leaf** — one value a decomposition yields. If a returned `Sample` is
  decomposed into its key expression and its payload, those two are its leaves.
- **Hoist** — an intermediate value the plan binds once because more than one
  leaf reaches through it.
- **Delivery** — emitting a decomposition: reach each leaf from the returned
  value, encode each into a value the target language can receive, and perform
  the foreign call.
- **Selector** — the synthesized `i32` a decomposed sum contributes, naming
  which alternative is live. It is already in the plan, as
  `LeafSource::Selector`.
- **Segment** — a selector leaf together with the leaves of the alternatives it
  selects between. Only one alternative's leaves are live per value.
- **Bridge** — the adapter's half of a registry-composed shape. For a `Product`
  it is three answers: the intermediate type the wire carries, how to read part
  *i* out of it, and how to build the source value from converted parts
  (`ProductBridge`). The registry performs the traversal and calls the bridge
  for the representation half.
- **Source-value walk** — the traversal of a Rust value's structure a converter
  body performs: reading fields, matching alternatives, reaching a leaf through
  a chain of accessors. Ending adapter-side instances of this was #596's goal.

## Goal

Delivery is composed by the registry. An adapter supplies how a leaf is encoded
and how the call is made; it supplies no rule about how a decomposed value is
reached, owned or grouped.

## What is unfinished

Line references are against `b18de9d1`, this umbrella's head.

**Five rules stayed in `prebindgen-jni/src/jni/emit/delivery.rs`.** None is JNI
policy — #596 step 3's own scope says JniGen keeps "jvalue layout, local-frame
sizing, cached method lookup and exception routing", and these are none of
those. Each is a fact about Rust values that a second adapter decomposing a
return would have to restate:

- **Rebasing and ownership** (`:774`). Which hoist a leaf reaches off — the
  innermost one, a conditional hoist's `Some` binding, or the returned value
  itself — and whether the reached place is moved or cloned.
- **Sum segmentation** (`:785`). A segment is emitted as one `match`, because
  only one alternative's leaves are live.
- **Optional-sum gating** (`:835`). An `Option<sum>` gates the whole segment
  rather than each leaf, because absence cannot be the per-leaf null an
  ordinary optional field gets (#220).
- **Borrow projection** (`:828`). A plain field chain is borrowed directly
  rather than through the base, which the borrow checker rejects once a sibling
  leaf has moved a field out of it.
- **The gated leaf reach** (`reach_leaf`, `:592`). A second derivation of
  `unfold::reach_leaf_flat`, handling an optional step by emitting an absent
  arm. Only what absence looks like belongs to the adapter.

**The registry models the shape and the adapter owns its consequence.**
`UnfoldPlan` carries the selector already. The rule that follows from it — that
the leaves after a selector are alternatives of one segment — is not in the
registry, and a registry test attributes the synthesis to "the JNI adapter". An
adapter reading the plan receives a flat leaf list with a selector in it. Not
recognising the segment does not fail to compile; it reads a dead alternative's
fields.

**The reason the walk moved applies to what did not move.**
`reach_leaf_flat`'s own doc says the walk belongs to the registry because two
copies drifted: "the shortcut was missing the field clone and handed `&F` to an
`F` converter". Two leaf-reaching derivations still exist, and the one still in
JniGen is the harder of the pair.

**Why the split came out here.** #596 step 3 promised "an adapter bridge for
encoding a leaf and performing the delivery call". No such bridge exists; the
registry exports five free functions and a data trait, and no composer. With
nowhere to put the adapter's half, nothing entangled with encoding could move,
so what crossed is what was already separable. Steps 2b and 4 had
`ProductBridge` and `ChoiceBridge` to hand the representation half to, which is
why they could move a whole traversal and this step could not.

**The bridge is already half-written, in the wrong crate.** JniGen has
`DeliveryContext` (`:387`), whose four methods are `qualify`, `leaf_is_prim`,
`leaf_wire` and `sum`. Three of those are generic questions about a leaf that
any adapter must answer. It is typed on JniGen's own `OutWire` rather than on
`DecomposedLeaf`, which is the only thing keeping it local.

## Success criteria

- A delivery bridge lives in the registry, generic over `DecomposedLeaf`, and
  JniGen implements it.
- The registry performs the delivery traversal: it binds the hoists, reaches
  each leaf, recognises each segment, and applies each gate.
- `emit/delivery.rs` holds `jvalue` layout, local-frame sizing, cached method
  lookup, exception routing and the leaf encoding itself — and no rule about
  reaching, owning or grouping a decomposed value.
- One leaf-reaching derivation, not two.
- Generated output is byte-identical, or a step says why in its own PR.
- Cbindgen is untouched: it declares no decomposition, and this umbrella
  proposes none for it.
- #513's record matches the code when this lands, including the step-7 comment
  that currently lists delivery among the moved walks.

## Restrictions

- **Analyze Flat; generate Rust only.** Planning may inspect Flat facts and
  retain `TypeRef`, and may not spell or reparse a captured Rust type.
- The registry stays language-agnostic. It gains no JVM naming, no descriptors,
  no `jvalue`, and no Kotlin anything — including in doc comments, which is
  what step 1 below already had to fix.
- `RustWriter` stays sealed to final rendering.
- Exported C ABI, JNI names and descriptors, and generated Kotlin behaviour stay
  semantically unchanged unless a step calls out an intentional change.

## Plan

Each box is one pull request against this umbrella's branch, reviewed and
merged before the next begins. The list is the intended route rather than a
contract.

- [x] **1. Record what delivery still walks.** State in `emit/delivery.rs` which
  rules it retains and why they could not move; stop two registry docs
  explaining language-agnostic functions in JNI terms; fix `reach_optional`'s
  link to a function that is not in that crate. Docs only.
- [x] **2. Give the delivery walk its bridge (#608).** Lift `DeliveryContext` into the
  registry, generic over `DecomposedLeaf`, and add the two operations it lacks:
  encode one leaf into a target value, and place that value as a call argument.
  JniGen implements it with what it already has. No traversal moves yet — this
  is the step that gives the following ones somewhere to put the adapter's half.
  *Done.* `DeliveryBridge` carries `qualify`, `sum`, `encode` and `argument`;
  the last two are live. `leaf_is_prim` and `leaf_wire` stayed with JniGen —
  with the encode on the bridge their only callers are its own — and the
  identity leaf's encode waits for the ownership answer step 4 moves.
- [x] **3. One leaf reach (#609).** Fold JniGen's `reach_leaf` into
  `reach_leaf_flat`, with the absent value a bridge operation rather than a
  reason to keep a second copy. This is the drift `reach_leaf_flat`'s doc warns
  about, closed rather than described.
  *Done.* `reach_leaf` takes a `LeafAt` and does the gating, the refusal and
  the ownership terminal; `DeliveryBridge::absent` supplies the `None` arm.
  JniGen's three-way move/clone/compose dispatch collapsed to one call and
  `emit/delivery.rs` lost 95 lines. Output changed in 11 places — a non-owned
  field read is `(&v.f).clone()` everywhere now, the spelling that also holds
  for a reference-typed field. The review found a hardcoded `base_is_ref` the
  merge carried over from JniGen, fixed with `reach_optional`'s own rule and a
  regression.
- [x] **4. Rebasing and ownership move (#610).** The registry decides which hoist a
  leaf reaches off and whether the reached place is moved or cloned, since it
  owns the hoists and the paths already.
  *Done.* `Hoisted::place` returns a `LeafPlace` — base, remaining path,
  ownership, and which conditional arm the statements belong in — and
  `LeafPlace::owned` gives the place a leaf may move out of, both deciding
  through one `reached_is_ours`. JniGen's `rebase` closure, its duplicate
  `TypeKind::Ref` ownership test and two of its three `conditional` queries are
  gone. The review caught a false ownership claim in the moved doc, which had
  been wrong in JniGen's own comment before the move.
- [x] **5. Segments and gates move (#611).** The registry recognises a segment from the
  selector the plan already carries, and applies the optional-sum gate. This is
  the rule whose absence is silent rather than a compile error, so it is the one
  worth moving most.
  *Done.* `DecomposedLeaf` gained `selects` and `group`; `unfold::segments`
  derives the segments and `unfold::segment` gates one, with
  `DeliveryBridge::slot` saying what an unfilled slot holds.
  `unfold::conditional_arm` — the same rule over a hoist — and the shared
  `bind_as_option` moved with them. `emit/delivery.rs` walks nothing now.
- [x] **6. Reconcile (#612).** Tick #513's criterion 3 and the `emit/delivery.rs`
  clause of criterion 4, or name what remains. Correct the step-7 comment on
  #513 that lists delivery among the moved walks.
  *Done.* #513 carries the correction — delivery was relocated, not composed,
  when that comment was written — with what this umbrella cost: +414 production
  lines net, the registry up 553 and JniGen down 139, output changed in 11
  places, Cbindgen untouched. #596 carries a note that its criterion 3 is
  completed here. Both records now say what the code does.

## Not in scope

The whole-object output encode is the other walk #596 did not compose, and that
one was deliberate: #603 recorded why with a test, and #602 carries the
decomposition support it would need first. It stays with #602.

## Verification baseline

The base passes 835 workspace tests, strict Clippy, strict rustdoc, the
regeneration check, the C smoke test under ASan/LSan/UBSan, and the 61-section
Kotlin/JNI covertest. Steps 3 to 5 are covered end to end by that JVM run rather
than by Rust compilation alone, because a mis-grouped segment compiles.

Note for every step: the formatting check is

```
cargo fmt --check -- --config "unstable_features=true,imports_granularity=Crate,group_imports=StdExternalCrate"
```

A plain `cargo fmt --check` passes on import grouping this rejects, which is how
two files reached #513 needing #606.

Related to #513, #596 and #602.

— Claude Code (Opus 5)






