### PR TITLE
Nested gates in the decomposition: one selector owns another

### DIFF
--- a/docs/plan-duplication.md
+++ b/docs/plan-duplication.md
@@ -93,10 +93,23 @@ of those is what `GenerationPlan<R>` is for; the rest is the sidecar #613 keeps.
 
 ### Data-class decomposition
 
-A data class is decomposed twice, by `struct_out_wires_at` and by `StructPlan`,
-with different coverage — the registry-facing one refuses a nested data class
-behind `Option` or `Vec`. #602 carries the missing support and #603 pinned the
-disagreement with a standing check; step 3 removes the second derivation.
+A data class is decomposed twice, by `struct_out_wires_at` and by `StructPlan`.
+
+They had different coverage when this baseline was taken — the registry-facing
+one refused a sum field, a nested data class behind an `Option`, a handle and an
+`enum_class` field — which is why #602 carried the missing support and #603
+pinned the agreement, where both applied, with a standing check.
+
+That coverage gap is closed. #616 taught the walk a sum field, #617 an optional
+nested class behind its presence flag, and #618 one selector inside another
+(which also unrefused handle and `enum_class` fields, and with them `Option<sum>`
+and a gated class that selects of its own). What is left to decline is
+structural: a repeated nested class under a `Vec`, a field the model does not
+hold as a named one, nesting past 16 — none of which `StructPlan` serves either.
+
+So the two walks no longer differ in coverage; they duplicate one leaf
+derivation, and `assert_leaf_derivations_agree` is what says so. #619 is the
+paired child that deletes the second one, and step 3 stays open until it lands.
 
 ## Size baseline
 

