### PR TITLE
One stage order, stored in execution order

### DIFF
--- a/prebindgen-jni/src/jni/compile.rs
+++ b/prebindgen-jni/src/jni/compile.rs
@@ -788,11 +788,36 @@ fn staged_chain(
 ) -> prebindgen_registry::generation::ConversionChain<JRepresentation> {
     use prebindgen_registry::generation::{ChainValue, Cleanup, ConversionChain, ConverterStep};
     let (from, into) = match direction {
-        Direction::Construct => (ChainValue::Intermediate(inner_key), ChainValue::Source),
-        Direction::Deconstruct => (ChainValue::Source, ChainValue::Intermediate(inner_key)),
+        Direction::Construct => (
+            ChainValue::Intermediate(inner_key.clone()),
+            ChainValue::Source,
+        ),
+        Direction::Deconstruct => (
+            ChainValue::Source,
+            ChainValue::Intermediate(inner_key.clone()),
+        ),
     };
     let own = ConverterStep::new(from, into, operation, failure, Cleanup::None);
-    let inner = inner.steps().iter().cloned();
+    // `ChainValue::Source` names the source value of the fragment that OWNS
+    // the chain, so the inner fragment's steps change meaning when they are
+    // embedded in this one: what was the inner's source value is this
+    // fragment's `inner_key` carrier. Rebasing it is what keeps the steps
+    // adjacent — each step's `into` is the next step's `from` — with `Source`
+    // appearing only at the end of a construct chain and the start of a
+    // deconstruct one.
+    let rebase = |value: &ChainValue<TypeKey>| match value {
+        ChainValue::Source => ChainValue::Intermediate(inner_key.clone()),
+        ChainValue::Intermediate(key) => ChainValue::Intermediate(key.clone()),
+    };
+    let inner = inner.steps().iter().map(|step| {
+        ConverterStep::new(
+            rebase(step.from()),
+            rebase(step.into()),
+            step.operation().clone(),
+            step.failure(),
+            step.cleanup().clone(),
+        )
+    });
     let steps: Vec<ConverterStep<JRepresentation>> = match direction {
         Direction::Construct => inner.chain(std::iter::once(own)).collect(),
         Direction::Deconstruct => std::iter::once(own).chain(inner).collect(),
@@ -4629,6 +4654,102 @@ mod chain_tests {
             source.key(),
             crossing.row(prebindgen_registry::recipe::RecipeName::new(name)),
         )
+    }
+
+    /// One inner chain, in the frame of the fragment that owns it.
+    fn inner_chain(
+        direction: Direction,
+        stage: OperationId,
+        key: &TypeKey,
+    ) -> ConversionChain<JRepresentation> {
+        let (from, into) = match direction {
+            Direction::Construct => (ChainValue::Intermediate(key.clone()), ChainValue::Source),
+            Direction::Deconstruct => (ChainValue::Source, ChainValue::Intermediate(key.clone())),
+        };
+        ConversionChain::Steps(vec![ConverterStep::<JRepresentation>::new(
+            from,
+            into,
+            stage,
+            Failure::Fallible,
+            prebindgen_registry::generation::Cleanup::None,
+        )])
+    }
+
+    /// Every step's destination is the next step's origin, and `Source`
+    /// appears once: at the END of a construct chain and the START of a
+    /// deconstruct one.
+    ///
+    /// The endpoints are what makes the chain a chain. `ChainValue::Source`
+    /// names the source value of the fragment that OWNS the chain, so an inner
+    /// fragment's steps mean something different once they are embedded in an
+    /// outer one — its source value is the outer fragment's carrier. Copying
+    /// them verbatim leaves `Source` in the middle and the steps either side of
+    /// it disconnected, which `validate_chain` rejects as a broken chain and
+    /// today's renderers miss because they read only the operation (#615
+    /// review).
+    #[test]
+    fn an_embedded_chain_is_rebased_into_the_outer_frame() {
+        for direction in [Direction::Construct, Direction::Deconstruct] {
+            let inner_key = TypeKey::parse("Label").expect("test key");
+            let deeper_key = TypeKey::parse("Deeper").expect("test key");
+            let inner_stage = OperationId::stage(fragment_id("inner"), 0);
+            let outer_stage = OperationId::stage(fragment_id("outer"), 0);
+            // The inner fragment's own chain already reaches ITS source value
+            // through a carrier of its own, so the rebase has to cross a chain
+            // that is more than one step long.
+            let inner = staged_chain(
+                direction,
+                inner_stage.clone(),
+                deeper_key,
+                &inner_chain(
+                    direction,
+                    OperationId::stage(fragment_id("deeper"), 0),
+                    &TypeKey::parse("Deepest").expect("test key"),
+                ),
+                Failure::Fallible,
+            );
+
+            let chain = staged_chain(
+                direction,
+                outer_stage.clone(),
+                inner_key.clone(),
+                &inner,
+                Failure::Fallible,
+            );
+            let steps = chain.steps();
+            assert_eq!(steps.len(), 3, "{direction:?}: every step is retained");
+
+            for pair in steps.windows(2) {
+                assert_eq!(
+                    ConverterStep::into(&pair[0]),
+                    ConverterStep::from(&pair[1]),
+                    "{direction:?}: each step's destination is the next one's origin, \
+                     in {chain:?}",
+                    chain = steps
+                        .iter()
+                        .map(|step| format!("{:?} -> {:?}", step.from(), step.into()))
+                        .collect::<Vec<_>>()
+                );
+            }
+            let sources = steps
+                .iter()
+                .filter(|step| {
+                    matches!(ConverterStep::from(step), ChainValue::Source)
+                        || matches!(ConverterStep::into(step), ChainValue::Source)
+                })
+                .count();
+            assert_eq!(sources, 1, "{direction:?}: `Source` appears once");
+            match direction {
+                Direction::Construct => assert!(
+                    matches!(ConverterStep::into(&steps[2]), ChainValue::Source),
+                    "constructing ends at the source value"
+                ),
+                Direction::Deconstruct => assert!(
+                    matches!(ConverterStep::from(&steps[0]), ChainValue::Source),
+                    "deconstructing starts at the source value"
+                ),
+            }
+        }
     }
 
     /// A chain is stored in EXECUTION order for its own direction, which is

--- a/prebindgen-jni/src/jni/compile.rs
+++ b/prebindgen-jni/src/jni/compile.rs
@@ -103,7 +103,7 @@ pub(crate) fn optional_pair_plan_candidate(ext: &Declarations, arg: &TypeRef) ->
     JniPrim::from_wire(&inner_entry.destination).is_some()
         && inner_entry.niches.clone().carve().is_none()
         && inner_entry.metadata.projection.is_none()
-        && inner_entry.pre_stages.is_empty()
+        && inner_entry.0.chain.steps().is_empty()
 }
 
 /// Kotlin spelling of the niche consumed by the outer Optional enum layer.
