### PR TITLE
Give the delivery walk its bridge

### DIFF
--- a/prebindgen-jni/src/jni/emit/delivery.rs
+++ b/prebindgen-jni/src/jni/emit/delivery.rs
@@ -23,14 +23,19 @@
 //!   `unfold::reach_leaf_flat` that handles an optional step by emitting an
 //!   absent arm. Only what absence looks like is this adapter's.
 //!
-//! They are here because there is no delivery bridge to hand the encoding half
-//! to, so nothing could be lifted without lifting `jvalue` layout with it. See
-//! the umbrella that tracks moving them.
+//! They are still here, but the reason they had to be is gone: the encoding
+//! half now has somewhere to go. [`DeliveryBridge`] is the registry's, this
+//! module implements it for [`FrozenDelivery`], and two of its operations are
+//! live — a leaf's encode, and how a filled slot rides the call. What remains
+//! above is reaching, owning and grouping, which the steps after this one
+//! move onto the walk that already owns the hoists.
+//!
+//! [`DeliveryBridge`]: prebindgen_registry::unfold::DeliveryBridge
 
 use prebindgen_registry::{
     unfold::{
         bind_hoists, fold_steps, project_leading_fields, steps_are_movable, DecomposedLeaf,
-        PathStep,
+        DeliveryBridge, PathStep,
     },
     Conversions,
 };
@@ -380,20 +385,6 @@ pub(crate) struct Delivered<'a> {
     pub(crate) chain: Option<crate::jni::compile::ComposedChain>,
 }
 
-/// Facts the leaf renderer may consult after a delivery operation has been
-/// selected. The live implementation serves ordinary wrapper rendering; an
-/// Invoke plan freezes the same answers so callback planning does not retain a
-/// registry or obtain [`prebindgen_registry::RustWriter`].
-pub(crate) trait DeliveryContext {
-    fn qualify(&self, ident: &syn::Ident) -> syn::Path;
-    fn leaf_is_prim(&self, leaf: &crate::jni::compile::OutWire) -> bool;
-    fn leaf_wire(&self, leaf: &crate::jni::compile::OutWire) -> syn::Type;
-    fn sum(
-        &self,
-        leaf: &crate::jni::compile::OutWire,
-    ) -> (syn::Path, &prebindgen_registry::flat::Variant);
-}
-
 #[derive(Clone)]
 struct FrozenSum {
     source: syn::Path,
@@ -502,20 +493,29 @@ impl FrozenDelivery {
     }
 }
 