--- a/docs/sum-types.md
+++ b/docs/sum-types.md
@@ -528,7 +528,16 @@ do not count.
 | **D** | [#149](https://github.com/milyin/prebindgen/issues/149) | jnigen: tag-gated groups on both flatten paths — `FlatFieldNode::Sum`, the struct-or-sum root, the `kt_access` expression-template refactor, `PlanFieldKind::Sum`. Unblocks flat #31 + #11, and flat #30 in its struct-field form (`ReplyStruct { result: ReplyResult, … }`). | C |
 | **E** | [#150](https://github.com/milyin/prebindgen/issues/150) | core + jnigen: sum-typed returns and callback arguments — the unfold selector. Needed when a function's **own** return (or a callback argument) is the sum, e.g. a `reply_get_result(&Reply) -> ReplyResult` accessor mirroring base's `Reply::result()`. | D |
 
-A sum nested as a **data-class field** keeps the whole-value `fromParts` path (stage D's
-`PlanFieldKind::Sum`); the fixed-builder leaf synthesis for value structs still declines a sum
-field. Flattening that too is a wire-width/allocation optimization of an already-correct path, not
-a capability, so it is deliberately not part of stage E.
+A sum nested as a **data-class field** was written here as keeping the whole-value `fromParts`
+path (stage D's `PlanFieldKind::Sum`), because the fixed-builder leaf synthesis for value structs
+declined a sum field. That flattening was called a wire-width/allocation optimization of an
+already-correct path rather than a capability, and so deliberately left out of stage E.
+
+It has since been done, under #613 step 3: [#616](https://github.com/milyin/prebindgen/pull/616)
+taught the registry-facing decomposition a sum field — a tag naming the live alternative, then one
+group of leaves per alternative — and [#618](https://github.com/milyin/prebindgen/pull/618) let one
+selector own another, so an `Option<sum>` field and a gated class that selects of its own decompose
+too. A sum-typed field now keeps its parent on the **fixed-builder** path: it crosses as leaves and
+no JVM object is built for the sum. The whole-value encode remains for the shapes the decomposition
+declines structurally, and [#619](https://github.com/milyin/prebindgen/issues/619) is where the
+second leaf derivation behind it goes.

--- a/examples/covertest-kotlin/build.rs
+++ b/examples/covertest-kotlin/build.rs
@@ -383,6 +383,8 @@ fn main() {
                 // stamp is sometimes there, and the decomposition says so with
                 // a presence flag ahead of the child's leaves.
                 .class(data_class!(Envelope))
+                .class(data_class!(Window))
+                .class(data_class!(Frame))
                 .class(
                     data_class!(Stamp)
                         .method(fun!(stamp_secs))
@@ -650,6 +652,8 @@ fn main() {
                 // The optional nested class on both delivery routes.
                 .fun(fun!(envelope_new))
                 .fun(fun!(envelope_each))
+                .fun(fun!(frame_new))
+                .fun(fun!(frame_each))
                 // …and reached one level deeper still, through a nested data
                 // class rather than a sum.
                 .fun(fun!(dossier_new))

--- a/examples/covertest-kotlin/kotlin/REPORT.md
+++ b/examples/covertest-kotlin/kotlin/REPORT.md
@@ -93,6 +93,9 @@ Base package: `io.prebindgen.covertest`
 - `envelope_each` — `fun envelopeEach(n: Long, sink: EnvelopeCallback, onError: JniErrorHandler<Unit>)`
 - `envelope_new` — `fun envelopeNew(id: Long, present: Boolean, onError: JniErrorHandler<Envelope?>): Envelope?`
   - shaped by: return `Envelope` decomposed → [id, stamp__present, stamp__secs, stamp__nanos] (Callback delivery)
+- `frame_each` — `fun frameEach(n: Long, sink: FrameCallback, onError: JniErrorHandler<Unit>)`
+- `frame_new` — `fun frameNew(id: Long, window: Boolean, span: Boolean, which: Long, onError: JniErrorHandler<Frame?>): Frame?`
+  - shaped by: return `Frame` decomposed → [id, window__present, window__label, window__span__present, window__span__secs, window__span__nanos, window__reading__tag, window__reading__exact_v0, window__reading__range_low, window__reading__range_high, window__reading__tagged_v0, window__reading__tagged_v1, window__reading__companion_v0] (Callback delivery)
 - `hold_echo` — `fun holdEcho(h: Hold, onError: JniErrorHandler<Hold?>): Hold?`
   - shaped by: return `Hold` decomposed → [tag, for_v0] (Callback delivery)
 - `hold_policy_echo` — `fun holdPolicyEcho(p: HoldPolicy, onError: JniErrorHandler<HoldPolicy?>): HoldPolicy?`
@@ -250,6 +253,7 @@ Base package: `io.prebindgen.covertest`
 - `DurationBoundary`: data_class → `io.prebindgen.covertest.model.DurationBoundary` (wire `jni :: objects :: JObject`, input `JObject` opt-in)
 - `Envelope`: data_class → `io.prebindgen.covertest.model.Envelope` (wire `jni :: objects :: JObject`)
 - `EscapeProbe`: ptr_class → `io.prebindgen.covertest.esc_pkg.Esc_Probe` (wire `jni :: sys :: jlong`)
+- `Frame`: data_class → `io.prebindgen.covertest.model.Frame` (wire `jni :: objects :: JObject`)
 - `Hold`: sealed_class → `io.prebindgen.covertest.model.Hold` (wire `?`)
 - `HoldPolicy`: data_class → `io.prebindgen.covertest.model.HoldPolicy` (wire `jni :: objects :: JObject`)
 - `Holder`: data_class → `io.prebindgen.covertest.Holder` (wire `jni :: objects :: JObject`)
@@ -289,6 +293,7 @@ Base package: `io.prebindgen.covertest`
 - `Vault`: ptr_class → `io.prebindgen.covertest.model.Vault` (wire `jni :: sys :: jlong`)
 - `VaultHolder`: ptr_class → `io.prebindgen.covertest.model.VaultHolder` (wire `jni :: sys :: jlong`)
 - `Verdict`: data_class → `io.prebindgen.covertest.model.Verdict` (wire `jni :: objects :: JObject`)
+- `Window`: data_class → `io.prebindgen.covertest.model.Window` (wire `jni :: objects :: JObject`)
 - `WrappedFields`: data_class → `io.prebindgen.covertest.WrappedFields` (wire `jni :: objects :: JObject`)
 
 ## conversions

--- a/examples/covertest-kotlin/kotlin/REPORT.md
+++ b/examples/covertest-kotlin/kotlin/REPORT.md
@@ -55,6 +55,7 @@ Base package: `io.prebindgen.covertest`
 
 - `annotated_alternate_value` — `fun annotatedAlternateValue(a: Annotated, onError: JniErrorHandler<Double?>): Double?`
 - `annotated_new` — `fun annotatedNew(payload: Payload, ttl: Long?, priority: Priority?, onError: JniErrorHandler<Annotated?>): Annotated?`
+  - shaped by: return `Annotated` decomposed → [payload__id, payload__seq, payload__value, payload__flag, payload__label, alternate__present, alternate__id, alternate__seq, alternate__value, alternate__flag, alternate__label, ttl, priority] (Callback delivery)
 - `annotated_payload_value` — `fun annotatedPayloadValue(a: Annotated, onError: JniErrorHandler<Double>): Double`
 - `annotated_priority` — `fun annotatedPriority(a: Annotated, onError: JniErrorHandler<Priority?>): Priority?`
 - `annotated_ttl` — `fun annotatedTtl(a: Annotated, onError: JniErrorHandler<Long?>): Long?`
@@ -83,6 +84,7 @@ Base package: `io.prebindgen.covertest`
 - `const_array_echo` — `fun constArrayEcho(value: ConstArray, onError: JniErrorHandler<ConstArray?>): ConstArray?`
   - shaped by: return `ConstArray` decomposed → [bytes] (Callback delivery)
 - `dossier_new` — `fun dossierNew(note: Long, tag: Long, count: Long, total: Double, onError: JniErrorHandler<Dossier?>): Dossier?`
+  - shaped by: return `Dossier` decomposed → [note, holder__tag, holder__summary] (Callback delivery)
 - `duration_boundary_echo` — `fun durationBoundaryEcho(value: DurationBoundary, onError: JniErrorHandler<DurationBoundary?>): DurationBoundary?`
   - shaped by: return `DurationBoundary` decomposed → [required, delay] (Callback delivery)
 - `duration_emit` — `fun durationEmit(value: ULong, f: DurationCallback, onError: JniErrorHandler<Unit>)`
@@ -94,6 +96,7 @@ Base package: `io.prebindgen.covertest`
 - `hold_echo` — `fun holdEcho(h: Hold, onError: JniErrorHandler<Hold?>): Hold?`
   - shaped by: return `Hold` decomposed → [tag, for_v0] (Callback delivery)
 - `hold_policy_echo` — `fun holdPolicyEcho(p: HoldPolicy, onError: JniErrorHandler<HoldPolicy?>): HoldPolicy?`
+  - shaped by: return `HoldPolicy` decomposed → [hold__tag, hold__for_v0, grace__present, grace__tag, grace__for_v0] (Callback delivery)
 - `holder_tag_or` — `fun holderTagOr(h: Holder?, fallback: Long, onError: JniErrorHandler<Long>): Long`
 - `ingot_optional_grams` — `fun ingotOptionalGrams(i: Ingot?, onError: JniErrorHandler<Long>): Long`
 - `label_borrowed_concat` — `fun labelBorrowedConcat(labels: List<String>, onError: JniErrorHandler<String?>): String?`
@@ -110,8 +113,10 @@ Base package: `io.prebindgen.covertest`
 - `marker_of` — `fun markerOf(which: Int, onError: JniErrorHandler<Marker?>): Marker?`
   - shaped by: return `Marker` decomposed → [tag, ranked_v0] (Callback delivery)
 - `maybe_holder_new` — `fun maybeHolderNew(tag: Long, count: Long, total: Double, present: Boolean, onError: JniErrorHandler<MaybeHolder?>): MaybeHolder?`
+  - shaped by: return `MaybeHolder` decomposed → [tag, summary] (Callback delivery)
 - `object_boundary_value` — `fun objectBoundaryValue(value: ObjectBoundary, onError: JniErrorHandler<Long>): Long`
 - `observation_new` — `fun observationNew(which: Int, withFallback: Boolean, onError: JniErrorHandler<Observation?>): Observation?`
+  - shaped by: return `Observation` decomposed → [id, reading__tag, reading__exact_v0, reading__range_low, reading__range_high, reading__tagged_v0, reading__tagged_v1, reading__companion_v0, fallback__present, fallback__tag, fallback__exact_v0, fallback__range_low, fallback__range_high, fallback__tagged_v0, fallback__tagged_v1, fallback__companion_v0, note] (Callback delivery)
 - `observation_which` — `fun observationWhich(o: Observation, onError: JniErrorHandler<Int>): Int`
 - `payload_priority` — `fun payloadPriority(p: Payload, onError: JniErrorHandler<Priority?>): Priority?`
 - `percent_invalid_output` — `fun percentInvalidOutput(onError: JniErrorHandler<Int?>): Int?`

--- a/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest.kt
+++ b/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest.kt
@@ -1318,6 +1318,19 @@ internal object CovNative {
     external fun escape_probe_value(p: Long, errorSink: Any): Long
 
     @JvmSynthetic
+    external fun frameEach(n: Long, sink: Any, errorSink: Any)
+
+    @JvmSynthetic
+    external fun frameNew(
+        id: Long,
+        window: Boolean,
+        span: Boolean,
+        which: Long,
+        build: Any,
+        errorSink: Any,
+    ): Any?
+
+    @JvmSynthetic
     external fun holdEcho(h: Hold, build: Any, errorSink: Any): Any?
 
     @JvmSynthetic

--- a/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest.kt
+++ b/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest.kt
@@ -3,15 +3,12 @@
 package io.prebindgen.covertest
 
 import io.prebindgen.covertest.analytics.Summary
-import io.prebindgen.covertest.model.Annotated
 import io.prebindgen.covertest.model.BlobValue
 import io.prebindgen.covertest.model.DurationBoundary
 import io.prebindgen.covertest.model.Hold
-import io.prebindgen.covertest.model.HoldPolicy
 import io.prebindgen.covertest.model.Ingot
 import io.prebindgen.covertest.model.Lookup
 import io.prebindgen.covertest.model.ObjectBoundary
-import io.prebindgen.covertest.model.Observation
 import io.prebindgen.covertest.model.Priority
 import io.prebindgen.covertest.model.Stamp
 import java.lang.ref.Cleaner
@@ -774,6 +771,14 @@ internal fun u64Callback.asRaw(): u64CallbackRaw =
         )
     }
 
+internal fun interface DossierBuilderRaw<out R> {
+    public fun run(note: Long, holder__tag: Long, holder__summary: Long): R
+}
+
+@get:JvmSynthetic
+internal val __DossierBuilderRaw: DossierBuilderRaw<Dossier> =
+DossierBuilderRaw { note, holder__tag, holder__summary -> Dossier.fromParts(note, holder__tag, holder__summary) }
+
 public fun interface LedgerBuilder<out R> {
     public fun run(
         ledgerFiled__summary__count: Long?,
@@ -862,6 +867,14 @@ internal fun <R> LedgerBuilder<R>.asRaw(): LedgerBuilderRaw<R> =
             ledgerArchived__label
         )
     }
+
+internal fun interface MaybeHolderBuilderRaw<out R> {
+    public fun run(tag: Long, summary: Long): R
+}
+
+@get:JvmSynthetic
+internal val __MaybeHolderBuilderRaw: MaybeHolderBuilderRaw<MaybeHolder> =
+MaybeHolderBuilderRaw { tag, summary -> MaybeHolder.fromParts(tag, summary) }
 
 public fun interface PayloadBuilder<out R> {
     public fun run(id: Long, seq: Int, value: Double, flag: Boolean, label: String?): R
@@ -1097,8 +1110,9 @@ internal object CovNative {
         ttlPresent: Boolean,
         ttlValue: Long,
         priority: Int,
+        build: Any,
         errorSink: Any,
-    ): Annotated
+    ): Any?
 
     @JvmSynthetic
     external fun annotatedPayloadValue(
@@ -1275,8 +1289,9 @@ internal object CovNative {
         tag: Long,
         count: Long,
         total: Double,
+        build: Any,
         errorSink: Any,
-    ): Dossier
+    ): Any?
 
     @JvmSynthetic
     external fun durationBoundaryEcho(value: DurationBoundary, build: Any, errorSink: Any): Any?
@@ -1309,8 +1324,9 @@ internal object CovNative {
     external fun holdPolicyEcho(
         pHold: Hold,
         pGrace: io.prebindgen.covertest.model.Hold?,
+        build: Any,
         errorSink: Any,
-    ): HoldPolicy
+    ): Any?
 
     @JvmSynthetic
     external fun holderTagOr(
@@ -1363,8 +1379,9 @@ internal object CovNative {
         count: Long,
         total: Double,
         present: Boolean,
+        build: Any,
         errorSink: Any,
-    ): MaybeHolder
+    ): Any?
 
     @JvmSynthetic
     external fun millisAdd(a: Long, b: Long, errorSink: Any): Long
@@ -1373,7 +1390,7 @@ internal object CovNative {
     external fun objectBoundaryValue(value: ObjectBoundary, errorSink: Any): Long
 
     @JvmSynthetic
-    external fun observationNew(which: Int, withFallback: Boolean, errorSink: Any): Observation
+    external fun observationNew(which: Int, withFallback: Boolean, build: Any, errorSink: Any): Any?
 
     @JvmSynthetic
     external fun observationWhich(

--- a/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest/model.kt
+++ b/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest/model.kt
@@ -16,6 +16,8 @@ import io.prebindgen.covertest.Payload
 import io.prebindgen.covertest.Ranked
 import io.prebindgen.covertest.TicksCallback
 import io.prebindgen.covertest.WrappedFields
+import io.prebindgen.covertest.__DossierBuilderRaw
+import io.prebindgen.covertest.__MaybeHolderBuilderRaw
 import io.prebindgen.covertest.__u64FolderRawHolder
 import io.prebindgen.covertest.analytics.Summary
 import io.prebindgen.covertest.analytics.SummaryBuilder
@@ -1473,6 +1475,28 @@ internal fun VerdictCallback.asRaw(): VerdictCallbackRaw =
         }
     }
 
+public fun interface AnnotatedBuilder<out R> {
+    public fun run(
+        payload__id: Long,
+        payload__seq: Int,
+        payload__value: Double,
+        payload__flag: Boolean,
+        payload__label: String?,
+        alternate__present: Boolean,
+        alternate__id: Long,
+        alternate__seq: Int,
+        alternate__value: Double,
+        alternate__flag: Boolean,
+        alternate__label: String?,
+        ttl: Long?,
+        priority: Int,
+    ): R
+}
+
+@get:JvmSynthetic
+internal val __AnnotatedBuilder: AnnotatedBuilder<Annotated> =
+AnnotatedBuilder { payload__id, payload__seq, payload__value, payload__flag, payload__label, alternate__present, alternate__id, alternate__seq, alternate__value, alternate__flag, alternate__label, ttl, priority -> Annotated.fromParts(payload__id, payload__seq, payload__value, payload__flag, payload__label, alternate__present, alternate__id, alternate__seq, alternate__value, alternate__flag, alternate__label, ttl, priority) }
+
 public fun interface ArraysBuilder<out R> {
     public fun run(
         bytes: ByteArray,
@@ -1531,6 +1555,20 @@ HoldBuilderRaw { tag, for_v0 ->
     when (tag) { 0 -> Hold.Indefinite; 1 -> Hold.For(for_v0.toULong()); else -> throw IllegalArgumentException("Hold: invalid tag $tag") }
 }
 
+internal fun interface HoldPolicyBuilderRaw<out R> {
+    public fun run(
+        hold__tag: Int,
+        hold__for_v0: Long,
+        grace__present: Boolean,
+        grace__tag: Int,
+        grace__for_v0: Long,
+    ): R
+}
+
+@get:JvmSynthetic
+internal val __HoldPolicyBuilderRaw: HoldPolicyBuilderRaw<HoldPolicy> =
+HoldPolicyBuilderRaw { hold__tag, hold__for_v0, grace__present, grace__tag, grace__for_v0 -> HoldPolicy.fromParts(hold__tag, hold__for_v0, grace__present, grace__tag, grace__for_v0) }
+
 internal fun interface LayeredBuilderRaw<out R> {
     public fun run(
         tag: Int,
@@ -1569,6 +1607,32 @@ internal val __MarkerBuilder: MarkerBuilder<Marker> =
 MarkerBuilder { tag, ranked_v0 ->
     when (tag) { 0 -> Marker.None_; 1 -> Marker.Ranked(if (ranked_v0 == Int.MIN_VALUE) null else Priority.fromInt(ranked_v0)); else -> throw IllegalArgumentException("Marker: invalid tag $tag") }
 }
+
+public fun interface ObservationBuilder<out R> {
+    public fun run(
+        id: Long,
+        reading__tag: Int,
+        reading__exact_v0: Long,
+        reading__range_low: Long,
+        reading__range_high: Long,
+        reading__tagged_v0: String?,
+        reading__tagged_v1: Int,
+        reading__companion_v0: Long,
+        fallback__present: Boolean,
+        fallback__tag: Int,
+        fallback__exact_v0: Long,
+        fallback__range_low: Long,
+        fallback__range_high: Long,
+        fallback__tagged_v0: String?,
+        fallback__tagged_v1: Int,
+        fallback__companion_v0: Long,
+        note: String,
+    ): R
+}
+
+@get:JvmSynthetic
+internal val __ObservationBuilder: ObservationBuilder<Observation> =
+ObservationBuilder { id, reading__tag, reading__exact_v0, reading__range_low, reading__range_high, reading__tagged_v0, reading__tagged_v1, reading__companion_v0, fallback__present, fallback__tag, fallback__exact_v0, fallback__range_low, fallback__range_high, fallback__tagged_v0, fallback__tagged_v1, fallback__companion_v0, note -> Observation.fromParts(id, reading__tag, reading__exact_v0, reading__range_low, reading__range_high, reading__tagged_v0, reading__tagged_v1, reading__companion_v0, fallback__present, fallback__tag, fallback__exact_v0, fallback__range_low, fallback__range_high, fallback__tagged_v0, fallback__tagged_v1, fallback__companion_v0, note) }
 
 public fun interface ProbeBuilder<out R> {
     public fun run(
@@ -1938,7 +2002,10 @@ public fun labelBorrowedConcat(labels: List<String>, onError: JniErrorHandler<St
 /**
  * Assemble an [`Annotated`] (nested data-class **output** + bare
  * `Option<scalar>` / `Option<enum>` inputs).
+ *
+ * The Rust `Annotated` result is delivered decomposed: the builder callback receives (`payload__id`, `payload__seq`, `payload__value`, `payload__flag`, `payload__label`, `alternate__present`, `alternate__id`, `alternate__seq`, `alternate__value`, `alternate__flag`, `alternate__label`, `ttl`, `priority`).
  */
+@Suppress("UNCHECKED_CAST")
 public fun annotatedNew(
     payload: Payload,
     ttl: Long?,
@@ -1955,10 +2022,11 @@ public fun annotatedNew(
         ttl != null,
         ttl ?: 0L,
         priority?.value ?: Int.MIN_VALUE,
+        __AnnotatedBuilder,
         __bcap,
     )
     if (__bcap.failed) return onError.run(__bcap.ze0)
-    return __ret
+    return __ret as Annotated
 }
 
 /**
@@ -2071,16 +2139,19 @@ public fun annotatedPayloadValue(a: Annotated, onError: JniErrorHandler<Double>)
  * Build an [`Observation`] carrying the selected alternative, optionally with
  * a `fallback` (the next alternative round-robin) — a **sum as a struct
  * field** crossing Rust → Kotlin, required and optional in one value.
+ *
+ * The Rust `Observation` result is delivered decomposed: the builder callback receives (`id`, `reading__tag`, `reading__exact_v0`, `reading__range_low`, `reading__range_high`, `reading__tagged_v0`, `reading__tagged_v1`, `reading__companion_v0`, `fallback__present`, `fallback__tag`, `fallback__exact_v0`, `fallback__range_low`, `fallback__range_high`, `fallback__tagged_v0`, `fallback__tagged_v1`, `fallback__companion_v0`, `note`).
  */
+@Suppress("UNCHECKED_CAST")
 public fun observationNew(
     which: Int,
     withFallback: Boolean,
     onError: JniErrorHandler<Observation?>,
 ): Observation? {
     val __bcap = JniErrorHandlerCapture.acquire()
-    val __ret = CovNative.observationNew(which, withFallback, __bcap)
+    val __ret = CovNative.observationNew(which, withFallback, __ObservationBuilder, __bcap)
     if (__bcap.failed) return onError.run(__bcap.ze0)
-    return __ret
+    return __ret as Observation
 }
 
 /**
@@ -2353,7 +2424,12 @@ public fun envelopeEach(n: Long, sink: EnvelopeCallback, onError: JniErrorHandle
     if (__bcap.failed) return onError.run(__bcap.ze0)
 }
 
-/** Build a [`Dossier`] over a fresh [`Summary`] — the two-level container. */
+/**
+ * Build a [`Dossier`] over a fresh [`Summary`] — the two-level container.
+ *
+ * The Rust `Dossier` result is delivered decomposed: the builder callback receives (`note`, `holder__tag`, `holder__summary`).
+ */
+@Suppress("UNCHECKED_CAST")
 public fun dossierNew(
     note: Long,
     tag: Long,
@@ -2362,12 +2438,17 @@ public fun dossierNew(
     onError: JniErrorHandler<Dossier?>,
 ): Dossier? {
     val __bcap = JniErrorHandlerCapture.acquire()
-    val __ret = CovNative.dossierNew(note, tag, count, total, __bcap)
+    val __ret = CovNative.dossierNew(note, tag, count, total, __DossierBuilderRaw, __bcap)
     if (__bcap.failed) return onError.run(__bcap.ze0)
-    return __ret
+    return __ret as Dossier
 }
 
-/** Build a [`MaybeHolder`] with the handle present or absent. */
+/**
+ * Build a [`MaybeHolder`] with the handle present or absent.
+ *
+ * The Rust `MaybeHolder` result is delivered decomposed: the builder callback receives (`tag`, `summary`).
+ */
+@Suppress("UNCHECKED_CAST")
 public fun maybeHolderNew(
     tag: Long,
     count: Long,
@@ -2376,9 +2457,16 @@ public fun maybeHolderNew(
     onError: JniErrorHandler<MaybeHolder?>,
 ): MaybeHolder? {
     val __bcap = JniErrorHandlerCapture.acquire()
-    val __ret = CovNative.maybeHolderNew(tag, count, total, present, __bcap)
+    val __ret = CovNative.maybeHolderNew(
+        tag,
+        count,
+        total,
+        present,
+        __MaybeHolderBuilderRaw,
+        __bcap,
+    )
     if (__bcap.failed) return onError.run(__bcap.ze0)
-    return __ret
+    return __ret as MaybeHolder
 }
 
 /**
@@ -2842,12 +2930,17 @@ public fun holdEcho(h: Hold, onError: JniErrorHandler<Hold?>): Hold? {
     return __ret as Hold
 }
 
-/** Round-trip a data class carrying converted-payload sums. */
+/**
+ * Round-trip a data class carrying converted-payload sums.
+ *
+ * The Rust `HoldPolicy` result is delivered decomposed: the builder callback receives (`hold__tag`, `hold__for_v0`, `grace__present`, `grace__tag`, `grace__for_v0`).
+ */
+@Suppress("UNCHECKED_CAST")
 public fun holdPolicyEcho(p: HoldPolicy, onError: JniErrorHandler<HoldPolicy?>): HoldPolicy? {
     val __bcap = JniErrorHandlerCapture.acquire()
-    val __ret = CovNative.holdPolicyEcho(p.hold, p.grace, __bcap)
+    val __ret = CovNative.holdPolicyEcho(p.hold, p.grace, __HoldPolicyBuilderRaw, __bcap)
     if (__bcap.failed) return onError.run(__bcap.ze0)
-    return __ret
+    return __ret as HoldPolicy
 }
 
 /**

--- a/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest/model.kt
+++ b/examples/covertest-kotlin/kotlin/generated/io/prebindgen/covertest/model.kt
@@ -526,6 +526,28 @@ public data class Envelope(val id: Long, val stamp: Stamp?) {
     }
 }
 
+/** The gate over [`Window`]: one selector owning two. */
+public data class Frame(val id: Long, val window: Window?) {
+    public companion object {
+        @JvmStatic
+        public fun fromParts(
+            id: Long,
+            window__present: Boolean,
+            window_label: String?,
+            window_span__present: Boolean,
+            window_span_secs: Long,
+            window_span_nanos: Long,
+            window_reading__tag: Int,
+            window_reading_exact_v0: Long,
+            window_reading_range_low: Long,
+            window_reading_range_high: Long,
+            window_reading_tagged_v0: String?,
+            window_reading_tagged_v1: Int,
+            window_reading_companion_v0: Long,
+        ): Frame = Frame(id, if (window__present) Window.fromParts(window_label!!, window_span__present, window_span_secs, window_span_nanos, window_reading__tag, window_reading_exact_v0, window_reading_range_low, window_reading_range_high, window_reading_tagged_v0, window_reading_tagged_v1, window_reading_companion_v0) else null)
+    }
+}
+
 /**
  * A retention policy: a required converted-payload sum beside an optional one.
  *
@@ -1074,6 +1096,34 @@ public data class Verdict(val id: Long, val outcome: Lookup) : AutoCloseable {
     }
 }
 
+/**
+ * The value an optional nested class gates when that class **selects of its
+ * own** — a presence flag and a tag, one arm inside another.
+ *
+ * `span` is a second presence, `reading` a sum tag. Both sit inside the group
+ * `Frame::window`'s own flag gates, which is the shape a flat group number
+ * could not state: each of these is a member of the outer group AND a
+ * selector of its own (#602).
+ */
+public data class Window(val label: String, val span: Stamp?, val reading: Reading) {
+    public companion object {
+        @JvmStatic
+        public fun fromParts(
+            label: String,
+            span__present: Boolean,
+            span_secs: Long,
+            span_nanos: Long,
+            reading__tag: Int,
+            reading_exact_v0: Long,
+            reading_range_low: Long,
+            reading_range_high: Long,
+            reading_tagged_v0: String?,
+            reading_tagged_v1: Int,
+            reading_companion_v0: Long,
+        ): Window = Window(label, if (span__present) Stamp.fromParts(span_secs, span_nanos) else null, when (reading__tag) { 0 -> Reading.Missing; 1 -> Reading.Exact(reading_exact_v0); 2 -> Reading.Range(reading_range_low, reading_range_high); 3 -> Reading.Tagged(reading_tagged_v0!!, Priority.fromInt(reading_tagged_v1)); 4 -> Reading.Companion(reading_companion_v0); else -> throw IllegalArgumentException("Reading: invalid tag $reading__tag") })
+    }
+}
+
 /** Typed handle for a native Zenoh `Ingot`. */
 public class Ingot private constructor(initialPtr: Long) : NativeHandle(initialPtr) {
     @Synchronized
@@ -1320,6 +1370,49 @@ internal fun EnvelopeCallback.asRaw(): EnvelopeCallbackRaw =
         )
     }
 
+public fun interface FrameCallback {
+    public fun run(frame: Frame)
+}
+
+internal fun interface FrameCallbackRaw {
+    public fun run(
+        id: Long,
+        window__present: Boolean,
+        window__label: String?,
+        window__span__present: Boolean,
+        window__span__secs: Long,
+        window__span__nanos: Long,
+        window__reading__tag: Int,
+        window__reading__exact_v0: Long,
+        window__reading__range_low: Long,
+        window__reading__range_high: Long,
+        window__reading__tagged_v0: String?,
+        window__reading__tagged_v1: Int,
+        window__reading__companion_v0: Long,
+    )
+}
+
+@JvmSynthetic
+internal fun FrameCallback.asRaw(): FrameCallbackRaw =
+    FrameCallbackRaw {
+        id,
+        window__present,
+        window__label,
+        window__span__present,
+        window__span__secs,
+        window__span__nanos,
+        window__reading__tag,
+        window__reading__exact_v0,
+        window__reading__range_low,
+        window__reading__range_high,
+        window__reading__tagged_v0,
+        window__reading__tagged_v1,
+        window__reading__companion_v0 ->
+        run(
+            Frame.fromParts(id, window__present, window__label, window__span__present, window__span__secs, window__span__nanos, window__reading__tag, window__reading__exact_v0, window__reading__range_low, window__reading__range_high, window__reading__tagged_v0, window__reading__tagged_v1, window__reading__companion_v0)
+        )
+    }
+
 public fun interface LookupCallback {
     public fun run(lookup: Lookup)
 }
@@ -1544,6 +1637,28 @@ public fun interface EnvelopeBuilder<out R> {
 @get:JvmSynthetic
 internal val __EnvelopeBuilder: EnvelopeBuilder<Envelope> =
 EnvelopeBuilder { id, stamp__present, stamp__secs, stamp__nanos -> Envelope.fromParts(id, stamp__present, stamp__secs, stamp__nanos) }
+
+public fun interface FrameBuilder<out R> {
+    public fun run(
+        id: Long,
+        window__present: Boolean,
+        window__label: String?,
+        window__span__present: Boolean,
+        window__span__secs: Long,
+        window__span__nanos: Long,
+        window__reading__tag: Int,
+        window__reading__exact_v0: Long,
+        window__reading__range_low: Long,
+        window__reading__range_high: Long,
+        window__reading__tagged_v0: String?,
+        window__reading__tagged_v1: Int,
+        window__reading__companion_v0: Long,
+    ): R
+}
+
+@get:JvmSynthetic
+internal val __FrameBuilder: FrameBuilder<Frame> =
+FrameBuilder { id, window__present, window__label, window__span__present, window__span__secs, window__span__nanos, window__reading__tag, window__reading__exact_v0, window__reading__range_low, window__reading__range_high, window__reading__tagged_v0, window__reading__tagged_v1, window__reading__companion_v0 -> Frame.fromParts(id, window__present, window__label, window__span__present, window__span__secs, window__span__nanos, window__reading__tag, window__reading__exact_v0, window__reading__range_low, window__reading__range_high, window__reading__tagged_v0, window__reading__tagged_v1, window__reading__companion_v0) }
 
 internal fun interface HoldBuilderRaw<out R> {
     public fun run(tag: Int, for_v0: Long): R
@@ -2421,6 +2536,38 @@ public fun envelopeNew(id: Long, present: Boolean, onError: JniErrorHandler<Enve
 public fun envelopeEach(n: Long, sink: EnvelopeCallback, onError: JniErrorHandler<Unit>) {
     val __bcap = JniErrorHandlerCapture.acquire()
     CovNative.envelopeEach(n, sink.asRaw(), __bcap)
+    if (__bcap.failed) return onError.run(__bcap.ze0)
+}
+
+/**
+ * Build a [`Frame`]. `window` absent, `window` present with `span` absent, and
+ * both present are the three states of the outer gate; `which` picks the
+ * alternative of the tag nested beside it.
+ *
+ * The Rust `Frame` result is delivered decomposed: the builder callback receives (`id`, `window__present`, `window__label`, `window__span__present`, `window__span__secs`, `window__span__nanos`, `window__reading__tag`, `window__reading__exact_v0`, `window__reading__range_low`, `window__reading__range_high`, `window__reading__tagged_v0`, `window__reading__tagged_v1`, `window__reading__companion_v0`).
+ */
+@Suppress("UNCHECKED_CAST")
+public fun frameNew(
+    id: Long,
+    window: Boolean,
+    span: Boolean,
+    which: Long,
+    onError: JniErrorHandler<Frame?>,
+): Frame? {
+    val __bcap = JniErrorHandlerCapture.acquire()
+    val __ret = CovNative.frameNew(id, window, span, which, __FrameBuilder, __bcap)
+    if (__bcap.failed) return onError.run(__bcap.ze0)
+    return __ret as Frame
+}
+
+/**
+ * The same value handed to a callback — the route that decomposes it into
+ * leaves and reassembles them through the foreign builder, which is where a
+ * nested gate has to hold.
+ */
+public fun frameEach(n: Long, sink: FrameCallback, onError: JniErrorHandler<Unit>) {
+    val __bcap = JniErrorHandlerCapture.acquire()
+    CovNative.frameEach(n, sink.asRaw(), __bcap)
     if (__bcap.failed) return onError.run(__bcap.ze0)
 }
 

--- a/examples/covertest-kotlin/kotlin/io/prebindgen/covertest/Test.kt
+++ b/examples/covertest-kotlin/kotlin/io/prebindgen/covertest/Test.kt
@@ -104,6 +104,9 @@ import io.prebindgen.covertest.model.layeredOf
 import io.prebindgen.covertest.model.Envelope
 import io.prebindgen.covertest.model.envelopeEach
 import io.prebindgen.covertest.model.envelopeNew
+import io.prebindgen.covertest.model.Frame
+import io.prebindgen.covertest.model.frameEach
+import io.prebindgen.covertest.model.frameNew
 import io.prebindgen.covertest.model.verdictEach
 import io.prebindgen.covertest.model.verdictNew
 import io.prebindgen.covertest.model.dossierNew
@@ -725,6 +728,69 @@ fun main() {
             seen.add("${envelope.id}:${envelope.stamp?.secs ?: "-"}")
         }, boom).orThrow()
         check(seen == listOf("0:-", "1:1", "2:-", "3:3")) { "got $seen" }
+    }
+
+    // A gate INSIDE a gate: `Frame.window` is optional, and the `Window` it
+    // gates selects twice of its own — a second presence (`span`) and a sum tag
+    // (`reading`). A flat group number could not state that, since each inner
+    // selector is a member of the outer group AND a selector of its own; the
+    // arm PATH can, and `segments` reads one level at a time.
+    //
+    // `REPORT.md` records that this takes fixed-builder delivery: `Frame`
+    // decomposed into thirteen leaves, `window__present` gating
+    // `window__span__present` and `window__reading__tag` and everything under
+    // them. What is checked here is that the leaves reassemble to the value
+    // they came from — through the class's own factory on the return route and
+    // through its builder interface on the callback route.
+    section("a gate inside a gate (nested selectors under one presence flag)") {
+        // Outer absent: every inner slot carries a wire default, and neither
+        // inner selector may be read as if it had chosen something.
+        val none = frameNew(1L, false, true, 2L, boom).orThrow()
+        check(none.id == 1L)
+        check(none.window == null) { "got ${none.window}" }
+
+        // Outer present, inner presence absent — the two flags are independent
+        // facts, and the inner one must survive the outer arm defaulting.
+        val noSpan = frameNew(2L, true, false, 1L, boom).orThrow()
+        check(noSpan.window?.span == null) { "got ${noSpan.window?.span}" }
+        check(noSpan.window?.reading == Reading.Exact(42L))
+        check(noSpan.window?.label == "w2")
+
+        // Both present, with the nested tag live beside the nested flag.
+        val both = frameNew(3L, true, true, 2L, boom).orThrow()
+        check(both.window?.span == Stamp(3L, 6L)) { "got ${both.window?.span}" }
+        check(both.window?.reading == Reading.Range(1L, 9L))
+
+        // Every alternative of the nested tag, under a live outer gate: an
+        // inner group is selected from inside an arm the outer flag opened.
+        val readings = (0..4).map { frameNew(4L, true, true, it.toLong(), boom).orThrow().window?.reading }
+        check(
+            readings == listOf(
+                Reading.Missing,
+                Reading.Exact(42L),
+                Reading.Range(1L, 9L),
+                Reading.Tagged("warm", Priority.HIGH),
+                Reading.Companion(5L),
+            )
+        ) { "got $readings" }
+
+        // …and the same values by the other route, which fills the gated slots
+        // through the builder interface rather than the factory.
+        val seen = mutableListOf<String>()
+        frameEach(6L, { frame ->
+            val w = frame.window
+            seen.add("${frame.id}:${w?.span?.secs ?: "-"}:${w?.reading?.let { it::class.simpleName } ?: "-"}")
+        }, boom).orThrow()
+        check(
+            seen == listOf(
+                "0:-:-",
+                "1:1:Exact",
+                "2:-:Range",
+                "3:-:-",
+                "4:-:Companion",
+                "5:5:Companion",
+            )
+        ) { "got $seen" }
     }
 
     // The same data class arriving at a CALLBACK rather than as a return.

--- a/examples/covertest-kotlin/src/generated_bindings.rs
+++ b/examples/covertest-kotlin/src/generated_bindings.rs
@@ -3593,6 +3593,246 @@ pub(crate) unsafe fn __jni_out_convert_EscapeProbe_jni_handle_codec_own_output_t
     clippy::nonminimal_bool,
     clippy::eq_op
 )]
+pub(crate) unsafe fn __jni_in_convert_wire_to_Frame_615e8910e0e6ad93<'env, 'v>(
+    env: &mut jni::JNIEnv<'env>,
+    v: &jni::objects::JObject<'v>,
+) -> ::core::result::Result<perftest_flat::Frame, __JniErr> {
+    Ok({
+        let __id_raw: jni::sys::jlong = env
+            .get_field(v, "id", "J")
+            .and_then(|val| val.j())
+            .map_err(|e| <__JniErr as ::core::convert::From<
+                String,
+            >>::from(format!("Frame.id: {}", e)))? as _;
+        let __window_raw: jni::objects::JObject = env
+            .get_field(v, "window", "Lio/prebindgen/covertest/model/Window;")
+            .and_then(|val| val.l())
+            .map_err(|e| <__JniErr as ::core::convert::From<
+                String,
+            >>::from(format!("Frame.window: {}", e)))?;
+        perftest_flat::Frame {
+            id: __jni_in_convert_wire_to_i64_da07d745d9e26f71(env, &__id_raw)?,
+            window: __jni_in_convert_wire_to_Option_Window_jni_optional_intermediate_input_niche_888f85208ea0eeed(
+                env,
+                &__window_raw,
+            )?,
+        }
+    })
+}
+#[allow(
+    non_snake_case,
+    unused_mut,
+    unused_variables,
+    unused_braces,
+    unused_parens,
+    dead_code,
+    clippy::useless_conversion,
+    clippy::needless_question_mark,
+    clippy::let_and_return,
+    clippy::nonminimal_bool,
+    clippy::eq_op
+)]
+pub(crate) unsafe fn __jni_out_convert_Frame_to_wire_00a9c6a49943fae6<'a>(
+    env: &mut jni::JNIEnv<'a>,
+    v: perftest_flat::Frame,
+) -> ::core::result::Result<jni::objects::JObject<'a>, __JniErr> {
+    Ok({
+        let ___id: jni::sys::jlong = __jni_out_convert_i64_to_wire_15d458bf28dc9c80(
+            env,
+            v.id.clone(),
+        )?;
+        let ___window_present: jni::sys::jboolean;
+        let ___window_label: jni::objects::JObject;
+        let ___window_span_present: jni::sys::jboolean;
+        let ___window_span_secs: jni::sys::jlong;
+        let ___window_span_nanos: jni::sys::jlong;
+        let ___window_reading__tag: jni::sys::jint;
+        let ___window_reading_exact_v0: jni::sys::jlong;
+        let ___window_reading_range_low: jni::sys::jlong;
+        let ___window_reading_range_high: jni::sys::jlong;
+        let ___window_reading_tagged_v0: jni::objects::JObject;
+        let ___window_reading_tagged_v1: jni::sys::jint;
+        let ___window_reading_companion_v0: jni::sys::jlong;
+        let __on0: &::core::option::Option<_> = &v.window;
+        match __on0 {
+            ::core::option::Option::Some(__c0) => {
+                let __arm0__window_label: jni::objects::JObject = __jni_out_convert_jni_text_codec_owned_to_wire_1b6cdff0ec9adbcb(
+                        env,
+                        __c0.label.clone(),
+                    )?
+                    .into();
+                let __arm0__window_span_present: jni::sys::jboolean;
+                let __arm0__window_span_secs: jni::sys::jlong;
+                let __arm0__window_span_nanos: jni::sys::jlong;
+                let __on1: &::core::option::Option<_> = &__c0.span;
+                match __on1 {
+                    ::core::option::Option::Some(__c1) => {
+                        let __arm0_arm0__window_span_secs: jni::sys::jlong = __jni_out_convert_i64_to_wire_15d458bf28dc9c80(
+                            env,
+                            __c1.secs.clone(),
+                        )?;
+                        let __arm0_arm0__window_span_nanos: jni::sys::jlong = __jni_out_convert_i64_to_wire_15d458bf28dc9c80(
+                            env,
+                            __c1.nanos.clone(),
+                        )?;
+                        __arm0__window_span_present = 1u8;
+                        __arm0__window_span_secs = __arm0_arm0__window_span_secs;
+                        __arm0__window_span_nanos = __arm0_arm0__window_span_nanos;
+                    }
+                    ::core::option::Option::None => {
+                        __arm0__window_span_present = 0u8;
+                        __arm0__window_span_secs = 0i64;
+                        __arm0__window_span_nanos = 0i64;
+                    }
+                }
+                let __arm0__window_reading__tag: jni::sys::jint;
+                let __arm0__window_reading_exact_v0: jni::sys::jlong;
+                let __arm0__window_reading_range_low: jni::sys::jlong;
+                let __arm0__window_reading_range_high: jni::sys::jlong;
+                let __arm0__window_reading_tagged_v0: jni::objects::JObject;
+                let __arm0__window_reading_tagged_v1: jni::sys::jint;
+                let __arm0__window_reading_companion_v0: jni::sys::jlong;
+                match &__c0.reading {
+                    perftest_flat::Reading::Missing => {
+                        __arm0__window_reading__tag = 0;
+                        __arm0__window_reading_exact_v0 = 0i64;
+                        __arm0__window_reading_range_low = 0i64;
+                        __arm0__window_reading_range_high = 0i64;
+                        __arm0__window_reading_tagged_v0 = jni::objects::JObject::null();
+                        __arm0__window_reading_tagged_v1 = 0i32;
+                        __arm0__window_reading_companion_v0 = 0i64;
+                    }
+                    perftest_flat::Reading::Exact(__s1_0) => {
+                        let __arm1_arm0__window_reading_exact_v0: jni::sys::jlong = __jni_out_convert_i64_to_wire_15d458bf28dc9c80(
+                            env,
+                            __s1_0.clone(),
+                        )?;
+                        __arm0__window_reading__tag = 1;
+                        __arm0__window_reading_exact_v0 = __arm1_arm0__window_reading_exact_v0;
+                        __arm0__window_reading_range_low = 0i64;
+                        __arm0__window_reading_range_high = 0i64;
+                        __arm0__window_reading_tagged_v0 = jni::objects::JObject::null();
+                        __arm0__window_reading_tagged_v1 = 0i32;
+                        __arm0__window_reading_companion_v0 = 0i64;
+                    }
+                    perftest_flat::Reading::Range { low: __s1_0, high: __s1_1 } => {
+                        let __arm2_arm0__window_reading_range_low: jni::sys::jlong = __jni_out_convert_i64_to_wire_15d458bf28dc9c80(
+                            env,
+                            __s1_0.clone(),
+                        )?;
+                        let __arm2_arm0__window_reading_range_high: jni::sys::jlong = __jni_out_convert_i64_to_wire_15d458bf28dc9c80(
+                            env,
+                            __s1_1.clone(),
+                        )?;
+                        __arm0__window_reading__tag = 2;
+                        __arm0__window_reading_range_low = __arm2_arm0__window_reading_range_low;
+                        __arm0__window_reading_range_high = __arm2_arm0__window_reading_range_high;
+                        __arm0__window_reading_exact_v0 = 0i64;
+                        __arm0__window_reading_tagged_v0 = jni::objects::JObject::null();
+                        __arm0__window_reading_tagged_v1 = 0i32;
+                        __arm0__window_reading_companion_v0 = 0i64;
+                    }
+                    perftest_flat::Reading::Labeled(__s1_0, __s1_1) => {
+                        let __arm3_arm0__window_reading_tagged_v0: jni::objects::JObject = __jni_out_convert_jni_text_codec_owned_to_wire_1b6cdff0ec9adbcb(
+                                env,
+                                __s1_0.clone(),
+                            )?
+                            .into();
+                        let __arm3_arm0__window_reading_tagged_v1: jni::sys::jint = __jni_out_convert_Priority_to_wire_55b65fa623d4787e(
+                            env,
+                            __s1_1.clone(),
+                        )?;
+                        __arm0__window_reading__tag = 3;
+                        __arm0__window_reading_tagged_v0 = __arm3_arm0__window_reading_tagged_v0;
+                        __arm0__window_reading_tagged_v1 = __arm3_arm0__window_reading_tagged_v1;
+                        __arm0__window_reading_exact_v0 = 0i64;
+                        __arm0__window_reading_range_low = 0i64;
+                        __arm0__window_reading_range_high = 0i64;
+                        __arm0__window_reading_companion_v0 = 0i64;
+                    }
+                    perftest_flat::Reading::Companion(__s1_0) => {
+                        let __arm4_arm0__window_reading_companion_v0: jni::sys::jlong = __jni_out_convert_i64_to_wire_15d458bf28dc9c80(
+                            env,
+                            __s1_0.clone(),
+                        )?;
+                        __arm0__window_reading__tag = 4;
+                        __arm0__window_reading_companion_v0 = __arm4_arm0__window_reading_companion_v0;
+                        __arm0__window_reading_exact_v0 = 0i64;
+                        __arm0__window_reading_range_low = 0i64;
+                        __arm0__window_reading_range_high = 0i64;
+                        __arm0__window_reading_tagged_v0 = jni::objects::JObject::null();
+                        __arm0__window_reading_tagged_v1 = 0i32;
+                    }
+                }
+                ___window_present = 1u8;
+                ___window_label = __arm0__window_label;
+                ___window_span_present = __arm0__window_span_present;
+                ___window_span_secs = __arm0__window_span_secs;
+                ___window_span_nanos = __arm0__window_span_nanos;
+                ___window_reading__tag = __arm0__window_reading__tag;
+                ___window_reading_exact_v0 = __arm0__window_reading_exact_v0;
+                ___window_reading_range_low = __arm0__window_reading_range_low;
+                ___window_reading_range_high = __arm0__window_reading_range_high;
+                ___window_reading_tagged_v0 = __arm0__window_reading_tagged_v0;
+                ___window_reading_tagged_v1 = __arm0__window_reading_tagged_v1;
+                ___window_reading_companion_v0 = __arm0__window_reading_companion_v0;
+            }
+            ::core::option::Option::None => {
+                ___window_present = 0u8;
+                ___window_label = jni::objects::JObject::null();
+                ___window_span_present = 0u8;
+                ___window_span_secs = 0i64;
+                ___window_span_nanos = 0i64;
+                ___window_reading__tag = 0i32;
+                ___window_reading_exact_v0 = 0i64;
+                ___window_reading_range_low = 0i64;
+                ___window_reading_range_high = 0i64;
+                ___window_reading_tagged_v0 = jni::objects::JObject::null();
+                ___window_reading_tagged_v1 = 0i32;
+                ___window_reading_companion_v0 = 0i64;
+            }
+        }
+        let __obj = env
+            .call_static_method(
+                "io/prebindgen/covertest/model/Frame",
+                "fromParts",
+                "(JZLjava/lang/String;ZJJIJJJLjava/lang/String;IJ)Lio/prebindgen/covertest/model/Frame;",
+                &[
+                    jni::objects::JValue::from(___id),
+                    jni::objects::JValue::from(___window_present),
+                    jni::objects::JValue::Object(&___window_label),
+                    jni::objects::JValue::from(___window_span_present),
+                    jni::objects::JValue::from(___window_span_secs),
+                    jni::objects::JValue::from(___window_span_nanos),
+                    jni::objects::JValue::from(___window_reading__tag),
+                    jni::objects::JValue::from(___window_reading_exact_v0),
+                    jni::objects::JValue::from(___window_reading_range_low),
+                    jni::objects::JValue::from(___window_reading_range_high),
+                    jni::objects::JValue::Object(&___window_reading_tagged_v0),
+                    jni::objects::JValue::from(___window_reading_tagged_v1),
+                    jni::objects::JValue::from(___window_reading_companion_v0),
+                ],
+            )
+            .and_then(|__v| __v.l())
+            .map_err(|e| <__JniErr as ::core::convert::From<
+                String,
+            >>::from(format!("encode struct via fromParts: {}", e)))?;
+        __obj
+    })
+}
+#[allow(
+    non_snake_case,
+    unused_mut,
+    unused_variables,
+    unused_braces,
+    unused_parens,
+    dead_code,
+    clippy::useless_conversion,
+    clippy::needless_question_mark,
+    clippy::let_and_return,
+    clippy::nonminimal_bool,
+    clippy::eq_op
+)]
 pub(crate) unsafe fn __jni_in_convert_wire_to_Hold_5a6747f2776b0f97<'env, 'v>(
     env: &mut jni::JNIEnv<'env>,
     v: &jni::objects::JObject<'v>,
@@ -9207,6 +9447,65 @@ pub(crate) unsafe fn __jni_in_convert_wire_to_Option_Vec_u8_jni_optional_interme
     clippy::nonminimal_bool,
     clippy::eq_op
 )]
+pub(crate) unsafe fn __jni_in_convert_wire_to_Option_Window_jni_optional_intermediate_input_niche_888f85208ea0eeed<
+    'env,
+    'v,
+>(
+    env: &mut jni::JNIEnv<'env>,
+    v: &jni::objects::JObject<'v>,
+) -> ::core::result::Result<::core::option::Option<perftest_flat::Window>, __JniErr> {
+    ::core::result::Result::Ok({
+        if v.is_null() {
+            ::core::option::Option::None
+        } else {
+            let __present = v;
+            ::core::option::Option::Some(
+                __jni_in_convert_wire_to_Window_62b0b918ad538b95(env, __present)?,
+            )
+        }
+    })
+}
+#[allow(
+    non_snake_case,
+    unused_mut,
+    unused_variables,
+    unused_braces,
+    unused_parens,
+    dead_code,
+    clippy::useless_conversion,
+    clippy::needless_question_mark,
+    clippy::let_and_return,
+    clippy::nonminimal_bool,
+    clippy::eq_op
+)]
+pub(crate) unsafe fn __jni_out_convert_Option_Window_jni_optional_intermediate_output_niche_to_wire_734a4b66dfe1279b<
+    'a,
+>(
+    env: &mut jni::JNIEnv<'a>,
+    v: ::core::option::Option<perftest_flat::Window>,
+) -> ::core::result::Result<jni::objects::JObject<'a>, __JniErr> {
+    ::core::result::Result::Ok({
+        match v {
+            ::core::option::Option::Some(__value) => {
+                __jni_out_convert_Window_to_wire_fb0337c2cf374fa2(env, __value)?
+            }
+            ::core::option::Option::None => jni::objects::JObject::null().into(),
+        }
+    })
+}
+#[allow(
+    non_snake_case,
+    unused_mut,
+    unused_variables,
+    unused_braces,
+    unused_parens,
+    dead_code,
+    clippy::useless_conversion,
+    clippy::needless_question_mark,
+    clippy::let_and_return,
+    clippy::nonminimal_bool,
+    clippy::eq_op
+)]
 pub(crate) unsafe fn __jni_in_convert_wire_to_Option_f64_jni_optional_intermediate_input_gated_10d98a298d62e1f5<
     'env,
     'v,
@@ -11274,6 +11573,211 @@ pub(crate) unsafe fn __jni_out_convert_Verdict_to_wire_26a1dc521db8a9ae<'a>(
     clippy::nonminimal_bool,
     clippy::eq_op
 )]
