### PR TITLE
An optional nested data class decomposes behind its presence

### DIFF
--- a/examples/covertest-kotlin/build.rs
+++ b/examples/covertest-kotlin/build.rs
@@ -379,6 +379,10 @@ fn main() {
                 // instance methods (`secs()` / `nanos()`) whose receiver crosses
                 // as those field leaves, and `Vec<Stamp>` surfaces as
                 // `List<Stamp>`.
+                // The optional nested class #602 names first: `Envelope`'s
+                // stamp is sometimes there, and the decomposition says so with
+                // a presence flag ahead of the child's leaves.
+                .class(data_class!(Envelope))
                 .class(
                     data_class!(Stamp)
                         .method(fun!(stamp_secs))
@@ -643,6 +647,9 @@ fn main() {
                 // return path — a different question about the same leaves
                 // (#616 review).
                 .fun(fun!(verdict_each))
+                // The optional nested class on both delivery routes.
+                .fun(fun!(envelope_new))
+                .fun(fun!(envelope_each))
                 // …and reached one level deeper still, through a nested data
                 // class rather than a sum.
                 .fun(fun!(dossier_new))

--- a/examples/covertest-kotlin/kotlin/REPORT.md
+++ b/examples/covertest-kotlin/kotlin/REPORT.md
@@ -88,6 +88,9 @@ Base package: `io.prebindgen.covertest`
 - `duration_emit` — `fun durationEmit(value: ULong, f: DurationCallback, onError: JniErrorHandler<Unit>)`
 - `duration_optional` — `fun durationOptional(value: ULong?, onError: JniErrorHandler<ULong?>): ULong?`
 - `duration_out_of_range` — `fun durationOutOfRange(onError: JniErrorHandler<ULong?>): ULong?`
+- `envelope_each` — `fun envelopeEach(n: Long, sink: EnvelopeCallback, onError: JniErrorHandler<Unit>)`
+- `envelope_new` — `fun envelopeNew(id: Long, present: Boolean, onError: JniErrorHandler<Envelope?>): Envelope?`
+  - shaped by: return `Envelope` decomposed → [id, stamp__present, stamp__secs, stamp__nanos] (Callback delivery)
 - `hold_echo` — `fun holdEcho(h: Hold, onError: JniErrorHandler<Hold?>): Hold?`
   - shaped by: return `Hold` decomposed → [tag, for_v0] (Callback delivery)
 - `hold_policy_echo` — `fun holdPolicyEcho(p: HoldPolicy, onError: JniErrorHandler<HoldPolicy?>): HoldPolicy?`
@@ -240,6 +243,7 @@ Base package: `io.prebindgen.covertest`
 - `ConstArray`: data_class → `io.prebindgen.covertest.model.ConstArray` (wire `jni :: objects :: JObject`)
 - `Dossier`: data_class → `io.prebindgen.covertest.Dossier` (wire `jni :: objects :: JObject`)
 - `DurationBoundary`: data_class → `io.prebindgen.covertest.model.DurationBoundary` (wire `jni :: objects :: JObject`, input `JObject` opt-in)
+- `Envelope`: data_class → `io.prebindgen.covertest.model.Envelope` (wire `jni :: objects :: JObject`)
 - `EscapeProbe`: ptr_class → `io.prebindgen.covertest.esc_pkg.Esc_Probe` (wire `jni :: sys :: jlong`)
 - `Hold`: sealed_class → `io.prebindgen.covertest.model.Hold` (wire `?`)
 - `HoldPolicy`: data_class → `io.prebindgen.covertest.model.HoldPolicy` (wire `jni :: objects :: JObject`)

--- a/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest.kt
+++ b/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest.kt
@@ -1291,6 +1291,12 @@ internal object CovNative {
     external fun durationOutOfRange(errorSink: Any): Long
 
     @JvmSynthetic
+    external fun envelopeEach(n: Long, sink: Any, errorSink: Any)
+
+    @JvmSynthetic
+    external fun envelopeNew(id: Long, present: Boolean, build: Any, errorSink: Any): Any?
+
+    @JvmSynthetic
     external fun escapeProbeNew(value: Long, errorSink: Any): Long
 
     @JvmSynthetic

--- a/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest/model.kt
+++ b/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest/model.kt
@@ -503,6 +503,28 @@ public data class DurationBoundary(val required: ULong, val delay: ULong?) {
 }
 
 /**
+ * A data class whose nested class sits behind an `Option` — the shape #602
+ * names first and the one a decomposition refused outright until it learned
+ * a presence flag.
+ *
+ * Nothing else about it is unusual: a sibling scalar beside a nested class
+ * that is sometimes there. `Annotated` has the same field, but also an
+ * `enum_class` one, which is a refusal of its own — so the shape needs a
+ * struct of its own to show up at all.
+ */
+public data class Envelope(val id: Long, val stamp: Stamp?) {
+    public companion object {
+        @JvmStatic
+        public fun fromParts(
+            id: Long,
+            stamp__present: Boolean,
+            stamp_secs: Long,
+            stamp_nanos: Long,
+        ): Envelope = Envelope(id, if (stamp__present) Stamp.fromParts(stamp_secs, stamp_nanos) else null)
+    }
+}
+
+/**
  * A retention policy: a required converted-payload sum beside an optional one.
  *
  * The data-class position for [`Hold`], so the converted payload is exercised
@@ -1276,6 +1298,26 @@ public class VaultHolder private constructor(initialPtr: Long) : NativeHandle(in
     }
 }
 
+public fun interface EnvelopeCallback {
+    public fun run(envelope: Envelope)
+}
+
+internal fun interface EnvelopeCallbackRaw {
+    public fun run(id: Long, stamp__present: Boolean, stamp__secs: Long, stamp__nanos: Long)
+}
+
+@JvmSynthetic
+internal fun EnvelopeCallback.asRaw(): EnvelopeCallbackRaw =
+    EnvelopeCallbackRaw {
+        id,
+        stamp__present,
+        stamp__secs,
+        stamp__nanos ->
+        run(
+            Envelope.fromParts(id, stamp__present, stamp__secs, stamp__nanos)
+        )
+    }
+
 public fun interface LookupCallback {
     public fun run(lookup: Lookup)
 }
@@ -1470,6 +1512,14 @@ internal fun interface DurationBoundaryBuilderRaw<out R> {
 @get:JvmSynthetic
 internal val __DurationBoundaryBuilderRaw: DurationBoundaryBuilderRaw<DurationBoundary> =
 DurationBoundaryBuilderRaw { required, delay -> DurationBoundary.fromParts(required, delay) }
+
+public fun interface EnvelopeBuilder<out R> {
+    public fun run(id: Long, stamp__present: Boolean, stamp__secs: Long, stamp__nanos: Long): R
+}
+
+@get:JvmSynthetic
+internal val __EnvelopeBuilder: EnvelopeBuilder<Envelope> =
+EnvelopeBuilder { id, stamp__present, stamp__secs, stamp__nanos -> Envelope.fromParts(id, stamp__present, stamp__secs, stamp__nanos) }
 
 internal fun interface HoldBuilderRaw<out R> {
     public fun run(tag: Int, for_v0: Long): R
@@ -2277,6 +2327,29 @@ public fun verdictEach(
 ) {
     val __bcap = JniErrorHandlerCapture.acquire()
     CovNative.verdictEach(n, total, sink.asRaw(), __bcap)
+    if (__bcap.failed) return onError.run(__bcap.ze0)
+}
+
+/**
+ * Build an [`Envelope`], with or without its nested stamp.
+ *
+ * The Rust `Envelope` result is delivered decomposed: the builder callback receives (`id`, `stamp__present`, `stamp__secs`, `stamp__nanos`).
+ */
+@Suppress("UNCHECKED_CAST")
+public fun envelopeNew(id: Long, present: Boolean, onError: JniErrorHandler<Envelope?>): Envelope? {
+    val __bcap = JniErrorHandlerCapture.acquire()
+    val __ret = CovNative.envelopeNew(id, present, __EnvelopeBuilder, __bcap)
+    if (__bcap.failed) return onError.run(__bcap.ze0)
+    return __ret as Envelope
+}
+
+/**
+ * The same value handed to a callback, which reassembles the leaves by the
+ * other route.
+ */
+public fun envelopeEach(n: Long, sink: EnvelopeCallback, onError: JniErrorHandler<Unit>) {
+    val __bcap = JniErrorHandlerCapture.acquire()
+    CovNative.envelopeEach(n, sink.asRaw(), __bcap)
     if (__bcap.failed) return onError.run(__bcap.ze0)
 }
 

--- a/examples/covertest-kotlin/kotlin/io/prebindgen/covertest/Test.kt
+++ b/examples/covertest-kotlin/kotlin/io/prebindgen/covertest/Test.kt
@@ -101,6 +101,9 @@ import io.prebindgen.covertest.model.probeEach
 import io.prebindgen.covertest.model.probeNew
 import io.prebindgen.covertest.model.lookupOf
 import io.prebindgen.covertest.model.layeredOf
+import io.prebindgen.covertest.model.Envelope
+import io.prebindgen.covertest.model.envelopeEach
+import io.prebindgen.covertest.model.envelopeNew
 import io.prebindgen.covertest.model.verdictEach
 import io.prebindgen.covertest.model.verdictNew
 import io.prebindgen.covertest.model.dossierNew
@@ -698,6 +701,30 @@ fun main() {
         val absent = verdictNew(8L, 0L, 0.0, boom).orThrow()
         check(absent.outcome === Lookup.Absent)
         absent.close()
+    }
+
+    // An OPTIONAL nested data class, the shape #602 names first. The
+    // decomposition refused it outright until it learned a presence flag, so a
+    // struct carrying one got no fixed-builder delivery at all — on either
+    // route. Both routes are here because they fill the gated slots by
+    // different code: a return through the class's own factory, a callback
+    // through its interface.
+    section("an optional nested data class crosses as presence plus its group") {
+        val present = envelopeNew(7L, true, boom).orThrow()
+        check(present.id == 7L)
+        check(present.stamp == Stamp(7L, 14L)) { "got ${present.stamp}" }
+
+        // Absent: the flag is false and the group carries wire defaults, which
+        // the factory must read as "no value" rather than as a zeroed one.
+        val absent = envelopeNew(9L, false, boom).orThrow()
+        check(absent.id == 9L)
+        check(absent.stamp == null) { "got ${absent.stamp}" }
+
+        val seen = mutableListOf<String>()
+        envelopeEach(4L, { envelope ->
+            seen.add("${envelope.id}:${envelope.stamp?.secs ?: "-"}")
+        }, boom).orThrow()
+        check(seen == listOf("0:-", "1:1", "2:-", "3:3")) { "got $seen" }
     }
 
     // The same data class arriving at a CALLBACK rather than as a return.

--- a/examples/covertest-kotlin/src/generated_bindings.rs
+++ b/examples/covertest-kotlin/src/generated_bindings.rs
@@ -1676,49 +1676,49 @@ pub(crate) unsafe fn __jni_out_convert_Annotated_to_wire_e7aba1468b19001a<'a>(
             )?
             .into();
         let ___alternate_present: jni::sys::jboolean;
-        let ___alternate_o0: jni::sys::jlong;
-        let ___alternate_o1: jni::sys::jint;
-        let ___alternate_o2: jni::sys::jdouble;
-        let ___alternate_o3: jni::sys::jboolean;
-        let ___alternate_o4: jni::objects::JObject;
+        let ___alternate_id: jni::sys::jlong;
+        let ___alternate_seq: jni::sys::jint;
+        let ___alternate_value: jni::sys::jdouble;
+        let ___alternate_flag: jni::sys::jboolean;
+        let ___alternate_label: jni::objects::JObject;
         let __on0: &::core::option::Option<_> = &v.alternate;
         match __on0 {
             ::core::option::Option::Some(__c0) => {
-                let ___alternate_id: jni::sys::jlong = __jni_out_convert_i64_to_wire_15d458bf28dc9c80(
+                let __arm0__alternate_id: jni::sys::jlong = __jni_out_convert_i64_to_wire_15d458bf28dc9c80(
                     env,
                     __c0.id.clone(),
                 )?;
-                let ___alternate_seq: jni::sys::jint = __jni_out_convert_i32_to_wire_67173b19ae5a9348(
+                let __arm0__alternate_seq: jni::sys::jint = __jni_out_convert_i32_to_wire_67173b19ae5a9348(
                     env,
                     __c0.seq.clone(),
                 )?;
-                let ___alternate_value: jni::sys::jdouble = __jni_out_convert_f64_to_wire_61461de12ea6bc04(
+                let __arm0__alternate_value: jni::sys::jdouble = __jni_out_convert_f64_to_wire_61461de12ea6bc04(
                     env,
                     __c0.value.clone(),
                 )?;
-                let ___alternate_flag: jni::sys::jboolean = __jni_out_convert_bool_to_wire_3ee62077915d5228(
+                let __arm0__alternate_flag: jni::sys::jboolean = __jni_out_convert_bool_to_wire_3ee62077915d5228(
                     env,
                     __c0.flag.clone(),
                 )?;
-                let ___alternate_label: jni::objects::JObject = __jni_out_convert_Option_Box_String_jni_optional_intermediate_output_niche_to_wire_57342b1f497b4507(
+                let __arm0__alternate_label: jni::objects::JObject = __jni_out_convert_Option_Box_String_jni_optional_intermediate_output_niche_to_wire_57342b1f497b4507(
                         env,
                         __c0.label.clone(),
                     )?
                     .into();
                 ___alternate_present = 1u8;
-                ___alternate_o0 = ___alternate_id;
-                ___alternate_o1 = ___alternate_seq;
-                ___alternate_o2 = ___alternate_value;
-                ___alternate_o3 = ___alternate_flag;
-                ___alternate_o4 = ___alternate_label;
+                ___alternate_id = __arm0__alternate_id;
+                ___alternate_seq = __arm0__alternate_seq;
+                ___alternate_value = __arm0__alternate_value;
+                ___alternate_flag = __arm0__alternate_flag;
+                ___alternate_label = __arm0__alternate_label;
             }
             ::core::option::Option::None => {
                 ___alternate_present = 0u8;
-                ___alternate_o0 = 0i64;
-                ___alternate_o1 = 0i32;
-                ___alternate_o2 = 0.0f64;
-                ___alternate_o3 = 0u8;
-                ___alternate_o4 = jni::objects::JObject::null();
+                ___alternate_id = 0i64;
+                ___alternate_seq = 0i32;
+                ___alternate_value = 0.0f64;
+                ___alternate_flag = 0u8;
+                ___alternate_label = jni::objects::JObject::null();
             }
         }
         let ___ttl: jni::objects::JObject = __jni_out_convert_Option_i64_jni_optional_intermediate_output_boxed_to_wire_a906c53b92fcc585(
@@ -1741,11 +1741,11 @@ pub(crate) unsafe fn __jni_out_convert_Annotated_to_wire_e7aba1468b19001a<'a>(
                     jni::objects::JValue::from(___payload_flag),
                     jni::objects::JValue::Object(&___payload_label),
                     jni::objects::JValue::from(___alternate_present),
-                    jni::objects::JValue::from(___alternate_o0),
-                    jni::objects::JValue::from(___alternate_o1),
-                    jni::objects::JValue::from(___alternate_o2),
-                    jni::objects::JValue::from(___alternate_o3),
-                    jni::objects::JValue::Object(&___alternate_o4),
+                    jni::objects::JValue::from(___alternate_id),
+                    jni::objects::JValue::from(___alternate_seq),
+                    jni::objects::JValue::from(___alternate_value),
+                    jni::objects::JValue::from(___alternate_flag),
+                    jni::objects::JValue::Object(&___alternate_label),
                     jni::objects::JValue::Object(&___ttl),
                     jni::objects::JValue::from(___priority),
                 ],
@@ -3415,6 +3415,110 @@ pub(crate) unsafe fn __jni_out_convert_DurationBoundary_to_wire_3e3dd8df0414a6fa
                 &[
                     jni::objects::JValue::from(___required),
                     jni::objects::JValue::from(___delay),
+                ],
+            )
+            .and_then(|__v| __v.l())
+            .map_err(|e| <__JniErr as ::core::convert::From<
+                String,
+            >>::from(format!("encode struct via fromParts: {}", e)))?;
+        __obj
+    })
+}
+#[allow(
+    non_snake_case,
+    unused_mut,
+    unused_variables,
+    unused_braces,
+    unused_parens,
+    dead_code,
+    clippy::useless_conversion,
+    clippy::needless_question_mark,
+    clippy::let_and_return,
+    clippy::nonminimal_bool,
+    clippy::eq_op
+)]
+pub(crate) unsafe fn __jni_in_convert_wire_to_Envelope_acbb011ea2aa03e5<'env, 'v>(
+    env: &mut jni::JNIEnv<'env>,
+    v: &jni::objects::JObject<'v>,
+) -> ::core::result::Result<perftest_flat::Envelope, __JniErr> {
+    Ok({
+        let __id_raw: jni::sys::jlong = env
+            .get_field(v, "id", "J")
+            .and_then(|val| val.j())
+            .map_err(|e| <__JniErr as ::core::convert::From<
+                String,
+            >>::from(format!("Envelope.id: {}", e)))? as _;
+        let __stamp_raw: jni::objects::JObject = env
+            .get_field(v, "stamp", "Lio/prebindgen/covertest/model/Stamp;")
+            .and_then(|val| val.l())
+            .map_err(|e| <__JniErr as ::core::convert::From<
+                String,
+            >>::from(format!("Envelope.stamp: {}", e)))?;
+        perftest_flat::Envelope {
+            id: __jni_in_convert_wire_to_i64_da07d745d9e26f71(env, &__id_raw)?,
+            stamp: __jni_in_convert_wire_to_Option_Stamp_jni_optional_intermediate_input_niche_e4305db2eca2412c(
+                env,
+                &__stamp_raw,
+            )?,
+        }
+    })
+}
+#[allow(
+    non_snake_case,
+    unused_mut,
+    unused_variables,
+    unused_braces,
+    unused_parens,
+    dead_code,
+    clippy::useless_conversion,
+    clippy::needless_question_mark,
+    clippy::let_and_return,
+    clippy::nonminimal_bool,
+    clippy::eq_op
+)]
+pub(crate) unsafe fn __jni_out_convert_Envelope_to_wire_c1f991e7596a2df6<'a>(
+    env: &mut jni::JNIEnv<'a>,
+    v: perftest_flat::Envelope,
+) -> ::core::result::Result<jni::objects::JObject<'a>, __JniErr> {
+    Ok({
+        let ___id: jni::sys::jlong = __jni_out_convert_i64_to_wire_15d458bf28dc9c80(
+            env,
+            v.id.clone(),
+        )?;
+        let ___stamp_present: jni::sys::jboolean;
+        let ___stamp_secs: jni::sys::jlong;
+        let ___stamp_nanos: jni::sys::jlong;
+        let __on0: &::core::option::Option<_> = &v.stamp;
+        match __on0 {
+            ::core::option::Option::Some(__c0) => {
+                let __arm0__stamp_secs: jni::sys::jlong = __jni_out_convert_i64_to_wire_15d458bf28dc9c80(
+                    env,
+                    __c0.secs.clone(),
+                )?;
+                let __arm0__stamp_nanos: jni::sys::jlong = __jni_out_convert_i64_to_wire_15d458bf28dc9c80(
+                    env,
+                    __c0.nanos.clone(),
+                )?;
+                ___stamp_present = 1u8;
+                ___stamp_secs = __arm0__stamp_secs;
+                ___stamp_nanos = __arm0__stamp_nanos;
+            }
+            ::core::option::Option::None => {
+                ___stamp_present = 0u8;
+                ___stamp_secs = 0i64;
+                ___stamp_nanos = 0i64;
+            }
+        }
+        let __obj = env
+            .call_static_method(
+                "io/prebindgen/covertest/model/Envelope",
+                "fromParts",
+                "(JZJJ)Lio/prebindgen/covertest/model/Envelope;",
+                &[
+                    jni::objects::JValue::from(___id),
+                    jni::objects::JValue::from(___stamp_present),
+                    jni::objects::JValue::from(___stamp_secs),
+                    jni::objects::JValue::from(___stamp_nanos),
                 ],
             )
             .and_then(|__v| __v.l())
@@ -8724,6 +8828,37 @@ pub(crate) unsafe fn __jni_out_convert_Option_Reading_jni_optional_intermediate_
     clippy::nonminimal_bool,
     clippy::eq_op
 )]
