### PR TITLE
A sum field decomposes into its tag and groups

### DIFF
--- a/examples/covertest-kotlin/build.rs
+++ b/examples/covertest-kotlin/build.rs
@@ -638,6 +638,11 @@ fn main() {
                 // #218: the same handle reached through a data-class FIELD, so
                 // the JVM harness can assert the container's cascade closes it.
                 .fun(fun!(verdict_new))
+                // …and the same data class handed to a CALLBACK, which
+                // reassembles through the interface path rather than the
+                // return path — a different question about the same leaves
+                // (#616 review).
+                .fun(fun!(verdict_each))
                 // …and reached one level deeper still, through a nested data
                 // class rather than a sum.
                 .fun(fun!(dossier_new))

--- a/examples/covertest-kotlin/kotlin/REPORT.md
+++ b/examples/covertest-kotlin/kotlin/REPORT.md
@@ -151,6 +151,7 @@ Base package: `io.prebindgen.covertest`
   - shaped by: return `u64` decomposed → [] (Callback delivery)
 - `vault_holder_new` — `fun <R> vaultHolderNew(seq: Long, count: Long, maybeCount: Long, onError: JniErrorHandler<R?>, build: VaultHolderBuilder<R>): R?`
   - shaped by: return `VaultHolder` decomposed → [vaultHolderVault__always, vaultHolderVault__maybe] (Callback delivery)
+- `verdict_each` — `fun verdictEach(n: Long, total: Double, sink: VerdictCallback, onError: JniErrorHandler<Unit>)`
 - `verdict_new` — `fun verdictNew(id: Long, count: Long, total: Double, onError: JniErrorHandler<Verdict?>): Verdict?`
   - shaped by: return `Verdict` decomposed → [id, outcome__tag, outcome__found_v0, outcome__failed_v0] (Callback delivery)
 - `wrapped_fields_sum` — `fun wrappedFieldsSum(w: WrappedFields, onError: JniErrorHandler<Long>): Long`

--- a/examples/covertest-kotlin/kotlin/REPORT.md
+++ b/examples/covertest-kotlin/kotlin/REPORT.md
@@ -139,6 +139,7 @@ Base package: `io.prebindgen.covertest`
 - `stamp_series` — `fun stampSeries(count: Long, onError: JniErrorHandler<List<Stamp>?>): List<Stamp>?`
   - shaped by: return `Stamp` decomposed → [secs, nanos] (Callback delivery)
 - `tagged_new` — `fun taggedNew(which: Int, onError: JniErrorHandler<Tagged?>): Tagged?`
+  - shaped by: return `Tagged` decomposed → [id, marker__tag, marker__ranked_v0] (Callback delivery)
 - `tagged_rank` — `fun taggedRank(t: Tagged, onError: JniErrorHandler<Int>): Int`
 - `ticks_emit` — `fun ticksEmit(f: TicksCallback, onError: JniErrorHandler<Unit>)`
 - `unsigned_data_maybe` — `fun unsignedDataMaybe(value: Unsigned, onError: JniErrorHandler<ULong?>): ULong?`
@@ -151,6 +152,7 @@ Base package: `io.prebindgen.covertest`
 - `vault_holder_new` — `fun <R> vaultHolderNew(seq: Long, count: Long, maybeCount: Long, onError: JniErrorHandler<R?>, build: VaultHolderBuilder<R>): R?`
   - shaped by: return `VaultHolder` decomposed → [vaultHolderVault__always, vaultHolderVault__maybe] (Callback delivery)
 - `verdict_new` — `fun verdictNew(id: Long, count: Long, total: Double, onError: JniErrorHandler<Verdict?>): Verdict?`
+  - shaped by: return `Verdict` decomposed → [id, outcome__tag, outcome__found_v0, outcome__failed_v0] (Callback delivery)
 - `wrapped_fields_sum` — `fun wrappedFieldsSum(w: WrappedFields, onError: JniErrorHandler<Long>): Long`
 
 ## package `io.prebindgen.covertest.storage`

--- a/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest.kt
+++ b/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest.kt
@@ -14,8 +14,6 @@ import io.prebindgen.covertest.model.ObjectBoundary
 import io.prebindgen.covertest.model.Observation
 import io.prebindgen.covertest.model.Priority
 import io.prebindgen.covertest.model.Stamp
-import io.prebindgen.covertest.model.Tagged
-import io.prebindgen.covertest.model.Verdict
 import java.lang.ref.Cleaner
 import java.lang.ref.Cleaner.Cleanable
 import java.util.concurrent.atomic.AtomicLong
@@ -1768,7 +1766,7 @@ internal object CovNative {
     external fun summaryTotalRaw(s: Long, errorSink: Any): Double
 
     @JvmSynthetic
-    external fun taggedNew(which: Int, errorSink: Any): Tagged
+    external fun taggedNew(which: Int, build: Any, errorSink: Any): Any?
 
     @JvmSynthetic
     external fun taggedRank(tId: Long, tMarkerTag: Int, tMarkerRankedV0: Int, errorSink: Any): Int
@@ -1817,7 +1815,7 @@ internal object CovNative {
     ): Any?
 
     @JvmSynthetic
-    external fun verdictNew(id: Long, count: Long, total: Double, errorSink: Any): Verdict
+    external fun verdictNew(id: Long, count: Long, total: Double, build: Any, errorSink: Any): Any?
 
     @JvmSynthetic
     external fun wrappedFieldsSum(

--- a/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest.kt
+++ b/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest.kt
@@ -1815,6 +1815,9 @@ internal object CovNative {
     ): Any?
 
     @JvmSynthetic
+    external fun verdictEach(n: Long, total: Double, sink: Any, errorSink: Any)
+
+    @JvmSynthetic
     external fun verdictNew(id: Long, count: Long, total: Double, build: Any, errorSink: Any): Any?
 
     @JvmSynthetic

--- a/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest/model.kt
+++ b/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest/model.kt
@@ -1403,6 +1403,34 @@ internal fun ReportCallback.asRaw(): ReportCallbackRaw =
         }
     }
 
+public fun interface VerdictCallback {
+    public fun run(verdict: Verdict)
+}
+
+internal fun interface VerdictCallbackRaw {
+    public fun run(
+        id: Long,
+        outcome__tag: Int,
+        outcome__found_v0: Long,
+        outcome__failed_v0: String?,
+    )
+}
+
+@JvmSynthetic
+internal fun VerdictCallback.asRaw(): VerdictCallbackRaw =
+    VerdictCallbackRaw {
+        id,
+        outcome__tag,
+        outcome__found_v0,
+        outcome__failed_v0 ->
+        val __own0 = Verdict.fromParts(id, outcome__tag, outcome__found_v0, outcome__failed_v0)
+        try {
+            run(__own0)
+        } finally {
+            __own0.close()
+        }
+    }
+
 public fun interface ArraysBuilder<out R> {
     public fun run(
         bytes: ByteArray,
@@ -2230,6 +2258,26 @@ public fun verdictNew(
     val __ret = CovNative.verdictNew(id, count, total, __VerdictBuilderRaw, __bcap)
     if (__bcap.failed) return onError.run(__bcap.ze0)
     return __ret as Verdict
+}
+
+/**
+ * A `Verdict` — a `data_class` whose field is a **sum** — handed to a
+ * callback, which is the other half of what #602's coverage buys.
+ *
+ * A returned `Verdict` reaches its foreign builder through the return path;
+ * this one reaches the callback-interface path, whose reassembly asks a
+ * different question about the same leaves. Both must rebuild the value from
+ * its tag and groups rather than through a whole JVM object.
+ */
+public fun verdictEach(
+    n: Long,
+    total: Double,
+    sink: VerdictCallback,
+    onError: JniErrorHandler<Unit>,
+) {
+    val __bcap = JniErrorHandlerCapture.acquire()
+    CovNative.verdictEach(n, total, sink.asRaw(), __bcap)
+    if (__bcap.failed) return onError.run(__bcap.ze0)
 }
 
 /** Build a [`Dossier`] over a fresh [`Summary`] — the two-level container. */

--- a/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest/model.kt
+++ b/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest/model.kt
@@ -1570,6 +1570,14 @@ public fun interface StampBuilder<out R> {
 internal val __StampBuilder: StampBuilder<Stamp> =
 StampBuilder { secs, nanos -> Stamp.fromParts(secs, nanos) }
 
+public fun interface TaggedBuilder<out R> {
+    public fun run(id: Long, marker__tag: Int, marker__ranked_v0: Int): R
+}
+
+@get:JvmSynthetic
+internal val __TaggedBuilder: TaggedBuilder<Tagged> =
+TaggedBuilder { id, marker__tag, marker__ranked_v0 -> Tagged.fromParts(id, marker__tag, marker__ranked_v0) }
+
 internal fun interface UnsignedBuilderRaw<out R> {
     public fun run(byte: Int, short: Int, int: Long, long: Long, maybeLong: Long?): R
 }
@@ -1596,6 +1604,19 @@ internal fun <R> VaultHolderBuilder<R>.asRaw(): VaultHolderBuilderRaw<R> =
             vaultHolderVault__maybe?.let { if (it == 0L) null else Ingot.fromRawPtr(it) }
         )
     }
+
+internal fun interface VerdictBuilderRaw<out R> {
+    public fun run(
+        id: Long,
+        outcome__tag: Int,
+        outcome__found_v0: Long,
+        outcome__failed_v0: String?,
+    ): R
+}
+
+@get:JvmSynthetic
+internal val __VerdictBuilderRaw: VerdictBuilderRaw<Verdict> =
+VerdictBuilderRaw { id, outcome__tag, outcome__found_v0, outcome__failed_v0 -> Verdict.fromParts(id, outcome__tag, outcome__found_v0, outcome__failed_v0) }
 
 internal fun interface ReadingFolderRaw<A> {
     public fun run(
@@ -2022,12 +2043,17 @@ public fun observationWhich(o: Observation, onError: JniErrorHandler<Int>): Int 
     return __ret
 }
 
-/** Build a [`Tagged`]: `which` 0 = `None_`, 1 = `Ranked(None)`, 2 = `Ranked(Some(High))`. */
+/**
+ * Build a [`Tagged`]: `which` 0 = `None_`, 1 = `Ranked(None)`, 2 = `Ranked(Some(High))`.
+ *
+ * The Rust `Tagged` result is delivered decomposed: the builder callback receives (`id`, `marker__tag`, `marker__ranked_v0`).
+ */
+@Suppress("UNCHECKED_CAST")
 public fun taggedNew(which: Int, onError: JniErrorHandler<Tagged?>): Tagged? {
     val __bcap = JniErrorHandlerCapture.acquire()
-    val __ret = CovNative.taggedNew(which, __bcap)
+    val __ret = CovNative.taggedNew(which, __TaggedBuilder, __bcap)
     if (__bcap.failed) return onError.run(__bcap.ze0)
-    return __ret
+    return __ret as Tagged
 }
 
 /**
@@ -2188,7 +2214,12 @@ public fun ticksEmit(f: TicksCallback, onError: JniErrorHandler<Unit>) {
     if (__bcap.failed) return onError.run(__bcap.ze0)
 }
 
-/** Build a [`Verdict`] whose outcome comes from [`lookup_of`]. */
+/**
+ * Build a [`Verdict`] whose outcome comes from [`lookup_of`].
+ *
+ * The Rust `Verdict` result is delivered decomposed: the builder callback receives (`id`, `outcome__tag`, `outcome__found_v0`, `outcome__failed_v0`).
+ */
+@Suppress("UNCHECKED_CAST")
 public fun verdictNew(
     id: Long,
     count: Long,
@@ -2196,9 +2227,9 @@ public fun verdictNew(
     onError: JniErrorHandler<Verdict?>,
 ): Verdict? {
     val __bcap = JniErrorHandlerCapture.acquire()
-    val __ret = CovNative.verdictNew(id, count, total, __bcap)
+    val __ret = CovNative.verdictNew(id, count, total, __VerdictBuilderRaw, __bcap)
     if (__bcap.failed) return onError.run(__bcap.ze0)
-    return __ret
+    return __ret as Verdict
 }
 
 /** Build a [`Dossier`] over a fresh [`Summary`] — the two-level container. */

--- a/examples/covertest-kotlin/kotlin/io/prebindgen/covertest/Test.kt
+++ b/examples/covertest-kotlin/kotlin/io/prebindgen/covertest/Test.kt
@@ -101,6 +101,7 @@ import io.prebindgen.covertest.model.probeEach
 import io.prebindgen.covertest.model.probeNew
 import io.prebindgen.covertest.model.lookupOf
 import io.prebindgen.covertest.model.layeredOf
+import io.prebindgen.covertest.model.verdictEach
 import io.prebindgen.covertest.model.verdictNew
 import io.prebindgen.covertest.model.dossierNew
 import io.prebindgen.covertest.model.archiveReading
@@ -697,6 +698,42 @@ fun main() {
         val absent = verdictNew(8L, 0L, 0.0, boom).orThrow()
         check(absent.outcome === Lookup.Absent)
         absent.close()
+    }
+
+    // The same data class arriving at a CALLBACK rather than as a return.
+    //
+    // #602 taught the decomposition a sum-typed field, so `Verdict` crosses as
+    // its leaves — `id`, the outcome's tag, and one slot per alternative — on
+    // both paths. They are two different reassemblies of the same leaves: the
+    // return path builds through the class's own `fromParts`, and this one
+    // through the callback interface, whose derivation asked a different
+    // question about the tag and used to reject a struct that merely contains
+    // one (#616 review). Only a run proves both rebuild the same value.
+    section("a data class with a sum field arrives whole at a callback") {
+        val seen = mutableListOf<String>()
+        val escaped = mutableListOf<Summary>()
+        verdictEach(3L, 2.5, { verdict ->
+            seen.add("${verdict.id}:" + when (val o = verdict.outcome) {
+                is Lookup.Failed -> "failed:${o.v0}"
+                Lookup.Absent -> "absent"
+                is Lookup.Found -> {
+                    val s = o.v0
+                    check(!s.isClosed())
+                    escaped.add(s)
+                    "found:${s.count(boom)}"
+                }
+            })
+        }, boom).orThrow()
+
+        // One value per iteration, each rebuilt from the leaves: the id is the
+        // sibling field, and the outcome is the alternative its tag selected —
+        // all three alternatives, since `lookup_of(i - 1)` walks them.
+        check(seen == listOf("0:failed:negative count", "1:absent", "2:found:1")) { "got $seen" }
+
+        // The container is closed when `run` returns, and its cascade reaches
+        // the handle the sum holds — the same close-unless-taken contract a
+        // bare handle argument has.
+        check(escaped.all { it.isClosed() }) { "the cascade closed every payload" }
     }
 
     // The FOURTH position, and the row an emission test cannot cover: the field

--- a/examples/covertest-kotlin/src/generated_bindings.rs
+++ b/examples/covertest-kotlin/src/generated_bindings.rs
@@ -3676,15 +3676,15 @@ pub(crate) unsafe fn __jni_out_convert_HoldPolicy_to_wire_3068aef2f204dafc<'a>(
 ) -> ::core::result::Result<jni::objects::JObject<'a>, __JniErr> {
     Ok({
         let ___hold__tag: jni::sys::jint;
-        let ___hold_g0: jni::sys::jlong;
+        let ___hold_for_v0: jni::sys::jlong;
         match &v.hold {
             perftest_flat::Hold::Indefinite => {
                 ___hold__tag = 0;
-                ___hold_g0 = 0i64;
+                ___hold_for_v0 = 0i64;
             }
             perftest_flat::Hold::For(__s0_0) => {
-                let ___hold_for_v0: jni::sys::jlong = {
-                    let ___hold_for_v0_s0 = __jni_out_stage_0_Duration_to_wire_37da00112022eac0(
+                let ___hold_for_v0_xg: jni::sys::jlong = {
+                    let ___hold_for_v0_xg_s0 = __jni_out_stage_0_Duration_to_wire_37da00112022eac0(
                             env,
                             __s0_0.clone(),
                         )
@@ -3693,16 +3693,16 @@ pub(crate) unsafe fn __jni_out_convert_HoldPolicy_to_wire_3068aef2f204dafc<'a>(
                         >>::from(__e.to_string()))?;
                     __jni_out_convert_u64_to_wire_c9db59f6e5bef648(
                         env,
-                        ___hold_for_v0_s0,
+                        ___hold_for_v0_xg_s0,
                     )?
                 };
                 ___hold__tag = 1;
-                ___hold_g0 = ___hold_for_v0;
+                ___hold_for_v0 = ___hold_for_v0_xg;
             }
         }
         let ___grace_present: jni::sys::jboolean;
         let ___grace__tag: jni::sys::jint;
-        let ___grace_g0: jni::sys::jlong;
+        let ___grace_for_v0: jni::sys::jlong;
         let __oc0: &::core::option::Option<_> = &v.grace;
         match __oc0 {
             ::core::option::Option::Some(__o0) => {
@@ -3710,11 +3710,11 @@ pub(crate) unsafe fn __jni_out_convert_HoldPolicy_to_wire_3068aef2f204dafc<'a>(
                 match __o0 {
                     perftest_flat::Hold::Indefinite => {
                         ___grace__tag = 0;
-                        ___grace_g0 = 0i64;
+                        ___grace_for_v0 = 0i64;
                     }
                     perftest_flat::Hold::For(__s0_0) => {
-                        let ___grace_for_v0: jni::sys::jlong = {
-                            let ___grace_for_v0_s0 = __jni_out_stage_0_Duration_to_wire_37da00112022eac0(
+                        let ___grace_for_v0_xg: jni::sys::jlong = {
+                            let ___grace_for_v0_xg_s0 = __jni_out_stage_0_Duration_to_wire_37da00112022eac0(
                                     env,
                                     __s0_0.clone(),
                                 )
@@ -3723,18 +3723,18 @@ pub(crate) unsafe fn __jni_out_convert_HoldPolicy_to_wire_3068aef2f204dafc<'a>(
                                 >>::from(__e.to_string()))?;
                             __jni_out_convert_u64_to_wire_c9db59f6e5bef648(
                                 env,
-                                ___grace_for_v0_s0,
+                                ___grace_for_v0_xg_s0,
                             )?
                         };
                         ___grace__tag = 1;
-                        ___grace_g0 = ___grace_for_v0;
+                        ___grace_for_v0 = ___grace_for_v0_xg;
                     }
                 }
             }
             ::core::option::Option::None => {
                 ___grace_present = 0u8;
                 ___grace__tag = 0i32;
-                ___grace_g0 = 0i64;
+                ___grace_for_v0 = 0i64;
             }
         }
         let __obj = env
@@ -3744,10 +3744,10 @@ pub(crate) unsafe fn __jni_out_convert_HoldPolicy_to_wire_3068aef2f204dafc<'a>(
                 "(IJZIJ)Lio/prebindgen/covertest/model/HoldPolicy;",
                 &[
                     jni::objects::JValue::from(___hold__tag),
-                    jni::objects::JValue::from(___hold_g0),
+                    jni::objects::JValue::from(___hold_for_v0),
                     jni::objects::JValue::from(___grace_present),
                     jni::objects::JValue::from(___grace__tag),
-                    jni::objects::JValue::from(___grace_g0),
+                    jni::objects::JValue::from(___grace_for_v0),
                 ],
             )
             .and_then(|__v| __v.l())
@@ -7441,92 +7441,92 @@ pub(crate) unsafe fn __jni_out_convert_Observation_to_wire_d96ad3cc48a04f0a<'a>(
             v.id.clone(),
         )?;
         let ___reading__tag: jni::sys::jint;
-        let ___reading_g0: jni::sys::jlong;
-        let ___reading_g1: jni::sys::jlong;
-        let ___reading_g2: jni::sys::jlong;
-        let ___reading_g3: jni::objects::JObject;
-        let ___reading_g4: jni::sys::jint;
-        let ___reading_g5: jni::sys::jlong;
+        let ___reading_exact_v0: jni::sys::jlong;
+        let ___reading_range_low: jni::sys::jlong;
+        let ___reading_range_high: jni::sys::jlong;
+        let ___reading_tagged_v0: jni::objects::JObject;
+        let ___reading_tagged_v1: jni::sys::jint;
+        let ___reading_companion_v0: jni::sys::jlong;
         match &v.reading {
             perftest_flat::Reading::Missing => {
                 ___reading__tag = 0;
-                ___reading_g0 = 0i64;
-                ___reading_g1 = 0i64;
-                ___reading_g2 = 0i64;
-                ___reading_g3 = jni::objects::JObject::null();
-                ___reading_g4 = 0i32;
-                ___reading_g5 = 0i64;
+                ___reading_exact_v0 = 0i64;
+                ___reading_range_low = 0i64;
+                ___reading_range_high = 0i64;
+                ___reading_tagged_v0 = jni::objects::JObject::null();
+                ___reading_tagged_v1 = 0i32;
+                ___reading_companion_v0 = 0i64;
             }
             perftest_flat::Reading::Exact(__s0_0) => {
-                let ___reading_exact_v0: jni::sys::jlong = __jni_out_convert_i64_to_wire_15d458bf28dc9c80(
+                let ___reading_exact_v0_xg: jni::sys::jlong = __jni_out_convert_i64_to_wire_15d458bf28dc9c80(
                     env,
                     __s0_0.clone(),
                 )?;
                 ___reading__tag = 1;
-                ___reading_g0 = ___reading_exact_v0;
-                ___reading_g1 = 0i64;
-                ___reading_g2 = 0i64;
-                ___reading_g3 = jni::objects::JObject::null();
-                ___reading_g4 = 0i32;
-                ___reading_g5 = 0i64;
+                ___reading_exact_v0 = ___reading_exact_v0_xg;
+                ___reading_range_low = 0i64;
+                ___reading_range_high = 0i64;
+                ___reading_tagged_v0 = jni::objects::JObject::null();
+                ___reading_tagged_v1 = 0i32;
+                ___reading_companion_v0 = 0i64;
             }
             perftest_flat::Reading::Range { low: __s0_0, high: __s0_1 } => {
-                let ___reading_range_low: jni::sys::jlong = __jni_out_convert_i64_to_wire_15d458bf28dc9c80(
+                let ___reading_range_low_xg: jni::sys::jlong = __jni_out_convert_i64_to_wire_15d458bf28dc9c80(
                     env,
                     __s0_0.clone(),
                 )?;
-                let ___reading_range_high: jni::sys::jlong = __jni_out_convert_i64_to_wire_15d458bf28dc9c80(
+                let ___reading_range_high_xg: jni::sys::jlong = __jni_out_convert_i64_to_wire_15d458bf28dc9c80(
                     env,
                     __s0_1.clone(),
                 )?;
                 ___reading__tag = 2;
-                ___reading_g1 = ___reading_range_low;
-                ___reading_g2 = ___reading_range_high;
-                ___reading_g0 = 0i64;
-                ___reading_g3 = jni::objects::JObject::null();
-                ___reading_g4 = 0i32;
-                ___reading_g5 = 0i64;
+                ___reading_range_low = ___reading_range_low_xg;
+                ___reading_range_high = ___reading_range_high_xg;
+                ___reading_exact_v0 = 0i64;
+                ___reading_tagged_v0 = jni::objects::JObject::null();
+                ___reading_tagged_v1 = 0i32;
+                ___reading_companion_v0 = 0i64;
             }
             perftest_flat::Reading::Labeled(__s0_0, __s0_1) => {
-                let ___reading_tagged_v0: jni::objects::JObject = __jni_out_convert_jni_text_codec_owned_to_wire_1b6cdff0ec9adbcb(
+                let ___reading_tagged_v0_xg: jni::objects::JObject = __jni_out_convert_jni_text_codec_owned_to_wire_1b6cdff0ec9adbcb(
                         env,
                         __s0_0.clone(),
                     )?
                     .into();
-                let ___reading_tagged_v1: jni::sys::jint = __jni_out_convert_Priority_to_wire_55b65fa623d4787e(
+                let ___reading_tagged_v1_xg: jni::sys::jint = __jni_out_convert_Priority_to_wire_55b65fa623d4787e(
                     env,
                     __s0_1.clone(),
                 )?;
                 ___reading__tag = 3;
-                ___reading_g3 = ___reading_tagged_v0;
-                ___reading_g4 = ___reading_tagged_v1;
-                ___reading_g0 = 0i64;
-                ___reading_g1 = 0i64;
-                ___reading_g2 = 0i64;
-                ___reading_g5 = 0i64;
+                ___reading_tagged_v0 = ___reading_tagged_v0_xg;
+                ___reading_tagged_v1 = ___reading_tagged_v1_xg;
+                ___reading_exact_v0 = 0i64;
+                ___reading_range_low = 0i64;
+                ___reading_range_high = 0i64;
+                ___reading_companion_v0 = 0i64;
             }
             perftest_flat::Reading::Companion(__s0_0) => {
-                let ___reading_companion_v0: jni::sys::jlong = __jni_out_convert_i64_to_wire_15d458bf28dc9c80(
+                let ___reading_companion_v0_xg: jni::sys::jlong = __jni_out_convert_i64_to_wire_15d458bf28dc9c80(
                     env,
                     __s0_0.clone(),
                 )?;
                 ___reading__tag = 4;
-                ___reading_g5 = ___reading_companion_v0;
-                ___reading_g0 = 0i64;
-                ___reading_g1 = 0i64;
-                ___reading_g2 = 0i64;
-                ___reading_g3 = jni::objects::JObject::null();
-                ___reading_g4 = 0i32;
+                ___reading_companion_v0 = ___reading_companion_v0_xg;
+                ___reading_exact_v0 = 0i64;
+                ___reading_range_low = 0i64;
+                ___reading_range_high = 0i64;
+                ___reading_tagged_v0 = jni::objects::JObject::null();
+                ___reading_tagged_v1 = 0i32;
             }
         }
         let ___fallback_present: jni::sys::jboolean;
         let ___fallback__tag: jni::sys::jint;
-        let ___fallback_g0: jni::sys::jlong;
-        let ___fallback_g1: jni::sys::jlong;
-        let ___fallback_g2: jni::sys::jlong;
-        let ___fallback_g3: jni::objects::JObject;
-        let ___fallback_g4: jni::sys::jint;
-        let ___fallback_g5: jni::sys::jlong;
+        let ___fallback_exact_v0: jni::sys::jlong;
+        let ___fallback_range_low: jni::sys::jlong;
+        let ___fallback_range_high: jni::sys::jlong;
+        let ___fallback_tagged_v0: jni::objects::JObject;
+        let ___fallback_tagged_v1: jni::sys::jint;
+        let ___fallback_companion_v0: jni::sys::jlong;
         let __oc0: &::core::option::Option<_> = &v.fallback;
         match __oc0 {
             ::core::option::Option::Some(__o0) => {
@@ -7534,85 +7534,85 @@ pub(crate) unsafe fn __jni_out_convert_Observation_to_wire_d96ad3cc48a04f0a<'a>(
                 match __o0 {
                     perftest_flat::Reading::Missing => {
                         ___fallback__tag = 0;
-                        ___fallback_g0 = 0i64;
-                        ___fallback_g1 = 0i64;
-                        ___fallback_g2 = 0i64;
-                        ___fallback_g3 = jni::objects::JObject::null();
-                        ___fallback_g4 = 0i32;
-                        ___fallback_g5 = 0i64;
+                        ___fallback_exact_v0 = 0i64;
+                        ___fallback_range_low = 0i64;
+                        ___fallback_range_high = 0i64;
+                        ___fallback_tagged_v0 = jni::objects::JObject::null();
+                        ___fallback_tagged_v1 = 0i32;
+                        ___fallback_companion_v0 = 0i64;
                     }
                     perftest_flat::Reading::Exact(__s0_0) => {
-                        let ___fallback_exact_v0: jni::sys::jlong = __jni_out_convert_i64_to_wire_15d458bf28dc9c80(
+                        let ___fallback_exact_v0_xg: jni::sys::jlong = __jni_out_convert_i64_to_wire_15d458bf28dc9c80(
                             env,
                             __s0_0.clone(),
                         )?;
                         ___fallback__tag = 1;
-                        ___fallback_g0 = ___fallback_exact_v0;
-                        ___fallback_g1 = 0i64;
-                        ___fallback_g2 = 0i64;
-                        ___fallback_g3 = jni::objects::JObject::null();
-                        ___fallback_g4 = 0i32;
-                        ___fallback_g5 = 0i64;
+                        ___fallback_exact_v0 = ___fallback_exact_v0_xg;
+                        ___fallback_range_low = 0i64;
+                        ___fallback_range_high = 0i64;
+                        ___fallback_tagged_v0 = jni::objects::JObject::null();
+                        ___fallback_tagged_v1 = 0i32;
+                        ___fallback_companion_v0 = 0i64;
                     }
                     perftest_flat::Reading::Range { low: __s0_0, high: __s0_1 } => {
-                        let ___fallback_range_low: jni::sys::jlong = __jni_out_convert_i64_to_wire_15d458bf28dc9c80(
+                        let ___fallback_range_low_xg: jni::sys::jlong = __jni_out_convert_i64_to_wire_15d458bf28dc9c80(
                             env,
                             __s0_0.clone(),
                         )?;
-                        let ___fallback_range_high: jni::sys::jlong = __jni_out_convert_i64_to_wire_15d458bf28dc9c80(
+                        let ___fallback_range_high_xg: jni::sys::jlong = __jni_out_convert_i64_to_wire_15d458bf28dc9c80(
                             env,
                             __s0_1.clone(),
                         )?;
                         ___fallback__tag = 2;
-                        ___fallback_g1 = ___fallback_range_low;
-                        ___fallback_g2 = ___fallback_range_high;
-                        ___fallback_g0 = 0i64;
-                        ___fallback_g3 = jni::objects::JObject::null();
-                        ___fallback_g4 = 0i32;
-                        ___fallback_g5 = 0i64;
+                        ___fallback_range_low = ___fallback_range_low_xg;
+                        ___fallback_range_high = ___fallback_range_high_xg;
+                        ___fallback_exact_v0 = 0i64;
+                        ___fallback_tagged_v0 = jni::objects::JObject::null();
+                        ___fallback_tagged_v1 = 0i32;
+                        ___fallback_companion_v0 = 0i64;
                     }
                     perftest_flat::Reading::Labeled(__s0_0, __s0_1) => {
-                        let ___fallback_tagged_v0: jni::objects::JObject = __jni_out_convert_jni_text_codec_owned_to_wire_1b6cdff0ec9adbcb(
+                        let ___fallback_tagged_v0_xg: jni::objects::JObject = __jni_out_convert_jni_text_codec_owned_to_wire_1b6cdff0ec9adbcb(
                                 env,
                                 __s0_0.clone(),
                             )?
                             .into();
-                        let ___fallback_tagged_v1: jni::sys::jint = __jni_out_convert_Priority_to_wire_55b65fa623d4787e(
+                        let ___fallback_tagged_v1_xg: jni::sys::jint = __jni_out_convert_Priority_to_wire_55b65fa623d4787e(
                             env,
                             __s0_1.clone(),
                         )?;
                         ___fallback__tag = 3;
-                        ___fallback_g3 = ___fallback_tagged_v0;
-                        ___fallback_g4 = ___fallback_tagged_v1;
-                        ___fallback_g0 = 0i64;
-                        ___fallback_g1 = 0i64;
-                        ___fallback_g2 = 0i64;
-                        ___fallback_g5 = 0i64;
+                        ___fallback_tagged_v0 = ___fallback_tagged_v0_xg;
+                        ___fallback_tagged_v1 = ___fallback_tagged_v1_xg;
+                        ___fallback_exact_v0 = 0i64;
+                        ___fallback_range_low = 0i64;
+                        ___fallback_range_high = 0i64;
+                        ___fallback_companion_v0 = 0i64;
                     }
                     perftest_flat::Reading::Companion(__s0_0) => {
-                        let ___fallback_companion_v0: jni::sys::jlong = __jni_out_convert_i64_to_wire_15d458bf28dc9c80(
+                        let ___fallback_companion_v0_xg: jni::sys::jlong = __jni_out_convert_i64_to_wire_15d458bf28dc9c80(
                             env,
                             __s0_0.clone(),
                         )?;
                         ___fallback__tag = 4;
-                        ___fallback_g5 = ___fallback_companion_v0;
-                        ___fallback_g0 = 0i64;
-                        ___fallback_g1 = 0i64;
-                        ___fallback_g2 = 0i64;
-                        ___fallback_g3 = jni::objects::JObject::null();
-                        ___fallback_g4 = 0i32;
+                        ___fallback_companion_v0 = ___fallback_companion_v0_xg;
+                        ___fallback_exact_v0 = 0i64;
+                        ___fallback_range_low = 0i64;
+                        ___fallback_range_high = 0i64;
+                        ___fallback_tagged_v0 = jni::objects::JObject::null();
+                        ___fallback_tagged_v1 = 0i32;
                     }
                 }
             }
             ::core::option::Option::None => {
                 ___fallback_present = 0u8;
                 ___fallback__tag = 0i32;
-                ___fallback_g0 = 0i64;
-                ___fallback_g1 = 0i64;
-                ___fallback_g2 = 0i64;
-                ___fallback_g3 = jni::objects::JObject::null();
-                ___fallback_g4 = 0i32;
-                ___fallback_g5 = 0i64;
+                ___fallback_exact_v0 = 0i64;
+                ___fallback_range_low = 0i64;
+                ___fallback_range_high = 0i64;
+                ___fallback_tagged_v0 = jni::objects::JObject::null();
+                ___fallback_tagged_v1 = 0i32;
+                ___fallback_companion_v0 = 0i64;
             }
         }
         let ___note: jni::objects::JObject = __jni_out_convert_jni_text_codec_owned_to_wire_1b6cdff0ec9adbcb(
@@ -7628,20 +7628,20 @@ pub(crate) unsafe fn __jni_out_convert_Observation_to_wire_d96ad3cc48a04f0a<'a>(
                 &[
                     jni::objects::JValue::from(___id),
                     jni::objects::JValue::from(___reading__tag),
-                    jni::objects::JValue::from(___reading_g0),
-                    jni::objects::JValue::from(___reading_g1),
-                    jni::objects::JValue::from(___reading_g2),
-                    jni::objects::JValue::Object(&___reading_g3),
-                    jni::objects::JValue::from(___reading_g4),
-                    jni::objects::JValue::from(___reading_g5),
+                    jni::objects::JValue::from(___reading_exact_v0),
+                    jni::objects::JValue::from(___reading_range_low),
+                    jni::objects::JValue::from(___reading_range_high),
+                    jni::objects::JValue::Object(&___reading_tagged_v0),
+                    jni::objects::JValue::from(___reading_tagged_v1),
+                    jni::objects::JValue::from(___reading_companion_v0),
                     jni::objects::JValue::from(___fallback_present),
                     jni::objects::JValue::from(___fallback__tag),
-                    jni::objects::JValue::from(___fallback_g0),
-                    jni::objects::JValue::from(___fallback_g1),
-                    jni::objects::JValue::from(___fallback_g2),
-                    jni::objects::JValue::Object(&___fallback_g3),
-                    jni::objects::JValue::from(___fallback_g4),
-                    jni::objects::JValue::from(___fallback_g5),
+                    jni::objects::JValue::from(___fallback_exact_v0),
+                    jni::objects::JValue::from(___fallback_range_low),
+                    jni::objects::JValue::from(___fallback_range_high),
+                    jni::objects::JValue::Object(&___fallback_tagged_v0),
+                    jni::objects::JValue::from(___fallback_tagged_v1),
+                    jni::objects::JValue::from(___fallback_companion_v0),
                     jni::objects::JValue::Object(&___note),
                 ],
             )
@@ -10348,6 +10348,37 @@ pub(crate) unsafe fn __jni_in_convert_wire_to_Tagged_279b04b60843d675<'env, 'v>(
     clippy::nonminimal_bool,
     clippy::eq_op
 )]
+#[inline(always)]
+pub(crate) unsafe fn __jni_out_convert_Tagged_jni_product_intermediate_tuple_to_wire_69425de72da0b919<
+    'a,
+>(
+    env: &mut jni::JNIEnv<'a>,
+    v: perftest_flat::Tagged,
+) -> ::core::result::Result<
+    (jni::sys::jlong, (jni::sys::jint, (), (jni::sys::jint,))),
+    __JniErr,
+> {
+    ::core::result::Result::Ok((
+        __jni_out_convert_i64_to_wire_15d458bf28dc9c80(env, v.id)?,
+        __jni_out_convert_Marker_jni_choice_intermediate_tagged_tuple_to_wire_ded71b6862a11416(
+            env,
+            v.marker,
+        )?,
+    ))
+}
+#[allow(
+    non_snake_case,
+    unused_mut,
+    unused_variables,
+    unused_braces,
+    unused_parens,
+    dead_code,
+    clippy::useless_conversion,
+    clippy::needless_question_mark,
+    clippy::let_and_return,
+    clippy::nonminimal_bool,
+    clippy::eq_op
+)]
 pub(crate) unsafe fn __jni_out_convert_Tagged_to_wire_b6acfb4fd9df43fa<'a>(
     env: &mut jni::JNIEnv<'a>,
     v: perftest_flat::Tagged,
@@ -10358,19 +10389,19 @@ pub(crate) unsafe fn __jni_out_convert_Tagged_to_wire_b6acfb4fd9df43fa<'a>(
             v.id.clone(),
         )?;
         let ___marker__tag: jni::sys::jint;
-        let ___marker_g0: jni::sys::jint;
+        let ___marker_ranked_v0: jni::sys::jint;
         match &v.marker {
             perftest_flat::Marker::None_ => {
                 ___marker__tag = 0;
-                ___marker_g0 = 0i32;
+                ___marker_ranked_v0 = 0i32;
             }
             perftest_flat::Marker::Ranked(__s0_0) => {
-                let ___marker_ranked_v0: jni::sys::jint = __jni_out_convert_Option_Priority_jni_optional_intermediate_output_niche_to_wire_f8a537414a30bc3f(
+                let ___marker_ranked_v0_xg: jni::sys::jint = __jni_out_convert_Option_Priority_jni_optional_intermediate_output_niche_to_wire_f8a537414a30bc3f(
                     env,
                     __s0_0.clone(),
                 )?;
                 ___marker__tag = 1;
-                ___marker_g0 = ___marker_ranked_v0;
+                ___marker_ranked_v0 = ___marker_ranked_v0_xg;
             }
         }
         let __obj = env
@@ -10381,7 +10412,7 @@ pub(crate) unsafe fn __jni_out_convert_Tagged_to_wire_b6acfb4fd9df43fa<'a>(
                 &[
                     jni::objects::JValue::from(___id),
                     jni::objects::JValue::from(___marker__tag),
-                    jni::objects::JValue::from(___marker_g0),
+                    jni::objects::JValue::from(___marker_ranked_v0),
                 ],
             )
             .and_then(|__v| __v.l())
@@ -10917,6 +10948,40 @@ pub(crate) unsafe fn __jni_in_convert_wire_to_Verdict_21661560f50a2bdb<'env, 'v>
     clippy::nonminimal_bool,
     clippy::eq_op
 )]
+#[inline(always)]
+pub(crate) unsafe fn __jni_out_convert_Verdict_jni_product_intermediate_tuple_to_wire_c931393a6622afaa<
+    'a,
+>(
+    env: &mut jni::JNIEnv<'a>,
+    v: perftest_flat::Verdict,
+) -> ::core::result::Result<
+    (
+        jni::sys::jlong,
+        (jni::sys::jint, (), (jni::sys::jlong,), (jni::objects::JString<'a>,)),
+    ),
+    __JniErr,
+> {
+    ::core::result::Result::Ok((
+        __jni_out_convert_i64_to_wire_15d458bf28dc9c80(env, v.id)?,
+        __jni_out_convert_Lookup_jni_choice_intermediate_tagged_tuple_to_wire_84cb04db62f15f7a(
+            env,
+            v.outcome,
+        )?,
+    ))
+}
+#[allow(
+    non_snake_case,
+    unused_mut,
+    unused_variables,
+    unused_braces,
+    unused_parens,
+    dead_code,
+    clippy::useless_conversion,
+    clippy::needless_question_mark,
+    clippy::let_and_return,
+    clippy::nonminimal_bool,
+    clippy::eq_op
+)]
 pub(crate) unsafe fn __jni_out_convert_Verdict_to_wire_26a1dc521db8a9ae<'a>(
     env: &mut jni::JNIEnv<'a>,
     v: perftest_flat::Verdict,
@@ -10927,32 +10992,32 @@ pub(crate) unsafe fn __jni_out_convert_Verdict_to_wire_26a1dc521db8a9ae<'a>(
             v.id.clone(),
         )?;
         let ___outcome__tag: jni::sys::jint;
-        let ___outcome_g0: jni::sys::jlong;
-        let ___outcome_g1: jni::objects::JObject;
+        let ___outcome_found_v0: jni::sys::jlong;
+        let ___outcome_failed_v0: jni::objects::JObject;
         match &v.outcome {
             perftest_flat::Lookup::Absent => {
                 ___outcome__tag = 0;
-                ___outcome_g0 = 0i64;
-                ___outcome_g1 = jni::objects::JObject::null();
+                ___outcome_found_v0 = 0i64;
+                ___outcome_failed_v0 = jni::objects::JObject::null();
             }
             perftest_flat::Lookup::Found(__s0_0) => {
-                let ___outcome_found_v0: jni::sys::jlong = __jni_out_convert_Summary_jni_handle_codec_own_output_to_wire_236099c944f0abfc(
+                let ___outcome_found_v0_xg: jni::sys::jlong = __jni_out_convert_Summary_jni_handle_codec_own_output_to_wire_236099c944f0abfc(
                     env,
                     __s0_0.clone(),
                 )?;
                 ___outcome__tag = 1;
-                ___outcome_g0 = ___outcome_found_v0;
-                ___outcome_g1 = jni::objects::JObject::null();
+                ___outcome_found_v0 = ___outcome_found_v0_xg;
+                ___outcome_failed_v0 = jni::objects::JObject::null();
             }
             perftest_flat::Lookup::Failed(__s0_0) => {
-                let ___outcome_failed_v0: jni::objects::JObject = __jni_out_convert_jni_text_codec_owned_to_wire_1b6cdff0ec9adbcb(
+                let ___outcome_failed_v0_xg: jni::objects::JObject = __jni_out_convert_jni_text_codec_owned_to_wire_1b6cdff0ec9adbcb(
                         env,
                         __s0_0.clone(),
                     )?
                     .into();
                 ___outcome__tag = 2;
-                ___outcome_g1 = ___outcome_failed_v0;
-                ___outcome_g0 = 0i64;
+                ___outcome_failed_v0 = ___outcome_failed_v0_xg;
+                ___outcome_found_v0 = 0i64;
             }
         }
         let __obj = env
@@ -10963,8 +11028,8 @@ pub(crate) unsafe fn __jni_out_convert_Verdict_to_wire_26a1dc521db8a9ae<'a>(
                 &[
                     jni::objects::JValue::from(___id),
                     jni::objects::JValue::from(___outcome__tag),
-                    jni::objects::JValue::from(___outcome_g0),
-                    jni::objects::JValue::Object(&___outcome_g1),
+                    jni::objects::JValue::from(___outcome_found_v0),
+                    jni::objects::JValue::Object(&___outcome_failed_v0),
                 ],
             )
             .and_then(|__v| __v.l())
@@ -25473,6 +25538,7 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_taggedNew<'a>(
     mut env: jni::JNIEnv<'a>,
     _class: jni::objects::JClass<'a>,
     which: jni::sys::jint,
+    __builder: jni::objects::JObject<'a>,
     __error_sink: jni::objects::JObject<'a>,
 ) -> jni::objects::JObject<'a> {
     #[allow(non_upper_case_globals)]
@@ -25493,17 +25559,60 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_taggedNew<'a>(
             return jni::objects::JObject::null().into();
         }
     };
+    #[allow(non_upper_case_globals)]
+    static __CB_MID: ::prebindgen_jni_runtime::CachedIfaceMethod = ::prebindgen_jni_runtime::CachedIfaceMethod::new();
+    const __CB_FQN: &str = "io/prebindgen/covertest/model/TaggedBuilder";
+    const __CB_DESCR: &str = "(JII)Ljava/lang/Object;";
     let __out = perftest_flat::tagged_new(which);
-    match __jni_out_convert_Tagged_to_wire_b6acfb4fd9df43fa(&mut env, __out) {
-        ::core::result::Result::Ok(__w) => __w,
-        ::core::result::Result::Err(__e) => {
+    let (__chain_wire0, (__chain_wire1, (), (__chain_wire2,))) = match __jni_out_convert_Tagged_jni_product_intermediate_tuple_to_wire_69425de72da0b919(
+        &mut env,
+        __out,
+    ) {
+        ::core::result::Result::Ok(__intermediate) => __intermediate,
+        ::core::result::Result::Err(__chain_error) => {
             signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                &__e.to_string(),
+                &__chain_error.to_string(),
+            );
+            return jni::objects::JObject::null().into();
+        }
+    };
+    let __obj0 = jni::sys::jvalue {
+        j: __chain_wire0,
+    };
+    let __obj1 = jni::sys::jvalue {
+        i: __chain_wire1,
+    };
+    let __obj2 = jni::sys::jvalue {
+        i: __chain_wire2,
+    };
+    match __CB_MID
+        .call_object(
+            &mut env,
+            __CB_FQN,
+            "run",
+            __CB_DESCR,
+            &__builder,
+            &[__obj0, __obj1, __obj2],
+        )
+    {
+        ::core::result::Result::Ok(__o) => __o,
+        ::core::result::Result::Err(__e) => {
+            let _ = env.exception_describe();
+            let __e2 = <__JniErr as ::core::convert::From<
+                String,
+            >>::from(__e.to_string());
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e2.to_string(),
             );
             jni::objects::JObject::null().into()
         }
@@ -26185,6 +26294,7 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_verdictNew<'a>(
     id: jni::sys::jlong,
     count: jni::sys::jlong,
     total: jni::sys::jdouble,
+    __builder: jni::objects::JObject<'a>,
     __error_sink: jni::objects::JObject<'a>,
 ) -> jni::objects::JObject<'a> {
     #[allow(non_upper_case_globals)]
@@ -26233,17 +26343,68 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_verdictNew<'a>(
             return jni::objects::JObject::null().into();
         }
     };
+    #[allow(non_upper_case_globals)]
+    static __CB_MID: ::prebindgen_jni_runtime::CachedIfaceMethod = ::prebindgen_jni_runtime::CachedIfaceMethod::new();
+    const __CB_FQN: &str = "io/prebindgen/covertest/model/VerdictBuilderRaw";
+    const __CB_DESCR: &str = "(JIJLjava/lang/String;)Ljava/lang/Object;";
     let __out = perftest_flat::verdict_new(id, count, total);
-    match __jni_out_convert_Verdict_to_wire_26a1dc521db8a9ae(&mut env, __out) {
-        ::core::result::Result::Ok(__w) => __w,
-        ::core::result::Result::Err(__e) => {
+    let (__chain_wire0, (__chain_wire1, (), (__chain_wire2,), (__chain_wire3,))) = match __jni_out_convert_Verdict_jni_product_intermediate_tuple_to_wire_c931393a6622afaa(
+        &mut env,
+        __out,
+    ) {
+        ::core::result::Result::Ok(__intermediate) => __intermediate,
+        ::core::result::Result::Err(__chain_error) => {
             signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                &__e.to_string(),
+                &__chain_error.to_string(),
+            );
+            return jni::objects::JObject::null().into();
+        }
+    };
+    let __obj0 = jni::sys::jvalue {
+        j: __chain_wire0,
+    };
+    let __obj1 = jni::sys::jvalue {
+        i: __chain_wire1,
+    };
+    let __obj2 = jni::sys::jvalue {
+        j: __chain_wire2,
+    };
+    let __obj3: jni::objects::JObject = __chain_wire3.into();
+    match __CB_MID
+        .call_object(
+            &mut env,
+            __CB_FQN,
+            "run",
+            __CB_DESCR,
+            &__builder,
+            &[
+                __obj0,
+                __obj1,
+                __obj2,
+                jni::sys::jvalue {
+                    l: __obj3.as_raw(),
+                },
+            ],
+        )
+    {
+        ::core::result::Result::Ok(__o) => __o,
+        ::core::result::Result::Err(__e) => {
+            let _ = env.exception_describe();
+            let __e2 = <__JniErr as ::core::convert::From<
+                String,
+            >>::from(__e.to_string());
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e2.to_string(),
             );
             jni::objects::JObject::null().into()
         }

--- a/examples/covertest-kotlin/src/generated_bindings.rs
+++ b/examples/covertest-kotlin/src/generated_bindings.rs
@@ -3683,8 +3683,8 @@ pub(crate) unsafe fn __jni_out_convert_HoldPolicy_to_wire_3068aef2f204dafc<'a>(
                 ___hold_for_v0 = 0i64;
             }
             perftest_flat::Hold::For(__s0_0) => {
-                let ___hold_for_v0_xg: jni::sys::jlong = {
-                    let ___hold_for_v0_xg_s0 = __jni_out_stage_0_Duration_to_wire_37da00112022eac0(
+                let __arm1__hold_for_v0: jni::sys::jlong = {
+                    let __arm1__hold_for_v0_s0 = __jni_out_stage_0_Duration_to_wire_37da00112022eac0(
                             env,
                             __s0_0.clone(),
                         )
@@ -3693,11 +3693,11 @@ pub(crate) unsafe fn __jni_out_convert_HoldPolicy_to_wire_3068aef2f204dafc<'a>(
                         >>::from(__e.to_string()))?;
                     __jni_out_convert_u64_to_wire_c9db59f6e5bef648(
                         env,
-                        ___hold_for_v0_xg_s0,
+                        __arm1__hold_for_v0_s0,
                     )?
                 };
                 ___hold__tag = 1;
-                ___hold_for_v0 = ___hold_for_v0_xg;
+                ___hold_for_v0 = __arm1__hold_for_v0;
             }
         }
         let ___grace_present: jni::sys::jboolean;
@@ -3713,8 +3713,8 @@ pub(crate) unsafe fn __jni_out_convert_HoldPolicy_to_wire_3068aef2f204dafc<'a>(
                         ___grace_for_v0 = 0i64;
                     }
                     perftest_flat::Hold::For(__s0_0) => {
-                        let ___grace_for_v0_xg: jni::sys::jlong = {
-                            let ___grace_for_v0_xg_s0 = __jni_out_stage_0_Duration_to_wire_37da00112022eac0(
+                        let __arm1__grace_for_v0: jni::sys::jlong = {
+                            let __arm1__grace_for_v0_s0 = __jni_out_stage_0_Duration_to_wire_37da00112022eac0(
                                     env,
                                     __s0_0.clone(),
                                 )
@@ -3723,11 +3723,11 @@ pub(crate) unsafe fn __jni_out_convert_HoldPolicy_to_wire_3068aef2f204dafc<'a>(
                                 >>::from(__e.to_string()))?;
                             __jni_out_convert_u64_to_wire_c9db59f6e5bef648(
                                 env,
-                                ___grace_for_v0_xg_s0,
+                                __arm1__grace_for_v0_s0,
                             )?
                         };
                         ___grace__tag = 1;
-                        ___grace_for_v0 = ___grace_for_v0_xg;
+                        ___grace_for_v0 = __arm1__grace_for_v0;
                     }
                 }
             }
@@ -7458,12 +7458,12 @@ pub(crate) unsafe fn __jni_out_convert_Observation_to_wire_d96ad3cc48a04f0a<'a>(
                 ___reading_companion_v0 = 0i64;
             }
             perftest_flat::Reading::Exact(__s0_0) => {
-                let ___reading_exact_v0_xg: jni::sys::jlong = __jni_out_convert_i64_to_wire_15d458bf28dc9c80(
+                let __arm1__reading_exact_v0: jni::sys::jlong = __jni_out_convert_i64_to_wire_15d458bf28dc9c80(
                     env,
                     __s0_0.clone(),
                 )?;
                 ___reading__tag = 1;
-                ___reading_exact_v0 = ___reading_exact_v0_xg;
+                ___reading_exact_v0 = __arm1__reading_exact_v0;
                 ___reading_range_low = 0i64;
                 ___reading_range_high = 0i64;
                 ___reading_tagged_v0 = jni::objects::JObject::null();
@@ -7471,47 +7471,47 @@ pub(crate) unsafe fn __jni_out_convert_Observation_to_wire_d96ad3cc48a04f0a<'a>(
                 ___reading_companion_v0 = 0i64;
             }
             perftest_flat::Reading::Range { low: __s0_0, high: __s0_1 } => {
-                let ___reading_range_low_xg: jni::sys::jlong = __jni_out_convert_i64_to_wire_15d458bf28dc9c80(
+                let __arm2__reading_range_low: jni::sys::jlong = __jni_out_convert_i64_to_wire_15d458bf28dc9c80(
                     env,
                     __s0_0.clone(),
                 )?;
-                let ___reading_range_high_xg: jni::sys::jlong = __jni_out_convert_i64_to_wire_15d458bf28dc9c80(
+                let __arm2__reading_range_high: jni::sys::jlong = __jni_out_convert_i64_to_wire_15d458bf28dc9c80(
                     env,
                     __s0_1.clone(),
                 )?;
                 ___reading__tag = 2;
-                ___reading_range_low = ___reading_range_low_xg;
-                ___reading_range_high = ___reading_range_high_xg;
+                ___reading_range_low = __arm2__reading_range_low;
+                ___reading_range_high = __arm2__reading_range_high;
                 ___reading_exact_v0 = 0i64;
                 ___reading_tagged_v0 = jni::objects::JObject::null();
                 ___reading_tagged_v1 = 0i32;
                 ___reading_companion_v0 = 0i64;
             }
             perftest_flat::Reading::Labeled(__s0_0, __s0_1) => {
-                let ___reading_tagged_v0_xg: jni::objects::JObject = __jni_out_convert_jni_text_codec_owned_to_wire_1b6cdff0ec9adbcb(
+                let __arm3__reading_tagged_v0: jni::objects::JObject = __jni_out_convert_jni_text_codec_owned_to_wire_1b6cdff0ec9adbcb(
                         env,
                         __s0_0.clone(),
                     )?
                     .into();
-                let ___reading_tagged_v1_xg: jni::sys::jint = __jni_out_convert_Priority_to_wire_55b65fa623d4787e(
+                let __arm3__reading_tagged_v1: jni::sys::jint = __jni_out_convert_Priority_to_wire_55b65fa623d4787e(
                     env,
                     __s0_1.clone(),
                 )?;
                 ___reading__tag = 3;
-                ___reading_tagged_v0 = ___reading_tagged_v0_xg;
-                ___reading_tagged_v1 = ___reading_tagged_v1_xg;
+                ___reading_tagged_v0 = __arm3__reading_tagged_v0;
+                ___reading_tagged_v1 = __arm3__reading_tagged_v1;
                 ___reading_exact_v0 = 0i64;
                 ___reading_range_low = 0i64;
                 ___reading_range_high = 0i64;
                 ___reading_companion_v0 = 0i64;
             }
             perftest_flat::Reading::Companion(__s0_0) => {
-                let ___reading_companion_v0_xg: jni::sys::jlong = __jni_out_convert_i64_to_wire_15d458bf28dc9c80(
+                let __arm4__reading_companion_v0: jni::sys::jlong = __jni_out_convert_i64_to_wire_15d458bf28dc9c80(
                     env,
                     __s0_0.clone(),
                 )?;
                 ___reading__tag = 4;
-                ___reading_companion_v0 = ___reading_companion_v0_xg;
+                ___reading_companion_v0 = __arm4__reading_companion_v0;
                 ___reading_exact_v0 = 0i64;
                 ___reading_range_low = 0i64;
                 ___reading_range_high = 0i64;
@@ -7542,12 +7542,12 @@ pub(crate) unsafe fn __jni_out_convert_Observation_to_wire_d96ad3cc48a04f0a<'a>(
                         ___fallback_companion_v0 = 0i64;
                     }
                     perftest_flat::Reading::Exact(__s0_0) => {
-                        let ___fallback_exact_v0_xg: jni::sys::jlong = __jni_out_convert_i64_to_wire_15d458bf28dc9c80(
+                        let __arm1__fallback_exact_v0: jni::sys::jlong = __jni_out_convert_i64_to_wire_15d458bf28dc9c80(
                             env,
                             __s0_0.clone(),
                         )?;
                         ___fallback__tag = 1;
-                        ___fallback_exact_v0 = ___fallback_exact_v0_xg;
+                        ___fallback_exact_v0 = __arm1__fallback_exact_v0;
                         ___fallback_range_low = 0i64;
                         ___fallback_range_high = 0i64;
                         ___fallback_tagged_v0 = jni::objects::JObject::null();
@@ -7555,47 +7555,47 @@ pub(crate) unsafe fn __jni_out_convert_Observation_to_wire_d96ad3cc48a04f0a<'a>(
                         ___fallback_companion_v0 = 0i64;
                     }
                     perftest_flat::Reading::Range { low: __s0_0, high: __s0_1 } => {
-                        let ___fallback_range_low_xg: jni::sys::jlong = __jni_out_convert_i64_to_wire_15d458bf28dc9c80(
+                        let __arm2__fallback_range_low: jni::sys::jlong = __jni_out_convert_i64_to_wire_15d458bf28dc9c80(
                             env,
                             __s0_0.clone(),
                         )?;
-                        let ___fallback_range_high_xg: jni::sys::jlong = __jni_out_convert_i64_to_wire_15d458bf28dc9c80(
+                        let __arm2__fallback_range_high: jni::sys::jlong = __jni_out_convert_i64_to_wire_15d458bf28dc9c80(
                             env,
                             __s0_1.clone(),
                         )?;
                         ___fallback__tag = 2;
-                        ___fallback_range_low = ___fallback_range_low_xg;
-                        ___fallback_range_high = ___fallback_range_high_xg;
+                        ___fallback_range_low = __arm2__fallback_range_low;
+                        ___fallback_range_high = __arm2__fallback_range_high;
                         ___fallback_exact_v0 = 0i64;
                         ___fallback_tagged_v0 = jni::objects::JObject::null();
                         ___fallback_tagged_v1 = 0i32;
                         ___fallback_companion_v0 = 0i64;
                     }
                     perftest_flat::Reading::Labeled(__s0_0, __s0_1) => {
-                        let ___fallback_tagged_v0_xg: jni::objects::JObject = __jni_out_convert_jni_text_codec_owned_to_wire_1b6cdff0ec9adbcb(
+                        let __arm3__fallback_tagged_v0: jni::objects::JObject = __jni_out_convert_jni_text_codec_owned_to_wire_1b6cdff0ec9adbcb(
                                 env,
                                 __s0_0.clone(),
                             )?
                             .into();
-                        let ___fallback_tagged_v1_xg: jni::sys::jint = __jni_out_convert_Priority_to_wire_55b65fa623d4787e(
+                        let __arm3__fallback_tagged_v1: jni::sys::jint = __jni_out_convert_Priority_to_wire_55b65fa623d4787e(
                             env,
                             __s0_1.clone(),
                         )?;
                         ___fallback__tag = 3;
-                        ___fallback_tagged_v0 = ___fallback_tagged_v0_xg;
-                        ___fallback_tagged_v1 = ___fallback_tagged_v1_xg;
+                        ___fallback_tagged_v0 = __arm3__fallback_tagged_v0;
+                        ___fallback_tagged_v1 = __arm3__fallback_tagged_v1;
                         ___fallback_exact_v0 = 0i64;
                         ___fallback_range_low = 0i64;
                         ___fallback_range_high = 0i64;
                         ___fallback_companion_v0 = 0i64;
                     }
                     perftest_flat::Reading::Companion(__s0_0) => {
-                        let ___fallback_companion_v0_xg: jni::sys::jlong = __jni_out_convert_i64_to_wire_15d458bf28dc9c80(
+                        let __arm4__fallback_companion_v0: jni::sys::jlong = __jni_out_convert_i64_to_wire_15d458bf28dc9c80(
                             env,
                             __s0_0.clone(),
                         )?;
                         ___fallback__tag = 4;
-                        ___fallback_companion_v0 = ___fallback_companion_v0_xg;
+                        ___fallback_companion_v0 = __arm4__fallback_companion_v0;
                         ___fallback_exact_v0 = 0i64;
                         ___fallback_range_low = 0i64;
                         ___fallback_range_high = 0i64;
@@ -10396,12 +10396,12 @@ pub(crate) unsafe fn __jni_out_convert_Tagged_to_wire_b6acfb4fd9df43fa<'a>(
                 ___marker_ranked_v0 = 0i32;
             }
             perftest_flat::Marker::Ranked(__s0_0) => {
-                let ___marker_ranked_v0_xg: jni::sys::jint = __jni_out_convert_Option_Priority_jni_optional_intermediate_output_niche_to_wire_f8a537414a30bc3f(
+                let __arm1__marker_ranked_v0: jni::sys::jint = __jni_out_convert_Option_Priority_jni_optional_intermediate_output_niche_to_wire_f8a537414a30bc3f(
                     env,
                     __s0_0.clone(),
                 )?;
                 ___marker__tag = 1;
-                ___marker_ranked_v0 = ___marker_ranked_v0_xg;
+                ___marker_ranked_v0 = __arm1__marker_ranked_v0;
             }
         }
         let __obj = env
@@ -11001,22 +11001,22 @@ pub(crate) unsafe fn __jni_out_convert_Verdict_to_wire_26a1dc521db8a9ae<'a>(
                 ___outcome_failed_v0 = jni::objects::JObject::null();
             }
             perftest_flat::Lookup::Found(__s0_0) => {
-                let ___outcome_found_v0_xg: jni::sys::jlong = __jni_out_convert_Summary_jni_handle_codec_own_output_to_wire_236099c944f0abfc(
+                let __arm1__outcome_found_v0: jni::sys::jlong = __jni_out_convert_Summary_jni_handle_codec_own_output_to_wire_236099c944f0abfc(
                     env,
                     __s0_0.clone(),
                 )?;
                 ___outcome__tag = 1;
-                ___outcome_found_v0 = ___outcome_found_v0_xg;
+                ___outcome_found_v0 = __arm1__outcome_found_v0;
                 ___outcome_failed_v0 = jni::objects::JObject::null();
             }
             perftest_flat::Lookup::Failed(__s0_0) => {
-                let ___outcome_failed_v0_xg: jni::objects::JObject = __jni_out_convert_jni_text_codec_owned_to_wire_1b6cdff0ec9adbcb(
+                let __arm2__outcome_failed_v0: jni::objects::JObject = __jni_out_convert_jni_text_codec_owned_to_wire_1b6cdff0ec9adbcb(
                         env,
                         __s0_0.clone(),
                     )?
                     .into();
                 ___outcome__tag = 2;
-                ___outcome_failed_v0 = ___outcome_failed_v0_xg;
+                ___outcome_failed_v0 = __arm2__outcome_failed_v0;
                 ___outcome_found_v0 = 0i64;
             }
         }
@@ -14389,6 +14389,128 @@ pub(crate) unsafe fn __jni_in_convert_wire_to_impl_Fn_Vec_Option_Ticks_Send_Sync
                         "{} callback error: {e}", "Fn(Vec < Option < Ticks > >)"
                     )
                 });
+        })
+    })
+}
+#[allow(
+    non_snake_case,
+    unused_mut,
+    unused_variables,
+    unused_braces,
+    unused_parens,
+    dead_code,
+    clippy::useless_conversion,
+    clippy::needless_question_mark,
+    clippy::let_and_return,
+    clippy::nonminimal_bool,
+    clippy::eq_op
+)]
+pub(crate) unsafe fn __jni_in_convert_wire_to_impl_Fn_Verdict_Send_Sync_static_2a95bb2d7b157f05<
+    'env,
+    'v,
+>(
+    env: &mut jni::JNIEnv<'env>,
+    v: &jni::objects::JObject<'v>,
+) -> ::core::result::Result<
+    impl Fn(perftest_flat::Verdict) + Send + Sync + 'static,
+    __JniErr,
+> {
+    Ok({
+        use std::sync::Arc;
+        let java_vm = Arc::new(
+            env
+                .get_java_vm()
+                .map_err(|e| <__JniErr as ::core::convert::From<
+                    String,
+                >>::from(format!("Unable to retrieve JVM: {}", e)))?,
+        );
+        let callback_global_ref = env
+            .new_global_ref(&v)
+            .map_err(|e| <__JniErr as ::core::convert::From<
+                String,
+            >>::from(format!("Unable to global-ref callback: {}", e)))?;
+        let __invoke_class = env
+            .get_object_class(&v)
+            .map_err(|e| <__JniErr as ::core::convert::From<
+                String,
+            >>::from(
+                format!("Unable to get callback class for {}: {}", "Fn(Verdict)", e),
+            ))?;
+        let __invoke_id = env
+            .get_method_id(&__invoke_class, "run", "(JIJLjava/lang/String;)V")
+            .map_err(|e| <__JniErr as ::core::convert::From<
+                String,
+            >>::from(format!("Unable to resolve run for {}: {}", "Fn(Verdict)", e)))?;
+        Box::new(move |__cb_arg0: perftest_flat::Verdict| {
+            let _ = (|| -> ::core::result::Result<(), __JniErr> {
+                let mut env = java_vm
+                    .attach_current_thread_as_daemon()
+                    .map_err(|e| <__JniErr as ::core::convert::From<
+                        String,
+                    >>::from(format!("Attach thread for {}: {}", "Fn(Verdict)", e)))?;
+                env.push_local_frame(16)
+                    .map_err(|e| <__JniErr as ::core::convert::From<
+                        String,
+                    >>::from(format!("push local frame for {}: {}", "Fn(Verdict)", e)))?;
+                let __frame_res = (|| -> ::core::result::Result<(), __JniErr> {
+                    let (
+                        __chain_wire0,
+                        (__chain_wire1, (), (__chain_wire2,), (__chain_wire3,)),
+                    ) = match __jni_out_convert_Verdict_jni_product_intermediate_tuple_to_wire_c931393a6622afaa(
+                        &mut env,
+                        __cb_arg0,
+                    ) {
+                        ::core::result::Result::Ok(__intermediate) => __intermediate,
+                        ::core::result::Result::Err(__chain_error) => {
+                            return ::core::result::Result::Err(
+                                <__JniErr as ::core::convert::From<
+                                    String,
+                                >>::from(__chain_error.to_string()),
+                            );
+                        }
+                    };
+                    let __cb0_obj0 = jni::sys::jvalue {
+                        j: __chain_wire0,
+                    };
+                    let __cb0_obj1 = jni::sys::jvalue {
+                        i: __chain_wire1,
+                    };
+                    let __cb0_obj2 = jni::sys::jvalue {
+                        j: __chain_wire2,
+                    };
+                    let __cb0_obj3: jni::objects::JObject = __chain_wire3.into();
+                    let __call_res: ::core::result::Result<(), __JniErr> = unsafe {
+                        env.call_method_unchecked(
+                            &callback_global_ref,
+                            __invoke_id,
+                            jni::signature::ReturnType::Primitive(
+                                jni::signature::Primitive::Void,
+                            ),
+                            &[
+                                __cb0_obj0,
+                                __cb0_obj1,
+                                __cb0_obj2,
+                                jni::sys::jvalue {
+                                    l: __cb0_obj3.as_raw(),
+                                },
+                            ],
+                        )
+                    }
+                        .map(|_| ())
+                        .map_err(|e| {
+                            let _ = env.exception_describe();
+                            <__JniErr as ::core::convert::From<
+                                String,
+                            >>::from(e.to_string())
+                        });
+                    __call_res?;
+                    Ok(())
+                })();
+                let _ = unsafe { env.pop_local_frame(&jni::objects::JObject::null()) };
+                __frame_res?;
+                Ok(())
+            })()
+                .map_err(|e| tracing::error!("{} callback error: {e}", "Fn(Verdict)"));
         })
     })
 }
@@ -26283,6 +26405,81 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_vaultHolderNew<'
                 &__e2.to_string(),
             );
             jni::objects::JObject::null().into()
+        }
+    }
+}
+#[no_mangle]
+#[allow(non_snake_case, unused_mut, unused_variables, dead_code)]
+pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_verdictEach<'a>(
+    mut env: jni::JNIEnv<'a>,
+    _class: jni::objects::JClass<'a>,
+    n: jni::sys::jlong,
+    total: jni::sys::jdouble,
+    sink: jni::objects::JObject<'a>,
+    __error_sink: jni::objects::JObject<'a>,
+) -> () {
+    #[allow(non_upper_case_globals)]
+    static __SINK_MID: ::prebindgen_jni_runtime::CachedIfaceMethod = ::prebindgen_jni_runtime::CachedIfaceMethod::new();
+    const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
+    const __SINK_DESCR: &str = "(Ljava/lang/String;)Ljava/lang/Object;";
+    let n = match __jni_in_convert_wire_to_i64_da07d745d9e26f71(&mut env, &n) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__e) => {
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e.to_string(),
+            );
+            return ();
+        }
+    };
+    let total = match __jni_in_convert_wire_to_f64_b312e1b95182cdfd(&mut env, &total) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__e) => {
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e.to_string(),
+            );
+            return ();
+        }
+    };
+    let sink = match __jni_in_convert_wire_to_impl_Fn_Verdict_Send_Sync_static_2a95bb2d7b157f05(
+        &mut env,
+        &sink,
+    ) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__e) => {
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e.to_string(),
+            );
+            return ();
+        }
+    };
+    let __out = perftest_flat::verdict_each(n, total, sink);
+    match __jni_out_convert_unit_to_wire_9e1510fd173c1fd6(&mut env, __out) {
+        ::core::result::Result::Ok(__w) => __w,
+        ::core::result::Result::Err(__e) => {
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e.to_string(),
+            );
+            ()
         }
     }
 }