+pub(crate) unsafe fn __jni_in_convert_wire_to_Window_62b0b918ad538b95<'env, 'v>(
+    env: &mut jni::JNIEnv<'env>,
+    v: &jni::objects::JObject<'v>,
+) -> ::core::result::Result<perftest_flat::Window, __JniErr> {
+    Ok({
+        let __label_jobj: jni::objects::JObject = env
+            .get_field(v, "label", "Ljava/lang/String;")
+            .and_then(|val| val.l())
+            .map_err(|e| <__JniErr as ::core::convert::From<
+                String,
+            >>::from(format!("Window.label: {}", e)))?;
+        let __label_raw: jni::objects::JString = __label_jobj.into();
+        let __span_raw: jni::objects::JObject = env
+            .get_field(v, "span", "Lio/prebindgen/covertest/model/Stamp;")
+            .and_then(|val| val.l())
+            .map_err(|e| <__JniErr as ::core::convert::From<
+                String,
+            >>::from(format!("Window.span: {}", e)))?;
+        let __reading_raw: jni::objects::JObject = env
+            .get_field(v, "reading", "Lio/prebindgen/covertest/model/Reading;")
+            .and_then(|val| val.l())
+            .map_err(|e| <__JniErr as ::core::convert::From<
+                String,
+            >>::from(format!("Window.reading: {}", e)))?;
+        perftest_flat::Window {
+            label: __jni_in_convert_wire_to_jni_text_codec_owned_40915aa02cf8d9ce(
+                env,
+                &__label_raw,
+            )?,
+            span: __jni_in_convert_wire_to_Option_Stamp_jni_optional_intermediate_input_niche_e4305db2eca2412c(
+                env,
+                &__span_raw,
+            )?,
+            reading: __jni_in_convert_wire_to_Reading_a358e65c0c39d007(
+                env,
+                &__reading_raw,
+            )?,
+        }
+    })
+}
+#[allow(
+    non_snake_case,
+    unused_mut,
+    unused_variables,
+    unused_braces,
+    unused_parens,
+    dead_code,
+    clippy::useless_conversion,
+    clippy::needless_question_mark,
+    clippy::let_and_return,
+    clippy::nonminimal_bool,
+    clippy::eq_op
+)]
+pub(crate) unsafe fn __jni_out_convert_Window_to_wire_fb0337c2cf374fa2<'a>(
+    env: &mut jni::JNIEnv<'a>,
+    v: perftest_flat::Window,
+) -> ::core::result::Result<jni::objects::JObject<'a>, __JniErr> {
+    Ok({
+        let ___label: jni::objects::JObject = __jni_out_convert_jni_text_codec_owned_to_wire_1b6cdff0ec9adbcb(
+                env,
+                v.label.clone(),
+            )?
+            .into();
+        let ___span_present: jni::sys::jboolean;
+        let ___span_secs: jni::sys::jlong;
+        let ___span_nanos: jni::sys::jlong;
+        let __on0: &::core::option::Option<_> = &v.span;
+        match __on0 {
+            ::core::option::Option::Some(__c0) => {
+                let __arm0__span_secs: jni::sys::jlong = __jni_out_convert_i64_to_wire_15d458bf28dc9c80(
+                    env,
+                    __c0.secs.clone(),
+                )?;
+                let __arm0__span_nanos: jni::sys::jlong = __jni_out_convert_i64_to_wire_15d458bf28dc9c80(
+                    env,
+                    __c0.nanos.clone(),
+                )?;
+                ___span_present = 1u8;
+                ___span_secs = __arm0__span_secs;
+                ___span_nanos = __arm0__span_nanos;
+            }
+            ::core::option::Option::None => {
+                ___span_present = 0u8;
+                ___span_secs = 0i64;
+                ___span_nanos = 0i64;
+            }
+        }
+        let ___reading__tag: jni::sys::jint;
+        let ___reading_exact_v0: jni::sys::jlong;
+        let ___reading_range_low: jni::sys::jlong;
+        let ___reading_range_high: jni::sys::jlong;
+        let ___reading_tagged_v0: jni::objects::JObject;
+        let ___reading_tagged_v1: jni::sys::jint;
+        let ___reading_companion_v0: jni::sys::jlong;
+        match &v.reading {
+            perftest_flat::Reading::Missing => {
+                ___reading__tag = 0;
+                ___reading_exact_v0 = 0i64;
+                ___reading_range_low = 0i64;
+                ___reading_range_high = 0i64;
+                ___reading_tagged_v0 = jni::objects::JObject::null();
+                ___reading_tagged_v1 = 0i32;
+                ___reading_companion_v0 = 0i64;
+            }
+            perftest_flat::Reading::Exact(__s0_0) => {
+                let __arm1__reading_exact_v0: jni::sys::jlong = __jni_out_convert_i64_to_wire_15d458bf28dc9c80(
+                    env,
+                    __s0_0.clone(),
+                )?;
+                ___reading__tag = 1;
+                ___reading_exact_v0 = __arm1__reading_exact_v0;
+                ___reading_range_low = 0i64;
+                ___reading_range_high = 0i64;
+                ___reading_tagged_v0 = jni::objects::JObject::null();
+                ___reading_tagged_v1 = 0i32;
+                ___reading_companion_v0 = 0i64;
+            }
+            perftest_flat::Reading::Range { low: __s0_0, high: __s0_1 } => {
+                let __arm2__reading_range_low: jni::sys::jlong = __jni_out_convert_i64_to_wire_15d458bf28dc9c80(
+                    env,
+                    __s0_0.clone(),
+                )?;
+                let __arm2__reading_range_high: jni::sys::jlong = __jni_out_convert_i64_to_wire_15d458bf28dc9c80(
+                    env,
+                    __s0_1.clone(),
+                )?;
+                ___reading__tag = 2;
+                ___reading_range_low = __arm2__reading_range_low;
+                ___reading_range_high = __arm2__reading_range_high;
+                ___reading_exact_v0 = 0i64;
+                ___reading_tagged_v0 = jni::objects::JObject::null();
+                ___reading_tagged_v1 = 0i32;
+                ___reading_companion_v0 = 0i64;
+            }
+            perftest_flat::Reading::Labeled(__s0_0, __s0_1) => {
+                let __arm3__reading_tagged_v0: jni::objects::JObject = __jni_out_convert_jni_text_codec_owned_to_wire_1b6cdff0ec9adbcb(
+                        env,
+                        __s0_0.clone(),
+                    )?
+                    .into();
+                let __arm3__reading_tagged_v1: jni::sys::jint = __jni_out_convert_Priority_to_wire_55b65fa623d4787e(
+                    env,
+                    __s0_1.clone(),
+                )?;
+                ___reading__tag = 3;
+                ___reading_tagged_v0 = __arm3__reading_tagged_v0;
+                ___reading_tagged_v1 = __arm3__reading_tagged_v1;
+                ___reading_exact_v0 = 0i64;
+                ___reading_range_low = 0i64;
+                ___reading_range_high = 0i64;
+                ___reading_companion_v0 = 0i64;
+            }
+            perftest_flat::Reading::Companion(__s0_0) => {
+                let __arm4__reading_companion_v0: jni::sys::jlong = __jni_out_convert_i64_to_wire_15d458bf28dc9c80(
+                    env,
+                    __s0_0.clone(),
+                )?;
+                ___reading__tag = 4;
+                ___reading_companion_v0 = __arm4__reading_companion_v0;
+                ___reading_exact_v0 = 0i64;
+                ___reading_range_low = 0i64;
+                ___reading_range_high = 0i64;
+                ___reading_tagged_v0 = jni::objects::JObject::null();
+                ___reading_tagged_v1 = 0i32;
+            }
+        }
+        let __obj = env
+            .call_static_method(
+                "io/prebindgen/covertest/model/Window",
+                "fromParts",
+                "(Ljava/lang/String;ZJJIJJJLjava/lang/String;IJ)Lio/prebindgen/covertest/model/Window;",
+                &[
+                    jni::objects::JValue::Object(&___label),
+                    jni::objects::JValue::from(___span_present),
+                    jni::objects::JValue::from(___span_secs),
+                    jni::objects::JValue::from(___span_nanos),
+                    jni::objects::JValue::from(___reading__tag),
+                    jni::objects::JValue::from(___reading_exact_v0),
+                    jni::objects::JValue::from(___reading_range_low),
+                    jni::objects::JValue::from(___reading_range_high),
+                    jni::objects::JValue::Object(&___reading_tagged_v0),
+                    jni::objects::JValue::from(___reading_tagged_v1),
+                    jni::objects::JValue::from(___reading_companion_v0),
+                ],
+            )
+            .and_then(|__v| __v.l())
+            .map_err(|e| <__JniErr as ::core::convert::From<
+                String,
+            >>::from(format!("encode struct via fromParts: {}", e)))?;
+        __obj
+    })
+}
+#[allow(
+    non_snake_case,
+    unused_mut,
+    unused_variables,
+    unused_braces,
+    unused_parens,
+    dead_code,
+    clippy::useless_conversion,
+    clippy::needless_question_mark,
+    clippy::let_and_return,
+    clippy::nonminimal_bool,
+    clippy::eq_op
+)]
 #[inline(always)]
 pub(crate) unsafe fn __jni_in_convert_wire_to_WrappedFields_jni_product_intermediate_tuple_d3f01dec8ef9b8fe<
     'env,
@@ -12842,6 +13346,414 @@ pub(crate) unsafe fn __jni_in_convert_wire_to_impl_Fn_Envelope_Send_Sync_static_
                 Ok(())
             })()
                 .map_err(|e| tracing::error!("{} callback error: {e}", "Fn(Envelope)"));
+        })
+    })
+}
+#[allow(
+    non_snake_case,
+    unused_mut,
+    unused_variables,
+    unused_braces,
+    unused_parens,
+    dead_code,
+    clippy::useless_conversion,
+    clippy::needless_question_mark,
+    clippy::let_and_return,
+    clippy::nonminimal_bool,
+    clippy::eq_op
+)]
+pub(crate) unsafe fn __jni_in_convert_wire_to_impl_Fn_Frame_Send_Sync_static_403c0e908ef1b499<
+    'env,
+    'v,
+>(
+    env: &mut jni::JNIEnv<'env>,
+    v: &jni::objects::JObject<'v>,
+) -> ::core::result::Result<
+    impl Fn(perftest_flat::Frame) + Send + Sync + 'static,
+    __JniErr,
+> {
+    Ok({
+        use std::sync::Arc;
+        let java_vm = Arc::new(
+            env
+                .get_java_vm()
+                .map_err(|e| <__JniErr as ::core::convert::From<
+                    String,
+                >>::from(format!("Unable to retrieve JVM: {}", e)))?,
+        );
+        let callback_global_ref = env
+            .new_global_ref(&v)
+            .map_err(|e| <__JniErr as ::core::convert::From<
+                String,
+            >>::from(format!("Unable to global-ref callback: {}", e)))?;
+        let __invoke_class = env
+            .get_object_class(&v)
+            .map_err(|e| <__JniErr as ::core::convert::From<
+                String,
+            >>::from(
+                format!("Unable to get callback class for {}: {}", "Fn(Frame)", e),
+            ))?;
+        let __invoke_id = env
+            .get_method_id(
+                &__invoke_class,
+                "run",
+                "(JZLjava/lang/String;ZJJIJJJLjava/lang/String;IJ)V",
+            )
+            .map_err(|e| <__JniErr as ::core::convert::From<
+                String,
+            >>::from(format!("Unable to resolve run for {}: {}", "Fn(Frame)", e)))?;
+        Box::new(move |__cb_arg0: perftest_flat::Frame| {
+            let _ = (|| -> ::core::result::Result<(), __JniErr> {
+                let mut env = java_vm
+                    .attach_current_thread_as_daemon()
+                    .map_err(|e| <__JniErr as ::core::convert::From<
+                        String,
+                    >>::from(format!("Attach thread for {}: {}", "Fn(Frame)", e)))?;
+                env.push_local_frame(32)
+                    .map_err(|e| <__JniErr as ::core::convert::From<
+                        String,
+                    >>::from(format!("push local frame for {}: {}", "Fn(Frame)", e)))?;
+                let __frame_res = (|| -> ::core::result::Result<(), __JniErr> {
+                    let (
+                        __cb0_obj1,
+                        __cb0_obj2,
+                        __cb0_obj3,
+                        __cb0_obj4,
+                        __cb0_obj5,
+                        __cb0_obj6,
+                        __cb0_obj7,
+                        __cb0_obj8,
+                        __cb0_obj9,
+                        __cb0_obj10,
+                        __cb0_obj11,
+                        __cb0_obj12,
+                    ): (
+                        jni::sys::jvalue,
+                        jni::objects::JObject,
+                        jni::sys::jvalue,
+                        jni::sys::jvalue,
+                        jni::sys::jvalue,
+                        jni::sys::jvalue,
+                        jni::sys::jvalue,
+                        jni::sys::jvalue,
+                        jni::sys::jvalue,
+                        jni::objects::JObject,
+                        jni::sys::jvalue,
+                        jni::sys::jvalue,
+                    ) = {
+                        let __so1: &::core::option::Option<_> = &(&__cb_arg0).window;
+                        match __so1 {
+                            ::core::option::Option::Some(__sg1) => {
+                                let __cb0_obj1: jni::sys::jvalue = jni::sys::jvalue {
+                                    z: 1u8,
+                                };
+                                let (
+                                    __cb0_obj3,
+                                    __cb0_obj4,
+                                    __cb0_obj5,
+                                ): (jni::sys::jvalue, jni::sys::jvalue, jni::sys::jvalue) = {
+                                    let __so3: &::core::option::Option<_> = &(__sg1).span;
+                                    match __so3 {
+                                        ::core::option::Option::Some(__sg3) => {
+                                            let __cb0_obj3: jni::sys::jvalue = jni::sys::jvalue {
+                                                z: 1u8,
+                                            };
+                                            let __cb0_obj4: jni::sys::jvalue = {
+                                                let __enc1 = match __jni_out_convert_i64_to_wire_15d458bf28dc9c80(
+                                                    &mut env,
+                                                    (&(__sg3).secs).clone(),
+                                                ) {
+                                                    ::core::result::Result::Ok(__w) => __w,
+                                                    ::core::result::Result::Err(__e) => {
+                                                        return ::core::result::Result::Err(
+                                                            <__JniErr as ::core::convert::From<
+                                                                String,
+                                                            >>::from(__e.to_string()),
+                                                        );
+                                                    }
+                                                };
+                                                jni::sys::jvalue { j: __enc1 }
+                                            };
+                                            let __cb0_obj5: jni::sys::jvalue = {
+                                                let __enc2 = match __jni_out_convert_i64_to_wire_15d458bf28dc9c80(
+                                                    &mut env,
+                                                    (&(__sg3).nanos).clone(),
+                                                ) {
+                                                    ::core::result::Result::Ok(__w) => __w,
+                                                    ::core::result::Result::Err(__e) => {
+                                                        return ::core::result::Result::Err(
+                                                            <__JniErr as ::core::convert::From<
+                                                                String,
+                                                            >>::from(__e.to_string()),
+                                                        );
+                                                    }
+                                                };
+                                                jni::sys::jvalue { j: __enc2 }
+                                            };
+                                            (__cb0_obj3, __cb0_obj4, __cb0_obj5)
+                                        }
+                                        ::core::option::Option::None => {
+                                            (
+                                                jni::sys::jvalue { z: 0u8 },
+                                                jni::sys::jvalue { j: 0i64 },
+                                                jni::sys::jvalue { j: 0i64 },
+                                            )
+                                        }
+                                    }
+                                };
+                                let __cb0_obj6: jni::sys::jvalue;
+                                let __cb0_obj7: jni::sys::jvalue;
+                                let __cb0_obj8: jni::sys::jvalue;
+                                let __cb0_obj9: jni::sys::jvalue;
+                                let __cb0_obj10: jni::objects::JObject;
+                                let __cb0_obj11: jni::sys::jvalue;
+                                let __cb0_obj12: jni::sys::jvalue;
+                                match &(__sg1).reading {
+                                    perftest_flat::Reading::Missing => {
+                                        __cb0_obj6 = jni::sys::jvalue { i: 0 };
+                                        __cb0_obj7 = jni::sys::jvalue { j: 0i64 };
+                                        __cb0_obj8 = jni::sys::jvalue { j: 0i64 };
+                                        __cb0_obj9 = jni::sys::jvalue { j: 0i64 };
+                                        __cb0_obj10 = jni::objects::JObject::null();
+                                        __cb0_obj11 = jni::sys::jvalue { i: 0i32 };
+                                        __cb0_obj12 = jni::sys::jvalue { j: 0i64 };
+                                    }
+                                    perftest_flat::Reading::Exact(__sv0) => {
+                                        let __enc___cb0_obj7 = match __jni_out_convert_i64_to_wire_15d458bf28dc9c80(
+                                            &mut env,
+                                            __sv0.clone(),
+                                        ) {
+                                            ::core::result::Result::Ok(__w) => __w,
+                                            ::core::result::Result::Err(__e) => {
+                                                return ::core::result::Result::Err(
+                                                    <__JniErr as ::core::convert::From<
+                                                        String,
+                                                    >>::from(__e.to_string()),
+                                                );
+                                            }
+                                        };
+                                        __cb0_obj7 = jni::sys::jvalue {
+                                            j: __enc___cb0_obj7,
+                                        };
+                                        __cb0_obj6 = jni::sys::jvalue { i: 1 };
+                                        __cb0_obj8 = jni::sys::jvalue { j: 0i64 };
+                                        __cb0_obj9 = jni::sys::jvalue { j: 0i64 };
+                                        __cb0_obj10 = jni::objects::JObject::null();
+                                        __cb0_obj11 = jni::sys::jvalue { i: 0i32 };
+                                        __cb0_obj12 = jni::sys::jvalue { j: 0i64 };
+                                    }
+                                    perftest_flat::Reading::Range {
+                                        low: __sv0,
+                                        high: __sv1,
+                                    } => {
+                                        let __enc___cb0_obj8 = match __jni_out_convert_i64_to_wire_15d458bf28dc9c80(
+                                            &mut env,
+                                            __sv0.clone(),
+                                        ) {
+                                            ::core::result::Result::Ok(__w) => __w,
+                                            ::core::result::Result::Err(__e) => {
+                                                return ::core::result::Result::Err(
+                                                    <__JniErr as ::core::convert::From<
+                                                        String,
+                                                    >>::from(__e.to_string()),
+                                                );
+                                            }
+                                        };
+                                        __cb0_obj8 = jni::sys::jvalue {
+                                            j: __enc___cb0_obj8,
+                                        };
+                                        let __enc___cb0_obj9 = match __jni_out_convert_i64_to_wire_15d458bf28dc9c80(
+                                            &mut env,
+                                            __sv1.clone(),
+                                        ) {
+                                            ::core::result::Result::Ok(__w) => __w,
+                                            ::core::result::Result::Err(__e) => {
+                                                return ::core::result::Result::Err(
+                                                    <__JniErr as ::core::convert::From<
+                                                        String,
+                                                    >>::from(__e.to_string()),
+                                                );
+                                            }
+                                        };
+                                        __cb0_obj9 = jni::sys::jvalue {
+                                            j: __enc___cb0_obj9,
+                                        };
+                                        __cb0_obj6 = jni::sys::jvalue { i: 2 };
+                                        __cb0_obj7 = jni::sys::jvalue { j: 0i64 };
+                                        __cb0_obj10 = jni::objects::JObject::null();
+                                        __cb0_obj11 = jni::sys::jvalue { i: 0i32 };
+                                        __cb0_obj12 = jni::sys::jvalue { j: 0i64 };
+                                    }
+                                    perftest_flat::Reading::Labeled(__sv0, __sv1) => {
+                                        let __enc___cb0_obj10 = match __jni_out_convert_jni_text_codec_owned_to_wire_1b6cdff0ec9adbcb(
+                                            &mut env,
+                                            __sv0.clone(),
+                                        ) {
+                                            ::core::result::Result::Ok(__w) => __w,
+                                            ::core::result::Result::Err(__e) => {
+                                                return ::core::result::Result::Err(
+                                                    <__JniErr as ::core::convert::From<
+                                                        String,
+                                                    >>::from(__e.to_string()),
+                                                );
+                                            }
+                                        };
+                                        __cb0_obj10 = __enc___cb0_obj10.into();
+                                        let __enc___cb0_obj11 = match __jni_out_convert_Priority_to_wire_55b65fa623d4787e(
+                                            &mut env,
+                                            __sv1.clone(),
+                                        ) {
+                                            ::core::result::Result::Ok(__w) => __w,
+                                            ::core::result::Result::Err(__e) => {
+                                                return ::core::result::Result::Err(
+                                                    <__JniErr as ::core::convert::From<
+                                                        String,
+                                                    >>::from(__e.to_string()),
+                                                );
+                                            }
+                                        };
+                                        __cb0_obj11 = jni::sys::jvalue {
+                                            i: __enc___cb0_obj11,
+                                        };
+                                        __cb0_obj6 = jni::sys::jvalue { i: 3 };
+                                        __cb0_obj7 = jni::sys::jvalue { j: 0i64 };
+                                        __cb0_obj8 = jni::sys::jvalue { j: 0i64 };
+                                        __cb0_obj9 = jni::sys::jvalue { j: 0i64 };
+                                        __cb0_obj12 = jni::sys::jvalue { j: 0i64 };
+                                    }
+                                    perftest_flat::Reading::Companion(__sv0) => {
+                                        let __enc___cb0_obj12 = match __jni_out_convert_i64_to_wire_15d458bf28dc9c80(
+                                            &mut env,
+                                            __sv0.clone(),
+                                        ) {
+                                            ::core::result::Result::Ok(__w) => __w,
+                                            ::core::result::Result::Err(__e) => {
+                                                return ::core::result::Result::Err(
+                                                    <__JniErr as ::core::convert::From<
+                                                        String,
+                                                    >>::from(__e.to_string()),
+                                                );
+                                            }
+                                        };
+                                        __cb0_obj12 = jni::sys::jvalue {
+                                            j: __enc___cb0_obj12,
+                                        };
+                                        __cb0_obj6 = jni::sys::jvalue { i: 4 };
+                                        __cb0_obj7 = jni::sys::jvalue { j: 0i64 };
+                                        __cb0_obj8 = jni::sys::jvalue { j: 0i64 };
+                                        __cb0_obj9 = jni::sys::jvalue { j: 0i64 };
+                                        __cb0_obj10 = jni::objects::JObject::null();
+                                        __cb0_obj11 = jni::sys::jvalue { i: 0i32 };
+                                    }
+                                }
+                                let __cb0_obj2: jni::objects::JObject = {
+                                    let __enc1 = match __jni_out_convert_jni_text_codec_owned_to_wire_1b6cdff0ec9adbcb(
+                                        &mut env,
+                                        (&(__sg1).label).clone(),
+                                    ) {
+                                        ::core::result::Result::Ok(__w) => __w,
+                                        ::core::result::Result::Err(__e) => {
+                                            return ::core::result::Result::Err(
+                                                <__JniErr as ::core::convert::From<
+                                                    String,
+                                                >>::from(__e.to_string()),
+                                            );
+                                        }
+                                    };
+                                    __enc1.into()
+                                };
+                                (
+                                    __cb0_obj1,
+                                    __cb0_obj2,
+                                    __cb0_obj3,
+                                    __cb0_obj4,
+                                    __cb0_obj5,
+                                    __cb0_obj6,
+                                    __cb0_obj7,
+                                    __cb0_obj8,
+                                    __cb0_obj9,
+                                    __cb0_obj10,
+                                    __cb0_obj11,
+                                    __cb0_obj12,
+                                )
+                            }
+                            ::core::option::Option::None => {
+                                (
+                                    jni::sys::jvalue { z: 0u8 },
+                                    jni::objects::JObject::null(),
+                                    jni::sys::jvalue { z: 0u8 },
+                                    jni::sys::jvalue { j: 0i64 },
+                                    jni::sys::jvalue { j: 0i64 },
+                                    jni::sys::jvalue { i: 0i32 },
+                                    jni::sys::jvalue { j: 0i64 },
+                                    jni::sys::jvalue { j: 0i64 },
+                                    jni::sys::jvalue { j: 0i64 },
+                                    jni::objects::JObject::null(),
+                                    jni::sys::jvalue { i: 0i32 },
+                                    jni::sys::jvalue { j: 0i64 },
+                                )
+                            }
+                        }
+                    };
+                    let __cb0_obj0: jni::sys::jvalue = {
+                        let __enc0 = match __jni_out_convert_i64_to_wire_15d458bf28dc9c80(
+                            &mut env,
+                            (&__cb_arg0.id).clone(),
+                        ) {
+                            ::core::result::Result::Ok(__w) => __w,
+                            ::core::result::Result::Err(__e) => {
+                                return ::core::result::Result::Err(
+                                    <__JniErr as ::core::convert::From<
+                                        String,
+                                    >>::from(__e.to_string()),
+                                );
+                            }
+                        };
+                        jni::sys::jvalue { j: __enc0 }
+                    };
+                    let __call_res: ::core::result::Result<(), __JniErr> = unsafe {
+                        env.call_method_unchecked(
+                            &callback_global_ref,
+                            __invoke_id,
+                            jni::signature::ReturnType::Primitive(
+                                jni::signature::Primitive::Void,
+                            ),
+                            &[
+                                __cb0_obj0,
+                                __cb0_obj1,
+                                jni::sys::jvalue {
+                                    l: __cb0_obj2.as_raw(),
+                                },
+                                __cb0_obj3,
+                                __cb0_obj4,
+                                __cb0_obj5,
+                                __cb0_obj6,
+                                __cb0_obj7,
+                                __cb0_obj8,
+                                __cb0_obj9,
+                                jni::sys::jvalue {
+                                    l: __cb0_obj10.as_raw(),
+                                },
+                                __cb0_obj11,
+                                __cb0_obj12,
+                            ],
+                        )
+                    }
+                        .map(|_| ())
+                        .map_err(|e| {
+                            let _ = env.exception_describe();
+                            <__JniErr as ::core::convert::From<
+                                String,
+                            >>::from(e.to_string())
+                        });
+                    __call_res?;
+                    Ok(())
+                })();
+                let _ = unsafe { env.pop_local_frame(&jni::objects::JObject::null()) };
+                __frame_res?;
+                Ok(())
+            })()
+                .map_err(|e| tracing::error!("{} callback error: {e}", "Fn(Frame)"));
         })
     })
 }