+pub(crate) unsafe fn __jni_in_convert_wire_to_Option_Stamp_jni_optional_intermediate_input_niche_e4305db2eca2412c<
+    'env,
+    'v,
+>(
+    env: &mut jni::JNIEnv<'env>,
+    v: &jni::objects::JObject<'v>,
+) -> ::core::result::Result<::core::option::Option<perftest_flat::Stamp>, __JniErr> {
+    ::core::result::Result::Ok({
+        if v.is_null() {
+            ::core::option::Option::None
+        } else {
+            let __present = v;
+            ::core::option::Option::Some(
+                __jni_in_convert_wire_to_Stamp_cccc3794c11688eb(env, __present)?,
+            )
+        }
+    })
+}
+#[allow(
+    non_snake_case,
+    unused_mut,
+    unused_variables,
+    unused_braces,
+    unused_parens,
+    dead_code,
+    clippy::useless_conversion,
+    clippy::needless_question_mark,
+    clippy::let_and_return,
+    clippy::nonminimal_bool,
+    clippy::eq_op
+)]
 pub(crate) unsafe fn __jni_out_convert_Option_Stamp_jni_optional_intermediate_output_niche_to_wire_4df932077a6f39aa<
     'a,
 >(
@@ -12459,6 +12594,167 @@ pub(crate) unsafe fn __jni_in_convert_wire_to_impl_Fn_Duration_Send_Sync_static_
                 Ok(())
             })()
                 .map_err(|e| tracing::error!("{} callback error: {e}", "Fn(Duration)"));
