### PR TITLE
Reconcile the record with the code

### DIFF
--- a/prebindgen-jni/src/jni/emit/delivery.rs
+++ b/prebindgen-jni/src/jni/emit/delivery.rs
@@ -744,15 +744,13 @@ pub(crate) fn encode_plan_leaves(
     // conditional form may carry a sum field and that segment has to land in
     // the arm too: emitted ahead of it, its `match` would reach a binding the
     // arm has not introduced yet.
-    let mut cond_stmts: std::collections::BTreeMap<usize, TokenStream> = hoists
+    // Which arm a leaf belongs in is its place's answer, asked here the same
+    // way every other consumer asks it — a bucket exists exactly where some
+    // leaf reports one.
+    let mut cond_stmts: std::collections::BTreeMap<usize, TokenStream> = wires
         .iter()
-        .enumerate()
-        .filter_map(|(i, _)| {
-            wires
-                .iter()
-                .any(|w| hoisted.conditional(w.reach()).is_some_and(|(j, ..)| j == i))
-                .then_some((i, TokenStream::new()))
-        })
+        .filter_map(|leaf| place(leaf).conditional)
+        .map(|i| (i, TokenStream::new()))
         .collect();
 
     for seg in &sum_segments {


### PR DESCRIPTION
Step 6 of #607, and its last. One small code change, then the records.

## The code half

The last query in `emit/delivery.rs` that asked which leaves are grouped
together now asks the same way every other consumer does. Building the buckets
for conditional arms called `Hoisted::conditional` directly; it reads
`LeafPlace::conditional` instead, so "which arm does this leaf belong in" has
one caller shape rather than two. Output is byte-identical.

One `reach()` read is left in that file, and it is not a traversal:
`FrozenDelivery::new` walks a plan's steps to collect the origin module of each
accessor, which is what `DeliveryBridge::qualify` answers from.

## The records

Nothing is posted until this is approved. Below is what goes where.

### On #513, as a comment

> ## Delivery is composed now — correcting an earlier claim
>
> The step-7 comment above lists delivery among the walks #596 moved. That was
> wrong when it was written, and #607's own first step says so: #596 moved
> delivery's mechanical half — folding a path, binding the hoists, the flat
> leaf reach — and left five rules about Rust values in
> `prebindgen-jni/src/jni/emit/delivery.rs`. The walk had no bridge to hand the
> encoding half to, so nothing entangled with encoding could cross.
>
> #607 finished it. `DeliveryBridge` (#608) gave the walk the adapter's half —
> encoding a leaf, placing it as a call argument, what a slot holds unfilled,
> what absence looks like. Then the rules crossed: one leaf reach with the
> gating and the ownership terminal in it (#609), where a leaf's reach starts
> and whether the place is moved (#610), and segment recognition with the
> optional-sum gate and the conditional arm (#611).
>
> `emit/delivery.rs` walks nothing now, and its module doc says so. It holds
> the `DeliveryBridge` implementation and JNI policy: `jvalue` layout,
> local-frame sizing, cached method lookup, exception routing.
>
> **What this cost.** Measured across the whole umbrella, excluding tests and
> generated files: production Rust +971 / −557, net +414 lines — the registry
> gained 553 and JniGen shed 139. `emit/delivery.rs` went 1515 lines to 1360. Generated output changed in 11
> places, all in #609 and all the same spelling change — a non-owned field read
> is `(&v.f).clone()` everywhere now, which is the spelling that also holds
> when the field is itself a reference. Cbindgen is untouched: it declares no
> decomposition.
>
> **Gate 6 of this PR now reads true.** It was written during #596's
> reconciliation on the belief that delivery had moved; the whole-object output
> encode it names as the exception is still the exception, and #602 still
> carries it.
>
> One thing #607 did not change, and it is worth stating rather than leaving to
> be discovered: `walk.rs` has one consumer and `DecomposedLeaf` one production
> implementation. Cbindgen has no decomposition feature and none is proposed.
> The walk is in the registry because a decomposition walk is the registry's
> subject and one home means one implementation — not because a second adapter
> reuses it today.

### On #596, as a comment

> #607 completed criterion 3 of this umbrella. Delivery is composed by the
> registry now, not merely relocated to it: the walk binds the hoists, reaches
> each leaf, gates each optional step, decides what is moved, recognises each
> segment and applies its gate, calling `DeliveryBridge` for the
> target-language half. The `emit/delivery.rs` clause of the criterion below it
> is true as well — that file holds bridge operations and JVM policy and no
> source-value traversal.
>
> The criterion is left as it was written. It described this branch accurately
> when it merged, and #607 is where the change is recorded.

## Verification

836 tests, 0 clippy warnings under `--all-targets --all-features -- --deny
warnings`, strict rustdoc clean, the CI-configured `cargo fmt --check` clean,
`PASS - regen check clean`, covertest 61/61 JVM sections.

— Claude Code (Opus 5)