@@ -18122,6 +19034,522 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_escape_1probe_1v
                 &__e.to_string(),
             );
             0 as jni::sys::jlong
+        }
+    }
+}
+#[no_mangle]
+#[allow(non_snake_case, unused_mut, unused_variables, dead_code)]
+pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_frameEach<'a>(
+    mut env: jni::JNIEnv<'a>,
+    _class: jni::objects::JClass<'a>,
+    n: jni::sys::jlong,
+    sink: jni::objects::JObject<'a>,
+    __error_sink: jni::objects::JObject<'a>,
+) -> () {
+    #[allow(non_upper_case_globals)]
+    static __SINK_MID: ::prebindgen_jni_runtime::CachedIfaceMethod = ::prebindgen_jni_runtime::CachedIfaceMethod::new();
+    const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
+    const __SINK_DESCR: &str = "(Ljava/lang/String;)Ljava/lang/Object;";
+    let n = match __jni_in_convert_wire_to_i64_da07d745d9e26f71(&mut env, &n) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__e) => {
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e.to_string(),
+            );
+            return ();
+        }
+    };
+    let sink = match __jni_in_convert_wire_to_impl_Fn_Frame_Send_Sync_static_403c0e908ef1b499(
+        &mut env,
+        &sink,
+    ) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__e) => {
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e.to_string(),
+            );
+            return ();
+        }
+    };
+    let __out = perftest_flat::frame_each(n, sink);
+    match __jni_out_convert_unit_to_wire_9e1510fd173c1fd6(&mut env, __out) {
+        ::core::result::Result::Ok(__w) => __w,
+        ::core::result::Result::Err(__e) => {
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e.to_string(),
+            );
+            ()
+        }
+    }
+}
+#[no_mangle]
+#[allow(non_snake_case, unused_mut, unused_variables, dead_code)]
+pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_frameNew<'a>(
+    mut env: jni::JNIEnv<'a>,
+    _class: jni::objects::JClass<'a>,
+    id: jni::sys::jlong,
+    window: jni::sys::jboolean,
+    span: jni::sys::jboolean,
+    which: jni::sys::jlong,
+    __builder: jni::objects::JObject<'a>,
+    __error_sink: jni::objects::JObject<'a>,
+) -> jni::objects::JObject<'a> {
+    #[allow(non_upper_case_globals)]
+    static __SINK_MID: ::prebindgen_jni_runtime::CachedIfaceMethod = ::prebindgen_jni_runtime::CachedIfaceMethod::new();
+    const __SINK_FQN: &str = "io/prebindgen/covertest/JniErrorHandler";
+    const __SINK_DESCR: &str = "(Ljava/lang/String;)Ljava/lang/Object;";
+    let id = match __jni_in_convert_wire_to_i64_da07d745d9e26f71(&mut env, &id) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__e) => {
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e.to_string(),
+            );
+            return jni::objects::JObject::null().into();
+        }
+    };
+    let window = match __jni_in_convert_wire_to_bool_1be2f6c32f925207(
+        &mut env,
+        &window,
+    ) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__e) => {
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e.to_string(),
+            );
+            return jni::objects::JObject::null().into();
+        }
+    };
+    let span = match __jni_in_convert_wire_to_bool_1be2f6c32f925207(&mut env, &span) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__e) => {
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e.to_string(),
+            );
+            return jni::objects::JObject::null().into();
+        }
+    };
+    let which = match __jni_in_convert_wire_to_i64_da07d745d9e26f71(&mut env, &which) {
+        ::core::result::Result::Ok(__v) => __v,
+        ::core::result::Result::Err(__e) => {
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e.to_string(),
+            );
+            return jni::objects::JObject::null().into();
+        }
+    };
+    #[allow(non_upper_case_globals)]
+    static __CB_MID: ::prebindgen_jni_runtime::CachedIfaceMethod = ::prebindgen_jni_runtime::CachedIfaceMethod::new();
+    const __CB_FQN: &str = "io/prebindgen/covertest/model/FrameBuilder";
+    const __CB_DESCR: &str = "(JZLjava/lang/String;ZJJIJJJLjava/lang/String;IJ)Ljava/lang/Object;";
+    let __out = perftest_flat::frame_new(id, window, span, which);
+    let (
+        __obj1,
+        __obj2,
+        __obj3,
+        __obj4,
+        __obj5,
+        __obj6,
+        __obj7,
+        __obj8,
+        __obj9,
+        __obj10,
+        __obj11,
+        __obj12,
+    ): (
+        jni::sys::jvalue,
+        jni::objects::JObject,
+        jni::sys::jvalue,
+        jni::sys::jvalue,
+        jni::sys::jvalue,
+        jni::sys::jvalue,
+        jni::sys::jvalue,
+        jni::sys::jvalue,
+        jni::sys::jvalue,
+        jni::objects::JObject,
+        jni::sys::jvalue,
+        jni::sys::jvalue,
+    ) = {
+        let __so1: &::core::option::Option<_> = &(&__out).window;
+        match __so1 {
+            ::core::option::Option::Some(__sg1) => {
+                let __obj1: jni::sys::jvalue = jni::sys::jvalue { z: 1u8 };
+                let (
+                    __obj3,
+                    __obj4,
+                    __obj5,
+                ): (jni::sys::jvalue, jni::sys::jvalue, jni::sys::jvalue) = {
+                    let __so3: &::core::option::Option<_> = &(__sg1).span;
+                    match __so3 {
+                        ::core::option::Option::Some(__sg3) => {
+                            let __obj3: jni::sys::jvalue = jni::sys::jvalue { z: 1u8 };
+                            let __obj4: jni::sys::jvalue = {
+                                let __enc1 = match __jni_out_convert_i64_to_wire_15d458bf28dc9c80(
+                                    &mut env,
+                                    (&(__sg3).secs).clone(),
+                                ) {
+                                    ::core::result::Result::Ok(__w) => __w,
+                                    ::core::result::Result::Err(__e) => {
+                                        signal_binding_error(
+                                            &mut env,
+                                            &__error_sink,
+                                            &__SINK_MID,
+                                            __SINK_FQN,
+                                            __SINK_DESCR,
+                                            &__e.to_string(),
+                                        );
+                                        return jni::objects::JObject::null().into();
+                                    }
+                                };
+                                jni::sys::jvalue { j: __enc1 }
+                            };
+                            let __obj5: jni::sys::jvalue = {
+                                let __enc2 = match __jni_out_convert_i64_to_wire_15d458bf28dc9c80(
+                                    &mut env,
+                                    (&(__sg3).nanos).clone(),
+                                ) {
+                                    ::core::result::Result::Ok(__w) => __w,
+                                    ::core::result::Result::Err(__e) => {
+                                        signal_binding_error(
+                                            &mut env,
+                                            &__error_sink,
+                                            &__SINK_MID,
+                                            __SINK_FQN,
+                                            __SINK_DESCR,
+                                            &__e.to_string(),
+                                        );
+                                        return jni::objects::JObject::null().into();
+                                    }
+                                };
+                                jni::sys::jvalue { j: __enc2 }
+                            };
+                            (__obj3, __obj4, __obj5)
+                        }
+                        ::core::option::Option::None => {
+                            (
+                                jni::sys::jvalue { z: 0u8 },
+                                jni::sys::jvalue { j: 0i64 },
+                                jni::sys::jvalue { j: 0i64 },
+                            )
+                        }
+                    }
+                };
+                let __obj6: jni::sys::jvalue;
+                let __obj7: jni::sys::jvalue;
+                let __obj8: jni::sys::jvalue;
+                let __obj9: jni::sys::jvalue;
+                let __obj10: jni::objects::JObject;
+                let __obj11: jni::sys::jvalue;
+                let __obj12: jni::sys::jvalue;
+                match &(__sg1).reading {
+                    perftest_flat::Reading::Missing => {
+                        __obj6 = jni::sys::jvalue { i: 0 };
+                        __obj7 = jni::sys::jvalue { j: 0i64 };
+                        __obj8 = jni::sys::jvalue { j: 0i64 };
+                        __obj9 = jni::sys::jvalue { j: 0i64 };
+                        __obj10 = jni::objects::JObject::null();
+                        __obj11 = jni::sys::jvalue { i: 0i32 };
+                        __obj12 = jni::sys::jvalue { j: 0i64 };
+                    }
+                    perftest_flat::Reading::Exact(__sv0) => {
+                        let __enc___obj7 = match __jni_out_convert_i64_to_wire_15d458bf28dc9c80(
+                            &mut env,
+                            __sv0.clone(),
+                        ) {
+                            ::core::result::Result::Ok(__w) => __w,
+                            ::core::result::Result::Err(__e) => {
+                                signal_binding_error(
+                                    &mut env,
+                                    &__error_sink,
+                                    &__SINK_MID,
+                                    __SINK_FQN,
+                                    __SINK_DESCR,
+                                    &__e.to_string(),
+                                );
+                                return jni::objects::JObject::null().into();
+                            }
+                        };
+                        __obj7 = jni::sys::jvalue {
+                            j: __enc___obj7,
+                        };
+                        __obj6 = jni::sys::jvalue { i: 1 };
+                        __obj8 = jni::sys::jvalue { j: 0i64 };
+                        __obj9 = jni::sys::jvalue { j: 0i64 };
+                        __obj10 = jni::objects::JObject::null();
+                        __obj11 = jni::sys::jvalue { i: 0i32 };
+                        __obj12 = jni::sys::jvalue { j: 0i64 };
+                    }
+                    perftest_flat::Reading::Range { low: __sv0, high: __sv1 } => {
+                        let __enc___obj8 = match __jni_out_convert_i64_to_wire_15d458bf28dc9c80(
+                            &mut env,
+                            __sv0.clone(),
+                        ) {
+                            ::core::result::Result::Ok(__w) => __w,
+                            ::core::result::Result::Err(__e) => {
+                                signal_binding_error(
+                                    &mut env,
+                                    &__error_sink,
+                                    &__SINK_MID,
+                                    __SINK_FQN,
+                                    __SINK_DESCR,
+                                    &__e.to_string(),
+                                );
+                                return jni::objects::JObject::null().into();
+                            }
+                        };
+                        __obj8 = jni::sys::jvalue {
+                            j: __enc___obj8,
+                        };
+                        let __enc___obj9 = match __jni_out_convert_i64_to_wire_15d458bf28dc9c80(
+                            &mut env,
+                            __sv1.clone(),
+                        ) {
+                            ::core::result::Result::Ok(__w) => __w,
+                            ::core::result::Result::Err(__e) => {
+                                signal_binding_error(
+                                    &mut env,
+                                    &__error_sink,
+                                    &__SINK_MID,
+                                    __SINK_FQN,
+                                    __SINK_DESCR,
+                                    &__e.to_string(),
+                                );
+                                return jni::objects::JObject::null().into();
+                            }
+                        };
+                        __obj9 = jni::sys::jvalue {
+                            j: __enc___obj9,
+                        };
+                        __obj6 = jni::sys::jvalue { i: 2 };
+                        __obj7 = jni::sys::jvalue { j: 0i64 };
+                        __obj10 = jni::objects::JObject::null();
+                        __obj11 = jni::sys::jvalue { i: 0i32 };
+                        __obj12 = jni::sys::jvalue { j: 0i64 };
+                    }
+                    perftest_flat::Reading::Labeled(__sv0, __sv1) => {
+                        let __enc___obj10 = match __jni_out_convert_jni_text_codec_owned_to_wire_1b6cdff0ec9adbcb(
+                            &mut env,
+                            __sv0.clone(),
+                        ) {
+                            ::core::result::Result::Ok(__w) => __w,
+                            ::core::result::Result::Err(__e) => {
+                                signal_binding_error(
+                                    &mut env,
+                                    &__error_sink,
+                                    &__SINK_MID,
+                                    __SINK_FQN,
+                                    __SINK_DESCR,
+                                    &__e.to_string(),
+                                );
+                                return jni::objects::JObject::null().into();
+                            }
+                        };
+                        __obj10 = __enc___obj10.into();
+                        let __enc___obj11 = match __jni_out_convert_Priority_to_wire_55b65fa623d4787e(
+                            &mut env,
+                            __sv1.clone(),
+                        ) {
+                            ::core::result::Result::Ok(__w) => __w,
+                            ::core::result::Result::Err(__e) => {
+                                signal_binding_error(
+                                    &mut env,
+                                    &__error_sink,
+                                    &__SINK_MID,
+                                    __SINK_FQN,
+                                    __SINK_DESCR,
+                                    &__e.to_string(),
+                                );
+                                return jni::objects::JObject::null().into();
+                            }
+                        };
+                        __obj11 = jni::sys::jvalue {
+                            i: __enc___obj11,
+                        };
+                        __obj6 = jni::sys::jvalue { i: 3 };
+                        __obj7 = jni::sys::jvalue { j: 0i64 };
+                        __obj8 = jni::sys::jvalue { j: 0i64 };
+                        __obj9 = jni::sys::jvalue { j: 0i64 };
+                        __obj12 = jni::sys::jvalue { j: 0i64 };
+                    }
+                    perftest_flat::Reading::Companion(__sv0) => {
+                        let __enc___obj12 = match __jni_out_convert_i64_to_wire_15d458bf28dc9c80(
+                            &mut env,
+                            __sv0.clone(),
+                        ) {
+                            ::core::result::Result::Ok(__w) => __w,
+                            ::core::result::Result::Err(__e) => {
+                                signal_binding_error(
+                                    &mut env,
+                                    &__error_sink,
+                                    &__SINK_MID,
+                                    __SINK_FQN,
+                                    __SINK_DESCR,
+                                    &__e.to_string(),
+                                );
+                                return jni::objects::JObject::null().into();
+                            }
+                        };
+                        __obj12 = jni::sys::jvalue {
+                            j: __enc___obj12,
+                        };
+                        __obj6 = jni::sys::jvalue { i: 4 };
+                        __obj7 = jni::sys::jvalue { j: 0i64 };
+                        __obj8 = jni::sys::jvalue { j: 0i64 };
+                        __obj9 = jni::sys::jvalue { j: 0i64 };
+                        __obj10 = jni::objects::JObject::null();
+                        __obj11 = jni::sys::jvalue { i: 0i32 };
+                    }
+                }
+                let __obj2: jni::objects::JObject = {
+                    let __enc1 = match __jni_out_convert_jni_text_codec_owned_to_wire_1b6cdff0ec9adbcb(
+                        &mut env,
+                        (&(__sg1).label).clone(),
+                    ) {
+                        ::core::result::Result::Ok(__w) => __w,
+                        ::core::result::Result::Err(__e) => {
+                            signal_binding_error(
+                                &mut env,
+                                &__error_sink,
+                                &__SINK_MID,
+                                __SINK_FQN,
+                                __SINK_DESCR,
+                                &__e.to_string(),
+                            );
+                            return jni::objects::JObject::null().into();
+                        }
+                    };
+                    __enc1.into()
+                };
+                (
+                    __obj1,
+                    __obj2,
+                    __obj3,
+                    __obj4,
+                    __obj5,
+                    __obj6,
+                    __obj7,
+                    __obj8,
+                    __obj9,
+                    __obj10,
+                    __obj11,
+                    __obj12,
+                )
+            }
+            ::core::option::Option::None => {
+                (
+                    jni::sys::jvalue { z: 0u8 },
+                    jni::objects::JObject::null(),
+                    jni::sys::jvalue { z: 0u8 },
+                    jni::sys::jvalue { j: 0i64 },
+                    jni::sys::jvalue { j: 0i64 },
+                    jni::sys::jvalue { i: 0i32 },
+                    jni::sys::jvalue { j: 0i64 },
+                    jni::sys::jvalue { j: 0i64 },
+                    jni::sys::jvalue { j: 0i64 },
+                    jni::objects::JObject::null(),
+                    jni::sys::jvalue { i: 0i32 },
+                    jni::sys::jvalue { j: 0i64 },
+                )
+            }
+        }
+    };
+    let __obj0: jni::sys::jvalue = {
+        let __enc0 = match __jni_out_convert_i64_to_wire_15d458bf28dc9c80(
+            &mut env,
+            (&__out.id).clone(),
+        ) {
+            ::core::result::Result::Ok(__w) => __w,
+            ::core::result::Result::Err(__e) => {
+                signal_binding_error(
+                    &mut env,
+                    &__error_sink,
+                    &__SINK_MID,
+                    __SINK_FQN,
+                    __SINK_DESCR,
+                    &__e.to_string(),
+                );
+                return jni::objects::JObject::null().into();
+            }
+        };
+        jni::sys::jvalue { j: __enc0 }
+    };
+    match __CB_MID
+        .call_object(
+            &mut env,
+            __CB_FQN,
+            "run",
+            __CB_DESCR,
+            &__builder,
+            &[
+                __obj0,
+                __obj1,
+                jni::sys::jvalue {
+                    l: __obj2.as_raw(),
+                },
+                __obj3,
+                __obj4,
+                __obj5,
+                __obj6,
+                __obj7,
+                __obj8,
+                __obj9,
+                jni::sys::jvalue {
+                    l: __obj10.as_raw(),
+                },
+                __obj11,
+                __obj12,
+            ],
+        )
+    {
+        ::core::result::Result::Ok(__o) => __o,
+        ::core::result::Result::Err(__e) => {
+            let _ = env.exception_describe();
+            let __e2 = <__JniErr as ::core::convert::From<
+                String,
+            >>::from(__e.to_string());
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e2.to_string(),
+            );
+            jni::objects::JObject::null().into()
         }
     }
 }

--- a/examples/covertest-kotlin/src/generated_bindings.rs
+++ b/examples/covertest-kotlin/src/generated_bindings.rs
@@ -3188,6 +3188,37 @@ pub(crate) unsafe fn __jni_in_convert_wire_to_Dossier_5316a15bb0813dfb<'env, 'v>
     clippy::nonminimal_bool,
     clippy::eq_op
 )]
+#[inline(always)]
+pub(crate) unsafe fn __jni_out_convert_Dossier_jni_product_intermediate_tuple_to_wire_65c44423ebbab4ea<
+    'a,
+>(
+    env: &mut jni::JNIEnv<'a>,
+    v: perftest_flat::Dossier,
+) -> ::core::result::Result<
+    (jni::sys::jlong, (jni::sys::jlong, jni::sys::jlong)),
+    __JniErr,
+> {
+    ::core::result::Result::Ok((
+        __jni_out_convert_i64_to_wire_15d458bf28dc9c80(env, v.note)?,
+        __jni_out_convert_Holder_jni_product_intermediate_tuple_to_wire_2a1ff6bf243ab85f(
+            env,
+            v.holder,
+        )?,
+    ))
+}
+#[allow(
+    non_snake_case,
+    unused_mut,
+    unused_variables,
+    unused_braces,
+    unused_parens,
+    dead_code,
+    clippy::useless_conversion,
+    clippy::needless_question_mark,
+    clippy::let_and_return,
+    clippy::nonminimal_bool,
+    clippy::eq_op
+)]
 pub(crate) unsafe fn __jni_out_convert_Dossier_to_wire_3471beb9c18a07a2<'a>(
     env: &mut jni::JNIEnv<'a>,
     v: perftest_flat::Dossier,
@@ -3951,6 +3982,34 @@ pub(crate) unsafe fn __jni_in_convert_wire_to_Holder_e0a7dbed55dd2865<'env, 'v>(
     clippy::nonminimal_bool,
     clippy::eq_op
 )]
+#[inline(always)]
+pub(crate) unsafe fn __jni_out_convert_Holder_jni_product_intermediate_tuple_to_wire_2a1ff6bf243ab85f<
+    'a,
+>(
+    env: &mut jni::JNIEnv<'a>,
+    v: perftest_flat::Holder,
+) -> ::core::result::Result<(jni::sys::jlong, jni::sys::jlong), __JniErr> {
+    ::core::result::Result::Ok((
+        __jni_out_convert_i64_to_wire_15d458bf28dc9c80(env, v.tag)?,
+        __jni_out_convert_Summary_jni_handle_codec_own_output_to_wire_236099c944f0abfc(
+            env,
+            v.summary,
+        )?,
+    ))
+}
+#[allow(
+    non_snake_case,
+    unused_mut,
+    unused_variables,
+    unused_braces,
+    unused_parens,
+    dead_code,
+    clippy::useless_conversion,
+    clippy::needless_question_mark,
+    clippy::let_and_return,
+    clippy::nonminimal_bool,
+    clippy::eq_op
+)]
 pub(crate) unsafe fn __jni_out_convert_Holder_to_wire_35267746a549279a<'a>(
     env: &mut jni::JNIEnv<'a>,
     v: perftest_flat::Holder,