+        })
+    })
+}
+#[allow(
+    non_snake_case,
+    unused_mut,
+    unused_variables,
+    unused_braces,
+    unused_parens,
+    dead_code,
+    clippy::useless_conversion,
+    clippy::needless_question_mark,
+    clippy::let_and_return,
+    clippy::nonminimal_bool,
+    clippy::eq_op
+)]
+pub(crate) unsafe fn __jni_in_convert_wire_to_impl_Fn_Envelope_Send_Sync_static_aeebfa75b28fc34b<
+    'env,
+    'v,
+>(
+    env: &mut jni::JNIEnv<'env>,
+    v: &jni::objects::JObject<'v>,
+) -> ::core::result::Result<
+    impl Fn(perftest_flat::Envelope) + Send + Sync + 'static,
+    __JniErr,
+> {
+    Ok({
+        use std::sync::Arc;
+        let java_vm = Arc::new(
+            env
+                .get_java_vm()
+                .map_err(|e| <__JniErr as ::core::convert::From<
+                    String,
+                >>::from(format!("Unable to retrieve JVM: {}", e)))?,
+        );
+        let callback_global_ref = env
+            .new_global_ref(&v)
+            .map_err(|e| <__JniErr as ::core::convert::From<
+                String,
+            >>::from(format!("Unable to global-ref callback: {}", e)))?;
+        let __invoke_class = env
+            .get_object_class(&v)
+            .map_err(|e| <__JniErr as ::core::convert::From<
+                String,
+            >>::from(
+                format!("Unable to get callback class for {}: {}", "Fn(Envelope)", e),
+            ))?;
+        let __invoke_id = env
+            .get_method_id(&__invoke_class, "run", "(JZJJ)V")
+            .map_err(|e| <__JniErr as ::core::convert::From<
+                String,
+            >>::from(format!("Unable to resolve run for {}: {}", "Fn(Envelope)", e)))?;
+        Box::new(move |__cb_arg0: perftest_flat::Envelope| {
+            let _ = (|| -> ::core::result::Result<(), __JniErr> {
+                let mut env = java_vm
+                    .attach_current_thread_as_daemon()
+                    .map_err(|e| <__JniErr as ::core::convert::From<
+                        String,
+                    >>::from(format!("Attach thread for {}: {}", "Fn(Envelope)", e)))?;
+                env.push_local_frame(16)
+                    .map_err(|e| <__JniErr as ::core::convert::From<
+                        String,
+                    >>::from(
+                        format!("push local frame for {}: {}", "Fn(Envelope)", e),
+                    ))?;
+                let __frame_res = (|| -> ::core::result::Result<(), __JniErr> {
+                    let (
+                        __cb0_obj1,
+                        __cb0_obj2,
+                        __cb0_obj3,
+                    ): (jni::sys::jvalue, jni::sys::jvalue, jni::sys::jvalue) = {
+                        let __so1: &::core::option::Option<_> = &(&__cb_arg0).stamp;
+                        match __so1 {
+                            ::core::option::Option::Some(__sg1) => {
+                                let __cb0_obj1: jni::sys::jvalue = jni::sys::jvalue {
+                                    z: 1u8,
+                                };
+                                let __cb0_obj2: jni::sys::jvalue = {
+                                    let __enc1 = match __jni_out_convert_i64_to_wire_15d458bf28dc9c80(
+                                        &mut env,
+                                        (&(__sg1).secs).clone(),
+                                    ) {
+                                        ::core::result::Result::Ok(__w) => __w,
+                                        ::core::result::Result::Err(__e) => {
+                                            return ::core::result::Result::Err(
+                                                <__JniErr as ::core::convert::From<
+                                                    String,
+                                                >>::from(__e.to_string()),
+                                            );
+                                        }
+                                    };
+                                    jni::sys::jvalue { j: __enc1 }
+                                };
+                                let __cb0_obj3: jni::sys::jvalue = {
+                                    let __enc2 = match __jni_out_convert_i64_to_wire_15d458bf28dc9c80(
+                                        &mut env,
+                                        (&(__sg1).nanos).clone(),
+                                    ) {
+                                        ::core::result::Result::Ok(__w) => __w,
+                                        ::core::result::Result::Err(__e) => {
+                                            return ::core::result::Result::Err(
+                                                <__JniErr as ::core::convert::From<
+                                                    String,
+                                                >>::from(__e.to_string()),
+                                            );
+                                        }
+                                    };
+                                    jni::sys::jvalue { j: __enc2 }
+                                };
+                                (__cb0_obj1, __cb0_obj2, __cb0_obj3)
+                            }
+                            ::core::option::Option::None => {
+                                (
+                                    jni::sys::jvalue { z: 0u8 },
+                                    jni::sys::jvalue { j: 0i64 },
+                                    jni::sys::jvalue { j: 0i64 },
+                                )
+                            }
+                        }
+                    };
+                    let __cb0_obj0: jni::sys::jvalue = {
+                        let __enc0 = match __jni_out_convert_i64_to_wire_15d458bf28dc9c80(
+                            &mut env,
+                            (&__cb_arg0.id).clone(),
+                        ) {
+                            ::core::result::Result::Ok(__w) => __w,
+                            ::core::result::Result::Err(__e) => {
+                                return ::core::result::Result::Err(
+                                    <__JniErr as ::core::convert::From<
+                                        String,
+                                    >>::from(__e.to_string()),
+                                );
+                            }
+                        };
+                        jni::sys::jvalue { j: __enc0 }
+                    };
+                    let __call_res: ::core::result::Result<(), __JniErr> = unsafe {
+                        env.call_method_unchecked(
+                            &callback_global_ref,
+                            __invoke_id,
+                            jni::signature::ReturnType::Primitive(
+                                jni::signature::Primitive::Void,
+                            ),
+                            &[__cb0_obj0, __cb0_obj1, __cb0_obj2, __cb0_obj3],
+                        )
+                    }
+                        .map(|_| ())
+                        .map_err(|e| {
+                            let _ = env.exception_describe();
+                            <__JniErr as ::core::convert::From<
+                                String,
+                            >>::from(e.to_string())
+                        });
+                    __call_res?;
+                    Ok(())
+                })();
+                let _ = unsafe { env.pop_local_frame(&jni::objects::JObject::null()) };
+                __frame_res?;
+                Ok(())
+            })()
+                .map_err(|e| tracing::error!("{} callback error: {e}", "Fn(Envelope)"));
         })
     })
 }
@@ -17076,6 +17372,224 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_durationOutOfRan
                 &__e.to_string(),
             );
             0 as jni::sys::jlong