--- a/examples/perftest-flat/src/ext.rs
+++ b/examples/perftest-flat/src/ext.rs
@@ -521,6 +521,23 @@ pub struct Verdict {
     pub outcome: Lookup,
 }
 
+/// A `Verdict` — a `data_class` whose field is a **sum** — handed to a
+/// callback, which is the other half of what #602's coverage buys.
+///
+/// A returned `Verdict` reaches its foreign builder through the return path;
+/// this one reaches the callback-interface path, whose reassembly asks a
+/// different question about the same leaves. Both must rebuild the value from
+/// its tag and groups rather than through a whole JVM object.
+#[prebindgen]
+pub fn verdict_each(n: i64, total: f64, sink: impl Fn(Verdict) + Send + Sync + 'static) {
+    for i in 0..n {
+        sink(Verdict {
+            id: i,
+            outcome: lookup_of(i - 1, total),
+        });
+    }
+}
+
 /// Build a [`Verdict`] whose outcome comes from [`lookup_of`].
 #[prebindgen]
 pub fn verdict_new(id: i64, count: i64, total: f64) -> Verdict {

--- a/prebindgen-jni/src/jni/compile.rs
+++ b/prebindgen-jni/src/jni/compile.rs
@@ -4378,9 +4378,33 @@ impl Declarations {
             // look through, `Vec` to decline — never a last path segment.
             let probe = field.ty.optional_inner().unwrap_or(&field.ty);
             match self.type_kind(registry, &probe.key()) {
-                crate::jni::classify::TypeKind::Handle
-                | crate::jni::classify::TypeKind::Enum
-                | crate::jni::classify::TypeKind::Sum => return None,
+                crate::jni::classify::TypeKind::Handle | crate::jni::classify::TypeKind::Enum => {
+                    return None
+                }
+                // A `sealed_class` field contributes what a sealed_class
+                // crossing does — a tag naming the live alternative, then one
+                // group of leaves per alternative — reached through this
+                // field. Only one group is live per value, which is what the
+                // registry's segment gate emits as a single `match`.
+                crate::jni::classify::TypeKind::Sum => {
+                    if field.ty.optional_inner().is_some() {
+                        return None;
+                    }
+                    let sum_ident = match probe.unwrapped().kind() {
+                        TypeKind::Named { id, .. } => id.ident()?,
+                        _ => return None,
+                    };
+                    let reach: Vec<prebindgen_registry::unfold::PathStep> =
+                        field_path.iter().map(field_step).collect();
+                    for wire in self.sum_out_wires(registry, &sum_ident, probe)? {
+                        wires.push(OutWire {
+                            name: format!("{name}__{}", wire.name),
+                            reach: reach.clone(),
+                            ..wire
+                        });
+                    }
+                    continue;
+                }
                 // A nested `data_class` inlines when it is reached directly.
                 // Behind an `Option` or a `Vec` there is no chain to reach
                 // through, so the whole value stays object-shaped.

--- a/prebindgen-jni/src/jni/emit/struct_out.rs
+++ b/prebindgen-jni/src/jni/emit/struct_out.rs
@@ -164,20 +164,28 @@ pub(crate) fn encode_leaves(
         .collect()
 }
 
-/// The segment marking an arm-local binding, dropped from the outer slot it
-/// feeds. A leaf's name is the same on both sides — it is one leaf — and the
-/// marker is what lets the two live in one function.
-const ARM_MARKER: &str = "_xg";
+/// The prefix an arm-local binding carries, and the outer slot it feeds.
+///
+/// A leaf's name is the same on both sides — it is one leaf — so the two would
+/// collide in one function. The arm-local name is the outer name with a
+/// **prefix** this module adds, which is why recovering the outer one is
+/// stripping a known prefix at a known position rather than searching for a
+/// marker: `base` and every slot fragment come from source identifiers, and
+/// any sentinel spelled inside one of them can appear in the middle of a name
+/// too (#616 review).
+fn arm_local_base(tag: usize, base: &str) -> String {
+    format!("arm{tag}_{base}")
+}
 
-/// The outer slot ident for an arm-local binding.
-fn outer_of(inner: &proc_macro2::Ident) -> proc_macro2::Ident {
+/// The outer slot ident for an arm-local binding produced under
+/// [`arm_local_base`].
+fn outer_of(tag: usize, inner: &proc_macro2::Ident) -> proc_macro2::Ident {
     let name = inner.to_string();
-    let outer = name.replacen(ARM_MARKER, "", 1);
-    assert_ne!(
-        outer, name,
-        "an arm-local binding carries the marker its outer slot drops"
-    );
-    format_ident!("{outer}")
+    let prefix = format!("__arm{tag}_");
+    let rest = name.strip_prefix(&prefix).unwrap_or_else(|| {
+        panic!("an arm-local binding starts with the prefix its outer slot drops: `{name}`")
+    });
+    format_ident!("__{rest}")
 }
 
 fn encode_plan(
@@ -409,7 +417,7 @@ fn encode_field(
                     slots: Vec<EncSlot>,
                 }
                 let mut arms: Vec<Arm> = Vec::new();
-                for v in variants {
+                for (tag, v) in variants.iter().enumerate() {
                     let vident = &v.rust_ident;
                     let binds: Vec<syn::Ident> = (0..v.fields.len())
                         .map(|i| format_ident!("__s{}_{}", depth, i))
@@ -420,7 +428,7 @@ fn encode_field(
                         // The arm's own bindings carry a marker segment the
                         // outer slots drop: the two are the same leaf and want
                         // the same name, and one scope assigns from the other.
-                        let fbase = format!("{base}_{}{ARM_MARKER}", f.slot);
+                        let fbase = arm_local_base(tag, &format!("{base}_{}", f.slot));
                         let bind_expr = quote!(#bind);
                         let (p, s) =
                             encode_field(&f.kind, &bind_expr, &fbase, depth + 1, env_expr, emit);
@@ -459,8 +467,13 @@ fn encode_field(
                 // construction rather than by a positional coincidence. The
                 // inner binding of the same name lives inside its match arm
                 // and shadows nothing the outer tuple reads.
-                let outer_ids: Vec<proc_macro2::Ident> =
-                    all.iter().map(|slot| outer_of(&slot.ident)).collect();
+                let outer_ids: Vec<proc_macro2::Ident> = arms
+                    .iter()
+                    .enumerate()
+                    .flat_map(|(tag, arm)| {
+                        arm.slots.iter().map(move |slot| outer_of(tag, &slot.ident))
+                    })
+                    .collect();
                 let outer_tys: Vec<TokenStream> = all.iter().map(|s| s.wire_ty.clone()).collect();
                 let defaults: Vec<TokenStream> = all.iter().map(|s| s.default.clone()).collect();
 

--- a/prebindgen-jni/src/jni/emit/struct_out.rs
+++ b/prebindgen-jni/src/jni/emit/struct_out.rs
@@ -104,7 +104,15 @@ pub(crate) fn synth_value_struct_leaves(
                 out_ty: w.out_ty,
                 identity: false,
                 nullable: w.nullable,
-                source: LeafSource::Reach,
+                // A selector is not read off a place: the emitter assigns the
+                // live alternative's number in each arm of its `match`, which
+                // is what `LeafSource::SumTag` says and what keeps
+                // `OutWire::from_leaf` round-tripping it back to a tag rather
+                // than trying to compile the sum type as a crossing.
+                source: match w.from {
+                    crate::jni::compile::OutFrom::Tag => LeafSource::SumTag,
+                    _ => LeafSource::Reach,
+                },
                 group: w.group,
             })
             .collect(),
@@ -154,6 +162,22 @@ pub(crate) fn encode_leaves(
             )
         })
         .collect()
+}
+
+/// The segment marking an arm-local binding, dropped from the outer slot it
+/// feeds. A leaf's name is the same on both sides — it is one leaf — and the
+/// marker is what lets the two live in one function.
+const ARM_MARKER: &str = "_xg";
+
+/// The outer slot ident for an arm-local binding.
+fn outer_of(inner: &proc_macro2::Ident) -> proc_macro2::Ident {
+    let name = inner.to_string();
+    let outer = name.replacen(ARM_MARKER, "", 1);
+    assert_ne!(
+        outer, name,
+        "an arm-local binding carries the marker its outer slot drops"
+    );
+    format_ident!("{outer}")
 }
 
 fn encode_plan(
@@ -393,7 +417,10 @@ fn encode_field(
                     let mut vpre = TokenStream::new();
                     let mut vslots: Vec<EncSlot> = Vec::new();
                     for (f, bind) in v.fields.iter().zip(&binds) {
-                        let fbase = format!("{base}_{}", f.slot);
+                        // The arm's own bindings carry a marker segment the
+                        // outer slots drop: the two are the same leaf and want
+                        // the same name, and one scope assigns from the other.
+                        let fbase = format!("{base}_{}{ARM_MARKER}", f.slot);
                         let bind_expr = quote!(#bind);
                         let (p, s) =
                             encode_field(&f.kind, &bind_expr, &fbase, depth + 1, env_expr, emit);
@@ -425,9 +452,15 @@ fn encode_field(
                 // side in variant order. Each arm assigns its own group from
                 // the values it just computed and defaults all the others.
                 let all: Vec<&EncSlot> = arms.iter().flat_map(|a| a.slots.iter()).collect();
-                let outer_ids: Vec<proc_macro2::Ident> = (0..all.len())
-                    .map(|i| format_ident!("__{}_g{}", base, i))
-                    .collect();
+                // Named after the leaf each slot carries — `__outcome_found_v0`,
+                // not `__outcome_g0`. The inner bindings already use that
+                // naming, and it is what the registry-facing decomposition
+                // calls the same leaf, so the two derivations agree by
+                // construction rather than by a positional coincidence. The
+                // inner binding of the same name lives inside its match arm
+                // and shadows nothing the outer tuple reads.
+                let outer_ids: Vec<proc_macro2::Ident> =
+                    all.iter().map(|slot| outer_of(&slot.ident)).collect();
                 let outer_tys: Vec<TokenStream> = all.iter().map(|s| s.wire_ty.clone()).collect();
                 let defaults: Vec<TokenStream> = all.iter().map(|s| s.default.clone()).collect();
 
@@ -515,8 +548,12 @@ fn encode_field(
                         default: quote!(0u8),
                     });
                 }
+                // A sum field's slots sit one level inside the struct, the
+                // same as an inlined nested class's: the tag and the groups
+                // are reached THROUGH the field. The decomposition says so by
+                // joining the names with `__`, and depth is that count.
                 slots.push(EncSlot {
-                    depth,
+                    depth: depth + 1,
                     ident: tag_id,
                     wire_ty: quote!(jni::sys::jint),
                     descriptor: "I".to_string(),
@@ -525,7 +562,7 @@ fn encode_field(
                 });
                 for (i, sl) in all.iter().enumerate() {
                     slots.push(EncSlot {
-                        depth,
+                        depth: sl.depth,
                         ident: outer_ids[i].clone(),
                         wire_ty: sl.wire_ty.clone(),
                         descriptor: sl.descriptor.clone(),

--- a/prebindgen-jni/src/jni/emit/sum_out.rs
+++ b/prebindgen-jni/src/jni/emit/sum_out.rs
@@ -115,21 +115,15 @@ pub(crate) fn leaf_slot(
     }
 }
 
-/// True when these values decompose a sum — they carry the synthesized
-/// selector. The one place that question is asked, so every consumer agrees on
-/// it.
-pub(crate) fn is_sum_row(leaves: &[crate::jni::compile::OutWire]) -> bool {
-    leaves.iter().any(|l| l.is_tag())
-}
-
 /// Whether the delivered value **is** a sum, rather than merely containing one.
 ///
 /// The tag comes first and reaches nothing: it selects over the whole value.
 /// A struct with a sum-typed FIELD also carries a tag — reached through that
 /// field — and is a product whose fields include a segment. The two were the
 /// same question only while a field could not decompose to a tag, which is
-/// what #602 changed: a builder asked [`is_sum_row`] and tried to build a
-/// sealed-class builder for a struct.
+/// what #602 changed: the predicate this replaced answered "any leaf is a
+/// tag", and a builder asking it tried to build a sealed-class builder for a
+/// struct.
 pub(crate) fn is_whole_sum_row(leaves: &[crate::jni::compile::OutWire]) -> bool {
     leaves
         .first()

--- a/prebindgen-jni/src/jni/emit/sum_out.rs
+++ b/prebindgen-jni/src/jni/emit/sum_out.rs
@@ -122,6 +122,20 @@ pub(crate) fn is_sum_row(leaves: &[crate::jni::compile::OutWire]) -> bool {
     leaves.iter().any(|l| l.is_tag())
 }
 
+/// Whether the delivered value **is** a sum, rather than merely containing one.
+///
+/// The tag comes first and reaches nothing: it selects over the whole value.
+/// A struct with a sum-typed FIELD also carries a tag — reached through that
+/// field — and is a product whose fields include a segment. The two were the
+/// same question only while a field could not decompose to a tag, which is
+/// what #602 changed: a builder asked [`is_sum_row`] and tried to build a
+/// sealed-class builder for a struct.
+pub(crate) fn is_whole_sum_row(leaves: &[crate::jni::compile::OutWire]) -> bool {
+    leaves
+        .first()
+        .is_some_and(|leaf| leaf.is_tag() && leaf.reach.is_empty())
+}
+
 /// Emit the Rust-side encode of a decomposed sum: ONE `match` over the value
 /// binding the tag and EVERY group's slots — the live group from its variant
 /// pattern's payload bindings, every other group from the same wire defaults an

--- a/prebindgen-jni/src/jni/iface.rs
+++ b/prebindgen-jni/src/jni/iface.rs
@@ -1306,16 +1306,39 @@ fn fixed_reassembly(
     class_fqn: &str,
     first_slot: usize,
 ) -> (String, Vec<String>) {
-    let slots: Vec<String> = (0..wires.len())
-        .map(|i| format!("${}", i + first_slot))
-        .collect();
-    if !is_sum_row(wires) {
+    // Whether the delivered value IS a sum, not whether it contains one. A
+    // struct with a sum-typed field carries a tag and still reassembles
+    // through its own `fromParts`, with the field's `when` inlined as one
+    // argument; asking the containing question sent it to `sum_reconstruct`,
+    // which panics on a struct (#616 review).
+    if !crate::jni::emit::is_whole_sum_row(wires) {
+        let slots: Vec<String> = (0..wires.len())
+            .map(|i| format!("${}", i + first_slot))
+            .collect();
         let class_short = class_fqn.rsplit('.').next().unwrap_or(class_fqn);
         return (
             format!("{class_short}.fromParts({})", slots.join(", ")),
             Vec::new(),
         );
     }
+    sum_segment_reassembly(ext, registry, source, wires, first_slot)
+}
+
+/// The `when` that rebuilds one sum from its own segment — a selector followed
+/// by its groups.
+///
+/// Called directly where the caller has already isolated the segment, and
+/// through [`fixed_reassembly`] where the whole delivered value is the sum.
+fn sum_segment_reassembly(
+    ext: &Declarations,
+    registry: &impl Conversions,
+    source: &TypeKey,
+    wires: &[crate::jni::compile::OutWire],
+    first_slot: usize,
+) -> (String, Vec<String>) {
+    let slots: Vec<String> = (0..wires.len())
+        .map(|i| format!("${}", i + first_slot))
+        .collect();
     let params = plan_leaf_params(ext, wires).unwrap_or_default();
     let mut imports: BTreeSet<String> = BTreeSet::new();
     let (_, when) = ext.sum_reconstruct(registry, source, wires, &params, &slots, &mut imports);
@@ -1473,12 +1496,13 @@ pub(crate) fn callback_iface_spec(
                     if leaf.is_tag() {
                         any_fixed = true;
                         let fqn = ext.kotlin_fqn(&leaf.out_ty.key())?;
-                        let (reassemble, imports) = fixed_reassembly(
+                        // An isolated segment: its first leaf IS the tag, so
+                        // the `when` is the answer without asking again.
+                        let (reassemble, imports) = sum_segment_reassembly(
                             ext,
                             registry,
                             &leaf.out_ty.key(),
                             &wires[k..seg],
-                            &fqn,
                             0,
                         );
                         groups.push(GroupDesc {

--- a/prebindgen-jni/src/jni/kotlin_emit.rs
+++ b/prebindgen-jni/src/jni/kotlin_emit.rs
@@ -1233,8 +1233,12 @@ impl Declarations {
                             .decon
                             .clone()
                             .expect("fixed decomposed output carries its declaration plan");
-                        let sum =
-                            is_sum_row(&crate::jni::compile::OutWire::from_leaves(&unfold.leaves));
+                        // Whether the delivered value IS a sum — a struct
+                        // with a sum-typed field contains a tag and still
+                        // reassembles through its own `fromParts`.
+                        let sum = crate::jni::emit::is_whole_sum_row(
+                            &crate::jni::compile::OutWire::from_leaves(&unfold.leaves),
+                        );
                         match (output.iterable_fold, sum) {
                             (true, true) => FixedSingleton::SumFolder(decon),
                             (true, false) => FixedSingleton::StructFolder(decon),

--- a/prebindgen-jni/src/jni/tests/flatten.rs
+++ b/prebindgen-jni/src/jni/tests/flatten.rs
@@ -2477,6 +2477,84 @@ fn the_two_derivations_agree_on_a_nested_data_class() {
 /// the two as different coverage rather than composing one from the other.
 ///
 /// If this ever starts returning `Some`, the encode should be rendered from
+/// A `sealed_class` field decomposes: the struct's leaves carry the sum's tag
+/// and one group per alternative, reached through the field.
+///
+/// This is #602's larger half — a sum field was the most common refusal, four
+/// of the nine in the two examples — and what it buys is fixed-builder
+/// delivery: a declared function returning the struct, or an `impl Fn(T)`
+/// callback taking one, now hands the foreign builder leaves instead of
+/// falling back to a whole JVM object.
+#[test]
+fn a_sum_field_decomposes_into_its_tag_and_groups() {
+    let loc = myflat_loc();
+    let items: Vec<(syn::Item, prebindgen::SourceLocation)> = vec![
+        (
+            syn::Item::Enum(syn::parse_quote!(
+                pub enum Outcome {
+                    Found(i64),
+                    Missing,
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Struct(syn::parse_quote!(
+                pub struct Holder {
+                    pub id: i64,
+                    pub outcome: Outcome,
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn holder_id(h: Holder) -> i64 {
+                    unimplemented!()
+                }
+            )),
+            loc.clone(),
+        ),
+    ];
+    let registry = crate::test_util::reg_from_items(declare_referenced(items)).expect("index");
+    let jni = JniGenBuilder::new()
+        .set_package_prefix("io.test.jni")
+        .package(
+            crate::package!()
+                .class(crate::sealed_class!(Outcome))
+                .class(crate::data_class!(Holder))
+                .fun(prebindgen_registry::fun!(holder_id)),
+        );
+    let gen = jni.build_with(registry).expect("resolve");
+
+    let holder: syn::Ident = syn::parse_quote!(Holder);
+    let wires = gen
+        .declarations()
+        .struct_out_wires_of(gen.registry(), &holder)
+        .expect("a sum field no longer refuses the decomposition");
+    let names: Vec<&str> = wires.iter().map(|wire| wire.name.as_str()).collect();
+    assert_eq!(
+        names,
+        ["id", "outcome__tag", "outcome__found_v0"],
+        "the sibling field, then the sum's tag and its one payload group, \
+         each named through the field that carries them"
+    );
+    assert!(
+        wires[1].is_tag(),
+        "the selector is a tag, not a value read off a place"
+    );
+    assert_eq!(
+        wires[2].group,
+        Some(0),
+        "the payload joins the group its tag selects"
+    );
+    assert!(
+        !wires[1].reach.is_empty(),
+        "and the tag is reached THROUGH the field, which is what distinguishes \
+         a struct carrying a sum from a value that IS one"
+    );
+}
+
 /// the decomposition and this test deleted; see #602.
 #[test]
 fn the_decomposition_refuses_what_the_whole_object_encode_supports() {

--- a/prebindgen-jni/src/jni/tests/flatten.rs
+++ b/prebindgen-jni/src/jni/tests/flatten.rs
@@ -2467,16 +2467,6 @@ fn the_two_derivations_agree_on_a_nested_data_class() {
     gen.write_rust(dir.join("gen.rs")).expect("write_rust");
 }
 
-/// The whole-object encode covers a shape the registry-facing decomposition
-/// refuses, and that divergence is deliberate.
-///
-/// `struct_out_wires_of` returns `None` for a struct with a nested
-/// `data_class` behind an `Option`, because there is no chain to reach the
-/// inlined leaves through. The whole-object output encode supports it as a
-/// `present` flag plus a defaulted group — which is why #596 step 5 records
-/// the two as different coverage rather than composing one from the other.
-///
-/// If this ever starts returning `Some`, the encode should be rendered from
 /// A `sealed_class` field decomposes: the struct's leaves carry the sum's tag
 /// and one group per alternative, reached through the field.
 ///
@@ -2555,6 +2545,90 @@ fn a_sum_field_decomposes_into_its_tag_and_groups() {
     );
 }
 
+/// A field whose own name contains what used to be the arm-local marker is
+/// just a name.
+///
+/// The encode binds a sum's groups twice — once inside each match arm, once in
+/// the tuple those arms fill — and the two are the same leaf, so they cannot
+/// share a name. The arm-local one carries a generated `__arm{tag}_` prefix,
+/// and the outer name is recovered by stripping it at that known position. An
+/// earlier version searched the middle of the ident for a sentinel, which any
+/// source-derived component could contain (#616 review); this fixture spells
+/// that sentinel in a field name and in a variant payload beneath it.
+///
+/// `write_rust` is what makes it a regression rather than an inspection: it
+/// renders the encode and runs `assert_leaf_derivations_agree` over the
+/// result.
+#[test]
+fn a_field_named_like_the_arm_marker_is_just_a_field() {
+    let loc = myflat_loc();
+    let items: Vec<(syn::Item, prebindgen::SourceLocation)> = vec![
+        (
+            syn::Item::Enum(syn::parse_quote!(
+                pub enum Outcome_xg {
+                    Found_xg(i64),
+                    Missing,
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Struct(syn::parse_quote!(
+                pub struct Holder {
+                    pub id: i64,
+                    pub state_xg: Outcome_xg,
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn holder_id(h: Holder) -> i64 {
+                    unimplemented!()
+                }
+            )),
+            loc.clone(),
+        ),
+    ];
+    let registry = crate::test_util::reg_from_items(declare_referenced(items)).expect("index");
+    let jni = JniGenBuilder::new()
+        .set_package_prefix("io.test.jni")
+        .package(
+            crate::package!()
+                .class(crate::sealed_class!(Outcome_xg))
+                .class(crate::data_class!(Holder))
+                .fun(prebindgen_registry::fun!(holder_id)),
+        );
+    let gen = jni.build_with(registry).expect("resolve");
+
+    let holder: syn::Ident = syn::parse_quote!(Holder);
+    let wires = gen
+        .declarations()
+        .struct_out_wires_of(gen.registry(), &holder)
+        .expect("a sum field decomposes whatever its name spells");
+    let names: Vec<&str> = wires.iter().map(|wire| wire.name.as_str()).collect();
+    assert_eq!(
+        names,
+        ["id", "stateXg__tag", "stateXg__found_xg_v0"],
+        "the sentinel is part of the name, not a marker to search for"
+    );
+
+    // Rendering is what runs the encode and the agreement check over it.
+    let dir = unique_test_dir("jnigen_arm_marker_name");
+    std::fs::create_dir_all(&dir).unwrap();
+    gen.write_rust(dir.join("gen.rs")).expect("write_rust");
+}
+
+/// The whole-object encode covers a shape the registry-facing decomposition
+/// refuses, and that divergence is deliberate.
+///
+/// `struct_out_wires_of` returns `None` for a struct with a nested
+/// `data_class` behind an `Option`, because there is no chain to reach the
+/// inlined leaves through. The whole-object output encode supports it as a
+/// `present` flag plus a defaulted group — which is why #596 step 5 records
+/// the two as different coverage rather than composing one from the other.
+///
+/// If this ever starts returning `Some`, the encode should be rendered from
 /// the decomposition and this test deleted; see #602.
 #[test]
 fn the_decomposition_refuses_what_the_whole_object_encode_supports() {


### PR DESCRIPTION
Step 3 of #613, first of two children. This one teaches the registry-facing
decomposition a **sum-typed field**; the paired child adds the optional nested
class, renders the whole-object encode from the decomposition, and deletes the
second derivation with the agreement check that holds the two together.

## Why a sum field first, and why the halves are separable here

I measured which of `struct_out_wires_at`'s refusals actually fire, by
instrumenting each `return None` and regenerating both examples. Distinct
`struct.field` refusal sites:

| refusal | sites |
|---|---|
| a **sum**-typed field | 4 |
| a **handle** field | 2 |
| an **enum_class** field | 2 |
| a nested data class behind `Option` or `Vec` | 1 |

The sum field is the largest single cause, not the gated nested class #602
leads with — and handle and enum fields are a third refusal that issue does not
mention at all. Both measurements are now recorded there.

The two shapes are separable because each is a whole coverage step on its own:
a struct with a sum field decomposes here and a struct with an optional nested
class still refuses, pinned by the existing
`the_decomposition_refuses_what_the_whole_object_encode_supports`.

## What this is not

Not a refactoring. Producing leaves **is** the decision to deliver a type by
leaves — `build_value_decons` registers a `ValueDecon` — so a struct that
decomposes leaves the whole-object path and takes the fixed-builder one. Two
functions in `covertest-kotlin` move with it:

```
tagged_new  — return `Tagged`  decomposed → [id, marker__tag, marker__ranked_v0]
verdict_new — return `Verdict` decomposed → [id, outcome__tag,
                                             outcome__found_v0, outcome__failed_v0]
```

Their **public Kotlin signatures are unchanged**; the private JNI boundary
gains a builder parameter, which is the #602 coverage addition the umbrella's
compatibility rule carves out.

## Three conflations this surfaced

Each was invisible while a struct field could not decompose to a tag:

- **A tag lost its source.** `synth_value_struct_leaves` mapped every wire to
  `LeafSource::Reach`, so a tag round-tripped back as a value and the compiler
  tried to build a crossing for the sum type. It now maps `OutFrom::Tag` to
  `LeafSource::SumTag`.
- **`is_sum_row` meant two things.** "Any leaf is a tag" answered both "does
  this row need sum reconstruction" (true for a struct with a sum field) and
  "is the delivered value itself a sum" (false for it). The second is now
  `is_whole_sum_row` — first leaf, tag, empty reach — and the Kotlin builder
  asks that one, instead of trying to build a sealed-class builder for a
  struct.
- **The encode named a sum's slots positionally.** `__outcome_g0` where the
  decomposition says `outcome__found_v0`, and at the parent's depth where the
  decomposition counts one level of inlining. The encode now names them after
  the leaf and counts the depth, so `assert_leaf_derivations_agree` — the
  standing check from #603 — passes on a shape it had never seen. It caught
  both, which is what it is for.

## Verification

- `covertest-kotlin` passes all **62 JVM sections** — one more than before, a
  new one taking a data class with a sum field to a **callback**, since the
  return path and the callback-interface path reassemble the same leaves by
  different routes. The return coverage is exercised too rather than merely
  compiled: `Test.kt` already calls `verdictNew` and `taggedNew`, and those
  calls now cross through the fixed-builder route.
- 841 tests, 0 clippy warnings under `--all-targets --all-features -- --deny
  warnings`, strict rustdoc clean, the CI-configured `cargo fmt --check` clean.
- Generated output changes deliberately: two new builder interfaces, the two
  native descriptors above, and the whole-object encode's arm-local names.
  `a_sum_field_decomposes_into_its_tag_and_groups` pins the new leaves.

## Production cost

Shared core 0, C adapter 0, JNI adapter **+110** (30,786 against the 30,676
this branch starts from).

— Claude Code (Opus 5)