@@ -4651,6 +4710,34 @@ pub(crate) unsafe fn __jni_in_convert_wire_to_MaybeHolder_fcb77d18203824e3<'env,
             )?,
         }
     })
+}
+#[allow(
+    non_snake_case,
+    unused_mut,
+    unused_variables,
+    unused_braces,
+    unused_parens,
+    dead_code,
+    clippy::useless_conversion,
+    clippy::needless_question_mark,
+    clippy::let_and_return,
+    clippy::nonminimal_bool,
+    clippy::eq_op
+)]
+#[inline(always)]
+pub(crate) unsafe fn __jni_out_convert_MaybeHolder_jni_product_intermediate_tuple_to_wire_e5339f5bbe94e623<
+    'a,
+>(
+    env: &mut jni::JNIEnv<'a>,
+    v: perftest_flat::MaybeHolder,
+) -> ::core::result::Result<(jni::sys::jlong, jni::sys::jlong), __JniErr> {
+    ::core::result::Result::Ok((
+        __jni_out_convert_i64_to_wire_15d458bf28dc9c80(env, v.tag)?,
+        __jni_out_convert_Option_Summary_jni_optional_intermediate_output_niche_to_wire_eb293aceaadb405f(
+            env,
+            v.summary,
+        )?,
+    ))
 }
 #[allow(
     non_snake_case,
@@ -15129,6 +15216,7 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_annotatedNew<'a>
     ttl_present: jni::sys::jboolean,
     ttl_value: jni::sys::jlong,
     priority: jni::sys::jint,
+    __builder: jni::objects::JObject<'a>,
     __error_sink: jni::objects::JObject<'a>,
 ) -> jni::objects::JObject<'a> {
     #[allow(non_upper_case_globals)]
@@ -15186,17 +15274,327 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_annotatedNew<'a>
             return jni::objects::JObject::null().into();
         }
     };
+    #[allow(non_upper_case_globals)]
+    static __CB_MID: ::prebindgen_jni_runtime::CachedIfaceMethod = ::prebindgen_jni_runtime::CachedIfaceMethod::new();
+    const __CB_FQN: &str = "io/prebindgen/covertest/model/AnnotatedBuilder";
+    const __CB_DESCR: &str = "(JIDZLjava/lang/String;ZJIDZLjava/lang/String;Ljava/lang/Long;I)Ljava/lang/Object;";
     let __out = perftest_flat::annotated_new(payload, ttl, priority);
-    match __jni_out_convert_Annotated_to_wire_e7aba1468b19001a(&mut env, __out) {
-        ::core::result::Result::Ok(__w) => __w,
+    let (
+        __obj5,
+        __obj6,
+        __obj7,
+        __obj8,
+        __obj9,
+        __obj10,
+    ): (
+        jni::sys::jvalue,
+        jni::sys::jvalue,
+        jni::sys::jvalue,
+        jni::sys::jvalue,
+        jni::sys::jvalue,
+        jni::objects::JObject,
+    ) = {
+        let __so5: &::core::option::Option<_> = &(&__out).alternate;
+        match __so5 {
+            ::core::option::Option::Some(__sg5) => {
+                let __obj5: jni::sys::jvalue = jni::sys::jvalue { z: 1u8 };
+                let __obj6: jni::sys::jvalue = {
+                    let __enc1 = match __jni_out_convert_i64_to_wire_15d458bf28dc9c80(
+                        &mut env,
+                        (&(__sg5).id).clone(),
+                    ) {
+                        ::core::result::Result::Ok(__w) => __w,
+                        ::core::result::Result::Err(__e) => {
+                            signal_binding_error(
+                                &mut env,
+                                &__error_sink,
+                                &__SINK_MID,
+                                __SINK_FQN,
+                                __SINK_DESCR,
+                                &__e.to_string(),
+                            );
+                            return jni::objects::JObject::null().into();
+                        }
+                    };
+                    jni::sys::jvalue { j: __enc1 }
+                };
+                let __obj7: jni::sys::jvalue = {
+                    let __enc2 = match __jni_out_convert_i32_to_wire_67173b19ae5a9348(
+                        &mut env,
+                        (&(__sg5).seq).clone(),
+                    ) {
+                        ::core::result::Result::Ok(__w) => __w,
+                        ::core::result::Result::Err(__e) => {
+                            signal_binding_error(
+                                &mut env,
+                                &__error_sink,
+                                &__SINK_MID,
+                                __SINK_FQN,
+                                __SINK_DESCR,
+                                &__e.to_string(),
+                            );
+                            return jni::objects::JObject::null().into();
+                        }
+                    };
+                    jni::sys::jvalue { i: __enc2 }
+                };
+                let __obj8: jni::sys::jvalue = {
+                    let __enc3 = match __jni_out_convert_f64_to_wire_61461de12ea6bc04(
+                        &mut env,
+                        (&(__sg5).value).clone(),
+                    ) {
+                        ::core::result::Result::Ok(__w) => __w,
+                        ::core::result::Result::Err(__e) => {
+                            signal_binding_error(
+                                &mut env,
+                                &__error_sink,
+                                &__SINK_MID,
+                                __SINK_FQN,
+                                __SINK_DESCR,
+                                &__e.to_string(),
+                            );
+                            return jni::objects::JObject::null().into();
+                        }
+                    };
+                    jni::sys::jvalue { d: __enc3 }
+                };
+                let __obj9: jni::sys::jvalue = {
+                    let __enc4 = match __jni_out_convert_bool_to_wire_3ee62077915d5228(
+                        &mut env,
+                        (&(__sg5).flag).clone(),
+                    ) {
+                        ::core::result::Result::Ok(__w) => __w,
+                        ::core::result::Result::Err(__e) => {
+                            signal_binding_error(
+                                &mut env,
+                                &__error_sink,
+                                &__SINK_MID,
+                                __SINK_FQN,
+                                __SINK_DESCR,
+                                &__e.to_string(),
+                            );
+                            return jni::objects::JObject::null().into();
+                        }
+                    };
+                    jni::sys::jvalue { z: __enc4 }
+                };
+                let __obj10: jni::objects::JObject = {
+                    let __enc5 = match __jni_out_convert_Option_Box_String_jni_optional_intermediate_output_niche_to_wire_57342b1f497b4507(
+                        &mut env,
+                        (&(__sg5).label).clone(),
+                    ) {
+                        ::core::result::Result::Ok(__w) => __w,
+                        ::core::result::Result::Err(__e) => {
+                            signal_binding_error(
+                                &mut env,
+                                &__error_sink,
+                                &__SINK_MID,
+                                __SINK_FQN,
+                                __SINK_DESCR,
+                                &__e.to_string(),
+                            );
+                            return jni::objects::JObject::null().into();
+                        }
+                    };
+                    __enc5.into()
+                };
+                (__obj5, __obj6, __obj7, __obj8, __obj9, __obj10)
+            }
+            ::core::option::Option::None => {
+                (
+                    jni::sys::jvalue { z: 0u8 },
+                    jni::sys::jvalue { j: 0i64 },
+                    jni::sys::jvalue { i: 0i32 },
+                    jni::sys::jvalue { d: 0.0f64 },
+                    jni::sys::jvalue { z: 0u8 },
+                    jni::objects::JObject::null(),
+                )
+            }
+        }
+    };
+    let __obj0: jni::sys::jvalue = {
+        let __enc0 = match __jni_out_convert_i64_to_wire_15d458bf28dc9c80(
+            &mut env,
+            (&__out.payload.id).clone(),
+        ) {
+            ::core::result::Result::Ok(__w) => __w,
+            ::core::result::Result::Err(__e) => {
+                signal_binding_error(
+                    &mut env,
+                    &__error_sink,
+                    &__SINK_MID,
+                    __SINK_FQN,
+                    __SINK_DESCR,
+                    &__e.to_string(),
+                );
+                return jni::objects::JObject::null().into();
+            }
+        };
+        jni::sys::jvalue { j: __enc0 }
+    };
+    let __obj1: jni::sys::jvalue = {
+        let __enc1 = match __jni_out_convert_i32_to_wire_67173b19ae5a9348(
+            &mut env,
+            (&__out.payload.seq).clone(),
+        ) {
+            ::core::result::Result::Ok(__w) => __w,
+            ::core::result::Result::Err(__e) => {
+                signal_binding_error(
+                    &mut env,
+                    &__error_sink,
+                    &__SINK_MID,
+                    __SINK_FQN,
+                    __SINK_DESCR,
+                    &__e.to_string(),
+                );
+                return jni::objects::JObject::null().into();
+            }
+        };
+        jni::sys::jvalue { i: __enc1 }
+    };
+    let __obj2: jni::sys::jvalue = {
+        let __enc2 = match __jni_out_convert_f64_to_wire_61461de12ea6bc04(
+            &mut env,
+            (&__out.payload.value).clone(),
+        ) {
+            ::core::result::Result::Ok(__w) => __w,
+            ::core::result::Result::Err(__e) => {
+                signal_binding_error(
+                    &mut env,
+                    &__error_sink,
+                    &__SINK_MID,
+                    __SINK_FQN,
+                    __SINK_DESCR,
+                    &__e.to_string(),
+                );
+                return jni::objects::JObject::null().into();
+            }
+        };
+        jni::sys::jvalue { d: __enc2 }
+    };
+    let __obj3: jni::sys::jvalue = {
+        let __enc3 = match __jni_out_convert_bool_to_wire_3ee62077915d5228(
+            &mut env,
+            (&__out.payload.flag).clone(),
+        ) {
+            ::core::result::Result::Ok(__w) => __w,
+            ::core::result::Result::Err(__e) => {
+                signal_binding_error(
+                    &mut env,
+                    &__error_sink,
+                    &__SINK_MID,
+                    __SINK_FQN,
+                    __SINK_DESCR,
+                    &__e.to_string(),
+                );
+                return jni::objects::JObject::null().into();
+            }
+        };
+        jni::sys::jvalue { z: __enc3 }
+    };
+    let __obj4: jni::objects::JObject = {
+        let __enc4 = match __jni_out_convert_Option_Box_String_jni_optional_intermediate_output_niche_to_wire_57342b1f497b4507(
+            &mut env,
+            (&__out.payload.label).clone(),
+        ) {
+            ::core::result::Result::Ok(__w) => __w,
+            ::core::result::Result::Err(__e) => {
+                signal_binding_error(
+                    &mut env,
+                    &__error_sink,
+                    &__SINK_MID,
+                    __SINK_FQN,
+                    __SINK_DESCR,
+                    &__e.to_string(),
+                );
+                return jni::objects::JObject::null().into();
+            }
+        };
+        __enc4.into()
+    };
+    let __obj11: jni::objects::JObject = {
+        let __enc11 = match __jni_out_convert_Option_i64_jni_optional_intermediate_output_boxed_to_wire_a906c53b92fcc585(
+            &mut env,
+            (&__out.ttl).clone(),
+        ) {
+            ::core::result::Result::Ok(__w) => __w,
+            ::core::result::Result::Err(__e) => {
+                signal_binding_error(
+                    &mut env,
+                    &__error_sink,
+                    &__SINK_MID,
+                    __SINK_FQN,
+                    __SINK_DESCR,
+                    &__e.to_string(),
+                );
+                return jni::objects::JObject::null().into();
+            }
+        };
+        __enc11
+    };
+    let __obj12: jni::sys::jvalue = {
+        let __enc12 = match __jni_out_convert_Option_Priority_jni_optional_intermediate_output_niche_to_wire_f8a537414a30bc3f(
+            &mut env,
+            (&__out.priority).clone(),
+        ) {
+            ::core::result::Result::Ok(__w) => __w,
+            ::core::result::Result::Err(__e) => {
+                signal_binding_error(
+                    &mut env,
+                    &__error_sink,
+                    &__SINK_MID,
+                    __SINK_FQN,
+                    __SINK_DESCR,
+                    &__e.to_string(),
+                );
+                return jni::objects::JObject::null().into();
+            }
+        };
+        jni::sys::jvalue { i: __enc12 }
+    };
+    match __CB_MID
+        .call_object(
+            &mut env,
+            __CB_FQN,
+            "run",
+            __CB_DESCR,
+            &__builder,
+            &[
+                __obj0,
+                __obj1,
+                __obj2,
+                __obj3,
+                jni::sys::jvalue {
+                    l: __obj4.as_raw(),
+                },
+                __obj5,
+                __obj6,
+                __obj7,
+                __obj8,
+                __obj9,
+                jni::sys::jvalue {
+                    l: __obj10.as_raw(),
+                },
+                jni::sys::jvalue {
+                    l: __obj11.as_raw(),
+                },
+                __obj12,
+            ],
+        )
+    {
+        ::core::result::Result::Ok(__o) => __o,
         ::core::result::Result::Err(__e) => {
+            let _ = env.exception_describe();
+            let __e2 = <__JniErr as ::core::convert::From<
+                String,
+            >>::from(__e.to_string());
             signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                &__e.to_string(),
+                &__e2.to_string(),
             );
             jni::objects::JObject::null().into()
         }
@@ -17058,6 +17456,7 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_dossierNew<'a>(
     tag: jni::sys::jlong,
     count: jni::sys::jlong,
     total: jni::sys::jdouble,
+    __builder: jni::objects::JObject<'a>,
     __error_sink: jni::objects::JObject<'a>,
 ) -> jni::objects::JObject<'a> {
     #[allow(non_upper_case_globals)]
@@ -17120,17 +17519,60 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_dossierNew<'a>(
             return jni::objects::JObject::null().into();
         }
     };
+    #[allow(non_upper_case_globals)]
+    static __CB_MID: ::prebindgen_jni_runtime::CachedIfaceMethod = ::prebindgen_jni_runtime::CachedIfaceMethod::new();
+    const __CB_FQN: &str = "io/prebindgen/covertest/DossierBuilderRaw";
+    const __CB_DESCR: &str = "(JJJ)Ljava/lang/Object;";
     let __out = perftest_flat::dossier_new(note, tag, count, total);
-    match __jni_out_convert_Dossier_to_wire_3471beb9c18a07a2(&mut env, __out) {
-        ::core::result::Result::Ok(__w) => __w,
-        ::core::result::Result::Err(__e) => {
+    let (__chain_wire0, (__chain_wire1, __chain_wire2)) = match __jni_out_convert_Dossier_jni_product_intermediate_tuple_to_wire_65c44423ebbab4ea(
+        &mut env,
+        __out,
+    ) {
+        ::core::result::Result::Ok(__intermediate) => __intermediate,
+        ::core::result::Result::Err(__chain_error) => {
             signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                &__e.to_string(),
+                &__chain_error.to_string(),
+            );
+            return jni::objects::JObject::null().into();
+        }
+    };
+    let __obj0 = jni::sys::jvalue {
+        j: __chain_wire0,
+    };
+    let __obj1 = jni::sys::jvalue {
+        j: __chain_wire1,
+    };
+    let __obj2 = jni::sys::jvalue {
+        j: __chain_wire2,
+    };
+    match __CB_MID
+        .call_object(
+            &mut env,
+            __CB_FQN,
+            "run",
+            __CB_DESCR,
+            &__builder,
+            &[__obj0, __obj1, __obj2],
+        )
+    {
+        ::core::result::Result::Ok(__o) => __o,
+        ::core::result::Result::Err(__e) => {
+            let _ = env.exception_describe();
+            let __e2 = <__JniErr as ::core::convert::From<
+                String,
+            >>::from(__e.to_string());
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e2.to_string(),
             );
             jni::objects::JObject::null().into()
         }
@@ -17773,6 +18215,7 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_holdPolicyEcho<'
     _class: jni::objects::JClass<'a>,
     p_hold: jni::objects::JObject<'a>,
     p_grace: jni::objects::JObject<'a>,
+    __builder: jni::objects::JObject<'a>,
     __error_sink: jni::objects::JObject<'a>,
 ) -> jni::objects::JObject<'a> {
     #[allow(non_upper_case_globals)]
@@ -17796,17 +18239,138 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_holdPolicyEcho<'
             return jni::objects::JObject::null().into();
         }
     };
+    #[allow(non_upper_case_globals)]
+    static __CB_MID: ::prebindgen_jni_runtime::CachedIfaceMethod = ::prebindgen_jni_runtime::CachedIfaceMethod::new();
+    const __CB_FQN: &str = "io/prebindgen/covertest/model/HoldPolicyBuilderRaw";
+    const __CB_DESCR: &str = "(IJZIJ)Ljava/lang/Object;";
     let __out = perftest_flat::hold_policy_echo(p);
-    match __jni_out_convert_HoldPolicy_to_wire_3068aef2f204dafc(&mut env, __out) {
-        ::core::result::Result::Ok(__w) => __w,
+    let __obj0: jni::sys::jvalue;
+    let __obj1: jni::sys::jvalue;
+    match &__out.hold {
+        perftest_flat::Hold::Indefinite => {
+            __obj0 = jni::sys::jvalue { i: 0 };
+            __obj1 = jni::sys::jvalue { j: 0i64 };
+        }
+        perftest_flat::Hold::For(__sv0) => {
+            let __enc___obj1 = match (|| -> ::core::result::Result<_, __JniErr> {
+                {
+                    let __chain_s0 = __jni_out_stage_0_Duration_to_wire_37da00112022eac0(
+                            &mut env,
+                            __sv0.clone(),
+                        )
+                        .map_err(|__e| <__JniErr as ::core::convert::From<
+                            String,
+                        >>::from(__e.to_string()))?;
+                    __jni_out_convert_u64_to_wire_c9db59f6e5bef648(&mut env, __chain_s0)
+                }
+            })() {
+                ::core::result::Result::Ok(__w) => __w,
+                ::core::result::Result::Err(__e) => {
+                    signal_binding_error(
+                        &mut env,
+                        &__error_sink,
+                        &__SINK_MID,
+                        __SINK_FQN,
+                        __SINK_DESCR,
+                        &__e.to_string(),
+                    );
+                    return jni::objects::JObject::null().into();
+                }
+            };
+            __obj1 = jni::sys::jvalue {
+                j: __enc___obj1,
+            };
+            __obj0 = jni::sys::jvalue { i: 1 };
+        }
+    }
+    let (
+        __obj2,
+        __obj3,
+        __obj4,
+    ): (jni::sys::jvalue, jni::sys::jvalue, jni::sys::jvalue) = {
+        let __so2: &::core::option::Option<_> = &(&__out).grace;
+        match __so2 {
+            ::core::option::Option::Some(__sg2) => {
+                let __obj2: jni::sys::jvalue = jni::sys::jvalue { z: 1u8 };
+                let __obj3: jni::sys::jvalue;
+                let __obj4: jni::sys::jvalue;
+                match __sg2 {
+                    perftest_flat::Hold::Indefinite => {
+                        __obj3 = jni::sys::jvalue { i: 0 };
+                        __obj4 = jni::sys::jvalue { j: 0i64 };
+                    }
+                    perftest_flat::Hold::For(__sv0) => {
+                        let __enc___obj4 = match (|| -> ::core::result::Result<
+                            _,
+                            __JniErr,
+                        > {
+                            {
+                                let __chain_s0 = __jni_out_stage_0_Duration_to_wire_37da00112022eac0(
+                                        &mut env,
+                                        __sv0.clone(),
+                                    )
+                                    .map_err(|__e| <__JniErr as ::core::convert::From<
+                                        String,
+                                    >>::from(__e.to_string()))?;
+                                __jni_out_convert_u64_to_wire_c9db59f6e5bef648(
+                                    &mut env,
+                                    __chain_s0,
+                                )
+                            }
+                        })() {
+                            ::core::result::Result::Ok(__w) => __w,
+                            ::core::result::Result::Err(__e) => {
+                                signal_binding_error(
+                                    &mut env,
+                                    &__error_sink,
+                                    &__SINK_MID,
+                                    __SINK_FQN,
+                                    __SINK_DESCR,
+                                    &__e.to_string(),
+                                );
+                                return jni::objects::JObject::null().into();
+                            }
+                        };
+                        __obj4 = jni::sys::jvalue {
+                            j: __enc___obj4,
+                        };
+                        __obj3 = jni::sys::jvalue { i: 1 };
+                    }
+                }
+                (__obj2, __obj3, __obj4)
+            }
+            ::core::option::Option::None => {
+                (
+                    jni::sys::jvalue { z: 0u8 },
+                    jni::sys::jvalue { i: 0i32 },
+                    jni::sys::jvalue { j: 0i64 },
+                )
+            }
+        }
+    };
+    match __CB_MID
+        .call_object(
+            &mut env,
+            __CB_FQN,
+            "run",
+            __CB_DESCR,
+            &__builder,
+            &[__obj0, __obj1, __obj2, __obj3, __obj4],
+        )
+    {
+        ::core::result::Result::Ok(__o) => __o,
         ::core::result::Result::Err(__e) => {
+            let _ = env.exception_describe();
+            let __e2 = <__JniErr as ::core::convert::From<
+                String,
+            >>::from(__e.to_string());
             signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                &__e.to_string(),
+                &__e2.to_string(),
             );
             jni::objects::JObject::null().into()
         }
@@ -19408,6 +19972,7 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_maybeHolderNew<'
     count: jni::sys::jlong,
     total: jni::sys::jdouble,
     present: jni::sys::jboolean,
+    __builder: jni::objects::JObject<'a>,
     __error_sink: jni::objects::JObject<'a>,
 ) -> jni::objects::JObject<'a> {
     #[allow(non_upper_case_globals)]
@@ -19473,17 +20038,57 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_maybeHolderNew<'
             return jni::objects::JObject::null().into();
         }
     };
+    #[allow(non_upper_case_globals)]
+    static __CB_MID: ::prebindgen_jni_runtime::CachedIfaceMethod = ::prebindgen_jni_runtime::CachedIfaceMethod::new();
+    const __CB_FQN: &str = "io/prebindgen/covertest/MaybeHolderBuilderRaw";
+    const __CB_DESCR: &str = "(JJ)Ljava/lang/Object;";
     let __out = perftest_flat::maybe_holder_new(tag, count, total, present);
-    match __jni_out_convert_MaybeHolder_to_wire_9c674d8cda401732(&mut env, __out) {
-        ::core::result::Result::Ok(__w) => __w,
-        ::core::result::Result::Err(__e) => {
+    let (__chain_wire0, __chain_wire1) = match __jni_out_convert_MaybeHolder_jni_product_intermediate_tuple_to_wire_e5339f5bbe94e623(
+        &mut env,
+        __out,
+    ) {
+        ::core::result::Result::Ok(__intermediate) => __intermediate,
+        ::core::result::Result::Err(__chain_error) => {
             signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                &__e.to_string(),
+                &__chain_error.to_string(),
+            );
+            return jni::objects::JObject::null().into();
+        }
+    };
+    let __obj0 = jni::sys::jvalue {
+        j: __chain_wire0,
+    };
+    let __obj1 = jni::sys::jvalue {
+        j: __chain_wire1,
+    };
+    match __CB_MID
+        .call_object(
+            &mut env,
+            __CB_FQN,
+            "run",
+            __CB_DESCR,
+            &__builder,
+            &[__obj0, __obj1],
+        )
+    {
+        ::core::result::Result::Ok(__o) => __o,
+        ::core::result::Result::Err(__e) => {
+            let _ = env.exception_describe();
+            let __e2 = <__JniErr as ::core::convert::From<
+                String,
+            >>::from(__e.to_string());
+            signal_binding_error(
+                &mut env,
+                &__error_sink,
+                &__SINK_MID,
+                __SINK_FQN,
+                __SINK_DESCR,
+                &__e2.to_string(),
             );
             jni::objects::JObject::null().into()
         }
@@ -19639,6 +20244,7 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_observationNew<'
     _class: jni::objects::JClass<'a>,
     which: jni::sys::jint,
     with_fallback: jni::sys::jboolean,
+    __builder: jni::objects::JObject<'a>,
     __error_sink: jni::objects::JObject<'a>,
 ) -> jni::objects::JObject<'a> {
     #[allow(non_upper_case_globals)]
@@ -19676,17 +20282,469 @@ pub unsafe extern "C" fn Java_io_prebindgen_covertest_CovNative_observationNew<'
             return jni::objects::JObject::null().into();
         }
     };
+    #[allow(non_upper_case_globals)]
+    static __CB_MID: ::prebindgen_jni_runtime::CachedIfaceMethod = ::prebindgen_jni_runtime::CachedIfaceMethod::new();
+    const __CB_FQN: &str = "io/prebindgen/covertest/model/ObservationBuilder";
+    const __CB_DESCR: &str = "(JIJJJLjava/lang/String;IJZIJJJLjava/lang/String;IJLjava/lang/String;)Ljava/lang/Object;";
     let __out = perftest_flat::observation_new(which, with_fallback);