+        }
+    }
+}
+#[no_mangle]
+#[allow(non_snake_case, unused_mut, unused_variables, dead_code)]
+pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_envelopeEach<'a>(
+    mut env: jni::JNIEnv<'a>,
+    _class: jni::objects::JClass<'a>,
+    n: jni::sys::jlong,
+    sink: jni::objects::JObject<'a>,
+    __error_sink: jni::objects::JObject<'a>,
+) -> () {
+    #[allow(non_upper_case_globals)]
+    static __SINK_MID: ::prebindgen_jni_runtime::CachedIfaceMethod = ::prebindgen_jni_runtime::CachedIfaceMethod::new();
+    const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
+    const __SINK_DESCR: &str = "(Ljava/lang/String;)Ljava/lang/Object;";
+    let n = match __jni_in_convert_wire_to_i64_da07d745d9e26f71(&mut env, &n) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__e) => {
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e.to_string(),
+            );
+            return ();
+        }
+    };
+    let sink = match __jni_in_convert_wire_to_impl_Fn_Envelope_Send_Sync_static_aeebfa75b28fc34b(
+        &mut env,
+        &sink,
+    ) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__e) => {
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e.to_string(),
+            );
+            return ();
+        }
+    };
+    let __out = perftest_flat::envelope_each(n, sink);
+    match __jni_out_convert_unit_to_wire_9e1510fd173c1fd6(&mut env, __out) {
+        ::core::result::Result::Ok(__w) => __w,
+        ::core::result::Result::Err(__e) => {
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e.to_string(),
+            );
+            ()
+        }
+    }
+}
+#[no_mangle]
+#[allow(non_snake_case, unused_mut, unused_variables, dead_code)]
+pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_envelopeNew<'a>(
+    mut env: jni::JNIEnv<'a>,
+    _class: jni::objects::JClass<'a>,
+    id: jni::sys::jlong,
+    present: jni::sys::jboolean,
+    __builder: jni::objects::JObject<'a>,
+    __error_sink: jni::objects::JObject<'a>,
+) -> jni::objects::JObject<'a> {
+    #[allow(non_upper_case_globals)]
+    static __SINK_MID: ::prebindgen_jni_runtime::CachedIfaceMethod = ::prebindgen_jni_runtime::CachedIfaceMethod::new();
+    const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
+    const __SINK_DESCR: &str = "(Ljava/lang/String;)Ljava/lang/Object;";
+    let id = match __jni_in_convert_wire_to_i64_da07d745d9e26f71(&mut env, &id) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__e) => {
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e.to_string(),
+            );
+            return jni::objects::JObject::null().into();
+        }
+    };
+    let present = match __jni_in_convert_wire_to_bool_1be2f6c32f925207(
+        &mut env,
+        &present,
+    ) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__e) => {
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e.to_string(),
+            );
+            return jni::objects::JObject::null().into();
+        }
+    };
+    #[allow(non_upper_case_globals)]
+    static __CB_MID: ::prebindgen_jni_runtime::CachedIfaceMethod = ::prebindgen_jni_runtime::CachedIfaceMethod::new();
+    const __CB_FQN: &str = "io/prebindgen/covertest/model/EnvelopeBuilder";
+    const __CB_DESCR: &str = "(JZJJ)Ljava/lang/Object;";
+    let __out = perftest_flat::envelope_new(id, present);
+    let (
+        __obj1,
+        __obj2,
+        __obj3,
+    ): (jni::sys::jvalue, jni::sys::jvalue, jni::sys::jvalue) = {
+        let __so1: &::core::option::Option<_> = &(&__out).stamp;
+        match __so1 {
+            ::core::option::Option::Some(__sg1) => {
+                let __obj1: jni::sys::jvalue = jni::sys::jvalue { z: 1u8 };
+                let __obj2: jni::sys::jvalue = {
+                    let __enc1 = match __jni_out_convert_i64_to_wire_15d458bf28dc9c80(
+                        &mut env,
+                        (&(__sg1).secs).clone(),
+                    ) {
+                        ::core::result::Result::Ok(__w) => __w,
+                        ::core::result::Result::Err(__e) => {
+                            signal_binding_error(
+                                &mut env,
+                                &__error_sink,
+                                &__SINK_MID,
+                                __SINK_FQN,
+                                __SINK_DESCR,
+                                &__e.to_string(),
+                            );
+                            return jni::objects::JObject::null().into();
+                        }
+                    };
+                    jni::sys::jvalue { j: __enc1 }
+                };
+                let __obj3: jni::sys::jvalue = {
+                    let __enc2 = match __jni_out_convert_i64_to_wire_15d458bf28dc9c80(
+                        &mut env,
+                        (&(__sg1).nanos).clone(),
+                    ) {
+                        ::core::result::Result::Ok(__w) => __w,
+                        ::core::result::Result::Err(__e) => {
+                            signal_binding_error(
+                                &mut env,
+                                &__error_sink,
+                                &__SINK_MID,
+                                __SINK_FQN,
+                                __SINK_DESCR,
+                                &__e.to_string(),
+                            );
+                            return jni::objects::JObject::null().into();
+                        }
+                    };
+                    jni::sys::jvalue { j: __enc2 }
+                };
+                (__obj1, __obj2, __obj3)
+            }
+            ::core::option::Option::None => {
+                (
+                    jni::sys::jvalue { z: 0u8 },
+                    jni::sys::jvalue { j: 0i64 },
+                    jni::sys::jvalue { j: 0i64 },
+                )
+            }
+        }
+    };
+    let __obj0: jni::sys::jvalue = {
+        let __enc0 = match __jni_out_convert_i64_to_wire_15d458bf28dc9c80(
+            &mut env,
+            (&__out.id).clone(),
+        ) {
+            ::core::result::Result::Ok(__w) => __w,
+            ::core::result::Result::Err(__e) => {
+                signal_binding_error(
+                    &mut env,
+                    &__error_sink,
+                    &__SINK_MID,
+                    __SINK_FQN,
+                    __SINK_DESCR,
+                    &__e.to_string(),
+                );
+                return jni::objects::JObject::null().into();
+            }
+        };
+        jni::sys::jvalue { j: __enc0 }
+    };
+    match __CB_MID
+        .call_object(
+            &mut env,
+            __CB_FQN,
+            "run",
+            __CB_DESCR,
+            &__builder,
+            &[__obj0, __obj1, __obj2, __obj3],
+        )
+    {
+        ::core::result::Result::Ok(__o) => __o,
+        ::core::result::Result::Err(__e) => {
+            let _ = env.exception_describe();
+            let __e2 = <__JniErr as ::core::convert::From<
+                String,
+            >>::from(__e.to_string());
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e2.to_string(),
+            );
+            jni::objects::JObject::null().into()
         }
     }
 }

--- a/examples/perftest-flat/src/ext.rs
+++ b/examples/perftest-flat/src/ext.rs
@@ -604,6 +604,47 @@ pub struct Stamp {
     pub nanos: i64,
 }
 
