### PR TITLE
One leaf reach

### DIFF
--- a/examples/covertest-kotlin/src/generated_bindings.rs
+++ b/examples/covertest-kotlin/src/generated_bindings.rs
@@ -13668,7 +13668,7 @@ pub(crate) unsafe fn __jni_in_convert_wire_to_impl_Fn_Probe_Send_Sync_static_b0d
                     let __cb0_obj0: jni::sys::jvalue = {
                         let __enc0 = match __jni_out_convert_i64_to_wire_15d458bf28dc9c80(
                             &mut env,
-                            __vf0.seq.clone(),
+                            (&__vf0.seq).clone(),
                         ) {
                             ::core::result::Result::Ok(__w) => __w,
                             ::core::result::Result::Err(__e) => {
@@ -20059,7 +20059,7 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_probeNew<'a>(
     let __obj0: jni::sys::jvalue = {
         let __enc0 = match __jni_out_convert_i64_to_wire_15d458bf28dc9c80(
             &mut env,
-            __vf0.seq.clone(),
+            (&__vf0.seq).clone(),
         ) {
             ::core::result::Result::Ok(__w) => __w,
             ::core::result::Result::Err(__e) => {
@@ -20953,7 +20953,7 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_spanHolderNew<'a
                     {
                         let __chain_s0 = __jni_out_stage_0_Duration_to_wire_37da00112022eac0(
                                 &mut env,
-                                __u0.required.clone(),
+                                (&__u0.required).clone(),
                             )
                             .map_err(|__e| <__JniErr as ::core::convert::From<
                                 String,
@@ -20995,7 +20995,7 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_spanHolderNew<'a
             let __obj1: jni::objects::JObject = {
                 let __enc1 = match __jni_out_convert_Option_Duration_jni_optional_intermediate_output_niche_to_wire_dc11bc4c611f2997(
                     &mut env,
-                    __u0.delay.clone(),
+                    (&__u0.delay).clone(),
                 ) {
                     ::core::result::Result::Ok(__w) => __w,
                     ::core::result::Result::Err(__e) => {
@@ -26073,7 +26073,7 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_vaultHolderNew<'
             let __obj0: jni::objects::JObject = {
                 let __enc0 = match __jni_out_convert_Ingot_jni_handle_codec_own_output_to_wire_c5c73cbcd23adbdb(
                     &mut env,
-                    __u0.always.clone(),
+                    (&__u0.always).clone(),
                 ) {
                     ::core::result::Result::Ok(__w) => __w,
                     ::core::result::Result::Err(__e) => {
@@ -26106,7 +26106,7 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_vaultHolderNew<'
             let __obj1: jni::objects::JObject = {
                 let __enc1 = match __jni_out_convert_Option_Ingot_jni_optional_intermediate_output_niche_to_wire_5b17cf852f44637e(
                     &mut env,
-                    __u0.maybe.clone(),
+                    (&__u0.maybe).clone(),
                 ) {
                     ::core::result::Result::Ok(__w) => __w,
                     ::core::result::Result::Err(__e) => {

--- a/examples/emitcheck/src/generated_bindings.rs
+++ b/examples/emitcheck/src/generated_bindings.rs
@@ -401,7 +401,7 @@ pub(crate) unsafe fn __jni_in_convert_wire_to_impl_Fn_ZSample_Send_Sync_static_7
                     let __cb0_obj2: jni::objects::JObject = {
                         let __enc2 = match __jni_out_convert_Vec_u8_to_wire_e9499bf0a706b1a2(
                             &mut env,
-                            __vf0.seq_plain.clone(),
+                            (&__vf0.seq_plain).clone(),
                         ) {
                             ::core::result::Result::Ok(__w) => __w,
                             ::core::result::Result::Err(__e) => {
@@ -417,7 +417,7 @@ pub(crate) unsafe fn __jni_in_convert_wire_to_impl_Fn_ZSample_Send_Sync_static_7
                     let __cb0_obj3: jni::objects::JObject = {
                         let __enc3 = match __jni_out_convert_Cow_static_u8_to_wire_d9a36c77f96791fc(
                             &mut env,
-                            __vf0.seq_cow.clone(),
+                            (&__vf0.seq_cow).clone(),
                         ) {
                             ::core::result::Result::Ok(__w) => __w,
                             ::core::result::Result::Err(__e) => {
@@ -433,7 +433,7 @@ pub(crate) unsafe fn __jni_in_convert_wire_to_impl_Fn_ZSample_Send_Sync_static_7
                     let __cb0_obj4: jni::objects::JObject = {
                         let __enc4 = match __jni_out_convert_jni_text_codec_owned_to_wire_1b6cdff0ec9adbcb(
                             &mut env,
-                            __vf0.text_plain.clone(),
+                            (&__vf0.text_plain).clone(),
                         ) {
                             ::core::result::Result::Ok(__w) => __w,
                             ::core::result::Result::Err(__e) => {
@@ -449,7 +449,7 @@ pub(crate) unsafe fn __jni_in_convert_wire_to_impl_Fn_ZSample_Send_Sync_static_7
                     let __cb0_obj5: jni::objects::JObject = {
                         let __enc5 = match __jni_out_convert_Box_String_to_wire_445d29257759cad9(
                             &mut env,
-                            __vf0.text_boxed.clone(),
+                            (&__vf0.text_boxed).clone(),
                         ) {
                             ::core::result::Result::Ok(__w) => __w,
                             ::core::result::Result::Err(__e) => {
@@ -465,7 +465,7 @@ pub(crate) unsafe fn __jni_in_convert_wire_to_impl_Fn_ZSample_Send_Sync_static_7
                     let __cb0_obj6: jni::objects::JObject = {
                         let __enc6 = match __jni_out_convert_Cow_static_str_to_wire_1c9aa86df48df08e(
                             &mut env,
-                            __vf0.text_cow.clone(),
+                            (&__vf0.text_cow).clone(),
                         ) {
                             ::core::result::Result::Ok(__w) => __w,
                             ::core::result::Result::Err(__e) => {

--- a/prebindgen-jni/src/jni/emit/delivery.rs
+++ b/prebindgen-jni/src/jni/emit/delivery.rs
@@ -34,8 +34,8 @@
 
 use prebindgen_registry::{
     unfold::{
-        bind_hoists, fold_steps, project_leading_fields, steps_are_movable, DecomposedLeaf,
-        DeliveryBridge, PathStep,
+        bind_hoists, fold_steps, project_leading_fields, steps_are_movable, DeliveryBridge,
+        PathStep,
     },
     Conversions,
 };
@@ -599,6 +599,13 @@ impl prebindgen_registry::unfold::DeliveryBridge for FrozenDelivery {
         quote! { let #slot: jni::objects::JObject = #expr; }
     }
 
+    /// A leaf whose value was not there delivers a JVM null. Every slot that
+    /// can be absent is an object slot for exactly that reason: a primitive
+    /// one has no null to carry.
+    fn absent(&self) -> TokenStream {
+        quote!(jni::objects::JObject::null())
+    }
+
     /// How a filled slot rides the typed `run` call: a primitive-wire leaf IS
     /// its jvalue, and every other leaf's `JObject` passes its raw pointer in
     /// the `l` slot. Matches the descriptor [`crate::jni::iface`] derives for
@@ -655,82 +662,6 @@ impl<'a> Delivered<'a> {
 /// must MOVE the payload keeps its direct match; see `owned_place` below.
 pub(crate) fn bind_as_option(e: &TokenStream, bind: &syn::Ident) -> TokenStream {
     quote! { let #bind: &::core::option::Option<_> = #e; }
-}
-
-/// Reach a leaf's input by folding its `path` over `base`, then hand the
-/// reached expression to `body` (which renders the encode and yields
-/// `JObject`). Every optional nesting step becomes a `match`: its `None` arm
-/// short-circuits the whole leaf to `JObject::null()` (the value is absent ⇒
-/// the leaf is null) — any number of optional steps on the path nest.
-/// With `unwrap_last == false` the final path element composes directly — a
-/// non-identity leaf's converter takes the final step's **full** type
-/// (`Option` included), so only the steps *before* it are nesting. An
-/// identity leaf (`unwrap_last == true`) delivers the reached value itself, so
-/// a final `Option` step unwraps too.
-fn reach_leaf(
-    qualify: &dyn Fn(&syn::Ident) -> syn::Path,
-    path: &[PathStep],
-    base: TokenStream,
-    base_is_ref: bool,
-    unwrap_last: bool,
-    depth: usize,
-    body: &dyn Fn(TokenStream) -> TokenStream,
-) -> TokenStream {
-    let limit = if unwrap_last {
-        path.len()
-    } else {
-        path.len().saturating_sub(1)
-    };
-    let (e, lead) = project_leading_fields(&base, base_is_ref, path);
-    match (lead..limit).find(|&i| path[i].is_optional()) {
-        // No (more) optional nesting steps: compose the rest plainly.
-        None => body(fold_steps(qualify, &path[lead..], e, false)),
-        Some(k) => {
-            // Through the optional step INCLUSIVE: the same fold, so the
-            // borrow in front of it is the ordinary rule rather than a second
-            // statement of it.
-            let opt_e = fold_steps(qualify, &path[lead..=k], e, false);
-            let nested = format_ident!("__n{}", depth);
-            let inner = reach_leaf(
-                qualify,
-                &path[k + 1..],
-                quote!(#nested),
-                true,
-                unwrap_last,
-                depth + 1,
-                body,
-            );
-            // A FIELD read composes to a borrow (`&(e).f`), so it goes through
-            // a coercion site and the destructuring stops caring which
-            // representation the source spelled the optional as.
-            //
-            // A CALL composes to the accessor's own returned value, which is
-            // owned and whose payload downstream may move. Borrowing it to
-            // coerce would change that ownership, so it keeps its direct match
-            // — and an owned position could not be made representation-agnostic
-            // this way regardless (see [`bind_as_option`]).
-            if path[k].is_field() {
-                let opt_bind = format_ident!("__o{}", depth);
-                let coerce = bind_as_option(&opt_e, &opt_bind);
-                quote! {
-                    {
-                        #coerce
-                        match #opt_bind {
-                            ::core::option::Option::Some(#nested) => { #inner }
-                            ::core::option::Option::None => jni::objects::JObject::null(),
-                        }
-                    }
-                }
-            } else {
-                quote! {
-                    match #opt_e {
-                        ::core::option::Option::Some(#nested) => { #inner }
-                        ::core::option::Option::None => jni::objects::JObject::null(),
-                    }
-                }
-            }
-        }
-    }
 }
 
 /// Encode a plan's leaves off `value` (`__out`, a `Some`-bound `__inner`, a Vec
@@ -1034,6 +965,30 @@ pub(crate) fn encode_plan_leaves(
         };
         let (value, by_ref, path, consuming) = rebase(leaf);
         let value = &value;
+        // Every reach below is the registry's, with this adapter's absence in
+        // its `None` arms. The terminal treatment — move, clone or borrow —
+        // comes with it, which is what let the three-way dispatch this loop
+        // used to make disappear.
+        let absent = || DeliveryBridge::absent(context);
+        let gated = |path: &[PathStep],
+                     base: TokenStream,
+                     base_is_ref: bool,
+                     unwrap_last: bool,
+                     body: &dyn Fn(TokenStream) -> TokenStream| {
+            prebindgen_registry::unfold::reach_leaf(
+                &qualify,
+                prebindgen_registry::unfold::LeafAt {
+                    leaf,
+                    path,
+                    base,
+                    base_is_ref,
+                    consuming,
+                    unwrap_last,
+                },
+                Some(&absent),
+                body,
+            )
+        };
         let (frozen_pipeline, frozen_projection) = match &leaf.abi {
             Some(crate::jni::compile::OutAbi::Value(value)) => {
                 (&value.pipeline, value.projection.as_ref())
@@ -1170,21 +1125,13 @@ pub(crate) fn encode_plan_leaves(
                     } else if !leaf.nullable {
                         // Reached non-null handle: clone via the converter,
                         // raw jlong (no Option steps on the path).
-                        let expr = reach_leaf(
-                            &qualify,
-                            &path,
-                            value.clone(),
-                            by_ref,
-                            true,
-                            0,
-                            &|reached| {
-                                let __encoded = conv(quote!(#reached));
-                                quote! {{
-                                    let #handle_ident: jni::sys::jlong = #__encoded;
-                                    jni::sys::jvalue { j: #handle_ident }
-                                }}
-                            },
-                        );
+                        let expr = gated(&path, value.clone(), by_ref, true, &|reached| {
+                            let __encoded = conv(quote!(#reached));
+                            quote! {{
+                                let #handle_ident: jni::sys::jlong = #__encoded;
+                                jni::sys::jvalue { j: #handle_ident }
+                            }}
+                        });
                         stmts.extend(quote! {
                             let #obj_ident: jni::sys::jvalue = #expr;
                         });
@@ -1193,26 +1140,18 @@ pub(crate) fn encode_plan_leaves(
                         // `java.lang.Long` when present (cached valueOf),
                         // JVM null when absent — matching the `Long?` param.
                         let box_fail = fail(quote!(__e.to_string()));
-                        let expr = reach_leaf(
-                            &qualify,
-                            &path,
-                            value.clone(),
-                            by_ref,
-                            true,
-                            0,
-                            &|reached| {
-                                let __encoded = conv(quote!(#reached));
-                                quote! {{
-                                    let #handle_ident: jni::sys::jlong = #__encoded;
-                                    match ::prebindgen_jni_runtime::box_jlong(&mut env, #handle_ident) {
-                                        ::core::result::Result::Ok(__o) => __o,
-                                        ::core::result::Result::Err(__e) => {
-                                            #box_fail
-                                        }
+                        let expr = gated(&path, value.clone(), by_ref, true, &|reached| {
+                            let __encoded = conv(quote!(#reached));
+                            quote! {{
+                                let #handle_ident: jni::sys::jlong = #__encoded;
+                                match ::prebindgen_jni_runtime::box_jlong(&mut env, #handle_ident) {
+                                    ::core::result::Result::Ok(__o) => __o,
+                                    ::core::result::Result::Err(__e) => {
+                                        #box_fail
                                     }
-                                }}
-                            },
-                        );
+                                }
+                            }}
+                        });
                         stmts.extend(bind_obj(obj_ident, expr));
                     }
                 }
@@ -1229,38 +1168,24 @@ pub(crate) fn encode_plan_leaves(
                         let expr = encode(value.clone());
                         stmts.extend(quote! { let #obj_ident: jni::sys::jvalue = #expr; });
                     } else if !leaf.nullable {
-                        let expr = reach_leaf(
-                            &qualify,
-                            &path,
-                            value.clone(),
-                            by_ref,
-                            true,
-                            0,
-                            &|reached| encode(quote!(*#reached)),
-                        );
+                        let expr = gated(&path, value.clone(), by_ref, true, &|reached| {
+                            encode(quote!(*#reached))
+                        });
                         stmts.extend(quote! { let #obj_ident: jni::sys::jvalue = #expr; });
                     } else {
                         let box_fail = fail(quote!(__e.to_string()));
-                        let expr = reach_leaf(
-                            &qualify,
-                            &path,
-                            value.clone(),
-                            by_ref,
-                            true,
-                            0,
-                            &|reached| {
-                                let __encoded = conv(quote!(*#reached));
-                                quote! {{
-                                    let #enc_ident: jni::sys::jlong = #__encoded;
-                                    match ::prebindgen_jni_runtime::box_jlong(&mut env, #enc_ident) {
-                                        ::core::result::Result::Ok(__o) => __o,
-                                        ::core::result::Result::Err(__e) => {
-                                            #box_fail
-                                        }
+                        let expr = gated(&path, value.clone(), by_ref, true, &|reached| {
+                            let __encoded = conv(quote!(*#reached));
+                            quote! {{
+                                let #enc_ident: jni::sys::jlong = #__encoded;
+                                match ::prebindgen_jni_runtime::box_jlong(&mut env, #enc_ident) {
+                                    ::core::result::Result::Ok(__o) => __o,
+                                    ::core::result::Result::Err(__e) => {
+                                        #box_fail
                                     }
-                                }}
-                            },
-                        );
+                                }
+                            }}
+                        });
                         stmts.extend(bind_obj(obj_ident, expr));
                     }
                 }
@@ -1279,38 +1204,10 @@ pub(crate) fn encode_plan_leaves(
         // Which of the two it is, asked of the wire: a field read ends its
         // reach in a field step, an accessor's ends at the call. That is what
         // `LeafSource` said, and saying it off the reach keeps one answer.
+        // A non-identity leaf's converter takes the final step's full type,
+        // `Option` included, so the last step is not unwrapped here.
         let reach = |body: &dyn Fn(TokenStream) -> TokenStream| -> TokenStream {
-            match leaf.is_field_read() {
-                false => reach_leaf(&qualify, &path, value.clone(), by_ref, false, 0, body),
-                // Under a CONSUMING value form the leaf owns its field, so it
-                // is **moved** out; the whole point of consuming is that this
-                // clone disappears. Each field is read by exactly one leaf, so
-                // the partial moves are disjoint — but nothing may then borrow
-                // the local as a whole, which is why the reach below projects
-                // the field directly rather than through `&(&local)`.
-                true if path.iter().all(PathStep::is_plain_field) => {
-                    let segs: Vec<&syn::Ident> = path.iter().map(PathStep::ident).collect();
-                    match consuming {
-                        true => body(quote!(#value #(.#segs)*)),
-                        false => body(quote!(#value #(.#segs)*.clone())),
-                    }
-                }
-                // A `.fields()` leaf reaches its field through the value-form
-                // accessor, so the path can be mixed: compose it like an
-                // accessor leaf — the final step composes directly, since the
-                // converter takes the field type as written (`Option` and all)
-                // — and clone the reached borrow, which is what a field leaf
-                // delivers.
-                true => reach_leaf(
-                    &qualify,
-                    &path,
-                    value.clone(),
-                    by_ref,
-                    false,
-                    0,
-                    &|reached| body(quote!((#reached).clone())),
-                ),
-            }
+            gated(&path, value.clone(), by_ref, false, body)
         };
 
         // The encode itself is the bridge's: this loop hands it the leaf's
@@ -1481,13 +1378,18 @@ mod tests {
                 true,
                 LeafSource::Reach,
             );
-            let got = prebindgen_registry::unfold::reach_leaf_flat(
+            let got = prebindgen_registry::unfold::reach_leaf(
                 &qualify,
-                &crate::jni::compile::OutWire::from_leaf(&l),
-                &path,
-                quote!(__src),
-                false,
-                false,
+                prebindgen_registry::unfold::LeafAt {
+                    leaf: &crate::jni::compile::OutWire::from_leaf(&l),
+                    path: &path,
+                    base: quote!(__src),
+                    base_is_ref: false,
+                    consuming: false,
+                    unwrap_last: false,
+                },
+                None,
+                &|reached| reached,
             )
             .to_string();
             assert!(
@@ -1508,13 +1410,18 @@ mod tests {
             true,
             LeafSource::Reach,
         );
-        let got = prebindgen_registry::unfold::reach_leaf_flat(
+        let got = prebindgen_registry::unfold::reach_leaf(
             &qualify,
-            &crate::jni::compile::OutWire::from_leaf(&l),
-            &path,
-            quote!(__src),
-            false,
-            false,
+            prebindgen_registry::unfold::LeafAt {
+                leaf: &crate::jni::compile::OutWire::from_leaf(&l),
+                path: &path,
+                base: quote!(__src),
+                base_is_ref: false,
+                consuming: false,
+                unwrap_last: false,
+            },
+            None,
+            &|reached| reached,
         )
         .to_string();
         assert!(
@@ -1540,13 +1447,18 @@ mod tests {
             false,
             LeafSource::Reach,
         );
-        let got = prebindgen_registry::unfold::reach_leaf_flat(
+        let got = prebindgen_registry::unfold::reach_leaf(
             &qualify,
-            &crate::jni::compile::OutWire::from_leaf(&l),
-            &path,
-            quote!(__src),
-            false,
-            false,
+            prebindgen_registry::unfold::LeafAt {
+                leaf: &crate::jni::compile::OutWire::from_leaf(&l),
+                path: &path,
+                base: quote!(__src),
+                base_is_ref: false,
+                consuming: false,
+                unwrap_last: false,
+            },
+            None,
+            &|reached| reached,
         )
         .to_string();
         assert!(
@@ -1572,13 +1484,18 @@ mod tests {
         // The suffix a rebase would hand over — the optional call is gone from
         // it, and used to take the guard with it.
         let rest = vec![PathStep::field(syn::parse_quote!(a), false)];
-        let _ = prebindgen_registry::unfold::reach_leaf_flat(
+        let _ = prebindgen_registry::unfold::reach_leaf(
             &qualify,
-            &crate::jni::compile::OutWire::from_leaf(&l),
-            &rest,
-            quote!(__vf0),
-            false,
-            false,
+            prebindgen_registry::unfold::LeafAt {
+                leaf: &crate::jni::compile::OutWire::from_leaf(&l),
+                path: &rest,
+                base: quote!(__vf0),
+                base_is_ref: false,
+                consuming: false,
+                unwrap_last: false,
+            },
+            None,
+            &|reached| reached,
         );
     }
 }

--- a/prebindgen-jni/src/jni/emit/delivery.rs
+++ b/prebindgen-jni/src/jni/emit/delivery.rs
@@ -1430,6 +1430,48 @@ mod tests {
         );
     }
 
+    /// An owned `Option` payload is borrowed for the accessor that follows it.
+    ///
+    /// The `Some(..)` arm of a gated step binds the step's own value, and an
+    /// accessor returning `Option<T>` binds a bare `T` there. Composing the
+    /// next accessor straight onto it hands `T` to a receiver typed `&T` —
+    /// ill-typed Rust in the consumer's crate, and invisible here until a
+    /// reach has BOTH an owned optional step and something after it. The gated
+    /// reach hardcoded "already a reference" for years because no declared
+    /// leaf had that shape (#609 review). The hoist side of the same rule is
+    /// pinned by `value_form::an_owned_optional_payload_is_borrowed_for_the_steps_after_it`.
+    #[test]
+    fn a_gated_owned_payload_is_borrowed_for_the_step_after_it() {
+        let path = vec![
+            PathStep::call(syn::parse_quote!(get_opt), true, true),
+            PathStep::call(syn::parse_quote!(next), false, false),
+        ];
+        let l = leaf(
+            syn::parse_quote!(Owned),
+            path.clone(),
+            false,
+            LeafSource::Reach,
+        );
+        let got = prebindgen_registry::unfold::reach_leaf(
+            &qualify,
+            prebindgen_registry::unfold::LeafAt {
+                leaf: &crate::jni::compile::OutWire::from_leaf(&l),
+                path: &path,
+                base: quote!(__src),
+                base_is_ref: false,
+                consuming: false,
+                unwrap_last: true,
+            },
+            Some(&|| quote!(__absent)),
+            &|reached| reached,
+        )
+        .to_string();
+        assert!(
+            got.contains("next (& __n0)"),
+            "the owned payload is borrowed for the accessor that follows it — got `{got}`"
+        );
+    }
+
     /// A `Field` leaf is cloned out of the place it reached, whatever the path
     /// shape says — its converter takes the field type as written.
     ///

--- a/prebindgen-jni/src/jni/emit/wrapper.rs
+++ b/prebindgen-jni/src/jni/emit/wrapper.rs
@@ -3,7 +3,7 @@
 
 use prebindgen_registry::{
     types_util::result_ok_type,
-    unfold::{bind_hoists, reach_leaf_flat},
+    unfold::{bind_hoists, reach_leaf, LeafAt},
     Conversions,
 };
 
@@ -330,24 +330,30 @@ impl JWrapper {
             let compose = |base: TokenStream, base_is_ref: bool| -> Option<TokenStream> {
                 let hoisted = bind_hoists(&qualify, &uplan.hoists, &base, base_is_ref);
                 let stmts = &hoisted.stmts;
-                let reached = match hoisted.rebase(&leaf.path) {
-                    Some((local, rest, consuming)) => reach_leaf_flat(
-                        &qualify,
-                        &crate::jni::compile::OutWire::from_leaf(leaf),
-                        &rest,
-                        quote!(#local),
-                        false,
-                        consuming,
-                    ),
-                    None => reach_leaf_flat(
-                        &qualify,
-                        &crate::jni::compile::OutWire::from_leaf(leaf),
-                        &leaf.path,
-                        base.clone(),
-                        base_is_ref,
-                        false,
-                    ),
+                let wire = crate::jni::compile::OutWire::from_leaf(leaf);
+                let rebased = hoisted.rebase(&leaf.path);
+                let (path, from, from_is_ref, consuming) = match &rebased {
+                    Some((local, rest, consuming)) => {
+                        (rest.as_slice(), quote!(#local), false, *consuming)
+                    }
+                    None => (leaf.path.as_slice(), base.clone(), base_is_ref, false),
                 };
+                // `absent: None` — a single delivered return has no arm to put
+                // an absent value in, so an optional step on the way to this
+                // leaf is refused rather than gated.
+                let reached = reach_leaf(
+                    &qualify,
+                    LeafAt {
+                        leaf: &wire,
+                        path,
+                        base: from,
+                        base_is_ref: from_is_ref,
+                        consuming,
+                        unwrap_last: false,
+                    },
+                    None,
+                    &|reached| reached,
+                );
                 if stmts.is_empty() && reached.to_string() == base.to_string() {
                     return None;
                 }

--- a/prebindgen-jni/src/jni/tests/value_form.rs
+++ b/prebindgen-jni/src/jni/tests/value_form.rs
@@ -180,7 +180,7 @@ fn an_optional_field_reaches_its_converter_whole() {
     );
     for field in ["stamp", "attachment"] {
         assert!(
-            rust.contains(&format!(".{field}.clone()")),
+            rust.contains(&format!(".{field}).clone()")),
             "`{field}` must be cloned whole, not matched open:\n{rust}"
         );
         assert!(
@@ -2627,8 +2627,11 @@ fn a_consuming_value_form_moves_its_fields() {
         rust.contains("__vf0.label") && rust.contains("__vf0.count"),
         "each field is read off the one hoisted local:\n{rust}"
     );
+    // Spelled the way a clone reaches a field it does not own — off the
+    // borrow, `(&__vf0.label).clone()` — since that is what would appear here
+    // if the form stopped consuming.
     assert!(
-        !rust.contains("__vf0.label.clone()") && !rust.contains("__vf0.count.clone()"),
+        !rust.contains(".label).clone()") && !rust.contains(".count).clone()"),
         "and MOVED out of it — a consuming form exists precisely to drop these \
          clones:\n{rust}"
     );
@@ -2649,7 +2652,7 @@ fn the_borrowing_value_form_still_clones() {
         "a `&T` accessor is still handed a borrow:\n{rust}"
     );
     assert!(
-        rust.contains("__vf0.label.clone()"),
+        rust.contains("(&__vf0.label).clone()"),
         "and its fields are still cloned out:\n{rust}"
     );
 }

--- a/prebindgen-registry/src/unfold.rs
+++ b/prebindgen-registry/src/unfold.rs
@@ -35,8 +35,8 @@ use crate::{
 mod error;
 mod walk;
 pub use walk::{
-    bind_hoists, compose_step, fold_steps, project_leading_fields, reach_leaf_flat, DecomposedLeaf,
-    DeliveryBridge, Hoisted, Reach,
+    bind_hoists, compose_step, fold_steps, project_leading_fields, reach_leaf, DecomposedLeaf,
+    DeliveryBridge, Hoisted, LeafAt, Reach,
 };
 
 mod plan;

--- a/prebindgen-registry/src/unfold/walk.rs
+++ b/prebindgen-registry/src/unfold/walk.rs
@@ -91,6 +91,12 @@ pub trait DeliveryBridge {
 
     /// The expression that passes `slot` as one argument of the delivery call.
     fn argument(&self, leaf: &Self::Leaf, slot: &syn::Ident) -> TokenStream;
+
+    /// What a leaf delivers when an optional step on the way to it found
+    /// nothing. [`reach_leaf`] gates on this rather than on a value of its
+    /// own: absence is a target-language representation, and this crate has
+    /// none.
+    fn absent(&self) -> TokenStream;
 }
 
 /// Compose one [`PathStep`] onto the reference expression reached so far.
@@ -204,24 +210,137 @@ pub fn project_leading_fields(
     (quote!(&#base #(.#segs)*), n)
 }
 
-/// Fold a leaf's whole `path` over `base` with no optional-step handling, then
-/// apply the terminal treatment the leaf calls for: a leaf reached by a field
-/// read is **cloned** out of the place it reached, because its converter takes
-/// the field type as written (owned); every other leaf keeps the borrow its
-/// converter expects.
+/// One leaf, and the place a reach of it starts from.
+///
+/// A caller that has already bound a hoist hands over the local it bound and
+/// the steps that are left, which is why `path` is a suffix of the leaf's own
+/// reach rather than always equal to it.
+pub struct LeafAt<'a, L> {
+    /// The leaf being reached.
+    pub leaf: &'a L,
+    /// The steps still to walk from `base`.
+    pub path: &'a [PathStep],
+    /// What the walk starts from — the delivered value, or a local a hoist or
+    /// a gate bound.
+    pub base: TokenStream,
+    /// Whether `base` is already a reference.
+    pub base_is_ref: bool,
+    /// Whether the form that produced `base` gave its value away, which is
+    /// what lets a field of it be moved rather than cloned.
+    pub consuming: bool,
+    /// Whether a FINAL optional step is gated too. An identity leaf delivers
+    /// the reached value itself, so it is; every other leaf hands the final
+    /// step's full type to its own converter, `Option` and all.
+    pub unwrap_last: bool,
+}
+
+/// Reach one leaf from `base` and hand what it reached to `body`.
+///
+/// Three things happen on the way, and all three are facts about Rust values
+/// rather than about any target language:
+///
+/// * **Gating.** An optional step before the leaf becomes a `match` whose
+///   `None` arm yields `absent()` — the adapter's own absence, since this
+///   crate has none to offer. `unwrap_last` says whether a FINAL optional step
+///   is gated too: an identity leaf delivers the reached value itself, so it
+///   is, while every other leaf hands the final step's full type to its own
+///   converter, `Option` and all.
+/// * **Refusal.** `absent` is `None` at a site that cannot express absence at
+///   all — a single delivered return value, which has no arm to put one in.
+///   An optional step before the end is then refused rather than composed into
+///   code the consumer's crate cannot type-check.
+/// * **Ownership**: the reached place is moved when it is ours, cloned when
+///   it is a field read of a place that is not, and borrowed otherwise.
 ///
 /// One derivation, used by every delivery an adapter renders and by the
 /// single-leaf shortcut a decomposed return takes. They drifted once while
 /// they were two — the shortcut was missing the field clone and handed `&F` to
-/// an `F` converter — which is why the walk is the registry's.
-pub fn reach_leaf_flat<L: DecomposedLeaf>(
+/// an `F` converter — and a second pair, ungated here and gated in JniGen,
+/// drifted the same way until #607 folded them together.
+pub fn reach_leaf<L: DecomposedLeaf>(
     qualify: &dyn Fn(&syn::Ident) -> syn::Path,
-    leaf: &L,
-    path: &[PathStep],
-    base: TokenStream,
-    base_is_ref: bool,
-    consuming: bool,
+    at: LeafAt<'_, L>,
+    absent: Option<&dyn Fn() -> TokenStream>,
+    body: &dyn Fn(TokenStream) -> TokenStream,
 ) -> TokenStream {
+    reach_leaf_at(qualify, at, absent, 0, body)
+}
+
+fn reach_leaf_at<L: DecomposedLeaf>(
+    qualify: &dyn Fn(&syn::Ident) -> syn::Path,
+    at: LeafAt<'_, L>,
+    absent: Option<&dyn Fn() -> TokenStream>,
+    depth: usize,
+    body: &dyn Fn(TokenStream) -> TokenStream,
+) -> TokenStream {
+    let LeafAt {
+        path,
+        ref base,
+        base_is_ref,
+        unwrap_last,
+        ..
+    } = at;
+    // Every optional step on the way to the leaf becomes a `match` whose
+    // `None` arm is the adapter's absent value. A site with no absent value to
+    // give — a single delivered return, which has no arm to put one in —
+    // passes `None`, and an optional step before the end is then refused
+    // rather than composed into code the consumer's crate cannot type-check.
+    if let Some(absent) = absent {
+        let limit = if unwrap_last {
+            path.len()
+        } else {
+            // A non-identity leaf's converter takes the final step's FULL type,
+            // `Option` included, so only the steps before it are nesting.
+            path.len().saturating_sub(1)
+        };
+        let (projected, lead) = project_leading_fields(base, base_is_ref, path);
+        if let Some(k) = (lead..limit).find(|&i| path[i].is_optional()) {
+            // Through the optional step INCLUSIVE: the same fold, so the borrow
+            // in front of it is the ordinary rule rather than a second
+            // statement of it.
+            let opt_e = fold_steps(qualify, &path[lead..=k], projected, false);
+            let nested = format_ident!("__n{}", depth);
+            let inner = reach_leaf_at(
+                qualify,
+                LeafAt {
+                    path: &path[k + 1..],
+                    base: quote!(#nested),
+                    base_is_ref: true,
+                    ..at
+                },
+                Some(absent),
+                depth + 1,
+                body,
+            );
+            let gone = absent();
+            // A FIELD read composes to a borrow (`&(e).f`), so it goes through
+            // a coercion site and the destructuring stops caring which
+            // representation the source spelled the optional as (#268).
+            //
+            // A CALL composes to the accessor's own returned value, which is
+            // owned and whose payload downstream may move. Borrowing it to
+            // coerce would change that ownership, so it keeps its direct match.
+            if path[k].is_field() {
+                let opt_bind = format_ident!("__o{}", depth);
+                return quote! {
+                    {
+                        let #opt_bind: &::core::option::Option<_> = #opt_e;
+                        match #opt_bind {
+                            ::core::option::Option::Some(#nested) => { #inner }
+                            ::core::option::Option::None => #gone,
+                        }
+                    }
+                };
+            }
+            return quote! {
+                match #opt_e {
+                    ::core::option::Option::Some(#nested) => { #inner }
+                    ::core::option::Option::None => #gone,
+                }
+            };
+        }
+        return body(reached_place(qualify, &at));
+    }
     // An optional step BEFORE the last one needs a `match` whose `None` arm has
     // somewhere to go. This derivation has none — it yields a plain Rust value,
     // not a representation that can carry absence — so the shape is refused
@@ -235,13 +354,13 @@ pub fn reach_leaf_flat<L: DecomposedLeaf>(
     // conditional one, which is the case that cannot compose (an `Option<T>`
     // local with a field read hung off it). The full path is what the shape
     // question is about.
-    let own_path = leaf.reach();
+    let own_path = at.leaf.reach();
     assert!(
         !own_path.iter().rev().skip(1).any(PathStep::is_optional),
         "unfold: leaf `{}` reaches through an optional step but is \
          delivered as a single return value, which has no `None` arm — this \
          shape needs callback delivery",
-        leaf.name(),
+        at.leaf.name(),
     );
     // Whether what this leaf reaches is OURS, and so is moved rather than
     // borrowed or cloned. The two leaf kinds say it differently:
@@ -264,6 +383,25 @@ pub fn reach_leaf_flat<L: DecomposedLeaf>(
     // somewhere else. `plan.rs` says two readings would drift and the
     // disagreement would be a borrow handed to an owning converter; this is the
     // second reading, removed.
+    body(reached_place(qualify, &at))
+}
+
+/// The place a leaf reaches, with the terminal treatment its ownership calls
+/// for: moved out when it is ours and the path projects a place, cloned out
+/// when it is a field read of a place that is not, and borrowed otherwise.
+fn reached_place<L: DecomposedLeaf>(
+    qualify: &dyn Fn(&syn::Ident) -> syn::Path,
+    at: &LeafAt<'_, L>,
+) -> TokenStream {
+    let LeafAt {
+        leaf,
+        path,
+        base,
+        base_is_ref,
+        consuming,
+        ..
+    } = at;
+    let (base_is_ref, consuming) = (*base_is_ref, *consuming);
     let reached_is_ours = if leaf.identity() {
         !matches!(
             leaf.source().kind(),
@@ -276,8 +414,15 @@ pub fn reach_leaf_flat<L: DecomposedLeaf>(
         let segs: Vec<&syn::Ident> = path.iter().map(PathStep::ident).collect();
         return quote!(#base #(.#segs)*);
     }
-    let (e, lead) = project_leading_fields(&base, base_is_ref, path);
+    let (e, lead) = project_leading_fields(base, base_is_ref, path);
     let e = fold_steps(qualify, &path[lead..], e, false);
+    // Cloned out of the BORROW the reach yields, not out of the place behind
+    // it. The two agree for a field of an owned type and disagree for a field
+    // that is itself a reference: `place.clone()` there resolves through the
+    // reference and deep-clones the pointee, where the converter takes the
+    // field type as written. JniGen's own reach spelled it the short way and
+    // no declared field exercised the difference — the drift this step exists
+    // to close.
     if leaf.is_field_read() {
         quote!((#e).clone())
     } else {
@@ -361,9 +506,11 @@ impl Hoisted {
 /// the innermost reached expression as a BARE value — the chain's last link
 /// wraps it.
 ///
-/// The gated reach this mirrors is not in this crate. JniGen keeps its own, as
-/// `emit::delivery::reach_leaf`, because the absent value is its
-/// representation's — which is one of the walks this module was meant to end.
+/// The gated reach this mirrors is [`reach_leaf`], which takes the absent
+/// value from the adapter rather than choosing one. This one yields an
+/// `Option` instead, because what it binds is a hoist rather than a delivered
+/// leaf: the value form runs where the value is present, and the `None` the
+/// chain produces is the local's own.
 ///
 /// This is how a CONDITIONAL value form is bound — the accessor runs only where
 /// the value it decomposes is actually present.

--- a/prebindgen-registry/src/unfold/walk.rs
+++ b/prebindgen-registry/src/unfold/walk.rs
@@ -300,12 +300,25 @@ fn reach_leaf_at<L: DecomposedLeaf>(
             // statement of it.
             let opt_e = fold_steps(qualify, &path[lead..=k], projected, false);
             let nested = format_ident!("__n{}", depth);
+            // What the arm binds is the step's OWN value: an owned payload is
+            // a bare `T`, so composing the next step onto it directly would
+            // hand `T` to an accessor typed for `&T`. Say it is not a
+            // reference and let `project_leading_fields` borrow it; a borrowed
+            // payload is already one and passes through. With no steps left
+            // the binding goes to `body` untouched, which is what lets an
+            // owned payload be moved rather than borrowed straight back.
+            //
+            // The same rule [`reach_optional`] states for a conditional
+            // hoist's prefix. This used to be a hardcoded `true` in the gated
+            // reach JniGen owned, where an `Option<T>` accessor followed by
+            // another accessor emitted `next(__n0)` against a `&T` receiver.
+            let rest = &path[k + 1..];
             let inner = reach_leaf_at(
                 qualify,
                 LeafAt {
-                    path: &path[k + 1..],
+                    path: rest,
                     base: quote!(#nested),
-                    base_is_ref: true,
+                    base_is_ref: rest.is_empty() || !path[k].yields_owned(),
                     ..at
                 },
                 Some(absent),


### PR DESCRIPTION
Step 3 of #607.

Two functions reached a leaf. `prebindgen_registry::unfold::reach_leaf_flat`
folded a path onto a base and applied the terminal treatment ownership called
for. `emit::delivery::reach_leaf` in JniGen did the same fold, but gated every
optional step on the way with a `match` whose `None` arm delivered a JVM null.
The second existed because the registry had no absent value to put in that arm.
Now it does — the bridge #608 added supplies one — so there is one.

## The merged reach

`reach_leaf` takes a `LeafAt`: the leaf, the steps still to walk, what to walk
them from, and whether that base is a reference, came from a consuming form, or
should have a final optional step unwrapped. It does three things, all facts
about Rust values rather than about any target language:

- **Gates.** An optional step becomes a `match` whose `None` arm is
  `DeliveryBridge::absent()` — the new operation, JNI's being a JVM null.
- **Refuses.** `absent: None` says the site has no arm to put an absent value
  in — a single delivered return — so an optional step before the end is
  refused rather than composed into code the consumer's crate cannot
  type-check. That is the assert that used to be the flat derivation's alone.
- **Owns.** The reached place is moved when it is ours, cloned when it is a
  field read of a place that is not, and borrowed otherwise.

The third is why JniGen's delivery loop lost its three-way dispatch: it used to
decide move-or-clone-or-compose itself, before calling the gated reach, because
that reach applied no terminal treatment. One call now covers all three arms.
`emit/delivery.rs` is 95 lines shorter; the deleted `reach_leaf` was 79 of them.

## Generated output changes, in 11 places

A field read of a place that is not ours is now spelled `(&v.f).clone()`
everywhere. JniGen spelled it `v.f.clone()` when the whole path was plain
fields.

The two are the same value for a field of an owned type, which is every field
in these fixtures, and they differ for a field that is itself a reference:
`v.f.clone()` there resolves through the reference and deep-clones the pointee,
where the leaf's converter takes the field type as written and wants the
reference back. The merged reach keeps the borrow, which is the answer that
holds for both. Nothing declared exercises the difference today — a second
derivation being right by accident is the drift this step closes, and the same
drift `reach_leaf_flat`'s own doc records from the last time these two were
apart.

Three test assertions move with the spelling. The third is the one worth
naming: `a_consuming_value_form_moves_its_fields` asserts a clone is **absent**,
and its old substring would no longer match the clone it is meant to catch, so
it now matches on `.label).clone()`. Mutating the move branch away fails it,
along with three sibling tests.

## Verification

835 tests, 0 clippy warnings under `--all-targets --all-features -- --deny
warnings`, strict rustdoc clean, the CI-configured `cargo fmt --check` clean,
`PASS - regen check clean` against the regenerated goldens, and the covertest
passes all 61 JVM sections.

— Claude Code (Opus 5)