@@ -182,12 +182,51 @@ pub(crate) fn optional_pair_plan(
     })
 }
 
+/// JniGen's half of the canonical generation plan.
+///
+/// Declared here so a JNI fragment can state its conversion chain in the
+/// registry's vocabulary — [`prebindgen_registry::generation::ConversionChain`]
+/// — rather than in a row of its own. #613 step 4 is what puts JNI fragments
+/// and sites into `FragmentPlan` / `SitePlan`; this states the representation
+/// those will be over, and the chain is its first live use.
+pub(crate) struct JRepresentation;
+
+impl prebindgen_registry::generation::Representation for JRepresentation {
+    /// A stage's carrier is named by the crossing it converts, which is what
+    /// JniGen already keys its fragments on.
+    type Intermediate = TypeKey;
+    /// One stage: the identity of the artifact that renders it.
+    type Step = OperationId;
+    type ConverterArtifact = crate::jni::chain::JFunction;
+    type TerminalCodec = crate::jni::chain::JFunction;
+    type ProductBridge = crate::jni::chain::JFunction;
+    type OptionalBridge = crate::jni::chain::JFunction;
+    type SequenceBridge = crate::jni::chain::JFunction;
+    type ChoiceBridge = crate::jni::chain::JFunction;
+    type CallbackBridge = crate::jni::chain::JFunction;
+    type Niche = String;
+    type Cleanup = ();
+    type FailureRoute = ();
+    type AbiLayout = JLayout;
+    type Artifact = crate::jni::generation::JFinalArtifact;
+}
+
 /// The JNI adapter's answer for one crossing.
 ///
 /// What a `ConverterImpl` was, minus the bookkeeping the table now does.
 #[derive(Clone)]
 pub(crate) struct JFrag {
     pub(crate) conv: ConverterImpl<KotlinMeta>,
+    /// The conversions between this fragment's wire value and its source
+    /// value, in **execution order for this fragment's direction** — from the
+    /// wire when constructing, from the source when deconstructing.
+    ///
+    /// The registry's chain rather than a row of this adapter's own. It
+    /// replaced `ConverterImpl::pre_stages`, which stored one order and left
+    /// each reader to reverse it for input; storing execution order means the
+    /// reversal happens once, where the chain is built and the direction is
+    /// already in hand.
+    pub(crate) chain: prebindgen_registry::generation::ConversionChain<JRepresentation>,
     pub(crate) rust: crate::jni::chain::JFunction,
     /// Frozen semantic stages beside the wire-facing converter. The
     /// compatibility ConverterImpl keeps marker functions for ordering and
@@ -687,6 +726,10 @@ pub(crate) struct Wire {
     /// the value calls it through its wire-facing function **and** whatever
     /// Rust-side stages follow, and a name says nothing about those.
     pub(crate) entry: Option<ConverterImpl<KotlinMeta>>,
+    /// This wire's fragment's conversion chain, in execution order — copied
+    /// from the fragment when the wire is built, because the Rust side that
+    /// rebuilds the value calls the wire-facing converter and then these.
+    pub(crate) stages: Vec<OperationId>,
     /// For a nested owned handle: where Kotlin finds the handle **object**, as
     /// against the `Long` this wire carries.
     ///
@@ -728,10 +771,52 @@ impl Carrier for JFrag {
     }
 }
 
+/// One stage in front of `inner`'s chain, in execution order for `direction`.
+///
+/// A stage converts between the fragment's own source value and the value the
+/// inner fragment carries, so the two endpoints are `ChainValue::Source` and
+/// the inner crossing's key. Which is `from` and which is `into` is the whole
+/// difference between the directions: constructing ends at the source value
+/// and deconstructing starts there, which is also why the inner steps run
+/// before the new one in one direction and after it in the other.
+fn staged_chain(
+    direction: Direction,
+    operation: OperationId,
+    inner_key: TypeKey,
+    inner: &prebindgen_registry::generation::ConversionChain<JRepresentation>,
+    failure: prebindgen_registry::generation::Failure,
+) -> prebindgen_registry::generation::ConversionChain<JRepresentation> {
+    use prebindgen_registry::generation::{ChainValue, Cleanup, ConversionChain, ConverterStep};
+    let (from, into) = match direction {
+        Direction::Construct => (ChainValue::Intermediate(inner_key), ChainValue::Source),
+        Direction::Deconstruct => (ChainValue::Source, ChainValue::Intermediate(inner_key)),
+    };
+    let own = ConverterStep::new(from, into, operation, failure, Cleanup::None);
+    let inner = inner.steps().iter().cloned();
+    let steps: Vec<ConverterStep<JRepresentation>> = match direction {
+        Direction::Construct => inner.chain(std::iter::once(own)).collect(),
+        Direction::Deconstruct => std::iter::once(own).chain(inner).collect(),
+    };
+    ConversionChain::Steps(steps)
+}
+
 impl JFrag {
     fn new(at: At<'_>, conv: ConverterImpl<KotlinMeta>) -> Self {
         let rust = crate::jni::chain::JFunction::marker(conv.converter_id().clone());
         Self::planned(at, conv, rust)
+    }
+
+    /// A fragment whose source value is reached through explicit stages.
+    fn planned_staged(
+        at: At<'_>,
+        chain: prebindgen_registry::generation::ConversionChain<JRepresentation>,
+        conv: ConverterImpl<KotlinMeta>,
+        rust: crate::jni::chain::JFunction,
+    ) -> Self {
+        Self {
+            chain,
+            ..Self::planned(at, conv, rust)
+        }
     }
 
     fn planned(
@@ -742,6 +827,7 @@ impl JFrag {
         let validity = validity_of(at.crossing.direction(), at.crossing.mode());
         Self {
             conv,
+            chain: prebindgen_registry::generation::ConversionChain::Direct,
             rust,
             rust_stages: Vec::new(),
             choice_arm: None,
@@ -768,10 +854,10 @@ impl JFrag {
         std::iter::once(self.rust.clone())
             .chain(self.rust_stages.iter().cloned())
             .chain(
-                self.conv
-                    .pre_stages
+                self.chain
+                    .steps()
                     .iter()
-                    .map(|stage| crate::jni::chain::JFunction::marker(stage.converter.clone())),
+                    .map(|step| crate::jni::chain::JFunction::marker(step.operation().clone())),
             )
             .collect()
     }
@@ -1126,7 +1212,6 @@ impl<R: Conversions> JCompile<'_, R> {
         };
         let conv = ConverterImpl {
             subs: vec![],
-            pre_stages: vec![],
             converter: operation,
             destination: wire,
             niches,
@@ -1193,7 +1278,6 @@ impl<R: Conversions> JCompile<'_, R> {
             at,
             ConverterImpl {
                 subs: Vec::new(),
-                pre_stages: Vec::new(),
                 converter: operation.clone(),
                 destination: wire,
                 niches,
@@ -1237,7 +1321,6 @@ impl<R: Conversions> JCompile<'_, R> {
             at,
             ConverterImpl {
                 subs: Vec::new(),
-                pre_stages: Vec::new(),
                 converter: operation.clone(),
                 destination: wire.clone(),
                 niches: default_niches_for_wire(&wire),
@@ -1309,7 +1392,6 @@ impl<R: Conversions> JCompile<'_, R> {
         metadata.niche_sentinels = niche_sentinels;
         let conv = ConverterImpl {
             subs: vec![],
-            pre_stages: vec![],
             converter: operation,
             destination: wire,
             niches,
@@ -1343,7 +1425,6 @@ impl<R: Conversions> JCompile<'_, R> {
         );
         let conv = ConverterImpl {
             subs: vec![],
-            pre_stages: vec![],
             converter: operation,
             destination: wire,
             niches,
@@ -1498,10 +1579,10 @@ impl<R: Conversions> JCompile<'_, R> {
                 operation,
             });
         Some(JFrag {
+            chain: prebindgen_registry::generation::ConversionChain::Direct,
             conv: ConverterImpl {
                 destination: wire,
                 converter: operation_id,
-                pre_stages: Vec::new(),
                 niches: Niches::one(syn::parse_quote!(0i64), syn::parse_quote!(*v == 0)),
                 metadata,
                 subs,
@@ -1533,11 +1614,15 @@ impl<R: Conversions> JCompile<'_, R> {
         let (ok, err) = source.fallible_parts()?;
         let success = self.decls.out_frag(ok)?;
         let operation = OperationId::stage(at.fragment_id(), 0);
-        let mut pre_stages = vec![Stage {
-            converter: operation.clone(),
-            metadata: KotlinMeta::default(),
-        }];
-        pre_stages.extend(success.pre_stages.iter().cloned());
+        // Peeling a `Result` IS the failure edge: the `Err` arm is what the
+        // site has to route, which is why this stage is always fallible.
+        let chain = staged_chain(
+            at.crossing.direction(),
+            operation.clone(),
+            ok.key(),
+            &success.0.chain,
+            prebindgen_registry::generation::Failure::Fallible,
+        );
         let rust = crate::jni::chain::JFunction::result(crate::jni::chain::JResultPlan {
             operation,
             reachable: std::rc::Rc::new(std::cell::Cell::new(false)),
@@ -1546,12 +1631,12 @@ impl<R: Conversions> JCompile<'_, R> {
             ok: ok.clone(),
             err: err.clone(),
         });
-        Some(JFrag::planned(
+        Some(JFrag::planned_staged(
             at,
+            chain,
             ConverterImpl {
                 destination: success.destination.clone(),
                 converter: success.converter.clone(),
-                pre_stages,
                 niches: default_niches_for_wire(&success.destination),
                 metadata: KotlinMeta {
                     kotlin_name: success.metadata.kotlin_name.clone(),
@@ -1593,16 +1678,15 @@ impl<R: Conversions> JCompile<'_, R> {
                 crate::jni::trait_impl::read_through_erased_wrappers(source, quote!(__probe))?;
             }
         }
-        let stages = match direction {
-            Direction::Construct => entry
-                .input_stage_order()
-                .map(|(_, stage)| stage.converter.clone())
-                .collect(),
-            Direction::Deconstruct => entry
-                .output_stage_order()
-                .map(|(_, stage)| stage.converter.clone())
-                .collect(),
-        };
+        // In execution order already — the chain stores it that way for the
+        // fragment's own direction, so neither arm reverses anything.
+        let stages: Vec<OperationId> = entry
+            .0
+            .chain
+            .steps()
+            .iter()
+            .map(|step| step.operation().clone())
+            .collect();
         // The outer bridge already receives the exact parameter form expected
         // by the child converter: a pointer by value, otherwise a borrowed JNI
         // object/scalar wire. Do not add the ordinary site-level borrow again.
@@ -1633,7 +1717,6 @@ impl<R: Conversions> JCompile<'_, R> {
             ConverterImpl {
                 destination: entry.destination.clone(),
                 converter: operation,
-                pre_stages: Vec::new(),
                 niches: entry.niches.clone(),
                 metadata: entry.metadata.clone(),
                 subs: vec![stripped],
@@ -1768,6 +1851,25 @@ impl<R: Conversions> JCompile<'_, R> {
             }
         }
         let operation = OperationId::stage(at.fragment_id(), 0);
+        // A declared conversion fails when the declaration says it can: a
+        // `try_into!` trait bound, or a `fun!` whose function returns a
+        // `Result`. A domain adds a failure edge of its own, so a conversion
+        // carrying one is fallible whatever its call says.
+        let fallible = match &call {
+            crate::jni::chain::JCustomCall::Trait { fallible } => *fallible,
+            crate::jni::chain::JCustomCall::Function { error, .. } => error.is_some(),
+        } || decl.domain().is_some();
+        let chain = staged_chain(
+            direction,
+            operation.clone(),
+            representation_key.clone(),
+            &inner.0.chain,
+            if fallible {
+                prebindgen_registry::generation::Failure::Fallible
+            } else {
+                prebindgen_registry::generation::Failure::Infallible
+            },
+        );
         let plan = crate::jni::chain::JFunction::custom_conversion(
             crate::jni::chain::JCustomConversionPlan {
                 operation: operation.clone(),
@@ -1778,11 +1880,6 @@ impl<R: Conversions> JCompile<'_, R> {
                 domain: decl.domain().clone(),
             },
         );
-        let mut pre_stages = vec![Stage {
-            converter: operation,
-            metadata: KotlinMeta::default(),
-        }];
-        pre_stages.extend(inner.pre_stages.iter().cloned());
         let (niches, sentinels) = self.decls.conversion_domain_niches(
             &source.key(),
             self.registry,
@@ -1799,12 +1896,11 @@ impl<R: Conversions> JCompile<'_, R> {
         let conv = ConverterImpl {
             destination: inner.destination.clone(),
             converter: inner.converter.clone(),
-            pre_stages,
             niches,
             metadata,
             subs: vec![representation_key],
         };
-        let mut fragment = JFrag::planned(at, conv, inner.0.rust.clone());
+        let mut fragment = JFrag::planned_staged(at, chain, conv, inner.0.rust.clone());
         fragment.rust_stages.push(plan);
         Some(fragment)
     }
@@ -1822,18 +1918,12 @@ impl<R: Conversions> JCompile<'_, R> {
         mode: Mode,
         frag: &JFrag,
     ) -> crate::jni::chain::JChild {
-        let stages = match direction {
-            Direction::Construct => frag
-                .conv
-                .input_stage_order()
-                .map(|(_, stage)| stage.converter.clone())
-                .collect(),
-            Direction::Deconstruct => frag
-                .conv
-                .output_stage_order()
-                .map(|(_, stage)| stage.converter.clone())
-                .collect(),
-        };
+        let stages: Vec<OperationId> = frag
+            .chain
+            .steps()
+            .iter()
+            .map(|step| step.operation().clone())
+            .collect();
         match direction {
             Direction::Construct => crate::jni::chain::JChild::input(
                 frag.conv.converter_id().clone(),
@@ -1939,10 +2029,10 @@ impl<R: Conversions> JCompile<'_, R> {
             },
         });
         Some(JFrag {
+            chain: prebindgen_registry::generation::ConversionChain::Direct,
             conv: ConverterImpl {
                 destination: intermediate,
                 converter: operation,
-                pre_stages: Vec::new(),
                 niches: Niches::empty(),
                 metadata: KotlinMeta::default(),
                 subs: parts.iter().map(|(part, _)| part.ty.key()).collect(),
@@ -2103,10 +2193,10 @@ impl<R: Conversions> JCompile<'_, R> {
             },
         });
         Some(JFrag {
+            chain: prebindgen_registry::generation::ConversionChain::Direct,
             conv: ConverterImpl {
                 destination,
                 converter: operation,
-                pre_stages: Vec::new(),
                 niches: Niches::empty(),
                 metadata: KotlinMeta::default(),
                 subs: parts_subs(arms),
@@ -2255,10 +2345,10 @@ impl<R: Conversions> JCompile<'_, R> {
             Direction::Deconstruct => default_niches_for_wire(&destination),
         };
         Some(JFrag {
+            chain: prebindgen_registry::generation::ConversionChain::Direct,
             conv: ConverterImpl {
                 destination,
                 converter: operation,
-                pre_stages: Vec::new(),
                 niches,
                 metadata: KotlinMeta {
                     kotlin_name,
@@ -2337,10 +2427,10 @@ impl<R: Conversions> JCompile<'_, R> {
                 ..projection
             });
         Some(JFrag {
+            chain: prebindgen_registry::generation::ConversionChain::Direct,
             conv: ConverterImpl {
                 destination: wire,
                 converter: operation,
-                pre_stages: Vec::new(),
                 niches: Niches::empty(),
                 metadata: KotlinMeta {
                     kotlin_name,
@@ -2420,18 +2510,12 @@ impl<R: Conversions> JCompile<'_, R> {
         let wrappers = composable_wrappers(at.crossing)?;
 
         let inner_wire = inner.conv.destination.clone();
-        let stages = match direction {
-            Direction::Construct => inner
-                .conv
-                .input_stage_order()
-                .map(|(_, stage)| stage.converter.clone())
-                .collect(),
-            Direction::Deconstruct => inner
-                .conv
-                .output_stage_order()
-                .map(|(_, stage)| stage.converter.clone())
-                .collect(),
-        };
+        let stages: Vec<OperationId> = inner
+            .chain
+            .steps()
+            .iter()
+            .map(|step| step.operation().clone())
+            .collect();
 
         let (bridge, child, destination, niches, nullable_kind, layout, input_by_ref) =
             match direction {
@@ -2630,10 +2714,10 @@ impl<R: Conversions> JCompile<'_, R> {
             input_by_ref,
         });
         Some(JFrag {
+            chain: prebindgen_registry::generation::ConversionChain::Direct,
             conv: ConverterImpl {
                 destination,
                 converter: operation,
-                pre_stages: Vec::new(),
                 niches,
                 metadata: KotlinMeta {
                     projection,
@@ -2932,6 +3016,7 @@ impl<R: Conversions> Compile for JCompile<'_, R> {
                 // The gate reads the object itself, not through it.
                 access: Access::read(" != null"),
                 entry: None,
+                stages: Vec::new(),
                 handle_target: None,
                 handle_nullable: false,
                 absent: None,
@@ -3047,6 +3132,7 @@ impl<R: Conversions> Compile for JCompile<'_, R> {
                         // wire reaches on from there.
                         access: w.access.clone().under(&field_kt(part)),
                         entry: w.entry.clone(),
+                        stages: w.stages.clone(),
                         handle_target: w.handle_target.as_ref().map(|t| {
                             std::iter::once(Nav {
                                 field: field_kt(part),
@@ -3076,6 +3162,7 @@ impl<R: Conversions> Compile for JCompile<'_, R> {
                     path: part.name.clone(),
                     access: Access::read("").under(&field_kt(part)),
                     entry: None,
+                    stages: Vec::new(),
                     handle_target: Some(vec![Nav {
                         field: field_kt(part),
                         gated: false,
@@ -3523,6 +3610,17 @@ impl ComposedChain {
 pub(crate) struct Conv(std::rc::Rc<JFrag>);
 
 impl Conv {
+    /// This crossing's conversion chain, in execution order — the stage
+    /// identities a caller has to invoke around the wire-facing converter.
+    pub(crate) fn stages(&self) -> Vec<OperationId> {
+        self.0
+            .chain
+            .steps()
+            .iter()
+            .map(|step| step.operation().clone())
+            .collect()
+    }
+
     pub(crate) fn activate(&self) {
         self.0.rust.mark_reachable();
     }
@@ -3612,9 +3710,7 @@ impl Wire {
     /// build helper declines such an element rather than emit a call that does
     /// not compile.
     pub(crate) fn staged(&self) -> bool {
-        self.entry
-            .as_ref()
-            .is_some_and(|e| !e.pre_stages.is_empty())
+        !self.stages.is_empty()
     }
 
     /// Whether this value is a gate rather than something that crosses.
@@ -3645,7 +3741,6 @@ impl<R: Conversions> JCompile<'_, R> {
         ConverterImpl {
             destination: syn::parse_quote!(()),
             converter: OperationId::converter(at.fragment_id()),
-            pre_stages: Vec::new(),
             niches: Niches::empty(),
             metadata: KotlinMeta::default(),
             subs,
@@ -3748,6 +3843,12 @@ impl<R: Conversions> JCompile<'_, R> {
             path: part.name.clone(),
             access: Access::Read { walk, tail },
             entry: Some(frag.conv.clone()),
+            stages: frag
+                .chain
+                .steps()
+                .iter()
+                .map(|step| step.operation().clone())
+                .collect(),
             handle_target: None,
             handle_nullable: false,
             absent,
@@ -4009,6 +4110,12 @@ impl<R: Conversions> JCompile<'_, R> {
                 zero,
             },
             entry: Some(frag.conv.clone()),
+            stages: frag
+                .chain
+                .steps()
+                .iter()
+                .map(|step| step.operation().clone())
+                .collect(),
             handle_target: None,
             handle_nullable: false,
             absent: None,
@@ -4037,6 +4144,8 @@ impl<R: Conversions> JCompile<'_, R> {
             })
             .collect();
         let mut wires = vec![Wire {
+            // A tag converts nothing: it is read on the Rust side.
+            stages: Vec::new(),
             ty: syn::parse_quote!(jni::sys::jint),
             kt_ty: "Int".to_string(),
             path: "_tag".to_string(),
@@ -4097,7 +4206,7 @@ impl<R: Conversions> JCompile<'_, R> {
         }
         let c = &inner.conv;
         let prim = crate::jni::JniPrim::from_wire(&c.destination)?;
-        if c.niches.clone().carve().is_some() || !c.pre_stages.is_empty() {
+        if c.niches.clone().carve().is_some() || !inner.chain.steps().is_empty() {
             return None;
         }
         // An unsigned representation is the one projection that still takes the
@@ -4146,6 +4255,7 @@ impl<R: Conversions> JCompile<'_, R> {
                 path: "present".to_string(),
                 access: Access::read(" != null"),
                 entry: None,
+                stages: Vec::new(),
                 handle_target: None,
                 handle_nullable: false,
                 absent: None,
@@ -4158,6 +4268,9 @@ impl<R: Conversions> JCompile<'_, R> {
                 path: "value".to_string(),
                 access: value_access,
                 entry: Some(c.clone()),
+                // Refused above unless the inner fragment's chain is empty, so
+                // this value crosses through its converter alone.
+                stages: Vec::new(),
                 handle_target: None,
                 handle_nullable: false,
                 absent: None,
@@ -4499,4 +4612,93 @@ fn is_choice(frag: &JFrag) -> bool {
         .as_ref()
         .and_then(|w| w.first())
         .is_some_and(|w| matches!(w.access, Access::Select { .. }))
+}
+
+#[cfg(test)]
+mod chain_tests {
+    use prebindgen_registry::generation::{ChainValue, ConversionChain, ConverterStep, Failure};
+
+    use super::*;
+
+    fn fragment_id(name: &str) -> prebindgen_registry::FragmentId {
+        let source =
+            prebindgen_registry::flat::TypeRef::scalar(prebindgen_registry::flat::ScalarKind::I64);
+        let crossing =
+            prebindgen_registry::recipe::Crossing::new(source.clone(), Direction::Construct);
+        prebindgen_registry::FragmentId::new(
+            source.key(),
+            crossing.row(prebindgen_registry::recipe::RecipeName::new(name)),
+        )
+    }
+
+    /// A chain is stored in EXECUTION order for its own direction, which is
+    /// the whole reason the two stage-order readers are gone.
+    ///
+    /// The stages nest outward: an outer conversion is declared over an inner
+    /// fragment that already has one. Constructing runs the inner stage first
+    /// and ends at the source value; deconstructing starts at the source value
+    /// and runs the outer stage first. `pre_stages` stored one of those and
+    /// left each reader to reverse it, which is a rule two places could
+    /// disagree about.
+    #[test]
+    fn a_chain_stores_execution_order_for_its_own_direction() {
+        let inner_key = TypeKey::parse("Inner").expect("test key");
+        let inner_stage = OperationId::stage(fragment_id("inner"), 0);
+        let inner = ConversionChain::Steps(vec![ConverterStep::<JRepresentation>::new(
+            ChainValue::Source,
+            ChainValue::Intermediate(inner_key.clone()),
+            inner_stage.clone(),
+            Failure::Fallible,
+            prebindgen_registry::generation::Cleanup::None,
+        )]);
+        let outer_stage = OperationId::stage(fragment_id("outer"), 0);
+
+        let constructing = staged_chain(
+            Direction::Construct,
+            outer_stage.clone(),
+            inner_key.clone(),
+            &inner,
+            Failure::Fallible,
+        );
+        assert_eq!(
+            constructing
+                .steps()
+                .iter()
+                .map(|step| step.operation().clone())
+                .collect::<Vec<_>>(),
+            vec![inner_stage.clone(), outer_stage.clone()],
+            "constructing ends at the source value, so the outer stage runs last"
+        );
+        assert!(
+            matches!(
+                ConverterStep::into(&constructing.steps()[1]),
+                ChainValue::Source
+            ),
+            "and the last step's destination IS the source value"
+        );
+
+        let deconstructing = staged_chain(
+            Direction::Deconstruct,
+            outer_stage.clone(),
+            inner_key,
+            &inner,
+            Failure::Fallible,
+        );
+        assert_eq!(
+            deconstructing
+                .steps()
+                .iter()
+                .map(|step| step.operation().clone())
+                .collect::<Vec<_>>(),
+            vec![outer_stage, inner_stage],
+            "deconstructing starts at the source value, so the outer stage runs first"
+        );
+        assert!(
+            matches!(
+                ConverterStep::from(&deconstructing.steps()[0]),
+                ChainValue::Source
+            ),
+            "and the first step's origin IS the source value"
+        );
+    }
 }

--- a/prebindgen-jni/src/jni/mod.rs
+++ b/prebindgen-jni/src/jni/mod.rs
@@ -44,7 +44,7 @@ pub(crate) use prebindgen_registry::{
     flat::Origin,
     types_util::{option_inner_type, vec_inner_type},
     ArtifactId, ConverterImpl, Direction, NicheSlot, Niches, OperationId, Prebindgen, Registry,
-    ScalarValue, Stage, TypeKey,
+    ScalarValue, TypeKey,
 };
 pub(crate) use proc_macro2::{Span, TokenStream};
 pub(crate) use quote::{format_ident, quote, ToTokens};

--- a/prebindgen-jni/src/jni/struct_plan.rs
+++ b/prebindgen-jni/src/jni/struct_plan.rs
@@ -75,13 +75,17 @@ impl ConvChain {
         );
     }
 
-    /// Read the chain off a resolved output entry.
-    fn of(entry: &prebindgen_registry::ConverterImpl<KotlinMeta>) -> Self {
+    /// Read the chain off a wire's resolved output conversion.
+    ///
+    /// `stages` comes from the wire rather than the converter: the stage order
+    /// is the fragment's conversion chain, and a `ConverterImpl` is the
+    /// wire-facing end of it alone.
+    fn of(
+        entry: &prebindgen_registry::ConverterImpl<KotlinMeta>,
+        stages: &[prebindgen_registry::generation::OperationId],
+    ) -> Self {
         ConvChain {
-            stages: entry
-                .output_stage_order()
-                .map(|(_, stage)| stage.converter.clone())
-                .collect(),
+            stages: stages.to_vec(),
             function: entry.converter_id().clone(),
         }
     }
@@ -378,7 +382,8 @@ pub(crate) fn classify_field(
 
     let field_entry = ext.out_frag(reading)?;
     field_entry.activate();
-    let conv = ConvChain::of(&field_entry);
+    let stages = field_entry.stages();
+    let conv = ConvChain::of(&field_entry, &stages);
 
     {
         // Projection leaf (opaque handle / `ULong`).

--- a/prebindgen-jni/src/jni/trait_impl.rs
+++ b/prebindgen-jni/src/jni/trait_impl.rs
@@ -522,7 +522,6 @@ impl Declarations {
             subs: vec![],
             destination: inner.destination.clone(),
             converter: inner.converter.clone(),
-            pre_stages: vec![],
             niches: inner.niches.clone(),
             metadata: KotlinMeta {
                 kotlin_name,
@@ -1090,7 +1089,6 @@ impl Declarations {
         // arg types' callback plans, not carried in metadata.
         let conv = ConverterImpl {
             subs: vec![],
-            pre_stages: vec![],
             converter: operation,
             destination: wire,
             niches,

--- a/prebindgen-registry/src/generation.rs
+++ b/prebindgen-registry/src/generation.rs
@@ -683,6 +683,7 @@ pub enum Failure {
 }
 
 /// When an adapter cleanup operation runs.
+#[derive(Clone)]
 pub enum Cleanup<C> {
     /// Explicitly no cleanup is required.
     None,
@@ -773,6 +774,40 @@ pub enum ConversionChain<R: Representation> {
     Direct,
     /// One or more explicit internal conversions.
     Steps(Vec<ConverterStep<R>>),
+}
+
+// Cloned where a chain travels with the fragment that owns it. Written out
+// rather than derived: `derive(Clone)` would require `R: Clone`, and `R` is a
+// marker type naming an adapter's associated types rather than a value.
+impl<R: Representation> Clone for ConversionChain<R>
+where
+    R::Intermediate: Clone,
+    R::Step: Clone,
+    R::Cleanup: Clone,
+{
+    fn clone(&self) -> Self {
+        match self {
+            Self::Direct => Self::Direct,
+            Self::Steps(steps) => Self::Steps(steps.clone()),
+        }
+    }
+}
+
+impl<R: Representation> Clone for ConverterStep<R>
+where
+    R::Intermediate: Clone,
+    R::Step: Clone,
+    R::Cleanup: Clone,
+{
+    fn clone(&self) -> Self {
+        Self {
+            from: self.from.clone(),
+            into: self.into.clone(),
+            operation: self.operation.clone(),
+            failure: self.failure,
+            cleanup: self.cleanup.clone(),
+        }
+    }
 }
 
 impl<R: Representation> ConversionChain<R> {

--- a/prebindgen-registry/src/lib.rs
+++ b/prebindgen-registry/src/lib.rs
@@ -143,7 +143,7 @@ pub use self::{
         SitePlan,
     },
     niches::{NicheSlot, Niches},
-    prebindgen::{ConverterImpl, NamePredicate, Prebindgen, Stage},
+    prebindgen::{ConverterImpl, NamePredicate, Prebindgen},
     registry::{
         Answer, Building, Conversions, Crossing, Decompositions, Direction, DuplicateNameError,
         NotExpressibleEntry, Registry, RegistryBuilder, ScanError, TypeKey, TypeKeyParseError,

--- a/prebindgen-registry/src/prebindgen.rs
+++ b/prebindgen-registry/src/prebindgen.rs
@@ -22,30 +22,6 @@ use crate::{generation::OperationId, niches::Niches, registry::Registry};
 /// family rather than an exact ident).
 pub type NamePredicate = std::sync::Arc<dyn Fn(&str) -> bool + Send + Sync>;
 
-/// One link in a converter's [stage chain](`ConverterImpl::pre_stages`) —
-/// a value-inspecting step that sits between the rust value the
-/// `#[prebindgen]` fn yields/receives and the wire-facing
-/// [`ConverterImpl::converter`].
-///
-/// Each stage is a fallible `In → Result<Out, Err>` function. The core
-/// pipeline only ever orders [`Self::converter`]; how a
-/// stage's `Err` arm is surfaced to the foreign side — throw an exception,
-/// return an error code, set `errno`, … — is entirely up to the
-/// destination-language adapter and is described by [`Self::metadata`].
-#[derive(Clone)]
-pub struct Stage<M = ()> {
-    /// Stable identity of this stage's separately retained executable
-    /// artifact.
-    pub converter: OperationId,
-    /// Adapter-specific extras for this stage — the same type as the owning
-    /// converter's ([`ConverterImpl::metadata`]). The core never
-    /// inspects this; the adapter's emitter reads it to decide how the
-    /// stage's `Err` arm is surfaced (e.g. a JNI adapter stores the JVM
-    /// exception class and `throw_*` fn to call here; a C adapter might
-    /// store the error-code sentinel). Defaults to `()`.
-    pub metadata: M,
-}
-
 /// Result of resolving one converter — the wire (destination) type the rest
 /// of the registry sees, plus the identity of its separately retained
 /// executable artifact.
@@ -69,19 +45,6 @@ pub struct ConverterImpl<M = ()> {
     /// (it takes the wire); for output direction this is the LAST stage
     /// (it produces the wire).
     pub converter: OperationId,
-    /// **Rust-side** stages that compose with [`Self::converter`] to form
-    /// the full conversion chain. Default empty — a 1-stage converter
-    /// is just `function`.
-    ///
-    /// Order is rust-side-first → function-side-last. Concretely:
-    /// * **Input** (wire → rust): chain runs `wire → function →
-    ///   pre_stages[0] → pre_stages[1] → … → pre_stages[N-1] → rust`.
-    /// * **Output** (rust → wire): chain runs `rust → pre_stages[N-1] →
-    ///   … → pre_stages[1] → pre_stages[0] → function → wire`.
-    ///
-    /// Each stage is fallible; how its `Err` arm is surfaced is adapter
-    /// specific and carried in [`Stage::metadata`].
-    pub pre_stages: Vec<Stage<M>>,
     /// Bit-patterns the wire type can represent but this converter never
     /// produces (output) and rejects (input). Wrapper handlers like
     /// `Option<_>` consume one slot for their own discriminant and
@@ -122,18 +85,6 @@ impl<M> ConverterImpl<M> {
     /// Wire type this conversion carries on success.
     pub fn wire_type(&self) -> &syn::Type {
         &self.destination
-    }
-
-    /// Rust-side stages in input execution order, after the wire-facing
-    /// converter has decoded the wire value.
-    pub fn input_stage_order(&self) -> impl Iterator<Item = (usize, &Stage<M>)> {
-        self.pre_stages.iter().enumerate().rev()
-    }
-
-    /// Rust-side stages in output execution order, before the wire-facing
-    /// converter encodes the final wire value.
-    pub fn output_stage_order(&self) -> impl Iterator<Item = (usize, &Stage<M>)> {
-        self.pre_stages.iter().enumerate()
     }
 }
 

--- a/prebindgen-registry/src/registry/tests.rs
+++ b/prebindgen-registry/src/registry/tests.rs
@@ -202,21 +202,9 @@ fn conversion_helpers_expose_converter_chain_contract() {
         crossing.row(crate::recipe::RecipeName::new("test")),
     );
     let converter = crate::OperationId::converter(fragment.clone());
-    let stage_rust = crate::OperationId::stage(fragment.clone(), 0);
-    let stage_wire = crate::OperationId::stage(fragment, 1);
     let entry = crate::ConverterImpl {
         destination: syn::parse_quote!(jni::sys::jlong),
         converter: converter.clone(),
-        pre_stages: vec![
-            crate::Stage {
-                converter: stage_rust.clone(),
-                metadata: (),
-            },
-            crate::Stage {
-                converter: stage_wire.clone(),
-                metadata: (),
-            },
-        ],
         subs: vec![
             TypeKey::parse("Rust").expect("test type"),
             TypeKey::parse("Mid").expect("test type"),
@@ -230,20 +218,9 @@ fn conversion_helpers_expose_converter_chain_contract() {
         TypeKey::from_type(entry.wire_type()),
         TypeKey::parse("jni::sys::jlong").expect("test type")
     );
-    assert_eq!(
-        entry
-            .output_stage_order()
-            .map(|(_, s)| s.converter.clone())
-            .collect::<Vec<_>>(),
-        vec![stage_rust.clone(), stage_wire.clone()]
-    );
-    assert_eq!(
-        entry
-            .input_stage_order()
-            .map(|(_, s)| s.converter.clone())
-            .collect::<Vec<_>>(),
-        vec![stage_wire, stage_rust]
-    );
+    // The stages this used to carry are a `ConversionChain` now: one order,
+    // stored in execution order for the fragment's direction, rather than one
+    // stored order and two readers that walked it opposite ways.
     assert_eq!(
         entry.subs.iter().map(TypeKey::as_str).collect::<Vec<_>>(),
         vec!["Rust", "Mid"]
@@ -257,8 +234,8 @@ fn conversion_helpers_expose_converter_chain_contract() {
 fn conversion_carriers_cannot_store_complete_rust_syntax() {
     let source = include_str!("../prebindgen.rs");
     let carriers = source
-        .split_once("pub struct Stage")
-        .expect("Stage declaration")
+        .split_once("pub struct ConverterImpl")
+        .expect("ConverterImpl declaration")
         .1
         .split_once("/// The single extension point")
         .expect("end of conversion carriers")
@@ -269,7 +246,11 @@ fn conversion_carriers_cannot_store_complete_rust_syntax() {
         !carriers.contains("pub converter: syn::Ident"),
         "{carriers}"
     );
-    assert_eq!(carriers.matches("pub converter: OperationId").count(), 2);
+    // One identity: the wire-facing converter. The stage identities that used
+    // to sit beside it in a `Stage` row are a `ConversionChain` now.
+    assert_eq!(carriers.matches("pub converter: OperationId").count(), 1);
+    assert!(!source.contains("pub struct Stage"), "{source}");
+    assert!(!source.contains("pre_stages"), "{source}");
 
     let chain = include_str!("../chain.rs");
     assert!(!chain.contains("Call::complete"), "{chain}");
@@ -1459,7 +1440,7 @@ fn a_type_only_a_local_fn_writes_still_has_a_reading() {
             Some(ConverterImpl {
                 destination: syn::parse_quote!(()),
                 converter: crate::OperationId::converter(fragment),
-                pre_stages: vec![],
+
                 subs: vec![],
                 niches: Niches::empty(),
                 metadata: (),


### PR DESCRIPTION
Step 2 of #613.

A crossing's conversion stages were stated twice: `ConverterImpl::pre_stages`, a
`Vec<Stage<M>>` on the shared converter row, and `ConversionChain`, the
registry's canonical vocabulary that no production code built. This deletes the
first and gives the second its first live use.

## What moved

`ConverterImpl` loses `pre_stages`; `Stage<M>` and the two order readers —
`input_stage_order` / `output_stage_order` — are deleted outright. A JNI
fragment carries a `ConversionChain<JRepresentation>` instead.

**`JRepresentation`** is JniGen's `Representation` impl. #613 step 4 is what
puts JNI fragments and sites into `FragmentPlan` / `SitePlan`; this states the
representation those will be over, because a chain cannot be spelled without
one. Its `Step` is an `OperationId` — the identity the old row carried — and
its `Intermediate` is the `TypeKey` JniGen already keys fragments on.

**The order is stored once.** `pre_stages` held one order and left each reader
to decide which way to walk it: three sites reversed it for input and read it
forward for output. A chain is stored in execution order for its own direction,
so all five readers now read `steps()` and nothing reverses. The reversal
happens where the chain is built, where the direction is already in hand.

**The failure edge is stated.** Each step carries a `Failure`: peeling a
`Result` is always fallible, since the `Err` arm is what a site must route, and
a declared conversion is fallible when its `try_into!` bound, its function's
`Result` return, or its representation domain says so. `pre_stages` had nowhere
to put that — `Stage::metadata` was `KotlinMeta::default()` at both producers,
carrying nothing.

## What this costs

| | production |
|---|---|
| shared core | **−14** (`Stage`, `pre_stages`, two readers; `Clone` for the chain types) |
| C adapter | **0** |
| JNI adapter | **+142** |

The JNI growth is `JRepresentation` (26), the chain builder (28), the staged
constructor (12), and the stage lists two carriers now hold explicitly
(`Wire::stages`, `Conv::stages`) where they used to reach through
`ConverterImpl`. That is the foundation steps 4 and 5 delete `JFrag`, `JPlan`
and `JLayout` against; if those steps do not pay it back, the umbrella's size
gate fails and this is the line it fails on.

## Verification

Generated output is byte-identical: `PASS - regen check clean`, and the
covertest passes all 61 JVM sections. 839 tests, 0 clippy warnings under
`--all-targets --all-features -- --deny warnings`, strict rustdoc clean, the
CI-configured `cargo fmt --check` clean.

Two tests pin the chain, and each fails on its own mutation and on nothing else:

- `a_chain_stores_execution_order_for_its_own_direction` — the rule the two
  readers used to hold between them. Constructing runs the inner stage first
  and ends at `ChainValue::Source`; deconstructing starts there and runs the
  outer stage first. Storing the same order for both directions fails it.
- `an_embedded_chain_is_rebased_into_the_outer_frame` — every step's
  destination is the next step's origin, and `Source` appears exactly once, at
  the end of a construct chain or the start of a deconstruct one. Embedding an
  inner chain verbatim fails it, naming the disconnected steps.

— Claude Code (Opus 5)