+/// A data class whose nested class sits behind an `Option` — the shape #602
+/// names first and the one a decomposition refused outright until it learned
+/// a presence flag.
+///
+/// Nothing else about it is unusual: a sibling scalar beside a nested class
+/// that is sometimes there. `Annotated` has the same field, but also an
+/// `enum_class` one, which is a refusal of its own — so the shape needs a
+/// struct of its own to show up at all.
+#[prebindgen]
+pub struct Envelope {
+    pub id: i64,
+    pub stamp: Option<Stamp>,
+}
+
+/// Build an [`Envelope`], with or without its nested stamp.
+#[prebindgen]
+pub fn envelope_new(id: i64, present: bool) -> Envelope {
+    Envelope {
+        id,
+        stamp: present.then(|| Stamp {
+            secs: id,
+            nanos: id * 2,
+        }),
+    }
+}
+
+/// The same value handed to a callback, which reassembles the leaves by the
+/// other route.
+#[prebindgen]
+pub fn envelope_each(n: i64, sink: impl Fn(Envelope) + Send + Sync + 'static) {
+    for i in 0..n {
+        sink(Envelope {
+            id: i,
+            stamp: (i % 2 == 1).then(|| Stamp {
+                secs: i,
+                nanos: i * 2,
+            }),
+        });
+    }
+}
+
 /// Build a [`Stamp`] (data-class **return**).
 #[prebindgen]
 pub fn stamp_new(secs: i64, nanos: i64) -> Stamp {

--- a/prebindgen-jni/src/jni/compile.rs
+++ b/prebindgen-jni/src/jni/compile.rs
@@ -4465,6 +4465,21 @@ impl Declarations {
                     }
                     let inlined =
                         self.struct_out_wires_at(registry, &child, &field_path, &name, depth + 1)?;
+                    // One selector may not own another yet: `group` is a flat
+                    // `Option<i32>`, so a selector inside this group would have
+                    // to be both "the group's member" and "a selector of its
+                    // own", and `segments` would return overlapping ranges.
+                    // Refused HERE, before the leaves are registered as a
+                    // `ValueDecon`, so the shape stays on the whole-object path
+                    // rather than panicking during rendering. Nested segments
+                    // are the endpoint; see #602.
+                    if optional
+                        && inlined
+                            .iter()
+                            .any(prebindgen_registry::unfold::DecomposedLeaf::selects)
+                    {
+                        return None;
+                    }
                     wires.extend(inlined.into_iter().map(|wire| {
                         let mut reach = wire.reach;
                         if optional {

--- a/prebindgen-jni/src/jni/compile.rs
+++ b/prebindgen-jni/src/jni/compile.rs
@@ -548,6 +548,9 @@ pub(crate) struct OutWire {
 pub(crate) enum OutAbi {
     /// Synthesized Choice selector: raw `jint`, with no converter.
     Tag,
+    /// Synthesized presence flag: raw `jboolean`, with no converter. The value
+    /// it tests crosses through the leaves it gates, not through this one.
+    Present,
     /// One value encoded through its registry-planned pipeline. Projection is
     /// retained because handle/unsigned delivery owns special jvalue policy.
     Value(Box<OutValueAbi>),
@@ -566,7 +569,9 @@ impl OutAbi {
     /// converted.
     pub(crate) fn calls(&self, out: &mut Vec<prebindgen_registry::write::ArtifactKey>) {
         match self {
-            Self::Tag => {}
+            // Assigned, not converted: a tag by the emitter, a presence flag
+            // by the gate that unwrapped the value.
+            Self::Tag | Self::Present => {}
             Self::Value(value) => value.pipeline.calls(out),
         }
     }
@@ -596,7 +601,11 @@ impl prebindgen_registry::unfold::DecomposedLeaf for OutWire {
     }
 
     fn selects(&self) -> bool {
-        self.is_tag()
+        // A presence flag selects too: between the group being live and the
+        // group carrying its defaults. The walk emits both as one gated
+        // segment, which is the shape an absent optional needs — a per-leaf
+        // absent value cannot fill a primitive slot.
+        matches!(self.from, OutFrom::Tag | OutFrom::Present)
     }
 
     fn group(&self) -> Option<i32> {
@@ -625,6 +634,7 @@ impl OutWire {
             group: leaf.group,
             from: match &leaf.source {
                 LeafSource::SumTag => OutFrom::Tag,
+                LeafSource::Presence => OutFrom::Present,
                 LeafSource::VariantField { variant, member } => OutFrom::Payload {
                     variant: Some(variant.clone()),
                     member: member.clone(),
@@ -684,6 +694,10 @@ pub(crate) enum OutFrom {
     /// Read off the place [`OutWire::reach`] names — a field access, or the
     /// result of the accessor the reach ends in.
     Place,
+    /// The synthesized presence of an optional value the decomposition looks
+    /// through: the emitter tests the place [`OutWire::reach`] names and the
+    /// leaves after it carry the value when it is there.
+    Present,
     /// A payload of one alternative, bound by that arm's pattern.
     Payload {
         /// The alternative's ident as the source enum declares it. Empty until
@@ -2796,6 +2810,8 @@ pub(crate) fn freeze_out_wires(
             let mut wire = OutWire::from_leaf(leaf);
             wire.abi = Some(if wire.is_tag() {
                 OutAbi::Tag
+            } else if matches!(wire.from, OutFrom::Present) {
+                OutAbi::Present
             } else {
                 let crossing = prebindgen_registry::recipe::Crossing::new(
                     wire.out_ty.clone(),
@@ -4405,40 +4421,70 @@ impl Declarations {
                     }
                     continue;
                 }
-                // A nested `data_class` inlines when it is reached directly.
-                // Behind an `Option` or a `Vec` there is no chain to reach
-                // through, so the whole value stays object-shaped.
+                // A nested `data_class` inlines: its own leaves are reached
+                // through this field. An OPTIONAL one contributes a presence
+                // flag ahead of them, and its group carries wire defaults when
+                // the value is absent — the same shape a sum field's tag gives
+                // its groups, with presence in place of an alternative.
                 //
-                // This refusal is why the whole-object output encode
-                // (`emit/struct_out.rs`) is not rendered from this
-                // decomposition: it supports the shapes refused here — an
-                // optional nested class becomes a `present` flag plus a
-                // defaulted group, and a sum field a tag plus one group per
-                // variant. Delivering those to a foreign builder is a feature
-                // this decomposition does not have: the encode is a superset
-                // rather than a second implementation. Where both apply they
-                // name the same leaves, which `assert_leaf_derivations_agree`
-                // checks. See #596 step 5, and #602.
+                // A `Vec` of them is still refused: a repeated value has no
+                // fixed number of leaves to lay side by side, which is a
+                // sequence rather than a decomposition.
                 crate::jni::classify::TypeKind::DataStruct {
                     st: _,
                     cfg: Some(_),
                 } => {
-                    if field.ty.optional_inner().is_some()
-                        || matches!(field.ty.kind(), TypeKind::Vec(_))
-                    {
+                    if matches!(field.ty.kind(), TypeKind::Vec(_)) {
                         return None;
                     }
                     let child = match probe.unwrapped().kind() {
                         TypeKind::Named { id, .. } => id.ident()?,
                         _ => return None,
                     };
-                    wires.extend(self.struct_out_wires_at(
-                        registry,
-                        &child,
-                        &field_path,
-                        &name,
-                        depth + 1,
-                    )?);
+                    let optional = field.ty.optional_inner().is_some();
+                    if optional {
+                        // The flag's own reach ends in the OPTIONAL step it
+                        // tests: presence is the gate, and the walk emits a
+                        // gate exactly where a segment's selector reaches
+                        // through one. The group's leaves then reach on from
+                        // the value that gate unwrapped.
+                        let mut reach: Vec<prebindgen_registry::unfold::PathStep> =
+                            field_path.iter().map(field_step).collect();
+                        reach[path.len()] =
+                            prebindgen_registry::unfold::PathStep::field(fname.clone(), true);
+                        wires.push(OutWire {
+                            name: format!("{name}__{}", crate::jni::emit::PRESENT_LEAF),
+                            out_ty: field.ty.clone(),
+                            group: None,
+                            from: OutFrom::Present,
+                            reach,
+                            nullable: false,
+                            identity: false,
+                            abi: None,
+                        });
+                    }
+                    let inlined =
+                        self.struct_out_wires_at(registry, &child, &field_path, &name, depth + 1)?;
+                    wires.extend(inlined.into_iter().map(|wire| {
+                        let mut reach = wire.reach;
+                        if optional {
+                            // The step reaching THIS field is optional for the
+                            // child's leaves: they are inside the value the
+                            // presence flag tests, so the walk gates them on
+                            // it. The flag's own reach stops at the `Option`,
+                            // which is the value it tests rather than one
+                            // inside it.
+                            reach[path.len()] =
+                                prebindgen_registry::unfold::PathStep::field(fname.clone(), true);
+                        }
+                        OutWire {
+                            reach,
+                            // Under a presence flag the child's leaves are the
+                            // one group that flag gates.
+                            group: optional.then_some(0).or(wire.group),
+                            ..wire
+                        }
+                    }));
                     continue;
                 }
                 _ => {}

--- a/prebindgen-jni/src/jni/emit/callback.rs
+++ b/prebindgen-jni/src/jni/emit/callback.rs
@@ -201,6 +201,8 @@ fn freeze_callback_delivery(
             .map(|mut wire| {
                 wire.abi = Some(if wire.is_tag() {
                     crate::jni::compile::OutAbi::Tag
+                } else if matches!(wire.from, crate::jni::compile::OutFrom::Present) {
+                    crate::jni::compile::OutAbi::Present
                 } else {
                     ext.out_frag(&wire.out_ty)?.output_abi()
                 });

--- a/prebindgen-jni/src/jni/emit/delivery.rs
+++ b/prebindgen-jni/src/jni/emit/delivery.rs
@@ -533,8 +533,8 @@ impl prebindgen_registry::unfold::DeliveryBridge for FrozenDelivery {
     ) -> TokenStream {
         let pipeline = match &leaf.abi {
             Some(crate::jni::compile::OutAbi::Value(value)) => &value.pipeline,
-            Some(crate::jni::compile::OutAbi::Tag) => {
-                unreachable!("a sum selector is encoded with its own segment")
+            Some(crate::jni::compile::OutAbi::Tag) | Some(crate::jni::compile::OutAbi::Present) => {
+                unreachable!("a selector is encoded with its own segment")
             }
             None => panic!(
                 "jnigen delivery: leaf `{}` reached Rust rendering without a frozen output ABI",
@@ -768,14 +768,30 @@ pub(crate) fn encode_plan_leaves(
             &wires[seg.clone()],
             &obj_idents[seg.clone()],
             &|matched| {
-                let (stmts, args) = encode_sum_group(
-                    context,
-                    &wires[seg.clone()],
-                    &obj_idents[seg.clone()],
-                    matched,
-                    fail,
-                    emit,
-                );
+                // A segment is selected by a tag or by a presence flag, and
+                // the two fill their group differently: one alternative's
+                // payload, or the child's own leaves off the value the gate
+                // unwrapped.
+                let (stmts, args) = if wires[seg.start].is_tag() {
+                    encode_sum_group(
+                        context,
+                        &wires[seg.clone()],
+                        &obj_idents[seg.clone()],
+                        matched,
+                        fail,
+                        emit,
+                    )
+                } else {
+                    crate::jni::emit::encode_presence_group(
+                        context,
+                        &wires[seg.clone()],
+                        &obj_idents[seg.clone()],
+                        matched,
+                        &qualify,
+                        fail,
+                        emit,
+                    )
+                };
                 *group_args.borrow_mut() = args;
                 stmts
             },
@@ -843,8 +859,8 @@ pub(crate) fn encode_plan_leaves(
             Some(crate::jni::compile::OutAbi::Value(value)) => {
                 (&value.pipeline, value.projection.as_ref())
             }
-            Some(crate::jni::compile::OutAbi::Tag) => {
-                unreachable!("sum selector segments are encoded above")
+            Some(crate::jni::compile::OutAbi::Tag) | Some(crate::jni::compile::OutAbi::Present) => {
+                unreachable!("selector segments are encoded above")
             }
             None => panic!(
                 "jnigen delivery: leaf `{}` reached Rust rendering without a frozen output ABI",
@@ -1064,6 +1080,7 @@ pub(crate) fn encode_plan_leaves(
 fn frozen_leaf_wire(leaf: &crate::jni::compile::OutWire) -> syn::Type {
     match &leaf.abi {
         Some(crate::jni::compile::OutAbi::Tag) => syn::parse_quote!(jni::sys::jint),
+        Some(crate::jni::compile::OutAbi::Present) => syn::parse_quote!(jni::sys::jboolean),
         Some(crate::jni::compile::OutAbi::Value(value)) => value.pipeline.wire().clone(),
         None => panic!("frozen JNI delivery leaf `{}` has no output ABI", leaf.name),
     }
@@ -1083,6 +1100,11 @@ fn frozen_leaf_wire(leaf: &crate::jni::compile::OutWire) -> syn::Type {
 fn frozen_leaf_is_prim(leaf: &crate::jni::compile::OutWire) -> bool {
     if leaf.is_tag() {
         return !leaf.nullable;
+    }
+    // A presence flag is a `jboolean` the gate assigns — there is nothing to
+    // box and no value behind it that could be absent.
+    if matches!(leaf.abi, Some(crate::jni::compile::OutAbi::Present)) {
+        return true;
     }
     if leaf.nullable {
         return false;

--- a/prebindgen-jni/src/jni/emit/struct_out.rs
+++ b/prebindgen-jni/src/jni/emit/struct_out.rs
@@ -111,6 +111,7 @@ pub(crate) fn synth_value_struct_leaves(
                 // than trying to compile the sum type as a crossing.
                 source: match w.from {
                     crate::jni::compile::OutFrom::Tag => LeafSource::SumTag,
+                    crate::jni::compile::OutFrom::Present => LeafSource::Presence,
                     _ => LeafSource::Reach,
                 },
                 group: w.group,
@@ -173,6 +174,10 @@ pub(crate) fn encode_leaves(
 /// marker: `base` and every slot fragment come from source identifiers, and
 /// any sentinel spelled inside one of them can appear in the middle of a name
 /// too (#616 review).
+/// The one "arm" an optional value has: present. Absence contributes no
+/// bindings of its own, only the defaults its group carries.
+const PRESENT_ARM: usize = 0;
+
 fn arm_local_base(tag: usize, base: &str) -> String {
     format!("arm{tag}_{base}")
 }
@@ -343,11 +348,22 @@ fn encode_field(
                 } else {
                     let cbind = format_ident!("__c{}", depth);
                     let child_access = quote! { #cbind };
-                    let (child_pre, child_slots) =
-                        encode_plan(child, &child_access, base, depth + 1, env_expr, emit);
+                    // The child encodes under an arm-local base, and the outer
+                    // slots drop that prefix: the two are the same leaf, named
+                    // the same way the decomposition names it, and one scope
+                    // assigns from the other.
+                    let (child_pre, child_slots) = encode_plan(
+                        child,
+                        &child_access,
+                        &arm_local_base(PRESENT_ARM, base),
+                        depth + 1,
+                        env_expr,
+                        emit,
+                    );
                     let flag_id = format_ident!("__{}_present", base);
-                    let outer_ids: Vec<proc_macro2::Ident> = (0..child_slots.len())
-                        .map(|i| format_ident!("__{}_o{}", base, i))
+                    let outer_ids: Vec<proc_macro2::Ident> = child_slots
+                        .iter()
+                        .map(|slot| outer_of(PRESENT_ARM, &slot.ident))
                         .collect();
                     let outer_tys: Vec<TokenStream> =
                         child_slots.iter().map(|sl| sl.wire_ty.clone()).collect();
@@ -377,8 +393,11 @@ fn encode_field(
                             }
                         }
                     });
+                    // The flag sits one level inside the struct, with the
+                    // group it gates: it is reached THROUGH this field, which
+                    // is what the decomposition's `__` join says.
                     slots.push(EncSlot {
-                        depth,
+                        depth: depth + 1,
                         ident: flag_id,
                         wire_ty: quote!(jni::sys::jboolean),
                         descriptor: "Z".to_string(),
@@ -387,7 +406,7 @@ fn encode_field(
                     });
                     for (i, sl) in child_slots.iter().enumerate() {
                         slots.push(EncSlot {
-                            depth,
+                            depth: sl.depth,
                             ident: outer_ids[i].clone(),
                             wire_ty: sl.wire_ty.clone(),
                             descriptor: sl.descriptor.clone(),

--- a/prebindgen-jni/src/jni/emit/sum_out.rs
+++ b/prebindgen-jni/src/jni/emit/sum_out.rs
@@ -25,6 +25,10 @@ use super::*;
 /// variant fragment from its property.
 pub(crate) const SUM_TAG_LEAF: &str = "tag";
 
+/// The leaf-name fragment of a presence flag — what an optional nested class
+/// contributes ahead of the group it gates.
+pub(crate) const PRESENT_LEAF: &str = "present";
+
 /// The leaves of one `sealed_class`-declared sum, as the expansion plans want
 /// them: the [`LeafSource::SumTag`] selector followed by one
 /// [`LeafSource::VariantField`] leaf per payload field, in tag order, each
@@ -64,6 +68,7 @@ pub(crate) fn synth_sum_leaves(
                     }
                 }
                 crate::jni::compile::OutFrom::Place => LeafSource::Reach,
+                crate::jni::compile::OutFrom::Present => LeafSource::Presence,
             },
             group: w.group,
         })
@@ -303,8 +308,8 @@ fn encode_group_leaf(
 ) -> TokenStream {
     let frozen_pipeline = match &leaf.abi {
         Some(crate::jni::compile::OutAbi::Value(value)) => &value.pipeline,
-        Some(crate::jni::compile::OutAbi::Tag) => {
-            unreachable!("a Choice payload is not its selector")
+        Some(crate::jni::compile::OutAbi::Tag) | Some(crate::jni::compile::OutAbi::Present) => {
+            unreachable!("a segment's payload is not its selector")
         }
         None => panic!(
             "jnigen sum delivery: payload leaf `{}` reached Rust rendering without a frozen output ABI",
@@ -339,4 +344,58 @@ fn encode_group_leaf(
             #obj_ident = #cast;
         }
     }
+}
+
+/// The encode of a **presence** segment: an optional nested value's flag and
+/// the leaves it gates, from the value the walk has already unwrapped.
+///
+/// [`prebindgen_registry::unfold::segment`] supplies the gate — one tuple bind
+/// whose absent arm carries every slot's default — and calls this for the
+/// present arm, so what is here is the flag and the child's own leaves read
+/// off the unwrapped value. The sum twin next to it answers the same shape
+/// with alternatives in place of presence.
+pub(crate) fn encode_presence_group(
+    context: &crate::jni::emit::delivery::FrozenDelivery,
+    leaves: &[crate::jni::compile::OutWire],
+    obj_idents: &[syn::Ident],
+    matched: TokenStream,
+    qualify: &dyn Fn(&syn::Ident) -> syn::Path,
+    fail: &dyn Fn(TokenStream) -> TokenStream,
+    emit: &prebindgen_registry::RustWriter,
+) -> (TokenStream, Vec<TokenStream>) {
+    use prebindgen_registry::unfold::DeliveryBridge;
+
+    let flag = &obj_idents[0];
+    let flag_slot = leaf_slot(context, &leaves[0]);
+    let flag_ty = &flag_slot.ty;
+    let mut stmts = quote! { let #flag: #flag_ty = jni::sys::jvalue { z: 1u8 }; };
+    let mut args: Vec<TokenStream> = vec![quote!(#flag)];
+
+    // The prefix the presence flag reaches is already consumed: the walk bound
+    // what it found there, so each gated leaf reaches on from that binding.
+    let consumed = leaves[0].reach.len();
+    for (index, leaf) in leaves.iter().enumerate().skip(1) {
+        let slot = &obj_idents[index];
+        let tail: Vec<prebindgen_registry::unfold::PathStep> =
+            leaf.reach.iter().skip(consumed).cloned().collect();
+        let matched = matched.clone();
+        let reach = |body: &dyn Fn(TokenStream) -> TokenStream| -> TokenStream {
+            prebindgen_registry::unfold::reach_leaf(
+                qualify,
+                prebindgen_registry::unfold::LeafAt {
+                    leaf,
+                    path: &tail,
+                    base: matched.clone(),
+                    base_is_ref: true,
+                    consuming: false,
+                    unwrap_last: false,
+                },
+                Some(&|| DeliveryBridge::absent(context)),
+                body,
+            )
+        };
+        stmts.extend(context.encode(leaf, index, slot, &reach, fail, emit));
+        args.push(context.argument(leaf, slot));
+    }
+    (stmts, args)
 }

--- a/prebindgen-jni/src/jni/iface.rs
+++ b/prebindgen-jni/src/jni/iface.rs
@@ -921,6 +921,13 @@ fn plan_leaf_param(
         let ty = if leaf.nullable { ty.nullable() } else { ty };
         return Some(IfaceParam::same(name, ty));
     }
+    // A presence flag has no converter behind it either: it is a `Boolean` the
+    // gate assigns, and the value it speaks for crosses through the leaves it
+    // gates rather than through this slot. Its `out_ty` is that optional value,
+    // which is why the type cannot be read off it.
+    if matches!(leaf.from, crate::jni::compile::OutFrom::Present) {
+        return Some(IfaceParam::same(name, KtType::boolean()));
+    }
     // A group slot is INERT whenever another variant is live, and the encoder
     // fills an inert object slot with `JObject::null()`. A JVM null handed to a
     // non-null Kotlin parameter throws inside the intrinsic null-check before

--- a/prebindgen-jni/src/jni/mod.rs
+++ b/prebindgen-jni/src/jni/mod.rs
@@ -499,6 +499,7 @@ fn leaf_reach(leaf: &prebindgen_registry::unfold::UnfoldLeaf) -> String {
     use prebindgen_registry::unfold::LeafSource;
     match &leaf.source {
         LeafSource::SumTag => "tag".to_string(),
+        LeafSource::Presence => format!("present({})", reach_of(&leaf.path)),
         LeafSource::VariantField { variant, member } => format!(
             "{variant}.{}",
             crate::jni::struct_plan::sum_field_prop_name(member)
@@ -642,6 +643,9 @@ impl JniGen {
                 .map(|w| {
                     let from = match &w.from {
                         crate::jni::compile::OutFrom::Tag => "tag".to_string(),
+                        crate::jni::compile::OutFrom::Present => {
+                            format!("present({})", reach_of(&w.reach))
+                        }
                         crate::jni::compile::OutFrom::Place => reach_of(&w.reach),
                         crate::jni::compile::OutFrom::Payload { variant, member } => format!(
                             "{}.{}",
@@ -708,6 +712,9 @@ impl JniGen {
                 .map(|w| {
                     let from = match &w.from {
                         crate::jni::compile::OutFrom::Tag => "tag".to_string(),
+                        crate::jni::compile::OutFrom::Present => {
+                            format!("present({})", reach_of(&w.reach))
+                        }
                         crate::jni::compile::OutFrom::Place => reach_of(&w.reach),
                         crate::jni::compile::OutFrom::Payload { variant, member } => format!(
                             "{}.{}",

--- a/prebindgen-jni/src/jni/tests/flatten.rs
+++ b/prebindgen-jni/src/jni/tests/flatten.rs
@@ -2545,6 +2545,95 @@ fn a_sum_field_decomposes_into_its_tag_and_groups() {
     );
 }
 
+/// One selector may not own another: an optional nested class whose own child
+/// carries a selector stays on the whole-object path.
+///
+/// `group` is a flat `Option<i32>`, so a nested selector would have to be both
+/// a member of the outer group and a selector of its own, and `segments` would
+/// return overlapping ranges — the outer render then reaches the inner
+/// selector as if it were an ordinary payload. Refusing is a decomposition
+/// this adapter declines, not a panic during `write_rust`: the value keeps the
+/// whole-object encode, which handles the shape.
+///
+/// Nested segments are the endpoint (#602). Until then this test is what says
+/// the boundary is deliberate, and `write_rust` is what proves the refusal
+/// happens before anything renders.
+#[test]
+fn a_selector_inside_a_gated_group_is_refused_rather_than_rendered() {
+    let loc = myflat_loc();
+    let items: Vec<(syn::Item, prebindgen::SourceLocation)> = vec![
+        (
+            syn::Item::Struct(syn::parse_quote!(
+                pub struct Leaf {
+                    pub id: i64,
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Struct(syn::parse_quote!(
+                pub struct Mid {
+                    pub inner: Option<Leaf>,
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Struct(syn::parse_quote!(
+                pub struct Outer {
+                    pub mid: Option<Mid>,
+                }
+            )),
+            loc.clone(),
+        ),
+        (
+            syn::Item::Fn(syn::parse_quote!(
+                pub fn outer_new() -> Outer {
+                    unimplemented!()
+                }
+            )),
+            loc.clone(),
+        ),
+    ];
+    let registry = crate::test_util::reg_from_items(declare_referenced(items)).expect("index");
+    let jni = JniGenBuilder::new()
+        .set_package_prefix("io.test.jni")
+        .package(
+            crate::package!()
+                .class(crate::data_class!(Leaf))
+                .class(crate::data_class!(Mid))
+                .class(crate::data_class!(Outer))
+                .fun(prebindgen_registry::fun!(outer_new)),
+        );
+    let gen = jni.build_with(registry).expect("resolve");
+
+    // `Mid` decomposes: one selector, its own group.
+    let mid: syn::Ident = syn::parse_quote!(Mid);
+    let names: Vec<String> = gen
+        .declarations()
+        .struct_out_wires_of(gen.registry(), &mid)
+        .expect("one level of gating decomposes")
+        .iter()
+        .map(|wire| wire.name.clone())
+        .collect();
+    assert_eq!(names, ["inner__present", "inner__id"]);
+
+    // `Outer` would need a selector inside a gated group, and declines.
+    let outer: syn::Ident = syn::parse_quote!(Outer);
+    assert!(
+        gen.declarations()
+            .struct_out_wires_of(gen.registry(), &outer)
+            .is_none(),
+        "a selector inside a gated group is refused"
+    );
+
+    // And the refusal holds through rendering: `Outer` keeps the whole-object
+    // encode rather than reaching a selector where a payload was expected.
+    let dir = unique_test_dir("jnigen_nested_selector");
+    std::fs::create_dir_all(&dir).unwrap();
+    gen.write_rust(dir.join("gen.rs")).expect("write_rust");
+}
+
 /// A field whose own name contains what used to be the arm-local marker is
 /// just a name.
 ///

--- a/prebindgen-jni/src/jni/tests/flatten.rs
+++ b/prebindgen-jni/src/jni/tests/flatten.rs
@@ -2619,19 +2619,20 @@ fn a_field_named_like_the_arm_marker_is_just_a_field() {
     gen.write_rust(dir.join("gen.rs")).expect("write_rust");
 }
 
-/// The whole-object encode covers a shape the registry-facing decomposition
-/// refuses, and that divergence is deliberate.
+/// An OPTIONAL nested `data_class` decomposes: a presence flag, then the
+/// child's leaves as the group it gates.
 ///
-/// `struct_out_wires_of` returns `None` for a struct with a nested
-/// `data_class` behind an `Option`, because there is no chain to reach the
-/// inlined leaves through. The whole-object output encode supports it as a
-/// `present` flag plus a defaulted group — which is why #596 step 5 records
-/// the two as different coverage rather than composing one from the other.
+/// This was the refusal #602 leads with, and the one this test used to pin the
+/// other way round. The whole-object encode always supported the shape — a
+/// `present` flag plus a defaulted group — and the decomposition refusing it
+/// is what kept a struct with an optional nested class off fixed-builder
+/// delivery entirely.
 ///
-/// If this ever starts returning `Some`, the encode should be rendered from
-/// the decomposition and this test deleted; see #602.
+/// A `Vec` of them is still refused, and that one is not a gap: a repeated
+/// value has no fixed number of leaves to lay beside its siblings, which is a
+/// sequence rather than a decomposition.
 #[test]
-fn the_decomposition_refuses_what_the_whole_object_encode_supports() {
+fn an_optional_nested_class_decomposes_behind_its_presence() {
     let loc = myflat_loc();
     let items: Vec<(syn::Item, prebindgen::SourceLocation)> = vec![
         (
@@ -2671,22 +2672,30 @@ fn the_decomposition_refuses_what_the_whole_object_encode_supports() {
     let gen = jni.build_with(registry).expect("resolve");
 
     let holder: syn::Ident = syn::parse_quote!(Holder);
+    let wires = gen
+        .declarations()
+        .struct_out_wires_of(gen.registry(), &holder)
+        .expect("an optional nested data class no longer refuses the decomposition");
+    let names: Vec<&str> = wires.iter().map(|wire| wire.name.as_str()).collect();
+    assert_eq!(
+        names,
+        ["inner__present", "inner__id"],
+        "the presence flag, then the child's leaves"
+    );
     assert!(
-        gen.declarations()
-            .struct_out_wires_of(gen.registry(), &holder)
-            .is_none(),
-        "the decomposition refuses an optional nested data class"
+        matches!(wires[0].from, crate::jni::compile::OutFrom::Present),
+        "presence is synthesized, not read off a place holding a boolean"
+    );
+    assert_eq!(
+        wires[1].group,
+        Some(0),
+        "the child's leaves are the one group that flag gates"
     );
 
-    let dir = unique_test_dir("jnigen_decomposition_refusal");
+    // Rendering runs the encode and `assert_leaf_derivations_agree` over it.
+    let dir = unique_test_dir("jnigen_optional_nested");
     std::fs::create_dir_all(&dir).unwrap();
-    let rust = std::fs::read_to_string(gen.write_rust(dir.join("gen.rs")).expect("write_rust"))
-        .expect("read generated file");
-    let compact: String = rust.split_whitespace().collect();
-    assert!(
-        compact.contains("__inner_present"),
-        "the whole-object encode still supports it, as a present flag:\n{rust}"
-    );
+    gen.write_rust(dir.join("gen.rs")).expect("write_rust");
 }
 
 /// A nullable primitive keeps the allocation-free `(present, value)` pair

--- a/prebindgen-registry/src/unfold/plan.rs
+++ b/prebindgen-registry/src/unfold/plan.rs
@@ -350,26 +350,44 @@ pub struct UnfoldLeaf {
     /// `match Some/None`.
     pub nullable: bool,
     /// How [`Self::path`] is reached from the value — an accessor-fn chain
-    /// (default), a struct-field chain (synthesized `data_class`), or a
-    /// variant pattern binding (decomposed sum).
+    /// (default), a struct-field chain (synthesized `data_class`), a variant
+    /// pattern binding (decomposed sum), or one of the two synthesized
+    /// selectors, which are assigned rather than reached.
     pub source: LeafSource,
-    /// **Group membership**: `Some(tag)` marks the leaf as belonging to the
-    /// leaf group of the sum alternative with that tag — live only when the
-    /// value's [`LeafSource::SumTag`] leaf equals `tag`, wire-defaulted
-    /// otherwise. `None` for an unconditional (product) leaf, including the
-    /// tag leaf itself, which selects between groups rather than joining one.
+    /// **Group membership**: `Some(n)` marks the leaf as belonging to the
+    /// group a **selector** chooses — live only when that selector says so,
+    /// wire-defaulted otherwise. `None` for an unconditional leaf, and for a
+    /// selector itself, which chooses between groups rather than joining one.
+    ///
+    /// There are two selectors, and `n` means what each of them selects on:
+    ///
+    /// * a [`SumTag`](LeafSource::SumTag) chooses among alternatives, and `n`
+    ///   is the alternative's tag;
+    /// * a [`Presence`](LeafSource::Presence) chooses between "the value is
+    ///   there" and "it is not", and `n` is `0` — the one group a presence
+    ///   flag gates, carried by the leaves of the value it speaks for.
     ///
     /// Grouping is what turns a leaf list into a `match`: leaves sharing a
     /// group are emitted together in one arm instead of as independent
     /// per-leaf expressions.
+    ///
+    /// **One selector may not own another.** A group's leaves may not include
+    /// a selector, because this field cannot say both "member of the outer
+    /// group" and "selector of an inner one" at once —
+    /// [`segments`](crate::unfold::segments) would return overlapping ranges
+    /// and the outer render would meet a selector where a value was expected.
+    /// A decomposition that would need it declines instead, leaving the value
+    /// to whatever whole-value encode the adapter has. Nesting is the
+    /// endpoint; the representation it needs is not this one.
     pub group: Option<i32>,
 }
 
 impl UnfoldLeaf {
     /// Whether this leaf's [`out_ty`](Self::out_ty) needs a resolved **output
-    /// converter**. False only for the synthesized [`LeafSource::SumTag`]
-    /// selector: it is assigned per `match` arm, never converted, so requiring
-    /// a converter for it would make every sum depend on an unrelated `i32`
+    /// converter**. False for a synthesized **selector** — a
+    /// [`SumTag`](LeafSource::SumTag) or a [`Presence`](LeafSource::Presence):
+    /// each is assigned by the emitter rather than converted, so requiring
+    /// a converter for one would make every sum depend on an unrelated `i32`
     /// crossing existing in the binding.
     ///
     /// **This is the root question, not the registration question.** Every

--- a/prebindgen-registry/src/unfold/plan.rs
+++ b/prebindgen-registry/src/unfold/plan.rs
@@ -217,6 +217,18 @@ pub enum LeafSource {
         /// How the payload field is addressed in the arm's pattern.
         member: syn::Member,
     },
+    /// The **synthesized presence** of an optional value the decomposition
+    /// looks through: a boolean saying whether the leaves that follow carry
+    /// anything.
+    ///
+    /// The selector [`SumTag`](Self::SumTag) is for a value that is one of
+    /// several alternatives; this is for a value that is either there or not,
+    /// and the difference is not a two-alternative sum: absence has no
+    /// alternative of its own to name, and the group it gates is the value's
+    /// own leaves rather than one arm's payload. Like a tag it is not read off
+    /// the value — the emitter assigns it — so [`UnfoldLeaf::path`] reaches
+    /// the OPTIONAL value it tests, not a place holding a boolean.
+    Presence,
 }
 
 /// A resolved output expansion for one function.
@@ -367,6 +379,9 @@ impl UnfoldLeaf {
     /// an entry says one resolved — three separate claims, and a `SumTag` leaf
     /// makes only the first (#282).
     pub fn has_converter(&self) -> bool {
-        self.source != LeafSource::SumTag
+        // A presence flag is synthesized like a tag: it says whether the
+        // leaves after it carry anything, and the value it tests crosses
+        // through those leaves rather than through this one.
+        !matches!(self.source, LeafSource::SumTag | LeafSource::Presence)
     }
 }

--- a/prebindgen-registry/src/unfold/walk.rs
+++ b/prebindgen-registry/src/unfold/walk.rs
@@ -572,11 +572,13 @@ pub fn segments<L: DecomposedLeaf>(leaves: &[L]) -> Vec<std::ops::Range<usize>> 
 }
 
 /// Render one segment off `place`, gating the whole of it when the selector
-/// reaches its sum through an optional step.
+/// reaches the value it selects on through an optional step.
 ///
-/// `group` renders the segment's own encode from the expression naming the
-/// live sum — that half is the adapter's, since what a group of slots is
-/// filled with is a target-language question.
+/// A segment's **selected value** is what its selector chooses over: the sum a
+/// tag names an alternative of, or the optional value a presence flag says is
+/// there. `group` renders the segment's own encode from the expression naming
+/// it — that half is the adapter's, since what a group of slots is filled with
+/// is a target-language question.
 ///
 /// **An optional value gates the segment, not each slot.** A segment's leaves
 /// are not independent, so absence cannot be the per-leaf absent value
@@ -604,8 +606,9 @@ pub fn segment<B: DeliveryBridge>(
     // this field while sibling fields move is exactly what a consuming value
     // form does.
     let (projected, lead) = project_leading_fields(&place.base, place.base_is_ref, path);
-    // The selector's own path reaches the sum (empty when the sum IS the
-    // value), and a step on it MAY be optional.
+    // The selector's own path reaches the selected value (empty when that
+    // value IS the delivered one), and a step on it MAY be optional — which is
+    // always so for a presence flag, whose whole subject is that step.
     let Some(k) = (lead..path.len()).find(|&i| path[i].is_optional()) else {
         return group(fold_steps(qualify, &path[lead..], projected, false));
     };
@@ -615,9 +618,9 @@ pub fn segment<B: DeliveryBridge>(
     let opt_e = fold_steps(qualify, &path[lead..=k], projected, false);
     let bind = format_ident!("__sg{}", index);
     // ONE optional step is what this gate handles. A second one in the tail
-    // would compose `match &Option<..>` against bare variant patterns — an
-    // E0308 in the consumer's crate — so the named diagnostic is raised here
-    // instead.
+    // would compose `match &Option<..>` against the patterns the group's own
+    // encode writes — an E0308 in the consumer's crate — so the named
+    // diagnostic is raised here instead.
     //
     // `assert!`, not `debug_assert!`: a build script inherits the consumer's
     // profile, so a debug-only check is absent from exactly the release build
@@ -625,22 +628,22 @@ pub fn segment<B: DeliveryBridge>(
     // phrasing, as the single-return optional-step assert in [`reach_leaf`].
     //
     // The condition is what actually breaks, not the stronger fact that
-    // happens to hold: every sum leaf's path stops AT the sum, so the tail is
-    // empty today, but a NON-optional tail composes correctly through
-    // [`fold_steps`] — refusing it would refuse a shape that works.
+    // happens to hold: a selector's path stops AT the value it selects on, so
+    // the tail is empty today, but a NON-optional tail composes correctly
+    // through [`fold_steps`] — refusing it would refuse a shape that works.
     assert!(
         !path[k + 1..].iter().any(PathStep::is_optional),
-        "unfold: leaf `{}` reaches its sum through TWO optional steps — the \
-         segment gate has one `None` arm, so the second would be matched as if \
-         it were the sum itself",
+        "unfold: leaf `{}` reaches the value it selects on through TWO optional \
+         steps — the segment gate has one `None` arm, so the second would be \
+         matched as if it were that value itself",
         leaves
             .first()
             .expect("a segment has at least its selector")
             .name(),
     );
     // What the `match` binds, asked of the step rather than assumed: the FIELD
-    // branch scrutinizes `&Option<_>`, so ergonomics binds `&Sum` — a borrow.
-    // Only an owned-yielding CALL binds an owned value.
+    // branch scrutinizes `&Option<_>`, so ergonomics binds a borrow of the
+    // selected value. Only an owned-yielding CALL binds an owned one.
     let inner = group(fold_steps(
         qualify,
         &path[k + 1..],

--- a/prebindgen-registry/src/unfold/walk.rs
+++ b/prebindgen-registry/src/unfold/walk.rs
@@ -34,13 +34,23 @@ pub trait DecomposedLeaf {
     /// The reading the leaf delivers.
     fn source(&self) -> &TypeRef;
 
-    /// Whether this leaf is the synthesized **selector** — the value naming
-    /// which alternative of a decomposed sum is live. It selects between the
-    /// groups rather than joining one.
+    /// Whether this leaf is a synthesized **selector** — a value naming which
+    /// group of the leaves after it is live. It chooses between groups rather
+    /// than joining one, so its own [`Self::group`] is `None`.
+    ///
+    /// Two kinds select: a sum's tag, which names the live alternative, and an
+    /// optional value's presence, which says whether its one group carries
+    /// anything.
     fn selects(&self) -> bool;
 
-    /// The alternative this leaf belongs to, when it is one of a sum's group
-    /// leaves. `None` for a leaf that is always live.
+    /// The group this leaf belongs to — an alternative's tag, or `0` for the
+    /// one group a presence flag gates. `None` for a leaf that is always live,
+    /// and for a selector.
+    ///
+    /// A group's leaves may not include a selector: see
+    /// [`UnfoldLeaf::group`](crate::unfold::UnfoldLeaf::group) for why one
+    /// `Option<i32>` cannot express nesting, and what a decomposition does
+    /// instead.
     fn group(&self) -> Option<i32>;
 
     /// Whether the last step reaching it is a field read rather than a call.
@@ -530,11 +540,16 @@ fn reached_place<L: DecomposedLeaf>(
 /// The **segments** of a decomposition: each selector leaf, together with the
 /// group leaves that follow it.
 ///
-/// A sum's leaves are not independent — only one alternative is live per value
-/// — so a segment is emitted as one `match` rather than as a leaf at a time.
-/// The plan already says which leaves those are: a selector says so of itself,
-/// and each of the leaves after it carries the alternative it belongs to until
-/// one does not. A decomposition may carry several segments, or none: a sum
+/// A segment's leaves are not independent — one alternative of a sum is live
+/// per value, and a gated group is live only when its value is there — so a
+/// segment is emitted as one `match` rather than as a leaf at a time. The plan
+/// already says which leaves those are: a selector says so of itself, and each
+/// of the leaves after it carries the group it belongs to until one does not.
+///
+/// Segments do not nest: a group's leaves may not include a selector, or these
+/// ranges would overlap. [`UnfoldLeaf::group`](crate::unfold::UnfoldLeaf::group)
+/// states that invariant and what a decomposition does with a shape that would
+/// need it. A decomposition may carry several segments, or none: a sum
 /// that IS the delivered value is one segment covering everything, and a value
 /// form contributes one per sum-typed field.
 ///
@@ -563,8 +578,8 @@ pub fn segments<L: DecomposedLeaf>(leaves: &[L]) -> Vec<std::ops::Range<usize>> 
 /// live sum — that half is the adapter's, since what a group of slots is
 /// filled with is a target-language question.
 ///
-/// **An `Option<sum>` gates the segment, not each slot.** A sum's leaves are
-/// not independent, so absence cannot be the per-leaf absent value
+/// **An optional value gates the segment, not each slot.** A segment's leaves
+/// are not independent, so absence cannot be the per-leaf absent value
 /// [`reach_leaf`] gives an ordinary optional field: it is one tuple bind whose
 /// `None` arm carries every slot's default. That is the same shape a
 /// conditional value form's hoist emits, applied to an optional step inside


### PR DESCRIPTION
Step 3 of #613, second of three children. #616 taught the decomposition a
sum-typed field; this one teaches it an **optional nested data class**, the
shape #602 leads with. The third renders the whole-object encode from the
decomposition and deletes the second derivation with its agreement check.

## Presence is a selector

The registry's leaf vocabulary gains `LeafSource::Presence`: a synthesized
boolean saying whether the leaves after it carry anything. It is not a
two-alternative sum — absence has no alternative to name, and the group it
gates is the value's own leaves rather than one arm's payload — but it selects
in exactly the sense the delivery walk already understands, so a segment is now
"a tag or a presence flag, and the leaves that follow it".

That is what makes the shape work rather than merely compile. An absent
optional cannot be a per-leaf absent value: a JVM null does not fit a
primitive slot. It has to be the segment gate's `None` arm, which fills every
slot in the group with its default — the shape `unfold::segment` has emitted
since #611, reached here by giving the flag's own reach the optional step it
tests.

JniGen carries it as `OutFrom::Present` / `OutAbi::Present` — a `jboolean` the
gate assigns, with no converter behind it, exactly as a tag is a `jint` with
none. `encode_presence_group` fills the group from the value the gate
unwrapped, beside the sum twin that fills one alternative's payload.

## What it buys

`Envelope { id, stamp: Option<Stamp> }` in `perftest-flat`, delivered both
ways: `envelope_new` returns it, `envelope_each` hands it to a callback. Both
now cross as `[id, stamp__present, stamp__secs, stamp__nanos]` instead of a
whole JVM object.

A struct with this field previously got **no fixed-builder delivery at all**,
on either route. `Annotated` in the same crate has the field too, and stays on
the whole-object path — it also has an `enum_class` field, which is a separate
refusal this child does not touch (measured on #602: handle 2 sites, enum 2).

A `Vec` of nested classes is still refused, and that one is not a gap: a
repeated value has no fixed number of leaves to lay beside its siblings, which
is a sequence rather than a decomposition. The test says so.

## The encode had to agree

`assert_leaf_derivations_agree` — the standing check from #603 — caught the
whole-object encode naming an optional group's slots positionally
(`__maybe_o0`) at the parent's depth, where the decomposition says
`maybe__id` one level in. The encode now names them after the leaf and counts
the depth, the same correction #616 made for sums, with the arm-local bindings
carrying the generated `__arm{tag}_` prefix the outer slots drop.

## Verification

- `covertest-kotlin` passes all **63 JVM sections**, up from 62: a new one
  exercises both routes and both arms — a present stamp, an absent one whose
  group carries defaults the factory must read as "no value", and a callback
  alternating between them.
- 842 tests, 0 clippy warnings under `--all-targets --all-features -- --deny
  warnings`, strict rustdoc clean, the CI-configured `cargo fmt --check` clean.
- `an_optional_nested_class_decomposes_behind_its_presence` replaces the test
  that pinned the refusal, and renders through `write_rust` so the encode and
  the agreement check both run.

## One selector may not own another

`group` is a flat `Option<i32>`, so a selector inside a gated group would have
to say both "member of the outer group" and "selector of an inner one", and
`segments` would return overlapping ranges — the outer render would then meet a
selector where a value was expected (#617 review). A decomposition that would
need it **declines**, before the leaves are registered as a `ValueDecon`, so
the value keeps the whole-object encode rather than panicking during
rendering.

`a_selector_inside_a_gated_group_is_refused_rather_than_rendered` pins that on
`Outer -> Option<Mid> -> Option<Leaf>`: `Mid` decomposes, `Outer` declines, and
`write_rust` proves the refusal happens before anything renders. Removing the
refusal fails it.

The canonical contract says so too. `UnfoldLeaf::group`, `has_converter`,
`DecomposedLeaf::{selects, group}`, `segments` and `segment` described a sum's
tag and nothing else; they now state the generalized selector — a tag choosing
among alternatives, a presence choosing between "there" and "not" — and the
nesting invariant with it.

## Production cost

Shared core **+51**, C adapter **0**, JNI adapter **+170** — registry 16,790
and JNI 30,956, against the 16,739 and 30,786 this branch starts from.

The registry's share is the generalized contract and the presence vocabulary,
which are prose and one enum variant. Doc comments count: the reporter counts
production source lines, and a documentation-only commit moves the number.

— Claude Code (Opus 5)