-    match __jni_out_convert_Observation_to_wire_d96ad3cc48a04f0a(&mut env, __out) {
-        ::core::result::Result::Ok(__w) => __w,
+    let __obj1: jni::sys::jvalue;
+    let __obj2: jni::sys::jvalue;
+    let __obj3: jni::sys::jvalue;
+    let __obj4: jni::sys::jvalue;
+    let __obj5: jni::objects::JObject;
+    let __obj6: jni::sys::jvalue;
+    let __obj7: jni::sys::jvalue;
+    match &__out.reading {
+        perftest_flat::Reading::Missing => {
+            __obj1 = jni::sys::jvalue { i: 0 };
+            __obj2 = jni::sys::jvalue { j: 0i64 };
+            __obj3 = jni::sys::jvalue { j: 0i64 };
+            __obj4 = jni::sys::jvalue { j: 0i64 };
+            __obj5 = jni::objects::JObject::null();
+            __obj6 = jni::sys::jvalue { i: 0i32 };
+            __obj7 = jni::sys::jvalue { j: 0i64 };
+        }
+        perftest_flat::Reading::Exact(__sv0) => {
+            let __enc___obj2 = match __jni_out_convert_i64_to_wire_15d458bf28dc9c80(
+                &mut env,
+                __sv0.clone(),
+            ) {
+                ::core::result::Result::Ok(__w) => __w,
+                ::core::result::Result::Err(__e) => {
+                    signal_binding_error(
+                        &mut env,
+                        &__error_sink,
+                        &__SINK_MID,
+                        __SINK_FQN,
+                        __SINK_DESCR,
+                        &__e.to_string(),
+                    );
+                    return jni::objects::JObject::null().into();
+                }
+            };
+            __obj2 = jni::sys::jvalue {
+                j: __enc___obj2,
+            };
+            __obj1 = jni::sys::jvalue { i: 1 };
+            __obj3 = jni::sys::jvalue { j: 0i64 };
+            __obj4 = jni::sys::jvalue { j: 0i64 };
+            __obj5 = jni::objects::JObject::null();
+            __obj6 = jni::sys::jvalue { i: 0i32 };
+            __obj7 = jni::sys::jvalue { j: 0i64 };
+        }
+        perftest_flat::Reading::Range { low: __sv0, high: __sv1 } => {
+            let __enc___obj3 = match __jni_out_convert_i64_to_wire_15d458bf28dc9c80(
+                &mut env,
+                __sv0.clone(),
+            ) {
+                ::core::result::Result::Ok(__w) => __w,
+                ::core::result::Result::Err(__e) => {
+                    signal_binding_error(
+                        &mut env,
+                        &__error_sink,
+                        &__SINK_MID,
+                        __SINK_FQN,
+                        __SINK_DESCR,
+                        &__e.to_string(),
+                    );
+                    return jni::objects::JObject::null().into();
+                }
+            };
+            __obj3 = jni::sys::jvalue {
+                j: __enc___obj3,
+            };
+            let __enc___obj4 = match __jni_out_convert_i64_to_wire_15d458bf28dc9c80(
+                &mut env,
+                __sv1.clone(),
+            ) {
+                ::core::result::Result::Ok(__w) => __w,
+                ::core::result::Result::Err(__e) => {
+                    signal_binding_error(
+                        &mut env,
+                        &__error_sink,
+                        &__SINK_MID,
+                        __SINK_FQN,
+                        __SINK_DESCR,
+                        &__e.to_string(),
+                    );
+                    return jni::objects::JObject::null().into();
+                }
+            };
+            __obj4 = jni::sys::jvalue {
+                j: __enc___obj4,
+            };
+            __obj1 = jni::sys::jvalue { i: 2 };
+            __obj2 = jni::sys::jvalue { j: 0i64 };
+            __obj5 = jni::objects::JObject::null();
+            __obj6 = jni::sys::jvalue { i: 0i32 };
+            __obj7 = jni::sys::jvalue { j: 0i64 };
+        }
+        perftest_flat::Reading::Labeled(__sv0, __sv1) => {
+            let __enc___obj5 = match __jni_out_convert_jni_text_codec_owned_to_wire_1b6cdff0ec9adbcb(
+                &mut env,
+                __sv0.clone(),
+            ) {
+                ::core::result::Result::Ok(__w) => __w,
+                ::core::result::Result::Err(__e) => {
+                    signal_binding_error(
+                        &mut env,
+                        &__error_sink,
+                        &__SINK_MID,
+                        __SINK_FQN,
+                        __SINK_DESCR,
+                        &__e.to_string(),
+                    );
+                    return jni::objects::JObject::null().into();
+                }
+            };
+            __obj5 = __enc___obj5.into();
+            let __enc___obj6 = match __jni_out_convert_Priority_to_wire_55b65fa623d4787e(
+                &mut env,
+                __sv1.clone(),
+            ) {
+                ::core::result::Result::Ok(__w) => __w,
+                ::core::result::Result::Err(__e) => {
+                    signal_binding_error(
+                        &mut env,
+                        &__error_sink,
+                        &__SINK_MID,
+                        __SINK_FQN,
+                        __SINK_DESCR,
+                        &__e.to_string(),
+                    );
+                    return jni::objects::JObject::null().into();
+                }
+            };
+            __obj6 = jni::sys::jvalue {
+                i: __enc___obj6,
+            };
+            __obj1 = jni::sys::jvalue { i: 3 };
+            __obj2 = jni::sys::jvalue { j: 0i64 };
+            __obj3 = jni::sys::jvalue { j: 0i64 };
+            __obj4 = jni::sys::jvalue { j: 0i64 };
+            __obj7 = jni::sys::jvalue { j: 0i64 };
+        }
+        perftest_flat::Reading::Companion(__sv0) => {
+            let __enc___obj7 = match __jni_out_convert_i64_to_wire_15d458bf28dc9c80(
+                &mut env,
+                __sv0.clone(),
+            ) {
+                ::core::result::Result::Ok(__w) => __w,
+                ::core::result::Result::Err(__e) => {
+                    signal_binding_error(
+                        &mut env,
+                        &__error_sink,
+                        &__SINK_MID,
+                        __SINK_FQN,
+                        __SINK_DESCR,
+                        &__e.to_string(),
+                    );
+                    return jni::objects::JObject::null().into();
+                }
+            };
+            __obj7 = jni::sys::jvalue {
+                j: __enc___obj7,
+            };
+            __obj1 = jni::sys::jvalue { i: 4 };
+            __obj2 = jni::sys::jvalue { j: 0i64 };
+            __obj3 = jni::sys::jvalue { j: 0i64 };
+            __obj4 = jni::sys::jvalue { j: 0i64 };
+            __obj5 = jni::objects::JObject::null();
+            __obj6 = jni::sys::jvalue { i: 0i32 };
+        }
+    }
+    let (
+        __obj8,
+        __obj9,
+        __obj10,
+        __obj11,
+        __obj12,
+        __obj13,
+        __obj14,
+        __obj15,
+    ): (
+        jni::sys::jvalue,
+        jni::sys::jvalue,
+        jni::sys::jvalue,
+        jni::sys::jvalue,
+        jni::sys::jvalue,
+        jni::objects::JObject,
+        jni::sys::jvalue,
+        jni::sys::jvalue,
+    ) = {
+        let __so8: &::core::option::Option<_> = &(&__out).fallback;
+        match __so8 {
+            ::core::option::Option::Some(__sg8) => {
+                let __obj8: jni::sys::jvalue = jni::sys::jvalue { z: 1u8 };
+                let __obj9: jni::sys::jvalue;
+                let __obj10: jni::sys::jvalue;
+                let __obj11: jni::sys::jvalue;
+                let __obj12: jni::sys::jvalue;
+                let __obj13: jni::objects::JObject;
+                let __obj14: jni::sys::jvalue;
+                let __obj15: jni::sys::jvalue;
+                match __sg8 {
+                    perftest_flat::Reading::Missing => {
+                        __obj9 = jni::sys::jvalue { i: 0 };
+                        __obj10 = jni::sys::jvalue { j: 0i64 };
+                        __obj11 = jni::sys::jvalue { j: 0i64 };
+                        __obj12 = jni::sys::jvalue { j: 0i64 };
+                        __obj13 = jni::objects::JObject::null();
+                        __obj14 = jni::sys::jvalue { i: 0i32 };
+                        __obj15 = jni::sys::jvalue { j: 0i64 };
+                    }
+                    perftest_flat::Reading::Exact(__sv0) => {
+                        let __enc___obj10 = match __jni_out_convert_i64_to_wire_15d458bf28dc9c80(
+                            &mut env,
+                            __sv0.clone(),
+                        ) {
+                            ::core::result::Result::Ok(__w) => __w,
+                            ::core::result::Result::Err(__e) => {
+                                signal_binding_error(
+                                    &mut env,
+                                    &__error_sink,
+                                    &__SINK_MID,
+                                    __SINK_FQN,
+                                    __SINK_DESCR,
+                                    &__e.to_string(),
+                                );
+                                return jni::objects::JObject::null().into();
+                            }
+                        };
+                        __obj10 = jni::sys::jvalue {
+                            j: __enc___obj10,
+                        };
+                        __obj9 = jni::sys::jvalue { i: 1 };
+                        __obj11 = jni::sys::jvalue { j: 0i64 };
+                        __obj12 = jni::sys::jvalue { j: 0i64 };
+                        __obj13 = jni::objects::JObject::null();
+                        __obj14 = jni::sys::jvalue { i: 0i32 };
+                        __obj15 = jni::sys::jvalue { j: 0i64 };
+                    }
+                    perftest_flat::Reading::Range { low: __sv0, high: __sv1 } => {
+                        let __enc___obj11 = match __jni_out_convert_i64_to_wire_15d458bf28dc9c80(
+                            &mut env,
+                            __sv0.clone(),
+                        ) {
+                            ::core::result::Result::Ok(__w) => __w,
+                            ::core::result::Result::Err(__e) => {
+                                signal_binding_error(
+                                    &mut env,
+                                    &__error_sink,
+                                    &__SINK_MID,
+                                    __SINK_FQN,
+                                    __SINK_DESCR,
+                                    &__e.to_string(),
+                                );
+                                return jni::objects::JObject::null().into();
+                            }
+                        };
+                        __obj11 = jni::sys::jvalue {
+                            j: __enc___obj11,
+                        };
+                        let __enc___obj12 = match __jni_out_convert_i64_to_wire_15d458bf28dc9c80(
+                            &mut env,
+                            __sv1.clone(),
+                        ) {
+                            ::core::result::Result::Ok(__w) => __w,
+                            ::core::result::Result::Err(__e) => {
+                                signal_binding_error(
+                                    &mut env,
+                                    &__error_sink,
+                                    &__SINK_MID,
+                                    __SINK_FQN,
+                                    __SINK_DESCR,
+                                    &__e.to_string(),
+                                );
+                                return jni::objects::JObject::null().into();
+                            }
+                        };
+                        __obj12 = jni::sys::jvalue {
+                            j: __enc___obj12,
+                        };
+                        __obj9 = jni::sys::jvalue { i: 2 };
+                        __obj10 = jni::sys::jvalue { j: 0i64 };
+                        __obj13 = jni::objects::JObject::null();
+                        __obj14 = jni::sys::jvalue { i: 0i32 };
+                        __obj15 = jni::sys::jvalue { j: 0i64 };
+                    }
+                    perftest_flat::Reading::Labeled(__sv0, __sv1) => {
+                        let __enc___obj13 = match __jni_out_convert_jni_text_codec_owned_to_wire_1b6cdff0ec9adbcb(
+                            &mut env,
+                            __sv0.clone(),
+                        ) {
+                            ::core::result::Result::Ok(__w) => __w,
+                            ::core::result::Result::Err(__e) => {
+                                signal_binding_error(
+                                    &mut env,
+                                    &__error_sink,
+                                    &__SINK_MID,
+                                    __SINK_FQN,
+                                    __SINK_DESCR,
+                                    &__e.to_string(),
+                                );
+                                return jni::objects::JObject::null().into();
+                            }
+                        };
+                        __obj13 = __enc___obj13.into();
+                        let __enc___obj14 = match __jni_out_convert_Priority_to_wire_55b65fa623d4787e(
+                            &mut env,
+                            __sv1.clone(),
+                        ) {
+                            ::core::result::Result::Ok(__w) => __w,
+                            ::core::result::Result::Err(__e) => {
+                                signal_binding_error(
+                                    &mut env,
+                                    &__error_sink,
+                                    &__SINK_MID,
+                                    __SINK_FQN,
+                                    __SINK_DESCR,
+                                    &__e.to_string(),
+                                );
+                                return jni::objects::JObject::null().into();
+                            }
+                        };
+                        __obj14 = jni::sys::jvalue {
+                            i: __enc___obj14,
+                        };
+                        __obj9 = jni::sys::jvalue { i: 3 };
+                        __obj10 = jni::sys::jvalue { j: 0i64 };
+                        __obj11 = jni::sys::jvalue { j: 0i64 };
+                        __obj12 = jni::sys::jvalue { j: 0i64 };
+                        __obj15 = jni::sys::jvalue { j: 0i64 };
+                    }
+                    perftest_flat::Reading::Companion(__sv0) => {
+                        let __enc___obj15 = match __jni_out_convert_i64_to_wire_15d458bf28dc9c80(
+                            &mut env,
+                            __sv0.clone(),
+                        ) {
+                            ::core::result::Result::Ok(__w) => __w,
+                            ::core::result::Result::Err(__e) => {
+                                signal_binding_error(
+                                    &mut env,
+                                    &__error_sink,
+                                    &__SINK_MID,
+                                    __SINK_FQN,
+                                    __SINK_DESCR,
+                                    &__e.to_string(),
+                                );
+                                return jni::objects::JObject::null().into();
+                            }
+                        };
+                        __obj15 = jni::sys::jvalue {
+                            j: __enc___obj15,
+                        };
+                        __obj9 = jni::sys::jvalue { i: 4 };
+                        __obj10 = jni::sys::jvalue { j: 0i64 };
+                        __obj11 = jni::sys::jvalue { j: 0i64 };
+                        __obj12 = jni::sys::jvalue { j: 0i64 };
+                        __obj13 = jni::objects::JObject::null();
+                        __obj14 = jni::sys::jvalue { i: 0i32 };
+                    }
+                }
+                (__obj8, __obj9, __obj10, __obj11, __obj12, __obj13, __obj14, __obj15)
+            }
+            ::core::option::Option::None => {
+                (
+                    jni::sys::jvalue { z: 0u8 },
+                    jni::sys::jvalue { i: 0i32 },
+                    jni::sys::jvalue { j: 0i64 },
+                    jni::sys::jvalue { j: 0i64 },
+                    jni::sys::jvalue { j: 0i64 },
+                    jni::objects::JObject::null(),
+                    jni::sys::jvalue { i: 0i32 },
+                    jni::sys::jvalue { j: 0i64 },
+                )
+            }
+        }
+    };
+    let __obj0: jni::sys::jvalue = {
+        let __enc0 = match __jni_out_convert_i64_to_wire_15d458bf28dc9c80(
+            &mut env,
+            (&__out.id).clone(),
+        ) {
+            ::core::result::Result::Ok(__w) => __w,
+            ::core::result::Result::Err(__e) => {
+                signal_binding_error(
+                    &mut env,
+                    &__error_sink,
+                    &__SINK_MID,
+                    __SINK_FQN,
+                    __SINK_DESCR,
+                    &__e.to_string(),
+                );
+                return jni::objects::JObject::null().into();
+            }
+        };
+        jni::sys::jvalue { j: __enc0 }
+    };
+    let __obj16: jni::objects::JObject = {
+        let __enc16 = match __jni_out_convert_jni_text_codec_owned_to_wire_1b6cdff0ec9adbcb(
+            &mut env,
+            (&__out.note).clone(),
+        ) {
+            ::core::result::Result::Ok(__w) => __w,
+            ::core::result::Result::Err(__e) => {
+                signal_binding_error(
+                    &mut env,
+                    &__error_sink,
+                    &__SINK_MID,
+                    __SINK_FQN,
+                    __SINK_DESCR,
+                    &__e.to_string(),
+                );
+                return jni::objects::JObject::null().into();
+            }
+        };
+        __enc16.into()
+    };
+    match __CB_MID
+        .call_object(
+            &mut env,
+            __CB_FQN,
+            "run",
+            __CB_DESCR,
+            &__builder,
+            &[
+                __obj0,
+                __obj1,
+                __obj2,
+                __obj3,
+                __obj4,
+                jni::sys::jvalue {
+                    l: __obj5.as_raw(),
+                },
+                __obj6,
+                __obj7,
+                __obj8,
+                __obj9,
+                __obj10,
+                __obj11,
+                __obj12,
+                jni::sys::jvalue {
+                    l: __obj13.as_raw(),
+                },
+                __obj14,
+                __obj15,
+                jni::sys::jvalue {
+                    l: __obj16.as_raw(),
+                },
+            ],
+        )
+    {
+        ::core::result::Result::Ok(__o) => __o,
         ::core::result::Result::Err(__e) => {
+            let _ = env.exception_describe();
+            let __e2 = <__JniErr as ::core::convert::From<
+                String,
+            >>::from(__e.to_string());
             signal_binding_error(
                 &mut env,
                 &__error_sink,
                 &__SINK_MID,
                 __SINK_FQN,
                 __SINK_DESCR,
-                &__e.to_string(),
+                &__e2.to_string(),
             );
             jni::objects::JObject::null().into()
         }

--- a/examples/perftest-flat/src/ext.rs
+++ b/examples/perftest-flat/src/ext.rs
@@ -645,6 +645,61 @@ pub fn envelope_each(n: i64, sink: impl Fn(Envelope) + Send + Sync + 'static) {
     }
 }
 
+/// The value an optional nested class gates when that class **selects of its
+/// own** — a presence flag and a tag, one arm inside another.
+///
+/// `span` is a second presence, `reading` a sum tag. Both sit inside the group
+/// `Frame::window`'s own flag gates, which is the shape a flat group number
+/// could not state: each of these is a member of the outer group AND a
+/// selector of its own (#602).
+#[prebindgen]
+pub struct Window {
+    pub label: String,
+    pub span: Option<Stamp>,
+    pub reading: Reading,
+}
+
+/// The gate over [`Window`]: one selector owning two.
+#[prebindgen]
+pub struct Frame {
+    pub id: i64,
+    pub window: Option<Window>,
+}
+
+/// Build a [`Frame`]. `window` absent, `window` present with `span` absent, and
+/// both present are the three states of the outer gate; `which` picks the
+/// alternative of the tag nested beside it.
+#[prebindgen]
+pub fn frame_new(id: i64, window: bool, span: bool, which: i64) -> Frame {
+    Frame {
+        id,
+        window: window.then(|| Window {
+            label: format!("w{id}"),
+            span: span.then(|| Stamp {
+                secs: id,
+                nanos: id * 2,
+            }),
+            reading: match which {
+                0 => Reading::Missing,
+                1 => Reading::Exact(42),
+                2 => Reading::Range { low: 1, high: 9 },
+                3 => Reading::Labeled("warm".to_string(), Priority::High),
+                _ => Reading::Companion(5),
+            },
+        }),
+    }
+}
+
+/// The same value handed to a callback — the route that decomposes it into
+/// leaves and reassembles them through the foreign builder, which is where a
+/// nested gate has to hold.
+#[prebindgen]
+pub fn frame_each(n: i64, sink: impl Fn(Frame) + Send + Sync + 'static) {
+    for i in 0..n {
+        sink(frame_new(i, i % 3 != 0, i % 2 == 1, i));
+    }
+}
+
 /// Build a [`Stamp`] (data-class **return**).
 #[prebindgen]
 pub fn stamp_new(secs: i64, nanos: i64) -> Stamp {

--- a/prebindgen-jni/src/jni/compile.rs
+++ b/prebindgen-jni/src/jni/compile.rs
@@ -4326,11 +4326,25 @@ impl Declarations {
     /// that composes after it.
     ///
     /// `None` is this adapter declining, and it declines for the **whole**
-    /// value rather than per field. A handle, an `enum_class`, a sum, or a
-    /// `data_class` behind an `Option` or a `Vec` is delivered with a transform
-    /// the decoupled form does not carry, and one such field sends the whole
-    /// object down the whole-value `fromParts` path — so a recipe that decomposed
-    /// the rest of it would describe a shape nothing emits.
+    /// value rather than per field: one field it cannot state sends the whole
+    /// object down the whole-value `fromParts` path, because a recipe that
+    /// decomposed the rest of it would describe a shape nothing emits.
+    ///
+    /// What is left to decline is **structural**, not a missing transform. A
+    /// handle, an `enum_class`, a sum, an optional nested class and a selector
+    /// inside a gated group are all ordinary leaves here (#602): a fixed number
+    /// of values, laid side by side, each carrying its own conversion. The
+    /// declines are the shapes that have no such number:
+    ///
+    /// * a field the model does not hold as a named `data_class` field —
+    ///   a positional field, or a type that is not a path;
+    /// * a nested `data_class` **repeated** under a `Vec`, whose leaves would
+    ///   be as many as the value happens to hold. That is a sequence rather
+    ///   than a decomposition — and note that only a `Vec` DIRECTLY under a
+    ///   declared `data_class` reaches that arm: `Vec<Child>` keys as a
+    ///   sequence rather than a `DataStruct`, so it stays one leaf whose own
+    ///   converter is the element folder (#217);
+    /// * nesting deeper than 16, which a cyclic `data_class` would not end.
     pub(crate) fn struct_out_wires(
         &self,
         registry: &impl Conversions,

--- a/prebindgen-jni/src/jni/compile.rs
+++ b/prebindgen-jni/src/jni/compile.rs
@@ -492,15 +492,10 @@ pub(crate) struct OutWire {
     /// the tag carries is which alternative is live, and naming the sum is how
     /// an emitter finds the enum to match over.
     pub(crate) out_ty: TypeRef,
-    /// Which alternative produces this value, or `None` for one every call
-    /// produces — including the tag, which selects between the groups rather
-    /// than joining one.
-    ///
-    /// Composed and checked but not yet read outside the equivalence fixture:
-    /// grouping is what turns the list into a `match`, and the emitter that
-    /// writes that `match` still reads it off the leaf synthesis.
-    #[cfg_attr(not(test), allow(dead_code))]
-    pub(crate) group: Option<i32>,
+    /// The arms this value sits inside, outermost first — empty for one every
+    /// call produces, and for a selector, which carries the path it is nested
+    /// in rather than the arms it chooses between.
+    pub(crate) groups: Vec<i32>,
     /// How the Rust side reaches it.
     pub(crate) from: OutFrom,
     /// The steps from the crossed value down to this one.
@@ -608,8 +603,8 @@ impl prebindgen_registry::unfold::DecomposedLeaf for OutWire {
         matches!(self.from, OutFrom::Tag | OutFrom::Present)
     }
 
-    fn group(&self) -> Option<i32> {
-        self.group
+    fn groups(&self) -> &[i32] {
+        &self.groups
     }
 }
 
@@ -631,7 +626,7 @@ impl OutWire {
         Self {
             name: leaf.name.clone(),
             out_ty: leaf.out_ty.clone(),
-            group: leaf.group,
+            groups: leaf.groups.clone(),
             from: match &leaf.source {
                 LeafSource::SumTag => OutFrom::Tag,
                 LeafSource::Presence => OutFrom::Present,
@@ -660,7 +655,7 @@ impl OutWire {
     pub(crate) fn same_delivery(&self, other: &Self) -> bool {
         self.name == other.name
             && self.out_ty.key() == other.out_ty.key()
-            && self.group == other.group
+            && self.groups == other.groups
             && self.from == other.from
             && self.reach == other.reach
             && self.identity == other.identity
@@ -3915,7 +3910,7 @@ impl<R: Conversions> JCompile<'_, R> {
                     // is built from.
                     name: crate::jni::struct_plan::sum_field_prop_name(&part_member(part)?),
                     out_ty: part.ty.clone(),
-                    group: None,
+                    groups: Vec::new(),
                     from: OutFrom::Payload {
                         variant: None,
                         member: part_member(part)?,
@@ -4036,7 +4031,7 @@ impl<R: Conversions> JCompile<'_, R> {
             wires.push(OutWire {
                 name,
                 out_ty: part.ty.clone(),
-                group: None,
+                groups: Vec::new(),
                 // The chain starts at the accessor's result, which the emitter
                 // binds once. The call itself is the site's to make, so what a
                 // wire states is the field read off it.
@@ -4394,28 +4389,58 @@ impl Declarations {
             // look through, `Vec` to decline — never a last path segment.
             let probe = field.ty.optional_inner().unwrap_or(&field.ty);
             match self.type_kind(registry, &probe.key()) {
-                crate::jni::classify::TypeKind::Handle | crate::jni::classify::TypeKind::Enum => {
-                    return None
-                }
+                // A handle or an enum_class field is an ordinary leaf: its own
+                // output conversion carries it — a `jlong` for the handle the
+                // receiver adopts, a `jint` discriminant for the enum — and
+                // the whole-object encode has always emitted exactly that.
+                crate::jni::classify::TypeKind::Handle | crate::jni::classify::TypeKind::Enum => {}
                 // A `sealed_class` field contributes what a sealed_class
                 // crossing does — a tag naming the live alternative, then one
                 // group of leaves per alternative — reached through this
                 // field. Only one group is live per value, which is what the
                 // registry's segment gate emits as a single `match`.
                 crate::jni::classify::TypeKind::Sum => {
-                    if field.ty.optional_inner().is_some() {
-                        return None;
-                    }
                     let sum_ident = match probe.unwrapped().kind() {
                         TypeKind::Named { id, .. } => id.ident()?,
                         _ => return None,
                     };
-                    let reach: Vec<prebindgen_registry::unfold::PathStep> =
+                    let optional = field.ty.optional_inner().is_some();
+                    let mut reach: Vec<prebindgen_registry::unfold::PathStep> =
                         field_path.iter().map(field_step).collect();
+                    if optional {
+                        // An OPTIONAL sum is two selectors, one owning the
+                        // other: presence says whether there is an alternative
+                        // at all, and the tag names which. The flag's reach
+                        // ends AT the optional step it tests; the sum's leaves
+                        // reach through it, and their arm paths gain the one
+                        // group presence gates.
+                        let mut flag_reach = reach.clone();
+                        flag_reach[path.len()] =
+                            prebindgen_registry::unfold::PathStep::field(fname.clone(), true);
+                        wires.push(OutWire {
+                            name: format!("{name}__{}", crate::jni::emit::PRESENT_LEAF),
+                            out_ty: field.ty.clone(),
+                            groups: Vec::new(),
+                            from: OutFrom::Present,
+                            reach: flag_reach,
+                            nullable: false,
+                            identity: false,
+                            abi: None,
+                        });
+                        reach[path.len()] =
+                            prebindgen_registry::unfold::PathStep::field(fname.clone(), true);
+                    }
                     for wire in self.sum_out_wires(registry, &sum_ident, probe)? {
+                        let groups = match optional {
+                            true => std::iter::once(crate::jni::emit::PRESENT_ARM)
+                                .chain(wire.groups.iter().copied())
+                                .collect(),
+                            false => wire.groups,
+                        };
                         wires.push(OutWire {
                             name: format!("{name}__{}", wire.name),
                             reach: reach.clone(),
+                            groups,
                             ..wire
                         });
                     }
@@ -4455,7 +4480,7 @@ impl Declarations {
                         wires.push(OutWire {
                             name: format!("{name}__{}", crate::jni::emit::PRESENT_LEAF),
                             out_ty: field.ty.clone(),
-                            group: None,
+                            groups: Vec::new(),
                             from: OutFrom::Present,
                             reach,
                             nullable: false,
@@ -4465,21 +4490,6 @@ impl Declarations {
                     }
                     let inlined =
                         self.struct_out_wires_at(registry, &child, &field_path, &name, depth + 1)?;
-                    // One selector may not own another yet: `group` is a flat
-                    // `Option<i32>`, so a selector inside this group would have
-                    // to be both "the group's member" and "a selector of its
-                    // own", and `segments` would return overlapping ranges.
-                    // Refused HERE, before the leaves are registered as a
-                    // `ValueDecon`, so the shape stays on the whole-object path
-                    // rather than panicking during rendering. Nested segments
-                    // are the endpoint; see #602.
-                    if optional
-                        && inlined
-                            .iter()
-                            .any(prebindgen_registry::unfold::DecomposedLeaf::selects)
-                    {
-                        return None;
-                    }
                     wires.extend(inlined.into_iter().map(|wire| {
                         let mut reach = wire.reach;
                         if optional {
@@ -4495,8 +4505,15 @@ impl Declarations {
                         OutWire {
                             reach,
                             // Under a presence flag the child's leaves are the
-                            // one group that flag gates.
-                            group: optional.then_some(0).or(wire.group),
+                            // one group that flag gates — including a selector
+                            // of the child's own, which keeps its own arms one
+                            // level further in.
+                            groups: match optional {
+                                true => std::iter::once(crate::jni::emit::PRESENT_ARM)
+                                    .chain(wire.groups.iter().copied())
+                                    .collect(),
+                                false => wire.groups.clone(),
+                            },
                             ..wire
                         }
                     }));
@@ -4512,7 +4529,7 @@ impl Declarations {
             wires.push(OutWire {
                 name,
                 out_ty: field.ty.clone(),
-                group: None,
+                groups: Vec::new(),
                 from: OutFrom::Place,
                 reach: field_path.iter().map(field_step).collect(),
                 nullable: false,
@@ -4552,7 +4569,7 @@ impl Declarations {
         let mut wires = vec![OutWire {
             name: crate::jni::emit::SUM_TAG_LEAF.to_string(),
             out_ty: sum_ty.clone(),
-            group: None,
+            groups: Vec::new(),
             from: OutFrom::Tag,
             nullable: false,
             identity: false,
@@ -4569,7 +4586,7 @@ impl Declarations {
                         &crate::jni::struct_plan::sum_field_prop_name(&member),
                     ),
                     out_ty: field.ty.clone(),
-                    group: Some(crate::jni::struct_plan::sum_tag(alt)),
+                    groups: vec![crate::jni::struct_plan::sum_tag(alt)],
                     from: OutFrom::Payload {
                         variant: Some(alt.name.clone()),
                         member,

--- a/prebindgen-jni/src/jni/emit/delivery.rs
+++ b/prebindgen-jni/src/jni/emit/delivery.rs
@@ -772,26 +772,16 @@ pub(crate) fn encode_plan_leaves(
                 // the two fill their group differently: one alternative's
                 // payload, or the child's own leaves off the value the gate
                 // unwrapped.
-                let (stmts, args) = if wires[seg.start].is_tag() {
-                    encode_sum_group(
-                        context,
-                        &wires[seg.clone()],
-                        &obj_idents[seg.clone()],
-                        matched,
-                        fail,
-                        emit,
-                    )
-                } else {
-                    crate::jni::emit::encode_presence_group(
-                        context,
-                        &wires[seg.clone()],
-                        &obj_idents[seg.clone()],
-                        matched,
-                        &qualify,
-                        fail,
-                        emit,
-                    )
-                };
+                let (stmts, args) = crate::jni::emit::encode_segment_group(
+                    context,
+                    &wires[seg.clone()],
+                    &obj_idents[seg.clone()],
+                    matched,
+                    seg.start,
+                    &qualify,
+                    fail,
+                    emit,
+                );
                 *group_args.borrow_mut() = args;
                 stmts
             },
@@ -1176,7 +1166,7 @@ mod tests {
             identity,
             nullable: false,
             source,
-            group: None,
+            groups: Vec::new(),
         }
     }
 

--- a/prebindgen-jni/src/jni/emit/struct_out.rs
+++ b/prebindgen-jni/src/jni/emit/struct_out.rs
@@ -85,10 +85,13 @@ pub(crate) fn primitive_default_for_descriptor(sig: &str) -> TokenStream {
 /// `fromParts` parameters and the recipe identically, and two walks agreeing was a
 /// property nothing checked.
 ///
-/// `None` — the type keeps the whole-value `fromParts` path — when a field needs
-/// a transform this fixed builder cannot forward verbatim. See
-/// [`Declarations::struct_out_wires`] for which fields those are and why one of
-/// them declines the whole value.
+/// `None` — the type keeps the whole-value `fromParts` path — when a field is
+/// one the decomposition cannot state at all. Those are structural: a repeated
+/// nested class, a field the model does not hold as a named one, nesting past
+/// 16. Not a missing transform — a handle, an `enum_class`, a sum, an optional
+/// nested class and a selector inside a gated group all state fine, each
+/// carrying its own conversion (#602). See [`Declarations::struct_out_wires`]
+/// for the list and why one such field declines the whole value.
 pub(crate) fn synth_value_struct_leaves(
     ext: &Declarations,
     registry: &impl Conversions,
@@ -127,21 +130,18 @@ pub(crate) fn synth_value_struct_leaves(
 /// matched `__cN` under an Option); `prefix` namespaces the generated idents.
 /// Walk the struct's fields and encode each leaf into a `fromParts` argument.
 ///
-/// This is a source-value walk that the registry does not perform, and the
-/// reason is coverage rather than ownership. The registry-facing decomposition
-/// of a struct (`Declarations::struct_out_wires_at`) refuses a nested
-/// `data_class` behind an `Option` or a `Vec`; this encode supports both, an
-/// optional nested class as a `present` flag plus a defaulted group and a sum
-/// field as a tag plus one group per variant.
+/// This is a source-value walk that the registry does not perform, and what
+/// keeps it here is now only that nothing has moved it. The coverage reason is
+/// gone: #616, #617 and #618 taught the registry-facing decomposition
+/// (`Declarations::struct_out_wires_at`) every gated shape this encode
+/// supports — a sum field as a tag over one group per variant, an optional
+/// nested class as a presence flag over a defaulted group, and one selector
+/// inside another — so the two now cover the same shapes rather than differing.
 ///
-/// Rendering this through the registry's decomposition walk would therefore
-/// mean teaching that decomposition the gated shapes — which would also change
-/// what a foreign builder can be delivered, a feature rather than a
-/// refactoring. #596 step 5 records that decision; #602 proposes the feature.
-///
-/// Where both derivations do apply, they must name the same leaves in the same
-/// order: `JniGen::assert_leaf_derivations_agree` checks that on every binding
-/// a test writes, since that agreement is what #602 would rest on.
+/// Which makes this the duplication #613 step 3 exists to remove: two walks
+/// deriving one leaf list. `JniGen::assert_leaf_derivations_agree` is what says
+/// they still agree, on every binding a test writes, and #619 is where this
+/// walk goes and that check with it.
 /// The leaves this encode emits, flattened — the `fromParts` argument list,
 /// in order, each with how deeply nested the field it came from is.
 ///

--- a/prebindgen-jni/src/jni/emit/struct_out.rs
+++ b/prebindgen-jni/src/jni/emit/struct_out.rs
@@ -114,7 +114,7 @@ pub(crate) fn synth_value_struct_leaves(
                     crate::jni::compile::OutFrom::Present => LeafSource::Presence,
                     _ => LeafSource::Reach,
                 },
-                group: w.group,
+                groups: w.groups,
             })
             .collect(),
     )
@@ -176,7 +176,7 @@ pub(crate) fn encode_leaves(
 /// too (#616 review).
 /// The one "arm" an optional value has: present. Absence contributes no
 /// bindings of its own, only the defaults its group carries.
-const PRESENT_ARM: usize = 0;
+pub(crate) const PRESENT_ARM: i32 = 0;
 
 fn arm_local_base(tag: usize, base: &str) -> String {
     format!("arm{tag}_{base}")
@@ -355,7 +355,7 @@ fn encode_field(
                     let (child_pre, child_slots) = encode_plan(
                         child,
                         &child_access,
-                        &arm_local_base(PRESENT_ARM, base),
+                        &arm_local_base(PRESENT_ARM as usize, base),
                         depth + 1,
                         env_expr,
                         emit,
@@ -363,7 +363,7 @@ fn encode_field(
                     let flag_id = format_ident!("__{}_present", base);
                     let outer_ids: Vec<proc_macro2::Ident> = child_slots
                         .iter()
-                        .map(|slot| outer_of(PRESENT_ARM, &slot.ident))
+                        .map(|slot| outer_of(PRESENT_ARM as usize, &slot.ident))
                         .collect();
                     let outer_tys: Vec<TokenStream> =
                         child_slots.iter().map(|sl| sl.wire_ty.clone()).collect();
@@ -571,8 +571,14 @@ fn encode_field(
                             }
                         }
                     });
+                    // One level inside the struct, like the tag it gates and
+                    // like an optional nested class's own flag: it is reached
+                    // THROUGH this field. The decomposition says so by joining
+                    // the names with `__`, and this said `depth` — a
+                    // disagreement no shape reached while `Option<sum>` was
+                    // refused a decomposition to disagree with.
                     slots.push(EncSlot {
-                        depth,
+                        depth: depth + 1,
                         ident: flag_id,
                         wire_ty: quote!(jni::sys::jboolean),
                         descriptor: "Z".to_string(),

--- a/prebindgen-jni/src/jni/emit/sum_out.rs
+++ b/prebindgen-jni/src/jni/emit/sum_out.rs
@@ -4,7 +4,7 @@
 //! A sum is the one decomposition that is not a deterministic product: only
 //! ONE alternative's leaves are live per value. Core models that with a
 //! synthesized [`LeafSource::SumTag`] selector plus per-leaf
-//! [`UnfoldLeaf::group`] membership
+//! [`UnfoldLeaf::groups`] membership
 //! ([`apply_sum_returns`](prebindgen_registry::unfold::apply_sum_returns)); this
 //! module is the JNI adapter's two ends of it — [`synth_sum_leaves`] builds the
 //! leaf list before `resolve`, [`encode_sum_leaves`] emits the single `match`
@@ -32,7 +32,7 @@ pub(crate) const PRESENT_LEAF: &str = "present";
 /// The leaves of one `sealed_class`-declared sum, as the expansion plans want
 /// them: the [`LeafSource::SumTag`] selector followed by one
 /// [`LeafSource::VariantField`] leaf per payload field, in tag order, each
-/// carrying its variant's tag as its [`group`](UnfoldLeaf::group).
+/// carrying its variant's tag as its [`group`](UnfoldLeaf::groups).
 ///
 /// The list is `Declarations::sum_out_wires`', mapped. Runs BEFORE `resolve`,
 /// which is exactly why it shares that composition rather than walking the
@@ -70,7 +70,7 @@ pub(crate) fn synth_sum_leaves(
                 crate::jni::compile::OutFrom::Place => LeafSource::Reach,
                 crate::jni::compile::OutFrom::Present => LeafSource::Presence,
             },
-            group: w.group,
+            groups: w.groups.clone(),
         })
         .collect()
 }
@@ -202,6 +202,9 @@ pub(crate) fn encode_sum_group(
         .position(|l| l.is_tag())
         .expect("a sum plan carries its selector leaf");
     let tag_id = &obj_idents[tag_idx];
+    // How deep this segment sits is its own selector's answer — see
+    // `sum_reconstruct`, which reads the same fact for the Kotlin half.
+    let depth = leaves[tag_idx].groups.len();
     let arms: Vec<TokenStream> = sum
         .alternatives
         .iter()
@@ -210,7 +213,7 @@ pub(crate) fn encode_sum_group(
             let group: Vec<usize> = leaves
                 .iter()
                 .enumerate()
-                .filter(|(_, l)| l.group == Some(tag))
+                .filter(|(_, l)| l.groups.get(depth) == Some(&tag))
                 .map(|(i, _)| i)
                 .collect();
             let binds: Vec<syn::Ident> = group
@@ -346,6 +349,34 @@ fn encode_group_leaf(
     }
 }
 
+/// The encode of ONE segment's group, from the value the walk has unwrapped for
+/// it — the tag twin or the presence twin, chosen by the segment's own
+/// selector.
+///
+/// The two are told apart in one place because a group may contain a segment of
+/// its own: an optional nested class whose fields select, an `Option` of a sum.
+/// [`encode_presence_group`] meets those in its own leaves and asks here again,
+/// which is the same question its caller asked — so the answer is one function
+/// rather than a copy of the dispatch inside the recursion.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn encode_segment_group(
+    context: &crate::jni::emit::delivery::FrozenDelivery,
+    leaves: &[crate::jni::compile::OutWire],
+    obj_idents: &[syn::Ident],
+    matched: TokenStream,
+    index: usize,
+    qualify: &dyn Fn(&syn::Ident) -> syn::Path,
+    fail: &dyn Fn(TokenStream) -> TokenStream,
+    emit: &prebindgen_registry::RustWriter,
+) -> (TokenStream, Vec<TokenStream>) {
+    match leaves[0].is_tag() {
+        true => encode_sum_group(context, leaves, obj_idents, matched, fail, emit),
+        false => encode_presence_group(
+            context, leaves, obj_idents, matched, index, qualify, fail, emit,
+        ),
+    }
+}
+
 /// The encode of a **presence** segment: an optional nested value's flag and
 /// the leaves it gates, from the value the walk has already unwrapped.
 ///
@@ -354,11 +385,13 @@ fn encode_group_leaf(
 /// present arm, so what is here is the flag and the child's own leaves read
 /// off the unwrapped value. The sum twin next to it answers the same shape
 /// with alternatives in place of presence.
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn encode_presence_group(
     context: &crate::jni::emit::delivery::FrozenDelivery,
     leaves: &[crate::jni::compile::OutWire],
     obj_idents: &[syn::Ident],
     matched: TokenStream,
+    index: usize,
     qualify: &dyn Fn(&syn::Ident) -> syn::Path,
     fail: &dyn Fn(TokenStream) -> TokenStream,
     emit: &prebindgen_registry::RustWriter,
@@ -369,12 +402,65 @@ pub(crate) fn encode_presence_group(
     let flag_slot = leaf_slot(context, &leaves[0]);
     let flag_ty = &flag_slot.ty;
     let mut stmts = quote! { let #flag: #flag_ty = jni::sys::jvalue { z: 1u8 }; };
-    let mut args: Vec<TokenStream> = vec![quote!(#flag)];
+    // Filled by leaf position rather than appended: a nested segment fills a
+    // run of them at once, so the order they are produced in is not the order
+    // they are read in.
+    let mut args: Vec<TokenStream> = vec![TokenStream::new(); leaves.len()];
+    args[0] = quote!(#flag);
 
     // The prefix the presence flag reaches is already consumed: the walk bound
     // what it found there, so each gated leaf reaches on from that binding.
     let consumed = leaves[0].reach.len();
+    // A gated leaf may itself be a selector — the value this flag speaks for
+    // has a sum-typed field, or is an `Option<sum>` — and a segment's leaves
+    // are not independent, so those are emitted as their own gated `match`
+    // rather than one at a time. One level down from this flag's own, which is
+    // what [`segments_at`] reads.
+    let inner = prebindgen_registry::unfold::segments_at(leaves, leaves[0].groups.len() + 1);
+    let tail_of =
+        |leaf: &crate::jni::compile::OutWire| -> Vec<prebindgen_registry::unfold::PathStep> {
+            leaf.reach.iter().skip(consumed).cloned().collect()
+        };
+    for seg in &inner {
+        let seg_args = std::cell::RefCell::new(Vec::new());
+        let place = prebindgen_registry::unfold::LeafPlace {
+            base: matched.clone(),
+            base_is_ref: true,
+            path: tail_of(&leaves[seg.start]),
+            consuming: false,
+            conditional: None,
+        };
+        let seg_stmts = prebindgen_registry::unfold::segment(
+            context,
+            qualify,
+            &place,
+            index + seg.start,
+            &leaves[seg.clone()],
+            &obj_idents[seg.clone()],
+            &|m| {
+                let (stmts, args) = encode_segment_group(
+                    context,
+                    &leaves[seg.clone()],
+                    &obj_idents[seg.clone()],
+                    m,
+                    index + seg.start,
+                    qualify,
+                    fail,
+                    emit,
+                );
+                *seg_args.borrow_mut() = args;
+                stmts
+            },
+        );
+        stmts.extend(seg_stmts);
+        for (k, e) in seg_args.into_inner().into_iter().enumerate() {
+            args[seg.start + k] = e;
+        }
+    }
     for (index, leaf) in leaves.iter().enumerate().skip(1) {
+        if inner.iter().any(|s| s.contains(&index)) {
+            continue;
+        }
         let slot = &obj_idents[index];
         let tail: Vec<prebindgen_registry::unfold::PathStep> =
             leaf.reach.iter().skip(consumed).cloned().collect();
@@ -395,7 +481,7 @@ pub(crate) fn encode_presence_group(
             )
         };
         stmts.extend(context.encode(leaf, index, slot, &reach, fail, emit));
-        args.push(context.argument(leaf, slot));
+        args[index] = context.argument(leaf, slot);
     }
     (stmts, args)
 }

--- a/prebindgen-jni/src/jni/iface.rs
+++ b/prebindgen-jni/src/jni/iface.rs
@@ -935,7 +935,7 @@ fn plan_leaf_param(
     // here and re-asserted (`!!`) inside its own live arm — the same rule
     // `nullable_group_part` applies to the parent-inlined `fromParts`. Primitive
     // slots take their `0`/`false` default and stay unboxed.
-    let inert_nullable = leaf.group.is_some() && !leaf_ty_is_prim(ext, &leaf.out_ty);
+    let inert_nullable = !leaf.groups.is_empty() && !leaf_ty_is_prim(ext, &leaf.out_ty);
     leaf_iface_param(
         ext,
         name,
@@ -1494,7 +1494,7 @@ pub(crate) fn callback_iface_spec(
                     // `encode_plan_leaves` walks, asked the same way.
                     let seg = if leaf.is_tag() {
                         (k + 1..wires.len())
-                            .take_while(|&j| wires[j].group.is_some())
+                            .take_while(|&j| !wires[j].groups.is_empty())
                             .last()
                             .map_or(k + 1, |j| j + 1)
                     } else {

--- a/prebindgen-jni/src/jni/kotlin_emit.rs
+++ b/prebindgen-jni/src/jni/kotlin_emit.rs
@@ -1601,6 +1601,11 @@ impl Declarations {
             .sum()
             .unwrap_or_else(|| panic!("sum builder: `{ident}` is not a sealed class"));
         let tag = &names[0];
+        // How deep this segment sits is its own selector's answer: a sum field
+        // of a struct is at the top, an `Option<sum>`'s tag one arm inside the
+        // presence flag that gates it. Its alternatives extend that path by
+        // one, so that is where their tag is read.
+        let depth = leaves[0].groups.len();
 
         let mut arms: Vec<String> = Vec::new();
         for alt in &sum.alternatives {
@@ -1610,7 +1615,7 @@ impl Declarations {
                 .iter()
                 .zip(params)
                 .zip(names)
-                .filter(|((l, _), _)| l.group == Some(group))
+                .filter(|((l, _), _)| l.groups.get(depth) == Some(&group))
                 .map(|((l, p), n)| self.sum_ctor_arg(l, p, n, imports))
                 .collect();
             // Kotlin has no `B()` / `B {}` distinction to keep: a payload-less

--- a/prebindgen-jni/src/jni/mod.rs
+++ b/prebindgen-jni/src/jni/mod.rs
@@ -656,7 +656,7 @@ impl JniGen {
                             crate::jni::struct_plan::sum_field_prop_name(member)
                         ),
                     };
-                    format!("{}: {} <- {from} @{:?}", w.name, w.out_ty.key(), w.group)
+                    format!("{}: {} <- {from} @{:?}", w.name, w.out_ty.key(), w.groups)
                 })
                 .collect(),
         )
@@ -685,7 +685,7 @@ impl JniGen {
                         l.name,
                         l.out_ty.key(),
                         leaf_reach(l),
-                        l.group
+                        l.groups
                     )
                 })
                 .collect(),
@@ -725,7 +725,7 @@ impl JniGen {
                             crate::jni::struct_plan::sum_field_prop_name(member)
                         ),
                     };
-                    format!("{}: {} <- {from} @{:?}", w.name, w.out_ty.key(), w.group)
+                    format!("{}: {} <- {from} @{:?}", w.name, w.out_ty.key(), w.groups)
                 })
                 .collect(),
         )
@@ -779,7 +779,7 @@ impl JniGen {
                         l.name,
                         l.out_ty.key(),
                         leaf_reach(l),
-                        l.group
+                        l.groups
                     )
                 })
                 .collect(),

--- a/prebindgen-jni/src/jni/tests/flatten.rs
+++ b/prebindgen-jni/src/jni/tests/flatten.rs
@@ -2534,8 +2534,8 @@ fn a_sum_field_decomposes_into_its_tag_and_groups() {
         "the selector is a tag, not a value read off a place"
     );
     assert_eq!(
-        wires[2].group,
-        Some(0),
+        wires[2].groups,
+        vec![0],
         "the payload joins the group its tag selects"
     );
     assert!(
@@ -2545,21 +2545,17 @@ fn a_sum_field_decomposes_into_its_tag_and_groups() {
     );
 }
 
-/// One selector may not own another: an optional nested class whose own child
-/// carries a selector stays on the whole-object path.
+/// One selector owns another: an optional nested class whose own child carries
+/// a selector decomposes, with the inner selector one arm further in.
 ///
-/// `group` is a flat `Option<i32>`, so a nested selector would have to be both
-/// a member of the outer group and a selector of its own, and `segments` would
-/// return overlapping ranges — the outer render then reaches the inner
-/// selector as if it were an ordinary payload. Refusing is a decomposition
-/// this adapter declines, not a panic during `write_rust`: the value keeps the
-/// whole-object encode, which handles the shape.
-///
-/// Nested segments are the endpoint (#602). Until then this test is what says
-/// the boundary is deliberate, and `write_rust` is what proves the refusal
-/// happens before anything renders.
+/// A leaf's group is the **path** of arms it sits inside, so a nested selector
+/// is a member of the outer group (the path it carries) and a selector of its
+/// own (the paths its members carry, one longer) without those being two
+/// meanings of one number. `segments` reads one level at a time, so the ranges
+/// it returns for a level never overlap, and the renderer that enters an arm
+/// asks again one level down (#602).
 #[test]
-fn a_selector_inside_a_gated_group_is_refused_rather_than_rendered() {
+fn a_selector_inside_a_gated_group_is_a_segment_of_its_own() {
     let loc = myflat_loc();
     let items: Vec<(syn::Item, prebindgen::SourceLocation)> = vec![
         (
@@ -2618,17 +2614,38 @@ fn a_selector_inside_a_gated_group_is_refused_rather_than_rendered() {
         .collect();
     assert_eq!(names, ["inner__present", "inner__id"]);
 
-    // `Outer` would need a selector inside a gated group, and declines.
+    // `Outer` gates `Mid`'s own selector: two levels, and the arm paths say so.
     let outer: syn::Ident = syn::parse_quote!(Outer);
-    assert!(
-        gen.declarations()
-            .struct_out_wires_of(gen.registry(), &outer)
-            .is_none(),
-        "a selector inside a gated group is refused"
+    let wires = gen
+        .declarations()
+        .struct_out_wires_of(gen.registry(), &outer)
+        .expect("a selector inside a gated group decomposes");
+    let leaves: Vec<(String, Vec<i32>)> = wires
+        .iter()
+        .map(|wire| (wire.name.clone(), wire.groups.clone()))
+        .collect();
+    assert_eq!(
+        leaves,
+        [
+            ("mid__present".to_string(), vec![]),
+            ("mid__inner__present".to_string(), vec![0]),
+            ("mid__inner__id".to_string(), vec![0, 0]),
+        ],
+        "the outer flag is unconditional, the inner one sits in the group it          gates, and the leaf sits inside both"
+    );
+    assert_eq!(
+        prebindgen_registry::unfold::segments(&wires),
+        vec![0..3],
+        "one segment at the top level — the inner selector belongs to it          rather than opening a second, overlapping one"
+    );
+    assert_eq!(
+        prebindgen_registry::unfold::segments_at(&wires, 1),
+        vec![1..3],
+        "and it is a segment of its own, one level down"
     );
 
-    // And the refusal holds through rendering: `Outer` keeps the whole-object
-    // encode rather than reaching a selector where a payload was expected.
+    // And it renders: the inner selector is met as a segment rather than as a
+    // payload where a value was expected.
     let dir = unique_test_dir("jnigen_nested_selector");
     std::fs::create_dir_all(&dir).unwrap();
     gen.write_rust(dir.join("gen.rs")).expect("write_rust");
@@ -2776,8 +2793,8 @@ fn an_optional_nested_class_decomposes_behind_its_presence() {
         "presence is synthesized, not read off a place holding a boolean"
     );
     assert_eq!(
-        wires[1].group,
-        Some(0),
+        wires[1].groups,
+        vec![0],
         "the child's leaves are the one group that flag gates"
     );
 

--- a/prebindgen-jni/src/jni/tests/sealed.rs
+++ b/prebindgen-jni/src/jni/tests/sealed.rs
@@ -1420,10 +1420,11 @@ fn sum_return_group_can_own_a_handle() {
 ///   makes the two spellings agree is that `Lookup` is itself `AutoCloseable`
 ///   — the `when` over the alternatives lives in the sum, so the container
 ///   emits the same one-line cascade either way.
-/// * A sum field takes its parent off the fixed-builder path onto the
-///   whole-value `fromParts` bridge (`synth_value_struct_leaves` declines
-///   `TypeKind::Sum`), so the value costs a JVM object — a slower shape, not a
-///   broken one.
+/// * A sum field keeps its parent on the fixed-builder path: since #616 the
+///   decomposition states it as a tag over one group per alternative, so the
+///   value crosses as leaves and no JVM object is built for it. It used to
+///   decline, which cost the parent an object — a slower shape, not a broken
+///   one — and this test passed either way, since what it pins is the cascade.
 #[test]
 fn a_data_class_field_may_be_a_sum_carrying_a_handle() {
     let loc = myflat_loc();

--- a/prebindgen-jni/src/jni/tests/sealed.rs
+++ b/prebindgen-jni/src/jni/tests/sealed.rs
@@ -2458,12 +2458,12 @@ fn a_sealed_class_states_what_it_hands_out() {
     assert_eq!(
         composed,
         vec![
-            "tag: Reading <- tag @None",
-            "exact_v0: i64 <- Exact.v0 @Some(1)",
-            "range_low: i64 <- Range.low @Some(2)",
-            "range_high: i64 <- Range.high @Some(2)",
-            "tagged_v0: String <- Tagged.v0 @Some(3)",
-            "tagged_v1: Priority <- Tagged.v1 @Some(3)",
+            "tag: Reading <- tag @[]",
+            "exact_v0: i64 <- Exact.v0 @[1]",
+            "range_low: i64 <- Range.low @[2]",
+            "range_high: i64 <- Range.high @[2]",
+            "tagged_v0: String <- Tagged.v0 @[3]",
+            "tagged_v1: Priority <- Tagged.v1 @[3]",
         ],
         "the recipe states the tag, then one group per alternative",
     );
@@ -2560,9 +2560,9 @@ fn a_data_class_states_what_it_hands_out() {
         gen.out_lines_for_test("Wrapped")
             .expect("Wrapped states a deconstructing parts recipe"),
         vec![
-            "id: i64 <- id @None",
-            "inner__count: i64 <- inner.count @None",
-            "inner__label: String <- inner.label @None",
+            "id: i64 <- id @[]",
+            "inner__count: i64 <- inner.count @[]",
+            "inner__label: String <- inner.label @[]",
         ],
         "a nested data class contributes its own values, under its field's name",
     );
@@ -2576,9 +2576,14 @@ fn a_data_class_states_what_it_hands_out() {
             "the recipe and the leaf synthesis disagree on {short}",
         );
     }
-    assert!(
-        gen.out_lines_for_test("Guarded").is_none(),
-        "a handle field sends the whole object down the whole-value path",
+    // A handle field is an ordinary leaf: the handle crosses as the `jlong`
+    // the receiver adopts, which is what the whole-object encode has always
+    // emitted for it. Refusing it here kept such a struct off fixed-builder
+    // delivery for no reason the encode shares (#602).
+    assert_eq!(
+        gen.out_lines_for_test("Guarded")
+            .expect("a handle field decomposes like any other leaf"),
+        vec!["id: i64 <- id @[]", "held: Opaque <- held @[]"],
     );
 }
 
@@ -2632,10 +2637,10 @@ fn a_decomposed_return_is_a_site_asking_for_the_parts_row() {
     let gen = jni.build_with(registry).expect("resolve");
 
     let expected = vec![
-        "tag: Reading <- tag @None",
-        "exact_v0: i64 <- Exact.v0 @Some(1)",
-        "range_low: i64 <- Range.low @Some(2)",
-        "range_high: i64 <- Range.high @Some(2)",
+        "tag: Reading <- tag @[]",
+        "exact_v0: i64 <- Exact.v0 @[1]",
+        "range_low: i64 <- Range.low @[2]",
+        "range_high: i64 <- Range.high @[2]",
     ];
     assert_eq!(
         gen.return_site_lines_for_test("read_one")

--- a/prebindgen-jni/src/jni/tests/sealed.rs
+++ b/prebindgen-jni/src/jni/tests/sealed.rs
@@ -2479,12 +2479,15 @@ fn a_sealed_class_states_what_it_hands_out() {
 /// A `data_class` states a recipe saying what it hands out, and a field that is
 /// itself one contributes its own values under the parent's name and chain.
 ///
-/// The recipe declines for the **whole** value rather than per field, because the
-/// emitter it feeds does: a handle, an `enum_class`, a sum, or a `data_class`
-/// behind an `Option` or a `Vec` is delivered with a transform the decoupled
-/// form does not carry, and one such field sends the whole object down the
-/// whole-value `fromParts` path. So `Wrapped` composes and `Opaque`-bearing
-/// `Guarded` does not, and both agree with the synthesis they will replace.
+/// The recipe declines for the **whole** value rather than per field, because
+/// the emitter it feeds does: one field it cannot state sends the whole object
+/// down the whole-value `fromParts` path. What is left to decline is structural
+/// — a repeated nested class, a field the model does not hold as a named one —
+/// and a handle field is not one of those: it is an ordinary leaf whose own
+/// output conversion carries it as the `jlong` the receiver adopts, which is
+/// what the whole-object encode always emitted for it (#602). So `Wrapped` and
+/// `Opaque`-bearing `Guarded` both compose, and both agree with the synthesis
+/// they will replace.
 #[test]
 fn a_data_class_states_what_it_hands_out() {
     let loc = myflat_loc();
@@ -2566,9 +2569,10 @@ fn a_data_class_states_what_it_hands_out() {
         ],
         "a nested data class contributes its own values, under its field's name",
     );
-    // Compared as options, because declining is one of the two answers: a recipe
-    // that states nothing and a synthesis that returns nothing are the same
-    // claim, and `Guarded` makes it.
+    // Compared as options, because declining is still one of the two answers:
+    // a recipe that states nothing and a synthesis that returns nothing are the
+    // same claim. No type here makes it any more — the remaining declines are
+    // structural — so what this pins is that the two agree either way.
     for short in ["Wrapped", "Inner", "Guarded"] {
         assert_eq!(
             gen.out_lines_for_test(short),

--- a/prebindgen-jni/src/jni/tests/value_form.rs
+++ b/prebindgen-jni/src/jni/tests/value_form.rs
@@ -3619,7 +3619,7 @@ fn a_value_form_states_what_it_hands_out() {
     assert_eq!(
         gen.out_lines_for_test("Vault")
             .expect("Vault states a value-form recipe"),
-        vec!["seq: i64 <- seq @None", "tag: String <- label @None"],
+        vec!["seq: i64 <- seq @[]", "tag: String <- label @[]"],
         "the recipe hands out the value form's fields, named as declared",
     );
     assert_eq!(

--- a/prebindgen-registry/src/unfold.rs
+++ b/prebindgen-registry/src/unfold.rs
@@ -36,8 +36,8 @@ mod error;
 mod walk;
 pub use walk::{
     bind_as_option, bind_hoists, compose_step, conditional_arm, fold_steps, project_leading_fields,
-    reach_leaf, reached_is_ours, segment, segments, DecomposedLeaf, DeliveryBridge, Hoisted,
-    LeafAt, LeafPlace, Reach, Slot,
+    reach_leaf, reached_is_ours, segment, segments, segments_at, DecomposedLeaf, DeliveryBridge,
+    Hoisted, LeafAt, LeafPlace, Reach, Slot,
 };
 
 mod plan;
@@ -540,7 +540,7 @@ pub(crate) fn apply_value_structs(
 ///
 /// Its [`leaves`](Self::leaves) are a [`LeafSource::SumTag`] selector followed
 /// by one **group** per alternative ([`LeafSource::VariantField`] leaves
-/// carrying [`UnfoldLeaf::group`]). Exactly one group is live per value; the
+/// carrying [`UnfoldLeaf::groups`]). Exactly one group is live per value; the
 /// emitter reads the whole list as ONE `match` over the value, filling every
 /// inert slot with its wire default. The foreign side picks the live group by
 /// the tag and rebuilds the alternative, so no object is built on the Rust
@@ -1421,7 +1421,7 @@ fn flatten(
                     identity: true,
                     nullable,
                     source: LeafSource::Reach,
-                    group: None,
+                    groups: Vec::new(),
                 });
             }
             DeconRecord::Fields {
@@ -1604,7 +1604,7 @@ fn flatten(
                             identity: false,
                             nullable,
                             source: LeafSource::Reach,
-                            group: None,
+                            groups: Vec::new(),
                         });
                     }
                 }
@@ -1705,7 +1705,7 @@ fn flatten(
                         identity,
                         nullable,
                         source: LeafSource::Reach,
-                        group: None,
+                        groups: Vec::new(),
                     });
                 }
             }

--- a/prebindgen-registry/src/unfold/plan.rs
+++ b/prebindgen-registry/src/unfold/plan.rs
@@ -205,7 +205,7 @@ pub enum LeafSource {
     /// A payload field of ONE alternative of a decomposed sum, reached through
     /// a **variant pattern** rather than a path: the emitter binds `member`
     /// inside `variant`'s `match` arm. The leaf is live only when
-    /// [`UnfoldLeaf::group`] equals the value's tag; in every other arm its
+    /// [`UnfoldLeaf::groups`] ends in the value's tag; in every other arm its
     /// slot carries the wire default.
     ///
     /// This is the selector [`Reach`](Self::Reach) deliberately lacks — a
@@ -354,32 +354,33 @@ pub struct UnfoldLeaf {
     /// pattern binding (decomposed sum), or one of the two synthesized
     /// selectors, which are assigned rather than reached.
     pub source: LeafSource,
-    /// **Group membership**: `Some(n)` marks the leaf as belonging to the
-    /// group a **selector** chooses — live only when that selector says so,
-    /// wire-defaulted otherwise. `None` for an unconditional leaf, and for a
-    /// selector itself, which chooses between groups rather than joining one.
+    /// **Group membership**, as the path of arms this leaf sits inside —
+    /// outermost first. Empty for a leaf that is always live. A non-empty path
+    /// marks the leaf as belonging to the group a **selector** chooses: live
+    /// only when that selector says so, wire-defaulted otherwise.
     ///
-    /// There are two selectors, and `n` means what each of them selects on:
+    /// Each element is one arm, and what an arm number means is the selector's
+    /// own answer:
     ///
-    /// * a [`SumTag`](LeafSource::SumTag) chooses among alternatives, and `n`
-    ///   is the alternative's tag;
+    /// * a [`SumTag`](LeafSource::SumTag) chooses among alternatives, and its
+    ///   arm is the alternative's tag;
     /// * a [`Presence`](LeafSource::Presence) chooses between "the value is
-    ///   there" and "it is not", and `n` is `0` — the one group a presence
+    ///   there" and "it is not", and its arm is `0` — the one group a presence
     ///   flag gates, carried by the leaves of the value it speaks for.
     ///
     /// Grouping is what turns a leaf list into a `match`: leaves sharing a
     /// group are emitted together in one arm instead of as independent
     /// per-leaf expressions.
     ///
-    /// **One selector may not own another.** A group's leaves may not include
-    /// a selector, because this field cannot say both "member of the outer
-    /// group" and "selector of an inner one" at once —
-    /// [`segments`](crate::unfold::segments) would return overlapping ranges
-    /// and the outer render would meet a selector where a value was expected.
-    /// A decomposition that would need it declines instead, leaving the value
-    /// to whatever whole-value encode the adapter has. Nesting is the
-    /// endpoint; the representation it needs is not this one.
-    pub group: Option<i32>,
+    /// **A selector carries the path it is nested in, not its own arms.** An
+    /// unconditional selector's path is empty; one inside a group carries that
+    /// group's path, the same as any other member — which is what lets a
+    /// selector own another. Its own members extend that path by one, so
+    /// "member of the outer group" and "selector of an inner one" are two
+    /// different lengths of the same path rather than two meanings of one
+    /// number, and [`segments`](crate::unfold::segments) reads one nesting
+    /// level at a time (#602).
+    pub groups: Vec<i32>,
 }
 
 impl UnfoldLeaf {

--- a/prebindgen-registry/src/unfold/tests.rs
+++ b/prebindgen-registry/src/unfold/tests.rs
@@ -1100,7 +1100,7 @@ fn value_struct_vec_is_fixed_iterable_fold() {
         identity: false,
         nullable: false,
         source: LeafSource::Reach,
-        group: None,
+        groups: Vec::new(),
     };
     let vd = ValueDecon {
         key: TypeKey::from_type(&syn::parse_quote!(Payload)),
@@ -1154,7 +1154,7 @@ fn value_struct_slice_callback_is_fixed_iterable_fold() {
         identity: false,
         nullable: false,
         source: LeafSource::Reach,
-        group: None,
+        groups: Vec::new(),
     };
     let vd = ValueDecon {
         key: TypeKey::from_type(&syn::parse_quote!(Payload)),
@@ -1718,7 +1718,7 @@ fn reading_sum_decon() -> SumDecon {
         identity: false,
         nullable: false,
         source: LeafSource::SumTag,
-        group: None,
+        groups: Vec::new(),
     };
     let field = |name: &str, variant: &str, idx: u32, ty: syn::Type, group: i32| UnfoldLeaf {
         name: name.to_string(),
@@ -1730,7 +1730,7 @@ fn reading_sum_decon() -> SumDecon {
             variant: ident(variant),
             member: syn::Member::Unnamed(syn::Index::from(idx as usize)),
         },
-        group: Some(group),
+        groups: vec![group],
     };
     SumDecon {
         key: TypeKey::from_type(&syn::parse_quote!(Reading)),
@@ -1763,10 +1763,13 @@ fn sum_return_is_a_fixed_builder_plan() {
     assert!(!plan.by_ref);
     assert_eq!(plan.leaves.len(), 2, "the tag plus one group leaf");
     assert_eq!(plan.leaves[0].source, LeafSource::SumTag);
-    assert_eq!(plan.leaves[0].group, None, "the selector joins no group");
+    assert!(
+        plan.leaves[0].groups.is_empty(),
+        "the selector joins no group"
+    );
     assert_eq!(
-        plan.leaves[1].group,
-        Some(1),
+        plan.leaves[1].groups,
+        vec![1],
         "the group is its variant's tag"
     );
     assert!(matches!(
@@ -1918,7 +1921,7 @@ fn a_vec_of_optionals_installs_no_fixed_fold() {
         identity: false,
         nullable: false,
         source: LeafSource::Reach,
-        group: None,
+        groups: Vec::new(),
     };
     let vd = ValueDecon {
         key: TypeKey::from_type(&syn::parse_quote!(Payload)),

--- a/prebindgen-registry/src/unfold/walk.rs
+++ b/prebindgen-registry/src/unfold/walk.rs
@@ -36,22 +36,22 @@ pub trait DecomposedLeaf {
 
     /// Whether this leaf is a synthesized **selector** — a value naming which
     /// group of the leaves after it is live. It chooses between groups rather
-    /// than joining one, so its own [`Self::group`] is `None`.
+    /// than joining one, so its own [`Self::groups`] is the path it sits in,
+    /// not one of the arms it chooses.
     ///
     /// Two kinds select: a sum's tag, which names the live alternative, and an
     /// optional value's presence, which says whether its one group carries
     /// anything.
     fn selects(&self) -> bool;
 
-    /// The group this leaf belongs to — an alternative's tag, or `0` for the
-    /// one group a presence flag gates. `None` for a leaf that is always live,
-    /// and for a selector.
+    /// The arms this leaf sits inside, outermost first — empty for a leaf that
+    /// is always live. A selector carries the path it is nested in, and its own
+    /// members extend that path by one.
     ///
-    /// A group's leaves may not include a selector: see
-    /// [`UnfoldLeaf::group`](crate::unfold::UnfoldLeaf::group) for why one
-    /// `Option<i32>` cannot express nesting, and what a decomposition does
-    /// instead.
-    fn group(&self) -> Option<i32>;
+    /// See [`UnfoldLeaf::groups`](crate::unfold::UnfoldLeaf::groups) for what
+    /// an arm number means and why the path is what lets one selector own
+    /// another.
+    fn groups(&self) -> &[i32];
 
     /// Whether the last step reaching it is a field read rather than a call.
     ///
@@ -546,24 +546,42 @@ fn reached_place<L: DecomposedLeaf>(
 /// already says which leaves those are: a selector says so of itself, and each
 /// of the leaves after it carries the group it belongs to until one does not.
 ///
-/// Segments do not nest: a group's leaves may not include a selector, or these
-/// ranges would overlap. [`UnfoldLeaf::group`](crate::unfold::UnfoldLeaf::group)
-/// states that invariant and what a decomposition does with a shape that would
-/// need it. A decomposition may carry several segments, or none: a sum
-/// that IS the delivered value is one segment covering everything, and a value
-/// form contributes one per sum-typed field.
+/// **One nesting level at a time.** A group's leaves may themselves include a
+/// selector — an optional nested class whose own fields choose, an `Option` of
+/// a sum — and the ranges returned here would overlap if such an inner selector
+/// opened a segment of its own. So this answers for one level: at `depth`, the
+/// selectors whose arm path is exactly that deep, each with everything nested
+/// under it. A renderer that has entered an arm asks again one level down, and
+/// the inner selectors become the segments of that answer.
+///
+/// A decomposition may carry several segments, or none: a sum that IS the
+/// delivered value is one segment covering everything, and a value form
+/// contributes one per sum-typed field.
 ///
 /// Not recognising a segment is silent rather than a compile error — the
 /// leaves are all there, and a delivery that treats them as independent reads
 /// a dead alternative's fields — which is why this is the registry's answer
 /// and not an adapter's.
 pub fn segments<L: DecomposedLeaf>(leaves: &[L]) -> Vec<std::ops::Range<usize>> {
+    segments_at(leaves, 0)
+}
+
+/// [`segments`] one nesting level down: the selectors whose arm path is exactly
+/// `depth` long, with the leaves nested under each.
+///
+/// `depth` is how many arms the caller has already entered, so a leaf deeper
+/// than that belongs to the segment it follows rather than opening one.
+pub fn segments_at<L: DecomposedLeaf>(leaves: &[L], depth: usize) -> Vec<std::ops::Range<usize>> {
     let n = leaves.len();
+    let nested = |i: usize| leaves[i].groups().len() > depth;
+    // Exactly this deep, not "no deeper": a selector shallower than `depth`
+    // encloses the level being asked about rather than sitting on it, and
+    // answering with it would return the enclosing segment a second time.
     (0..n)
-        .filter(|&i| leaves[i].selects())
+        .filter(|&i| leaves[i].selects() && leaves[i].groups().len() == depth)
         .map(|start| {
             let end = (start + 1..n)
-                .take_while(|&i| leaves[i].group().is_some())
+                .take_while(|&i| nested(i))
                 .last()
                 .map_or(start + 1, |i| i + 1);
             start..end


### PR DESCRIPTION
Third child of #613 step 3, after #616 (sum fields) and #617 (optional nested
classes). Those two taught the registry decomposition one gate each. This one
lets a gate contain a gate, which is what the remaining refusals were about,
and it is the representation the #617 review named as this child's precondition
for deleting `StructPlan`'s parallel leaf derivation.

## The representation

A leaf's group was one arm number: `Some(n)` for a member of the group selector
`n` chooses, `None` for a leaf that is always live and for a selector itself.
That cannot say "member of the outer group **and** selector of an inner one" —
one number, two answers — so `segments` would return overlapping ranges and the
outer render would meet a selector where a payload was expected. Both #616 and
#617 refused such a shape rather than emit one.

`groups` is now the **path** of arms a leaf sits inside, outermost first. A
selector carries the path it is nested in, and its own members extend that path
by one, so the two facts are two lengths of one path rather than two meanings of
one number:

```
Outer { mid: Option<Mid> }, Mid { inner: Option<Leaf> }

mid__present          groups []       selector, always live
mid__inner__present   groups [0]      in the group `mid__present` gates — and a selector
mid__inner__id        groups [0, 0]   in the group `mid__inner__present` gates
```

`segments` answers for one level, and a renderer that has entered an arm asks
again one level down (`segments_at`). A segment's own depth is its selector's
path length, so nothing threads a counter: `encode_sum_group` and
`sum_reconstruct` read it off the leaf they were handed.

## What that unrefuses

Both remaining refusals in `struct_out_wires_at` were the same missing
representation, and both go:

- **`Option<sum>` field** — a presence flag gating a tag. Two selectors, one
  owning the other.
- **an optional nested class whose own fields select** — the gate #617 added,
  around a gate of its own.

Five declared types in the covertest change delivery as a result: `HoldPolicy`
and `Observation` (the `Option<sum>` carriers), and `Annotated`, `Dossier` and
`MaybeHolder`, which were refused for a handle or `enum_class` field. That
refusal is gone too: such a field is an ordinary leaf whose own output
conversion carries it — a `jlong` for the handle the receiver adopts, a `jint`
discriminant for the enum — which is exactly what the whole-object encode has
always emitted for it. Nothing about it needed a whole object.

`Vec` of a nested class stays refused, and for a reason that is not
representational: a repeated value has no fixed number of leaves to lay side by
side, which is a sequence rather than a decomposition.

**Generated output changes**, and this is the intended coverage improvement
step 3 describes. The five types cross by fixed-builder delivery rather than as
whole objects; Kotlin gains a builder for each and reassembles through the
`fromParts` those types already had, so the foreign half needed no nesting
logic of its own.

## A disagreement the new coverage exposed

The whole-object encode placed an `Option<sum>`'s presence flag at the
containing struct's depth, while the decomposition names it through the field
(`grace__present`) and so one level in. Every other flag in both derivations
agrees on the deeper answer, including the optional nested class's own. It went
unnoticed because `assert_leaf_derivations_agree` only compares where both
derivations exist, and `Option<sum>` had no decomposition to disagree with
until now. Fixed to `depth + 1`.

That is the check doing the job #603 built it for, one step before step 3
deletes what it compares.

## Verification

- workspace tests (843), clippy `--all-targets --all-features -D warnings`,
  `RUSTDOCFLAGS=-D warnings cargo doc`, the CI-configured `cargo fmt --check`
- `examples/regen-check.sh` — output changes as described above
- `examples/covertest-kotlin && ./gradlew run` — **64 sections pass**, one of
  them new: `Frame { id, window: Option<Window> }`, whose gated `Window` selects
  twice of its own (a second presence and a sum tag). Outer absent, outer
  present with the inner presence absent, both present, and every alternative of
  the nested tag from inside the arm the outer flag opened — on the return route
  and the callback route. Mutation-checked: dropping the recursion in
  `encode_presence_group` fails the build. The
  runtime evidence is already there rather than newly written: the
  `Option<sum>` sections exercise `Observation` in both directions, present and
  absent, across all five alternatives, and `HoldPolicy` with its optional
  group live, absent, and live-while-the-required-one-is-not. Those sections
  now run through the decomposed path.
- `a_selector_inside_a_gated_group_is_refused_rather_than_rendered` becomes
  `..._is_a_segment_of_its_own`: same fixture, now asserting the arm paths, the
  one top-level segment, and the inner segment one level down. Mutation-checked
  — reverting `segments_at`'s depth test to `<=` fails it.

## Cost

Canonical line report at this head, against this PR's base
(`feature/unified-generation-plan` at `200f6989`):

| crate | base | head | production delta |
|---|---|---|---|
| `prebindgen-registry` | 16,790 | 16,809 | **+19** |
| `prebindgen-jni` | 30,956 | 31,077 | **+121** |
| `prebindgen-c` | 8,754 | 8,754 | **0** |

**+140 production lines** total.

Step 3 is a net add until its last child: this one buys the coverage that lets
the next delete `StructPlan`'s leaf derivation, `encode_leaves`, and
`assert_leaf_derivations_agree` without leaving a shape behind.

## Paired deletion child: #619

Step 3 allows a migration slice to defer deletion only by naming the child that
performs it. That child is **#619**, opened with the scope promised here:
`StructPlan`'s leaf derivation (`encode_plan` / `encode_field`), `encode_leaves`,
`assert_leaf_derivations_agree` and its `write_rust` call, and the
`docs/plan-duplication.md` row recording the duplication. **Step 3 stays open
until #619 lands.**

Its coverage question is already settled rather than deferred: after this PR the
decomposition covers every shape a declared data class can hold, the `Vec` guard
in `struct_out_wires_at` is unreachable, and the one shape where the two
derivations disagree — an undeclared nested struct — is one `write_kotlin`
already refuses outright. Both measured with fixtures and recorded on #602.

— Claude Code (Opus 5)