-impl DeliveryContext for FrozenDelivery {
+impl FrozenDelivery {
+    /// Whether this leaf crosses the typed `run` as a raw primitive rather
+    /// than as an object. JNI's own question — which jvalue member a slot
+    /// carries — so it stays off the bridge.
+    pub(crate) fn leaf_is_prim(&self, leaf: &crate::jni::compile::OutWire) -> bool {
+        frozen_leaf_is_prim(leaf)
+    }
+
+    /// The Rust type this leaf's converter produces, which is what its jvalue
+    /// member and its slot default are read from.
+    pub(crate) fn leaf_wire(&self, leaf: &crate::jni::compile::OutWire) -> syn::Type {
+        frozen_leaf_wire(leaf)
+    }
+}
+
+impl prebindgen_registry::unfold::DeliveryBridge for FrozenDelivery {
+    type Leaf = crate::jni::compile::OutWire;
+
     fn qualify(&self, ident: &syn::Ident) -> syn::Path {
         self.modules
             .get(&ident.to_string())
             .unwrap_or_else(|| panic!("frozen JNI delivery has no origin for `{ident}`"))
             .clone()
-    }
-
-    fn leaf_is_prim(&self, leaf: &crate::jni::compile::OutWire) -> bool {
-        frozen_leaf_is_prim(leaf)
-    }
-
-    fn leaf_wire(&self, leaf: &crate::jni::compile::OutWire) -> syn::Type {
-        frozen_leaf_wire(leaf)
     }
 
     fn sum(
@@ -531,6 +531,84 @@ impl DeliveryContext for FrozenDelivery {
             .get(&id.name)
             .unwrap_or_else(|| panic!("frozen JNI delivery has no sum `{}`", id.name));
         (sum.source.clone(), &sum.model)
+    }
+
+    /// A leaf's own encode: run its output converter on the reached Rust
+    /// value, then present the result the way its slot carries it. A
+    /// primitive-wire leaf is a typed `jvalue` and crosses with no JNI call at
+    /// all; every other leaf becomes a `JObject`, boxing where the typed `run`
+    /// descriptor declares an object.
+    ///
+    /// Both forms encode INSIDE `reach`, so an absent value on the way to the
+    /// leaf yields this adapter's absence — a JVM null — rather than a value
+    /// the walk invented.
+    fn encode(
+        &self,
+        leaf: &crate::jni::compile::OutWire,
+        index: usize,
+        slot: &syn::Ident,
+        reach: &prebindgen_registry::unfold::Reach<'_>,
+        fail: &dyn Fn(TokenStream) -> TokenStream,
+        emit: &prebindgen_registry::RustWriter,
+    ) -> TokenStream {
+        let pipeline = match &leaf.abi {
+            Some(crate::jni::compile::OutAbi::Value(value)) => &value.pipeline,
+            Some(crate::jni::compile::OutAbi::Tag) => {
+                unreachable!("a sum selector is encoded with its own segment")
+            }
+            None => panic!(
+                "jnigen delivery: leaf `{}` reached Rust rendering without a frozen output ABI",
+                leaf.name
+            ),
+        };
+        let wire = pipeline.wire().clone();
+        let conv_fail = fail(quote!(__e.to_string()));
+        let convert = |input: TokenStream| -> TokenStream {
+            let call = pipeline.invoke(input, emit);
+            quote! {
+                match #call {
+                    ::core::result::Result::Ok(__w) => __w,
+                    ::core::result::Result::Err(__e) => {
+                        #conv_fail
+                    }
+                }
+            }
+        };
+        let encoded = format_ident!("__enc{}", index);
+        if self.leaf_is_prim(leaf) {
+            let letter = jni_field_access(&wire)
+                .expect("leaf_is_prim guarantees a primitive wire")
+                .1;
+            let expr = reach(&|reached| {
+                let converted = convert(quote!(#reached));
+                quote! {{
+                    let #encoded = #converted;
+                    jni::sys::jvalue { #letter: #encoded }
+                }}
+            });
+            return quote! { let #slot: jni::sys::jvalue = #expr; };
+        }
+        let cast = cast_wire_to_jobject(&encoded, &wire, fail);
+        let expr = reach(&|reached| {
+            let converted = convert(quote!(#reached));
+            quote! {{
+                let #encoded = #converted;
+                #cast
+            }}
+        });
+        quote! { let #slot: jni::objects::JObject = #expr; }
+    }
+
+    /// How a filled slot rides the typed `run` call: a primitive-wire leaf IS
+    /// its jvalue, and every other leaf's `JObject` passes its raw pointer in
+    /// the `l` slot. Matches the descriptor [`crate::jni::iface`] derives for
+    /// the same leaf.
+    fn argument(&self, leaf: &crate::jni::compile::OutWire, slot: &syn::Ident) -> TokenStream {
+        if self.leaf_is_prim(leaf) {
+            quote!(#slot)
+        } else {
+            quote!(jni::sys::jvalue { l: #slot.as_raw() })
+        }
     }
 }
 
@@ -668,7 +746,7 @@ fn reach_leaf(
 /// arm of fallible externs (whose `fail` routes an encoding failure to the
 /// binding-error channel).
 pub(crate) fn encode_plan_leaves(
-    context: &impl DeliveryContext,
+    context: &FrozenDelivery,
     site: Delivered<'_>,
     obj_idents: &[syn::Ident],
     value: &TokenStream,
@@ -688,19 +766,11 @@ pub(crate) fn encode_plan_leaves(
     let qualify = |id: &syn::Ident| -> syn::Path { context.qualify(id) };
     let n = wires.len();
 
-    // Typed `jvalue` argument expression per leaf, in leaf order: a non-null
-    // primitive-wire leaf passes its raw primitive (`__objN` IS the jvalue);
-    // every other leaf is a `JObject` local whose raw pointer rides the `l`
-    // slot. Matches the descriptor [`crate::jni::iface`]
-    // derives for the same leaf (primitive chunk vs object chunk).
+    // The argument expression per leaf, in leaf order — how a filled slot
+    // rides the call, which is the bridge's answer rather than this loop's.
     let mut arg_exprs: Vec<TokenStream> = Vec::with_capacity(n);
     for (idx, leaf) in wires.iter().enumerate() {
-        let obj_ident = &obj_idents[idx];
-        if context.leaf_is_prim(leaf) {
-            arg_exprs.push(quote!(#obj_ident));
-        } else {
-            arg_exprs.push(quote!(jni::sys::jvalue { l: #obj_ident.as_raw() }));
-        }
+        arg_exprs.push(context.argument(leaf, &obj_idents[idx]));
     }
 
     // A fixed decomposition has one Product, Optional or Choice intermediate.
@@ -977,7 +1047,6 @@ pub(crate) fn encode_plan_leaves(
             ),
         };
         let projection = frozen_projection;
-        let wire = frozen_pipeline.wire().clone();
         let conv_fail = fail(quote!(__e.to_string()));
         let conv = |input: TokenStream| -> TokenStream {
             let call = frozen_pipeline.invoke(input, emit);
@@ -1244,37 +1313,10 @@ pub(crate) fn encode_plan_leaves(
             }
         };
 
-        // A non-null primitive-wire leaf delivers its raw primitive as a typed
-        // `jvalue` — no boxing, no JNI call at all (the typed `run` descriptor
-        // declares the primitive). Everything else (object wires, and nullable
-        // leaves whose `None` arm must yield a JVM null) encodes the reached
-        // value with the leaf's output converter and casts to JObject.
-        let enc_ident = format_ident!("__enc{}", idx);
-        if context.leaf_is_prim(leaf) {
-            let letter = jni_field_access(&wire)
-                .expect("leaf_is_prim guarantees a primitive wire")
-                .1;
-            let expr = reach(&|reached| {
-                let __encoded = conv(quote!(#reached));
-                quote! {{
-                    let #enc_ident = #__encoded;
-                    jni::sys::jvalue { #letter: #enc_ident }
-                }}
-            });
-            stmts.extend(quote! {
-                let #obj_ident: jni::sys::jvalue = #expr;
-            });
-            continue;
-        }
-        let cast = cast_wire_to_jobject(&enc_ident, &wire, fail);
-        let expr = reach(&|reached| {
-            let __encoded = conv(quote!(#reached));
-            quote! {{
-                let #enc_ident = #__encoded;
-                #cast
-            }}
-        });
-        stmts.extend(bind_obj(obj_ident, expr));
+        // The encode itself is the bridge's: this loop hands it the leaf's
+        // reach and it says what the slot holds. Reaching is still decided
+        // here — which is what the steps after this one move.
+        stmts.extend(context.encode(leaf, idx, obj_ident, &reach, fail, emit));
     }
 
     // One `match` per conditional value form: the `Some` arm runs the leaves

--- a/prebindgen-jni/src/jni/emit/sum_out.rs
+++ b/prebindgen-jni/src/jni/emit/sum_out.rs
@@ -87,7 +87,7 @@ pub(crate) struct Slot {
 }
 
 pub(crate) fn leaf_slot(
-    context: &impl DeliveryContext,
+    context: &crate::jni::emit::delivery::FrozenDelivery,
     leaf: &crate::jni::compile::OutWire,
 ) -> Slot {
     if !context.leaf_is_prim(leaf) {
@@ -139,7 +139,7 @@ pub(crate) fn is_sum_row(leaves: &[crate::jni::compile::OutWire]) -> bool {
 /// is that a leaf here is not an independent expression — its slot exists in
 /// every arm and only one arm computes it.
 pub(crate) fn encode_sum_group(
-    context: &impl DeliveryContext,
+    context: &crate::jni::emit::delivery::FrozenDelivery,
     leaves: &[crate::jni::compile::OutWire],
     obj_idents: &[syn::Ident],
     matched: TokenStream,
@@ -153,7 +153,7 @@ pub(crate) fn encode_sum_group(
         .iter()
         .find(|l| l.is_tag())
         .expect("a sum segment carries its selector leaf");
-    let (source, sum) = context.sum(tag_leaf);
+    let (source, sum) = prebindgen_registry::unfold::DeliveryBridge::sum(context, tag_leaf);
 
     let slots: Vec<Slot> = leaves.iter().map(|l| leaf_slot(context, l)).collect();
 
@@ -285,7 +285,7 @@ pub(crate) fn encode_sum_group(
 /// payload and a struct field of the same type reach their converter the same
 /// way.
 fn encode_group_leaf(
-    context: &impl DeliveryContext,
+    context: &crate::jni::emit::delivery::FrozenDelivery,
     leaf: &crate::jni::compile::OutWire,
     obj_ident: &syn::Ident,
     prim: bool,

--- a/prebindgen-jni/src/jni/emit/wrapper.rs
+++ b/prebindgen-jni/src/jni/emit/wrapper.rs
@@ -318,7 +318,7 @@ impl JWrapper {
                 FnOutputPlan::Unfold(_) => unreachable!("a convert has a value output plan"),
             };
             let qualify = |id: &syn::Ident| -> syn::Path {
-                crate::jni::emit::DeliveryContext::qualify(delivery, id)
+                prebindgen_registry::unfold::DeliveryBridge::qualify(delivery, id)
             };
             // `None` when the reach is the IDENTITY of `base` and no value form had
             // to be bound — the leaf IS the value, so there is nothing to compose.

--- a/prebindgen-registry/src/unfold.rs
+++ b/prebindgen-registry/src/unfold.rs
@@ -36,7 +36,7 @@ mod error;
 mod walk;
 pub use walk::{
     bind_hoists, compose_step, fold_steps, project_leading_fields, reach_leaf_flat, DecomposedLeaf,
-    Hoisted,
+    DeliveryBridge, Hoisted, Reach,
 };
 
 mod plan;

--- a/prebindgen-registry/src/unfold/walk.rs
+++ b/prebindgen-registry/src/unfold/walk.rs
@@ -44,6 +44,55 @@ pub trait DecomposedLeaf {
     }
 }
 
+/// A leaf's reach, rendered **around** an encoding body: the walk hands the
+/// body the reached Rust expression and gets back the encoded value, so an
+/// absent value short-circuits to the adapter's own absence rather than to one
+/// the walk chose. `dyn` on both halves because each side is written where it
+/// is known and neither can name the other's closure.
+pub type Reach<'a> = dyn Fn(&dyn Fn(TokenStream) -> TokenStream) -> TokenStream + 'a;
+
+/// The adapter's half of a delivery.
+///
+/// The walk in this module owns how a decomposed value is reached — which
+/// hoist a leaf sits under, what is owned, what is borrowed. What a leaf
+/// becomes in the target language, and how the delivered values are handed to
+/// the call, is the adapter's, and this is where it says so. Stated over
+/// [`DecomposedLeaf`] rather than over an adapter's own leaf type, so the walk
+/// can call it.
+pub trait DeliveryBridge {
+    /// The adapter's leaf.
+    type Leaf: DecomposedLeaf;
+
+    /// Where the source item declaring `ident` is qualified from — the one
+    /// fact about a captured path this crate cannot answer for itself.
+    fn qualify(&self, ident: &syn::Ident) -> syn::Path;
+
+    /// The sum a selector leaf names: the qualified source path of the type,
+    /// and its Flat shape.
+    fn sum(&self, leaf: &Self::Leaf) -> (syn::Path, &prebindgen_flat::flat::Variant);
+
+    /// Encode one leaf into the value the delivery call receives, and bind
+    /// that value to `slot`.
+    ///
+    /// The adapter emits the binding rather than the walk, because the slot's
+    /// type is the adapter's: one leaf may cross as a scalar and the next as a
+    /// reference. `index` is the leaf's position in the delivery, which is
+    /// what any temporary the encode needs is named from. An encoding that can
+    /// fail routes its failure through `fail`.
+    fn encode(
+        &self,
+        leaf: &Self::Leaf,
+        index: usize,
+        slot: &syn::Ident,
+        reach: &Reach<'_>,
+        fail: &dyn Fn(TokenStream) -> TokenStream,
+        emit: &crate::RustWriter,
+    ) -> TokenStream;
+
+    /// The expression that passes `slot` as one argument of the delivery call.
+    fn argument(&self, leaf: &Self::Leaf, slot: &syn::Ident) -> TokenStream;
+}
+
 /// Compose one [`PathStep`] onto the reference expression reached so far.
 /// A `Call` applies its accessor (origin-qualified); a `Field` reads the field
 /// and re-borrows, so the result is a reference either way and steps chain


### PR DESCRIPTION
Step 2 of #607.

**Delivery** is emitting a decomposition: reaching each **leaf** — one of the
several values a returned Rust value is split into — encoding it into something
the target language can receive, and making the foreign call. #596 moved the
mechanical half of the reach into the registry and left the rules behind,
because there was nowhere to put the adapter's half: the registry exported five
free functions and no trait an encoder could implement. This adds that trait.

## What the bridge is

`prebindgen_registry::unfold::DeliveryBridge`, generic over `DecomposedLeaf`
through an associated `Leaf` type, with four operations:

- `qualify` — where the source item declaring an accessor is qualified from.
- `sum` — the sum a selector leaf names, as a source path and a Flat shape.
- `encode` — encode one leaf into the value the call receives, and bind it to
  its **slot**, the local the call's argument list reads. New.
- `argument` — the expression that passes a filled slot as one argument. New.

`encode` takes the leaf's reach as a `Reach<'_>`, a closure that renders the
reached Rust value **around** an encoding body. That inversion is the point:
the walk owns the reach and the adapter owns what happens at the bottom of it,
so an absent value on the way to a leaf short-circuits to the adapter's own
absence — a JVM null here — rather than to a value the registry picked. It is
the shape JniGen's own delivery loop already used internally, which is what
makes it implementable today rather than a guess at what steps 3 to 5 will
need.

## What JniGen does with it

`FrozenDelivery` implements it. Its `encode` is the value-leaf encode moved out
of the delivery loop unchanged: run the leaf's output converter on the reached
value, then bind a typed `jvalue` for a primitive-wire leaf or a `JObject` for
every other. Its `argument` is the loop's own argument rule.

Both are live. The loop calls `context.encode(...)` where it used to inline the
encode, and builds its argument list from `context.argument(...)`.

**Two things did not move, and neither is an oversight.**

*The identity leaf's encode.* An identity leaf delivers the returned value
itself, and how it is encoded depends on whether the place it reaches is the
delivery's to give away — moved into a `Box`, or cloned through the borrowed
converter. That ownership answer is what step 4 moves into the registry, so
until it arrives the identity branch has no way to receive it and stays in the
loop.

*`leaf_is_prim` and `leaf_wire`.* #607 expects three of `DeliveryContext`'s four
methods to be generic. With `encode` and `argument` on the bridge, their
remaining callers are all JNI's own — the chain-adapting path, the jvalue
member of a slot, a gate's slot defaults — so they became inherent methods on
`FrozenDelivery` instead of bridge operations. Nothing in the registry asks
them, and a bridge operation nobody calls is the vocabulary #605 had to delete.

`DeliveryContext` itself is gone. It had one implementation, so its four
consumers name `FrozenDelivery` directly.

## Verification

Generated output is byte-identical: `PASS - regen check clean`, and the
covertest passes all 61 JVM sections. 835 workspace tests, 0 clippy warnings
under `--all-targets --all-features -- --deny warnings`, strict rustdoc clean,
and the CI-configured `cargo fmt --check` clean.

Both new operations are load-bearing, which the goldens prove rather than a new
test: making `argument` always take the object form fails the covertest build
with 106 errors, because every primitive leaf's slot then disagrees with the
descriptor its interface declares.

— Claude Code (Opus 5)
